### PR TITLE
feat(objectstore): ObjectStoreErrorCodes call-site batch K3 (Q-Z + server/legacy) (#3067)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -242,11 +243,11 @@ public final class PSQueryPipe extends PSPipe {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (!ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -256,7 +257,7 @@ public final class PSQueryPipe extends PSPipe {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       try {
@@ -373,7 +374,7 @@ public final class PSQueryPipe extends PSPipe {
 
         Object[] args = new Object[] {dsName, "" + tabSize, "" + joinSize, "" + (tabSize - 1)};
 
-        cxt.validationError(this, IPSObjectStoreErrors.BE_TANK_JOINS_REQUIRED, args);
+        cxt.validationError(this, ObjectStoreErrorCodes.BE_TANK_JOINS_REQUIRED, args);
       }
     }
 
@@ -381,7 +382,7 @@ public final class PSQueryPipe extends PSPipe {
     cxt.pushParent(this);
     try {
       if (m_dataSelector == null) {
-        cxt.validationError(this, IPSObjectStoreErrors.QPIPE_DATA_SELECTOR_NULL, null);
+        cxt.validationError(this, ObjectStoreErrorCodes.QPIPE_DATA_SELECTOR_NULL, null);
       } else m_dataSelector.validate(cxt);
 
       /* if we're doing a heterogeneous join, they must provide the
@@ -399,7 +400,7 @@ public final class PSQueryPipe extends PSPipe {
             PSBackEndTable secondTable = (PSBackEndTable) tabs.get(i);
             if (!firstTable.isSameDatasource(secondTable)) {
               cxt.validationError(
-                  this, IPSObjectStoreErrors.HETERO_NATIVE_SELECT_NOT_SUPPORTED, null);
+                  this, ObjectStoreErrorCodes.HETERO_NATIVE_SELECT_NOT_SUPPORTED, null);
             }
           }
         }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -97,10 +98,10 @@ public class PSRecipient extends PSComponent {
 
   private static PSIllegalArgumentException validateName(String name) {
     if (null == name || name.length() == 0)
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.RECIPIENT_NAME_EMPTY);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.RECIPIENT_NAME_EMPTY.numericCode());
     else if (name.length() > MAX_RECIPIENT_NAME_LEN) {
       Object[] args = {MAX_RECIPIENT_NAME_LEN, name.length()};
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.RECIPIENT_NAME_TOO_BIG, args);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.RECIPIENT_NAME_TOO_BIG.numericCode(), args);
     }
 
     return null;
@@ -963,11 +964,11 @@ public class PSRecipient extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -978,7 +979,7 @@ public class PSRecipient extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     m_options = 0;
@@ -1014,11 +1015,11 @@ public class PSRecipient extends PSComponent {
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "Threshold/count", sTemp};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       } else if (isErrorThresholdByCount()) {
         Object[] args = {ms_NodeType, "Threshold/count", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // private          int         m_errorThresholdInterval = 0;
@@ -1029,11 +1030,11 @@ public class PSRecipient extends PSComponent {
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "Threshold/interval", sTemp};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       } else if (isErrorThresholdByInterval()) {
         Object[] args = {ms_NodeType, "Threshold/interval", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -1052,7 +1053,7 @@ public class PSRecipient extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "ApplicationEvents/authorizationFailure", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -1093,7 +1094,7 @@ public class PSRecipient extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "ApplicationEvents/poorResponseTime", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -1110,7 +1111,7 @@ public class PSRecipient extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "ApplicationEvents/largeRequestQueue", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -1131,7 +1132,7 @@ public class PSRecipient extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "BackEndEvents/authorizationFailure", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -1175,7 +1176,7 @@ public class PSRecipient extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "BackEndEvents/largeRequestQueue", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }

--- a/system/src/main/java/com/percussion/design/objectstore/PSReference.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSReference.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -120,11 +121,11 @@ public class PSReference extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -259,14 +260,14 @@ public class PSRelation extends PSDatabaseComponent implements Cloneable {
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, "[PSX???Relation]");
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, "[PSX???Relation]");
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
     Element key = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
 
     if (key == null) {
       Object[] args = {sourceNode.getTagName(), "[a key element]", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (key != null) {

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationship.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationship.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.percussion.cms.IPSConstants;
@@ -720,11 +721,11 @@ public class PSRelationship extends PSComponent {
       List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -742,20 +743,20 @@ public class PSRelationship extends PSComponent {
       data = tree.getElementData(ATTR_ID);
       if (data == null) {
         Object[] args = {XML_NODE_NAME, ATTR_ID, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       try {
         applyId(Integer.parseInt(data));
       } catch (NumberFormatException e) {
         Object[] args = {XML_NODE_NAME, ATTR_ID, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // REQUIRED: config attribute
       data = tree.getElementData(ATTR_CONFIG);
       if (data == null) {
         Object[] args = {XML_NODE_NAME, ATTR_CONFIG, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       if (m_config == null) {
         PSRelationshipConfigSet configs = PSRelationshipCommandHandler.getConfigurationSet();
@@ -763,7 +764,7 @@ public class PSRelationship extends PSComponent {
       }
       if (m_config == null) {
         Object[] args = {XML_NODE_NAME, ATTR_CONFIG, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: isPersisted attribute
@@ -775,12 +776,12 @@ public class PSRelationship extends PSComponent {
       node = tree.getNextElement(ELEM_OWNER, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, ELEM_OWNER, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       node = tree.getNextElement(PSLocator.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSLocator.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       m_owner = new PSLocator(node);
 
@@ -789,7 +790,7 @@ public class PSRelationship extends PSComponent {
       node = tree.getNextElement(ELEM_DEPENDENT, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, ELEM_DEPENDENT, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       try {
         setDependentCommunityId(PSXMLDomUtil.checkAttributeInt(node, ATTR_COMMUNITYID, false));
@@ -805,7 +806,7 @@ public class PSRelationship extends PSComponent {
       node = tree.getNextElement(PSLocator.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSLocator.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       m_dependent = new PSLocator(node);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -852,11 +853,11 @@ public class PSRelationshipConfig extends PSComponent implements IPSCatalogSumma
       Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -882,19 +883,19 @@ public class PSRelationshipConfig extends PSComponent implements IPSCatalogSumma
         setName(name);
       } catch (IllegalArgumentException e) {
         Object[] args = {XML_NODE_NAME, XML_ATTR_NAME, e.getLocalizedMessage()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       m_label = tree.getElementData(XML_ATTR_LABEL);
       if (m_label == null || m_label.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, XML_ATTR_LABEL, "null or empty"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       m_category = tree.getElementData(XML_ATTR_CATEGORY);
       if (m_category == null || m_category.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, XML_ATTR_CATEGORY, "null or empty"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       m_type =

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfigSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfigSet.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -264,11 +265,11 @@ public class PSRelationshipConfigSet extends PSCollectionComponent implements IP
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -298,7 +299,7 @@ public class PSRelationshipConfigSet extends PSCollectionComponent implements IP
             PSRelationshipConfig.XML_NODE_NAME,
             "Duplicate entry, must be unique server wide: " + config.getName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         add(config);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -79,7 +80,7 @@ public class PSRelationshipProperty extends PSNamedReplacementValue {
 
   // see base class for description
   public int getErrorCode() {
-    return IPSObjectStoreErrors.RELATIONSHIP_PROPERTY_NAME_EMPTY;
+    return ObjectStoreErrorCodes.RELATIONSHIP_PROPERTY_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -69,11 +70,11 @@ public final class PSRelationshipSet extends PSCollectionComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSReplacementValueFactory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSReplacementValueFactory.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
@@ -65,7 +66,7 @@ public abstract class PSReplacementValueFactory {
       throws PSUnknownNodeTypeException {
     if (node == null) {
       Object[] args = {xmlNodeName, xmlVarName, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // now figure out which type it is
@@ -76,7 +77,7 @@ public abstract class PSReplacementValueFactory {
       Class<?> replValueClass = ms_rvClasses.get(nodeName.toLowerCase());
       if (replValueClass == null) {
         Object[] args = {xmlNodeName, xmlVarName, nodeName};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       Class<?>[] constrArgs = {
@@ -99,13 +100,13 @@ public abstract class PSReplacementValueFactory {
     } catch (InvocationTargetException e) {
       Throwable orig = e.getTargetException();
       Object[] args = {xmlNodeName, xmlVarName, nodeName + ": " + orig.toString()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } catch (PSUnknownNodeTypeException e) {
       // no need to wrap this in a new PSUnknownNodeTypeException
       throw e;
     } catch (Exception e) {
       Object[] args = {xmlNodeName, xmlVarName, nodeName + ": " + e.toString()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return value;
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -184,7 +185,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
 
   private static PSIllegalArgumentException validateTargetDataSet(String name) {
     if (null == name || name.length() == 0)
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.REQLINK_DATA_SET_NULL);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.REQLINK_DATA_SET_NULL.numericCode());
 
     return null;
   }
@@ -225,7 +226,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
   private static PSIllegalArgumentException validateXmlField(String name) {
     if ((name != null) && (name.length() > MAX_XML_FIELD_NAME_LEN)) {
       Object[] args = {Integer.valueOf(MAX_XML_FIELD_NAME_LEN), Integer.valueOf(name.length())};
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.REQLINK_XML_FIELD_TOO_BIG, args);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.REQLINK_XML_FIELD_TOO_BIG.numericCode(), args);
     }
 
     return null;
@@ -347,11 +348,11 @@ public class PSRequestLink extends PSComponent implements IPSResults {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -361,7 +362,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("useHttpResponseForRedirect");
@@ -373,7 +374,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
     sTemp = tree.getElementData("type");
     if (sTemp == null) {
       Object[] args = {ms_NodeType, "type", ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else if (sTemp.equalsIgnoreCase("none")) m_requestType = RL_TYPE_NONE;
     else if (sTemp.equalsIgnoreCase("query")) m_requestType = RL_TYPE_QUERY;
     else if (sTemp.equalsIgnoreCase("insert")) m_requestType = RL_TYPE_INSERT;
@@ -381,7 +382,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
     else if (sTemp.equalsIgnoreCase("delete")) m_requestType = RL_TYPE_DELETE;
     else {
       Object[] args = {ms_NodeType, "type", sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     try { // private          String      m_dataSet = "";

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -465,11 +466,11 @@ public final class PSRequestor extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -479,7 +480,7 @@ public final class PSRequestor extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // the MIME type to use

--- a/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -206,7 +207,7 @@ public final class PSResourceCacheSettings extends PSComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -219,7 +220,7 @@ public final class PSResourceCacheSettings extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // get the enabled attribute
@@ -236,7 +237,7 @@ public final class PSResourceCacheSettings extends PSComponent {
       m_extraKeys.clear();
       Element keys = tree.getNextElement(KEYS_XML_EL, firstFlags);
       if (keys == null) {
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, KEYS_XML_EL);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, KEYS_XML_EL);
       }
 
       Element key = tree.getNextElement(KEY_XML_EL, firstFlags);
@@ -252,7 +253,7 @@ public final class PSResourceCacheSettings extends PSComponent {
         if (!(replVal instanceof PSNamedReplacementValue)) {
           Object args[] = {XML_NODE_NAME, KEY_XML_EL, child.getNodeName()};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         m_extraKeys.add(replVal);
@@ -264,7 +265,7 @@ public final class PSResourceCacheSettings extends PSComponent {
       m_dependencies.clear();
       Element deps = tree.getNextElement(DEPS_XML_EL, nextFlags);
       if (deps == null) {
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, DEPS_XML_EL);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, DEPS_XML_EL);
       }
 
       Element dep = tree.getNextElement(DEP_XML_EL, firstFlags);
@@ -273,7 +274,7 @@ public final class PSResourceCacheSettings extends PSComponent {
         if (resource.trim().length() == 0) {
           Object args[] = {XML_NODE_NAME, DEP_XML_EL, resource};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         m_dependencies.add(resource);

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -369,11 +370,11 @@ public final class PSResultPage extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -383,7 +384,7 @@ public final class PSResultPage extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       sTemp = tree.getElementData(ATTR_ALLOW_NAMESPACE_CLEANUP);
@@ -401,7 +402,7 @@ public final class PSResultPage extends PSComponent {
         } catch (MalformedURLException e) {
           Object[] args = {ms_NodeType, "styleSheet", "(URL: " + sTemp + ") " + e.getMessage()};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -165,11 +166,11 @@ public final class PSResultPageSet extends PSComponent implements IPSResults {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -179,7 +180,7 @@ public final class PSResultPageSet extends PSComponent implements IPSResults {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -244,11 +245,11 @@ public final class PSResultPager extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -258,7 +259,7 @@ public final class PSResultPager extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("maxRowsPerPage");
@@ -268,7 +269,7 @@ public final class PSResultPager extends PSComponent {
         m_maxRowsPerPage = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxRowsPerPage", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -279,7 +280,7 @@ public final class PSResultPager extends PSComponent {
         m_maxPages = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxPages", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -290,7 +291,7 @@ public final class PSResultPager extends PSComponent {
         m_maxPageLinks = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxPageLinks", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSDateFormatISO8601;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -227,12 +228,12 @@ public class PSRevisionEntry extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeType);
     }
 
     if (!ms_nodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_nodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Date;
@@ -234,12 +235,12 @@ public class PSRevisionHistory extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeType);
     }
 
     if (!ms_nodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_nodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRole.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRole.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.services.catalog.IPSCatalogSummary;
@@ -366,11 +367,11 @@ public final class PSRole extends PSDatabaseComponent implements Comparable, IPS
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -380,7 +381,7 @@ public final class PSRole extends PSDatabaseComponent implements Comparable, IPS
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("name");
@@ -389,7 +390,7 @@ public final class PSRole extends PSDatabaseComponent implements Comparable, IPS
     } catch (IllegalArgumentException e) {
       Object[] args = {ms_NodeType, "name", sTemp == null ? "empty" : sTemp};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // Restore our db state

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleConfiguration.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleConfiguration.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -106,16 +107,16 @@ public final class PSRoleConfiguration implements IPSDocument {
   public final void fromXml(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == sourceDoc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the correct root node tag
     if (false == ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Read PSXRoleConfiguration object attributes
@@ -131,14 +132,14 @@ public final class PSRoleConfiguration implements IPSDocument {
     e = tree.getNextElement(m_subjects.ms_NodeType, firstFlags);
     if (null == e) {
       Object[] args = {m_subjects.ms_NodeType, "null", "''"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_subjects.fromXml(e, null, null);
 
     e = tree.getNextElement(m_roles.ms_NodeType, nextFlags);
     if (null == e) {
       Object[] args = {m_roles.ms_NodeType, "null", "''"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_roles.fromXml(e, null, null);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -231,11 +232,11 @@ public final class PSRoleProvider extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -247,7 +248,7 @@ public final class PSRoleProvider extends PSComponent {
     Element reference = tree.getNextElement(PSReference.XML_NODE_NAME);
     if (reference == null && isDirectoryRoleProvider()) {
       Object[] args = {PSReference.XML_NODE_NAME, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     if (reference != null) m_directoryRef = new PSReference(reference, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRule.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRule.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -236,11 +237,11 @@ public final class PSRule extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -269,7 +270,7 @@ public final class PSRule extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, BOOLEAN_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       } else m_operator = BOOLEAN_AND;
 
@@ -286,7 +287,7 @@ public final class PSRule extends PSComponent {
             "null"
           };
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         while (node != null) {
           m_conditionalRules.add(new PSConditional(node, parentDoc, parentComponents));

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.server.PSServer;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -263,7 +264,7 @@ public final class PSSearchConfig extends PSComponent {
         if (m_maxSearchResult < 0) m_maxSearchResult = -1;
       } catch (NumberFormatException nfe) {
         Object args[] = {"PSXSearchConfiguration", MAX_SEARCH_RESULT_ATTR, nsMaxSearchResult};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -278,7 +279,7 @@ public final class PSSearchConfig extends PSComponent {
           if (null == propName || propName.trim().length() == 0) {
             String[] args = {propEl.getNodeName(), NAME_ATTR, propName};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
           }
           String value = PSXmlTreeWalker.getElementData(propEl);
           m_properties.put(propName, value);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -278,11 +279,11 @@ public class PSSearchProperties extends PSComponent {
   public final void fromXml(Element source, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSecurityConfiguration.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSecurityConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -149,17 +150,17 @@ public class PSSecurityConfiguration implements IPSDocument {
   public void fromXml(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (sourceDoc == null) {
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the security configuration type node
     if (false == ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceDoc);
@@ -168,12 +169,12 @@ public class PSSecurityConfiguration implements IPSDocument {
     String sTemp = tree.getElementData("forceSecureLogin");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "forceSecureLogin", "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else if (sTemp.equals(XML_FLAG_TYPE_YES)) setIsForceSecureLogin(XML_FLAG_TYPE_YES);
     else if (sTemp.equals(XML_FLAG_TYPE_NO)) setIsForceSecureLogin(XML_FLAG_TYPE_NO);
     else {
       Object[] args = {ms_NodeType, "forceSecureLogin", sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // Read path elements of the security configuration

--- a/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.PSEncryptionException;
@@ -134,7 +136,7 @@ public class PSSecurityProviderInstance extends PSComponent {
   private static PSIllegalArgumentException validateType(int type) {
     if (!PSSecurityProvider.isSupportedType(type)) {
       return new PSIllegalArgumentException(
-          IPSObjectStoreErrors.SPINST_TYPE_INVALID, String.valueOf(type));
+          DesignErrorCodes.SPINST_TYPE_INVALID.numericCode(), String.valueOf(type));
     }
     return null;
   }
@@ -192,7 +194,7 @@ public class PSSecurityProviderInstance extends PSComponent {
   private static PSIllegalArgumentException validateName(String name) {
     if ((null != name) && (name.length() > MAX_NAME_LEN)) {
       Object[] args = {Integer.valueOf(MAX_NAME_LEN), Integer.valueOf(name.length())};
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.SPINST_NAME_TOO_BIG, args);
+      return new PSIllegalArgumentException(DesignErrorCodes.SPINST_NAME_TOO_BIG.numericCode(), args);
     }
     return null;
   }
@@ -321,11 +323,11 @@ public class PSSecurityProviderInstance extends PSComponent {
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -335,19 +337,19 @@ public class PSSecurityProviderInstance extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("type");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "type", ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     int providerType = PSSecurityProvider.getSecurityProviderTypeFromXmlFlag(sTemp);
     if (providerType != 0) m_providerType = providerType;
     else {
       Object[] args = {ms_NodeType, "type", sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // get the instance name

--- a/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -184,7 +185,7 @@ public class PSServerCacheSettings extends PSComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -201,14 +202,14 @@ public class PSServerCacheSettings extends PSComponent {
         m_id = Integer.parseInt(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // REQUIRED: get the fieldSetRef attribute
       data = tree.getElementData(ENABLED_ATTR);
       if (data == null) {
         Object[] args = {XML_NODE_NAME, ENABLED_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       if (data.equalsIgnoreCase("yes")) setEnabled(true);
@@ -219,7 +220,7 @@ public class PSServerCacheSettings extends PSComponent {
         setMaxMemoryUsage(Long.parseLong(data));
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, MAX_MEMORY_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       try {
@@ -227,7 +228,7 @@ public class PSServerCacheSettings extends PSComponent {
         setMaxDiskUsage(Long.parseLong(data));
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, MAX_DISK_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       try {
@@ -235,7 +236,7 @@ public class PSServerCacheSettings extends PSComponent {
         setMaxPageSize(Long.parseLong(data));
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, MAX_PAGE_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       try {
@@ -243,7 +244,7 @@ public class PSServerCacheSettings extends PSComponent {
         setAgingTime(Long.parseLong(data));
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, AGING_TIME_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       data = tree.getElementData(FOLDER_CACHE_ENABLED_ATTR);

--- a/system/src/main/java/com/percussion/design/objectstore/PSServerConfiguration.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSServerConfiguration.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.PSSecurityProvider;
 import com.percussion.security.TLSSocketFactory;
@@ -181,7 +183,7 @@ public class PSServerConfiguration implements IPSDocument {
     int length = requestRoot.length();
     if (length > MAX_REQ_ROOT_LEN) {
       Object[] args = {MAX_REQ_ROOT_LEN, length};
-      throw new PSIllegalArgumentException(IPSObjectStoreErrors.SRV_ROOT_TOO_BIG, args);
+      throw new PSIllegalArgumentException(ObjectStoreErrorCodes.SRV_ROOT_TOO_BIG.numericCode(), args);
     }
 
     m_requestRoot = requestRoot;
@@ -212,11 +214,11 @@ public class PSServerConfiguration implements IPSDocument {
    * @see PSAcl
    */
   public void setAcl(PSAcl acl) throws PSIllegalArgumentException {
-    if (null == acl) throw new PSIllegalArgumentException(IPSObjectStoreErrors.SRV_ACL_NULL);
+    if (null == acl) throw new PSIllegalArgumentException(DesignErrorCodes.SRV_ACL_NULL.numericCode());
 
     PSCollection entries = acl.getEntries();
     int size = entries.size();
-    if (0 == size) throw new PSIllegalArgumentException(IPSObjectStoreErrors.SRV_ACL_EMPTY);
+    if (0 == size) throw new PSIllegalArgumentException(DesignErrorCodes.SRV_ACL_EMPTY.numericCode());
 
     int adminAccess = PSAclEntry.SACE_ADMINISTER_SERVER;
 
@@ -232,14 +234,14 @@ public class PSServerConfiguration implements IPSDocument {
 
       if (names.put(key, ace) != null) /* we've seen this already */
         throw new PSIllegalArgumentException(
-            IPSObjectStoreErrors.ACL_ENTRYLIST_DUPLICATE, ace.getName());
+            DesignErrorCodes.ACL_ENTRYLIST_DUPLICATE.numericCode(), ace.getName());
 
       level = ace.getAccessLevel();
       if ((level & adminAccess) == adminAccess) hasAdminAccess = true;
     }
 
     if (!hasAdminAccess)
-      throw new PSIllegalArgumentException(IPSObjectStoreErrors.SRV_ACL_NO_ADMIN);
+      throw new PSIllegalArgumentException(DesignErrorCodes.SRV_ACL_NO_ADMIN.numericCode());
 
     m_acl = acl;
     setModified(true);
@@ -462,7 +464,7 @@ public class PSServerConfiguration implements IPSDocument {
         Object[] args = {
           "Security Provider Instance", "PSSecurityProviderInstance", insts.getMemberClassName()
         };
-        throw new PSIllegalArgumentException(IPSObjectStoreErrors.COLL_BAD_CONTENT_TYPE, args);
+        throw new PSIllegalArgumentException(ObjectStoreErrorCodes.COLL_BAD_CONTENT_TYPE.numericCode(), args);
       }
     }
 
@@ -1110,16 +1112,16 @@ public class PSServerConfiguration implements IPSDocument {
   private void fromXmlBase(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == sourceDoc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the correct root node tag
     if (false == ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // get the server type
@@ -1135,7 +1137,7 @@ public class PSServerConfiguration implements IPSDocument {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // Get requestRoot from XML
@@ -1181,7 +1183,7 @@ public class PSServerConfiguration implements IPSDocument {
           m_sessionTimeout = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "userSessionTimeout", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
       // create user sessions time out
@@ -1192,7 +1194,7 @@ public class PSServerConfiguration implements IPSDocument {
           m_sessionWarning = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "userSessionWarning", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -1204,7 +1206,7 @@ public class PSServerConfiguration implements IPSDocument {
           setMaxOpenUserSessions(Integer.parseInt(sTemp));
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxOpenUserSessions", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
     }
@@ -1229,7 +1231,7 @@ public class PSServerConfiguration implements IPSDocument {
         if (sTemp != null) m_runningLogDays = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "runningLogDays", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -1354,7 +1356,7 @@ public class PSServerConfiguration implements IPSDocument {
           if (groupProvider == null) {
             Object[] args = {XML_GROUP_PROVIDERS_ELEMENT, curNodeType, "null"};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
           while (groupProvider != null) {
             m_groupProviders.add(PSGroupProviderInstance.newInstance(groupProvider));

--- a/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -294,11 +295,11 @@ public final class PSSharedFieldGroup extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -317,7 +318,7 @@ public final class PSSharedFieldGroup extends PSComponent {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null || m_name.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: get the filename attribute
@@ -328,7 +329,7 @@ public final class PSSharedFieldGroup extends PSComponent {
       node = tree.getNextElement(PSContainerLocator.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSContainerLocator.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_locator = new PSContainerLocator(node, parentDoc, parentComponents);
 
@@ -336,7 +337,7 @@ public final class PSSharedFieldGroup extends PSComponent {
       node = tree.getNextElement(PSFieldSet.XML_NODE_NAME, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSFieldSet.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_fieldSet = new PSFieldSet(node, parentDoc, parentComponents);
       m_fieldSet.setSourceType(PSField.TYPE_SHARED);
@@ -345,7 +346,7 @@ public final class PSSharedFieldGroup extends PSComponent {
       node = tree.getNextElement(PSUIDefinition.XML_NODE_NAME, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSUIDefinition.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_uiDefinition = new PSUIDefinition(node, parentDoc, parentComponents);
 
@@ -403,19 +404,19 @@ public final class PSSharedFieldGroup extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_name == null || m_name.trim().length() == 0)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_SHARED_FIELD_GROUP, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_SHARED_FIELD_GROUP, null);
 
     // do children
     context.pushParent(this);
     try {
       if (m_locator != null) m_locator.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_SHARED_FIELD_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_SHARED_FIELD_GROUP, null);
 
       if (m_fieldSet != null) m_fieldSet.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_SHARED_FIELD_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_SHARED_FIELD_GROUP, null);
 
       if (m_uiDefinition != null) m_uiDefinition.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_SHARED_FIELD_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_SHARED_FIELD_GROUP, null);
 
       if (m_validationRules != null) m_validationRules.validate(context);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -153,11 +154,11 @@ public class PSSortedColumn extends PSBackEndColumn {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (!ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -167,7 +168,7 @@ public class PSSortedColumn extends PSBackEndColumn {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // private         boolean            m_isAscending = true;
@@ -181,7 +182,7 @@ public class PSSortedColumn extends PSBackEndColumn {
 
       if (tree.getNextElement(PSBackEndColumn.ms_NodeType, firstFlags) == null) {
         Object[] args = {ms_NodeType, PSBackEndColumn.ms_NodeType, ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       super.fromXml((Element) tree.getCurrent(), parentDoc, parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -108,11 +109,11 @@ public class PSStylesheet extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -132,7 +133,7 @@ public class PSStylesheet extends PSComponent {
       node = tree.getNextElement(PSUrlRequest.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_request = new PSUrlRequest(node, parentDoc, parentComponents);
     } finally {
@@ -161,7 +162,7 @@ public class PSStylesheet extends PSComponent {
     context.pushParent(this);
     try {
       if (m_request != null) m_request.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_STYLESHEET, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_STYLESHEET, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -387,13 +388,13 @@ public abstract class PSSubject extends PSDatabaseComponent {
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     // make sure we got the Subject type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -403,23 +404,23 @@ public abstract class PSSubject extends PSDatabaseComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get the Subject type element from attribute
     sTemp = tree.getElementData("type");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "type", "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       try {
         applyType(Integer.valueOf(sTemp).intValue());
       } catch (NumberFormatException nfe) {
         Object[] args = {ms_NodeType, "type", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       } catch (IllegalArgumentException ie) {
         Object[] args = {ms_NodeType, "type", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -432,7 +433,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
       applyName(sTemp);
     } catch (IllegalArgumentException e) {
       Object[] args = {ms_NodeType, "name", e.toString()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -151,11 +152,11 @@ public class PSTableRef extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -168,7 +169,7 @@ public class PSTableRef extends PSComponent {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: get the table ref alias
@@ -195,7 +196,7 @@ public class PSTableRef extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_name == null || m_name.trim().length() == 0)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_TABLE_REF, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_TABLE_REF, null);
   }
 
   /** the XML node name */

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -210,11 +211,11 @@ public final class PSTableSet extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -240,14 +241,14 @@ public final class PSTableSet extends PSComponent {
         m_tableLocation = new PSTableLocator(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSTableLocator.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // REQUIRED: get the table refs
       node = tree.getNextElement(PSTableRef.XML_NODE_NAME, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSTableRef.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         m_tableRefs.add(new PSTableRef(node, parentDoc, parentComponents));
@@ -284,11 +285,11 @@ public final class PSTableSet extends PSComponent {
     context.pushParent(this);
     try {
       if (m_tableLocation != null) m_tableLocation.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_TABLE_SET, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_TABLE_SET, null);
 
       Iterator it = getTableRefs();
       if (!it.hasNext())
-        context.validationError(this, IPSObjectStoreErrors.INVALID_TABLE_SET, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_TABLE_SET, null);
       while (it.hasNext()) ((IPSComponent) it.next()).validate(context);
     } finally {
       context.popParent();

--- a/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -159,12 +160,12 @@ public class PSTextLiteral extends PSLiteral implements IPSMutatableReplacementV
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the ACL type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -174,7 +175,7 @@ public class PSTextLiteral extends PSLiteral implements IPSMutatableReplacementV
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // read text from XML node

--- a/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.debug.IPSTraceStateListener;
 import com.percussion.debug.PSTraceFlag;
 import com.percussion.debug.PSTraceMessageFactory;
@@ -291,13 +292,13 @@ public class PSTraceInfo extends PSComponent {
       throws PSUnknownNodeTypeException {
 
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     // make sure we got the correct type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -307,14 +308,14 @@ public class PSTraceInfo extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get the main trace enabled setting
     sTemp = tree.getElementData("traceEnabled");
     if ((sTemp == null) || !(sTemp.equals("yes") || sTemp.equals("no"))) {
       Object[] args = {ms_NodeType, "traceEnabled", ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       m_enabled = (sTemp.equals("yes") ? true : false);
     }
@@ -325,7 +326,7 @@ public class PSTraceInfo extends PSComponent {
       m_columnWidth = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, "traceOutputColumnWidth", ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get the Timestamp Only setting
@@ -334,7 +335,7 @@ public class PSTraceInfo extends PSComponent {
       Object[] args = {
         ms_NodeType, "traceTimestampOnlyenabled", ((sTemp == null) ? "null" : sTemp)
       };
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       m_timeStampOnly = (sTemp.equals("yes") ? true : false);
     }
@@ -349,7 +350,7 @@ public class PSTraceInfo extends PSComponent {
         if (sTemp.equals("yes")) m_traceFlag.setBit(o.getFlag());
         else if (!sTemp.equals("no")) {
           Object[] args = {ms_NodeType, o.getName(), sTemp};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -317,11 +318,11 @@ public final class PSUIDefinition extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -349,7 +350,7 @@ public final class PSUIDefinition extends PSComponent {
         if (node == null) {
           Object[] args = {XML_NODE_NAME, DEFAULT_UI_ELEM, "empty"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_defaultUI = new PSCollection(new PSUISet().getClass());
         while (node != null) {
@@ -367,7 +368,7 @@ public final class PSUIDefinition extends PSComponent {
         m_displayMapper = new PSDisplayMapper(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSDisplayMapper.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } finally {
       resetParentList(parentComponents, parentSize);
@@ -405,7 +406,7 @@ public final class PSUIDefinition extends PSComponent {
     context.pushParent(this);
     try {
       if (m_displayMapper != null) m_displayMapper.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_UI_DEFINITION, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_UI_DEFINITION, null);
 
       Iterator it = getDefaultUI();
       while (it.hasNext()) ((IPSComponent) it.next()).validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -389,11 +390,11 @@ public final class PSUISet extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSErrorManager;
 import com.percussion.error.PSException;
@@ -101,7 +102,7 @@ public class PSUnknownDocTypeException extends PSException {
    * @param e the exception to use as the error description
    */
   public PSUnknownDocTypeException(String parent, String child, PSException e) {
-    this(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, new Object[] {parent, child, ""});
+    this(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, new Object[] {parent, child, ""});
     m_exception = e;
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -200,11 +201,11 @@ public class PSUpdateColumn extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -214,7 +215,7 @@ public class PSUpdateColumn extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // private         boolean            m_key = false;
@@ -231,7 +232,7 @@ public class PSUpdateColumn extends PSComponent {
 
       if (tree.getNextElement(PSBackEndColumn.ms_NodeType, firstFlags) == null) {
         Object[] args = {ms_NodeType, PSBackEndColumn.ms_NodeType, ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       m_backEndColumn =

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -218,11 +219,11 @@ public final class PSUpdatePipe extends PSPipe {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -233,7 +234,7 @@ public final class PSUpdatePipe extends PSPipe {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       try { // set the pipe name
@@ -329,7 +330,7 @@ public final class PSUpdatePipe extends PSPipe {
       if (!(m_dataSynchronizer.isDeletingAllowed()
           || m_dataSynchronizer.isUpdatingAllowed()
           || m_dataSynchronizer.isInsertingAllowed())) {
-        cxt.validationError(this, IPSObjectStoreErrors.UPDATEPIPE_NO_SYNC_TYPES, null);
+        cxt.validationError(this, ObjectStoreErrorCodes.UPDATEPIPE_NO_SYNC_TYPES, null);
       }
     }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -350,11 +351,11 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -385,7 +386,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
             XML_NODE_NAME, PSExtensionCall.ms_NodeType + " and " + HREF_ELEM, "null"
           };
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         applyHref(PSXmlTreeWalker.getElementData(node));
 
@@ -436,7 +437,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
       if (m_converter == null) {
         // we must have the parts
         if (m_href == null)
-          context.validationError(this, IPSObjectStoreErrors.INVALID_URL_REQUEST, null);
+          context.validationError(this, ObjectStoreErrorCodes.INVALID_URL_REQUEST, null);
         Iterator it = getQueryParameters();
         while (it.hasNext()) ((IPSComponent) it.next()).validate(context);
       } else m_converter.validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUserConfiguration.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUserConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Enumeration;
@@ -204,15 +205,15 @@ public class PSUserConfiguration extends java.util.concurrent.ConcurrentHashMap
    */
   public void fromXml(Document sourceDoc) throws PSUnknownDocTypeException {
     if (sourceDoc == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (false == ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Read PSXUserConfiguration object attributes

--- a/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -71,7 +72,7 @@ public class PSUserContext extends PSNamedReplacementValue {
   protected int getErrorCode() {
     // no specific error code exists for this class, but this is the value
     // that the class has always returned
-    return IPSObjectStoreErrors.HTML_PARAM_NAME_EMPTY;
+    return ObjectStoreErrorCodes.HTML_PARAM_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with this instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -124,11 +125,11 @@ public class PSValidationRules extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSVersion.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSVersion.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.ParseException;
 import java.util.Date;
@@ -56,13 +57,13 @@ public class PSVersion {
    */
   public PSVersion(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeName);
     }
 
     // make sure we got the correct type node
     if (false == ms_nodeName.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_nodeName, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -73,7 +74,7 @@ public class PSVersion {
       m_versionNumber = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_nodeName, "Number", ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     sTemp = tree.getElementData("Introduced");
@@ -82,7 +83,7 @@ public class PSVersion {
       m_dateIntroduced = m_formatter.parse(sTemp.trim());
     } catch (Exception e) {
       Object[] args = {ms_nodeName, "Introduced", ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSVisibilityRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSVisibilityRules.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -101,11 +102,11 @@ public class PSVisibilityRules extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -134,7 +135,7 @@ public class PSVisibilityRules extends PSCollectionComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, DATA_HIDING_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -171,7 +172,7 @@ public class PSVisibilityRules extends PSCollectionComponent {
 
     if (m_dataHiding != DATA_HIDING_XML && m_dataHiding != DATA_HIDING_XSL) {
       Object[] args = {DATA_HIDING_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_DATA_HIDING, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_DATA_HIDING, args);
     }
 
     super.validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -178,11 +179,11 @@ public final class PSWhereClause extends PSConditional {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (!ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -192,7 +193,7 @@ public final class PSWhereClause extends PSConditional {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       sTemp = sourceNode.getAttribute("omitWhenNull");
@@ -203,7 +204,7 @@ public final class PSWhereClause extends PSConditional {
 
       if (tree.getNextElement(PSConditional.ms_NodeType, firstFlags) == null) {
         Object[] args = {ms_NodeType, PSConditional.ms_NodeType, ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       super.fromXml((Element) tree.getCurrent(), parentDoc, parentComponents);
     } finally {

--- a/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -55,7 +56,7 @@ public class PSXmlField extends PSNamedReplacementValue {
 
   // see base class for description
   protected int getErrorCode() {
-    return IPSObjectStoreErrors.XML_FIELD_NAME_EMPTY;
+    return ObjectStoreErrorCodes.XML_FIELD_NAME_EMPTY.numericCode();
   }
 
   // see base class for description

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndConnection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndConnection.java
@@ -17,9 +17,9 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSSystemValidationException;
@@ -443,11 +443,11 @@ public class PSLegacyBackEndConnection extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -457,14 +457,14 @@ public class PSLegacyBackEndConnection extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // get the driver name
       sTemp = tree.getElementData("jdbcDriverName");
       if ((sTemp == null) || (sTemp.length() == 0)) {
         Object[] args = {ms_NodeType, "jdbcDriverName", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_jdbcDriverName = sTemp;
 
@@ -472,7 +472,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
       sTemp = tree.getElementData("jdbcClassName");
       if ((sTemp == null) || (sTemp.length() == 0)) {
         Object[] args = {ms_NodeType, "jdbcClassName", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_jdbcClassName = sTemp;
 
@@ -490,7 +490,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
         m_connMin = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionMin", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read max connection count
@@ -499,7 +499,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
         m_connMax = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionMax", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read idle connection timeout (in seconds)
@@ -508,7 +508,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
         m_idleTimeoutSeconds = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionIdleTimeout", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read refresh period (in seconds) -- optional
@@ -518,7 +518,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
           setRefreshPeriodSeconds(Integer.parseInt(sTemp));
         } catch (Exception e) {
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
               new Object[] {ms_NodeType, "connectionRefreshPeriod", sTemp});
         }
     } finally {
@@ -560,7 +560,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
       Class.forName(m_jdbcClassName);
     } catch (Exception e) {
       Object[] args = new Object[] {m_jdbcClassName, e.toString()};
-      cxt.validationError(this, IPSObjectStoreErrors.JDBC_DRIVER_CLASS_LOAD_ERROR, args);
+      cxt.validationError(this, ObjectStoreErrorCodes.JDBC_DRIVER_CLASS_LOAD_ERROR, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndCredential.java
@@ -17,9 +17,9 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSConditional;
@@ -480,11 +480,11 @@ public class PSLegacyBackEndCredential extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -494,7 +494,7 @@ public class PSLegacyBackEndCredential extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // read Alias name

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndTable.java
@@ -17,9 +17,9 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
 import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndDataTank;
@@ -459,11 +459,11 @@ public class PSLegacyBackEndTable extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -473,7 +473,7 @@ public class PSLegacyBackEndTable extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try { // private      String          m_alias;

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.design.objectstore.legacy;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSProvider;
 import com.percussion.design.objectstore.PSSecurityProviderInstance;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -114,11 +114,11 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -128,19 +128,19 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("type");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "type", ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     int providerType = PSSecurityProvider.getSecurityProviderTypeFromXmlFlag(sTemp);
     if (providerType != 0) m_providerType = providerType;
     else {
       Object[] args = {ms_NodeType, "type", sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // get the instance name
@@ -180,7 +180,7 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
         if (groupProvider == null || groupProvider.trim().length() == 0) {
           Object[] args = {GROUP_PROVIDERS_ELEMENT, GROUP_NAME_ELEMENT, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_groupProviderNames.add(groupProvider);
         groupName = tree.getNextElement(GROUP_NAME_ELEMENT, nextFlags);

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyServerConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyServerConfig.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.objectstore.legacy;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAcl;
 import com.percussion.design.objectstore.PSAuthentication;
 import com.percussion.design.objectstore.PSDataEncryptor;
@@ -86,16 +86,16 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
   public void fromXml(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == sourceDoc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the correct root node tag
     if (false == ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // get the server type
@@ -111,7 +111,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // Get requestRoot from XML
@@ -172,7 +172,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_maxThreadsPerApp = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxThreadsPerApp", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -184,7 +184,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_minThreadsOnServer = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "minThreadsOnServer", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -196,7 +196,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_maxThreadsOnServer = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxThreadsOnServer", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -208,7 +208,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_idleThreadTimeout = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "idleThreadTimeout", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -220,7 +220,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_maxRequestsInQueuePerApp = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxRequestsInQueuePerApp", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -232,7 +232,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_maxRequestsInQueueOnServer = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxRequestsInQueueOnServer", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -244,7 +244,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_maxRequestTime = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxRequestTime", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -260,7 +260,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_sessionTimeout = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "userSessionTimeout", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
 
@@ -272,7 +272,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           setMaxOpenUserSessions(Integer.parseInt(sTemp));
         } catch (NumberFormatException e) {
           Object[] args = {ms_NodeType, "maxOpenUserSessions", sTemp};
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
     }
@@ -297,7 +297,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
         if (sTemp != null) m_runningLogDays = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "runningLogDays", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -361,7 +361,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           m_beLoginTimeoutSeconds = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "backEndLoginTimeout", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -391,7 +391,7 @@ public class PSLegacyServerConfig extends PSServerConfiguration {
           if (groupProvider == null) {
             Object[] args = {XML_GROUP_PROVIDERS_ELEMENT, curNodeType, "null"};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
           while (groupProvider != null) {
             m_groupProviders.add(PSGroupProviderInstance.newInstance(groupProvider));

--- a/system/src/main/java/com/percussion/design/objectstore/server/PSDatabaseComponentLoader.java
+++ b/system/src/main/java/com/percussion/design/objectstore/server/PSDatabaseComponentLoader.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.design.objectstore.server;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.data.IPSInternalRequestHandler;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.design.objectstore.IPSDatabaseComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSDatabaseComponent;
 import com.percussion.design.objectstore.PSDatabaseComponentCollection;
 import com.percussion.design.objectstore.PSRelation;
@@ -163,7 +163,7 @@ public class PSDatabaseComponentLoader {
           };
 
           throw new PSDatabaseComponentException(
-              IPSObjectStoreErrors.RELATED_DB_COMPONENT_LOAD_EXCEPTION, args);
+              ObjectStoreErrorCodes.RELATED_DB_COMPONENT_LOAD_EXCEPTION.numericCode(), args);
         }
 
         IPSDatabaseComponent component =
@@ -214,7 +214,7 @@ public class PSDatabaseComponentLoader {
       Object[] args = {resourceName, e.toString()};
 
       throw new PSDatabaseComponentException(
-          IPSObjectStoreErrors.DB_COMPONENT_LOAD_EXCEPTION, args);
+          ObjectStoreErrorCodes.DB_COMPONENT_LOAD_EXCEPTION.numericCode(), args);
     }
   }
 
@@ -284,7 +284,7 @@ public class PSDatabaseComponentLoader {
         "The internal request handler could not be loaded." + "  It may have failed to start"
       };
       throw new PSInternalRequestCallException(
-          IPSObjectStoreErrors.DB_COMPONENT_LOAD_EXCEPTION, args);
+          ObjectStoreErrorCodes.DB_COMPONENT_LOAD_EXCEPTION.numericCode(), args);
     }
 
     PSInternalRequest req = new PSInternalRequest(m_request, irh);

--- a/system/src/main/java/com/percussion/design/objectstore/server/PSServerXmlObjectStore.java
+++ b/system/src/main/java/com/percussion/design/objectstore/server/PSServerXmlObjectStore.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore.server;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.conn.PSServerException;
 import com.percussion.data.IPSInternalRequestHandler;
@@ -26,7 +27,6 @@ import com.percussion.data.PSMetaDataCache;
 import com.percussion.data.PSTableMetaData;
 import com.percussion.data.jdbc.PSFileSystemDriver;
 import com.percussion.data.vfs.IPSVirtualDirectory;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSAcl;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSApplication;
@@ -388,7 +388,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // Check to see if app is locked
     if (!isApplicationLocked(lockId, appName)) {
       Object[] args = {appName};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getApplicationLock(lockId, appName, 30);
@@ -558,7 +558,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // we assume the request root is the application directory
     PSApplicationSummary sum = m_objectStoreHandler.m_appSums.getSummary(appName);
 
-    if (sum == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_ROOT_REQD, appName);
+    if (sum == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode(), appName);
 
     String appRoot = sum.getAppRoot();
     File appDir = getAppRootDir(appRoot);
@@ -567,7 +567,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // then error
     if (!(appDir.exists() && appDir.isDirectory())) {
       Object[] args = {appName, appDir.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_DIR_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_DIR_NOT_FOUND.numericCode(), args);
     }
 
     File appFileName = new File(appDir, appFile.getPath());
@@ -582,18 +582,18 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
 
     } catch (FileNotFoundException e) {
       Object[] args = {appName, appFileName.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_FILE_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_FILE_NOT_FOUND.numericCode(), args);
 
     } catch (IOException e) {
       Object[] args = new Object[] {appFileName.toString(), e.toString()};
-      throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+      throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
     } finally {
       if (in != null) {
         try {
           m_objectStoreHandler.releaseInputStream(in, appFileName);
         } catch (IOException e) {
           Object[] args = new Object[] {appFileName.toString(), e.toString()};
-          throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+          throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
         }
       }
     }
@@ -684,7 +684,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
 
     // shouldn't be able to save files to apps that aren't locked
     if (!isApplicationLocked(lockId, appName + "-" + appFile.getName())) {
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, appName);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), appName);
     } else {
       // extend the lock to be sure we keep it
       getApplicationLock(lockId, appName + "-" + appFile.getName(), 30);
@@ -693,7 +693,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // we assume the request root is the application directory
     PSApplicationSummary sum = m_objectStoreHandler.m_appSums.getSummary(appName);
 
-    if (sum == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_ROOT_REQD, appName);
+    if (sum == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode(), appName);
 
     String appRoot = sum.getAppRoot();
     File appDir = getAppRootDir(appRoot);
@@ -715,7 +715,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // then error
     if ((!appDir.exists() && !appDir.mkdir()) || !appDir.isDirectory()) {
       Object[] args = {appName, appDir.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_DIR_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_DIR_NOT_FOUND.numericCode(), args);
     }
 
     File appFileName = new File(appDir, path);
@@ -723,7 +723,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     if (appFileName.exists()) {
       if (!appFileName.isFile()) {
         Object[] args = {appName, appFileName.getPath()};
-        throw new PSNotFoundException(IPSObjectStoreErrors.APP_FILE_NOT_FOUND, args);
+        throw new PSNotFoundException(ObjectStoreErrorCodes.APP_FILE_NOT_FOUND.numericCode(), args);
       }
       exists = true;
     } else {
@@ -733,7 +733,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
       if (parentDir != null) {
         if ((!parentDir.exists() && !parentDir.mkdirs()) || !parentDir.isDirectory()) {
           Object[] args = {appName, appFileName.getPath()};
-          throw new PSServerException(IPSObjectStoreErrors.APP_FILE_MKSUBDIR_ERROR, args);
+          throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_MKSUBDIR_ERROR.numericCode(), args);
         }
       }
     }
@@ -749,14 +749,14 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
 
     } catch (IOException e) {
       Object[] args = new Object[] {appFileName.toString(), e.toString()};
-      throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+      throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
     } finally {
       if (out != null) {
         try {
           m_objectStoreHandler.releaseOutputStream(out, appFileName);
         } catch (IOException e) {
           Object[] args = {appFileName.toString(), e.toString()};
-          throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+          throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
         }
       }
 
@@ -814,7 +814,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // we assume the request root is the application directory
     PSApplicationSummary sum = m_objectStoreHandler.m_appSums.getSummary(appName);
 
-    if (sum == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_ROOT_REQD, appName);
+    if (sum == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode(), appName);
 
     String appRoot = sum.getAppRoot();
     File appDir = getAppRootDir(appRoot);
@@ -836,7 +836,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // then error
     if ((!appDir.exists() && !appDir.mkdir()) || !appDir.isDirectory()) {
       Object[] args = {appName, appDir.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_DIR_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_DIR_NOT_FOUND.numericCode(), args);
     }
 
     File appFileName = new File(appDir, path);
@@ -844,7 +844,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     if (appFileName.exists()) {
       if (!appFileName.isFile()) {
         Object[] args = {appName, appFileName.getPath()};
-        throw new PSNotFoundException(IPSObjectStoreErrors.APP_FILE_NOT_FOUND, args);
+        throw new PSNotFoundException(ObjectStoreErrorCodes.APP_FILE_NOT_FOUND.numericCode(), args);
       }
       exists = true;
     } else {
@@ -854,7 +854,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
       if (parentDir != null) {
         if ((!parentDir.exists() && !parentDir.mkdirs()) || !parentDir.isDirectory()) {
           Object[] args = {appName, appFileName.getPath()};
-          throw new PSServerException(IPSObjectStoreErrors.APP_FILE_MKSUBDIR_ERROR, args);
+          throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_MKSUBDIR_ERROR.numericCode(), args);
         }
       }
     }
@@ -870,14 +870,14 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
 
     } catch (IOException e) {
       Object[] args = new Object[] {appFileName.toString(), e.toString()};
-      throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+      throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
     } finally {
       if (out != null) {
         try {
           m_objectStoreHandler.releaseOutputStream(out, appFileName);
         } catch (IOException e) {
           Object[] args = {appFileName.toString(), e.toString()};
-          throw new PSServerException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+          throw new PSServerException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
         }
       }
 
@@ -950,7 +950,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
 
     // shouldn't be able to save files to apps that aren't locked
     if (!isApplicationLocked(lockId, app.getName())) {
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, app.getName());
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), app.getName());
     } else {
       // extend the lock to be sure we keep it
       getApplicationLock(lockId, app.getName(), 30);
@@ -960,7 +960,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     PSApplicationSummary sum = m_objectStoreHandler.m_appSums.getSummary(app.getName());
 
     if (sum == null)
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_ROOT_REQD, app.getName());
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode(), app.getName());
 
     String appRoot = sum.getAppRoot();
     File appDir = new File(appRoot);
@@ -969,13 +969,13 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // then error
     if ((!appDir.exists() && !appDir.mkdir()) || !appDir.isDirectory()) {
       Object[] args = {app.getName(), appDir.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_DIR_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_DIR_NOT_FOUND.numericCode(), args);
     }
 
     // delete the app file if it exists
     if (!appFile.exists() || !appFile.isFile()) {
       Object[] args = {app.getName(), appFile.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_FILE_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_FILE_NOT_FOUND.numericCode(), args);
     }
 
     return deleteFile(appFile);
@@ -1017,7 +1017,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     if (!dontLockApp) {
       // shouldn't be able to save files to apps that aren't locked
       if (!isApplicationLocked(lockId, app.getName())) {
-        throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, app.getName());
+        throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), app.getName());
       } else {
         // extend the lock to be sure we keep it
         getApplicationLock(lockId, app.getName(), 30);
@@ -1028,7 +1028,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     PSApplicationSummary sum = m_objectStoreHandler.m_appSums.getSummary(app.getName());
 
     if (sum == null)
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_ROOT_REQD, app.getName());
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode(), app.getName());
 
     String appRoot = sum.getAppRoot();
     File appDir = new File(appRoot);
@@ -1037,13 +1037,13 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // then error
     if ((!appDir.exists() && !appDir.mkdir()) || !appDir.isDirectory()) {
       Object[] args = {app.getName(), appDir.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_DIR_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_DIR_NOT_FOUND.numericCode(), args);
     }
 
     // delete the app file if it exists
     if (!appFile.exists() || !appFile.isFile()) {
       Object[] args = {app.getName(), appFile.getPath()};
-      throw new PSNotFoundException(IPSObjectStoreErrors.APP_FILE_NOT_FOUND, args);
+      throw new PSNotFoundException(ObjectStoreErrorCodes.APP_FILE_NOT_FOUND.numericCode(), args);
     }
 
     return deleteFile(appFile);
@@ -1199,7 +1199,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
      */
     if (!isApplicationLocked(lockId, appName)) {
       Object[] args = {appName};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getApplicationLock(lockId, appName, 30);
@@ -1319,7 +1319,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
      */
     if (!isApplicationLocked(lockId, curName)) {
       Object[] args = {curName};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getApplicationLock(lockId, curName, 30);
@@ -1349,7 +1349,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
         // delete it if there is an error)
         if (!newRoot.mkdir()) {
           Object[] args = {curSum.getAppRoot(), app.getRequestRoot()};
-          throw new PSNonUniqueException(IPSObjectStoreErrors.APP_ROOT_RENAME_FAILED, args);
+          throw new PSNonUniqueException(ObjectStoreErrorCodes.APP_ROOT_RENAME_FAILED.numericCode(), args);
         }
 
         newAppDir = newRoot;
@@ -1411,7 +1411,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
           if (renameRoot) {
             if (!curAppRoot.renameTo(getAppRootDir(app.getRequestRoot()))) {
               Object[] args = {curSum.getAppRoot(), app.getRequestRoot()};
-              throw new PSNonUniqueException(IPSObjectStoreErrors.APP_ROOT_RENAME_FAILED, args);
+              throw new PSNonUniqueException(ObjectStoreErrorCodes.APP_ROOT_RENAME_FAILED.numericCode(), args);
             }
 
             // if also renaming, already fixed up the summary, otherwise
@@ -1476,7 +1476,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
       config.fromDb(new PSDatabaseComponentLoader(req));
       return config;
     } catch (Exception e) {
-      throw new PSServerException(IPSObjectStoreErrors.ROLE_CFG_LOAD_EXCEPTION, e.toString());
+      throw new PSServerException(ObjectStoreErrorCodes.ROLE_CFG_LOAD_EXCEPTION.numericCode(), e.toString());
     }
   }
 
@@ -1592,7 +1592,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // Check to see if config is locked
     if (!isServerConfigLocked(lockId)) {
       Object[] args = {SERVER_CONFIGURATION};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getServerConfigLock(lockId, 30);
@@ -1635,7 +1635,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // Check to see if config is locked
     if (!isServerConfigLocked(lockId)) {
       Object[] args = {SERVER_CONFIGURATION};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getServerConfigLock(lockId, 30);
@@ -1693,7 +1693,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
     // Check to see if config is locked
     if (!isServerConfigLocked(lockId)) {
       Object[] args = {SERVER_CONFIGURATION};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       getServerConfigLock(lockId, 30);
@@ -2849,7 +2849,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
                   (PSBackEndTable) tables.get(col.getTable().getAlias().toLowerCase());
               if (null == table) {
                 PSSystemValidationException e =
-                    new PSSystemValidationException(IPSObjectStoreErrors.BE_TABLE_NULL);
+                    new PSSystemValidationException(ObjectStoreErrorCodes.BE_TABLE_NULL);
                 throw new SQLException(e.getLocalizedMessage());
               }
               try {
@@ -3236,7 +3236,7 @@ public class PSServerXmlObjectStore extends PSObjectFactory {
   private void extendServerConfigLock(IPSLockerId lockId)
       throws PSServerException, PSNotLockedException, PSLockedException {
     if (!isServerConfigLocked(lockId)) {
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, SERVER_CONFIGURATION);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), SERVER_CONFIGURATION);
     } else {
       // extend the lock to be sure we keep it
       getServerConfigLock(lockId, 30);

--- a/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreHandler.java
+++ b/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreHandler.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore.server;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.conn.PSServerException;
 import com.percussion.content.IPSMimeContent;
 import com.percussion.content.IPSMimeContentTypes;
@@ -569,7 +570,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
           } else {
             PSException ex =
                 new PSUnknownDocTypeException(
-                    IPSObjectStoreErrors.XML_ELEMENT_NULL, "PSXApplication");
+                    ObjectStoreErrorCodes.XML_ELEMENT_NULL, "PSXApplication");
 
             Object[] args = new Object[] {app.getName(), ex.toString()};
             PSLogManager.write(
@@ -1204,7 +1205,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
           PSServerXmlObjectStore.getInstance().getContentEditorSystemDef();
 
       if (systemDef == null)
-        throw new PSServerException(IPSObjectStoreErrors.CE_SYSTEM_DEF_NOT_FOUND);
+        throw new PSServerException(ObjectStoreErrorCodes.CE_SYSTEM_DEF_NOT_FOUND.numericCode());
 
       return systemDef.toXml();
     } catch (RuntimeException e) {
@@ -1247,7 +1248,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
           PSServerXmlObjectStore.getInstance().getContentEditorSharedDef();
 
       if (sharedDef == null)
-        throw new PSServerException(IPSObjectStoreErrors.CE_SHARED_DEF_NOT_FOUND);
+        throw new PSServerException(ObjectStoreErrorCodes.CE_SHARED_DEF_NOT_FOUND.numericCode());
 
       return sharedDef.toXml();
     } catch (RuntimeException e) {
@@ -1365,21 +1366,21 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     Element tableLocElem = walker.getNextElement(PSTableLocator.XML_NODE_NAME, true, true);
     if (null == tableLocElem) {
       Object[] args = {ms_RootTableDefSave, PSTableLocator.XML_NODE_NAME, ""};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     PSTableLocator loc = null;
     try {
       loc = new PSTableLocator(tableLocElem, null, null);
     } catch (PSUnknownNodeTypeException e) {
       Object[] args = {ms_RootTableDefSave, PSTableLocator.XML_NODE_NAME, ""};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // first <tables> is the schema definition
     Element tableDefsElem = walker.getNextElement("tables", true, true);
     if (null == tableDefsElem) {
       Object[] args = {ms_RootTableDefSave, "tables", ""};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Connection conn = null;
@@ -1419,7 +1420,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
           if (PSJdbcTableFactory.catalogTable(conn, dbmsDef, dataTypeMap, tableName, false)
               != null) {
             String msg =
-                PSErrorManager.createMessage(IPSObjectStoreErrors.CREATE_TABLE_EXISTS, tableName);
+                PSErrorManager.createMessage(ObjectStoreErrorCodes.CREATE_TABLE_EXISTS.numericCode(), tableName);
             el = PSXmlDocumentBuilder.addElement(responseDoc, responseRoot, "error", msg);
             el.setAttribute("tableName", tableName);
             el.setAttribute("create", "y");
@@ -1583,7 +1584,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
       /* get the application XML tree */
       if (walker.getNextElement("PSXApplication", true, true) == null) {
         Object[] args = {ms_RootAppSave, "PSXApplication", ""};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       /* get the save flags */
@@ -2182,7 +2183,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
       /* get the application XML tree */
       if (walker.getNextElement("PSXUserConfiguration", true, true) == null) {
         Object[] args = {ms_RootUserConfigSave, "PSXUserConfiguration", ""};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       /* promote the cfg to root so we can do the save easily */
@@ -2302,7 +2303,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     // get the server config XML tree
     if (cfgEl == null) {
       Object[] args = {ms_RootServerConfigSave, "PSXServerConfiguration", ""};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     try {
@@ -2356,7 +2357,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
       // get the server config XML tree
       if (cfgEl == null) {
         Object[] args = {ms_RootRoleConfigSave, ROLE_CONFIG_ROOT_TAGNAME, ""};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // lock the config, save the file, and unlock the config
@@ -4296,7 +4297,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     // Check to see if config is locked
     if (!os.isServerConfigLocked(lockId)) {
       Object[] args = {"Server Configuration"};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       os.getServerConfigLock(lockId, 30);
@@ -4443,7 +4444,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     // Check to see if config is locked
     if (!os.isServerConfigLocked(lockId)) {
       Object[] args = {"Server Configuration"};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       os.getServerConfigLock(lockId, 30);
@@ -4586,7 +4587,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     // Check to see if config is locked
     if (!os.isServerConfigLocked(lockId)) {
       Object[] args = {"Server Configuration"};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       os.getServerConfigLock(lockId, 30);
@@ -4744,7 +4745,7 @@ public class PSXmlObjectStoreHandler extends PSObjectFactory
     // Check to see if config is locked
     if (!os.isServerConfigLocked(lockId)) {
       Object[] args = {"Server Configuration"};
-      throw new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, args);
+      throw new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), args);
     } else {
       // extend the lock to be sure we keep it
       os.getServerConfigLock(lockId, 30);

--- a/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreLockManager.java
+++ b/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreLockManager.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore.server;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSLockedException;
@@ -213,7 +214,7 @@ public class PSXmlObjectStoreLockManager extends PSObjectFactory
         throw new PSLockAcquisitionException(LOCK_CORRUPT_LOCKFILE, ioe.getMessage());
       } catch (InterruptedException inte) {
         if (lockedResults != null) {
-          lockedResults.setArgs(IPSObjectStoreErrors.LOCK_WAIT_INTERRUPTED, null);
+          lockedResults.setArgs(ObjectStoreErrorCodes.LOCK_WAIT_INTERRUPTED, null);
         }
         Thread.currentThread().interrupt();
       }

--- a/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreLockerId.java
+++ b/system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreLockerId.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.objectstore.server;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLockedException;
 import java.util.Properties;
 
@@ -114,13 +114,13 @@ public class PSXmlObjectStoreLockerId implements IPSLockerId {
       else {
         if (ex != null) {
           // same user, different session
-          ex.setErrorCode(IPSObjectStoreErrors.LOCK_ALREADY_HELD_SAME_USER);
+          ex.setErrorCode(ObjectStoreErrorCodes.LOCK_ALREADY_HELD_SAME_USER.numericCode());
         }
       }
     } else {
       if (ex != null) {
         // different user
-        ex.setErrorCode(IPSObjectStoreErrors.LOCK_ALREADY_HELD);
+        ex.setErrorCode(ObjectStoreErrorCodes.LOCK_ALREADY_HELD.numericCode());
       }
     }
 

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK3Test.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK3Test.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch K3 (#3067): design.objectstore Q–Z + server/legacy call sites must throw typed {@link
+ * ObjectStoreErrorCodes} (or Design-owned ACL/SPINST codes on {@link DesignErrorCodes}) where
+ * IPSErrorCode ctors exist — not bare {@code IPSObjectStoreErrors} ints.
+ */
+public class PSDesignObjectstoreTypedErrorCodeBatchK3Test {
+
+  @Test
+  public void referenceNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSReference((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void referenceWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotReference");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSReference(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void relationshipSetNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSRelationshipSet((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void relationshipSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotRelationshipSet");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSRelationshipSet(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void ruleNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSRule((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void ruleWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotRule");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSRule(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void tableRefNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSTableRef((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void tableRefWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotTableRef");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSTableRef(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void textLiteralNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSTextLiteral((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void textLiteralWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotTextLiteral");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSTextLiteral(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void urlRequestNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSUrlRequest((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void urlRequestWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotUrlRequest");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSUrlRequest(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void visibilityRulesNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSVisibilityRules((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void visibilityRulesWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotVisibilityRules");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSVisibilityRules(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void resultPagerNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSResultPager((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void resultPagerWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotResultPager");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSResultPager(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void recipientEmptyNameUsesNumericObjectStoreCode() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> new PSRecipient(""));
+    assertEquals(ObjectStoreErrorCodes.RECIPIENT_NAME_EMPTY.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void serverConfigurationNullAclUsesDesignCode() {
+    PSServerConfiguration cfg = new PSServerConfiguration();
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> cfg.setAcl(null));
+    assertEquals(DesignErrorCodes.SRV_ACL_NULL.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void relationshipPropertyNameEmptyUsesNumericCode() {
+    assertEquals(
+        ObjectStoreErrorCodes.RELATIONSHIP_PROPERTY_NAME_EMPTY.numericCode(),
+        new PSRelationshipProperty("x").getErrorCode());
+  }
+
+  @Test
+  public void xmlFieldNameEmptyUsesNumericCode() {
+    assertEquals(
+        ObjectStoreErrorCodes.XML_FIELD_NAME_EMPTY.numericCode(),
+        new PSXmlField("x").getErrorCode());
+  }
+}


### PR DESCRIPTION
## Summary
Call-site migration **batch K3** for parent residual #3050 / grandparent #2616 / issue #3067: migrate `com.percussion.design.objectstore` **Q–Z root** plus **server/** and **legacy/** from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes`.

### Scope
- **59 production files**, ~**316** call sites migrated (49 Q–Z root + 5 server + 5 legacy)
- Typed construction via existing `IPSErrorCode` ctors (`PSUnknownNodeTypeException`, `PSUnknownDocTypeException`, `PSSystemValidationException`, `validationError`)
- Int-only APIs use `.numericCode()`: `PSIllegalArgumentException`, `PSServerException`, `PSNotFoundException`, `PSNotLockedException`, `PSNonUniqueException`, `PSDatabaseComponentException`, `PSInternalRequestCallException`, `setErrorCode`, `createMessage`, int `getErrorCode()` returns
- Design-owned ACL / server-ACL / SP-instance ints use `DesignErrorCodes` (no re-register on ObjectStore; no new enum values)
- Zero residual `IPSObjectStoreErrors.` refs in Q–Z / server / legacy after this PR

### Out of scope
- D–H (K1 #3062 / PR #3066) and I–P (K2 #3063 / PR #3068) — independent open PRs; not thrashing those files
- New enum codes

### Parent
Parent residual: #3050 · Grandparent: #2616 · Prior: #3040 batch I; #3062 K1; #3063 K2

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` (JDK 21) — **BUILD SUCCESS**
- [x] New `PSDesignObjectstoreTypedErrorCodeBatchK3Test` — **Tests run: 20, Failures: 0**
- [x] Module suite aggregate surefire — **Tests run: 1831, Failures: 0, Errors: 0, Skipped: 238**

## Product documentation
- [x] N/A — pure tech-debt call-site migration; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; $env:JAVA_HOME=…jdk-21…; ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1831, Failures: 0; BatchK3Test: 20
- **downstream_checked:** none (call-site only; no public/protected signature or `final`/`sealed` changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3067

> Co-Authored by Grok Build using grok-4.5 with agent main.
