### PR TITLE
fix(perc-content-explorer): PSItemAssemblyManager rawtypes residual (#3057)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3057-psitemassemblymanager-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3057-psitemassemblymanager-rawtypes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: issue #3057 PSItemAssemblyManager rawtypes
+
+**Scope:** `modules/DesktopContentExplorer` — `PSItemAssemblyManager.java` + `PSItemAssemblyManagerTest.java`  
+**Base:** `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** rawtypes residual slice (prefer real generics; pure helpers unit-tested; no product behavior change)
+
+## Summary
+
+Parameterizes residual raw `Iterator` / `Map` / `HashMap` on `PSItemAssemblyManager` (insert/delete/update/reorder node lists + postData payload). Extracts pure static helpers (`isSlotTarget`, `resolveDropIndex`, `resolveReorderDropIndex`, `buildActiveAssemblerParams`) with behavioral unit tests. No Swing/server wiring in tests.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable paths).
+
+### Cross-platform path checklist
+
+N/A — no file I/O or path handling in this diff.
+
+### API shape / reverse deps (C2)
+
+Public/private method parameters changed raw `Iterator` → `Iterator<PSNode>` (erasure-compatible). Call sites only in `PSActionManager` within the same module (already typed `Iterator<PSNode>`). No monorepo reverse-dep blast radius beyond `DesktopContentExplorer`.
+
+## Build evidence
+
+```
+cd modules/DesktopContentExplorer
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 159, Failures: 0, Errors: 0
+# PSItemAssemblyManagerTest: 11 tests
+```
+
+## Product documentation
+
+N/A — pure tech-debt/rawtypes; no operator- or user-visible behavior change.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemAssemblyManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemAssemblyManager.java
@@ -69,16 +69,15 @@ public class PSItemAssemblyManager {
    * @param nodeList the list of nodes to insert at the specified target/targetParent, must not be
    *     <code>null</code>
    */
-  public void insert(PSNode targetParent, PSNode target, Iterator nodeList) {
+  public void insert(PSNode targetParent, PSNode target, Iterator<PSNode> nodeList) {
     if (targetParent == null) throw new IllegalArgumentException("targetParent must not be null");
 
     if (target == null) throw new IllegalArgumentException("target must not be null");
 
     if (nodeList == null) throw new IllegalArgumentException("nodeList must not be null");
 
-    int index = Integer.MAX_VALUE;
-    if (target.getType().equals(PSNode.TYPE_SLOT)) targetParent = target;
-    else index = target.getSortRank();
+    int index = resolveDropIndex(target);
+    if (isSlotTarget(target)) targetParent = target;
 
     PSActiveAssemblerHandlerRequest req = buildRequest(targetParent, nodeList);
 
@@ -98,7 +97,7 @@ public class PSItemAssemblyManager {
    * @param nodeList the list of <code>PSNode</code>s identifying the items, may not be <code>null
    *     </code> or empty.
    */
-  public void insert(String ownerContentId, String slotId, Iterator nodeList) {
+  public void insert(String ownerContentId, String slotId, Iterator<PSNode> nodeList) {
     PSActiveAssemblerHandlerRequest req = buildRequest(ownerContentId, slotId, nodeList);
 
     processActiveAssemblerRequest(req, "insert");
@@ -111,7 +110,7 @@ public class PSItemAssemblyManager {
    * @param nodeList this is the list of nodes to delete, must not be <code>
    * null</code>
    */
-  public void delete(PSNode target, Iterator nodeList) {
+  public void delete(PSNode target, Iterator<PSNode> nodeList) {
     if (target == null) throw new IllegalArgumentException("target must not be null");
 
     if (nodeList == null) throw new IllegalArgumentException("nodeList must not be null");
@@ -130,28 +129,13 @@ public class PSItemAssemblyManager {
   public void reorder(PSSelection selection, int direction) {
     if (selection == null) throw new IllegalArgumentException("selection must not be null");
 
-    boolean moveDown = (direction > 0);
-    if (moveDown) // move down requires 1 more because
-    direction++; // we move 1 above the index specified
-
-    int newIndex = (moveDown) ? 0 : Integer.MAX_VALUE;
     if (selection.getNodeListSize() > 0) {
-      Iterator iter = selection.getNodeList();
-      while (iter.hasNext()) {
-        PSNode node = (PSNode) iter.next();
-        int sortRank = node.getSortRank();
-        if (moveDown) {
-          if (sortRank > newIndex) newIndex = sortRank;
-        } else // moveUp
-        {
-          if (sortRank < newIndex) newIndex = sortRank;
-        }
-      }
+      int dropIndex = resolveReorderDropIndex(selection.getNodeList(), direction);
       PSActiveAssemblerHandlerRequest req =
           buildRequest(selection.getParent(), selection.getNodeList());
 
       // set the drop location index
-      req.setIndex(newIndex + direction);
+      req.setIndex(dropIndex);
 
       processActiveAssemblerRequest(req, "reorder");
     }
@@ -168,16 +152,15 @@ public class PSItemAssemblyManager {
    * @param nodeList the list of nodes to update at the specified target/targetParent, must not be
    *     <code>null</code>
    */
-  public void update(PSNode targetParent, PSNode target, Iterator nodeList) {
+  public void update(PSNode targetParent, PSNode target, Iterator<PSNode> nodeList) {
     if (targetParent == null) throw new IllegalArgumentException("targetParent must not be null");
 
     if (target == null) throw new IllegalArgumentException("target must not be null");
 
     if (nodeList == null) throw new IllegalArgumentException("nodeList must not be null");
 
-    int index = Integer.MAX_VALUE;
-    if (target.getType().equals(PSNode.TYPE_SLOT)) targetParent = target;
-    else index = target.getSortRank();
+    int index = resolveDropIndex(target);
+    if (isSlotTarget(target)) targetParent = target;
 
     PSActiveAssemblerHandlerRequest req = buildRequest(targetParent, nodeList);
 
@@ -198,7 +181,7 @@ public class PSItemAssemblyManager {
    * @param nodeList the list of nodes to reorder at the specified target/targetParent, must not be
    *     <code>null</code>
    */
-  public void reorder(PSNode targetParent, PSNode target, Iterator nodeList) {
+  public void reorder(PSNode targetParent, PSNode target, Iterator<PSNode> nodeList) {
     if (targetParent == null) throw new IllegalArgumentException("targetParent must not be null");
 
     if (target == null) throw new IllegalArgumentException("target must not be null");
@@ -207,13 +190,86 @@ public class PSItemAssemblyManager {
 
     PSActiveAssemblerHandlerRequest req = buildRequest(targetParent, nodeList);
 
-    int index = Integer.MAX_VALUE;
-    if (!target.getType().equals(PSNode.TYPE_SLOT)) index = target.getSortRank();
+    int index = resolveDropIndex(target);
 
     // set the drop location index
     req.setIndex(index);
 
     processActiveAssemblerRequest(req, "reorder");
+  }
+
+  /**
+   * Whether the target is a slot node (append at end; parent becomes the slot itself for
+   * insert/update).
+   *
+   * @param target node to check, may be <code>null</code>
+   * @return <code>true</code> if target is non-null and of type slot
+   */
+  static boolean isSlotTarget(PSNode target) {
+    return target != null && PSNode.TYPE_SLOT.equals(target.getType());
+  }
+
+  /**
+   * Resolve the drop index for insert/update/reorder against a target node. Slot targets append at
+   * the end ({@link Integer#MAX_VALUE}); item targets use {@link PSNode#getSortRank()}.
+   *
+   * @param target the drop target, must not be <code>null</code>
+   * @return drop index, always &gt; 0 for valid ranks or {@link Integer#MAX_VALUE} for slots
+   */
+  static int resolveDropIndex(PSNode target) {
+    if (target == null) throw new IllegalArgumentException("target must not be null");
+    if (isSlotTarget(target)) return Integer.MAX_VALUE;
+    return target.getSortRank();
+  }
+
+  /**
+   * Compute the active-assembler reorder drop index from selected nodes and move direction.
+   *
+   * <p>Historical behavior: move down uses the max sort rank among selected nodes and increments
+   * {@code direction} by one before adding; move up uses the min sort rank and adds {@code
+   * direction} unchanged.
+   *
+   * @param nodes selected nodes (consumed), must not be <code>null</code>
+   * @param direction &gt; 0 is move down, &lt;= 0 is move up
+   * @return computed drop index
+   */
+  static int resolveReorderDropIndex(Iterator<PSNode> nodes, int direction) {
+    if (nodes == null) throw new IllegalArgumentException("nodes must not be null");
+
+    boolean moveDown = (direction > 0);
+    if (moveDown) // move down requires 1 more because
+    direction++; // we move 1 above the index specified
+
+    int newIndex = (moveDown) ? 0 : Integer.MAX_VALUE;
+    while (nodes.hasNext()) {
+      PSNode node = nodes.next();
+      int sortRank = node.getSortRank();
+      if (moveDown) {
+        if (sortRank > newIndex) newIndex = sortRank;
+      } else // moveUp
+      {
+        if (sortRank < newIndex) newIndex = sortRank;
+      }
+    }
+    return newIndex + direction;
+  }
+
+  /**
+   * Build the POST parameter map for the active assembly app. Pure helper for typing and tests.
+   *
+   * @param action active assembly command (insert/delete/update/reorder), must not be <code>null
+   *     </code>
+   * @param inputDocXml XML string of the request document, must not be <code>null</code>
+   * @return mutable map with {@code sys_command} and {@link #INPUT_DOC} entries
+   */
+  static Map<String, String> buildActiveAssemblerParams(String action, String inputDocXml) {
+    if (action == null) throw new IllegalArgumentException("action must not be null");
+    if (inputDocXml == null) throw new IllegalArgumentException("inputDocXml must not be null");
+
+    Map<String, String> params = new HashMap<>();
+    params.put("sys_command", action);
+    params.put(INPUT_DOC, inputDocXml);
+    return params;
   }
 
   /**
@@ -228,7 +284,8 @@ public class PSItemAssemblyManager {
    * @return an active assembler object that can be transformed to XML and posted to the active
    *     assembler handler
    */
-  private PSActiveAssemblerHandlerRequest buildRequest(PSNode targetSlot, Iterator nodeList) {
+  private PSActiveAssemblerHandlerRequest buildRequest(
+      PSNode targetSlot, Iterator<PSNode> nodeList) {
     return buildRequest(targetSlot.getContentId(), targetSlot.getSlotId(), nodeList);
   }
 
@@ -244,7 +301,7 @@ public class PSItemAssemblyManager {
    * @return the request, never <code>null</code>
    */
   private PSActiveAssemblerHandlerRequest buildRequest(
-      String ownerContentId, String slotId, Iterator nodeList) {
+      String ownerContentId, String slotId, Iterator<PSNode> nodeList) {
     if (ownerContentId == null || ownerContentId.trim().length() == 0)
       throw new IllegalArgumentException("ownerContentId may not be null or empty.");
 
@@ -275,7 +332,7 @@ public class PSItemAssemblyManager {
 
     PSDependentSet dependents = new PSDependentSet();
     while (nodeList.hasNext()) {
-      PSNode src = (PSNode) nodeList.next();
+      PSNode src = nodeList.next();
       PSLocator loc = new PSLocator(src.getContentId(), src.getRevision());
 
       PSPropertySet props = new PSPropertySet();
@@ -326,9 +383,8 @@ public class PSItemAssemblyManager {
 
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
 
-    Map params = new HashMap();
-    params.put("sys_command", action);
-    params.put(INPUT_DOC, PSXmlDocumentBuilder.toString(req.toXml(doc)));
+    Map<String, String> params =
+        buildActiveAssemblerParams(action, PSXmlDocumentBuilder.toString(req.toXml(doc)));
 
     try {
       m_actionManager.postData(ACTIVE_ASSEMBLY_APP, params);

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSItemAssemblyManagerTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSItemAssemblyManagerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.objectstore.PSNode;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for pure helpers on {@link PSItemAssemblyManager} after rawtypes cleanup
+ * (#3057). Does not open the Swing applet (requires live server resources).
+ */
+public class PSItemAssemblyManagerTest {
+
+  @Test
+  public void isSlotTargetTrueForSlotType() {
+    PSNode slot = new PSNode("s", "Slot", PSNode.TYPE_SLOT, "", null, false, -1);
+    assertTrue(PSItemAssemblyManager.isSlotTarget(slot));
+  }
+
+  @Test
+  public void isSlotTargetFalseForItemOrNull() {
+    PSNode item = new PSNode("i", "Item", PSNode.TYPE_SLOT_ITEM, "", null, false, -1);
+    assertFalse(PSItemAssemblyManager.isSlotTarget(item));
+    assertFalse(PSItemAssemblyManager.isSlotTarget(null));
+  }
+
+  @Test
+  public void resolveDropIndexSlotIsMaxValue() {
+    PSNode slot = new PSNode("s", "Slot", PSNode.TYPE_SLOT, "", null, false, -1);
+    assertEquals(Integer.MAX_VALUE, PSItemAssemblyManager.resolveDropIndex(slot));
+  }
+
+  @Test
+  public void resolveDropIndexItemUsesSortRank() {
+    PSNode item = new PSNode("i", "Item", PSNode.TYPE_SLOT_ITEM, "", null, false, -1);
+    item.setProperty(IPSConstants.PROPERTY_SORTRANK, "7");
+    assertEquals(7, PSItemAssemblyManager.resolveDropIndex(item));
+  }
+
+  @Test
+  public void resolveDropIndexRejectsNull() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSItemAssemblyManager.resolveDropIndex(null));
+  }
+
+  @Test
+  public void resolveReorderDropIndexMoveDownUsesMaxRankPlusAdjustedDirection() {
+    PSNode a = rankNode("a", 2);
+    PSNode b = rankNode("b", 5);
+    // direction 1 -> moveDown increments to 2; max rank 5; result 7
+    assertEquals(
+        7,
+        PSItemAssemblyManager.resolveReorderDropIndex(Arrays.asList(a, b).iterator(), 1));
+  }
+
+  @Test
+  public void resolveReorderDropIndexMoveUpUsesMinRankPlusDirection() {
+    PSNode a = rankNode("a", 2);
+    PSNode b = rankNode("b", 5);
+    // direction -1; min rank 2; result 1
+    assertEquals(
+        1,
+        PSItemAssemblyManager.resolveReorderDropIndex(Arrays.asList(a, b).iterator(), -1));
+  }
+
+  @Test
+  public void resolveReorderDropIndexRejectsNullNodes() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSItemAssemblyManager.resolveReorderDropIndex(null, 1));
+  }
+
+  @Test
+  public void buildActiveAssemblerParamsTypedMap() {
+    Map<String, String> params =
+        PSItemAssemblyManager.buildActiveAssemblerParams("insert", "<doc/>");
+    assertEquals("insert", params.get("sys_command"));
+    assertEquals("<doc/>", params.get(PSItemAssemblyManager.INPUT_DOC));
+    assertEquals(2, params.size());
+  }
+
+  @Test
+  public void buildActiveAssemblerParamsRejectsNulls() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSItemAssemblyManager.buildActiveAssemblerParams(null, "<doc/>"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSItemAssemblyManager.buildActiveAssemblerParams("insert", null));
+  }
+
+  @Test
+  public void buildActiveAssemblerParamsEmptyDocAllowed() {
+    Map<String, String> params =
+        PSItemAssemblyManager.buildActiveAssemblerParams("delete", "");
+    assertEquals("", params.get(PSItemAssemblyManager.INPUT_DOC));
+  }
+
+  private static PSNode rankNode(String name, int rank) {
+    PSNode node = new PSNode(name, name, PSNode.TYPE_SLOT_ITEM, "", null, false, -1);
+    node.setProperty(IPSConstants.PROPERTY_SORTRANK, Integer.toString(rank));
+    return node;
+  }
+}


### PR DESCRIPTION
## Summary

Parameterize residual raw `Iterator` / `Map` / `HashMap` on **PSItemAssemblyManager** in `modules/DesktopContentExplorer` (insert/delete/update/reorder node lists + active-assembly postData payload). Extract pure static helpers with behavioral unit tests. No product behavior change.

Parent residual tracker: #2326  
Parent module tracker: #2045  
Parent monorepo tracker: #2200  
Prior slice: #3012 (PSOptionManager)

## Changes

- `Iterator` → `Iterator<PSNode>` on public insert/delete/update/reorder APIs and private `buildRequest`
- `Map`/`HashMap` postData → `Map<String, String>` via `buildActiveAssemblerParams`
- Pure helpers: `isSlotTarget`, `resolveDropIndex`, `resolveReorderDropIndex`, `buildActiveAssemblerParams`
- `PSItemAssemblyManagerTest` (11 tests)

## Test plan

- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] `PSItemAssemblyManagerTest`: 11 tests, 0 failures
- [x] Module suite: Tests run: 159, Failures: 0, Errors: 0
- [x] Erlang pre-commit review: approve (docs/ai-generated/code-reviews/issue-3057-psitemassemblymanager-rawtypes-erlang.md)

## Gates evidence

- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `..\..\mvnw.cmd clean install` from module dir → BUILD SUCCESS; Tests run: 159, Failures: 0, Errors: 0; PSItemAssemblyManagerTest: 11
- **downstream_checked:** monorepo grep for `PSItemAssemblyManager` — call sites only in same-module `PSActionManager` (already typed `Iterator<PSNode>`). No reverse-dep modules require reinstall (C2 public signature is erasure-compatible Iterator→Iterator&lt;PSNode&gt;).
- **Product documentation:** N/A — pure tech-debt/rawtypes; no operator- or user-visible behavior change.

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3057

> Co-Authored by Grok Build using grok-4.5 with agent main.
