### PR TITLE
fix(scripts): probe only active gh account in nightly i18n preflight

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -165,7 +165,7 @@ Automated nightly i18n translation refresh for the 16 base locales.
   ./scripts/nightly-i18n-refresh.sh --locale de
   ```
 
-- **Pre-flight checks**: Verifies `trans` (translate-shell) is on PATH, working tree is clean (in the worktree), on `main` branch (or detached HEAD at `origin/main` — git disallows two worktrees on the same branch), and `gh` is authenticated.
+- **Pre-flight checks**: Verifies `trans` (translate-shell) is on PATH, working tree is clean (in the worktree), on `main` branch (or detached HEAD at `origin/main` — git disallows two worktrees on the same branch), and the **active** `gh` account is authenticated (`gh auth status --active`). Inactive multi-account tokens that are expired do not fail this check.
 - **Pipeline**: Ensures worktree exists → fetches origin/main → checks for existing PR → creates branch → runs `i18n_translate_direct.py --target <locale>` → runs `i18n_translate_direct.py --target <locale> --fix-matching-en` → commits → pushes → creates PR.
 - **No spotless**: This wrapper does **not** invoke `mvnw spotless:apply`. The perc-i18n spotless config targets JSON (which we exclude due to the 4 MB translation cache) and the eclipseWtp XML formatter hangs on this environment's Eclipse OSGi classloader. TMX formatting is left to the translation script itself per `modules/perc-i18n/AGENTS.md`. The `scripts/cache/**` exclude in `modules/perc-i18n/pom.xml` is kept as defense in depth for manual spotless runs.
 - **Locking**: Uses `flock` on `tmp/nightly-i18n.lock` to prevent concurrent runs.

--- a/scripts/nightly_i18n_refresh.py
+++ b/scripts/nightly_i18n_refresh.py
@@ -178,8 +178,12 @@ def get_current_branch_worktree(worktree: Path) -> str:
 
 
 def check_gh_auth() -> bool:
-    """Check if gh is authenticated."""
-    cp = run(["gh", "auth", "status"])
+    """Check if the active gh account is authenticated.
+
+    Uses ``--active`` so inactive multi-account entries with expired tokens
+    do not fail the preflight when the active account is usable.
+    """
+    cp = run(["gh", "auth", "status", "--active"])
     return cp.returncode == 0
 
 

--- a/scripts/test_nightly_i18n_refresh.py
+++ b/scripts/test_nightly_i18n_refresh.py
@@ -271,6 +271,37 @@ class TestPreflightChecks(unittest.TestCase):
         self.assertEqual(failures, ["b"])
 
 
+class TestCheckGhAuth(unittest.TestCase):
+    """check_gh_auth must probe only the active gh account (--active)."""
+
+    def test_passes_when_active_account_ok(self):
+        original = m.run
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(list(args))
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        m.run = fake_run  # type: ignore[assignment]
+        try:
+            self.assertTrue(m.check_gh_auth())
+        finally:
+            m.run = original  # type: ignore[assignment]
+        self.assertEqual(calls, [["gh", "auth", "status", "--active"]])
+
+    def test_fails_when_active_account_not_authenticated(self):
+        original = m.run
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="not logged in")
+
+        m.run = fake_run  # type: ignore[assignment]
+        try:
+            self.assertFalse(m.check_gh_auth())
+        finally:
+            m.run = original  # type: ignore[assignment]
+
+
 class TestCommitMessage(unittest.TestCase):
     """Verify commit message assembly and footer contract."""
 
@@ -464,6 +495,7 @@ def main() -> int:
     suite.addTests(loader.loadTestsFromTestCase(TestUnpushedCommitsDetection))
     suite.addTests(loader.loadTestsFromTestCase(TestStagingPathBuilder))
     suite.addTests(loader.loadTestsFromTestCase(TestPreflightChecks))
+    suite.addTests(loader.loadTestsFromTestCase(TestCheckGhAuth))
     suite.addTests(loader.loadTestsFromTestCase(TestCommitMessage))
     suite.addTests(loader.loadTestsFromTestCase(TestPRBody))
     suite.addTests(loader.loadTestsFromTestCase(TestModuleConstants))


### PR DESCRIPTION
## Summary

Nightly i18n refresh preflight called `gh auth status`, which exits non-zero when **any** configured multi-account entry has an expired/invalid token—even if the **active** account is authenticated. On multi-account hosts that silently fails the nightly wrapper despite a usable active token.

This change uses `gh auth status --active`, updates `scripts/README.md`, and adds unit tests that assert the argv contract and pass/fail behavior.

## Test plan

1. `python3 scripts/test_nightly_i18n_refresh.py` — expect 35 tests OK (includes new `TestCheckGhAuth`).
2. On a multi-account host: compare `gh auth status` (may fail on inactive tokens) vs `gh auth status --active` (should succeed when the active account is valid).
3. Optional: dry-run preflight path that exercises `check_gh_auth()` after the change.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing; developer automation under `scripts/`)
- [x] **Unit / module tests** — behavioral tests for `check_gh_auth`; `python3 scripts/test_nightly_i18n_refresh.py` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — **N/A** (scripts only; no Maven modules)
- [x] **Cross-platform** — **N/A** (no path/file I/O changes)

### Review

- Erlang pre-commit review: **approve** (local report `docs/ai-generated/code-reviews/nightly-i18n-gh-auth-active-erlang.md`, not committed)

> Co-Authored by Grok Build 1.0.0 using Grok 4.5 with agent Grok.