### PR TITLE
fix(objectstore): ObjectStoreErrorCodes batch L residual (#3080)

### DIFF
--- a/system/src/main/java/com/percussion/data/PSFunctionCallExtractor.java
+++ b/system/src/main/java/com/percussion/data/PSFunctionCallExtractor.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.data;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSFunctionCall;
 import com.percussion.design.objectstore.PSFunctionParamValue;
@@ -150,7 +150,7 @@ public class PSFunctionCallExtractor extends PSDataExtractor {
     } catch (ParseException pex) {
       Object[] errArgs = new Object[] {funcDef.getName(), pex.getLocalizedMessage()};
       throw new PSDataExtractionException(
-          IPSObjectStoreErrors.DATABASE_FUNCTION_PARSE_ERROR, errArgs);
+          ObjectStoreErrorCodes.DATABASE_FUNCTION_PARSE_ERROR.numericCode(), errArgs);
     }
     return ret;
   }

--- a/system/src/main/java/com/percussion/data/PSUpdateHandler.java
+++ b/system/src/main/java/com/percussion/data/PSUpdateHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.data;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.debug.PSDebugLogHandler;
@@ -226,7 +227,7 @@ public class PSUpdateHandler extends PSDataHandler {
           } catch (java.net.MalformedURLException e) {
             Object[] args = {app.getName(), ds.getName(), page.getStyleSheet()};
             throw new PSIllegalArgumentException(
-                com.percussion.design.objectstore.IPSObjectStoreErrors.STYLE_SHEET_BAD_URL, args);
+                ObjectStoreErrorCodes.STYLE_SHEET_BAD_URL.numericCode(), args);
           }
         }
       }

--- a/system/src/main/java/com/percussion/debug/PSDebugManager.java
+++ b/system/src/main/java/com/percussion/debug/PSDebugManager.java
@@ -17,7 +17,7 @@
 
 package com.percussion.debug;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSTraceInfo;
 import com.percussion.error.PSNotFoundException;
@@ -67,7 +67,7 @@ public class PSDebugManager {
    */
   public PSDebugLogHandler getLogHandler(String appName) throws PSNotFoundException {
     PSDebugLogHandler dh = (PSDebugLogHandler) m_logHandlers.get(appName);
-    if (dh == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_NOT_FOUND, appName);
+    if (dh == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_NOT_FOUND.numericCode(), appName);
 
     return dh;
   }
@@ -142,7 +142,7 @@ public class PSDebugManager {
    */
   public PSTraceFlag getTraceOptionsFlag(String appName) throws PSNotFoundException {
     PSDebugLogHandler dh = getLogHandler(appName);
-    if (dh == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_NOT_FOUND, appName);
+    if (dh == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_NOT_FOUND.numericCode(), appName);
 
     return dh.getTraceInfo().getTraceOptionsFlag();
   }
@@ -158,7 +158,7 @@ public class PSDebugManager {
   public void setTraceOptionsFlag(String appName, PSTraceFlag traceFlags)
       throws PSNotFoundException {
     PSDebugLogHandler dh = getLogHandler(appName);
-    if (dh == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_NOT_FOUND, appName);
+    if (dh == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_NOT_FOUND.numericCode(), appName);
 
     PSTraceInfo info = dh.getTraceInfo();
     info.setTraceOptionsFlag(traceFlags);
@@ -173,7 +173,7 @@ public class PSDebugManager {
    */
   public void restoreInitialTraceOptions(String appName) throws PSNotFoundException {
     PSDebugLogHandler dh = getLogHandler(appName);
-    if (dh == null) throw new PSNotFoundException(IPSObjectStoreErrors.APP_NOT_FOUND, appName);
+    if (dh == null) throw new PSNotFoundException(ObjectStoreErrorCodes.APP_NOT_FOUND.numericCode(), appName);
 
     dh.getTraceInfo().restoreInitialOptions();
   }

--- a/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
@@ -17,6 +17,7 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.log.PSLogInformation;
 import com.percussion.util.PSMapClassToObject;
 import java.util.Enumeration;
@@ -89,7 +90,7 @@ public class PSErrorHttpCodes {
             Object[] args = {key, com.percussion.error.PSException.getStackTraceAsString(cnf)};
             com.percussion.log.PSLogManager.write(
                 new com.percussion.log.PSLogServerWarning(
-                    com.percussion.design.objectstore.IPSObjectStoreErrors.APP_NOT_FOUND,
+                    ObjectStoreErrorCodes.APP_NOT_FOUND.numericCode(),
                     args,
                     true,
                     "HttpErrorCodesLoader"));

--- a/system/src/main/java/com/percussion/extension/PSDatabaseFunction.java
+++ b/system/src/main/java/com/percussion/extension/PSDatabaseFunction.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.extension;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.HashMap;
@@ -153,13 +153,13 @@ public class PSDatabaseFunction {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     String sTemp = sourceNode.getAttribute(ATTR_FUNCTION_NAME);
     if ((sTemp == null) || (sTemp.trim().length() == 0)) {
       Object[] args = {NODE_NAME, ATTR_FUNCTION_NAME, sTemp == null ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_name = sTemp;
 

--- a/system/src/main/java/com/percussion/extension/PSDatabaseFunctionDef.java
+++ b/system/src/main/java/com/percussion/extension/PSDatabaseFunctionDef.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.extension;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -115,7 +115,7 @@ public class PSDatabaseFunctionDef implements Cloneable {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -128,7 +128,7 @@ public class PSDatabaseFunctionDef implements Cloneable {
     String sTemp = sourceNode.getAttribute(ATTR_FUNCTION_NAME);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {NODE_NAME, ATTR_FUNCTION_NAME, sTemp == null ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_name = sTemp;
 
@@ -141,7 +141,7 @@ public class PSDatabaseFunctionDef implements Cloneable {
         sTemp = DRIVER_TYPE_DEFAULT;
       } else {
         Object[] args = {NODE_NAME, ATTR_DRIVER, sTemp == null ? "null" : sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     m_driver = sTemp;
@@ -152,7 +152,7 @@ public class PSDatabaseFunctionDef implements Cloneable {
     if ((el == null) || (sTemp == null) || (sTemp.trim().length() < 1)) {
       if (!fromDefault) {
         Object[] args = {NODE_NAME, EL_BODY, sTemp == null ? "null" : sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } else {
       m_body = sTemp;
@@ -180,7 +180,7 @@ public class PSDatabaseFunctionDef implements Cloneable {
     if ((el == null) || (sTemp == null) || (sTemp.trim().length() < 1)) {
       if (!fromDefault) {
         Object[] args = {NODE_NAME, EL_DESCRIPTION, sTemp == null ? "null" : sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } else {
       m_desc = sTemp;

--- a/system/src/main/java/com/percussion/extension/PSDatabaseFunctionDefParam.java
+++ b/system/src/main/java/com/percussion/extension/PSDatabaseFunctionDefParam.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.extension;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -78,14 +78,14 @@ public class PSDatabaseFunctionDefParam implements Cloneable {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // name - required
     String sTemp = sourceNode.getAttribute(ATTR_NAME);
     if ((sTemp == null) || (sTemp.trim().length() == 0)) {
       Object[] args = {NODE_NAME, ATTR_NAME, sTemp == null ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_name = sTemp;
 

--- a/system/src/main/java/com/percussion/extension/PSDatabaseFunctionsColl.java
+++ b/system/src/main/java/com/percussion/extension/PSDatabaseFunctionsColl.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.extension;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -80,7 +80,7 @@ public class PSDatabaseFunctionsColl {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // construct the PSDatabaseFunction objects

--- a/system/src/main/java/com/percussion/i18n/PSLocale.java
+++ b/system/src/main/java/com/percussion/i18n/PSLocale.java
@@ -18,7 +18,7 @@
 package com.percussion.i18n;
 
 import com.percussion.data.PSDataExtractionException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.i18n.rxlt.PSLocaleHandler;
 import com.percussion.services.catalog.IPSCatalogSummary;
@@ -295,7 +295,7 @@ public class PSLocale implements IPSCatalogSummary {
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_languageString = getRequiredAttribute(source, ATTR_LANGUAGE_STRING);
@@ -311,7 +311,7 @@ public class PSLocale implements IPSCatalogSummary {
 
     if (!validateStatus(m_status)) {
       Object[] args = {source.getTagName(), ATTR_STATUS, status};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_version = null;
@@ -390,7 +390,7 @@ public class PSLocale implements IPSCatalogSummary {
     String val = source.getAttribute(attName);
     if (val == null || val.trim().length() == 0) {
       Object[] args = {source.getTagName(), attName, "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     return val;

--- a/system/src/main/java/com/percussion/security/PSBackendCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackendCataloger.java
@@ -17,7 +17,7 @@
 package com.percussion.security;
 
 import com.percussion.data.PSInternalRequestCallException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSGlobalSubject;
@@ -201,7 +201,7 @@ public class PSBackendCataloger {
     Element el = tree.getNextElement("Role", ms_firstFlags);
     if (null == el) {
       Object[] args = {"Roles", "Role", "Element is missing"};
-      throw new PSSecurityException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSSecurityException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), args);
     }
 
     PSAttributeList attribs = getAttributes(el);
@@ -361,7 +361,7 @@ public class PSBackendCataloger {
 
     if (!el.getTagName().equals("Subjects")) {
       Object[] args = {"Subjects", el.getTagName()};
-      throw new PSSecurityException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSSecurityException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), args);
     }
 
     return new ArrayList<>(processCatalogedSubjects(el, includeEmptySubjects));
@@ -407,7 +407,7 @@ public class PSBackendCataloger {
       String name = tree.getElementData("@name", false);
       if ((name == null) || (name.trim().length() == 0)) {
         Object[] args = {"Subject", "@name", "null"};
-        throw new PSSecurityException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSSecurityException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), args);
       }
 
       String type = tree.getElementData("@type", false);
@@ -426,7 +426,7 @@ public class PSBackendCataloger {
               + " or "
               + PSSubject.SUBJECT_TYPE_GROUP
         };
-        throw new PSSecurityException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSSecurityException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), args);
       }
 
       int subjectType = Integer.parseInt(type);

--- a/system/src/main/java/com/percussion/server/PSApplicationHandler.java
+++ b/system/src/main/java/com/percussion/server/PSApplicationHandler.java
@@ -27,7 +27,7 @@ import com.percussion.data.PSUpdateHandler;
 import com.percussion.debug.PSDebugLogHandler;
 import com.percussion.debug.PSDebugManager;
 import com.percussion.debug.PSTraceMessageFactory;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSContentEditor;
@@ -1641,7 +1641,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
             m_name, err.getErrorCode(), ((url == null) ? "" : url.toExternalForm()), e.toString()
           };
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CUSTOM_ERROR_URL_INVALID, args, m_application, errPages);
+              ObjectStoreErrorCodes.CUSTOM_ERROR_URL_INVALID.numericCode(), args, m_application, errPages);
         }
       }
       m_errorHandler = new PSErrorHandler(errPages, app.getNotifier(), app.getLogger());

--- a/system/src/main/java/com/percussion/server/PSRequestHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/server/PSRequestHandlerConfiguration.java
@@ -18,7 +18,7 @@
 package com.percussion.server;
 
 import com.percussion.conn.PSServerException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.general.IPSRhythmyxInfo;
@@ -147,12 +147,12 @@ public class PSRequestHandlerConfiguration {
       // validate that it is the correct type
       Element root = cfgDoc.getDocumentElement();
       if (root == null)
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, CONFIG_ROOT);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, CONFIG_ROOT);
 
       // make sure we got the correct root node tag
       if (false == CONFIG_ROOT.equals(root.getNodeName())) {
         Object[] args = {CONFIG_ROOT, root.getNodeName()};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       // walk it and load the handlers
@@ -177,14 +177,14 @@ public class PSRequestHandlerConfiguration {
         String handlerName = defEl.getAttribute("handlerName");
         if (handlerName == null || handlerName.length() == 0) {
           Object[] args = {searchEl, "handlerName", handlerName};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         // determine class name
         String className = defEl.getAttribute("className");
         if (className == null || className.length() == 0) {
           Object[] args = {searchEl, "className", className};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         // may not have a cfg file
@@ -199,21 +199,21 @@ public class PSRequestHandlerConfiguration {
 
         Element rootsEl = tree.getNextElement(rootsElName, firstFlags);
         if (rootsEl == null)
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, rootsElName);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, rootsElName);
 
         String rootElName = "RequestRoot";
         Element rootEl = tree.getNextElement(rootElName, firstFlags);
 
         // must have at least one root
         if (rootEl == null)
-          throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, rootElName);
+          throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, rootElName);
 
         while (rootEl != null) {
           String rootName = rootEl.getAttribute("baseName");
           if (rootName == null) {
             Object[] args = {rootElName, "baseName", rootName};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
           }
 
           // strip off leading "/" if there
@@ -226,7 +226,7 @@ public class PSRequestHandlerConfiguration {
 
           // must have at least one
           if (typeEl == null)
-            throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, typeElName);
+            throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, typeElName);
 
           while (typeEl != null) {
             methods.add(tree.getElementData(typeEl));

--- a/system/src/main/java/com/percussion/server/PSRequestPageMap.java
+++ b/system/src/main/java/com/percussion/server/PSRequestPageMap.java
@@ -18,7 +18,7 @@ package com.percussion.server;
 
 import com.percussion.data.PSConditionalEvaluator;
 import com.percussion.data.PSExecutionData;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSDataSet;
 import com.percussion.design.objectstore.PSRequestor;
 import com.percussion.design.objectstore.PSResultPage;
@@ -57,7 +57,7 @@ public class PSRequestPageMap {
     PSRequestor requestor = dataSet.getRequestor();
 
     if (requestor == null)
-      throw new PSIllegalArgumentException(IPSObjectStoreErrors.DATASET_REQUESTOR_NULL);
+      throw new PSIllegalArgumentException(ObjectStoreErrorCodes.DATASET_REQUESTOR_NULL.numericCode());
 
     m_reqPage = requestor.getRequestPage();
     m_reqHandler = rh;

--- a/system/src/main/java/com/percussion/server/PSServer.java
+++ b/system/src/main/java/com/percussion/server/PSServer.java
@@ -35,7 +35,7 @@ import com.percussion.data.PSMetaDataCache;
 import com.percussion.data.PSTableMetaData;
 import com.percussion.debug.PSDebugManager;
 import com.percussion.design.objectstore.IPSJavaPluginConfig;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSAttribute;
@@ -1758,7 +1758,7 @@ public class PSServer {
       int msgCode = 0;
       if (appRoot == null) {
         // this is not allowed!!
-        msgCode = IPSObjectStoreErrors.APP_ROOT_REQD;
+        msgCode = ObjectStoreErrorCodes.APP_ROOT_REQD.numericCode();
         Object[] args = {"application path not found", "server/startApplication"};
         throw new PSNotFoundException(msgCode, args);
       }
@@ -1777,7 +1777,7 @@ public class PSServer {
       if (o != null) {
         // warn that we've got one by this name already!!
         PSApplicationHandler appHandler = (PSApplicationHandler) o;
-        msgCode = IPSObjectStoreErrors.APP_REQUEST_ROOTS_DUP;
+        msgCode = ObjectStoreErrorCodes.APP_REQUEST_ROOTS_DUP.numericCode();
         Object[] args = {appHandler.getName(), appHandler.getRequestRoot()};
         PSLogManager.write(new PSLogServerWarning(msgCode, args, true, "Server"));
       }

--- a/system/src/main/java/com/percussion/server/actions/PSAction.java
+++ b/system/src/main/java/com/percussion/server/actions/PSAction.java
@@ -22,7 +22,7 @@ import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSExtensionRunner;
 import com.percussion.data.PSUrlRequestExtractor;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSExtensionCallSet;
 import com.percussion.design.objectstore.PSParam;
@@ -111,14 +111,14 @@ public class PSAction {
     String localName = sourceNode.getNodeName();
     if (!XML_NODE_NAME.equals(localName)) {
       Object[] args = {XML_NODE_NAME, localName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // process the name attribute (required)
     m_name = sourceNode.getAttribute(NAME_XATTR);
     if (m_name == null || m_name.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, NAME_XATTR, m_name};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // process the ignoreError attribute (optional -- known default)
@@ -144,7 +144,7 @@ public class PSAction {
       Object[] args = {
         PSParam.XML_NODE_NAME + " or " + PSExtensionCallSet.ms_NodeType, elem.getNodeName()
       };
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     while (elem != null && elem.getNodeName().equals(PSParam.XML_NODE_NAME)) {

--- a/system/src/main/java/com/percussion/server/actions/PSActionSet.java
+++ b/system/src/main/java/com/percussion/server/actions/PSActionSet.java
@@ -31,7 +31,7 @@ import com.percussion.data.PSInternalRequestURIResolver;
 import com.percussion.data.PSTransformErrorListener;
 import com.percussion.data.PSUrlRequestExtractor;
 import com.percussion.data.PSXslStyleSheetMerger;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSStylesheet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSUrlRequest;
@@ -143,14 +143,14 @@ public class PSActionSet {
     String localName = sourceNode.getNodeName();
     if (!XML_NODE_NAME.equals(localName)) {
       Object[] args = {XML_NODE_NAME, localName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // process the name attribute (required)
     m_name = sourceNode.getAttribute("name");
     if (m_name == null || m_name.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, "name", m_name};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     int searchChildren =
@@ -166,7 +166,7 @@ public class PSActionSet {
       Object[] args = {
         XML_NODE_NAME, PSAction.XML_NODE_NAME, (elem == null ? "null" : elem.getNodeName())
       };
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } else {
       // make sure each action name is unique by using a set
       Set actionNames = new HashSet();
@@ -192,7 +192,7 @@ public class PSActionSet {
       Object[] args = {
         XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, (elem == null ? "null" : elem.getNodeName())
       };
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } else m_redirect = new PSUrlRequest(elem, null, null);
 
     // process the stylesheet (optional)

--- a/system/src/main/java/com/percussion/server/cache/PSKeyRules.java
+++ b/system/src/main/java/com/percussion/server/cache/PSKeyRules.java
@@ -19,7 +19,7 @@ package com.percussion.server.cache;
 
 import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSRuleListEvaluator;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSRule;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSNotFoundException;
@@ -90,7 +90,7 @@ public class PSKeyRules {
     // validate the root
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     int firstFlags =
@@ -106,7 +106,7 @@ public class PSKeyRules {
       String keyName = keyRuleEl.getAttribute(KEY_NAME_ATTR);
       if (keyName.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, KEY_NAME_ATTR, keyName};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // get the list of the rules
@@ -116,7 +116,7 @@ public class PSKeyRules {
       // must have at least one rule
       if (ruleEl == null) {
         Object[] args = {XML_NODE_NAME, PSRule.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // add each rule to the list

--- a/system/src/main/java/com/percussion/server/config/PSConfigManager.java
+++ b/system/src/main/java/com/percussion/server/config/PSConfigManager.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.server.config;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSConfig;
 import com.percussion.design.objectstore.PSConfigurationFactory;
 import com.percussion.design.objectstore.PSLockedException;
@@ -251,7 +251,7 @@ public class PSConfigManager {
     }
 
     if (!(cfg.isLocked() && cfg.getLocker().equals(reqUser))) {
-      PSNotLockedException ex = new PSNotLockedException(IPSObjectStoreErrors.LOCK_NOT_HELD, name);
+      PSNotLockedException ex = new PSNotLockedException(ObjectStoreErrorCodes.LOCK_NOT_HELD.numericCode(), name);
       throw ex;
     }
 

--- a/system/src/main/java/com/percussion/server/job/PSJobException.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobException.java
@@ -17,7 +17,7 @@
 
 package com.percussion.server.job;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -104,7 +104,7 @@ public class PSJobException extends Exception {
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // get message code
@@ -114,7 +114,7 @@ public class PSJobException extends Exception {
       m_code = Integer.parseInt(sTemp);
     } catch (NumberFormatException e) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_MSG_CODE, sTemp == null ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get optional exception class

--- a/system/src/main/java/com/percussion/server/job/PSJobHandler.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandler.java
@@ -18,7 +18,7 @@
 package com.percussion.server.job;
 
 import com.percussion.conn.PSServerException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -266,7 +266,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
     } catch (NumberFormatException e) {
       Object[] msgArgs = {reqRoot.getTagName(), "id", id};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {reqRoot.getTagName(), une.getLocalizedMessage()};
       throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);
@@ -322,7 +322,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
     } catch (NumberFormatException e) {
       Object[] msgArgs = {reqRoot.getTagName(), "id", id};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {reqRoot.getTagName(), une.getLocalizedMessage()};
       throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);

--- a/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
@@ -17,7 +17,7 @@
 
 package com.percussion.server.job;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -96,12 +96,12 @@ public class PSJobHandlerConfiguration {
 
     Element root = config.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     // make sure we got the correct root node tag
     if (false == XML_NODE_NAME.equals(root.getNodeName())) {
       Object[] args = {XML_NODE_NAME, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(root);
@@ -115,7 +115,7 @@ public class PSJobHandlerConfiguration {
     // get handler init params
     Element params = walker.getNextElement("InitParams", firstFlag);
     if (params == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "InitParams");
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "InitParams");
 
     Properties handlerProps = loadInitParams(params, null);
     m_initParams.put(getContext(null, null), handlerProps);
@@ -124,7 +124,7 @@ public class PSJobHandlerConfiguration {
     walker.setCurrent(root);
     Element categories = walker.getNextElement("Categories", firstFlag);
     if (categories == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "Categories");
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "Categories");
 
     Element cat = walker.getNextElement("Category", firstFlag);
 
@@ -132,7 +132,7 @@ public class PSJobHandlerConfiguration {
       String catName = cat.getAttribute("name");
       if (catName == null || catName.trim().length() == 0) {
         Object[] args = {cat.getTagName(), "name", catName};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       String context = getContext(catName, null);
@@ -145,7 +145,7 @@ public class PSJobHandlerConfiguration {
       // load the jobs for this category
       Element jobs = walker.getNextElement("Jobs", firstFlag);
       if (jobs == null)
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "Jobs");
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "Jobs");
 
       Element job = walker.getNextElement("Job", firstFlag);
       while (job != null) {
@@ -153,13 +153,13 @@ public class PSJobHandlerConfiguration {
         String jobType = job.getAttribute("jobType");
         if (jobType == null || jobType.trim().length() == 0) {
           Object[] args = {job.getTagName(), "jobType", jobType};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         String className = job.getAttribute("className");
         if (className == null || className.trim().length() == 0) {
           Object[] args = {job.getTagName(), "className", className};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         String jobCtx = getContext(catName, jobType);
@@ -279,13 +279,13 @@ public class PSJobHandlerConfiguration {
       String attName = param.getAttribute("name");
       if (attName == null || attName.trim().length() == 0) {
         Object[] args = {"InitParam", "name", attName};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       String attVal = param.getAttribute("value");
       if (attVal == null || attVal.trim().length() == 0) {
         Object[] args = {"InitParam", "value", attVal};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       props.setProperty(attName, attVal);

--- a/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
+++ b/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.system.utils;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSConsole;
@@ -406,12 +406,12 @@ public class PSFormatVersion {
   private void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     // make sure we have a source node
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, NODE_TYPE);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, NODE_TYPE);
 
     // make sure we got the PSXFormatVersion type node
     if (false == NODE_TYPE.equals(sourceNode.getNodeName())) {
       Object[] args = {NODE_TYPE, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -470,7 +470,7 @@ public class PSFormatVersion {
       sTemp = def == null ? "" : def;
       if (required && sTemp.trim().length() == 0) {
         Object[] args = {NODE_TYPE, attrName, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return sTemp;

--- a/system/src/test/java/com/percussion/server/PSObjectStoreErrorCodesBatchLTest.java
+++ b/system/src/test/java/com/percussion/server/PSObjectStoreErrorCodesBatchLTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownDocTypeException;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.extension.PSDatabaseFunction;
+import com.percussion.extension.PSDatabaseFunctionManager;
+import com.percussion.i18n.PSLocale;
+import com.percussion.server.actions.PSAction;
+import com.percussion.server.actions.PSActionSet;
+import com.percussion.server.cache.PSKeyRules;
+import com.percussion.server.job.PSJobException;
+import com.percussion.server.job.PSJobHandlerConfiguration;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch L (#3080): remaining production call sites outside design.objectstore K must throw typed
+ * {@link ObjectStoreErrorCodes} (or {@code .numericCode()} peers where ctors are int-only) — not
+ * bare {@code IPSObjectStoreErrors} ints.
+ */
+public class PSObjectStoreErrorCodesBatchLTest {
+
+  @Test
+  public void actionWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAction");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAction(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void actionMissingNameUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = PSXmlDocumentBuilder.createRoot(doc, PSAction.XML_NODE_NAME);
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAction(empty));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void actionSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotActionSet");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSActionSet(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void actionSetMissingNameUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = PSXmlDocumentBuilder.createRoot(doc, PSActionSet.XML_NODE_NAME);
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSActionSet(empty));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void keyRulesWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotKeyRules");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSKeyRules(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void jobExceptionWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotJobException");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSJobException(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void jobExceptionMissingMsgCodeUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = PSXmlDocumentBuilder.createRoot(doc, PSJobException.XML_NODE_NAME);
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSJobException(empty));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void jobHandlerConfigNullRootUsesTypedNull() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    // no root element
+    PSUnknownDocTypeException ex =
+        assertThrows(PSUnknownDocTypeException.class, () -> new PSJobHandlerConfiguration(doc));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void jobHandlerConfigWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSXmlDocumentBuilder.createRoot(doc, "NotJobHandlerConfig");
+    PSUnknownDocTypeException ex =
+        assertThrows(PSUnknownDocTypeException.class, () -> new PSJobHandlerConfiguration(doc));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void localeWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotLocale");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSLocale(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void databaseFunctionWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDatabaseFunction");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () ->
+                new PSDatabaseFunction(
+                    PSDatabaseFunctionManager.FUNCTION_TYPE_SYSTEM, wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void databaseFunctionMissingNameUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty =
+        PSXmlDocumentBuilder.createRoot(doc, PSDatabaseFunction.getNodeName());
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () ->
+                new PSDatabaseFunction(
+                    PSDatabaseFunctionManager.FUNCTION_TYPE_SYSTEM, empty));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void requestPageMapNullRequestorUsesNumericDatasetRequestorNull() throws Exception {
+    // PSDataSet with no requestor configured
+    com.percussion.design.objectstore.PSDataSet dataSet =
+        new com.percussion.design.objectstore.PSDataSet("batchL");
+    PSIllegalArgumentException ex =
+        assertThrows(
+            PSIllegalArgumentException.class, () -> new PSRequestPageMap(dataSet, null));
+    assertEquals(
+        ObjectStoreErrorCodes.DATASET_REQUESTOR_NULL.numericCode(), ex.getErrorCode());
+    // int-only ctor: typed code is not retained
+  }
+}


### PR DESCRIPTION
## Summary
ObjectStoreErrorCodes **batch L** residual for #3080 (parent #2616; prior K residual #3050).

Migrates remaining **production** `IPSObjectStoreErrors` call sites **outside** completed design.objectstore K batches:

- **server** — `PSServer`, `PSApplicationHandler`, `PSRequestPageMap`, `PSRequestHandlerConfiguration`, `PSConfigManager`, `job/*`, `actions/*`, `cache/PSKeyRules`
- **extension** — `PSDatabaseFunction*`
- **data** — `PSFunctionCallExtractor`, `PSUpdateHandler`
- **security / debug / i18n / utils / error** — `PSBackendCataloger`, `PSDebugManager`, `PSLocale`, `PSFormatVersion`, `PSErrorHttpCodes`

Pattern matches K1–K3: typed `ObjectStoreErrorCodes` where `IPSErrorCode` constructors exist; `.numericCode()` peers for int-only APIs (`PSNotFoundException`, `PSNotLockedException`, `PSIllegalArgumentException`, `PSSecurityException`, `PSLogServerWarning`, 4-arg `PSSystemValidationException`).

### Out of scope (unchanged)
- design.objectstore K1–K3 files already on `ObjectStoreErrorCodes`
- `PSAclEntry` Design ACL codes (`ACL_*`) — DesignErrorCodes policy
- `implements IPSObjectStoreErrors` on `PSXmlObjectStoreHandler` / LockManager
- DesktopContentExplorer / Swing

## Test plan
- [x] `system` standalone: `..\mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **1931**, Failures: **0**, Errors: **0**, Skipped: **241**
- [x] New `PSObjectStoreErrorCodesBatchLTest` — **13** tests green (typed wrong-type / invalid-attr / null paths + `DATASET_REQUESTOR_NULL` numeric peer)
- [x] Product documentation: **N/A** — pure tech-debt error-code call-site migration; no operator/UI/API behavior change

## Gates evidence
```
cd system
..\mvnw.cmd clean install
# BUILD SUCCESS · Tests run: 1931, Failures: 0, Errors: 0, Skipped: 241
# modules_built=system
# downstream_checked=none (no public API signature / final / sealed change)
```

## Fixes
Fixes #3080  
Parent: #2616  
Also advances #3050 (design.objectstore residual cleared; only intentional ACL / interface-implement leftovers)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
