### PR TITLE
fix(system): classic app .json page match + live smoke (#2665)

### DIFF
--- a/docs/ai-generated/tasks/2662-classic-xml-app-json-io/2665-live-smoke-evidence.md
+++ b/docs/ai-generated/tasks/2662-classic-xml-app-json-io/2665-live-smoke-evidence.md
@@ -1,0 +1,88 @@
+# #2665 Live smoke: classic app GET `.json` + POST JSON body
+
+| Field | Value |
+|-------|-------|
+| **Parent** | [#2662](https://github.com/intersoftdatalabs-in/percussioncms/issues/2662) |
+| **Issue** | [#2665](https://github.com/intersoftdatalabs-in/percussioncms/issues/2665) |
+| **Env** | H2 QA cell via `perc-devctl qa-up` (container `perc-matrix-cms-h2`, host port **9993**) |
+| **Date (UTC)** | 2026-08-12 |
+| **Operator** | night-issue-prs / Grok Build (grok-4.5) |
+
+## Product bug found and fixed
+
+Before this fix, live `GET …/resource.json` returned **HTTP 404** even though:
+
+- `PSXmlDocumentJsonCodec` / `PSJsonContentParser` / `PAGE_TYPE_JSON` were present in `perc-system`
+- Unit tests for codec/parser/page-type were green (#2660)
+
+**Root cause:** `PSRequestPageMap.isMatch` only treated **`xml`** and **`txt`** as built-in document extensions when the requestor `MimeProperties` listed only `html`/`htm` (typical for stock system apps). Extension **`json`** failed the match → no dataset handler → 404.
+
+**Fix:** allow **`json`** alongside `xml`/`txt` in `PSRequestPageMap.isMatch` (+ unit test `PSRequestPageMapTest`).
+
+## Query GET smoke (PASS)
+
+Admin session against `http://127.0.0.1:9993` (in-cell base `http://127.0.0.1:9992`).
+
+| App | Resource | URL | Status | Content-Type | Notes |
+|-----|----------|-----|--------|--------------|-------|
+| `sys_commSupport` | `usercommunities` | `/Rhythmyx/sys_commSupport/usercommunities.xml` | 200 | `text/xml;charset=utf-8` | root `UserCommunities` |
+| `sys_commSupport` | `usercommunities` | `/Rhythmyx/sys_commSupport/usercommunities.json` | 200 | **`application/json;charset=utf-8`** | root object key `UserCommunities` |
+| `sys_commSupport` | `usercommunities` | `/Rhythmyx/sys_commSupport/usercommunities.txt` | 200 | `text/plain;charset=utf-8` | same XML body |
+| `sys_psxCataloger` | `getSites` | `/Rhythmyx/sys_psxCataloger/getSites.xml` | 200 | `text/xml;charset=utf-8` | root `Sites` |
+| `sys_psxCataloger` | `getSites` | `/Rhythmyx/sys_psxCataloger/getSites.json` | 200 | **`application/json;charset=utf-8`** | `{"Sites":{"Site":{"@name":""}}}` |
+| `sys_DisplayFormats` | `getDisplayProperties` | `/Rhythmyx/sys_DisplayFormats/getDisplayProperties.xml?id=1` | 200 | `text/xml;charset=utf-8` | root `PSX_PROPERTIES` |
+| `sys_DisplayFormats` | `getDisplayProperties` | `/Rhythmyx/sys_DisplayFormats/getDisplayProperties.json?id=1` | 200 | **`application/json;charset=utf-8`** | single root key |
+| `sys_commSupport` | (extensionless) | `/Rhythmyx/sys_commSupport/usercommunities` + `Accept: application/json` | 200 | **`application/json;charset=utf-8`** | Accept negotiation (#2663 path) |
+
+### Structure vs codec rules (usercommunities)
+
+XML attributes map to `@…` properties; element text under structured nodes uses `#text`:
+
+```json
+{"UserCommunities":{"@communities_enabled":"yes","@community":"10","@username":"Admin","Community":{"@commid":"10","#text":"Default"}}}
+```
+
+Parity assertions (live script): `@communities_enabled`, `@username`, `Community/@commid`, `Community/#text` match the XML document.
+
+## POST JSON body smoke
+
+| Case | URL | Content-Type | Result |
+|------|-----|--------------|--------|
+| POST JSON body to query resource | `/Rhythmyx/sys_commSupport/usercommunities.xml` | `application/json; charset=UTF-8` | **200** `text/xml` (body accepted; not 415) |
+| POST JSON body requesting JSON page | `/Rhythmyx/sys_commSupport/usercommunities.json` | `application/json; charset=UTF-8` | **200** `application/json` |
+| POST XML body (control) | `/Rhythmyx/sys_commSupport/usercommunities.xml` | `text/xml; charset=UTF-8` | **200** `text/xml` |
+
+### Full update-pipe round-trip
+
+**Skipped on this H2 seed (explicit):**
+
+- Query resources used above do not execute update pipes.
+- Stock apps with `PSXUpdatePipe` on this install (e.g. `sys_commSupport` relation updates, `sys_Keywords` insert/update/delete) mutate shared catalog/ACL data and are **not agent-safe** for unattended overnight smoke.
+- JSON **request** parsing remains covered by module unit tests: `PSJsonContentParserTest` (+ codec round-trip `PSXmlDocumentJsonCodecTest`).
+- Live POST trials still prove the server **accepts** `Content-Type: application/json` without media-type rejection.
+
+## Optional Playwright
+
+Not required: classic app URLs are not a product UI surface for this residual.
+
+## Reproduction commands
+
+```bash
+python docker/scripts/perc-devctl.py qa-up
+# after Admin password from container passwords file:
+# GET .xml / .json as above with session cookie
+python docker/scripts/perc-devctl.py qa-down
+```
+
+In-cell evidence runner (this PR tree): `tmp/classic-json-live-smoke.py` (not a product module).
+
+## Product bugs filed
+
+None separate: the live 404 is fixed in this PR (routing allowlist for `.json`).
+
+## Acceptance checklist
+
+- [x] Query `.json` smoke documented with evidence
+- [x] Update JSON body smoke documented (POST accept path + explicit skip for unsafe update resources)
+- [x] Product bug (`.json` 404) fixed here and linked via parent #2662
+- [x] Playwright optional — skipped (not required)

--- a/system/src/main/java/com/percussion/server/PSRequestPageMap.java
+++ b/system/src/main/java/com/percussion/server/PSRequestPageMap.java
@@ -138,7 +138,18 @@ public class PSRequestPageMap {
         if (dotIndex > -1) {
           String extension = resourcePortion.substring(dotIndex + 1);
           if (!m_extensionsSupported.contains(extension)) {
-            if (!extension.equals("txt") && !extension.equals("xml")) return false;
+            /*
+             * Built-in classic result encodings are always accepted even when
+             * MimeProperties only lists html/htm for XSL result pages. Without
+             * this, live GET …/resource.json returns 404 (handler never matches)
+             * despite PAGE_TYPE_JSON / PSResultSetHtmlConverter JSON support
+             * (#2665 live smoke residual of #2662 / #2660).
+             */
+            if (!extension.equals("txt")
+                && !extension.equals("xml")
+                && !extension.equals("json")) {
+              return false;
+            }
           }
         }
       }

--- a/system/src/test/java/com/percussion/server/PSRequestPageMapTest.java
+++ b/system/src/test/java/com/percussion/server/PSRequestPageMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2026 Percussion Software, Inc.
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class PSRequestPageMapTest {
   private static PSRequestPageMap buildMapWithHtmlMimeOnly(String requestPage) throws Exception {
     PSRequestor requestor = new PSRequestor();
     requestor.setRequestPage(requestPage);
-    HashMap mime = new HashMap();
+    HashMap<String, PSTextLiteral> mime = new HashMap<>();
     mime.put("html", new PSTextLiteral("text/html"));
     mime.put("htm", new PSTextLiteral("text/html"));
     requestor.setMimeProperties(mime);

--- a/system/src/test/java/com/percussion/server/PSRequestPageMapTest.java
+++ b/system/src/test/java/com/percussion/server/PSRequestPageMapTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSDataSet;
+import com.percussion.design.objectstore.PSRequestor;
+import com.percussion.design.objectstore.PSTextLiteral;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Regression: classic app request page matching must accept built-in document extensions (.xml /
+ * .txt / .json) even when the requestor MimeProperties only list html/htm (#2665 / #2660).
+ */
+class PSRequestPageMapTest {
+
+  @Test
+  void isMatch_acceptsBuiltInDocumentExtensionsWhenMimePropsAreHtmlOnly() throws Exception {
+    PSRequestPageMap map = buildMapWithHtmlMimeOnly("usercommunities");
+
+    assertTrue(map.isMatch(null, requestFor("/Rhythmyx/sys_commSupport/usercommunities.xml")));
+    assertTrue(map.isMatch(null, requestFor("/Rhythmyx/sys_commSupport/usercommunities.txt")));
+    assertTrue(
+        map.isMatch(null, requestFor("/Rhythmyx/sys_commSupport/usercommunities.json")),
+        ".json must match like .xml/.txt so live classic JSON I/O is reachable");
+  }
+
+  @Test
+  void isMatch_rejectsUnknownExtensionNotInMimeProps() throws Exception {
+    PSRequestPageMap map = buildMapWithHtmlMimeOnly("usercommunities");
+    assertFalse(map.isMatch(null, requestFor("/Rhythmyx/sys_commSupport/usercommunities.bin")));
+  }
+
+  @Test
+  void isMatch_acceptsExtensionListedInMimeProps() throws Exception {
+    PSRequestPageMap map = buildMapWithHtmlMimeOnly("usercommunities");
+    assertTrue(map.isMatch(null, requestFor("/Rhythmyx/sys_commSupport/usercommunities.html")));
+  }
+
+  private static PSRequestPageMap buildMapWithHtmlMimeOnly(String requestPage) throws Exception {
+    PSRequestor requestor = new PSRequestor();
+    requestor.setRequestPage(requestPage);
+    HashMap mime = new HashMap();
+    mime.put("html", new PSTextLiteral("text/html"));
+    mime.put("htm", new PSTextLiteral("text/html"));
+    requestor.setMimeProperties(mime);
+
+    PSDataSet dataSet = new PSDataSet("testDs");
+    dataSet.setRequestor(requestor);
+
+    return new PSRequestPageMap(dataSet, new NoopRequestHandler());
+  }
+
+  private static PSRequest requestFor(String fileUrl) {
+    MockHttpServletRequest servletReq = new MockHttpServletRequest("GET", fileUrl);
+    MockHttpServletResponse servletRes = new MockHttpServletResponse();
+    PSRequest request = new PSRequest(servletReq, servletRes, null, null);
+    request.setRequestFileURL(fileUrl);
+    return request;
+  }
+
+  /** Minimal handler so map construction does not need a full data pipeline. */
+  private static final class NoopRequestHandler implements IPSRequestHandler {
+    @Override
+    public void processRequest(PSRequest request) {
+      // no-op for unit test
+    }
+
+    @Override
+    public void shutdown() {
+      // no-op
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Live residual smoke for classic XML Application JSON I/O (**#2665** / parent **#2662**).

Found and fixed a **product bug**: stock system apps with html/htm-only `MimeProperties` returned **HTTP 404** for `GET …/resource.json` because `PSRequestPageMap.isMatch` only allowlisted `xml` and `txt` as built-in document extensions. Codec/parser code from #2660 was present but unreachable for those apps.

- Allow **`json`** in `PSRequestPageMap.isMatch` (with `xml`/`txt`)
- Unit test `PSRequestPageMapTest`
- Live evidence: `docs/ai-generated/tasks/2662-classic-xml-app-json-io/2665-live-smoke-evidence.md`

## Test plan

- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS (Tests run: 1874, Failures: 0, Errors: 0, Skipped: 238)
- [x] H2 QA cell: GET `.xml` / `.json` / `.txt` on `sys_commSupport/usercommunities`, `sys_psxCataloger/getSites`, `sys_DisplayFormats/getDisplayProperties`
- [x] Assert `Content-Type: application/json` and codec structure (`@` attrs, `#text`)
- [x] Accept `application/json` on extensionless URL
- [x] POST `application/json` body accepted (200, not 415) on query resource; full update-pipe round-trip skipped (no agent-safe update resource on stock seed — documented)
- [x] Playwright optional — not required

## Gates evidence

```
modules_built=system
command: cd system && ../mvnw.cmd clean install
BUILD SUCCESS
Tests run: 1874, Failures: 0, Errors: 0, Skipped: 238
downstream_checked=none (no public API signature / final / sealed change)
```

## Product documentation

- [ ] N/A — internal routing fix + agent live smoke evidence; developer product docs for classic JSON I/O already exist (`docs/developer-module/classic-xml-app-json-io.md` from #2660). No new operator-facing surface.

## Fixes

Fixes #2665  
Refs #2662  

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
