### PR TITLE
feat(rest): content-explorer folders REST facade over IPSContentWs (#3073)

### DIFF
--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -181,6 +181,54 @@ Content-type detail may still include **extra** per-item gaps (for example contr
 failures); those remain on the detail payload only. Structured `{ code, message }` entries apply
 on the Content Type / Template / Slot detail paths described above.
 
+## Content Explorer folders (Rhythmyx path façade)
+
+Public REST for **Rhythmyx** folder operations used by Content Explorer integrators and (later)
+Explorer mutation clients. Base path: **`/Rhythmyx/rest/content-explorer/folders`**.
+
+This surface is a thin façade over classic **`IPSContentWs`** folder methods (same domain path as
+SOAP content folder ops). It is **not** the CM1 site/asset `/rest/folders` resource and **not**
+pathmanagement browse/pagination (`/services/pathmanagement/path/*`).
+
+### Path forms
+
+Accept either repository form or a documented single-slash form; the server normalizes:
+
+| Client form | Normalized for WS |
+|-------------|-------------------|
+| `//Folders/...`, `//Sites/...` | kept |
+| `/Folders/...`, `/Sites/...` | promoted to `//…` |
+| `Folders/...`, `Sites/...` | promoted to `//…` |
+| `/` | root listing (`Folders` + `Sites`) |
+
+### Endpoints (v1)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/content-explorer/folders/by-path/{path}` | Load folder by RX path |
+| `GET` | `/content-explorer/folders/by-id/{id}` | Load folder by guid / content id |
+| `GET` | `…/by-id/{id}/children` | Direct children (items + folders) |
+| `GET` | `…/by-path/{path}/children` | Direct children by path |
+| `GET` | `…/by-id/{id}/child-folders` | Folder children only |
+| `GET` | `…/by-path/{path}/child-folders` | Folder children only by path |
+| `POST` | `/content-explorer/folders` | Add folder (`name` + `parentPath`) |
+| `POST` | `/content-explorer/folders/tree` | Add missing path segments (`path`) |
+| `PUT` | `/content-explorer/folders/by-id/{id}` | Save name / description / community / locale / properties |
+| `POST` | `/content-explorer/folders/move-children` | Multi-child move |
+| `POST` | `/content-explorer/folders/add-children` | Multi-child attach |
+| `POST` | `/content-explorer/folders/remove-children` | Multi-child detach (`purgeItems` optional) |
+| `DELETE` | `/content-explorer/folders/by-id/{id}?purge=false` | Recursive delete; optional purge |
+
+Prefer the generated **OpenAPI** schema for wire field names. Auth and folder ACLs of the underlying
+content web service still apply.
+
+### Migration notes
+
+- Content Explorer **browse / pagination** remains on pathmanagement until a deliberate client
+  switch; this façade ships for integrators and for a later dual-run mutation flag.
+- Do not confuse with foldermanagement workflow assignment (`/services/folders`) or CM1
+  `FoldersResource` section APIs.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the
@@ -192,3 +240,4 @@ on the Content Type / Template / Slot detail paths described above.
 
 - [Extensions & packages](id:developer-extensions)
 - [Build from source](id:developer-build-source)
+- [Content Explorer](id:admin-content-explorer)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentExplorerFolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentExplorerFolderAdaptor.java
@@ -1,0 +1,675 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.cms.objectstore.PSFolder;
+import com.percussion.cms.objectstore.PSFolderProperty;
+import com.percussion.cms.objectstore.PSObjectPermissions;
+import com.percussion.rest.contentexplorer.folders.AddFolderRequest;
+import com.percussion.rest.contentexplorer.folders.AddFolderTreeRequest;
+import com.percussion.rest.contentexplorer.folders.FolderChildrenRequest;
+import com.percussion.rest.contentexplorer.folders.IContentExplorerFolderAdaptor;
+import com.percussion.rest.contentexplorer.folders.RxFolder;
+import com.percussion.rest.contentexplorer.folders.RxFolderChildList;
+import com.percussion.rest.contentexplorer.folders.RxFolderProperty;
+import com.percussion.rest.contentexplorer.folders.RxFolderSummary;
+import com.percussion.services.content.data.PSItemSummary;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.content.PSContentWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Content-explorer folders REST façade (#3073 / parent #3054).
+ *
+ * <p>Thin apibridge over {@link IPSContentWs} folder methods — the same domain path classic Content
+ * Explorer / SOAP content folder ops use. Does not implement CM1 site-section semantics (see {@link
+ * FolderAdaptor}).
+ */
+@PSSiteManageBean
+public class ContentExplorerFolderAdaptor implements IContentExplorerFolderAdaptor {
+
+  private static final Logger log = LogManager.getLogger(ContentExplorerFolderAdaptor.class);
+
+  /** Safe id: digits, letters, hyphen, underscore, colon, period, slash (guid forms). */
+  private static final Pattern SAFE_ID = Pattern.compile("^[A-Za-z0-9_.:\\-/]+$");
+
+  private final IPSContentWs contentWs;
+  private final IPSIdMapper idMapper;
+  private final Function<String, IPSGuid> guidResolver;
+
+  @Autowired
+  public ContentExplorerFolderAdaptor(IPSIdMapper idMapper) {
+    this(PSContentWsLocator.getContentWebservice(), idMapper, idMapper::getGuid);
+  }
+
+  /** Package-visible for unit tests. */
+  ContentExplorerFolderAdaptor(
+      IPSContentWs contentWs, IPSIdMapper idMapper, Function<String, IPSGuid> guidResolver) {
+    this.contentWs = contentWs;
+    this.idMapper = idMapper;
+    this.guidResolver = guidResolver;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public adaptor API
+  // -------------------------------------------------------------------------
+
+  @Override
+  public RxFolder loadByPath(URI baseUri, String path) {
+    String normalized = normalizeRxPath(path);
+    if (normalized == null) {
+      throw new IllegalArgumentException("path is required");
+    }
+    try {
+      List<PSFolder> folders = contentWs.loadFolders(new String[] {normalized});
+      if (folders == null || folders.isEmpty() || folders.get(0) == null) {
+        return null;
+      }
+      RxFolder dto = toDto(folders.get(0));
+      if (dto.getPath() == null) {
+        dto.setPath(normalized);
+      }
+      return dto;
+    } catch (PSErrorResultsException e) {
+      log.debug("loadFolders path {} failed: {}", normalized, e.getAllErrorString());
+      return null;
+    } catch (PSErrorException e) {
+      log.debug("loadFolders path {} error: {}", normalized, e.getMessage());
+      return null;
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "load folder by path");
+    }
+  }
+
+  @Override
+  public RxFolder loadById(URI baseUri, String id) {
+    IPSGuid guid = resolveGuid(id);
+    try {
+      PSFolder folder = contentWs.loadFolder(guid, true);
+      if (folder == null) {
+        return null;
+      }
+      return toDto(folder);
+    } catch (PSErrorException e) {
+      log.debug("loadFolder id {} failed: {}", id, e.getMessage());
+      return null;
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "load folder by id");
+    }
+  }
+
+  @Override
+  public RxFolderChildList findChildrenById(URI baseUri, String id) {
+    IPSGuid guid = resolveGuid(id);
+    try {
+      List<PSItemSummary> children = contentWs.findFolderChildren(guid, false);
+      RxFolderChildList out = new RxFolderChildList(mapSummaries(children));
+      out.setParentId(idMapper.getString(guid));
+      return out;
+    } catch (PSErrorException e) {
+      throw notFoundOrServer(e, "Folder not found or cannot list children");
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "list children by id");
+    }
+  }
+
+  @Override
+  public RxFolderChildList findChildrenByPath(URI baseUri, String path) {
+    String normalized = normalizeRxPath(path);
+    if (normalized == null) {
+      throw new IllegalArgumentException("path is required");
+    }
+    try {
+      List<PSItemSummary> children = contentWs.findFolderChildren(normalized, false);
+      RxFolderChildList out = new RxFolderChildList(mapSummaries(children));
+      out.setParentPath(normalized);
+      return out;
+    } catch (PSErrorException e) {
+      throw notFoundOrServer(e, "Folder not found or cannot list children");
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "list children by path");
+    }
+  }
+
+  @Override
+  public RxFolderChildList findChildFoldersById(URI baseUri, String id) {
+    IPSGuid guid = resolveGuid(id);
+    try {
+      List<PSItemSummary> children = contentWs.findChildFolders(guid);
+      RxFolderChildList out = new RxFolderChildList(mapSummaries(children));
+      out.setParentId(idMapper.getString(guid));
+      return out;
+    } catch (PSErrorException e) {
+      throw notFoundOrServer(e, "Folder not found or cannot list child folders");
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "list child folders by id");
+    }
+  }
+
+  @Override
+  public RxFolderChildList findChildFoldersByPath(URI baseUri, String path) {
+    String normalized = normalizeRxPath(path);
+    if (normalized == null) {
+      throw new IllegalArgumentException("path is required");
+    }
+    // findChildFolders is id-only on IPSContentWs — resolve path first.
+    if ("/".equals(normalized)) {
+      // Root: children of "/" that are folders (Folders + Sites).
+      return findChildrenByPath(baseUri, "/");
+    }
+    RxFolder parent = loadByPath(baseUri, normalized);
+    if (parent == null || parent.getId() == null) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.NOT_FOUND).entity("Folder not found").build());
+    }
+    RxFolderChildList out = findChildFoldersById(baseUri, parent.getId());
+    out.setParentPath(normalized);
+    return out;
+  }
+
+  @Override
+  public RxFolder addFolder(URI baseUri, AddFolderRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    if (StringUtils.isBlank(request.getName())) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (StringUtils.isBlank(request.getParentPath())) {
+      throw new IllegalArgumentException("parentPath is required");
+    }
+    String parent = normalizeRxPath(request.getParentPath());
+    if (parent == null || "/".equals(parent)) {
+      throw new IllegalArgumentException("parentPath must be an existing folder path");
+    }
+    try {
+      PSFolder created;
+      if (StringUtils.isNotBlank(request.getSourcePath())) {
+        String src = normalizeRxPath(request.getSourcePath());
+        created = contentWs.addFolder(request.getName().trim(), parent, src, true);
+      } else {
+        created = contentWs.addFolder(request.getName().trim(), parent, true);
+      }
+      return toDto(created);
+    } catch (PSErrorException e) {
+      log.error("addFolder failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to add folder: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "add folder");
+    }
+  }
+
+  @Override
+  public List<RxFolder> addFolderTree(URI baseUri, AddFolderTreeRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    String path = normalizeRxPath(request.getPath());
+    if (path == null || "/".equals(path)) {
+      throw new IllegalArgumentException("path is required and must not be root alone");
+    }
+    try {
+      List<PSFolder> created = contentWs.addFolderTree(path, true);
+      List<RxFolder> out = new ArrayList<>();
+      if (created != null) {
+        for (PSFolder f : created) {
+          if (f != null) {
+            out.add(toDto(f));
+          }
+        }
+      }
+      return out;
+    } catch (PSErrorResultsException e) {
+      log.error("addFolderTree partial error: {}", e.getAllErrorString());
+      throw new WebApplicationException(
+          "Failed to add folder tree: " + e.getAllErrorString(),
+          e,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (PSErrorException e) {
+      log.error("addFolderTree failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to add folder tree: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "add folder tree");
+    }
+  }
+
+  @Override
+  public RxFolder saveFolder(URI baseUri, String id, RxFolder body) {
+    if (body == null) {
+      throw new IllegalArgumentException("folder body is required");
+    }
+    IPSGuid guid = resolveGuid(id);
+    try {
+      PSFolder existing = contentWs.loadFolder(guid, true);
+      if (existing == null) {
+        throw new WebApplicationException(
+            Response.status(Response.Status.NOT_FOUND).entity("Folder not found").build());
+      }
+      applyUpdates(existing, body);
+      PSFolder saved = contentWs.saveFolder(existing);
+      return toDto(saved != null ? saved : existing);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("saveFolder failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to save folder: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "save folder");
+    }
+  }
+
+  @Override
+  public void moveChildren(URI baseUri, FolderChildrenRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    String sourcePath = firstNonBlank(request.getSourcePath());
+    String targetPath = firstNonBlank(request.getTargetPath(), request.getParentPath());
+    String sourceId = firstNonBlank(request.getSourceId());
+    String targetId = firstNonBlank(request.getTargetId(), request.getParentId());
+
+    // null child list = move all children (WS contract); empty after resolve also → null
+    List<IPSGuid> childGuids = resolveChildGuids(request.getChildIds());
+    if (childGuids.isEmpty()) {
+      childGuids = null;
+    }
+
+    try {
+      if (StringUtils.isNotBlank(sourcePath) && StringUtils.isNotBlank(targetPath)) {
+        contentWs.moveFolderChildren(
+            normalizeRxPath(sourcePath), normalizeRxPath(targetPath), childGuids);
+        return;
+      }
+      if (StringUtils.isNotBlank(sourceId) && StringUtils.isNotBlank(targetId)) {
+        IPSGuid src = resolveGuid(sourceId);
+        IPSGuid tgt = resolveGuid(targetId);
+        boolean check =
+            request.getCheckFolderPermission() == null || request.getCheckFolderPermission();
+        contentWs.moveFolderChildren(src, tgt, childGuids, check);
+        return;
+      }
+      throw new IllegalArgumentException(
+          "move-children requires sourcePath+targetPath or sourceId+targetId");
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("moveFolderChildren failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to move children: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "move children");
+    }
+  }
+
+  @Override
+  public void addChildren(URI baseUri, FolderChildrenRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    String parentPath = firstNonBlank(request.getParentPath(), request.getTargetPath());
+    String parentId = firstNonBlank(request.getParentId(), request.getTargetId());
+    List<IPSGuid> childGuids = resolveChildGuids(request.getChildIds());
+    if (childGuids.isEmpty()) {
+      throw new IllegalArgumentException("childIds is required and must not be empty");
+    }
+    try {
+      if (StringUtils.isNotBlank(parentPath)) {
+        contentWs.addFolderChildren(normalizeRxPath(parentPath), childGuids);
+        return;
+      }
+      if (StringUtils.isNotBlank(parentId)) {
+        contentWs.addFolderChildren(resolveGuid(parentId), childGuids);
+        return;
+      }
+      throw new IllegalArgumentException("add-children requires parentPath or parentId");
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("addFolderChildren failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to add children: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "add children");
+    }
+  }
+
+  @Override
+  public void removeChildren(URI baseUri, FolderChildrenRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    String parentPath = firstNonBlank(request.getParentPath(), request.getTargetPath());
+    String parentId = firstNonBlank(request.getParentId(), request.getTargetId());
+    List<IPSGuid> childGuids = resolveChildGuids(request.getChildIds());
+    // null = remove all children (WS contract)
+    if (childGuids.isEmpty()) {
+      childGuids = null;
+    }
+    boolean purge = Boolean.TRUE.equals(request.getPurgeItems());
+    try {
+      if (StringUtils.isNotBlank(parentPath)) {
+        contentWs.removeFolderChildren(normalizeRxPath(parentPath), childGuids, purge);
+        return;
+      }
+      if (StringUtils.isNotBlank(parentId)) {
+        contentWs.removeFolderChildren(resolveGuid(parentId), childGuids, purge);
+        return;
+      }
+      throw new IllegalArgumentException("remove-children requires parentPath or parentId");
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorsException | PSErrorException e) {
+      log.error("removeFolderChildren failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to remove children: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "remove children");
+    }
+  }
+
+  @Override
+  public void deleteFolder(URI baseUri, String id, boolean purgeItems) {
+    IPSGuid guid = resolveGuid(id);
+    try {
+      contentWs.deleteFolders(List.of(guid), purgeItems, true);
+    } catch (PSErrorsException e) {
+      log.error("deleteFolders failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to delete folder: " + safeMessage(e), e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapRuntime(e, "delete folder");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Path normalize (package-visible for unit tests)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Normalize client path forms to repository RX paths expected by {@link IPSContentWs}.
+   *
+   * <ul>
+   *   <li>{@code /} → root listing path
+   *   <li>{@code //Folders/...} / {@code //Sites/...} kept (trailing slash stripped)
+   *   <li>{@code /Folders/...} / {@code /Sites/...} → double-slash form
+   *   <li>{@code Folders/...} / {@code Sites/...} → double-slash form
+   *   <li>Backslashes → forward slashes; drive-letter prefix stripped
+   * </ul>
+   *
+   * @return normalized path, or {@code null} when input is blank
+   */
+  static String normalizeRxPath(String path) {
+    if (path == null) {
+      return null;
+    }
+    String p = path.trim().replace('\\', '/');
+    if (p.isEmpty()) {
+      return null;
+    }
+    // Strip Windows drive letter if a client accidentally sent one.
+    if (p.length() >= 2 && Character.isLetter(p.charAt(0)) && p.charAt(1) == ':') {
+      p = p.substring(2);
+    }
+    if (p.isEmpty()) {
+      return null;
+    }
+
+    // Collapse accidental 3+ leading slashes to exactly two when repository-like.
+    while (p.startsWith("///")) {
+      p = p.substring(1);
+    }
+
+    boolean repoForm = p.startsWith("//");
+    if (repoForm) {
+      // Keep // prefix; collapse internal // after prefix.
+      String rest = p.substring(2).replaceAll("/{2,}", "/");
+      p = "//" + rest;
+    } else {
+      p = p.replaceAll("/{2,}", "/");
+      if (!p.startsWith("/")) {
+        p = "/" + p;
+      }
+      // Promote known roots to repository form.
+      String lower = p.toLowerCase(Locale.ROOT);
+      if (lower.equals("/folders")
+          || lower.startsWith("/folders/")
+          || lower.equals("/sites")
+          || lower.startsWith("/sites/")) {
+        p = "/" + p; // /Folders → //Folders
+      }
+    }
+
+    // Strip trailing slash except pure root forms.
+    if (p.length() > 1 && p.endsWith("/")) {
+      p = p.replaceAll("/+$", "");
+      if (p.equals("/") || p.equals("//")) {
+        return "/";
+      }
+      // If we stripped to empty after //, treat as root.
+      if (p.equals("//")) {
+        return "/";
+      }
+    }
+    if ("//".equals(p) || p.isEmpty()) {
+      return "/";
+    }
+    return p;
+  }
+
+  // -------------------------------------------------------------------------
+  // Mapping helpers
+  // -------------------------------------------------------------------------
+
+  private void applyUpdates(PSFolder existing, RxFolder body) {
+    if (StringUtils.isNotBlank(body.getName())) {
+      existing.setName(body.getName().trim());
+    }
+    if (body.getDescription() != null) {
+      existing.setDescription(body.getDescription());
+    }
+    if (body.getCommunityId() != null) {
+      existing.setCommunityId(body.getCommunityId());
+    }
+    if (StringUtils.isNotBlank(body.getLocale())) {
+      existing.setLocale(body.getLocale().trim());
+    }
+    if (body.getProperties() != null) {
+      for (RxFolderProperty prop : body.getProperties()) {
+        if (prop == null || StringUtils.isBlank(prop.getName())) {
+          continue;
+        }
+        String value = prop.getValue() != null ? prop.getValue() : "";
+        String desc = prop.getDescription() != null ? prop.getDescription() : "";
+        existing.setProperty(prop.getName().trim(), value, desc);
+      }
+    }
+  }
+
+  private RxFolder toDto(PSFolder folder) {
+    RxFolder dto = new RxFolder();
+    if (folder.getGuid() != null) {
+      dto.setId(idMapper.getString(folder.getGuid()));
+    } else if (folder.getLocator() != null) {
+      dto.setId(idMapper.getString(folder.getLocator()));
+      dto.setContentId((long) folder.getLocator().getId());
+    }
+    if (folder.getLocator() != null) {
+      dto.setContentId((long) folder.getLocator().getId());
+    }
+    dto.setName(folder.getName());
+    dto.setDescription(folder.getDescription());
+    dto.setCommunityId(folder.getCommunityId());
+    dto.setCommunityName(folder.getCommunityName());
+    dto.setLocale(folder.getLocale());
+    dto.setDisplayFormatName(folder.getDisplayFormatName());
+    dto.setPath(folder.getFolderPath());
+    PSObjectPermissions perms = folder.getPermissions();
+    if (perms != null) {
+      dto.setPermissions(perms.getPermissions());
+    }
+    List<RxFolderProperty> props = new ArrayList<>();
+    Iterator<PSFolderProperty> it = folder.getProperties();
+    while (it != null && it.hasNext()) {
+      PSFolderProperty p = it.next();
+      if (p == null) {
+        continue;
+      }
+      props.add(new RxFolderProperty(p.getName(), p.getValue(), p.getDescription()));
+    }
+    dto.setProperties(props);
+    return dto;
+  }
+
+  private List<RxFolderSummary> mapSummaries(List<PSItemSummary> children) {
+    List<RxFolderSummary> out = new ArrayList<>();
+    if (children == null) {
+      return out;
+    }
+    for (PSItemSummary s : children) {
+      if (s == null) {
+        continue;
+      }
+      RxFolderSummary row = new RxFolderSummary();
+      IPSGuid g = s.getGUID();
+      if (g instanceof PSLegacyGuid) {
+        row.setContentId((long) ((PSLegacyGuid) g).getContentId());
+      }
+      if (g != null) {
+        row.setId(idMapper.getString(g));
+      }
+      row.setName(s.getName());
+      if (s.getObjectType() != null) {
+        row.setObjectType(s.getObjectType().name());
+      }
+      row.setContentTypeName(s.getContentTypeName());
+      row.setContentTypeId(s.getContentTypeId());
+      out.add(row);
+    }
+    return out;
+  }
+
+  private IPSGuid resolveGuid(String id) {
+    if (StringUtils.isBlank(id)) {
+      throw new IllegalArgumentException("id is required");
+    }
+    String trimmed = id.trim();
+    if (!SAFE_ID.matcher(trimmed).matches()) {
+      throw new IllegalArgumentException("id contains invalid characters");
+    }
+    try {
+      // Numeric content id → legacy folder guid
+      if (trimmed.matches("\\d+")) {
+        long n = Long.parseLong(trimmed);
+        if (n <= 0 || n > Integer.MAX_VALUE) {
+          throw new IllegalArgumentException("id out of range: " + trimmed);
+        }
+        return new PSLegacyGuid((int) n, -1);
+      }
+      IPSGuid g = guidResolver.apply(trimmed);
+      if (g == null) {
+        throw new IllegalArgumentException("Unable to resolve id: " + trimmed);
+      }
+      return g;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Unable to resolve id: " + trimmed, e);
+    }
+  }
+
+  private List<IPSGuid> resolveChildGuids(List<String> childIds) {
+    List<IPSGuid> out = new ArrayList<>();
+    if (childIds == null) {
+      return out;
+    }
+    for (String c : childIds) {
+      if (StringUtils.isBlank(c)) {
+        continue;
+      }
+      out.add(resolveGuid(c));
+    }
+    return out;
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String v : values) {
+      if (StringUtils.isNotBlank(v)) {
+        return v;
+      }
+    }
+    return null;
+  }
+
+  private static String safeMessage(Throwable e) {
+    if (e == null || e.getMessage() == null) {
+      return "unknown error";
+    }
+    String m = e.getMessage();
+    return m.length() > 400 ? m.substring(0, 400) : m;
+  }
+
+  private static WebApplicationException notFoundOrServer(PSErrorException e, String clientMsg) {
+    String msg = e != null ? e.getMessage() : null;
+    // WS often signals missing folder as error; map to 404 when message suggests not found.
+    if (msg != null) {
+      String lower = msg.toLowerCase(Locale.ROOT);
+      if (lower.contains("not found")
+          || lower.contains("does not exist")
+          || lower.contains("invalid path")
+          || lower.contains("no folder")) {
+        return new WebApplicationException(
+            e, Response.status(Response.Status.NOT_FOUND).entity(clientMsg).build());
+      }
+    }
+    return new WebApplicationException(
+        e, Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(clientMsg).build());
+  }
+
+  private static RuntimeException mapRuntime(RuntimeException e, String op) {
+    if (e instanceof WebApplicationException || e instanceof IllegalArgumentException) {
+      return e;
+    }
+    log.error("Unexpected failure during {}: {}", op, e.getMessage(), e);
+    return e;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentExplorerFolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentExplorerFolderAdaptor.java
@@ -458,11 +458,11 @@ public class ContentExplorerFolderAdaptor implements IContentExplorerFolderAdapt
 
     boolean repoForm = p.startsWith("//");
     if (repoForm) {
-      // Keep // prefix; collapse internal // after prefix.
-      String rest = p.substring(2).replaceAll("/{2,}", "/");
+      // Keep // prefix; collapse internal // after prefix (linear helpers; CodeQL #1977).
+      String rest = collapseDuplicateSlashes(p.substring(2)); // linear, no regex (CodeQL #1977)
       p = "//" + rest;
     } else {
-      p = p.replaceAll("/{2,}", "/");
+      p = collapseDuplicateSlashes(p); // linear, no regex (CodeQL #1977)
       if (!p.startsWith("/")) {
         p = "/" + p;
       }
@@ -476,9 +476,9 @@ public class ContentExplorerFolderAdaptor implements IContentExplorerFolderAdapt
       }
     }
 
-    // Strip trailing slash except pure root forms.
+    // Strip trailing slash except pure root forms (linear helper; CodeQL #1977).
     if (p.length() > 1 && p.endsWith("/")) {
-      p = p.replaceAll("/+$", "");
+      p = stripTrailingSlashes(p); // linear, no regex (CodeQL #1977)
       if (p.equals("/") || p.equals("//")) {
         return "/";
       }
@@ -491,6 +491,43 @@ public class ContentExplorerFolderAdaptor implements IContentExplorerFolderAdapt
       return "/";
     }
     return p;
+  }
+
+
+  /**
+   * Collapse runs of {@code /} to a single slash in linear time (no regex). Avoids CodeQL
+   * {@code java/polynomial-redos} on user-supplied folder paths (alert #1977).
+   */
+  private static String collapseDuplicateSlashes(String s) {
+    if (s == null || s.length() < 2) {
+      return s;
+    }
+    StringBuilder out = new StringBuilder(s.length());
+    char prev = 0;
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c == '/' && prev == '/') {
+        continue;
+      }
+      out.append(c);
+      prev = c;
+    }
+    return out.toString();
+  }
+
+  /**
+   * Strip trailing {@code /} characters in linear time (no regex). Same CodeQL motivation as
+   * {@link #collapseDuplicateSlashes(String)}.
+   */
+  private static String stripTrailingSlashes(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    int end = s.length();
+    while (end > 0 && s.charAt(end - 1) == '/') {
+      end--;
+    }
+    return end == s.length() ? s : s.substring(0, end);
   }
 
   // -------------------------------------------------------------------------

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -85,6 +85,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="restDeliveryTypesResource" />
             <ref bean="restRelationshipSummaryResource" />
             <ref bean="restContentTranslationsResource" />
+            <ref bean="restContentExplorerFoldersResource" />
             <ref bean="restEditionsResource" />
             <ref bean="restExtensionsResource" />
             <ref bean="restItemFilterResource" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentExplorerFolderAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentExplorerFolderAdaptorTest.java
@@ -106,6 +106,23 @@ class ContentExplorerFolderAdaptorTest {
         "//Folders/a", ContentExplorerFolderAdaptor.normalizeRxPath("C:\\Folders\\a"));
   }
 
+
+  @Test
+  void normalizeCollapsesDuplicateSlashes() {
+    assertEquals("//Folders/a/b", ContentExplorerFolderAdaptor.normalizeRxPath("//Folders//a///b"));
+    assertEquals("//Folders/a", ContentExplorerFolderAdaptor.normalizeRxPath("/Folders//a//"));
+  }
+
+  @Test
+  void normalizeStripsLongTrailingSlashRunWithoutRegex() {
+    // Adversarial trailing-slash run must remain linear (CodeQL #1977 / java/polynomial-redos).
+    String path = "//Folders/a" + "/".repeat(5000);
+    long start = System.nanoTime();
+    assertEquals("//Folders/a", ContentExplorerFolderAdaptor.normalizeRxPath(path));
+    long ms = (System.nanoTime() - start) / 1_000_000L;
+    assertTrue(ms < 1000L, "normalizeRxPath took " + ms + "ms on long trailing slash run");
+  }
+
   // ---- load ----
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentExplorerFolderAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentExplorerFolderAdaptorTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSFolder;
+import com.percussion.rest.contentexplorer.folders.AddFolderRequest;
+import com.percussion.rest.contentexplorer.folders.AddFolderTreeRequest;
+import com.percussion.rest.contentexplorer.folders.FolderChildrenRequest;
+import com.percussion.rest.contentexplorer.folders.RxFolder;
+import com.percussion.rest.contentexplorer.folders.RxFolderChildList;
+import com.percussion.rest.contentexplorer.folders.RxFolderProperty;
+import com.percussion.services.content.data.PSItemSummary;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.content.IPSContentWs;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("UnitTest")
+class ContentExplorerFolderAdaptorTest {
+
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSIdMapper idMapper;
+
+  private ContentExplorerFolderAdaptor adaptor;
+  private final URI base = URI.create("http://localhost/rest");
+
+  @BeforeEach
+  void init() {
+    adaptor = new ContentExplorerFolderAdaptor(contentWs, idMapper, idMapper::getGuid);
+  }
+
+  // ---- path normalize ----
+
+  @Test
+  void normalizeKeepsDoubleSlashFolders() {
+    assertEquals("//Folders/a/b", ContentExplorerFolderAdaptor.normalizeRxPath("//Folders/a/b"));
+  }
+
+  @Test
+  void normalizePromotesSingleSlashFolders() {
+    assertEquals("//Folders/a", ContentExplorerFolderAdaptor.normalizeRxPath("/Folders/a"));
+  }
+
+  @Test
+  void normalizePromotesSites() {
+    assertEquals("//Sites/MySite", ContentExplorerFolderAdaptor.normalizeRxPath("/Sites/MySite"));
+    assertEquals("//Sites/MySite", ContentExplorerFolderAdaptor.normalizeRxPath("Sites/MySite"));
+  }
+
+  @Test
+  void normalizeRoot() {
+    assertEquals("/", ContentExplorerFolderAdaptor.normalizeRxPath("/"));
+  }
+
+  @Test
+  void normalizeBlankIsNull() {
+    assertNull(ContentExplorerFolderAdaptor.normalizeRxPath("  "));
+    assertNull(ContentExplorerFolderAdaptor.normalizeRxPath(null));
+  }
+
+  @Test
+  void normalizeStripsTrailingSlash() {
+    assertEquals("//Folders", ContentExplorerFolderAdaptor.normalizeRxPath("//Folders/"));
+  }
+
+  @Test
+  void normalizeBackslashAndDrive() {
+    assertEquals(
+        "//Folders/a", ContentExplorerFolderAdaptor.normalizeRxPath("C:\\Folders\\a"));
+  }
+
+  // ---- load ----
+
+  @Test
+  void loadByPathMapsFolder() throws Exception {
+    PSFolder folder = new PSFolder("Assets", 100, -1, 0, "desc");
+    folder.setGuid(new PSLegacyGuid(100, 1));
+    folder.setFolderPath("//Folders/$System$/Assets");
+    when(contentWs.loadFolders(new String[] {"//Folders/$System$/Assets"}))
+        .thenReturn(List.of(folder));
+    when(idMapper.getString(any(IPSGuid.class))).thenReturn("100");
+
+    RxFolder out = adaptor.loadByPath(base, "/Folders/$System$/Assets");
+
+    assertNotNull(out);
+    assertEquals("Assets", out.getName());
+    assertEquals("100", out.getId());
+    assertEquals("//Folders/$System$/Assets", out.getPath());
+  }
+
+  @Test
+  void loadByPathMissingReturnsNull() throws Exception {
+    when(contentWs.loadFolders(any(String[].class))).thenThrow(new PSErrorResultsException());
+    assertNull(adaptor.loadByPath(base, "//Folders/missing"));
+  }
+
+  @Test
+  void loadByIdUsesNumericContentId() throws Exception {
+    PSFolder folder = new PSFolder("X", 55, -1, 0, "");
+    folder.setGuid(new PSLegacyGuid(55, 1));
+    when(contentWs.loadFolder(any(IPSGuid.class), eq(true))).thenReturn(folder);
+    when(idMapper.getString(any(IPSGuid.class))).thenReturn("55");
+
+    RxFolder out = adaptor.loadById(base, "55");
+    assertEquals("X", out.getName());
+
+    ArgumentCaptor<IPSGuid> cap = ArgumentCaptor.forClass(IPSGuid.class);
+    verify(contentWs).loadFolder(cap.capture(), eq(true));
+    assertTrue(cap.getValue() instanceof PSLegacyGuid);
+    assertEquals(55, ((PSLegacyGuid) cap.getValue()).getContentId());
+  }
+
+  @Test
+  void loadByIdRejectsUnsafeChars() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.loadById(base, "a b"));
+  }
+
+  // ---- children ----
+
+  @Test
+  void findChildrenByPathDelegates() throws Exception {
+    PSItemSummary child = new PSItemSummary(200, "childFolder");
+    when(contentWs.findFolderChildren(eq("//Folders"), eq(false))).thenReturn(List.of(child));
+    when(idMapper.getString(any(IPSGuid.class))).thenReturn("200");
+
+    RxFolderChildList out = adaptor.findChildrenByPath(base, "/Folders");
+    assertEquals(1, out.getChildren().size());
+    assertEquals("childFolder", out.getChildren().get(0).getName());
+    assertEquals("//Folders", out.getParentPath());
+  }
+
+  // ---- add ----
+
+  @Test
+  void addFolderRequiresName() {
+    AddFolderRequest req = new AddFolderRequest();
+    req.setParentPath("//Folders");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addFolder(base, req));
+    assertTrue(ex.getMessage().contains("name"));
+  }
+
+  @Test
+  void addFolderCallsWs() throws Exception {
+    AddFolderRequest req = new AddFolderRequest();
+    req.setName("NewFolder");
+    req.setParentPath("/Folders");
+    PSFolder created = new PSFolder("NewFolder", 300, -1, 0, "");
+    created.setGuid(new PSLegacyGuid(300, 1));
+    when(contentWs.addFolder(eq("NewFolder"), eq("//Folders"), eq(true))).thenReturn(created);
+    when(idMapper.getString(any(IPSGuid.class))).thenReturn("300");
+
+    RxFolder out = adaptor.addFolder(base, req);
+    assertEquals("NewFolder", out.getName());
+  }
+
+  @Test
+  void addFolderTreeRequiresPath() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.addFolderTree(base, new AddFolderTreeRequest()));
+  }
+
+  // ---- save ----
+
+  @Test
+  void saveFolderAppliesNameAndProps() throws Exception {
+    PSFolder existing = new PSFolder("Old", 10, -1, 0, "d");
+    existing.setGuid(new PSLegacyGuid(10, 1));
+    when(contentWs.loadFolder(any(IPSGuid.class), eq(true))).thenReturn(existing);
+    when(contentWs.saveFolder(any(PSFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(idMapper.getString(any(IPSGuid.class))).thenReturn("10");
+
+    RxFolder body = new RxFolder();
+    body.setName("NewName");
+    body.setDescription("nd");
+    body.setProperties(List.of(new RxFolderProperty("sys_pubFileName", "pub", "")));
+
+    RxFolder out = adaptor.saveFolder(base, "10", body);
+    assertEquals("NewName", out.getName());
+    verify(contentWs).saveFolder(any(PSFolder.class));
+  }
+
+  // ---- multi-child ----
+
+  @Test
+  void moveChildrenByPath() throws Exception {
+    FolderChildrenRequest req = new FolderChildrenRequest();
+    req.setSourcePath("//Folders/a");
+    req.setTargetPath("//Folders/b");
+    req.setChildIds(List.of("5"));
+
+    adaptor.moveChildren(base, req);
+
+    verify(contentWs)
+        .moveFolderChildren(eq("//Folders/a"), eq("//Folders/b"), anyList());
+  }
+
+  @Test
+  void addChildrenRequiresParent() {
+    FolderChildrenRequest req = new FolderChildrenRequest();
+    req.setChildIds(List.of("1"));
+    assertThrows(IllegalArgumentException.class, () -> adaptor.addChildren(base, req));
+  }
+
+  @Test
+  void removeChildrenWithPurge() throws Exception {
+    FolderChildrenRequest req = new FolderChildrenRequest();
+    req.setParentPath("//Folders/a");
+    req.setChildIds(List.of("9"));
+    req.setPurgeItems(true);
+
+    adaptor.removeChildren(base, req);
+
+    verify(contentWs)
+        .removeFolderChildren(eq("//Folders/a"), anyList(), eq(true));
+  }
+
+  @Test
+  void deleteFolderCallsWs() throws Exception {
+    adaptor.deleteFolder(base, "42", false);
+    verify(contentWs).deleteFolders(anyList(), eq(false), eq(true));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -49,6 +49,8 @@ class CatalogRestJaxrsRegistrationTest {
     "restExtensionsResource",
     // #2429 P-Trans create-variant / item-locale façade
     "restContentTranslationsResource",
+    // #3073 content-explorer folders façade over IPSContentWs
+    "restContentExplorerFoldersResource",
   };
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/AddFolderRequest.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/AddFolderRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Request body for {@code IPSContentWs#addFolder}. */
+@XmlRootElement(name = "AddFolderRequest")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Create a single folder under an existing parent path")
+public class AddFolderRequest {
+
+  @Schema(description = "New folder name (unique under parent)", requiredMode = Schema.RequiredMode.REQUIRED)
+  private String name;
+
+  @Schema(
+      description =
+          "Fully qualified parent RX path (//Folders/… or //Sites/…; single-slash forms accepted)",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String parentPath;
+
+  @Schema(description = "Optional source folder path to clone ACLs/props from")
+  private String sourcePath;
+
+  public AddFolderRequest() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getParentPath() {
+    return parentPath;
+  }
+
+  public void setParentPath(String parentPath) {
+    this.parentPath = parentPath;
+  }
+
+  public String getSourcePath() {
+    return sourcePath;
+  }
+
+  public void setSourcePath(String sourcePath) {
+    this.sourcePath = sourcePath;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/AddFolderTreeRequest.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/AddFolderTreeRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Request body for {@code IPSContentWs#addFolderTree}. */
+@XmlRootElement(name = "AddFolderTreeRequest")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Create missing path segments for a fully qualified RX folder path")
+public class AddFolderTreeRequest {
+
+  @Schema(
+      description = "Fully qualified RX path to ensure (//Folders/a/b/c)",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String path;
+
+  public AddFolderTreeRequest() {}
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/ContentExplorerFoldersResource.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/ContentExplorerFoldersResource.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Public REST façade for Rhythmyx folder operations used by Content Explorer and integrators
+ * (#3073 / parent #3054).
+ *
+ * <pre>
+ *   GET    /Rhythmyx/rest/content-explorer/folders/by-path/{path}
+ *   GET    /Rhythmyx/rest/content-explorer/folders/by-id/{id}
+ *   GET    .../children | .../child-folders
+ *   POST   /Rhythmyx/rest/content-explorer/folders
+ *   POST   /Rhythmyx/rest/content-explorer/folders/tree
+ *   PUT    /Rhythmyx/rest/content-explorer/folders/by-id/{id}
+ *   POST   .../move-children | add-children | remove-children
+ *   DELETE /Rhythmyx/rest/content-explorer/folders/by-id/{id}?purge=
+ * </pre>
+ *
+ * <p>Thin HTTP layer over classic {@code IPSContentWs} folder methods (same domain path as SOAP
+ * content folder ops). Does <strong>not</strong> replace CM1 pathmanagement browse/pagination or
+ * the site-centric {@code /folders} resource.
+ *
+ * <p><strong>Out of scope:</strong> Explorer WebUI dual-run switch (#3074).
+ */
+@PSSiteManageBean(value = "restContentExplorerFoldersResource")
+@Path("/content-explorer/folders")
+@Tag(
+    name = "Content Explorer Folders",
+    description =
+        "Rhythmyx folder ops façade over IPSContentWs (//Folders / //Sites paths; not CM1 site"
+            + " FoldersResource)")
+public class ContentExplorerFoldersResource {
+
+  private static final Logger log = LogManager.getLogger(ContentExplorerFoldersResource.class);
+
+  private final IContentExplorerFolderAdaptor adaptor;
+
+  @Context private UriInfo uriInfo;
+
+  public ContentExplorerFoldersResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public ContentExplorerFoldersResource(IContentExplorerFolderAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
+  }
+
+  @GET
+  @Path("/by-path/{path:.+}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Load folder by RX path",
+      description =
+          "Loads a folder via IPSContentWs.loadFolders(paths). Accepts //Folders/… and //Sites/…"
+              + " forms; single-slash /Folders and /Sites are normalized. Use path '/' for root"
+              + " folders (Folders + Sites).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolder.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid path"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolder loadByPath(
+      @Parameter(name = "path", required = true, description = "Fully qualified RX path")
+          @PathParam("path")
+          String path) {
+    return call(
+        () -> {
+          RxFolder out = requireAdaptor().loadByPath(baseUri(), decodePath(path));
+          if (out == null) {
+            throw notFound("Folder not found");
+          }
+          return out;
+        },
+        "load folder by path");
+  }
+
+  @GET
+  @Path("/by-id/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Load folder by id",
+      description = "Loads a folder via IPSContentWs.loadFolder(guid).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolder.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid id"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolder loadById(
+      @Parameter(name = "id", required = true, description = "Folder guid or content id")
+          @PathParam("id")
+          String id) {
+    return call(
+        () -> {
+          RxFolder out = requireAdaptor().loadById(baseUri(), id);
+          if (out == null) {
+            throw notFound("Folder not found");
+          }
+          return out;
+        },
+        "load folder by id");
+  }
+
+  @GET
+  @Path("/by-id/{id}/children")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "List direct children by folder id",
+      description = "IPSContentWs.findFolderChildren(id) — items and folders.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolderChildList.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid id"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolderChildList childrenById(@PathParam("id") String id) {
+    return call(() -> requireAdaptor().findChildrenById(baseUri(), id), "list children by id");
+  }
+
+  @GET
+  @Path("/by-path/{path:.+}/children")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "List direct children by RX path",
+      description = "IPSContentWs.findFolderChildren(path). Path '/' returns root Folders + Sites.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolderChildList.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid path"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolderChildList childrenByPath(@PathParam("path") String path) {
+    return call(
+        () -> requireAdaptor().findChildrenByPath(baseUri(), decodePath(path)),
+        "list children by path");
+  }
+
+  @GET
+  @Path("/by-id/{id}/child-folders")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "List direct child folders by id",
+      description = "IPSContentWs.findChildFolders(id) — folders only.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolderChildList.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid id"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolderChildList childFoldersById(@PathParam("id") String id) {
+    return call(
+        () -> requireAdaptor().findChildFoldersById(baseUri(), id), "list child folders by id");
+  }
+
+  @GET
+  @Path("/by-path/{path:.+}/child-folders")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "List direct child folders by RX path",
+      description = "Resolves path then IPSContentWs.findChildFolders.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = RxFolderChildList.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid path"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolderChildList childFoldersByPath(@PathParam("path") String path) {
+    return call(
+        () -> requireAdaptor().findChildFoldersByPath(baseUri(), decodePath(path)),
+        "list child folders by path");
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Add a folder under a parent path",
+      description = "IPSContentWs.addFolder(name, parentPath[, sourcePath]).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = RxFolder.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolder addFolder(AddFolderRequest body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    return call(() -> requireAdaptor().addFolder(baseUri(), body), "add folder");
+  }
+
+  @POST
+  @Path("/tree")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Add a folder tree (missing path segments)",
+      description = "IPSContentWs.addFolderTree(path).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created folders (may be empty if path already exists)",
+            content =
+                @Content(array = @ArraySchema(schema = @Schema(implementation = RxFolder.class)))),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public List<RxFolder> addFolderTree(AddFolderTreeRequest body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    return call(() -> requireAdaptor().addFolderTree(baseUri(), body), "add folder tree");
+  }
+
+  @PUT
+  @Path("/by-id/{id}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Save folder name / description / community / locale / properties",
+      description =
+          "Loads the existing folder, applies non-null body fields, then IPSContentWs.saveFolder.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Saved",
+            content = @Content(schema = @Schema(implementation = RxFolder.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "404", description = "Folder not found"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public RxFolder saveFolder(@PathParam("id") String id, RxFolder body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    return call(() -> requireAdaptor().saveFolder(baseUri(), id, body), "save folder");
+  }
+
+  @POST
+  @Path("/move-children")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Move folder children source → target",
+      description = "IPSContentWs.moveFolderChildren.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Moved"),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public Response moveChildren(FolderChildrenRequest body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    call(
+        () -> {
+          requireAdaptor().moveChildren(baseUri(), body);
+          return null;
+        },
+        "move children");
+    return Response.noContent().build();
+  }
+
+  @POST
+  @Path("/add-children")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Add children to a parent folder",
+      description = "IPSContentWs.addFolderChildren.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Added"),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public Response addChildren(FolderChildrenRequest body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    call(
+        () -> {
+          requireAdaptor().addChildren(baseUri(), body);
+          return null;
+        },
+        "add children");
+    return Response.noContent().build();
+  }
+
+  @POST
+  @Path("/remove-children")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Remove children from a parent folder",
+      description = "IPSContentWs.removeFolderChildren (optional purge).",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Removed"),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public Response removeChildren(FolderChildrenRequest body) {
+    if (body == null) {
+      throw badRequest("Request body is required.");
+    }
+    call(
+        () -> {
+          requireAdaptor().removeChildren(baseUri(), body);
+          return null;
+        },
+        "remove children");
+    return Response.noContent().build();
+  }
+
+  @DELETE
+  @Path("/by-id/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Delete folder (recursive)",
+      description = "IPSContentWs.deleteFolders(ids, purgeItems).",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid id"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public Response deleteFolder(
+      @PathParam("id") String id,
+      @Parameter(description = "When true, purge child items (admin). Default false.")
+          @QueryParam("purge")
+          @DefaultValue("false")
+          boolean purge) {
+    call(
+        () -> {
+          requireAdaptor().deleteFolder(baseUri(), id, purge);
+          return null;
+        },
+        "delete folder");
+    return Response.noContent().build();
+  }
+
+  private <T> T call(CheckedSupplier<T> action, String op) {
+    try {
+      return action.get();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build());
+    } catch (SecurityException e) {
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.FORBIDDEN).entity(e.getMessage()).build());
+    } catch (Exception e) {
+      log.error("Failed to {} ({}): {}", op, e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(
+          e,
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Failed to " + op + ".")
+              .build());
+    }
+  }
+
+  private static String decodePath(String path) {
+    if (path == null) {
+      return null;
+    }
+    try {
+      return java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
+    } catch (RuntimeException e) {
+      return path;
+    }
+  }
+
+  private URI baseUri() {
+    return uriInfo == null ? null : uriInfo.getBaseUri();
+  }
+
+  private IContentExplorerFolderAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new WebApplicationException(
+          "Content explorer folders adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
+  }
+
+  private static WebApplicationException notFound(String msg) {
+    return new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity(msg).build());
+  }
+
+  private static WebApplicationException badRequest(String msg) {
+    return new WebApplicationException(
+        Response.status(Response.Status.BAD_REQUEST).entity(msg).build());
+  }
+
+  @FunctionalInterface
+  private interface CheckedSupplier<T> {
+    T get() throws Exception;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/FolderChildrenRequest.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/FolderChildrenRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared request body for multi-child folder ops (move / add / remove children).
+ *
+ * <p>Identify the parent (and for move, the source) by path or id. Child ids are content/folder
+ * guid strings.
+ */
+@XmlRootElement(name = "FolderChildrenRequest")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Multi-child folder operation request")
+public class FolderChildrenRequest {
+
+  @Schema(description = "Source folder path (move only)")
+  private String sourcePath;
+
+  @Schema(description = "Source folder id (move only)")
+  private String sourceId;
+
+  @Schema(description = "Target / parent folder path (add, remove, move target)")
+  private String targetPath;
+
+  @Schema(description = "Target / parent folder id")
+  private String targetId;
+
+  @Schema(description = "Parent path alias for add/remove (same as targetPath)")
+  private String parentPath;
+
+  @Schema(description = "Parent id alias for add/remove (same as targetId)")
+  private String parentId;
+
+  @Schema(description = "Child content/folder guid strings (or content ids)")
+  private List<String> childIds = new ArrayList<>();
+
+  @Schema(description = "When true, purge items on remove (requires admin). Default false.")
+  private Boolean purgeItems;
+
+  @Schema(description = "When true, enforce folder permission on move. Default true for WS.")
+  private Boolean checkFolderPermission;
+
+  public FolderChildrenRequest() {}
+
+  public String getSourcePath() {
+    return sourcePath;
+  }
+
+  public void setSourcePath(String sourcePath) {
+    this.sourcePath = sourcePath;
+  }
+
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  public void setSourceId(String sourceId) {
+    this.sourceId = sourceId;
+  }
+
+  public String getTargetPath() {
+    return targetPath;
+  }
+
+  public void setTargetPath(String targetPath) {
+    this.targetPath = targetPath;
+  }
+
+  public String getTargetId() {
+    return targetId;
+  }
+
+  public void setTargetId(String targetId) {
+    this.targetId = targetId;
+  }
+
+  public String getParentPath() {
+    return parentPath;
+  }
+
+  public void setParentPath(String parentPath) {
+    this.parentPath = parentPath;
+  }
+
+  public String getParentId() {
+    return parentId;
+  }
+
+  public void setParentId(String parentId) {
+    this.parentId = parentId;
+  }
+
+  public List<String> getChildIds() {
+    return childIds;
+  }
+
+  public void setChildIds(List<String> childIds) {
+    this.childIds = childIds != null ? childIds : new ArrayList<>();
+  }
+
+  public Boolean getPurgeItems() {
+    return purgeItems;
+  }
+
+  public void setPurgeItems(Boolean purgeItems) {
+    this.purgeItems = purgeItems;
+  }
+
+  public Boolean getCheckFolderPermission() {
+    return checkFolderPermission;
+  }
+
+  public void setCheckFolderPermission(Boolean checkFolderPermission) {
+    this.checkFolderPermission = checkFolderPermission;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/IContentExplorerFolderAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/IContentExplorerFolderAdaptor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Adaptor for content-explorer folder operations (#3073 / parent #3054).
+ *
+ * <p>HTTP lives on {@link ContentExplorerFoldersResource}; production impl is sitemanage apibridge
+ * wrapping classic {@code IPSContentWs} folder methods (same domain path as SOAP content folder
+ * ops).
+ *
+ * <p><strong>Out of scope:</strong> Explorer WebUI dual-run / client switch (#3074); CM1 site
+ * section semantics on {@code FoldersResource}.
+ */
+public interface IContentExplorerFolderAdaptor {
+
+  /** Load folder by fully qualified RX path (normalized in adaptor). */
+  RxFolder loadByPath(URI baseUri, String path);
+
+  /** Load folder by guid / content id string. */
+  RxFolder loadById(URI baseUri, String id);
+
+  /** Direct children (items + folders) by parent id. */
+  RxFolderChildList findChildrenById(URI baseUri, String id);
+
+  /** Direct children by RX path ({@code /} returns root Folders + Sites). */
+  RxFolderChildList findChildrenByPath(URI baseUri, String path);
+
+  /** Folder-only direct children by parent id. */
+  RxFolderChildList findChildFoldersById(URI baseUri, String id);
+
+  /** Folder-only direct children by RX path. */
+  RxFolderChildList findChildFoldersByPath(URI baseUri, String path);
+
+  /** Create a single folder under an existing parent. */
+  RxFolder addFolder(URI baseUri, AddFolderRequest request);
+
+  /** Create missing segments of a fully qualified path. */
+  List<RxFolder> addFolderTree(URI baseUri, AddFolderTreeRequest request);
+
+  /**
+   * Save an existing folder (name, description, community, locale, properties). Loads by id from
+   * path param; body supplies fields to apply.
+   */
+  RxFolder saveFolder(URI baseUri, String id, RxFolder folder);
+
+  /** Move children from source to target folder. */
+  void moveChildren(URI baseUri, FolderChildrenRequest request);
+
+  /** Add children to a parent folder. */
+  void addChildren(URI baseUri, FolderChildrenRequest request);
+
+  /** Remove children from a parent folder (optional purge). */
+  void removeChildren(URI baseUri, FolderChildrenRequest request);
+
+  /** Delete folder recursively; optional purge of child items. */
+  void deleteFolder(URI baseUri, String id, boolean purgeItems);
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolder.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolder.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Rhythmyx folder wire DTO for the content-explorer folders façade (not the CM1 site-centric {@code
+ * Folder} type).
+ */
+@XmlRootElement(name = "RxFolder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Rhythmyx folder (IPSContentWs / PSFolder façade)")
+public class RxFolder {
+
+  @Schema(description = "Folder guid string")
+  private String id;
+
+  @Schema(description = "Legacy content id")
+  private Long contentId;
+
+  @Schema(description = "Folder name / label")
+  private String name;
+
+  @Schema(description = "Fully qualified RX path when known (//Folders/... or //Sites/...)")
+  private String path;
+
+  @Schema(description = "Description")
+  private String description;
+
+  @Schema(description = "Community id (-1 = all communities)")
+  private Integer communityId;
+
+  @Schema(description = "Community name when loaded with transient data")
+  private String communityName;
+
+  @Schema(description = "Locale / language string (e.g. en-us)")
+  private String locale;
+
+  @Schema(description = "Default display format name when loaded with transient data")
+  private String displayFormatName;
+
+  @Schema(description = "Caller permission bitmask when available (transient)")
+  private Integer permissions;
+
+  @Schema(description = "Folder properties")
+  private List<RxFolderProperty> properties = new ArrayList<>();
+
+  public RxFolder() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(Long contentId) {
+    this.contentId = contentId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Integer getCommunityId() {
+    return communityId;
+  }
+
+  public void setCommunityId(Integer communityId) {
+    this.communityId = communityId;
+  }
+
+  public String getCommunityName() {
+    return communityName;
+  }
+
+  public void setCommunityName(String communityName) {
+    this.communityName = communityName;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  public String getDisplayFormatName() {
+    return displayFormatName;
+  }
+
+  public void setDisplayFormatName(String displayFormatName) {
+    this.displayFormatName = displayFormatName;
+  }
+
+  public Integer getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(Integer permissions) {
+    this.permissions = permissions;
+  }
+
+  public List<RxFolderProperty> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(List<RxFolderProperty> properties) {
+    this.properties = properties != null ? properties : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderChildList.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderChildList.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Direct children of a folder (items + folders, or folders-only). */
+@XmlRootElement(name = "RxFolderChildList")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "List of direct folder children")
+public class RxFolderChildList {
+
+  @Schema(description = "Parent folder path (normalized RX form) when requested by path")
+  private String parentPath;
+
+  @Schema(description = "Parent folder id when requested by id")
+  private String parentId;
+
+  @Schema(description = "Direct children")
+  private List<RxFolderSummary> children = new ArrayList<>();
+
+  public RxFolderChildList() {}
+
+  public RxFolderChildList(List<RxFolderSummary> children) {
+    this.children = children != null ? children : new ArrayList<>();
+  }
+
+  public String getParentPath() {
+    return parentPath;
+  }
+
+  public void setParentPath(String parentPath) {
+    this.parentPath = parentPath;
+  }
+
+  public String getParentId() {
+    return parentId;
+  }
+
+  public void setParentId(String parentId) {
+    this.parentId = parentId;
+  }
+
+  public List<RxFolderSummary> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<RxFolderSummary> children) {
+    this.children = children != null ? children : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderProperty.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderProperty.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Named folder property (RX {@code PSFolderProperty} wire shape). */
+@XmlRootElement(name = "RxFolderProperty")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Folder property name/value pair")
+public class RxFolderProperty {
+
+  @Schema(description = "Property name")
+  private String name;
+
+  @Schema(description = "Property value")
+  private String value;
+
+  @Schema(description = "Optional description")
+  private String description;
+
+  public RxFolderProperty() {}
+
+  public RxFolderProperty(String name, String value, String description) {
+    this.name = name;
+    this.value = value;
+    this.description = description;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderSummary.java
+++ b/rest/src/main/java/com/percussion/rest/contentexplorer/folders/RxFolderSummary.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Lightweight child / folder summary for content-explorer folder APIs (RX {@code PSItemSummary}
+ * shape).
+ */
+@XmlRootElement(name = "RxFolderSummary")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Folder or item summary under a parent folder")
+public class RxFolderSummary {
+
+  @Schema(description = "Legacy content id")
+  private Long contentId;
+
+  @Schema(description = "Guid string when available")
+  private String id;
+
+  @Schema(description = "Display name (folder name or sys_title)")
+  private String name;
+
+  @Schema(description = "Object type: FOLDER or ITEM")
+  private String objectType;
+
+  @Schema(description = "Content type name when known")
+  private String contentTypeName;
+
+  @Schema(description = "Content type id when known")
+  private Integer contentTypeId;
+
+  public RxFolderSummary() {}
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(Long contentId) {
+    this.contentId = contentId;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getObjectType() {
+    return objectType;
+  }
+
+  public void setObjectType(String objectType) {
+    this.objectType = objectType;
+  }
+
+  public String getContentTypeName() {
+    return contentTypeName;
+  }
+
+  public void setContentTypeName(String contentTypeName) {
+    this.contentTypeName = contentTypeName;
+  }
+
+  public Integer getContentTypeId() {
+    return contentTypeId;
+  }
+
+  public void setContentTypeId(Integer contentTypeId) {
+    this.contentTypeId = contentTypeId;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/contentexplorer/folders/ContentExplorerFoldersResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/contentexplorer/folders/ContentExplorerFoldersResourceTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contentexplorer.folders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * HTTP-layer tests for {@link ContentExplorerFoldersResource} (#3073). Domain behaviour is covered
+ * by sitemanage apibridge unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("UnitTest")
+class ContentExplorerFoldersResourceTest {
+
+  @Mock private IContentExplorerFolderAdaptor adaptor;
+
+  @Mock private UriInfo uriInfo;
+
+  private ContentExplorerFoldersResource resource;
+
+  @BeforeEach
+  void init() {
+    resource = new ContentExplorerFoldersResource(adaptor);
+    resource.setUriInfo(uriInfo);
+    org.mockito.Mockito.lenient()
+        .when(uriInfo.getBaseUri())
+        .thenReturn(UriBuilder.fromUri("http://localhost/rest").build());
+  }
+
+  @Test
+  void loadByPathDelegates() {
+    RxFolder expected = new RxFolder();
+    expected.setName("Folders");
+    expected.setPath("//Folders");
+    when(adaptor.loadByPath(any(), eq("//Folders"))).thenReturn(expected);
+
+    RxFolder out = resource.loadByPath("//Folders");
+
+    assertEquals("Folders", out.getName());
+    verify(adaptor).loadByPath(any(), eq("//Folders"));
+  }
+
+  @Test
+  void loadByPathNullIs404() {
+    when(adaptor.loadByPath(any(), eq("//Folders/missing"))).thenReturn(null);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.loadByPath("//Folders/missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void loadByIdDelegates() {
+    RxFolder expected = new RxFolder();
+    expected.setId("123");
+    when(adaptor.loadById(any(), eq("123"))).thenReturn(expected);
+
+    assertEquals("123", resource.loadById("123").getId());
+  }
+
+  @Test
+  void loadByIdIllegalArgumentIs400() {
+    when(adaptor.loadById(any(), eq("bad")))
+        .thenThrow(new IllegalArgumentException("id contains invalid characters"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.loadById("bad"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void childrenByPathDelegates() {
+    RxFolderChildList list = new RxFolderChildList(List.of());
+    list.setParentPath("//Folders");
+    when(adaptor.findChildrenByPath(any(), eq("//Folders"))).thenReturn(list);
+
+    assertEquals("//Folders", resource.childrenByPath("//Folders").getParentPath());
+  }
+
+  @Test
+  void addFolderNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.addFolder(null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void addFolderDelegates() {
+    AddFolderRequest body = new AddFolderRequest();
+    body.setName("New");
+    body.setParentPath("//Folders");
+    RxFolder created = new RxFolder();
+    created.setName("New");
+    when(adaptor.addFolder(any(), eq(body))).thenReturn(created);
+
+    assertEquals("New", resource.addFolder(body).getName());
+  }
+
+  @Test
+  void saveFolderDelegates() {
+    RxFolder body = new RxFolder();
+    body.setName("Renamed");
+    when(adaptor.saveFolder(any(), eq("10"), eq(body))).thenReturn(body);
+
+    assertEquals("Renamed", resource.saveFolder("10", body).getName());
+  }
+
+  @Test
+  void deleteFolderDelegates() {
+    resource.deleteFolder("10", true);
+    verify(adaptor).deleteFolder(any(), eq("10"), eq(true));
+  }
+
+  @Test
+  void moveChildrenNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.moveChildren(null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void moveChildrenReturns204() {
+    FolderChildrenRequest body = new FolderChildrenRequest();
+    body.setSourcePath("//Folders/a");
+    body.setTargetPath("//Folders/b");
+    assertEquals(204, resource.moveChildren(body).getStatus());
+    verify(adaptor).moveChildren(any(), eq(body));
+  }
+
+  @Test
+  void securityMapsTo403() {
+    when(adaptor.loadById(any(), eq("x"))).thenThrow(new SecurityException("denied"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.loadById("x"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void missingAdaptorIs503() {
+    ContentExplorerFoldersResource bare = new ContentExplorerFoldersResource();
+    bare.setUriInfo(uriInfo);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.loadById("1"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentExplorerFolderAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentExplorerFolderAdaptor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.contentexplorer.folders.AddFolderRequest;
+import com.percussion.rest.contentexplorer.folders.AddFolderTreeRequest;
+import com.percussion.rest.contentexplorer.folders.FolderChildrenRequest;
+import com.percussion.rest.contentexplorer.folders.IContentExplorerFolderAdaptor;
+import com.percussion.rest.contentexplorer.folders.RxFolder;
+import com.percussion.rest.contentexplorer.folders.RxFolderChildList;
+import java.net.URI;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link IContentExplorerFolderAdaptor}. Required for ApplicationContext load
+ * after constructor injection on {@code ContentExplorerFoldersResource}.
+ */
+@Component
+@Lazy
+public class TestContentExplorerFolderAdaptor implements IContentExplorerFolderAdaptor {
+
+  @Override
+  public RxFolder loadByPath(URI baseUri, String path) {
+    RxFolder f = new RxFolder();
+    f.setPath(path);
+    f.setName("stub");
+    f.setId("0");
+    return f;
+  }
+
+  @Override
+  public RxFolder loadById(URI baseUri, String id) {
+    RxFolder f = new RxFolder();
+    f.setId(id);
+    f.setName("stub");
+    return f;
+  }
+
+  @Override
+  public RxFolderChildList findChildrenById(URI baseUri, String id) {
+    RxFolderChildList list = new RxFolderChildList(List.of());
+    list.setParentId(id);
+    return list;
+  }
+
+  @Override
+  public RxFolderChildList findChildrenByPath(URI baseUri, String path) {
+    RxFolderChildList list = new RxFolderChildList(List.of());
+    list.setParentPath(path);
+    return list;
+  }
+
+  @Override
+  public RxFolderChildList findChildFoldersById(URI baseUri, String id) {
+    return findChildrenById(baseUri, id);
+  }
+
+  @Override
+  public RxFolderChildList findChildFoldersByPath(URI baseUri, String path) {
+    return findChildrenByPath(baseUri, path);
+  }
+
+  @Override
+  public RxFolder addFolder(URI baseUri, AddFolderRequest request) {
+    RxFolder f = new RxFolder();
+    f.setName(request != null ? request.getName() : null);
+    return f;
+  }
+
+  @Override
+  public List<RxFolder> addFolderTree(URI baseUri, AddFolderTreeRequest request) {
+    return List.of();
+  }
+
+  @Override
+  public RxFolder saveFolder(URI baseUri, String id, RxFolder folder) {
+    if (folder != null) {
+      folder.setId(id);
+    }
+    return folder;
+  }
+
+  @Override
+  public void moveChildren(URI baseUri, FolderChildrenRequest request) {
+    // no-op
+  }
+
+  @Override
+  public void addChildren(URI baseUri, FolderChildrenRequest request) {
+    // no-op
+  }
+
+  @Override
+  public void removeChildren(URI baseUri, FolderChildrenRequest request) {
+    // no-op
+  }
+
+  @Override
+  public void deleteFolder(URI baseUri, String id, boolean purgeItems) {
+    // no-op
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **content-explorer folders REST façade** over classic Rhythmyx **`IPSContentWs`** folder operations (parent design #3054 / PR #3072).

- New public surface `@Path("/content-explorer/folders")` in **rest**: wire DTOs, `IContentExplorerFolderAdaptor`, `ContentExplorerFoldersResource` (OpenAPI tags)
- **sitemanage** `ContentExplorerFolderAdaptor` wrapping `IPSContentWs` (load by path/id, children, addFolder/addFolderTree, save name/props, multi-child move/add/remove, delete+purge)
- Path normalization for `//Folders` / `//Sites` and single-slash forms
- Companions: Mockito resource tests, Spring `MainTest` adaptor stub, sitemanage unit tests, `rest-jax-rs` serviceBeans ref, product-docs REST notes
- **No** Explorer WebUI dual-run/switch (left for #3074)
- **No** rest→sitemanage Maven edge; CM1 `FoldersResource` unchanged

Parent tracker: **#3054**

Fixes #3073

## Test plan

- [x] `rest`: `mvnw clean install` — BUILD SUCCESS; Tests run: 319, Failures: 0, Errors: 0
- [x] `projects/sitemanage`: `mvnw clean install` — BUILD SUCCESS; Tests run: 998, Failures: 0, Errors: 0 (skipped 125)
- [x] New unit tests: `ContentExplorerFoldersResourceTest` (13), `ContentExplorerFolderAdaptorTest` (20, path normalize + ops)
- [x] `CatalogRestJaxrsRegistrationTest` includes `restContentExplorerFoldersResource`
- [ ] Human: optional live H2 smoke of `GET /Rhythmyx/rest/content-explorer/folders/by-path/...` after deploy (not required for merge of pure API slice)

### Gates evidence

- **Change class:** new public REST adaptor surface (content-explorer folders)
- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw clean install` → BUILD SUCCESS; Tests run: 319, Failures: 0, Errors: 0
  - `cd projects/sitemanage && ../../mvnw clean install` → BUILD SUCCESS; Tests run: 998, Failures: 0, Errors: 0
- **downstream_checked:** none (C2 N/A — no existing public type sealed/finalized; new types only; sitemanage is the reverse-dep that implements the new interface and was clean-installed)
- **Product documentation:** updated `product-docs/8.2/developer/rest.md` (Content Explorer folders section)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.