### PR TITLE
feat(profile): Security password/auth section (#2394)

### DIFF
--- a/WebUI/src/main/ts/api/user/userPasswordApi.ts
+++ b/WebUI/src/main/ts/api/user/userPasswordApi.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Self-service password change client (issue #2394 / parent #2374 slice 3).
+ *
+ * <p>PUT {@code /user/user/changepw} — server enforces self-only and only
+ * updates passwords for INTERNAL provider users. Prefer this over any
+ * parallel password store.</p>
+ */
+
+import { put } from "../client";
+import { PATHS } from "../paths";
+
+/** Legacy UI min length; server also rejects blank via parameter validation. */
+export const MIN_PASSWORD_LENGTH = 6;
+
+export type PasswordChangeInput = {
+  /** Signed-in user name (must match session; server rejects others). */
+  name: string;
+  password: string;
+  email?: string;
+  roles?: string[];
+};
+
+export type PasswordFieldErrors = {
+  newPassword?: string;
+  confirmPassword?: string;
+};
+
+export type PasswordValidationResult =
+  | { ok: true }
+  | { ok: false; fields: PasswordFieldErrors; formMessage?: string };
+
+/**
+ * Client-side password form checks (length + confirm match).
+ * Messages are key-agnostic — callers pass localized strings.
+ */
+export function validatePasswordChange(
+  newPassword: string,
+  confirmPassword: string,
+  labels: {
+    required: string;
+    tooShort: string;
+    mismatch: string;
+  },
+): PasswordValidationResult {
+  const fields: PasswordFieldErrors = {};
+  const next = newPassword ?? "";
+  const confirm = confirmPassword ?? "";
+
+  if (!next.trim()) {
+    fields.newPassword = labels.required;
+  } else if (next.length < MIN_PASSWORD_LENGTH) {
+    fields.newPassword = labels.tooShort;
+  }
+
+  if (!confirm) {
+    fields.confirmPassword = labels.required;
+  } else if (next && confirm !== next) {
+    fields.confirmPassword = labels.mismatch;
+  }
+
+  if (fields.newPassword || fields.confirmPassword) {
+    return { ok: false, fields };
+  }
+  return { ok: true };
+}
+
+/**
+ * PUT change password for the signed-in user only.
+ * Body shape matches legacy PercUserService / PSUser JAXB root.
+ */
+export async function changeMyPassword(
+  input: PasswordChangeInput,
+): Promise<void> {
+  const name = (input.name ?? "").trim();
+  const password = input.password ?? "";
+  if (!name) {
+    throw new Error("User name is required for password change");
+  }
+  if (!password) {
+    throw new Error("Password is required");
+  }
+
+  const body = {
+    User: {
+      name,
+      password,
+      email: input.email ?? "",
+      roles: Array.isArray(input.roles) ? input.roles : [],
+    },
+  };
+
+  await put<unknown>(PATHS.USER_CHANGE_PW, body);
+}

--- a/WebUI/src/main/ts/profile/ProfileShell.tsx
+++ b/WebUI/src/main/ts/profile/ProfileShell.tsx
@@ -22,6 +22,7 @@ import { AccountSection } from "./AccountSection";
 import { AvatarSection } from "./AvatarSection";
 import { PROFILE_MSG } from "./messages";
 import { PreferencesSection } from "./PreferencesSection";
+import { SecuritySection } from "./SecuritySection";
 import styles from "./ProfileShell.module.css";
 
 
@@ -69,8 +70,8 @@ const SECTIONS: {
 
 /**
  * User profile hub shell: landmarks, heading hierarchy, and section content.
- * Account (#2395), Preferences (#2396), and Avatar (#2397) are live; security
- * remains a placeholder until its slice lands.
+ * Account (#2395), Security (#2394), Preferences (#2396), and Avatar (#2397)
+ * are live product sections.
  */
 export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement {
   const reactId = useId();
@@ -131,6 +132,7 @@ export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement
         {SECTIONS.map((section) => {
           const headingId = `perc-profile-${section.id}-heading`;
           const isAccount = section.id === "account";
+          const isSecurity = section.id === "security";
           const isPreferences = section.id === "preferences";
           const isAvatar = section.id === "avatar";
           return (
@@ -154,6 +156,8 @@ export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement
               </p>
               {isAccount ? (
                 <AccountSection />
+              ) : isSecurity ? (
+                <SecuritySection />
               ) : isPreferences ? (
                 <PreferencesSection />
               ) : isAvatar ? (

--- a/WebUI/src/main/ts/profile/SecuritySection.module.css
+++ b/WebUI/src/main/ts/profile/SecuritySection.module.css
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.root {
+  margin-top: 0.25rem;
+}
+
+.muted {
+  margin: 0;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.5;
+}
+
+.externalBox {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #d8dee9);
+  background: var(--color-surface-muted, #f6f8fb);
+  color: var(--color-text, #181c2c);
+  line-height: 1.5;
+  max-width: 36rem;
+}
+
+.externalBox p {
+  margin: 0 0 0.5rem;
+}
+
+.externalBox p:last-child {
+  margin-bottom: 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  max-width: 28rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text, #181c2c);
+  line-height: 1.4;
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--color-text, #181c2c);
+  background: var(--color-surface, #fff);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.input[aria-invalid="true"] {
+  border-color: var(--color-danger, #b42318);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.4;
+}
+
+.fieldError,
+.formError {
+  margin: 0;
+  color: var(--color-danger-text, #7a1a12);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.success {
+  margin: 0;
+  color: var(--color-success, #067647);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.15rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: var(--color-primary, #4a6aa3);
+  color: #fff;
+  border-color: var(--color-primary, #4a6aa3);
+}
+
+.primaryButton:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.primaryButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.secondaryButton {
+  background: var(--color-surface, #fff);
+  color: var(--color-primary, #4a6aa3);
+  border-color: var(--color-border, #d8dee9);
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-danger-border, #fecaca);
+  background: var(--color-danger-surface, #fef2f2);
+  color: var(--color-danger-strong, #991b1b);
+}
+
+.errorBox p {
+  margin: 0;
+  line-height: 1.45;
+  color: var(--color-danger-strong, #991b1b);
+  word-break: break-word;
+}
+
+.statusRegion {
+  margin-top: 0.85rem;
+  min-height: 1.25rem;
+}

--- a/WebUI/src/main/ts/profile/SecuritySection.tsx
+++ b/WebUI/src/main/ts/profile/SecuritySection.tsx
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useId, useState } from "react";
+import {
+  formatApiError,
+  isSessionRedirectError,
+} from "../api/client";
+import {
+  type CurrentUserProfile,
+  getCurrentUserProfile,
+} from "../api/user/userProfileApi";
+import {
+  changeMyPassword,
+  MIN_PASSWORD_LENGTH,
+  validatePasswordChange,
+} from "../api/user/userPasswordApi";
+import { i18nKeyAttr } from "../i18n/i18nDom";
+import { message } from "../i18n/message";
+import { PROFILE_MSG } from "./messages";
+import styles from "./SecuritySection.module.css";
+
+export interface SecuritySectionProps {
+  /** Optional test double — defaults to live REST. */
+  loadProfile?: () => Promise<CurrentUserProfile>;
+  changePassword?: (input: {
+    name: string;
+    password: string;
+    email?: string;
+    roles?: string[];
+  }) => Promise<void>;
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; profile: CurrentUserProfile };
+
+/**
+ * Profile Security section (#2394 / parent #2374 slice 3).
+ *
+ * <p>INTERNAL users get a change-password form that reuses PUT
+ * {@code /user/user/changepw} (self-only). DIRECTORY/SSO users see a
+ * localized non-dead-end explanation — no always-fail form.</p>
+ */
+export function SecuritySection({
+  loadProfile = getCurrentUserProfile,
+  changePassword = changeMyPassword,
+}: SecuritySectionProps = {}): React.ReactElement {
+  const reactId = useId();
+  const formId = `perc-profile-security-form-${reactId}`;
+  const newPasswordId = `perc-profile-security-new-${reactId}`;
+  const confirmPasswordId = `perc-profile-security-confirm-${reactId}`;
+  const newErrorId = `perc-profile-security-new-error-${reactId}`;
+  const confirmErrorId = `perc-profile-security-confirm-error-${reactId}`;
+  const newHelpId = `perc-profile-security-new-help-${reactId}`;
+  const statusId = `perc-profile-security-status-${reactId}`;
+
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [newFieldError, setNewFieldError] = useState<string | null>(null);
+  const [confirmFieldError, setConfirmFieldError] = useState<string | null>(
+    null,
+  );
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoadState({ status: "loading" });
+    setNewFieldError(null);
+    setConfirmFieldError(null);
+    setFormError(null);
+    setSuccessMessage(null);
+    setNewPassword("");
+    setConfirmPassword("");
+    try {
+      const profile = await loadProfile();
+      setLoadState({ status: "ready", profile });
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setLoadState({
+        status: "error",
+        message: formatApiError(err, message(PROFILE_MSG.SECURITY_LOAD_ERROR)),
+      });
+    }
+  }, [loadProfile]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const clearFieldMessages = () => {
+    setNewFieldError(null);
+    setConfirmFieldError(null);
+    setFormError(null);
+    setSuccessMessage(null);
+  };
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (loadState.status !== "ready") {
+      return;
+    }
+    const { profile } = loadState;
+    if (profile.providerType !== "INTERNAL") {
+      return;
+    }
+
+    clearFieldMessages();
+
+    const validation = validatePasswordChange(newPassword, confirmPassword, {
+      required: message(PROFILE_MSG.PW_REQUIRED),
+      tooShort: message(PROFILE_MSG.PW_TOO_SHORT).replace(
+        "{0}",
+        String(MIN_PASSWORD_LENGTH),
+      ),
+      mismatch: message(PROFILE_MSG.PW_MISMATCH),
+    });
+
+    if (!validation.ok) {
+      setNewFieldError(validation.fields.newPassword ?? null);
+      setConfirmFieldError(validation.fields.confirmPassword ?? null);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await changePassword({
+        name: profile.name,
+        password: newPassword,
+        email: profile.email,
+        roles: profile.roles,
+      });
+      setNewPassword("");
+      setConfirmPassword("");
+      setSuccessMessage(message(PROFILE_MSG.PW_SAVE_SUCCESS));
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setFormError(formatApiError(err, message(PROFILE_MSG.PW_SAVE_ERROR)));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (loadState.status === "loading") {
+    return (
+      <div
+        className={styles.root}
+        data-testid="perc-profile-security"
+        aria-busy="true"
+      >
+        <p
+          className={styles.muted}
+          data-testid="perc-profile-security-loading"
+          {...i18nKeyAttr(PROFILE_MSG.SECURITY_LOADING)}
+        >
+          {message(PROFILE_MSG.SECURITY_LOADING)}
+        </p>
+      </div>
+    );
+  }
+
+  if (loadState.status === "error") {
+    return (
+      <div className={styles.root} data-testid="perc-profile-security">
+        <div
+          className={styles.errorBox}
+          role="alert"
+          data-testid="perc-profile-security-load-error"
+        >
+          <p {...i18nKeyAttr(PROFILE_MSG.SECURITY_LOAD_ERROR)}>
+            {loadState.message || message(PROFILE_MSG.SECURITY_LOAD_ERROR)}
+          </p>
+          <button
+            type="button"
+            className={styles.secondaryButton}
+            onClick={() => void load()}
+            data-testid="perc-profile-security-retry"
+            {...i18nKeyAttr(PROFILE_MSG.SECURITY_RETRY)}
+          >
+            {message(PROFILE_MSG.SECURITY_RETRY)}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { profile } = loadState;
+  const passwordChangeable = profile.providerType === "INTERNAL";
+
+  if (!passwordChangeable) {
+    return (
+      <div className={styles.root} data-testid="perc-profile-security">
+        <div
+          className={styles.externalBox}
+          data-testid="perc-profile-security-external"
+          role="status"
+        >
+          <p
+            data-testid="perc-profile-security-external-title"
+            {...i18nKeyAttr(PROFILE_MSG.PW_EXTERNAL_TITLE)}
+          >
+            {message(PROFILE_MSG.PW_EXTERNAL_TITLE)}
+          </p>
+          <p
+            data-testid="perc-profile-security-external-body"
+            {...i18nKeyAttr(PROFILE_MSG.PW_EXTERNAL_BODY)}
+          >
+            {message(PROFILE_MSG.PW_EXTERNAL_BODY)}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const newDescribedBy = [
+    newHelpId,
+    newFieldError ? newErrorId : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const confirmDescribedBy = confirmFieldError ? confirmErrorId : undefined;
+
+  return (
+    <div className={styles.root} data-testid="perc-profile-security">
+      <form
+        id={formId}
+        className={styles.form}
+        onSubmit={(e) => void onSubmit(e)}
+        noValidate
+        data-testid="perc-profile-security-form"
+      >
+        <div className={styles.field}>
+          <label
+            className={styles.label}
+            htmlFor={newPasswordId}
+            {...i18nKeyAttr(PROFILE_MSG.PW_NEW_LABEL)}
+          >
+            {message(PROFILE_MSG.PW_NEW_LABEL)}
+          </label>
+          <input
+            id={newPasswordId}
+            name="newPassword"
+            type="password"
+            autoComplete="new-password"
+            className={styles.input}
+            value={newPassword}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              clearFieldMessages();
+            }}
+            disabled={isSaving}
+            aria-invalid={newFieldError ? true : undefined}
+            aria-describedby={newDescribedBy || undefined}
+            data-testid="perc-profile-security-new-password"
+          />
+          <p
+            id={newHelpId}
+            className={styles.hint}
+            {...i18nKeyAttr(PROFILE_MSG.PW_LENGTH_HINT)}
+          >
+            {message(PROFILE_MSG.PW_LENGTH_HINT).replace(
+              "{0}",
+              String(MIN_PASSWORD_LENGTH),
+            )}
+          </p>
+          {newFieldError && (
+            <p
+              id={newErrorId}
+              className={styles.fieldError}
+              role="alert"
+              data-testid="perc-profile-security-new-error"
+            >
+              {newFieldError}
+            </p>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <label
+            className={styles.label}
+            htmlFor={confirmPasswordId}
+            {...i18nKeyAttr(PROFILE_MSG.PW_CONFIRM_LABEL)}
+          >
+            {message(PROFILE_MSG.PW_CONFIRM_LABEL)}
+          </label>
+          <input
+            id={confirmPasswordId}
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            className={styles.input}
+            value={confirmPassword}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value);
+              clearFieldMessages();
+            }}
+            disabled={isSaving}
+            aria-invalid={confirmFieldError ? true : undefined}
+            aria-describedby={confirmDescribedBy}
+            data-testid="perc-profile-security-confirm-password"
+          />
+          {confirmFieldError && (
+            <p
+              id={confirmErrorId}
+              className={styles.fieldError}
+              role="alert"
+              data-testid="perc-profile-security-confirm-error"
+            >
+              {confirmFieldError}
+            </p>
+          )}
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="submit"
+            className={styles.primaryButton}
+            disabled={isSaving}
+            data-testid="perc-profile-security-submit"
+            {...i18nKeyAttr(
+              isSaving ? PROFILE_MSG.PW_SAVING : PROFILE_MSG.PW_SUBMIT,
+            )}
+          >
+            {message(isSaving ? PROFILE_MSG.PW_SAVING : PROFILE_MSG.PW_SUBMIT)}
+          </button>
+        </div>
+      </form>
+
+      <div
+        id={statusId}
+        className={styles.statusRegion}
+        role="status"
+        aria-live="polite"
+        data-testid="perc-profile-security-status"
+      >
+        {successMessage && (
+          <p
+            className={styles.success}
+            data-testid="perc-profile-security-success"
+          >
+            {successMessage}
+          </p>
+        )}
+        {formError && (
+          <p
+            className={styles.formError}
+            data-testid="perc-profile-security-form-error"
+          >
+            {formError}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/profile/index.ts
+++ b/WebUI/src/main/ts/profile/index.ts
@@ -21,6 +21,8 @@ export { ProfileShell } from "./ProfileShell";
 export type { ProfileShellProps } from "./ProfileShell";
 export { PreferencesSection } from "./PreferencesSection";
 export type { PreferencesSectionProps } from "./PreferencesSection";
+export { SecuritySection } from "./SecuritySection";
+export type { SecuritySectionProps } from "./SecuritySection";
 export { AvatarSection } from "./AvatarSection";
 export type { AvatarSectionProps } from "./AvatarSection";
 export { UserAvatar } from "./UserAvatar";

--- a/WebUI/src/main/ts/profile/messages.ts
+++ b/WebUI/src/main/ts/profile/messages.ts
@@ -16,7 +16,8 @@
  */
 
 /**
- * User profile hub catalog keys (#2393 shell + #2395 account + #2396 preferences — parent #2374).
+ * User profile hub catalog keys (#2393 shell + #2395 account + #2396 preferences
+ * + #2394 security — parent #2374).
  * English after {@code @} is the source fallback when TMX is not loaded.
  */
 export const PROFILE_MSG = {
@@ -30,7 +31,7 @@ export const PROFILE_MSG = {
     "perc.ui.profile.modern@Your login id, email, provider, and role summary for this account.",
   SECTION_SECURITY: "perc.ui.profile.modern@Security",
   SECTION_SECURITY_BODY:
-    "perc.ui.profile.modern@Password and authentication options for your account will appear here.",
+    "perc.ui.profile.modern@Change your password when your account uses local authentication, or learn how directory and SSO accounts manage credentials.",
   SECTION_PREFERENCES: "perc.ui.profile.modern@Preferences",
   SECTION_PREFERENCES_BODY:
     "perc.ui.profile.modern@Choose your default CMS landing page and view preferences stored for your account.",
@@ -38,6 +39,29 @@ export const PROFILE_MSG = {
   SECTION_AVATAR_BODY:
     "perc.ui.profile.modern@Choose the email used for your Gravatar avatar and preview how it appears in the header.",
   COMING_SOON: "perc.ui.profile.modern@Coming soon",
+
+  // Security / password section (#2394)
+  SECURITY_LOADING: "perc.ui.profile.modern@Loading security settings…",
+  SECURITY_LOAD_ERROR:
+    "perc.ui.profile.modern@Could not load security settings.",
+  SECURITY_RETRY: "perc.ui.profile.modern@Try again",
+  PW_NEW_LABEL: "perc.ui.profile.modern@New password",
+  PW_CONFIRM_LABEL: "perc.ui.profile.modern@Confirm new password",
+  PW_LENGTH_HINT:
+    "perc.ui.profile.modern@Use at least {0} characters. Server password rules still apply.",
+  PW_REQUIRED: "perc.ui.profile.modern@Enter a password.",
+  PW_TOO_SHORT:
+    "perc.ui.profile.modern@Password must be at least {0} characters.",
+  PW_MISMATCH: "perc.ui.profile.modern@Passwords do not match.",
+  PW_SUBMIT: "perc.ui.profile.modern@Change password",
+  PW_SAVING: "perc.ui.profile.modern@Updating password…",
+  PW_SAVE_SUCCESS: "perc.ui.profile.modern@Your password was changed.",
+  PW_SAVE_ERROR:
+    "perc.ui.profile.modern@Unable to change your password. Check the requirements and try again.",
+  PW_EXTERNAL_TITLE:
+    "perc.ui.profile.modern@Password managed outside Percussion",
+  PW_EXTERNAL_BODY:
+    "perc.ui.profile.modern@Your account uses directory or single sign-on authentication. Change your password with your identity provider or IT administrator — it cannot be updated from this profile.",
 
   // Preferences section (#2396)
   PREF_LOADING: "perc.ui.profile.modern@Loading preferences…",

--- a/WebUI/src/test/ts/api/userPasswordApi.test.ts
+++ b/WebUI/src/test/ts/api/userPasswordApi.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { changeMyPassword } from "../../../main/ts/api/user/userPasswordApi";
+import { PATHS } from "../../../main/ts/api/paths";
+import * as client from "../../../main/ts/api/client";
+
+describe("userPasswordApi.changeMyPassword", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("PUTs User-rooted body to changepw with name, password, email, roles", async () => {
+    const putSpy = vi.spyOn(client, "put").mockResolvedValueOnce(undefined);
+    await changeMyPassword({
+      name: "Admin",
+      password: "secret1",
+      email: "admin@example.com",
+      roles: ["Admin", "Editor"],
+    });
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    expect(putSpy.mock.calls[0][0]).toBe(PATHS.USER_CHANGE_PW);
+    const body = putSpy.mock.calls[0][1] as {
+      User: { name: string; password: string; email: string; roles: string[] };
+    };
+    expect(body).toEqual({
+      User: {
+        name: "Admin",
+        password: "secret1",
+        email: "admin@example.com",
+        roles: ["Admin", "Editor"],
+      },
+    });
+  });
+
+  it("trims name and defaults email/roles when omitted", async () => {
+    const putSpy = vi.spyOn(client, "put").mockResolvedValueOnce(undefined);
+    await changeMyPassword({ name: "  ed  ", password: "abcdef" });
+    const body = putSpy.mock.calls[0][1] as {
+      User: { name: string; password: string; email: string; roles: string[] };
+    };
+    expect(body.User.name).toBe("ed");
+    expect(body.User.password).toBe("abcdef");
+    expect(body.User.email).toBe("");
+    expect(body.User.roles).toEqual([]);
+  });
+
+  it("rejects blank name before calling put", async () => {
+    const putSpy = vi.spyOn(client, "put");
+    await expect(
+      changeMyPassword({ name: "   ", password: "abcdef" }),
+    ).rejects.toThrow(/User name is required/i);
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty password before calling put", async () => {
+    const putSpy = vi.spyOn(client, "put");
+    await expect(
+      changeMyPassword({ name: "Admin", password: "" }),
+    ).rejects.toThrow(/Password is required/i);
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -182,12 +182,16 @@ describe("ProfileShell", () => {
       expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
       expect(screen.getByTestId("perc-profile-avatar")).toBeTruthy();
     });
-    expect(screen.queryByText("Coming soon")).toBeNull();
+    // Scope to section status testids — avoid document-wide "Coming soon" text match.
     expect(PROFILE_MSG.COMING_SOON).toContain("Coming soon");
-    expect(screen.queryByTestId("perc-profile-section-account-status")).toBeNull();
-    expect(screen.queryByTestId("perc-profile-section-security-status")).toBeNull();
-    expect(screen.queryByTestId("perc-profile-section-preferences-status")).toBeNull();
-    expect(screen.queryByTestId("perc-profile-section-avatar-status")).toBeNull();
+    for (const statusId of [
+      "perc-profile-section-account-status",
+      "perc-profile-section-security-status",
+      "perc-profile-section-preferences-status",
+      "perc-profile-section-avatar-status",
+    ]) {
+      expect(screen.queryByTestId(statusId)).toBeNull();
+    }
   });
 
   it("makes section landmarks focusable skip targets (tabIndex=-1)", async () => {

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -72,6 +72,12 @@ function renderShell() {
   );
 }
 
+vi.mock("../../../main/ts/api/user/userPasswordApi", () => ({
+  changeMyPassword: vi.fn().mockResolvedValue(undefined),
+  MIN_PASSWORD_LENGTH: 6,
+  validatePasswordChange: vi.fn().mockReturnValue({ ok: true }),
+}));
+
 vi.mock("../../../main/ts/api/user/userProfileApi", () => ({
   getCurrentUserProfile: vi.fn().mockResolvedValue({
     name: "Admin",
@@ -112,7 +118,7 @@ describe("ProfileShell", () => {
     };
   });
 
-  it("renders title, intro, four sections, live account/preferences/avatar", async () => {
+  it("renders title, intro, four sections, live account/security/preferences/avatar", async () => {
     renderShell();
     expect(screen.getByTestId("perc-profile-shell")).toBeTruthy();
     expect(screen.getByTestId("perc-profile-title").textContent).toBe("My profile");
@@ -129,6 +135,8 @@ describe("ProfileShell", () => {
       expect(screen.getByTestId("perc-profile-account-login").textContent).toBe(
         "Admin",
       );
+      expect(screen.getByTestId("perc-profile-security")).toBeTruthy();
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
       expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
       expect(screen.getByTestId("perc-profile-avatar")).toBeTruthy();
     });
@@ -166,21 +174,20 @@ describe("ProfileShell", () => {
     );
   });
 
-  it("marks only security as coming soon; account/preferences/avatar live", async () => {
+  it("marks no section as coming soon; all four sections live", async () => {
     renderShell();
     await waitFor(() => {
       expect(screen.getByTestId("perc-profile-account")).toBeTruthy();
+      expect(screen.getByTestId("perc-profile-security")).toBeTruthy();
       expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
       expect(screen.getByTestId("perc-profile-avatar")).toBeTruthy();
     });
-    const statuses = screen.getAllByText("Coming soon");
-    // Only Security remains a placeholder
-    expect(statuses.length).toBe(1);
+    expect(screen.queryByText("Coming soon")).toBeNull();
     expect(PROFILE_MSG.COMING_SOON).toContain("Coming soon");
     expect(screen.queryByTestId("perc-profile-section-account-status")).toBeNull();
+    expect(screen.queryByTestId("perc-profile-section-security-status")).toBeNull();
     expect(screen.queryByTestId("perc-profile-section-preferences-status")).toBeNull();
     expect(screen.queryByTestId("perc-profile-section-avatar-status")).toBeNull();
-    expect(screen.getByTestId("perc-profile-section-security-status")).toBeTruthy();
   });
 
   it("makes section landmarks focusable skip targets (tabIndex=-1)", async () => {

--- a/WebUI/src/test/ts/profile/SecuritySection.test.tsx
+++ b/WebUI/src/test/ts/profile/SecuritySection.test.tsx
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SecuritySection } from "../../../main/ts/profile/SecuritySection";
+import type { CurrentUserProfile } from "../../../main/ts/api/user/userProfileApi";
+import {
+  MIN_PASSWORD_LENGTH,
+  validatePasswordChange,
+} from "../../../main/ts/api/user/userPasswordApi";
+
+function internalProfile(
+  overrides: Partial<CurrentUserProfile> = {},
+): CurrentUserProfile {
+  return {
+    name: "Admin",
+    email: "admin@example.com",
+    providerType: "INTERNAL",
+    roles: ["Admin"],
+    communities: ["Default"],
+    currentCommunity: "Default",
+    adminUser: true,
+    designerUser: false,
+    accessibilityUser: false,
+    emailEditable: true,
+    ...overrides,
+  };
+}
+
+const labels = {
+  required: "Enter a password.",
+  tooShort: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+  mismatch: "Passwords do not match.",
+};
+
+describe("validatePasswordChange", () => {
+  it("requires both fields", () => {
+    const r = validatePasswordChange("", "", labels);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.fields.newPassword).toBe(labels.required);
+      expect(r.fields.confirmPassword).toBe(labels.required);
+    }
+  });
+
+  it("enforces min length", () => {
+    const r = validatePasswordChange("abc", "abc", labels);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.fields.newPassword).toBe(labels.tooShort);
+    }
+  });
+
+  it("requires confirm match", () => {
+    const r = validatePasswordChange("abcdef", "abcdeg", labels);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.fields.confirmPassword).toBe(labels.mismatch);
+    }
+  });
+
+  it("accepts valid matching password", () => {
+    const r = validatePasswordChange("abcdef", "abcdef", labels);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("SecuritySection", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+  });
+
+  it("renders change-password form for INTERNAL users", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    render(<SecuritySection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("perc-profile-security-new-password"),
+    ).toHaveAttribute("type", "password");
+    expect(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+    ).toHaveAttribute("type", "password");
+    expect(screen.getByTestId("perc-profile-security-submit")).toBeTruthy();
+    expect(screen.queryByTestId("perc-profile-security-external")).toBeNull();
+  });
+
+  it("shows external explanation for DIRECTORY users (no form)", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        name: "ldap.user",
+        providerType: "DIRECTORY",
+        emailEditable: false,
+      }),
+    );
+    render(<SecuritySection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-external")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("perc-profile-security-external-body").textContent,
+    ).toMatch(/directory|single sign-on/i);
+    expect(screen.queryByTestId("perc-profile-security-form")).toBeNull();
+    expect(
+      screen.queryByTestId("perc-profile-security-submit"),
+    ).toBeNull();
+  });
+
+  it("client validation: too short and mismatch set aria-invalid", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const changePassword = vi.fn();
+    render(
+      <SecuritySection
+        loadProfile={loadProfile}
+        changePassword={changePassword}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("perc-profile-security-new-password"), {
+      target: { value: "ab" },
+    });
+    fireEvent.change(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+      { target: { value: "ab" } },
+    );
+    fireEvent.click(screen.getByTestId("perc-profile-security-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-security-new-error"),
+      ).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("perc-profile-security-new-password"),
+    ).toHaveAttribute("aria-invalid", "true");
+    expect(changePassword).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId("perc-profile-security-new-password"), {
+      target: { value: "abcdef" },
+    });
+    fireEvent.change(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+      { target: { value: "abcdeg" } },
+    );
+    fireEvent.click(screen.getByTestId("perc-profile-security-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-security-confirm-error"),
+      ).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+    ).toHaveAttribute("aria-invalid", "true");
+    expect(changePassword).not.toHaveBeenCalled();
+  });
+
+  it("submits change password and announces success in live region", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const changePassword = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SecuritySection
+        loadProfile={loadProfile}
+        changePassword={changePassword}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("perc-profile-security-new-password"), {
+      target: { value: "newpass1" },
+    });
+    fireEvent.change(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+      { target: { value: "newpass1" } },
+    );
+    fireEvent.click(screen.getByTestId("perc-profile-security-submit"));
+
+    await waitFor(() => {
+      expect(changePassword).toHaveBeenCalledWith({
+        name: "Admin",
+        password: "newpass1",
+        email: "admin@example.com",
+        roles: ["Admin"],
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-security-success").textContent,
+      ).toMatch(/password was changed/i);
+    });
+    const status = screen.getByTestId("perc-profile-security-status");
+    expect(status.getAttribute("role")).toBe("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(
+      (
+        screen.getByTestId(
+          "perc-profile-security-new-password",
+        ) as HTMLInputElement
+      ).value,
+    ).toBe("");
+  });
+
+  it("maps API failure to form error live region", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const changePassword = vi.fn().mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "Server rejected password" },
+    });
+    render(
+      <SecuritySection
+        loadProfile={loadProfile}
+        changePassword={changePassword}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("perc-profile-security-new-password"), {
+      target: { value: "newpass1" },
+    });
+    fireEvent.change(
+      screen.getByTestId("perc-profile-security-confirm-password"),
+      { target: { value: "newpass1" } },
+    );
+    fireEvent.click(screen.getByTestId("perc-profile-security-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-security-form-error").textContent,
+      ).toContain("Server rejected password");
+    });
+    expect(screen.queryByTestId("perc-profile-security-success")).toBeNull();
+  });
+
+  it("shows load error with retry", async () => {
+    const loadProfile = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 500, statusText: "Error", body: null })
+      .mockResolvedValueOnce(internalProfile());
+    render(<SecuritySection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-security-load-error"),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-profile-security-retry"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-security-form")).toBeTruthy();
+    });
+    expect(loadProfile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -26951,6 +26951,52 @@ Niezapisane zmiany w „{1}” mogą zostać utracone.</seg></tuv></tu>
     <tu tuid="perc.ui.profile.modern@None">
       <tuv xml:lang="en-us"><seg>None</seg></tuv>
     <tuv xml:lang="lou"><seg>None</seg></tuv><tuv xml:lang="pl"><seg>Nic</seg></tuv></tu>
+    <!-- Issue #2394 / parent #2374 slice 3: Profile Security password section (en-us source; other locales fall back) -->
+    <tu tuid="perc.ui.profile.modern@Change your password when your account uses local authentication, or learn how directory and SSO accounts manage credentials.">
+      <tuv xml:lang="en-us"><seg>Change your password when your account uses local authentication, or learn how directory and SSO accounts manage credentials.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Loading security settings…">
+      <tuv xml:lang="en-us"><seg>Loading security settings…</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Could not load security settings.">
+      <tuv xml:lang="en-us"><seg>Could not load security settings.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@New password">
+      <tuv xml:lang="en-us"><seg>New password</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Confirm new password">
+      <tuv xml:lang="en-us"><seg>Confirm new password</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Use at least {0} characters. Server password rules still apply.">
+      <tuv xml:lang="en-us"><seg>Use at least {0} characters. Server password rules still apply.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Enter a password.">
+      <tuv xml:lang="en-us"><seg>Enter a password.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Password must be at least {0} characters.">
+      <tuv xml:lang="en-us"><seg>Password must be at least {0} characters.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Passwords do not match.">
+      <tuv xml:lang="en-us"><seg>Passwords do not match.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Change password">
+      <tuv xml:lang="en-us"><seg>Change password</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Updating password…">
+      <tuv xml:lang="en-us"><seg>Updating password…</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Your password was changed.">
+      <tuv xml:lang="en-us"><seg>Your password was changed.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Unable to change your password. Check the requirements and try again.">
+      <tuv xml:lang="en-us"><seg>Unable to change your password. Check the requirements and try again.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Password managed outside Percussion">
+      <tuv xml:lang="en-us"><seg>Password managed outside Percussion</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Your account uses directory or single sign-on authentication. Change your password with your identity provider or IT administrator — it cannot be updated from this profile.">
+      <tuv xml:lang="en-us"><seg>Your account uses directory or single sign-on authentication. Change your password with your identity provider or IT administrator — it cannot be updated from this profile.</seg></tuv>
+    </tu>
     <!-- Security Audit Log Admin UI (Phase 4 / #2619) — en-us source + lou -->
     <tu tuid="perc.ui.admin@System Tools">
       <tuv xml:lang="en-us"><seg>System Tools</seg></tuv>

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -837,11 +837,10 @@ hub chrome (`perc-profile-shell`).
 | Account edit | `tests/profile-account.spec.js` | `[data-testid="perc-profile-account"]` | #2395 |
 | Preferences | `tests/profile-preferences.spec.js` | `[data-testid="perc-profile-preferences"]` | #2396 |
 | Avatar / Gravatar | `tests/profile-avatar.spec.js` | `[data-testid="perc-profile-avatar"]` | #2397 |
-| Password (local auth) | *not on main yet* | — | #2394 (still open) — residual when form lands |
+| Password (local auth) | `tests/profile-password.spec.js` | `[data-testid="perc-profile-security"]` | #2394 / residual #2647 |
 
-Account also scans after a client email-validation error so `aria-invalid` /
-error live region stay free of serious/critical issues. Password form axe is
-intentionally out of scope until #2394 merges.
+Account and password also scan after a client validation error so `aria-invalid` /
+error live regions stay free of serious/critical issues.
 
 ```bash
 # After qa-up — path-filtered only (do not run full suite)
@@ -858,6 +857,10 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
   ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
   npm run test:surface -- --path tests/profile-avatar.spec.js --grep "axe-core"
 
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/profile-password.spec.js --grep "axe-core"
+
 # Multi-path landed form surfaces (axe only)
 TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
   ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
@@ -865,12 +868,14 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
     --path tests/profile-account.spec.js \
     --path tests/profile-preferences.spec.js \
     --path tests/profile-avatar.spec.js \
+    --path tests/profile-password.spec.js \
     --grep "axe-core"
 
 # List only (no live CMS)
 npm run test:surface:list -- --path tests/profile-account.spec.js
 npm run test:surface:list -- --path tests/profile-preferences.spec.js
 npm run test:surface:list -- --path tests/profile-avatar.spec.js
+npm run test:surface:list -- --path tests/profile-password.spec.js
 ```
 
 **`run-surface` refuses the full suite** unless you pass `--allow-full` (agents must

--- a/modules/perc-qa-automation/frontend/tests/profile-password.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-password.spec.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Profile Security password section smoke (#2394 / parent #2374 slice 3).
+ * Also covers residual #2647 axe form gate once password form is on the page.
+ *
+ * Surface-filtered only — not full suite:
+ *   npm run test:surface -- --path tests/profile-password.spec.js
+ *
+ * Axe form root (#2647):
+ *   npm run test:surface -- --path tests/profile-password.spec.js --grep "axe-core"
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Covers: INTERNAL Admin change-password form mount, client validation
+ * (agent-safe), optional success+restore when ADMIN_PASSWORD is available,
+ * and axe serious/critical zero on [data-testid="perc-profile-security"].
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+/** Form root for password / security section (not the whole profile shell). */
+const SECURITY_FORM_SCOPE = '[data-testid="perc-profile-security"]';
+
+function profileDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function expectSecurityMounted(page) {
+  await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-profile-section-security")).toBeVisible();
+  await expect(page.getByTestId("perc-profile-security")).toBeVisible({
+    timeout: 30_000,
+  });
+  // Loading finishes → form (Admin is INTERNAL) or external box
+  await expect(
+    page
+      .getByTestId("perc-profile-security-form")
+      .or(page.getByTestId("perc-profile-security-external")),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("Profile security password @profile @password @security @smoke", () => {
+  test("deep link shows change-password form for Admin (INTERNAL)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSecurityMounted(page);
+
+    await expect(page.getByTestId("perc-profile-security-form")).toBeVisible();
+    await expect(
+      page.getByTestId("perc-profile-security-new-password"),
+    ).toHaveAttribute("type", "password");
+    await expect(
+      page.getByTestId("perc-profile-security-confirm-password"),
+    ).toHaveAttribute("type", "password");
+    await expect(
+      page.getByTestId("perc-profile-security-submit"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("perc-profile-security-external"),
+    ).toHaveCount(0);
+  });
+
+  /**
+   * #2647 residual of #2503 — axe serious/critical zero on security form root
+   * after mount (labels, controls, live region wiring).
+   */
+  test("axe-core a11y gate — security form root (#2647)", async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSecurityMounted(page);
+    await expect(page.getByTestId("perc-profile-security-form")).toBeVisible();
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: SECURITY_FORM_SCOPE,
+    });
+  });
+
+  /**
+   * #2647 — axe after client validation error so aria-invalid / error live
+   * region on password fields stay free of serious/critical issues.
+   */
+  test("axe-core a11y gate — security form with validation error (#2647)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSecurityMounted(page);
+
+    await page.getByTestId("perc-profile-security-new-password").fill("ab");
+    await page
+      .getByTestId("perc-profile-security-confirm-password")
+      .fill("ab");
+    await page.getByTestId("perc-profile-security-submit").click();
+    await expect(
+      page.getByTestId("perc-profile-security-new-error"),
+    ).toBeVisible();
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: SECURITY_FORM_SCOPE,
+    });
+  });
+
+  test("client validation: too short and mismatch (agent-safe)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSecurityMounted(page);
+
+    const newPw = page.getByTestId("perc-profile-security-new-password");
+    const confirm = page.getByTestId("perc-profile-security-confirm-password");
+    const submit = page.getByTestId("perc-profile-security-submit");
+
+    // Too short
+    await newPw.fill("ab");
+    await confirm.fill("ab");
+    await submit.click();
+    await expect(
+      page.getByTestId("perc-profile-security-new-error"),
+    ).toBeVisible();
+    await expect(newPw).toHaveAttribute("aria-invalid", "true");
+    await expect(page.getByTestId("perc-profile-security-success")).toHaveCount(
+      0,
+    );
+
+    // Mismatch
+    await newPw.fill("abcdef");
+    await confirm.fill("abcdeg");
+    await submit.click();
+    await expect(
+      page.getByTestId("perc-profile-security-confirm-error"),
+    ).toBeVisible();
+    await expect(confirm).toHaveAttribute("aria-invalid", "true");
+    await expect(page.getByTestId("perc-profile-security-success")).toHaveCount(
+      0,
+    );
+  });
+
+  /**
+   * Success path: change password then restore original ADMIN_PASSWORD so the
+   * suite remains stable. Skipped when ADMIN_PASSWORD is unset (agent-safe
+   * validation tests above still run).
+   */
+  test("password change success and restore when ADMIN_PASSWORD set", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const original = process.env.ADMIN_PASSWORD;
+    test.skip(
+      !original,
+      "ADMIN_PASSWORD required for success+restore path",
+    );
+
+    await loginAsAdmin(page);
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSecurityMounted(page);
+
+    const tempPassword = `TmpPw${Date.now()}a`;
+    const newPw = page.getByTestId("perc-profile-security-new-password");
+    const confirm = page.getByTestId("perc-profile-security-confirm-password");
+    const submit = page.getByTestId("perc-profile-security-submit");
+
+    await newPw.fill(tempPassword);
+    await confirm.fill(tempPassword);
+    await submit.click();
+    await expect(
+      page.getByTestId("perc-profile-security-success"),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Restore original so subsequent tests / operators keep working
+    await newPw.fill(original);
+    await confirm.fill(original);
+    await submit.click();
+    await expect(
+      page.getByTestId("perc-profile-security-success"),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -47,6 +47,21 @@ Workflow states gate who can edit and publish. Common patterns:
   documentation for your configured authenticator.
 - Protect the login endpoint behind TLS at the reverse proxy or edge.
 
+## My profile — Security (password)
+
+Authenticated users open **My profile** from the header user menu (or deep link
+`spa.jsp?entry=profile`). The **Security** section behaves by account type:
+
+| Account type | What the user sees |
+|--------------|--------------------|
+| **Internal** (local auth) | Change-password form: new password + confirm. The product calls the existing self-only `PUT /user/user/changepw` endpoint; you cannot change another user’s password from this page. |
+| **Directory / SSO** | A localized explanation that credentials are managed by the identity provider or IT — **no** password form that would always fail. |
+
+Password rules enforced by the server (complexity / history filters when configured)
+still apply. Client-side checks require a non-empty password of at least six characters
+and a matching confirmation before submit. Success and failure messages are announced
+to assistive technology via a live region.
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.


### PR DESCRIPTION
## Summary
Implements **#2394** (parent epic **#2374** slice 3 — Profile Security password/auth).

- **INTERNAL** users: accessible change-password form that reuses existing `PUT /user/user/changepw` (self-only; no parallel password store).
- **DIRECTORY/SSO** users: localized non-dead-end explanation (no always-fail form).
- Client validation (required, min length 6, confirm match) with `aria-invalid` + polite live region for success/error; API failures mapped via `formatApiError`.
- Vitest for `validatePasswordChange` + `SecuritySection`; shell tests updated so Security is live.
- Surface-filtered Playwright `tests/profile-password.spec.js` (validation agent-safe; success+restore when `ADMIN_PASSWORD` set; axe form root for residual **#2647**).
- en-us TMX keys; product-docs `users-roles.md` My profile Security notes; QA README form-axe row.

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2374

## Test plan
- [x] `cd WebUI && ../mvnw clean install` — BUILD SUCCESS (Java Surefire 43 tests; Vitest suite including profile Security/ProfileShell)
- [x] `cd modules/perc-i18n && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS
- [x] Vitest focused: SecuritySection 10 + ProfileShell 4 passed
- [x] `npm run test:surface:list -- --path tests/profile-password.spec.js` — 5 tests listed
- [ ] Live CMS surface (after qa-up): `npm run test:surface -- --path tests/profile-password.spec.js`
- [ ] Human QA: INTERNAL change password; DIRECTORY explanation; a11y

### Gates evidence
- `modules_built`: WebUI, modules/perc-i18n, modules/perc-qa-automation
- `downstream_checked`: none (no public Java API shape change; client-only reuses existing changepw)
- Product documentation: updated `product-docs/8.2/admin/users-roles.md`

## Fixes
Fixes #2394  
Closes residual axe work in #2647 (covered by profile-password axe tests)

> Co-Authored by Grok Build using grok-4.5 with agent main.
