### PR TITLE
fix(system): PSFolderAcl conversion without PSXFolderAcl/PSXObjectAcl ERROR (#3077)

### DIFF
--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderAcl.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderAcl.java
@@ -18,6 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import java.util.Iterator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -40,29 +41,68 @@ public class PSFolderAcl extends PSObjectAcl {
   }
 
   /**
-   * Just like {@link #PSFolderAcl(Element)}, in addition, there are couple extra parameters.
+   * Constructs a folder ACL by copying ACL entries from a folder's {@link PSObjectAcl} and
+   * attaching the folder's content and community ids. Prefer this over round-tripping through
+   * {@code toXml()}/{@code fromXml()} when converting a live folder ACL for cache use.
    *
+   * <p>Does not invent a separate XML root name: folder ACLs share the {@code PSXObjectAcl} wire
+   * format of {@link PSObjectAcl}.
+   *
+   * @param source the object ACL to copy, may not be <code>null</code>
    * @param contentId The id of the folder for which this ACL defines security settings.
    * @param communityId The community id of the folder for which this ACL defines security settings.
+   * @throws IllegalArgumentException if <code>source</code> is <code>null</code>
+   */
+  public PSFolderAcl(PSObjectAcl source, int contentId, int communityId) {
+    super();
+    if (source == null) {
+      throw new IllegalArgumentException("source may not be null");
+    }
+    m_contentId = contentId;
+    m_communityId = communityId;
+    copyEntriesFrom(source);
+  }
+
+  /**
+   * Just like {@link #PSFolderAcl(Element)}, except content and community ids are supplied by the
+   * caller rather than read from element attributes. Accepts a {@code PSXObjectAcl} root element
+   * (the wire format produced by {@link PSObjectAcl#toXml(Document)}).
+   *
+   * @param element the element to load from, may not be <code>null</code>
+   * @param contentId The id of the folder for which this ACL defines security settings.
+   * @param communityId The community id of the folder for which this ACL defines security settings.
+   * @throws IllegalArgumentException if element is <code>null</code>
+   * @throws PSUnknownNodeTypeException if element is not of expected format.
    */
   public PSFolderAcl(Element element, int contentId, int communityId)
       throws PSUnknownNodeTypeException {
-    super(element);
+    // Empty super first: Element construction via PSDbComponentSet uses defaultNodeNameFor
+    // (PSFolderAcl → PSXFolderAcl), which does not match the shared PSXObjectAcl wire format.
+    // After full construction, fromXml honors PSObjectAcl.getNodeName() → PSXObjectAcl.
+    super();
+    if (element == null) {
+      throw new IllegalArgumentException("element may not be null");
+    }
+    super.fromXml(element);
     m_contentId = contentId;
     m_communityId = communityId;
   }
 
   /**
    * Constructs this object from the supplied element. See <code>fromXml()</code> for the expected
-   * form of xml.
+   * form of xml. Root element name is {@code PSXObjectAcl} (same as {@link PSObjectAcl}), with
+   * additional {@code contentId} and {@code communityId} attributes.
    *
    * @param element the element to load from, may not be <code>null</code>
    * @throws IllegalArgumentException if element is <code>null</code>
    * @throws PSUnknownNodeTypeException if element is not of expected format.
    */
   public PSFolderAcl(Element element) throws PSUnknownNodeTypeException {
-    super(element);
-    loadState(element);
+    super();
+    if (element == null) {
+      throw new IllegalArgumentException("element may not be null");
+    }
+    fromXml(element);
   }
 
   /**
@@ -119,6 +159,19 @@ public class PSFolderAcl extends PSObjectAcl {
   private void loadState(Element src) throws PSUnknownNodeTypeException {
     m_communityId = getIntAttrVal(src, XML_ATTR_COMMUNITYID);
     m_contentId = getIntAttrVal(src, XML_ATTR_CONTENTID);
+  }
+
+  /**
+   * Copies ACL entries from {@code source} into this set. Entries are cloned so the source
+   * collection is not shared with the folder ACL cache entry.
+   *
+   * @param source never {@code null}
+   */
+  private void copyEntriesFrom(PSObjectAcl source) {
+    Iterator<PSObjectAclEntry> entries = source.iterator();
+    while (entries.hasNext()) {
+      add((PSObjectAclEntry) entries.next().clone());
+    }
   }
 
   /**

--- a/system/src/main/java/com/percussion/server/cache/PSFolderEntry.java
+++ b/system/src/main/java/com/percussion/server/cache/PSFolderEntry.java
@@ -23,7 +23,6 @@ import com.percussion.cms.objectstore.PSFolderProperty;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.services.legacy.data.PSItemEntry;
-import com.percussion.xml.PSXmlDocumentBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.transaction.annotation.Transactional;
@@ -158,12 +157,14 @@ public class PSFolderEntry extends PSItemEntry {
    * @param folder the updated folder object.
    */
   void updateFolder(PSFolder folder) {
-    // create a PSFolderAcl from a PSObjectAcl
+    // Convert folder PSObjectAcl → PSFolderAcl without XML root-name mismatch
+    // (PSXObjectAcl vs derived PSXFolderAcl). See #3077.
     PSFolderAcl acl = null;
     try {
       int contentId = ((PSLocator) folder.getLocator()).getId();
-      Document doc = PSXmlDocumentBuilder.createXmlDocument();
-      acl = new PSFolderAcl(folder.getAcl().toXml(doc), contentId, folder.getCommunityId());
+      if (folder.getAcl() != null) {
+        acl = new PSFolderAcl(folder.getAcl(), contentId, folder.getCommunityId());
+      }
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));

--- a/system/src/test/java/com/percussion/cms/objectstore/PSFolderAclConversionTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSFolderAclConversionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc. and Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for {@link PSFolderAcl} conversion from {@link PSObjectAcl} (#3077).
+ *
+ * <p>Regression: {@code new PSFolderAcl(objectAcl.toXml(...), contentId, communityId)} used to fail
+ * with expected {@code PSXFolderAcl} vs found {@code PSXObjectAcl} because Element construction
+ * derived the root name from the subclass while the wire format remains {@code PSXObjectAcl}.
+ */
+public class PSFolderAclConversionTest {
+
+  private static PSObjectAcl sampleObjectAcl() {
+    PSObjectAcl acl = new PSObjectAcl();
+    acl.add(
+        new PSObjectAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+            PSObjectAclEntry.ACCESS_WRITE));
+    acl.add(
+        new PSObjectAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_TYPE_USER, "admin1", PSObjectAclEntry.ACCESS_ADMIN));
+    return acl;
+  }
+
+  @Test
+  public void fromObjectAclCopiesEntriesAndIdsWithoutXml() {
+    PSObjectAcl source = sampleObjectAcl();
+    int contentId = 301;
+    int communityId = 10;
+
+    PSFolderAcl folderAcl = new PSFolderAcl(source, contentId, communityId);
+
+    assertEquals(contentId, folderAcl.getContentId());
+    assertEquals(communityId, folderAcl.getCommunityId());
+    assertEquals(2, folderAcl.size());
+    assertNotNull(
+        folderAcl.getAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL));
+    assertEquals(
+        PSObjectAclEntry.ACCESS_WRITE,
+        folderAcl
+            .getAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL)
+            .getPermissions());
+    assertNotNull(folderAcl.getAclEntry("admin1", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+
+    // Cloned entries: mutating the source must not change the folder ACL
+    PSObjectAclEntry sourceEveryone =
+        source.getAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL);
+    sourceEveryone.setPermissions(PSObjectAclEntry.ACCESS_READ);
+    assertEquals(
+        PSObjectAclEntry.ACCESS_WRITE,
+        folderAcl
+            .getAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL)
+            .getPermissions());
+    assertNotSame(
+        sourceEveryone,
+        folderAcl.getAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL));
+  }
+
+  @Test
+  public void fromObjectAclRejectsNullSource() {
+    assertThrows(IllegalArgumentException.class, () -> new PSFolderAcl((PSObjectAcl) null, 1, 1));
+  }
+
+  @Test
+  public void elementCtorAcceptsPsObjectAclToXmlOutput() throws Exception {
+    PSObjectAcl source = sampleObjectAcl();
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = source.toXml(doc);
+
+    assertEquals(PSObjectAcl.XML_NODE_NAME, xml.getNodeName());
+
+    // Historic PSFolderEntry.updateFolder path — must not throw wrong-type on PSXObjectAcl
+    PSFolderAcl fromXml = new PSFolderAcl(xml, 501, -1);
+
+    assertEquals(501, fromXml.getContentId());
+    assertEquals(-1, fromXml.getCommunityId());
+    assertEquals(2, fromXml.size());
+    assertNotNull(fromXml.getAclEntry("admin1", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+    assertNotNull(
+        fromXml.getAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL));
+  }
+
+  @Test
+  public void folderAclXmlRoundTripKeepsPsObjectAclRootAndIds() throws Exception {
+    PSFolderAcl original = new PSFolderAcl(sampleObjectAcl(), 42, 7);
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+
+    assertEquals(PSObjectAcl.XML_NODE_NAME, xml.getNodeName());
+    assertEquals("42", xml.getAttribute("contentId"));
+    assertEquals("7", xml.getAttribute("communityId"));
+
+    PSFolderAcl restored = new PSFolderAcl(xml);
+    assertEquals(42, restored.getContentId());
+    assertEquals(7, restored.getCommunityId());
+    assertEquals(2, restored.size());
+    assertTrue(original.equals(restored));
+  }
+
+  @Test
+  public void emptyObjectAclConversionYieldsEmptyFolderAcl() {
+    PSFolderAcl folderAcl = new PSFolderAcl(new PSObjectAcl(), 9, 3);
+    assertEquals(9, folderAcl.getContentId());
+    assertEquals(3, folderAcl.getCommunityId());
+    assertEquals(0, folderAcl.size());
+    assertNull(folderAcl.getAclEntry("anyone", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+  }
+}

--- a/system/src/test/java/com/percussion/server/cache/PSFolderEntryUpdateFolderTest.java
+++ b/system/src/test/java/com/percussion/server/cache/PSFolderEntryUpdateFolderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc. and Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.percussion.cms.objectstore.PSFolder;
+import com.percussion.cms.objectstore.PSFolderAcl;
+import com.percussion.cms.objectstore.PSObjectAcl;
+import com.percussion.cms.objectstore.PSObjectAclEntry;
+import com.percussion.cms.objectstore.PSObjectPermissions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link PSFolderEntry#updateFolder(PSFolder)} ACL conversion (#3077). Ensures Assets-style
+ * permission reset can cache a {@link PSFolderAcl} without the historic PSXFolderAcl vs
+ * PSXObjectAcl ERROR path leaving {@code m_folderAcl} null.
+ */
+public class PSFolderEntryUpdateFolderTest {
+
+  @Test
+  public void updateFolderCachesFolderAclFromObjectAcl() {
+    PSFolder folder =
+        new PSFolder("Assets", 1001, 10, PSObjectPermissions.ACCESS_WRITE, "root assets");
+    PSObjectAcl acl = new PSObjectAcl();
+    acl.add(
+        new PSObjectAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+            PSObjectAclEntry.ACCESS_WRITE));
+    folder.setAcl(acl);
+
+    // Package ctor calls updateFolder — same conversion path as cache refresh after setDefaultPermissions
+    PSFolderEntry entry = new PSFolderEntry(folder);
+
+    PSFolderAcl cached = entry.getFolderAcl();
+    assertNotNull(cached, "folder ACL must be cached after updateFolder");
+    assertEquals(1001, cached.getContentId());
+    assertEquals(10, cached.getCommunityId());
+    assertEquals(1, cached.size());
+    assertNotNull(
+        cached.getAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL));
+    assertEquals(
+        PSObjectAclEntry.ACCESS_WRITE,
+        cached
+            .getAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE, PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL)
+            .getPermissions());
+    assertEquals("Assets", entry.getName());
+  }
+
+  @Test
+  public void updateFolderWithEmptyAclStillCachesEmptyFolderAcl() {
+    PSFolder folder =
+        new PSFolder("EmptyAcl", 55, -1, PSObjectPermissions.ACCESS_READ, "no entries");
+    // PSFolder starts with an empty PSObjectAcl
+    PSFolderEntry entry = new PSFolderEntry(folder);
+
+    PSFolderAcl cached = entry.getFolderAcl();
+    assertNotNull(cached);
+    assertEquals(55, cached.getContentId());
+    assertEquals(-1, cached.getCommunityId());
+    assertEquals(0, cached.size());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes startup ERROR in `PSFolderEntry` when Assets folder permissions are reset:

`A <PSXFolderAcl> XML element was expected but a <PSXObjectAcl> XML element was found instead.`

**Root cause:** `updateFolder` built `PSFolderAcl` via `folder.getAcl().toXml()` → `new PSFolderAcl(Element, contentId, communityId)`. Element construction used `defaultNodeNameFor(PSFolderAcl.class)` → `PSXFolderAcl`, while `PSObjectAcl.toXml()` emits `PSXObjectAcl`. The exception was caught and logged, leaving `m_folderAcl` null.

**Fix:**
- Add `PSFolderAcl(PSObjectAcl, contentId, communityId)` that copies/clones ACL entries (preferred conversion API; no new wire format).
- Fix Element constructors to call `fromXml` after empty `super()` so the shared `PSXObjectAcl` root is accepted.
- `PSFolderEntry.updateFolder` uses the conversion ctor.

**Grep:** only `PSFolderEntry` used `new PSFolderAcl(.*toXml` — fixed. Other call sites use `new PSFolderAcl(contentId, communityId)`.

Parent tracker: #3077

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Unit: `PSFolderAclConversionTest` — object-acl conversion, Element path from `PSObjectAcl.toXml()`, XML round-trip, null reject
- [x] Unit: `PSFolderEntryUpdateFolderTest` — cache populates folder ACL after update (Assets-style Everyone R/W entry)
- [x] Module: `cd system && ../mvnw clean install` — BUILD SUCCESS
- [ ] Optional post-merge: clean CMS H2 start log has no PSXFolderAcl vs PSXObjectAcl ERROR; `//Folders/$/Assets` default permissions remain Everyone R/W

## Gates evidence

**modules_built:** system

**build_evidence:**
```
cd system
../mvnw clean install
# BUILD SUCCESS
# Tests run: 1943, Failures: 0, Errors: 0, Skipped: 241
# Focused: PSFolderAclConversionTest (5), PSFolderEntryUpdateFolderTest (2) — green
```

**downstream_checked:** grep monorepo for `extends PSFolderAcl` (none) and `new PSFolderAcl` (only id-based ctors + this fix; no reverse-dep signature break — additive ctor only). C2 reverse-dep install not required (no final/signature break of existing overloads).

**Product documentation:** N/A — internal ACL cache conversion / startup ERROR noise; default permission behavior unchanged.

## Erlang self-review

- No path/file I/O changes
- Behavioral unit tests for new conversion + Element path + `updateFolder`
- No new XML root inventing PSXFolderAcl wire format
- Entries cloned so cache does not share mutable ACL entries with folder object

Fixes #3077

> Co-Authored by Grok Build using grok-4.5 with agent main.