### PR TITLE
fix(objectstore): ObjectStoreErrorCodes batch M modules/utils (#3082)

### DIFF
--- a/modules/utils/src/main/java/com/percussion/design/objectstore/ObjectStoreErrorCode.java
+++ b/modules/utils/src/main/java/com/percussion/design/objectstore/ObjectStoreErrorCode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import com.percussion.error.IPSErrorCode;
+
+/**
+ * Utils-local typed peers for the structural object-store XML codes used from this module.
+ *
+ * <p>Modules that depend on {@code audit-log} should prefer {@code
+ * com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes}. Utils cannot depend on
+ * {@code audit-log} ({@code audit-log} depends on utils), so these {@link IPSErrorCode} values
+ * carry the same numeric codes and non-auditable policy for typed {@link
+ * com.percussion.error.PSException} construction without a circular Maven dependency.
+ *
+ * <p>Numeric codes are identical to the legacy {@link IPSObjectStoreErrors} ints and to the
+ * matching {@code ObjectStoreErrorCodes} enum constants (2012 / 2014 / 2015).
+ */
+public enum ObjectStoreErrorCode implements IPSErrorCode {
+
+  /** Peer of {@link IPSObjectStoreErrors#XML_ELEMENT_WRONG_TYPE} / ObjectStoreErrorCodes same. */
+  XML_ELEMENT_WRONG_TYPE(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE),
+
+  /** Peer of {@link IPSObjectStoreErrors#XML_ELEMENT_INVALID_ATTR} / ObjectStoreErrorCodes same. */
+  XML_ELEMENT_INVALID_ATTR(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR),
+
+  /** Peer of {@link IPSObjectStoreErrors#XML_ELEMENT_INVALID_CHILD} / ObjectStoreErrorCodes same. */
+  XML_ELEMENT_INVALID_CHILD(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD);
+
+  private final int numericCode;
+
+  ObjectStoreErrorCode(int numericCode) {
+    this.numericCode = numericCode;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return false;
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/design/objectstore/PSUnknownNodeTypeException.java
+++ b/modules/utils/src/main/java/com/percussion/design/objectstore/PSUnknownNodeTypeException.java
@@ -92,16 +92,16 @@ public class PSUnknownNodeTypeException extends PSException {
   }
 
   /**
-   * Construct this exception using IPSObjectStore.XML_ELEMENT_INVALID_CHILD as the error message.
-   * The specified parent node, child element and PSException subclass will be used to construct the
-   * detail message.
+   * Construct this exception using {@link ObjectStoreErrorCode#XML_ELEMENT_INVALID_CHILD} as the
+   * error message. The specified parent node, child element and PSException subclass will be used
+   * to construct the detail message.
    *
    * @param parent the parent node
    * @param child the child element
    * @param e the exception to use as the error description
    */
   public PSUnknownNodeTypeException(String parent, String child, PSException e) {
-    this(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, new Object[] {parent, child, ""});
+    this(ObjectStoreErrorCode.XML_ELEMENT_INVALID_CHILD, new Object[] {parent, child, ""});
     m_exception = e;
   }
 

--- a/modules/utils/src/main/java/com/percussion/util/PSXMLDomUtil.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSXMLDomUtil.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.util;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.percussion.design.objectstore.ObjectStoreErrorCode;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlUtil;
 import java.util.ArrayList;
@@ -161,7 +161,7 @@ public class PSXMLDomUtil {
 
     if (nodeName != null && !nodeName.equals(name)) {
       Object[] args = {name, nodeName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE, args);
     }
   }
 
@@ -185,7 +185,7 @@ public class PSXMLDomUtil {
     String val = el.getAttribute(name);
     if (required && (val == null || val.trim().length() == 0)) {
       Object[] args = {el.getNodeName(), name, val};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, args);
     }
     return (val == null) ? "" : val;
   }
@@ -338,7 +338,7 @@ public class PSXMLDomUtil {
       if (!found) {
         String parentName = el.getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return index;

--- a/modules/utils/src/main/java/com/percussion/utils/exceptions/ConnectorConfigurationException.java
+++ b/modules/utils/src/main/java/com/percussion/utils/exceptions/ConnectorConfigurationException.java
@@ -17,7 +17,7 @@
 
 package com.percussion.utils.exceptions;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.percussion.design.objectstore.ObjectStoreErrorCode;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -130,7 +130,7 @@ public class ConnectorConfigurationException extends Exception {
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // get message code
@@ -140,7 +140,7 @@ public class ConnectorConfigurationException extends Exception {
       m_code = Integer.parseInt(sTemp);
     } catch (NumberFormatException e) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_MSG_CODE, sTemp == null ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get optional exception class

--- a/modules/utils/src/test/java/com/percussion/design/objectstore/PSObjectStoreErrorCodesBatchMTest.java
+++ b/modules/utils/src/test/java/com/percussion/design/objectstore/PSObjectStoreErrorCodesBatchMTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.error.PSException;
+import com.percussion.util.PSXMLDomUtil;
+import com.percussion.utils.exceptions.ConnectorConfigurationException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch M (#3082): modules/utils production call sites must throw typed {@link ObjectStoreErrorCode}
+ * (utils-local {@code IPSErrorCode} peers matching ObjectStoreErrorCodes numeric codes) — not bare
+ * {@code IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSObjectStoreErrorCodesBatchMTest {
+
+  @Test
+  public void objectStoreErrorCodePeersMatchLegacyInts() {
+    assertEquals(
+        IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+        ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE.numericCode());
+    assertEquals(
+        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+        ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR.numericCode());
+    assertEquals(
+        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+        ObjectStoreErrorCode.XML_ELEMENT_INVALID_CHILD.numericCode());
+    assertFalse(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE.isAuditable());
+    assertFalse(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR.isAuditable());
+    assertFalse(ObjectStoreErrorCode.XML_ELEMENT_INVALID_CHILD.isAuditable());
+  }
+
+  @Test
+  public void xmlDomUtilCheckNodeWrongTypeUsesTypedCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, "Actual");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> PSXMLDomUtil.checkNode(el, "Expected"));
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void xmlDomUtilCheckAttributeMissingUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, "Root");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> PSXMLDomUtil.checkAttribute(el, "req", true));
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void xmlDomUtilCheckAttributeEnumeratedIllegalUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, "Root");
+    el.setAttribute("mode", "illegal");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () ->
+                PSXMLDomUtil.checkAttributeEnumerated(
+                    el, "mode", new String[] {"default", "ok"}, false));
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void connectorConfigWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotConnectorConfigException");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new ConnectorConfigurationException(wrong));
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void connectorConfigInvalidMsgCodeUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root =
+        PSXmlDocumentBuilder.createRoot(doc, ConnectorConfigurationException.XML_NODE_NAME);
+    root.setAttribute("msgCode", "not-an-int");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new ConnectorConfigurationException(root));
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void unknownNodeTypeConvenienceCtorUsesTypedInvalidChild() {
+    PSException nested = new PSException(ObjectStoreErrorCode.XML_ELEMENT_WRONG_TYPE, "nested");
+    PSUnknownNodeTypeException ex =
+        new PSUnknownNodeTypeException("Parent", "Child", nested);
+    assertEquals(ObjectStoreErrorCode.XML_ELEMENT_INVALID_CHILD.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCode.XML_ELEMENT_INVALID_CHILD, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}


### PR DESCRIPTION
## Summary
ObjectStoreErrorCodes **batch M** residual for #3082 (parent #2616; prior L residual #3080 / PR #3081).

Migrates remaining **modules/utils** production `IPSObjectStoreErrors` call sites to typed `IPSErrorCode` construction.

**Dependency note:** `audit-log` depends on `utils`, so production utils code cannot import `com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes` without a circular Maven dependency. Batch M adds utils-local `ObjectStoreErrorCode` peers that implement `IPSErrorCode` with **identical numeric codes** (2012 / 2014 / 2015) and non-auditable policy — matching `IPSErrorCode` design ("without coupling utils to audit-log").

### Call sites
- `PSXMLDomUtil` — wrong-type / invalid-attr (checkNode, checkAttribute, checkAttributeEnumerated)
- `ConnectorConfigurationException` fromXml — wrong-type / invalid-attr
- `PSUnknownNodeTypeException` convenience ctor — invalid-child

### Out of scope (unchanged)
- DesktopContentExplorer / Swing (`PSNode`)
- `PSAclEntry` Design ACL codes
- `implements IPSObjectStoreErrors` on XmlObjectStore handler/lock manager

## Test plan
- [x] `modules/utils` standalone: `..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **374**, Failures: **0**, Errors: **0**, Skipped: **9**
- [x] New `PSObjectStoreErrorCodesBatchMTest` — **7** tests green (peer parity + all three production paths + convenience ctor)
- [x] Product documentation: **N/A** — pure tech-debt error-code call-site migration; no operator/UI/API behavior change

## Gates evidence
```
cd modules/utils
..\..\mvnw.cmd clean install
# BUILD SUCCESS · Tests run: 374, Failures: 0, Errors: 0, Skipped: 9
# modules_built=modules/utils
# downstream_checked=none (additive ObjectStoreErrorCode enum; no public method/ctor signature change, not final/sealed)
```

## Fixes
Fixes #3082  
Parent: #2616  

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.