### PR TITLE
feat(WebUI): Explorer dual-run flag + RX folder mutation switch (#3074)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/folderMutations.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/folderMutations.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dual-run folder mutation router for Content Explorer (#3074).
+ *
+ * <p>When the dual-run flag is <strong>off</strong>, delegates entirely to
+ * pathmanagement {@link pathApi}. When <strong>on</strong> and the path is
+ * under an RX-capable root ({@code /Folders}, {@code /Sites}), uses
+ * {@link rxFolderApi} (content-explorer folders REST). Browse/list stay on
+ * pathmanagement.</p>
+ *
+ * <p>ACL save ({@code saveFolderProperties}) remains on pathmanagement — the
+ * REST façade {@code RxFolder} property model is not a drop-in for CM1
+ * {@code PSFolderProperties} security UI.</p>
+ *
+ * <p>Copy ({@code moveItem} with {@code copy:true}) always stays on
+ * pathmanagement (no RX folder copy on the façade v1 surface).</p>
+ */
+
+import {
+  addNewFolder as pathAddNewFolder,
+  deleteItem as pathDeleteItem,
+  moveItem as pathMoveItem,
+  renameFolder as pathRenameFolder,
+} from "./pathApi";
+import {
+  addRxFolder,
+  deleteRxFolder,
+  loadFolderByPath,
+  moveRxFolderChildren,
+  parentFolderPath,
+  rxFolderToPathItem,
+  saveRxFolder,
+} from "./rxFolderApi";
+import { shouldUseRxFolderMutations } from "./rxFolderMutationsFlag";
+import type { PSMoveFolderItem, PSPathItem, PSRenameFolderItem } from "./types";
+
+/**
+ * Create a folder. Dual-run: RX REST under Folders/Sites when flag on.
+ */
+export async function addNewFolder(
+  path: string,
+  name: string,
+): Promise<PSPathItem> {
+  if (shouldUseRxFolderMutations(path)) {
+    const created = await addRxFolder(path, name);
+    return rxFolderToPathItem(created);
+  }
+  return pathAddNewFolder(path, name);
+}
+
+/**
+ * Rename a folder by path. Dual-run: load-by-path + save name via REST.
+ */
+export async function renameFolder(
+  body: PSRenameFolderItem,
+): Promise<PSPathItem> {
+  if (shouldUseRxFolderMutations(body.path)) {
+    const existing = await loadFolderByPath(body.path);
+    if (!existing?.id) {
+      throw new Error(
+        `renameFolder (RX): could not resolve folder id for path=${body.path}`,
+      );
+    }
+    const saved = await saveRxFolder(existing.id, { name: body.newName });
+    return rxFolderToPathItem(saved);
+  }
+  return pathRenameFolder(body);
+}
+
+/**
+ * Move (or copy) an item. Dual-run for non-copy moves under RX roots.
+ * Copy always uses pathmanagement.
+ */
+export async function moveItem(body: PSMoveFolderItem): Promise<void> {
+  if (body.copy) {
+    await pathMoveItem(body);
+    return;
+  }
+  // Prefer source path for RX gate; target must also be RX-capable when using REST.
+  if (
+    shouldUseRxFolderMutations(body.sourcePath) &&
+    shouldUseRxFolderMutations(body.targetPath)
+  ) {
+    const folder = await loadFolderByPath(body.sourcePath);
+    if (!folder?.id) {
+      throw new Error(
+        `moveItem (RX): could not resolve folder id for path=${body.sourcePath}`,
+      );
+    }
+    const sourceParent = parentFolderPath(body.sourcePath);
+    if (!sourceParent) {
+      throw new Error(
+        `moveItem (RX): cannot derive parent for path=${body.sourcePath}`,
+      );
+    }
+    await moveRxFolderChildren({
+      sourcePath: sourceParent,
+      targetPath: body.targetPath,
+      childIds: [folder.id],
+    });
+    return;
+  }
+  await pathMoveItem(body);
+}
+
+/**
+ * Delete a folder (or fall back to pathmanagement for non-folder items).
+ *
+ * <p>When dual-run is on and the path is RX-capable, attempts REST folder
+ * delete by id. On failure to resolve a folder (e.g. content item path),
+ * falls back to pathmanagement delete so non-folder deletes still work.</p>
+ */
+export async function deleteItem(path: string): Promise<void> {
+  if (shouldUseRxFolderMutations(path)) {
+    try {
+      const folder = await loadFolderByPath(path);
+      if (folder?.id) {
+        await deleteRxFolder(folder.id, false);
+        return;
+      }
+    } catch {
+      // Non-folder or not found on RX surface — pathmanagement handles items.
+    }
+  }
+  await pathDeleteItem(path);
+}
+
+/** Re-export flag helpers for call sites / tests. */
+export {
+  isRxCapableFolderPath,
+  isRxFolderMutationsEnabled,
+  shouldUseRxFolderMutations,
+} from "./rxFolderMutationsFlag";

--- a/WebUI/src/main/ts/api/contentExplorer/rxFolderApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/rxFolderApi.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typed client for the content-explorer folders REST façade (#3073 / #3074).
+ *
+ * <p>Peer of {@link pathApi} for <strong>mutations</strong> only. Browse /
+ * pagination remain on pathmanagement. Wire contract:
+ * {@code rest/.../contentexplorer/folders/ContentExplorerFoldersResource}
+ * and product-docs {@code developer/rest.md}.</p>
+ *
+ * <pre>
+ *   POST   /Rhythmyx/rest/content-explorer/folders
+ *   PUT    /Rhythmyx/rest/content-explorer/folders/by-id/{id}
+ *   POST   /Rhythmyx/rest/content-explorer/folders/move-children
+ *   DELETE /Rhythmyx/rest/content-explorer/folders/by-id/{id}?purge=
+ *   GET    /Rhythmyx/rest/content-explorer/folders/by-path/{path}
+ * </pre>
+ *
+ * <p>Base path follows content-explorer peers ({@code relationshipsApi},
+ * {@code translationsApi}): {@code /Rhythmyx/rest/content-explorer/folders}.</p>
+ */
+
+import { del, get, post, put } from "../client";
+import type { PSPathItem } from "./types";
+
+/** Wire DTO (subset) for {@code RxFolder}. */
+export interface RxFolder {
+  id?: string;
+  contentId?: number;
+  name?: string;
+  path?: string;
+  description?: string;
+  communityId?: number;
+  communityName?: string;
+  locale?: string;
+  displayFormatName?: string;
+  permissions?: number;
+  properties?: Array<{ name?: string; value?: string }>;
+}
+
+export interface AddFolderRequest {
+  name: string;
+  parentPath: string;
+  sourcePath?: string;
+}
+
+export interface FolderChildrenRequest {
+  sourcePath?: string;
+  sourceId?: string;
+  targetPath?: string;
+  targetId?: string;
+  parentPath?: string;
+  parentId?: string;
+  childIds?: string[];
+  purgeItems?: boolean;
+  checkFolderPermission?: boolean;
+}
+
+/**
+ * REST base for content-explorer folders. Hardcoded {@code /Rhythmyx/rest/…}
+ * to match relationships/translations peers; Jetty product context may still
+ * serve this path via reverse-proxy conventions used by those clients.
+ */
+export const RX_FOLDER_REST_BASE = "/Rhythmyx/rest/content-explorer/folders";
+
+/**
+ * Encode an RX / finder path for the JAX-RS {@code {path:.+}} segment.
+ *
+ * <p>Preserves a leading {@code //} repository prefix as two encoded empty
+ * segments is wrong — instead encode each non-empty segment and re-join with
+ * {@code /}. Leading double-slash is represented by prefixing the first
+ * segment path after encoding individual segments of the stripped form, then
+ * re-applying {@code //} when the original had repository form.</p>
+ *
+ * <p>Server {@code decodePath} + {@code normalizeRxPath} accept both
+ * {@code /Folders/...} and {@code //Folders/...}; we send a slash-joined
+ * encoded segment list without inventing a third dialect.</p>
+ */
+export function encodeRxFolderPath(path: string): string {
+  if (path == null || String(path).trim().length === 0) {
+    return "";
+  }
+  let p = String(path).trim().replace(/\\/g, "/");
+  const repo = p.startsWith("//");
+  // Strip leading slashes for segment split; re-apply single leading slash form
+  // (server promotes /Folders → //Folders).
+  while (p.startsWith("/")) {
+    p = p.slice(1);
+  }
+  const encoded = p
+    .split("/")
+    .filter((seg) => seg.length > 0)
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+  // Prefer single-slash form on the wire (Folders/…); server normalizes.
+  // Keep a leading slash only for pure root.
+  if (!encoded) {
+    return encodeURIComponent("/");
+  }
+  // For repository form we can still send Folders/... — adaptor promotes.
+  void repo;
+  return encoded;
+}
+
+function byPathUrl(path: string): string {
+  const suffix = encodeRxFolderPath(path);
+  return `${RX_FOLDER_REST_BASE}/by-path/${suffix}`;
+}
+
+function byIdUrl(id: string): string {
+  return `${RX_FOLDER_REST_BASE}/by-id/${encodeURIComponent(id)}`;
+}
+
+/** Map REST {@link RxFolder} to Explorer {@link PSPathItem} for callers that expect pathmanagement shape. */
+export function rxFolderToPathItem(folder: RxFolder | null | undefined): PSPathItem {
+  if (!folder) {
+    return { name: "", path: "" };
+  }
+  // Prefer finder-style single-slash path when REST returns // form so tree keys match.
+  let path = folder.path ?? "";
+  if (path.startsWith("//")) {
+    path = path.slice(1);
+  }
+  return {
+    id: folder.id,
+    name: folder.name ?? "",
+    path,
+    type: "folder",
+    category: "folder",
+    leaf: false,
+  };
+}
+
+/** Load folder by RX/finder path. */
+export async function loadFolderByPath(path: string): Promise<RxFolder> {
+  return get<RxFolder>(byPathUrl(path));
+}
+
+/** Load folder by guid / content id. */
+export async function loadFolderById(id: string): Promise<RxFolder> {
+  return get<RxFolder>(byIdUrl(id));
+}
+
+/** Create a single folder under {@code parentPath}. */
+export async function addRxFolder(
+  parentPath: string,
+  name: string,
+  sourcePath?: string,
+): Promise<RxFolder> {
+  const body: AddFolderRequest = { name, parentPath };
+  if (sourcePath) {
+    body.sourcePath = sourcePath;
+  }
+  return post<RxFolder>(RX_FOLDER_REST_BASE, body);
+}
+
+/** Save folder fields (rename via {@code name}). */
+export async function saveRxFolder(
+  id: string,
+  body: Partial<RxFolder>,
+): Promise<RxFolder> {
+  return put<RxFolder>(byIdUrl(id), body);
+}
+
+/** Move children from source parent to target parent. */
+export async function moveRxFolderChildren(
+  request: FolderChildrenRequest,
+): Promise<void> {
+  await post<void>(`${RX_FOLDER_REST_BASE}/move-children`, request);
+}
+
+/** Recursive delete folder by id. */
+export async function deleteRxFolder(
+  id: string,
+  purge = false,
+): Promise<void> {
+  const q = purge ? "?purge=true" : "?purge=false";
+  await del<void>(`${byIdUrl(id)}${q}`);
+}
+
+/**
+ * Parent path of a CMS folder path (finder or repository form).
+ *
+ * @returns parent path starting with {@code /} (or {@code //} when input was repo form),
+ *   or {@code null} when path has no parent segment.
+ */
+export function parentFolderPath(path: string | null | undefined): string | null {
+  if (path == null) {
+    return null;
+  }
+  let p = String(path).trim().replace(/\\/g, "/");
+  if (p.length === 0) {
+    return null;
+  }
+  const repo = p.startsWith("//");
+  while (p.endsWith("/") && p.length > 1) {
+    p = p.slice(0, -1);
+  }
+  const parts = p.split("/").filter((s) => s.length > 0);
+  if (parts.length <= 1) {
+    // Under a root (e.g. /Folders or //Sites) — parent is the root itself for
+    // multi-child ops when moving the only child… actually parent of /Folders/X
+    // is /Folders. Parent of /Folders is null (cannot move root).
+    return null;
+  }
+  parts.pop();
+  const joined = parts.join("/");
+  return repo ? `//${joined}` : `/${joined}`;
+}

--- a/WebUI/src/main/ts/api/contentExplorer/rxFolderMutationsFlag.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/rxFolderMutationsFlag.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dual-run feature flag for Content Explorer folder mutations (#3074 / parent #3054).
+ *
+ * <p>When <strong>off</strong> (default), Explorer create/rename/move/delete stay on
+ * pathmanagement ({@code pathApi.ts}) — zero behavior change.</p>
+ *
+ * <p>When <strong>on</strong>, mutations under RX-capable roots ({@code /Folders},
+ * {@code /Sites} and repository forms) use the content-explorer folders REST façade
+ * ({@code /Rhythmyx/rest/content-explorer/folders}). Browse / list / pagination remain
+ * on pathmanagement.</p>
+ *
+ * <h3>Resolution order (first hit wins)</h3>
+ * <ol>
+ *   <li>Test / programmatic override via {@link setRxFolderMutationsFlagOverride}</li>
+ *   <li>URL query {@code ?rxFolderMutations=1|true|on} (or {@code =0|false|off} to force off)</li>
+ *   <li>{@code sessionStorage} then {@code localStorage} key {@link RX_FOLDER_MUTATIONS_STORAGE_KEY}</li>
+ *   <li>{@code window.__PERC_RX_FOLDER_MUTATIONS__} (boolean or string)</li>
+ *   <li>Default {@code false}</li>
+ * </ol>
+ *
+ * <p>Operator-facing name (product-docs / {@code server.properties} comment):
+ * {@code perc.explorer.rxFolderMutations}. Server bootstrap injection is reserved;
+ * client dual-run uses the Explorer URL/storage pattern (peers: {@code legacyDashboard},
+ * {@code mkdLang}).</p>
+ */
+
+/** Storage / property key shared with product-docs and server.properties comments. */
+export const RX_FOLDER_MUTATIONS_STORAGE_KEY = "perc.explorer.rxFolderMutations";
+
+/** URL query param name for opt-in dual-run during QA. */
+export const RX_FOLDER_MUTATIONS_QUERY_PARAM = "rxFolderMutations";
+
+/** Window global for hosts / tests. */
+export const RX_FOLDER_MUTATIONS_WINDOW_KEY = "__PERC_RX_FOLDER_MUTATIONS__";
+
+let override: boolean | null = null;
+
+/**
+ * Force the flag for unit tests (or host harness). Pass {@code null} to clear.
+ */
+export function setRxFolderMutationsFlagOverride(value: boolean | null): void {
+  override = value;
+}
+
+/** @returns current override, or {@code null} when using live resolution. */
+export function getRxFolderMutationsFlagOverride(): boolean | null {
+  return override;
+}
+
+function parseTruthy(raw: string | null | undefined): boolean | null {
+  if (raw == null) {
+    return null;
+  }
+  const v = String(raw).trim().toLowerCase();
+  if (v === "" || v === "0" || v === "false" || v === "off" || v === "no") {
+    return false;
+  }
+  if (v === "1" || v === "true" || v === "on" || v === "yes") {
+    return true;
+  }
+  return null;
+}
+
+function readStorage(store: Storage | undefined): boolean | null {
+  if (!store) {
+    return null;
+  }
+  try {
+    return parseTruthy(store.getItem(RX_FOLDER_MUTATIONS_STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+function readWindowGlobal(): boolean | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    const w = window as unknown as Record<string, unknown>;
+    const raw = w[RX_FOLDER_MUTATIONS_WINDOW_KEY];
+    if (typeof raw === "boolean") {
+      return raw;
+    }
+    if (typeof raw === "string") {
+      return parseTruthy(raw);
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function readQueryParam(): boolean | null {
+  try {
+    if (typeof window === "undefined" || !window.location?.search) {
+      return null;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has(RX_FOLDER_MUTATIONS_QUERY_PARAM)) {
+      return null;
+    }
+    return parseTruthy(params.get(RX_FOLDER_MUTATIONS_QUERY_PARAM));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether Explorer folder mutations should use content-explorer folders REST.
+ *
+ * <p>Default {@code false}. Safe for SSR / non-browser (returns false).</p>
+ */
+export function isRxFolderMutationsEnabled(): boolean {
+  if (override !== null) {
+    return override;
+  }
+  const fromQuery = readQueryParam();
+  if (fromQuery !== null) {
+    return fromQuery;
+  }
+  try {
+    if (typeof sessionStorage !== "undefined") {
+      const fromSession = readStorage(sessionStorage);
+      if (fromSession !== null) {
+        return fromSession;
+      }
+    }
+  } catch {
+    /* private mode */
+  }
+  try {
+    if (typeof localStorage !== "undefined") {
+      const fromLocal = readStorage(localStorage);
+      if (fromLocal !== null) {
+        return fromLocal;
+      }
+    }
+  } catch {
+    /* private mode */
+  }
+  const fromWindow = readWindowGlobal();
+  if (fromWindow !== null) {
+    return fromWindow;
+  }
+  return false;
+}
+
+/**
+ * Whether a CMS path is under an RX-capable root that the content-explorer
+ * folders façade is intended to serve ({@code Folders} / {@code Sites}).
+ *
+ * <p>Accepts finder form ({@code /Folders/...}, {@code /Sites/...}) and
+ * repository form ({@code //Folders/...}, {@code //Sites/...}). Other roots
+ * ({@code /Assets}, {@code /Design}, {@code /Recycling}, …) stay on
+ * pathmanagement even when the dual-run flag is on.</p>
+ */
+export function isRxCapableFolderPath(path: string | null | undefined): boolean {
+  if (path == null) {
+    return false;
+  }
+  let p = String(path).trim().replace(/\\/g, "/");
+  if (p.length === 0) {
+    return false;
+  }
+  // Strip Windows drive letter if present.
+  if (p.length >= 2 && /[A-Za-z]/.test(p.charAt(0)) && p.charAt(1) === ":") {
+    p = p.slice(2);
+  }
+  // Collapse accidental triple+ leading slashes.
+  while (p.startsWith("///")) {
+    p = p.slice(1);
+  }
+  // Normalize to a form starting with / or //
+  if (!p.startsWith("/")) {
+    p = `/${p}`;
+  }
+  // Strip one leading slash for comparison so //Folders and /Folders share logic.
+  const withoutRepo = p.startsWith("//") ? p.slice(1) : p;
+  const lower = withoutRepo.toLowerCase();
+  return (
+    lower === "/folders" ||
+    lower.startsWith("/folders/") ||
+    lower === "/sites" ||
+    lower.startsWith("/sites/")
+  );
+}
+
+/**
+ * Dual-run gate for a specific mutation path: flag on <em>and</em> RX-capable root.
+ */
+export function shouldUseRxFolderMutations(
+  path: string | null | undefined,
+): boolean {
+  return isRxFolderMutationsEnabled() && isRxCapableFolderPath(path);
+}

--- a/WebUI/src/main/ts/contentExplorer/ReducedActions.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ReducedActions.tsx
@@ -30,7 +30,14 @@
 
 import React, { useCallback, useState } from "react";
 import { formatApiError } from "../api/client";
-import { addNewFolder, deleteItem, moveItem, renameFolder } from "../api/contentExplorer/pathApi";
+// Dual-run router (#3074): pathmanagement when flag off; RX folders REST under
+// /Folders and /Sites when perc.explorer.rxFolderMutations is on.
+import {
+  addNewFolder,
+  deleteItem,
+  moveItem,
+  renameFolder,
+} from "../api/contentExplorer/folderMutations";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { message } from "../i18n/message";
 import { isPreviewableItem } from "./previewItem";

--- a/WebUI/src/test/ts/contentExplorer/folderMutations.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderMutations.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addNewFolder,
+  deleteItem,
+  moveItem,
+  renameFolder,
+} from "../../../main/ts/api/contentExplorer/folderMutations";
+import { setRxFolderMutationsFlagOverride } from "../../../main/ts/api/contentExplorer/rxFolderMutationsFlag";
+import { mockFetch } from "./setup";
+
+describe("folderMutations dual-run routing (#3074)", () => {
+  beforeEach(() => {
+    setRxFolderMutationsFlagOverride(null);
+  });
+
+  afterEach(() => {
+    setRxFolderMutationsFlagOverride(null);
+  });
+
+  it("flag off: addNewFolder uses pathmanagement", async () => {
+    setRxFolderMutationsFlagOverride(false);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ PathItem: { name: "New", path: "/Folders/New" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await addNewFolder("/Folders", "New");
+    expect(last).toContain("/pathmanagement/path/addNewFolder");
+    expect(last).not.toContain("/content-explorer/folders");
+  });
+
+  it("flag on + RX path: addNewFolder uses content-explorer folders REST", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    let last = "";
+    let body: unknown;
+    mockFetch(async (input, init) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      body = JSON.parse(String((init as RequestInit)?.body ?? "{}"));
+      return new Response(
+        JSON.stringify({ id: "1-101-9", name: "New", path: "//Folders/New" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const item = await addNewFolder("/Folders", "New");
+    expect(last).toContain("/content-explorer/folders");
+    expect(last).not.toContain("/pathmanagement/");
+    expect(body).toEqual({ name: "New", parentPath: "/Folders" });
+    expect(item.path).toBe("/Folders/New");
+    expect(item.id).toBe("1-101-9");
+  });
+
+  it("flag on + non-RX path: stays on pathmanagement", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ PathItem: { name: "X", path: "/Assets/X" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await addNewFolder("/Assets", "X");
+    expect(last).toContain("/pathmanagement/path/addNewFolder");
+  });
+
+  it("flag on: renameFolder loads by path then PUTs by id", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    const urls: string[] = [];
+    mockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      urls.push(url);
+      const method = (init as RequestInit)?.method ?? "GET";
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({ id: "2-101-1", name: "Old", path: "//Folders/Old" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ id: "2-101-1", name: "NewName", path: "//Folders/NewName" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const item = await renameFolder({ path: "/Folders/Old", newName: "NewName" });
+    expect(urls.some((u) => u.includes("/by-path/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/by-id/2-101-1"))).toBe(true);
+    expect(item.name).toBe("NewName");
+  });
+
+  it("flag on: moveItem uses move-children with derived parent + id", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    mockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init as RequestInit)?.method ?? "GET";
+      const rawBody = (init as RequestInit)?.body;
+      calls.push({
+        url,
+        method,
+        body: rawBody ? JSON.parse(String(rawBody)) : undefined,
+      });
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({ id: "3-101-1", name: "Child", path: "//Folders/Child" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    await moveItem({
+      sourcePath: "/Folders/Child",
+      targetPath: "/Folders/Other",
+    });
+    const move = calls.find((c) => c.url.includes("/move-children"));
+    expect(move).toBeDefined();
+    expect(move!.body).toMatchObject({
+      sourcePath: "/Folders",
+      targetPath: "/Folders/Other",
+      childIds: ["3-101-1"],
+    });
+  });
+
+  it("copy always uses pathmanagement even when flag on", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ PathItem: { name: "C", path: "/Folders/C" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await moveItem({
+      sourcePath: "/Folders/Child",
+      targetPath: "/Folders/Other",
+      copy: true,
+    });
+    expect(last).toContain("/pathmanagement/path/moveItem");
+  });
+
+  it("flag on: deleteItem DELETEs by resolved folder id", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    const urls: string[] = [];
+    mockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      urls.push(url);
+      const method = (init as RequestInit)?.method ?? "GET";
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({ id: "4-101-1", name: "Gone", path: "//Folders/Gone" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    await deleteItem("/Folders/Gone");
+    expect(urls.some((u) => u.includes("DELETE") || u.includes("/by-id/4-101-1"))).toBe(
+      true,
+    );
+    expect(urls.some((u) => u.includes("/by-id/4-101-1") && u.includes("purge="))).toBe(
+      true,
+    );
+  });
+
+  it("flag off: deleteItem uses pathmanagement", async () => {
+    setRxFolderMutationsFlagOverride(false);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    await deleteItem("/Folders/Gone");
+    expect(last).toContain("/pathmanagement/path/delete");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/rxFolderApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/rxFolderApi.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  addRxFolder,
+  deleteRxFolder,
+  encodeRxFolderPath,
+  loadFolderByPath,
+  moveRxFolderChildren,
+  parentFolderPath,
+  RX_FOLDER_REST_BASE,
+  rxFolderToPathItem,
+  saveRxFolder,
+} from "../../../main/ts/api/contentExplorer/rxFolderApi";
+import { mockFetch } from "./setup";
+
+describe("encodeRxFolderPath", () => {
+  it("encodes segments without inventing a third dialect", () => {
+    expect(encodeRxFolderPath("/Folders/Foo Bar")).toBe("Folders/Foo%20Bar");
+    expect(encodeRxFolderPath("//Sites/MySite")).toBe("Sites/MySite");
+    expect(encodeRxFolderPath("Folders/Child")).toBe("Folders/Child");
+  });
+});
+
+describe("parentFolderPath", () => {
+  it("returns parent for nested finder and repo paths", () => {
+    expect(parentFolderPath("/Folders/A/B")).toBe("/Folders/A");
+    expect(parentFolderPath("//Folders/A/B")).toBe("//Folders/A");
+    expect(parentFolderPath("/Sites/MySite")).toBe("/Sites");
+  });
+
+  it("returns null at root folders", () => {
+    expect(parentFolderPath("/Folders")).toBeNull();
+    expect(parentFolderPath("//Sites")).toBeNull();
+    expect(parentFolderPath("/")).toBeNull();
+  });
+});
+
+describe("rxFolderToPathItem", () => {
+  it("maps REST folder to PSPathItem with finder-style path", () => {
+    const item = rxFolderToPathItem({
+      id: "1-101-9",
+      name: "Child",
+      path: "//Folders/Child",
+    });
+    expect(item.id).toBe("1-101-9");
+    expect(item.name).toBe("Child");
+    expect(item.path).toBe("/Folders/Child");
+    expect(item.type).toBe("folder");
+  });
+});
+
+describe("rxFolderApi HTTP", () => {
+  it("loadFolderByPath hits content-explorer folders by-path", async () => {
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ id: "1-101-1", name: "Folders", path: "//Folders" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const folder = await loadFolderByPath("/Folders");
+    expect(last).toContain(`${RX_FOLDER_REST_BASE}/by-path/Folders`);
+    expect(folder.name).toBe("Folders");
+  });
+
+  it("addRxFolder POSTs name + parentPath", async () => {
+    let method = "";
+    let body: unknown;
+    mockFetch(async (input, init) => {
+      method = (init as RequestInit)?.method ?? "GET";
+      body = JSON.parse(String((init as RequestInit)?.body ?? "{}"));
+      return new Response(
+        JSON.stringify({ id: "9-101-1", name: "New", path: "//Folders/New" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const created = await addRxFolder("/Folders", "New");
+    expect(method).toBe("POST");
+    expect(body).toEqual({ name: "New", parentPath: "/Folders" });
+    expect(created.id).toBe("9-101-1");
+  });
+
+  it("saveRxFolder PUTs by id", async () => {
+    let method = "";
+    let url = "";
+    mockFetch(async (input, init) => {
+      method = (init as RequestInit)?.method ?? "GET";
+      url = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ id: "9-101-1", name: "Renamed" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await saveRxFolder("9-101-1", { name: "Renamed" });
+    expect(method).toBe("PUT");
+    expect(url).toContain("/by-id/9-101-1");
+  });
+
+  it("moveRxFolderChildren POSTs move-children", async () => {
+    let url = "";
+    let body: unknown;
+    mockFetch(async (input, init) => {
+      url = typeof input === "string" ? input : (input as Request).url;
+      body = JSON.parse(String((init as RequestInit)?.body ?? "{}"));
+      return new Response(null, { status: 204 });
+    });
+    await moveRxFolderChildren({
+      sourcePath: "/Folders",
+      targetPath: "/Folders/Other",
+      childIds: ["9-101-1"],
+    });
+    expect(url).toContain("/move-children");
+    expect(body).toMatchObject({
+      sourcePath: "/Folders",
+      targetPath: "/Folders/Other",
+      childIds: ["9-101-1"],
+    });
+  });
+
+  it("deleteRxFolder DELETEs by id with purge query", async () => {
+    let method = "";
+    let url = "";
+    mockFetch(async (input, init) => {
+      method = (init as RequestInit)?.method ?? "GET";
+      url = typeof input === "string" ? input : (input as Request).url;
+      return new Response(null, { status: 204 });
+    });
+    await deleteRxFolder("9-101-1", false);
+    expect(method).toBe("DELETE");
+    expect(url).toContain("/by-id/9-101-1");
+    expect(url).toContain("purge=false");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/rxFolderMutationsFlag.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/rxFolderMutationsFlag.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isRxCapableFolderPath,
+  isRxFolderMutationsEnabled,
+  RX_FOLDER_MUTATIONS_STORAGE_KEY,
+  RX_FOLDER_MUTATIONS_WINDOW_KEY,
+  setRxFolderMutationsFlagOverride,
+  shouldUseRxFolderMutations,
+} from "../../../main/ts/api/contentExplorer/rxFolderMutationsFlag";
+
+describe("rxFolderMutationsFlag", () => {
+  beforeEach(() => {
+    setRxFolderMutationsFlagOverride(null);
+    try {
+      sessionStorage.removeItem(RX_FOLDER_MUTATIONS_STORAGE_KEY);
+      localStorage.removeItem(RX_FOLDER_MUTATIONS_STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    delete (window as unknown as Record<string, unknown>)[RX_FOLDER_MUTATIONS_WINDOW_KEY];
+    // Reset query string without full navigation when possible.
+    window.history.replaceState({}, "", window.location.pathname);
+  });
+
+  afterEach(() => {
+    setRxFolderMutationsFlagOverride(null);
+  });
+
+  it("defaults to false (zero behavior change)", () => {
+    expect(isRxFolderMutationsEnabled()).toBe(false);
+    expect(shouldUseRxFolderMutations("/Folders/Foo")).toBe(false);
+  });
+
+  it("honors programmatic override for tests", () => {
+    setRxFolderMutationsFlagOverride(true);
+    expect(isRxFolderMutationsEnabled()).toBe(true);
+    setRxFolderMutationsFlagOverride(false);
+    expect(isRxFolderMutationsEnabled()).toBe(false);
+  });
+
+  it("reads sessionStorage key when set", () => {
+    sessionStorage.setItem(RX_FOLDER_MUTATIONS_STORAGE_KEY, "true");
+    expect(isRxFolderMutationsEnabled()).toBe(true);
+    sessionStorage.setItem(RX_FOLDER_MUTATIONS_STORAGE_KEY, "0");
+    expect(isRxFolderMutationsEnabled()).toBe(false);
+  });
+
+  it("reads window global when set", () => {
+    (window as unknown as Record<string, unknown>)[RX_FOLDER_MUTATIONS_WINDOW_KEY] = true;
+    expect(isRxFolderMutationsEnabled()).toBe(true);
+  });
+});
+
+describe("isRxCapableFolderPath", () => {
+  it("accepts Folders and Sites finder and repository forms", () => {
+    expect(isRxCapableFolderPath("/Folders")).toBe(true);
+    expect(isRxCapableFolderPath("/Folders/Child")).toBe(true);
+    expect(isRxCapableFolderPath("//Folders/Child")).toBe(true);
+    expect(isRxCapableFolderPath("/Sites")).toBe(true);
+    expect(isRxCapableFolderPath("/Sites/MySite/section")).toBe(true);
+    expect(isRxCapableFolderPath("//Sites/MySite")).toBe(true);
+    expect(isRxCapableFolderPath("Folders/x")).toBe(true);
+  });
+
+  it("rejects non-RX roots and empty paths", () => {
+    expect(isRxCapableFolderPath(null)).toBe(false);
+    expect(isRxCapableFolderPath("")).toBe(false);
+    expect(isRxCapableFolderPath("/")).toBe(false);
+    expect(isRxCapableFolderPath("/Assets")).toBe(false);
+    expect(isRxCapableFolderPath("/Assets/uploads")).toBe(false);
+    expect(isRxCapableFolderPath("/Design")).toBe(false);
+    expect(isRxCapableFolderPath("/Recycling")).toBe(false);
+  });
+
+  it("shouldUseRxFolderMutations requires both flag and RX root", () => {
+    setRxFolderMutationsFlagOverride(true);
+    expect(shouldUseRxFolderMutations("/Folders/A")).toBe(true);
+    expect(shouldUseRxFolderMutations("/Assets/A")).toBe(false);
+    setRxFolderMutationsFlagOverride(false);
+    expect(shouldUseRxFolderMutations("/Folders/A")).toBe(false);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-rx-folder-mutations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-rx-folder-mutations.spec.js
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Surface tests: Explorer dual-run folder mutations + content-explorer folders REST
+ * (#3074 / parent #3054 / REST #3073).
+ *
+ * <p>Default product behavior is flag <strong>off</strong> (pathmanagement). This
+ * suite validates:</p>
+ * <ul>
+ *   <li>REST façade load by path for //Folders and //Sites (agent-safe H2)</li>
+ *   <li>REST create + delete under /Folders when façade is available</li>
+ *   <li>Explorer UI with dual-run flag on routes create-folder to content-explorer
+ *       folders (network assertion) when shell mounts</li>
+ * </ul>
+ *
+ * <pre>
+ *   # after perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \\
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=... \\
+ *     npm run test:surface -- --path tests/explorer-rx-folder-mutations.spec.js
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+
+const RX_FOLDERS = `${BASE_URL}/Rhythmyx/rest/content-explorer/folders`;
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&rxFolderMutations=1&_=${Date.now()}`;
+
+test.describe("Explorer RX folder mutations dual-run (#3074)", () => {
+  test("REST: load Folders root by path (content-explorer folders façade)", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const res = await request.get(`${RX_FOLDERS}/by-path/Folders`, { headers });
+    // Façade may be 200 with folder payload, or 404/503 on incomplete stacks —
+    // accept 200 as primary success; soft-skip when service unavailable.
+    if (res.status() === 503 || res.status() === 404) {
+      test.skip(
+        true,
+        `content-explorer folders by-path not available (HTTP ${res.status()})`,
+      );
+      return;
+    }
+    expect(
+      res.status(),
+      `GET ${RX_FOLDERS}/by-path/Folders should be 200`,
+    ).toBe(200);
+    const body = await res.json();
+    // Wire may be flat or root-wrapped; name/path when present should relate to Folders.
+    const name = body?.name ?? body?.RxFolder?.name;
+    const path = body?.path ?? body?.RxFolder?.path ?? "";
+    if (name) {
+      expect(String(name).toLowerCase()).toContain("folder");
+    }
+    if (path) {
+      expect(String(path).toLowerCase()).toMatch(/folders/);
+    }
+  });
+
+  test("REST: load Sites root by path", async ({ request }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const res = await request.get(`${RX_FOLDERS}/by-path/Sites`, { headers });
+    if (res.status() === 503 || res.status() === 404) {
+      test.skip(
+        true,
+        `content-explorer folders by-path Sites not available (HTTP ${res.status()})`,
+      );
+      return;
+    }
+    expect(res.status()).toBe(200);
+  });
+
+  test("REST: create then delete folder under Folders (mutation smoke)", async ({
+    request,
+  }) => {
+    test.setTimeout(60_000);
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    const folderName = `qa3074_${Date.now()}`;
+
+    const create = await request.post(RX_FOLDERS, {
+      headers,
+      data: { name: folderName, parentPath: "/Folders" },
+    });
+    if (create.status() === 503 || create.status() === 403) {
+      test.skip(
+        true,
+        `add folder not available (HTTP ${create.status()}) — façade or ACL`,
+      );
+      return;
+    }
+    expect(
+      [200, 201].includes(create.status()),
+      `POST add folder expected 200/201, got ${create.status()} body=${await create.text()}`,
+    ).toBeTruthy();
+
+    const created = await create.json();
+    const id = created?.id ?? created?.RxFolder?.id;
+    expect(id, "created folder must have id for delete").toBeTruthy();
+
+    const del = await request.delete(
+      `${RX_FOLDERS}/by-id/${encodeURIComponent(id)}?purge=false`,
+      { headers },
+    );
+    expect(
+      [200, 204].includes(del.status()),
+      `DELETE folder expected 200/204, got ${del.status()}`,
+    ).toBeTruthy();
+  });
+
+  test("UI: dual-run flag routes create-folder to content-explorer folders when used", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    const mutationUrls = [];
+    page.on("request", (req) => {
+      const u = req.url();
+      if (
+        u.includes("/content-explorer/folders") ||
+        u.includes("/pathmanagement/path/addNewFolder")
+      ) {
+        mutationUrls.push({ url: u, method: req.method() });
+      }
+    });
+
+    await page.goto(EXPLORER_URL);
+    await page.waitForLoadState("networkidle").catch(() => undefined);
+
+    // Prefer data-testid if present; otherwise reduced-actions create control.
+    const createBtn = page
+      .locator(
+        [
+          '[data-testid="explorer-create-folder"]',
+          'button:has-text("Create folder")',
+          'button:has-text("New folder")',
+          '[aria-label*="Create folder" i]',
+          '[aria-label*="New folder" i]',
+        ].join(", "),
+      )
+      .first();
+
+    const explorerChrome = page.locator(
+      '[data-testid="content-explorer"], [data-testid="explorer-shell"], [class*="ContentExplorer"]',
+    );
+
+    // If shell never mounts (route not wired on this stack), soft-pass with note.
+    const chromeVisible = await explorerChrome
+      .first()
+      .isVisible({ timeout: 15_000 })
+      .catch(() => false);
+    const createVisible = await createBtn
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+
+    if (!chromeVisible && !createVisible) {
+      test.skip(
+        true,
+        "Explorer shell/create control not visible — UI dual-run network assert skipped",
+      );
+      return;
+    }
+
+    // Navigate tree to Folders if a Folders node is present.
+    const foldersNode = page
+      .locator(
+        '[data-testid="explorer-tree"] >> text=Folders, [role="tree"] >> text=Folders, text=Folders',
+      )
+      .first();
+    if (await foldersNode.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      await foldersNode.click();
+      await page.waitForTimeout(500);
+    }
+
+    if (!createVisible) {
+      // Flag presence still validated: query param on URL for dual-run opt-in.
+      expect(page.url()).toContain("rxFolderMutations=1");
+      return;
+    }
+
+    // Intercept prompts used by reduced actions for folder name.
+    page.once("dialog", async (dialog) => {
+      await dialog.accept(`qa3074_ui_${Date.now()}`);
+    });
+
+    await createBtn.click();
+    await page.waitForTimeout(2_000);
+
+    const hitRx = mutationUrls.some((m) =>
+      m.url.includes("/content-explorer/folders"),
+    );
+    const hitPath = mutationUrls.some((m) =>
+      m.url.includes("/pathmanagement/path/addNewFolder"),
+    );
+
+    // Prefer RX when dual-run flag is on and Folders is selected; if no mutation
+    // fired (prompt cancelled / ACL), at least assert flag is in the URL.
+    if (hitRx || hitPath) {
+      expect(
+        hitRx,
+        `expected content-explorer folders mutation when flag on; saw ${JSON.stringify(mutationUrls)}`,
+      ).toBeTruthy();
+    } else {
+      expect(page.url()).toContain("rxFolderMutations=1");
+    }
+  });
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -42,6 +42,25 @@ Explorer. Use it when you need the full repository folder hierarchy rather than 
 Assets or Sites shortcuts. Expanding **Folders** loads children from the server; folder
 visibility still respects folder ACLs.
 
+## Folder mutations dual-run (optional)
+
+By default, Explorer **create / rename / move / delete** folder actions use the same
+pathmanagement REST surface as browse. Operators and QA can opt into a dual-run path that
+sends those mutations under **Folders** and **Sites** to the Rhythmyx content-explorer
+folders REST façade (`/Rhythmyx/rest/content-explorer/folders`) while list/pagination stay
+on pathmanagement.
+
+| Setting | Detail |
+|---------|--------|
+| Name | `perc.explorer.rxFolderMutations` |
+| Default | **off** |
+| Enable in browser | Append `?rxFolderMutations=1` to the Explorer URL, or set storage key `perc.explorer.rxFolderMutations` to `true` |
+| Scope when on | `/Folders` and `/Sites` (and repository `//…` forms) only |
+| Unchanged | Browse/list, folder ACL (security panel), copy, `/Assets` / `/Design` / `/Recycling` |
+
+Documented for integrators on [Public REST](id:developer-rest). Leave the flag **off** in
+production unless you are validating the RX folder façade with QA.
+
 ## Sites list and Create Site
 
 Under the tree root **Sites** you see traditional site folders available to your community

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -222,10 +222,26 @@ Accept either repository form or a documented single-slash form; the server norm
 Prefer the generated **OpenAPI** schema for wire field names. Auth and folder ACLs of the underlying
 content web service still apply.
 
+### Dual-run mutation flag (Explorer clients)
+
+Content Explorer can optionally route **folder mutations** (create / rename / move / delete)
+under **Folders** and **Sites** to this façade while **browse / list / pagination** stay on
+pathmanagement.
+
+| Item | Value |
+|------|--------|
+| Operator property name | `perc.explorer.rxFolderMutations` |
+| Default | **off** (pathmanagement only — zero behavior change) |
+| Client enable (QA / dual-run) | URL `?rxFolderMutations=1`, or `sessionStorage` / `localStorage` key `perc.explorer.rxFolderMutations=true`, or `window.__PERC_RX_FOLDER_MUTATIONS__ = true` |
+| When on | Mutations under `/Folders` and `/Sites` (and `//Folders` / `//Sites`) use this REST surface |
+| Still on pathmanagement | List/paginate, ACL folder-properties save, copy, non-RX roots (`/Assets`, `/Design`, `/Recycling`, …) |
+
+See also [Content Explorer](id:admin-content-explorer) dual-run notes.
+
 ### Migration notes
 
 - Content Explorer **browse / pagination** remains on pathmanagement until a deliberate client
-  switch; this façade ships for integrators and for a later dual-run mutation flag.
+  switch; mutation dual-run is **default off** (`perc.explorer.rxFolderMutations`).
 - Do not confuse with foldermanagement workflow assignment (`/services/folders`) or CM1
   `FoldersResource` section APIs.
 

--- a/system/config/Default/server.properties
+++ b/system/config/Default/server.properties
@@ -52,6 +52,9 @@ proxyPort=9992
 enablePagination=false
 brokenManagedLinkBehavior=deadLink
 enableDebugTools=false
+# Content Explorer dual-run folder mutations (#3074). Default off.
+# Client enable: ?rxFolderMutations=1 or storage perc.explorer.rxFolderMutations=true
+# perc.explorer.rxFolderMutations=false
 enableAuditLogging=true
 # System audit log (PSX_SYSTEM_AUDIT_LOG) retention days (NIST AU-11).
 # Default 365. Set <= 0 to disable automatic deletion.

--- a/system/config/server.properties
+++ b/system/config/server.properties
@@ -515,6 +515,26 @@ loginAutoComplete=off
 #################################################################
 sameSiteCookieMode=Lax
 
+#################################################################
+# Content Explorer dual-run: folder mutations via content-explorer
+# folders REST (#3074 / parent #3054).
+#
+# Operator-facing name: perc.explorer.rxFolderMutations
+# Default: off (pathmanagement create/rename/move/delete only).
+#
+# When on (client dual-run for QA / staged cutover), Explorer mutations
+# under /Folders and /Sites use /Rhythmyx/rest/content-explorer/folders
+# while browse/list remain on pathmanagement.
+#
+# Client enablement today (no server bootstrap required):
+#   URL ?rxFolderMutations=1
+#   sessionStorage/localStorage perc.explorer.rxFolderMutations=true
+#   window.__PERC_RX_FOLDER_MUTATIONS__ = true
+#
+# Uncomment / set true only when coordinating a dual-run validation.
+# perc.explorer.rxFolderMutations=false
+#################################################################
+
 ###########################################################################
 # allowedOrigins
 #  The property to control the access control allowed origin


### PR DESCRIPTION
## Summary

Implements **Explorer dual-run** for folder mutations after the #3073 content-explorer folders REST façade (#3084).

- **Flag** `perc.explorer.rxFolderMutations` **default OFF** — zero behavior change
- **When ON** (URL `?rxFolderMutations=1` / storage / window global): create/rename/move/delete under `/Folders` and `/Sites` use `/Rhythmyx/rest/content-explorer/folders`
- **Browse / list / pagination** stay on pathmanagement
- **Still pathmanagement:** copy, ACL `saveFolderProperties`, `/Assets` `/Design` `/Recycling`
- New WebUI peers: `rxFolderMutationsFlag.ts`, `rxFolderApi.ts`, `folderMutations.ts`; `ReducedActions` wired through router
- Vitest for flag, REST client, and dual-run routing
- Playwright surface: `modules/perc-qa-automation/frontend/tests/explorer-rx-folder-mutations.spec.js`
- product-docs admin + developer REST; server.properties operator comment

**Parent:** #3054  
**Fixes:** #3074  

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] WebUI `mvnw clean install` (includes Vitest) — BUILD SUCCESS; Vitest **1967** passed / 0 failed
- [x] Focused dual-run tests: `rxFolderMutationsFlag` + `rxFolderApi` + `folderMutations` (24 tests)
- [x] perc-qa-automation `npm run test:unit` — 226 passed
- [ ] Live surface after `perc-devctl qa-up`: `npm run test:surface -- --path tests/explorer-rx-folder-mutations.spec.js` (agent qa-up failed: H2 matrix probe / PSFolderAcl XML in dist — not caused by this PR; human QA on QA H2)
- [ ] Manual: flag off → create folder under Folders still pathmanagement; flag on → network shows content-explorer folders

## Gates evidence

```
modules_built=WebUI
commands:
  cd WebUI && ../mvnw.cmd clean install   # EXIT 0
  cd WebUI/src/main/frontend && npx vitest run  # 1967 passed
  cd modules/perc-qa-automation/frontend && npm run test:unit  # 226 pass
downstream_checked=none (TS client + docs only; no Java public API signature change)
```

## Product documentation

- [x] Updated `product-docs/8.2/admin/content-explorer.md` (dual-run section)
- [x] Updated `product-docs/8.2/developer/rest.md` (dual-run flag table)

## Out of scope

- REST façade implementation (already #3073 / PR #3084)
- Hard-cut of pathmanagement list
- Finder jQuery
- ACL save migration to RxFolder

> Co-Authored by Grok Build using grok-4.5 with agent main.
