### PR TITLE
fix(WebUI): fold Workflow admin into unified Admin shell (#3088)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminChrome.module.css
+++ b/WebUI/src/main/ts/admin/AdminChrome.module.css
@@ -34,19 +34,6 @@
   overflow-wrap: anywhere;
 }
 
-/* Sibling admin surface deep link after top-nav Admin consolidation (#2702) */
-.siblingLink {
-  font-size: 0.95rem;
-  color: #007ea8;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.siblingLink:hover,
-.siblingLink:focus {
-  text-decoration: underline;
-}
-
 .tabNav {
   display: flex;
   flex-wrap: wrap;

--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -15,22 +15,43 @@
  */
 
 import React, { useState } from "react";
-import { Link } from "react-router";
-import { message, MSG } from "../i18n/message";
+import { message } from "../i18n/message";
 import { ADMIN_MSG } from "./messages";
+import { WF_ADMIN_MSG } from "../workflowAdmin/messages";
 import { TasksSection } from "./TasksSection";
 import { TaskLogsSection } from "./TaskLogsSection";
 import { TaskNotifications } from "./TaskNotifications";
 import { ToolsSection } from "./tools/ToolsSection";
+import { WorkflowSection } from "../workflowAdmin/workflow/WorkflowSection";
+import { RolesSection } from "../workflowAdmin/role/RolesSection";
+import { UsersSection } from "../workflowAdmin/user/UsersSection";
+import { CategoriesSection } from "../workflowAdmin/category/CategoriesSection";
 import styles from "./AdminChrome.module.css";
 
-export type AdminTab = "tasks" | "logs" | "notifications" | "tools";
+/**
+ * Unified Admin product shell tabs (#3088).
+ * Former Workflow administration tabs (workflow / roles / users / categories)
+ * live here alongside tasks, logs, notifications, and system tools.
+ */
+export type AdminTab =
+  | "tasks"
+  | "logs"
+  | "notifications"
+  | "tools"
+  | "workflow"
+  | "roles"
+  | "users"
+  | "categories";
 
 const ADMIN_TABS: readonly AdminTab[] = [
   "tasks",
   "logs",
   "notifications",
   "tools",
+  "workflow",
+  "roles",
+  "users",
+  "categories",
 ];
 
 export function normalizeAdminShellTab(
@@ -75,14 +96,6 @@ export const AdminShell: React.FC<AdminShellProps> = ({
           <h1 data-testid="perc-admin-shell-title">
             {message(ADMIN_MSG.ADMIN_TITLE)}
           </h1>
-          {/* Top nav lands on Admin tools (#2784/#2953); keep Workflow admin reachable. */}
-          <Link
-            to="/workflow"
-            className={styles.siblingLink}
-            data-testid="admin-sibling-workflow-link"
-          >
-            {message(MSG.NAV_ADMINISTRATION)}
-          </Link>
         </div>
       </header>
 
@@ -142,6 +155,58 @@ export const AdminShell: React.FC<AdminShellProps> = ({
         >
           {message(ADMIN_MSG.TAB_TOOLS)}
         </button>
+
+        <button
+          type="button"
+          role="tab"
+          id="tab-workflow"
+          aria-selected={activeTab === "workflow"}
+          aria-controls="panel-workflow"
+          onClick={() => setActiveTab("workflow")}
+          className={tabClass("workflow")}
+          data-testid="tab-workflow"
+        >
+          {message(WF_ADMIN_MSG.TAB_WORKFLOW)}
+        </button>
+
+        <button
+          type="button"
+          role="tab"
+          id="tab-roles"
+          aria-selected={activeTab === "roles"}
+          aria-controls="panel-roles"
+          onClick={() => setActiveTab("roles")}
+          className={tabClass("roles")}
+          data-testid="tab-roles"
+        >
+          {message(WF_ADMIN_MSG.TAB_ROLES)}
+        </button>
+
+        <button
+          type="button"
+          role="tab"
+          id="tab-users"
+          aria-selected={activeTab === "users"}
+          aria-controls="panel-users"
+          onClick={() => setActiveTab("users")}
+          className={tabClass("users")}
+          data-testid="tab-users"
+        >
+          {message(WF_ADMIN_MSG.TAB_USERS)}
+        </button>
+
+        <button
+          type="button"
+          role="tab"
+          id="tab-categories"
+          aria-selected={activeTab === "categories"}
+          aria-controls="panel-categories"
+          onClick={() => setActiveTab("categories")}
+          className={tabClass("categories")}
+          data-testid="tab-categories"
+        >
+          {message(WF_ADMIN_MSG.TAB_CATEGORIES)}
+        </button>
       </nav>
 
       <main
@@ -154,6 +219,10 @@ export const AdminShell: React.FC<AdminShellProps> = ({
         {activeTab === "logs" && <TaskLogsSection />}
         {activeTab === "notifications" && <TaskNotifications />}
         {activeTab === "tools" && <ToolsSection />}
+        {activeTab === "workflow" && <WorkflowSection />}
+        {activeTab === "roles" && <RolesSection />}
+        {activeTab === "users" && <UsersSection />}
+        {activeTab === "categories" && <CategoriesSection />}
       </main>
     </div>
   );

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -79,7 +79,21 @@ export const WORKFLOW_TABS = [
 
 export type WorkflowTab = (typeof WORKFLOW_TABS)[number];
 
-export const ADMIN_TABS = ["tasks", "logs", "notifications", "tools"] as const;
+/**
+ * Unified Admin shell tabs (#3088). Includes former Workflow administration
+ * surfaces (workflow / roles / users / categories) so deep links and path
+ * segments share one product area under {@code /admin/*}.
+ */
+export const ADMIN_TABS = [
+  "tasks",
+  "logs",
+  "notifications",
+  "tools",
+  "workflow",
+  "roles",
+  "users",
+  "categories",
+] as const;
 
 export type AdminTab = (typeof ADMIN_TABS)[number];
 

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -86,11 +86,12 @@ export function parseEntryQuery(
       return { entry, section, siteId, serverId, clientPath };
     }
     case "workflow": {
-      const tab = normalizeWorkflowTab(tabParam ?? sectionParam);
+      // #3088: fold legacy workflow entry into unified Admin shell paths
+      const tab = normalizeWorkflowTab(tabParam ?? sectionParam) ?? "workflow";
       return {
         entry,
         tab,
-        clientPath: tab ? `/workflow/${tab}` : "/workflow",
+        clientPath: `/admin/${tab}`,
       };
     }
     case "admin": {
@@ -204,11 +205,12 @@ export function parseClientPath(
       return { entry, section, siteId, serverId, clientPath: cp };
     }
     case "workflow": {
-      const tab = normalizeWorkflowTab(second);
+      // Legacy path prefix still parseable; client path is Admin (#3088)
+      const tab = normalizeWorkflowTab(second) ?? "workflow";
       return {
         entry,
         tab,
-        clientPath: tab ? `/workflow/${tab}` : "/workflow",
+        clientPath: `/admin/${tab}`,
       };
     }
     case "admin": {

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -153,8 +153,8 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "admin":
-              // Consolidated Administration + Admin tools entry (#2702 / #2784).
-              // Landing: working Admin tools shell; /workflow remains deep-linked.
+              // Consolidated Admin entry (#2702 / #2784 / #3088).
+              // Landing: unified Admin shell; legacy /workflow* redirects into /admin*.
               return (
                 <li key={id}>
                   <NavLink

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -16,15 +16,15 @@
  */
 
 /**
- * Primary product top-nav order and role gates (issue #2702 / #2784).
+ * Primary product top-nav order and role gates (issue #2702 / #2784 / #3088).
  *
  * Dashboard is intentionally omitted from top chrome (gadgets remain on Home
  * via deep link {@code /home/gadgets}). Administration + Admin tools collapse
  * to a single {@code admin} item.
  *
- * <p>Landing is the working <strong>Admin tools</strong> shell at {@code /admin}
- * (#2784). Workflow administration remains at {@code /workflow} via deep link
- * and the Admin tools sibling cross-link.</p>
+ * <p>Landing is the unified <strong>Admin</strong> shell at {@code /admin}
+ * (#2784 / #3088). Workflow / roles / users / categories are Admin tabs;
+ * legacy {@code /workflow} paths redirect into {@code /admin/*}.</p>
  */
 
 export type TopNavItemId =
@@ -45,8 +45,8 @@ export interface TopNavGates {
 }
 
 /**
- * Client path for the consolidated Admin top-nav NavLink (#2784).
- * Prefer Admin tools over Workflow administration as the primary landing.
+ * Client path for the consolidated Admin top-nav NavLink (#2784 / #3088).
+ * Unified Admin shell (tasks, tools, workflow, roles, users, categories).
  */
 export const ADMIN_NAV_LANDING = "/admin";
 
@@ -76,7 +76,7 @@ export function topNavItemIds(gates: TopNavGates = {}): TopNavItemId[] {
 
 /**
  * Whether a client pathname should mark the consolidated Admin top-nav active.
- * Covers both admin-tools and workflow administration SPA routes.
+ * Covers unified Admin shell paths and legacy {@code /workflow*} redirects (#3088).
  */
 export function isAdminNavPath(pathname: string): boolean {
   const p = pathname || "";

--- a/WebUI/src/main/ts/app/routes/AdminRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/AdminRoute.tsx
@@ -26,7 +26,9 @@ const AdminShellLazy = lazy(() =>
 );
 
 /**
- * SPA Admin tools route — Admin only (includes tools tab).
+ * SPA Admin route — Admin only.
+ * Unified shell: tasks, logs, notifications, tools, workflow, roles, users,
+ * categories (#3088).
  */
 export function AdminRoute(): React.ReactElement {
   const { tab } = useParams();
@@ -34,10 +36,10 @@ export function AdminRoute(): React.ReactElement {
   return (
     <RequireRole gate="admin">
       <LazyRouteFrame
-        label="Admin tools"
+        label="Admin"
         fallback={
           <div data-testid="route-admin-loading" style={{ padding: "1.5rem" }}>
-            Loading Admin tools…
+            Loading Admin…
           </div>
         }
       >

--- a/WebUI/src/main/ts/app/routes/WorkflowRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/WorkflowRoute.tsx
@@ -15,34 +15,26 @@
  * limitations under the License.
  */
 
-import React, { lazy } from "react";
-import { useParams } from "react-router";
-import { loadComponent } from "../../registry";
-import { LazyRouteFrame } from "./RouteErrorBoundary";
+import React from "react";
+import { Navigate, useParams } from "react-router";
 import { RequireRole } from "./RequireRole";
-
-const WorkflowAdminShellLazy = lazy(() =>
-  loadComponent("WorkflowAdminShell").then((C) => ({ default: C })),
-);
+import { normalizeWorkflowTab } from "../deepLinks/allowlists";
 
 /**
- * SPA Administration (workflow) route — Admin only.
+ * Legacy SPA Administration (workflow) routes — Admin only.
+ *
+ * <p>#3088: {@code /workflow} and {@code /workflow/:tab} redirect into the
+ * unified Admin shell ({@code /admin/workflow}, {@code /admin/roles}, …)
+ * so bookmarks and docs keep working without a sibling product chrome.</p>
  */
 export function WorkflowRoute(): React.ReactElement {
   const { tab } = useParams();
+  const normalized = normalizeWorkflowTab(tab) ?? "workflow";
+  const target = `/admin/${normalized}`;
 
   return (
     <RequireRole gate="admin">
-      <LazyRouteFrame
-        label="Administration"
-        fallback={
-          <div data-testid="route-workflow-loading" style={{ padding: "1.5rem" }}>
-            Loading Administration…
-          </div>
-        }
-      >
-        <WorkflowAdminShellLazy embedded initialTab={tab} />
-      </LazyRouteFrame>
+      <Navigate to={target} replace />
     </RequireRole>
   );
 }

--- a/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react";
-import { Link } from "react-router";
-import { message, MSG } from "../i18n/message";
-import styles from "../admin/AdminChrome.module.css";
-import { WF_ADMIN_MSG } from "./messages";
-import { WorkflowSection } from "./workflow/WorkflowSection";
-import { RolesSection } from "./role/RolesSection";
-import { UsersSection } from "./user/UsersSection";
-import { CategoriesSection } from "./category/CategoriesSection";
+import React from "react";
+import { Navigate } from "react-router";
 
+/**
+ * Former product shell for Workflow / Roles / Users / Categories administration.
+ *
+ * <p>#3088 folds those surfaces into {@code AdminShell} under {@code /admin/*}.
+ * This component remains as a non-product redirect for residual registry loads
+ * and any legacy embed that still names {@code WorkflowAdminShell}.</p>
+ */
 export type WorkflowAdminTab = "workflow" | "roles" | "users" | "categories";
 
 const WORKFLOW_TABS: readonly WorkflowAdminTab[] = [
@@ -47,114 +47,16 @@ export function normalizeWorkflowAdminTab(
 
 export interface WorkflowAdminShellProps {
   initialTab?: WorkflowAdminTab | string;
-  /**
-   * When true (SPA AppLayout), shell is under product chrome.
-   * Reserved for layout tweaks; no BrandBar today.
-   */
+  /** @deprecated No longer used; shell is redirect-only. */
   embedded?: boolean;
 }
 
+/**
+ * Redirect-only stub: maps legacy Workflow admin tabs into unified Admin paths.
+ */
 export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
   initialTab = "workflow",
-  embedded: _embedded = false,
 }) => {
-  const [activeTab, setActiveTab] = useState<WorkflowAdminTab>(() =>
-    normalizeWorkflowAdminTab(initialTab),
-  );
-
-  const tabClass = (tab: WorkflowAdminTab): string =>
-    activeTab === tab ? `${styles.tab} ${styles.tabActive}` : styles.tab;
-
-  return (
-    <div
-      className={`perc-workflow-admin-shell ${styles.shell}`}
-      data-testid="perc-workflow-admin-shell"
-    >
-      <header className={styles.header}>
-        <div className={styles.headerRow}>
-          <h1 data-testid="perc-workflow-admin-shell-title">
-            {message(WF_ADMIN_MSG.TITLE)}
-          </h1>
-          {/* Admin tools is top-nav landing (#2784/#2953); cross-link when deep-linked here. */}
-          <Link
-            to="/admin"
-            className={styles.siblingLink}
-            data-testid="admin-sibling-tools-link"
-          >
-            {message(MSG.NAV_ADMIN_TOOLS)}
-          </Link>
-        </div>
-      </header>
-
-      <nav
-        className={`perc-tab-nav ${styles.tabNav}`}
-        role="tablist"
-        data-testid="perc-workflow-admin-tablist"
-      >
-        <button
-          type="button"
-          role="tab"
-          id="tab-workflow"
-          aria-selected={activeTab === "workflow"}
-          aria-controls="panel-workflow"
-          onClick={() => setActiveTab("workflow")}
-          className={tabClass("workflow")}
-          data-testid="tab-workflow"
-        >
-          {message(WF_ADMIN_MSG.TAB_WORKFLOW)}
-        </button>
-
-        <button
-          type="button"
-          role="tab"
-          id="tab-roles"
-          aria-selected={activeTab === "roles"}
-          aria-controls="panel-roles"
-          onClick={() => setActiveTab("roles")}
-          className={tabClass("roles")}
-          data-testid="tab-roles"
-        >
-          {message(WF_ADMIN_MSG.TAB_ROLES)}
-        </button>
-
-        <button
-          type="button"
-          role="tab"
-          id="tab-users"
-          aria-selected={activeTab === "users"}
-          aria-controls="panel-users"
-          onClick={() => setActiveTab("users")}
-          className={tabClass("users")}
-          data-testid="tab-users"
-        >
-          {message(WF_ADMIN_MSG.TAB_USERS)}
-        </button>
-
-        <button
-          type="button"
-          role="tab"
-          id="tab-categories"
-          aria-selected={activeTab === "categories"}
-          aria-controls="panel-categories"
-          onClick={() => setActiveTab("categories")}
-          className={tabClass("categories")}
-          data-testid="tab-categories"
-        >
-          {message(WF_ADMIN_MSG.TAB_CATEGORIES)}
-        </button>
-      </nav>
-
-      <main
-        className={`perc-tab-content ${styles.tabContent}`}
-        role="tabpanel"
-        id={`panel-${activeTab}`}
-        aria-labelledby={`tab-${activeTab}`}
-      >
-        {activeTab === "workflow" && <WorkflowSection />}
-        {activeTab === "roles" && <RolesSection />}
-        {activeTab === "users" && <UsersSection />}
-        {activeTab === "categories" && <CategoriesSection />}
-      </main>
-    </div>
-  );
+  const tab = normalizeWorkflowAdminTab(initialTab);
+  return <Navigate to={`/admin/${tab}`} replace />;
 };

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -227,8 +227,11 @@
         else if ("dash".equals(view))
             // PR-7: former peer dashboard → Home gadgets (not spa entry=dashboard)
             entry = "home";
+        else if ("workflow".equals(view))
+            // #3088: fold legacy Workflow admin view into unified Admin shell
+            entry = "admin";
         else if ("home".equals(view) || "publish".equals(view)
-                || "workflow".equals(view) || "admin".equals(view)
+                || "admin".equals(view)
                 || "developer".equals(view))
             entry = view;
         else
@@ -269,13 +272,15 @@
         }
         else if ("workflow".equals(view))
         {
+            // Map to Admin tab; default Workflow tab when no tab query
             String tab = firstAllowlisted(
                     request.getParameter("tab"),
                     request.getParameter("section"),
                     WORKFLOW_TABS,
                     null);
-            if (tab != null)
-                qs.append("&tab=").append(URLEncoder.encode(tab, "UTF-8"));
+            if (tab == null)
+                tab = "workflow";
+            qs.append("&tab=").append(URLEncoder.encode(tab, "UTF-8"));
         }
         else if ("admin".equals(view))
         {
@@ -666,8 +671,10 @@
     private static final String[] WORKFLOW_TABS = new String[]{
             "workflow", "roles", "users", "categories"
     };
+    /** Unified Admin shell tabs (#3088) — includes former Workflow admin tabs. */
     private static final String[] ADMIN_TABS = new String[]{
-            "tasks", "logs", "notifications", "tools"
+            "tasks", "logs", "notifications", "tools",
+            "workflow", "roles", "users", "categories"
     };
     private static final String[] DEVELOPER_SECTIONS = new String[]{
             "content-types", "templates", "slots", "keywords", "communities", "pipelines"

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -227,8 +227,11 @@
         else if ("dash".equals(view))
             // PR-7: former peer dashboard → Home gadgets (not spa entry=dashboard)
             entry = "home";
+        else if ("workflow".equals(view))
+            // #3088: fold legacy Workflow admin view into unified Admin shell
+            entry = "admin";
         else if ("home".equals(view) || "publish".equals(view)
-                || "workflow".equals(view) || "admin".equals(view)
+                || "admin".equals(view)
                 || "developer".equals(view))
             entry = view;
         else
@@ -269,13 +272,15 @@
         }
         else if ("workflow".equals(view))
         {
+            // Map to Admin tab; default Workflow tab when no tab query
             String tab = firstAllowlisted(
                     request.getParameter("tab"),
                     request.getParameter("section"),
                     WORKFLOW_TABS,
                     null);
-            if (tab != null)
-                qs.append("&tab=").append(URLEncoder.encode(tab, "UTF-8"));
+            if (tab == null)
+                tab = "workflow";
+            qs.append("&tab=").append(URLEncoder.encode(tab, "UTF-8"));
         }
         else if ("admin".equals(view))
         {
@@ -666,8 +671,10 @@
     private static final String[] WORKFLOW_TABS = new String[]{
             "workflow", "roles", "users", "categories"
     };
+    /** Unified Admin shell tabs (#3088) — includes former Workflow admin tabs. */
     private static final String[] ADMIN_TABS = new String[]{
-            "tasks", "logs", "notifications", "tools"
+            "tasks", "logs", "notifications", "tools",
+            "workflow", "roles", "users", "categories"
     };
     private static final String[] DEVELOPER_SECTIONS = new String[]{
             "content-types", "templates", "slots", "keywords", "communities", "pipelines"

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -30,11 +30,33 @@ vi.mock("../../../main/ts/admin/TaskLogsSection", () => ({
 }));
 
 vi.mock("../../../main/ts/admin/TaskNotifications", () => ({
-  TaskNotifications: () => <div data-testid="mock-notifications-section">Notifications Content</div>,
+  TaskNotifications: () => (
+    <div data-testid="mock-notifications-section">Notifications Content</div>
+  ),
 }));
 
 vi.mock("../../../main/ts/admin/tools/ToolsSection", () => ({
   ToolsSection: () => <div data-testid="mock-tools-section">Tools Content</div>,
+}));
+
+vi.mock("../../../main/ts/workflowAdmin/workflow/WorkflowSection", () => ({
+  WorkflowSection: () => (
+    <div data-testid="mock-workflow-section">Workflow Content</div>
+  ),
+}));
+
+vi.mock("../../../main/ts/workflowAdmin/role/RolesSection", () => ({
+  RolesSection: () => <div data-testid="perc-roles-section">Roles Content</div>,
+}));
+
+vi.mock("../../../main/ts/workflowAdmin/user/UsersSection", () => ({
+  UsersSection: () => <div data-testid="perc-users-section">Users Content</div>,
+}));
+
+vi.mock("../../../main/ts/workflowAdmin/category/CategoriesSection", () => ({
+  CategoriesSection: () => (
+    <div data-testid="perc-categories-section">Categories Content</div>
+  ),
 }));
 
 function renderShell(ui: React.ReactElement) {
@@ -46,7 +68,7 @@ function renderShell(ui: React.ReactElement) {
 }
 
 describe("AdminShell", () => {
-  it("renders Admin tools title and Administration sibling (#2953)", () => {
+  it("renders unified Admin title without sibling Workflow link (#3088)", () => {
     renderShell(<AdminShell />);
     expect(screen.getByTestId("perc-admin-shell")).toBeDefined();
     expect(screen.getByTestId("mock-tasks-section")).toBeDefined();
@@ -54,11 +76,9 @@ describe("AdminShell", () => {
     expect(screen.getByTestId("perc-admin-shell-title").textContent).toMatch(
       /Admin tools/i,
     );
-    const sibling = screen.getByTestId("admin-sibling-workflow-link");
-    expect(sibling).toBeDefined();
-    expect(sibling.textContent).toMatch(/Administration/i);
-    const href = sibling.getAttribute("href") || "";
-    expect(href === "/workflow" || href.endsWith("/workflow")).toBe(true);
+    // Sibling cross-links removed when Workflow admin folded into Admin (#3088)
+    expect(screen.queryByTestId("admin-sibling-workflow-link")).toBeNull();
+    expect(screen.queryByTestId("admin-sibling-tools-link")).toBeNull();
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
@@ -73,6 +93,10 @@ describe("AdminShell", () => {
     expect(screen.getByTestId("tab-logs")).toBeDefined();
     expect(screen.getByTestId("tab-notifications")).toBeDefined();
     expect(screen.getByTestId("tab-tools")).toBeDefined();
+    expect(screen.getByTestId("tab-workflow")).toBeDefined();
+    expect(screen.getByTestId("tab-roles")).toBeDefined();
+    expect(screen.getByTestId("tab-users")).toBeDefined();
+    expect(screen.getByTestId("tab-categories")).toBeDefined();
   });
 
   it("switches tabs when nav buttons are clicked", () => {
@@ -90,5 +114,23 @@ describe("AdminShell", () => {
     const toolsTab = screen.getByTestId("tab-tools");
     fireEvent.click(toolsTab);
     expect(screen.getByTestId("mock-tools-section")).toBeDefined();
+  });
+
+  it("hosts former Workflow admin sections as Admin tabs (#3088)", () => {
+    renderShell(<AdminShell initialTab="workflow" />);
+    expect(screen.getByTestId("mock-workflow-section")).toBeDefined();
+    expect(screen.getByTestId("tab-workflow").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+
+    fireEvent.click(screen.getByTestId("tab-roles"));
+    expect(screen.getByTestId("perc-roles-section")).toBeDefined();
+    expect(screen.queryByTestId("mock-workflow-section")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("tab-users"));
+    expect(screen.getByTestId("perc-users-section")).toBeDefined();
+
+    fireEvent.click(screen.getByTestId("tab-categories"));
+    expect(screen.getByTestId("perc-categories-section")).toBeDefined();
   });
 });

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -223,8 +223,9 @@ describe("App shell", () => {
     expect(nav).toBeTruthy();
   });
 
-  it("loads WorkflowAdminShell for admin entry", async () => {
-    window.history.replaceState({}, "", "/cm/app/workflow/roles");
+  it("folds workflow entry into unified AdminShell (#3088)", async () => {
+    // entry=workflow&tab=roles handoff lands on /admin/roles
+    window.history.replaceState({}, "", "/cm/app/admin/roles");
     render(
       <App
         bootstrap={bootstrap}
@@ -234,7 +235,7 @@ describe("App shell", () => {
     );
     expect(
       await screen.findByTestId(
-        "perc-workflow-admin-shell",
+        "perc-admin-shell",
         {},
         { timeout: SHELL_TIMEOUT },
       ),
@@ -242,6 +243,8 @@ describe("App shell", () => {
     expect(screen.getByTestId("tab-roles").getAttribute("aria-selected")).toBe(
       "true",
     );
+    // No sibling product chrome
+    expect(screen.queryByTestId("perc-workflow-admin-shell")).toBeNull();
   });
 
   it("loads AdminShell for admin tools entry", async () => {

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -125,11 +125,24 @@ describe("path-based SPA URLs (PR-9)", () => {
     expect(parseClientPath("/home/gadgets").entry).toBe("home");
     expect(parseClientPath("/home/gadgets").section).toBe("gadgets");
     expect(parseClientPath("/publish/logs", "?siteId=s1").siteId).toBe("s1");
+    // Legacy /workflow/* still parses, client path folds into Admin (#3088)
     expect(parseClientPath("/workflow/users").tab).toBe("users");
+    expect(parseClientPath("/workflow/users").clientPath).toBe("/admin/users");
     expect(parseClientPath("/admin/tools").clientPath).toBe("/admin/tools");
+    expect(parseClientPath("/admin/roles").tab).toBe("roles");
     expect(
       parseClientPath("/explorer", "?path=/Sites/demo").path,
     ).toBe("/Sites/demo");
+  });
+
+  it("workflow entry maps to unified Admin client paths (#3088)", () => {
+    expect(parseEntryQuery("?entry=workflow").clientPath).toBe(
+      "/admin/workflow",
+    );
+    expect(parseEntryQuery("?entry=workflow&tab=roles").clientPath).toBe(
+      "/admin/roles",
+    );
+    expect(parseEntryQuery("?entry=workflow&tab=roles").tab).toBe("roles");
   });
 
   it("resolveSpaReturnFromLocation prefers query then path", () => {

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -94,12 +94,18 @@ describe("TopNav (#2702)", () => {
     expect(screen.getByTestId("nav-explorer")).toBeTruthy();
   });
 
-  it("marks Admin active on admin-tools and workflow routes", () => {
+  it("marks Admin active on admin-tools, workflow tabs, and legacy /workflow", () => {
     const { unmount } = renderNav("/cm/app/admin/tools");
     expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
       "true",
     );
     unmount();
+    const { unmount: unmountRoles } = renderNav("/cm/app/admin/roles");
+    expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
+      "true",
+    );
+    unmountRoles();
+    // Legacy path still highlights Admin while redirect resolves (#3088)
     renderNav("/cm/app/workflow/roles");
     expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
       "true",

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -89,9 +89,12 @@ describe("ADMIN_NAV_LANDING (#2784)", () => {
 });
 
 describe("isAdminNavPath", () => {
-  it("marks admin-tools and workflow SPA paths as Admin-active", () => {
+  it("marks unified Admin shell and legacy workflow redirect paths as Admin-active (#3088)", () => {
     expect(isAdminNavPath("/admin")).toBe(true);
     expect(isAdminNavPath("/admin/tools")).toBe(true);
+    expect(isAdminNavPath("/admin/workflow")).toBe(true);
+    expect(isAdminNavPath("/admin/roles")).toBe(true);
+    // Legacy /workflow* still active while redirect resolves
     expect(isAdminNavPath("/workflow")).toBe(true);
     expect(isAdminNavPath("/workflow/roles")).toBe(true);
     expect(isAdminNavPath("/home")).toBe(false);

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
@@ -15,73 +15,55 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
-import { WorkflowAdminShell } from "../../../main/ts/workflowAdmin/WorkflowAdminShell";
+import { render } from "@testing-library/react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeWorkflowAdminTab,
+  WorkflowAdminShell,
+} from "../../../main/ts/workflowAdmin/WorkflowAdminShell";
 
-// Mock child components
-vi.mock("../../../main/ts/workflowAdmin/workflow/WorkflowSection", () => ({
-  WorkflowSection: () => <div data-testid="mock-workflow-section">Workflow Content</div>,
-}));
+function LocationProbe(): React.ReactElement {
+  const loc = useLocation();
+  return <div data-testid="location-pathname">{loc.pathname}</div>;
+}
 
-vi.mock("../../../main/ts/workflowAdmin/role/RolesSection", () => ({
-  RolesSection: () => <div data-testid="perc-roles-section">Roles Content</div>,
-}));
-
-vi.mock("../../../main/ts/workflowAdmin/user/UsersSection", () => ({
-  UsersSection: () => <div data-testid="perc-users-section">Users Content</div>,
-}));
-
-vi.mock("../../../main/ts/workflowAdmin/category/CategoriesSection", () => ({
-  CategoriesSection: () => <div data-testid="perc-categories-section">Categories Content</div>,
-}));
-
-function renderShell(ui: React.ReactElement) {
+function renderRedirect(initialTab?: string) {
   return render(
     <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/workflow"]}>
-      {ui}
+      <Routes>
+        <Route
+          path="/workflow"
+          element={<WorkflowAdminShell initialTab={initialTab} />}
+        />
+        <Route path="/admin/:tab" element={<LocationProbe />} />
+        <Route path="/admin" element={<LocationProbe />} />
+      </Routes>
     </MemoryRouter>,
   );
 }
 
 describe("WorkflowAdminShell", () => {
-  it("renders shell title and Admin tools sibling (#2953)", () => {
-    renderShell(<WorkflowAdminShell />);
-    expect(screen.getByTestId("perc-workflow-admin-shell")).toBeTruthy();
-    expect(screen.getByTestId("mock-workflow-section")).toBeTruthy();
-    expect(screen.getByTestId("perc-workflow-admin-shell-title")).toBeTruthy();
-    const sibling = screen.getByTestId("admin-sibling-tools-link");
-    expect(sibling).toBeTruthy();
-    expect(sibling.textContent).toMatch(/Admin tools/i);
-    const href = sibling.getAttribute("href") || "";
-    expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
+  it("is redirect-only into unified Admin paths (#3088)", () => {
+    const { getByTestId } = renderRedirect();
+    expect(getByTestId("location-pathname").textContent).toBe(
+      "/admin/workflow",
+    );
   });
 
-  it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
-    renderShell(<WorkflowAdminShell />);
-    const shell = screen.getByTestId("perc-workflow-admin-shell");
-    const tablist = screen.getByTestId("perc-workflow-admin-tablist");
-    expect(tablist.getAttribute("role")).toBe("tablist");
-    expect(tablist.className.length).toBeGreaterThan(0);
-    expect(shell.className.length).toBeGreaterThan(0);
+  it("maps initialTab to Admin tab path", () => {
+    const { getByTestId } = renderRedirect("roles");
+    expect(getByTestId("location-pathname").textContent).toBe("/admin/roles");
   });
 
-  it("switches tabs when nav buttons are clicked", () => {
-    renderShell(<WorkflowAdminShell />);
-
-    const rolesTab = screen.getByTestId("tab-roles");
-    fireEvent.click(rolesTab);
-    expect(screen.getByTestId("perc-roles-section")).toBeTruthy();
-    expect(screen.queryByTestId("mock-workflow-section")).toBeNull();
-
-    const usersTab = screen.getByTestId("tab-users");
-    fireEvent.click(usersTab);
-    expect(screen.getByTestId("perc-users-section")).toBeTruthy();
-
-    const catTab = screen.getByTestId("tab-categories");
-    fireEvent.click(catTab);
-    expect(screen.getByTestId("perc-categories-section")).toBeTruthy();
+  it("normalizeWorkflowAdminTab defaults and validates", () => {
+    expect(normalizeWorkflowAdminTab(undefined)).toBe("workflow");
+    expect(normalizeWorkflowAdminTab("users")).toBe("users");
+    expect(normalizeWorkflowAdminTab("nope")).toBe("workflow");
   });
 });
-

--- a/docs/ai-generated/code-reviews/issue-3088-fold-workflow-admin-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3088-fold-workflow-admin-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review: #3088 fold Workflow admin under Admin shell
+
+**Branch:** `fix/issue-3088-fold-workflow-admin-under-admin`  
+**Date:** 2026-08-11  
+**Reviewer:** Erlang (pre-commit gate, implementer self-review)
+
+## Summary
+
+Folds Workflow / Roles / Users / Categories administration into the unified
+`AdminShell` under `/admin/*`, redirects legacy `/workflow` routes and
+`view=workflow` deep links, removes sibling shell cross-links, and updates
+unit + Playwright + product-docs companions.
+
+## Scope
+
+- WebUI SPA: `AdminShell`, `WorkflowAdminShell` (redirect stub), `WorkflowRoute`,
+  `AdminRoute`, `allowlists`, `parseEntryQuery`, `topNavConfig`, `TopNav`, CSS
+- Server deep-link allowlists: dual-tree `index.jsp` (`ADMIN_TABS` + workflow view)
+- Tests: admin / workflowAdmin / App / topNav / parseEntryQuery
+- Playwright: top-nav, us1 workflow defs, bugs 945/2211/2959
+- product-docs: `product-docs/8.2/admin/index.md`
+
+**Out of scope (intentional):** item `workflowActions/*`, Developer → Workflows,
+legacy jQuery PercWorkflowView.
+
+**Cross-platform path review:** no new path/file I/O; JSP string path segments
+only; dual-tree `index.jsp` kept byte-identical via copy.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+### suggestion
+
+1. **AdminShell tab count (8 tabs)** — portrait wrap is covered by GH-945 Playwright
+   and CSS `flex-wrap`, but dense chrome may still feel crowded. Acceptable for #3088;
+   a later polish could group “system ops” vs “identity/workflow” if UX feedback
+   warrants it. No change required for this PR.
+
+2. **In-shell tab clicks do not update the URL** — pre-existing pattern for both
+   Admin and former Workflow shells (state-only tabs). Deep links still work via
+   `/admin/:tab`. Optional follow-up: sync `activeTab` to router on click.
+
+### nit
+
+1. `WorkflowAdminShell` remains in the component registry as a redirect stub for
+   residual loads; acceptable per issue (“reduce to non-product embed/redirect”).
+
+## Test evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (war produced;
+  Surefire Java 43 tests, 0 failures)
+- Focused Vitest: AdminShell, WorkflowAdminShell, App, topNav*, parseEntryQuery
+  → 46 passed
+
+## Memory patterns
+
+None hit for dual-shell chrome specifically; change-class companions (unit +
+Playwright + product-docs) applied for WebUI product screen IA change.

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
@@ -1,9 +1,11 @@
 /**
  * Issue #2211 / parent #959 slice 4 — Admin Users default landing control.
  *
- * WebUI product screen companion (Workflow Admin → Users tab → user editor).
+ * WebUI product screen companion (Admin → Users tab → user editor).
  * Verifies the select is present, options load, and saving clears/sets
  * override when the slice-2 homepage API is available.
+ *
+ * #3088: Users live under unified AdminShell (not sibling Workflow shell).
  *
  * Tags: @webui @admin @users @landing
  */
@@ -18,10 +20,10 @@ test.describe("Admin Users default landing page (#2211)", () => {
   test("Users tab exposes default landing control on edit", async ({
     page,
   }) => {
-    // SPA workflow admin hosts Users section
+    // SPA Admin hosts Users section (legacy view=workflow redirects here)
     await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
 
-    const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+    const shell = page.locator("[data-testid='perc-admin-shell']");
     await expect(shell).toBeVisible({ timeout: 30000 });
 
     const usersTab = page.locator("[data-testid='tab-users']");

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
@@ -1,9 +1,11 @@
 /**
- * Regression: Admin → Administration fails with TypeError e.map is not a function (#2959).
+ * Regression: Admin → Workflow fails with TypeError e.map is not a function (#2959).
  *
  * GET workflowmanagement/workflows/metadata often returns a Jackson root wrapper
  * ({ Workflow: [...] }). WorkflowSection must unwrap before workflows.map so the
- * Administration shell loads without RouteErrorBoundary.
+ * Admin shell loads without RouteErrorBoundary.
+ *
+ * #3088: Workflow admin lives under unified AdminShell (not sibling Workflow shell).
  *
  * Tags: @workflow-admin @administration @smoke @bug-2959
  *
@@ -27,15 +29,16 @@ test.describe("Administration WorkflowSection load (#2959)", () => {
       tag: ["@workflow-admin", "@administration", "@smoke", "@bug-2959"],
     },
     async ({ page }) => {
+      // Legacy view=workflow redirects into unified Admin workflow tab (#3088)
       await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
 
-      const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+      const shell = page.locator("[data-testid='perc-admin-shell']");
       await expect(shell).toBeVisible({ timeout: 30_000 });
 
-      // Must not crash into route error boundary (Unable to load Administration)
+      // Must not crash into route error boundary
       await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
       await expect(
-        page.getByText(/Unable to load Administration/i),
+        page.getByText(/Unable to load Admin/i),
       ).toHaveCount(0);
 
       const wfSection = page.locator("[data-testid='perc-workflow-section']");
@@ -44,11 +47,14 @@ test.describe("Administration WorkflowSection load (#2959)", () => {
         page.locator("[data-testid='create-workflow-button']"),
       ).toBeVisible();
       await expect(page.locator("[data-testid='tab-workflow']")).toBeVisible();
+      await expect(
+        page.locator("[data-testid='tab-workflow']"),
+      ).toHaveAttribute("aria-selected", "true");
     },
   );
 
   test(
-    "Admin sibling Administration link reaches workflow section",
+    "Admin workflow tab reaches workflow section (no sibling shell)",
     {
       tag: ["@workflow-admin", "@administration", "@bug-2959"],
     },
@@ -58,17 +64,12 @@ test.describe("Administration WorkflowSection load (#2959)", () => {
       const adminShell = page.locator("[data-testid='perc-admin-shell']");
       await expect(adminShell).toBeVisible({ timeout: 30_000 });
 
-      const workflowLink = page.getByTestId("admin-sibling-workflow-link");
-      if ((await workflowLink.count()) > 0) {
-        await workflowLink.click();
-      } else {
-        // Fallback deep link used by product nav when sibling chrome differs
-        await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
-      }
-
+      // Sibling cross-link removed (#3088); use in-shell Workflow tab
       await expect(
-        page.locator("[data-testid='perc-workflow-admin-shell']"),
-      ).toBeVisible({ timeout: 30_000 });
+        page.getByTestId("admin-sibling-workflow-link"),
+      ).toHaveCount(0);
+
+      await page.locator("[data-testid='tab-workflow']").click();
       await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
       await expect(
         page.locator("[data-testid='perc-workflow-section']"),

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-945-admin-portrait.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-945-admin-portrait.spec.js
@@ -19,6 +19,8 @@
  *
  * Primary Admin chrome (SPA AdminShell tabs) must remain clickable when the
  * viewport is phone-portrait sized — wrapping tabs / no fixed min-width clip.
+ *
+ * #3088: Workflow / roles / users / categories are Admin tabs in the same shell.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -50,6 +52,10 @@ test.describe("Admin portrait layout (GH-945)", () => {
       "tab-logs",
       "tab-notifications",
       "tab-tools",
+      "tab-workflow",
+      "tab-roles",
+      "tab-users",
+      "tab-categories",
     ]) {
       const tab = page.locator(`[data-testid='${id}']`);
       await expect(tab).toBeVisible();
@@ -72,17 +78,16 @@ test.describe("Admin portrait layout (GH-945)", () => {
     ).toBeVisible();
   });
 
-  test("Workflow AdminShell tabs remain visible in portrait", async ({
+  test("Admin workflow tabs remain visible in portrait (#3088)", async ({
     page,
   }) => {
+    // Legacy workflow entry redirects into Admin workflow tab
     await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
 
-    const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+    const shell = page.locator("[data-testid='perc-admin-shell']");
     await expect(shell).toBeVisible({ timeout: 20_000 });
 
-    const tablist = page.locator(
-      "[data-testid='perc-workflow-admin-tablist']",
-    );
+    const tablist = page.locator("[data-testid='perc-admin-tablist']");
     await expect(tablist).toBeVisible();
 
     for (const id of [

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -10,18 +10,17 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
 /**
- * Top navigation restructure (#2702 / #2784 / #2953):
+ * Top navigation restructure (#2702 / #2784 / #2953 / #3088):
  * - Dashboard removed from SPA top chrome
  * - Explorer immediately after Home
- * - Single consolidated Admin (no separate Administration + Admin tools)
- * - Admin lands on working Admin tools shell (/admin); Workflow via sibling
- * - Admin tools shell title + Administration sibling; /workflow → Admin tools sibling
+ * - Single consolidated Admin (no separate Administration + Admin tools shells)
+ * - Admin lands on unified Admin shell (/admin); workflow/roles/users/categories
+ *   are in-shell tabs (sibling chrome removed in #3088)
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -77,7 +76,7 @@ test.describe("Top nav restructure (#2702)", () => {
     });
     expect(adjacency).toBe(true);
 
-    // Consolidated Admin lands on working Admin tools shell (#2784 / #2953)
+    // Consolidated Admin lands on unified Admin shell (#2784 / #3088)
     await admin.click();
     await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
       timeout: 30_000,
@@ -85,21 +84,20 @@ test.describe("Top nav restructure (#2702)", () => {
     await expect(page.getByTestId("perc-admin-shell-title")).toContainText(
       /Admin tools/i,
     );
-    // Workflow administration still reachable from Admin tools sibling link
-    const workflowLink = page.getByTestId("admin-sibling-workflow-link");
-    await expect(workflowLink).toBeVisible();
-    await expect(workflowLink).toContainText(/Administration/i);
-    await workflowLink.click();
-    await expect(page.getByTestId("perc-workflow-admin-shell")).toBeVisible({
+    // No sibling cross-links; workflow is an Admin tab (#3088)
+    await expect(page.getByTestId("admin-sibling-workflow-link")).toHaveCount(0);
+    await expect(page.getByTestId("admin-sibling-tools-link")).toHaveCount(0);
+    await expect(page.getByTestId("tab-workflow")).toBeVisible();
+    await expect(page.getByTestId("tab-roles")).toBeVisible();
+    await expect(page.getByTestId("tab-users")).toBeVisible();
+    await expect(page.getByTestId("tab-categories")).toBeVisible();
+
+    await page.getByTestId("tab-workflow").click();
+    await expect(page.getByTestId("perc-workflow-section")).toBeVisible({
       timeout: 30_000,
     });
-    // Deep-linked Administration surface must offer Admin tools sibling (#2953)
-    const toolsLink = page.getByTestId("admin-sibling-tools-link");
-    await expect(toolsLink).toBeVisible();
-    await expect(toolsLink).toContainText(/Admin tools/i);
-    await toolsLink.click();
-    await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
-      timeout: 30_000,
-    });
+    // Still one Admin shell (no WorkflowAdminShell product chrome)
+    await expect(page.getByTestId("perc-admin-shell")).toBeVisible();
+    await expect(page.getByTestId("perc-workflow-admin-shell")).toHaveCount(0);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/us1-workflow-definitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-workflow-definitions.spec.js
@@ -10,23 +10,23 @@ test.describe("Workflow Administration - Workflow Definitions (US1)", () => {
     "navigate to workflow admin and verify shell and list render",
     { tag: ["@workflow-admin", "@administration", "@smoke"] },
     async ({ page }) => {
+      // Legacy view=workflow → unified Admin workflow tab (#3088)
       await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
 
-      // Verify WorkflowAdminShell container is present
-      const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+      const shell = page.locator("[data-testid='perc-admin-shell']");
       await expect(shell).toBeVisible({ timeout: 30_000 });
 
       // #2959: wrapper payload must not trip RouteErrorBoundary (e.map is not a function)
       await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
       await expect(
-        page.getByText(/Unable to load Administration/i),
+        page.getByText(/Unable to load Admin/i),
       ).toHaveCount(0);
 
       // Verify Workflow section table is visible
       const wfSection = page.locator("[data-testid='perc-workflow-section']");
       await expect(wfSection).toBeVisible({ timeout: 30_000 });
 
-      // Verify tabs are present
+      // Verify tabs are present on unified Admin shell
       await expect(page.locator("[data-testid='tab-workflow']")).toBeVisible();
       await expect(page.locator("[data-testid='tab-roles']")).toBeVisible();
       await expect(page.locator("[data-testid='tab-users']")).toBeVisible();

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -14,16 +14,25 @@ day-two server operations.
 
 ## Product Admin navigation (SPA)
 
-The top navigation exposes a **single Admin** item for administrators:
+The top navigation exposes a **single Admin** item for administrators. Admin opens one
+unified **Admin** product shell with tabs for:
 
-1. **Admin** opens the **Admin tools** shell (scheduled tasks, execution logs, notification
-   settings, and system tools such as the security audit log and consistency checker).
-2. From Admin tools, use the **Administration** sibling link (page header, right side) to open
-   workflow / users / roles / categories administration.
-3. From Administration, use the **Admin tools** sibling link to return to the tools shell.
+| Tab | Purpose |
+|-----|---------|
+| Scheduled Tasks | Create and run scheduled CMS tasks |
+| Execution Logs | Review task run history |
+| Notification Settings | Task email notification templates |
+| System Tools | Security audit log, consistency checker |
+| Workflow | Workflow definitions and site/folder assignment |
+| Roles | Role membership |
+| Users | User accounts and default landing |
+| Categories | Category tree administration |
 
-There are no separate top-nav entries for Administration and Admin tools. Both surfaces share
-the consolidated Admin highlight in the top bar.
+Legacy bookmarks and deep links under `/workflow` and `/workflow/:tab` redirect into the
+matching Admin tab (for example `/admin/workflow`, `/admin/roles`). There is no separate
+Workflow administration shell or sibling cross-link between Admin tools and Administration.
+
+Non-administrators never see the Admin top-nav item or these configuration surfaces.
 
 ## Topics
 


### PR DESCRIPTION
## Summary

Folds **Workflow administration** (workflows, roles, users, categories) into the unified **Admin** product shell under `/admin/*`, removing the sibling `WorkflowAdminShell` product chrome and cross-links (#3088).

- **AdminShell** hosts eight tabs: tasks, logs, notifications, tools, workflow, roles, users, categories
- **Legacy `/workflow` and `/workflow/:tab`** redirect to `/admin/workflow` (etc.) with Admin-only `RequireRole`
- **`view=workflow`** (index.jsp) maps to `entry=admin&tab=workflow` (or tab query); dual-tree index.jsp stay identical
- **Client deep links** `entry=workflow` resolve to `/admin/*` client paths
- **Sibling links** Admin↔Workflow removed
- **WorkflowAdminShell** reduced to redirect-only registry stub
- **product-docs** admin page documents one Admin area
- **Playwright** surface specs updated for single shell

Does **not** move Explorer item workflow actions or Developer → Workflows design objects.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3088

## Test plan

- [x] `cd WebUI && ../mvnw.cmd clean install` (includes frontend Vitest + Surefire)
- [x] Focused Vitest: AdminShell, WorkflowAdminShell redirect, App, topNav, parseEntryQuery (46 passed)
- [ ] Human QA: Admin top-nav → unified shell; Workflow/Roles/Users/Categories tabs; legacy `/workflow` bookmark; non-admin never sees Admin; portrait tabs wrap

## Gates evidence

**modules_built:** `WebUI`

**build_evidence:**
```
cd WebUI
../mvnw.cmd clean install
→ BUILD SUCCESS (exit 0); perc-web-ui-8.2.0-SNAPSHOT.war
Surefire: PSWebUiSpaFallbackFilterTest 10, GadgetRegistryTest 15, PSDefaultLandingViewTest 11, PSProxyHostSchemeTest 7 (0 failures)
Focused Vitest (post-install): 6 files, 46 tests passed
```

**downstream_checked:** none (no public Java API shape change; SPA IA only)

**Erlang:** approve — `docs/ai-generated/code-reviews/issue-3088-fold-workflow-admin-erlang.md`

## Product documentation

- [x] Updated `product-docs/8.2/admin/index.md` (single Admin area, tab table, legacy redirects)

## Checklist

- [x] Unit tests updated for new host / redirects
- [x] Playwright surface specs updated
- [x] Admin-only gate preserved
- [x] No merge by agent

> Co-Authored by Grok Build using grok-4.5 with agent main.
