### PR TITLE
fix(auditlog): unwrap WRAP_ROOT so Security Audit Log shows durable rows (#3089)

### DIFF
--- a/WebUI/src/main/ts/api/auditlog/auditLogApi.ts
+++ b/WebUI/src/main/ts/api/auditlog/auditLogApi.ts
@@ -24,6 +24,11 @@
  *
  * AuthZ (server): Admin role or role property {@code sys_securityAuditLogViewer}.
  * Unauthorized → HTTP 403.
+ *
+ * <p>REST {@code JacksonContextResolver} enables {@code WRAP_ROOT_VALUE}, so list/detail
+ * responses arrive as {@code {"SystemAuditLogPage":{…}}} / {@code {"SystemAuditLogEntry":{…}}}.
+ * Without client unwrap the Admin Security Audit Log viewer always shows 0 rows even when the
+ * durable store and Log4j dual-write succeeded (#3089, same class as #2708 / #3039).
  */
 
 import { get, isApiError } from "../client";
@@ -34,6 +39,12 @@ import type {
   SystemAuditLogEntry,
   SystemAuditLogPage,
 } from "./types";
+
+/** Jackson WRAP_ROOT_VALUE root for {@code SystemAuditLogPage}. */
+export const SYSTEM_AUDIT_LOG_PAGE_ROOT = "SystemAuditLogPage";
+
+/** Jackson WRAP_ROOT_VALUE root for {@code SystemAuditLogEntry}. */
+export const SYSTEM_AUDIT_LOG_ENTRY_ROOT = "SystemAuditLogEntry";
 
 export class AuditLogForbiddenError extends Error {
   readonly status = 403;
@@ -54,18 +65,87 @@ function rethrowIfForbidden(err: unknown): never {
   throw err;
 }
 
-function asPage(payload: unknown): SystemAuditLogPage {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function isAuditPageShape(o: Record<string, unknown>): boolean {
+  return (
+    Array.isArray(o.entries) ||
+    typeof o.total === "number" ||
+    typeof o.offset === "number" ||
+    typeof o.limit === "number"
+  );
+}
+
+function isAuditEntryShape(o: Record<string, unknown>): boolean {
+  return (
+    typeof o.auditId === "string" ||
+    typeof o.moduleCode === "string" ||
+    typeof o.eventType === "string" ||
+    typeof o.userMessage === "string" ||
+    typeof o.logMessage === "string"
+  );
+}
+
+/**
+ * Normalize a list response to a flat {@link SystemAuditLogPage}.
+ *
+ * <p>Prefers {@code {"SystemAuditLogPage":{…}}} (production WRAP_ROOT_VALUE); also accepts a
+ * flat body (unit tests / proxies that already unwrapped).
+ */
+export function unwrapSystemAuditLogPage(payload: unknown): SystemAuditLogPage {
   if (payload == null || typeof payload !== "object") {
     return { entries: [], total: 0, offset: 0, limit: 50 };
   }
-  const p = payload as SystemAuditLogPage;
-  const entries = Array.isArray(p.entries) ? p.entries : [];
+  const root = asRecord(payload);
+  if (!root) {
+    return { entries: [], total: 0, offset: 0, limit: 50 };
+  }
+  const nested = asRecord(
+    root[SYSTEM_AUDIT_LOG_PAGE_ROOT] ?? root.systemAuditLogPage,
+  );
+  const body = nested && isAuditPageShape(nested) ? nested : isAuditPageShape(root) ? root : null;
+  if (!body) {
+    return { entries: [], total: 0, offset: 0, limit: 50 };
+  }
+  const rawEntries = body.entries;
+  const entries: SystemAuditLogEntry[] = Array.isArray(rawEntries)
+    ? rawEntries.map((row) => unwrapSystemAuditLogEntry(row) ?? (row as SystemAuditLogEntry))
+    : [];
   return {
     entries,
-    total: typeof p.total === "number" ? p.total : entries.length,
-    offset: typeof p.offset === "number" ? p.offset : 0,
-    limit: typeof p.limit === "number" ? p.limit : 50,
+    total: typeof body.total === "number" ? body.total : entries.length,
+    offset: typeof body.offset === "number" ? body.offset : 0,
+    limit: typeof body.limit === "number" ? body.limit : 50,
   };
+}
+
+/**
+ * Normalize a detail response to a flat {@link SystemAuditLogEntry}.
+ *
+ * <p>Prefers {@code {"SystemAuditLogEntry":{…}}}; accepts flat bodies for tests.
+ */
+export function unwrapSystemAuditLogEntry(
+  payload: unknown,
+): SystemAuditLogEntry | null {
+  const root = asRecord(payload);
+  if (!root) {
+    return null;
+  }
+  const nested = asRecord(
+    root[SYSTEM_AUDIT_LOG_ENTRY_ROOT] ?? root.systemAuditLogEntry,
+  );
+  if (nested && isAuditEntryShape(nested)) {
+    return nested as SystemAuditLogEntry;
+  }
+  if (isAuditEntryShape(root)) {
+    return root as SystemAuditLogEntry;
+  }
+  return null;
 }
 
 /** Query a page of durable system audit log entries. */
@@ -75,7 +155,7 @@ export async function queryAuditLogEntries(
   const qs = buildAuditLogQueryString(params);
   try {
     const payload = await get<unknown>(`${PATHS.AUDIT_LOG_ENTRIES}${qs}`);
-    return asPage(payload);
+    return unwrapSystemAuditLogPage(payload);
   } catch (err) {
     rethrowIfForbidden(err);
   }
@@ -90,9 +170,14 @@ export async function getAuditLogEntry(
     throw new Error("auditId is required");
   }
   try {
-    return await get<SystemAuditLogEntry>(
+    const payload = await get<unknown>(
       `${PATHS.AUDIT_LOG_ENTRIES}/${encodeURIComponent(id)}`,
     );
+    const entry = unwrapSystemAuditLogEntry(payload);
+    if (!entry) {
+      throw new Error("Audit log entry response was empty or mis-shaped");
+    }
+    return entry;
   } catch (err) {
     rethrowIfForbidden(err);
   }

--- a/WebUI/src/main/ts/api/auditlog/index.ts
+++ b/WebUI/src/main/ts/api/auditlog/index.ts
@@ -18,6 +18,10 @@ export {
   AuditLogForbiddenError,
   getAuditLogEntry,
   queryAuditLogEntries,
+  SYSTEM_AUDIT_LOG_ENTRY_ROOT,
+  SYSTEM_AUDIT_LOG_PAGE_ROOT,
+  unwrapSystemAuditLogEntry,
+  unwrapSystemAuditLogPage,
 } from "./auditLogApi";
 export {
   AUDIT_LOG_PAGE_SIZE_OPTIONS,

--- a/WebUI/src/main/ts/api/auditlog/types.ts
+++ b/WebUI/src/main/ts/api/auditlog/types.ts
@@ -17,6 +17,11 @@
 /**
  * Wire types for {@code GET /services/auditlog/entries} (rest AuditLogResource).
  * Mirrors {@code com.percussion.rest.auditlog.SystemAuditLogEntry / SystemAuditLogPage}.
+ *
+ * <p>On the wire under {@code JacksonContextResolver} WRAP_ROOT_VALUE the page is nested as
+ * {@code {"SystemAuditLogPage":{ entries, total, … }}} and a detail row as
+ * {@code {"SystemAuditLogEntry":{…}}}. Prefer {@link unwrapSystemAuditLogPage} /
+ * {@link unwrapSystemAuditLogEntry} before reading fields (#3089).
  */
 
 export interface SystemAuditLogEntry {

--- a/WebUI/src/test/ts/api/auditlog/auditLogApi.test.ts
+++ b/WebUI/src/test/ts/api/auditlog/auditLogApi.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuditLogEntry,
+  queryAuditLogEntries,
+  SYSTEM_AUDIT_LOG_ENTRY_ROOT,
+  SYSTEM_AUDIT_LOG_PAGE_ROOT,
+  unwrapSystemAuditLogEntry,
+  unwrapSystemAuditLogPage,
+} from "../../../../main/ts/api/auditlog/auditLogApi";
+import * as client from "../../../../main/ts/api/client";
+
+vi.mock("../../../../main/ts/api/client", async () => {
+  const actual = await vi.importActual<typeof import("../../../../main/ts/api/client")>(
+    "../../../../main/ts/api/client",
+  );
+  return {
+    ...actual,
+    get: vi.fn(),
+  };
+});
+
+const sampleEntry = {
+  auditId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  eventTime: "2026-08-09T15:00:00Z",
+  moduleCode: "AUTH",
+  eventType: "AUTH_LOGIN",
+  outcome: "SUCCESS",
+  actor: "Admin",
+  userMessage: "User Admin logged in",
+  logMessage: "[AUTH-1001]-[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] login ok",
+};
+
+describe("unwrapSystemAuditLogPage", () => {
+  it("unwraps WRAP_ROOT SystemAuditLogPage so entries and total bind (#3089)", () => {
+    const page = unwrapSystemAuditLogPage({
+      [SYSTEM_AUDIT_LOG_PAGE_ROOT]: {
+        entries: [sampleEntry],
+        total: 1,
+        offset: 0,
+        limit: 50,
+      },
+    });
+    expect(page.total).toBe(1);
+    expect(page.entries).toHaveLength(1);
+    expect(page.entries?.[0]?.auditId).toBe(sampleEntry.auditId);
+    expect(page.entries?.[0]?.moduleCode).toBe("AUTH");
+  });
+
+  it("accepts flat page bodies (tests / already-unwrapped proxies)", () => {
+    const page = unwrapSystemAuditLogPage({
+      entries: [sampleEntry],
+      total: 3,
+      offset: 10,
+      limit: 25,
+    });
+    expect(page.total).toBe(3);
+    expect(page.offset).toBe(10);
+    expect(page.limit).toBe(25);
+    expect(page.entries).toHaveLength(1);
+  });
+
+  it("returns empty page for null or mis-shaped payloads (not throw)", () => {
+    expect(unwrapSystemAuditLogPage(null).total).toBe(0);
+    expect(unwrapSystemAuditLogPage(undefined).entries).toEqual([]);
+    expect(unwrapSystemAuditLogPage({ Error: { message: "x" } }).total).toBe(0);
+  });
+
+  it("without unwrap WRAP_ROOT would hide entries (regression guard)", () => {
+    const wire = {
+      [SYSTEM_AUDIT_LOG_PAGE_ROOT]: {
+        entries: [sampleEntry],
+        total: 1,
+      },
+    };
+    // Naive flat read (pre-#3089 asPage) sees no top-level entries.
+    const naiveEntries = Array.isArray((wire as { entries?: unknown }).entries)
+      ? (wire as { entries: unknown[] }).entries
+      : [];
+    expect(naiveEntries).toHaveLength(0);
+    expect(unwrapSystemAuditLogPage(wire).entries).toHaveLength(1);
+  });
+});
+
+describe("unwrapSystemAuditLogEntry", () => {
+  it("unwraps WRAP_ROOT SystemAuditLogEntry for detail panel", () => {
+    const entry = unwrapSystemAuditLogEntry({
+      [SYSTEM_AUDIT_LOG_ENTRY_ROOT]: sampleEntry,
+    });
+    expect(entry?.auditId).toBe(sampleEntry.auditId);
+    expect(entry?.userMessage).toContain("logged in");
+  });
+
+  it("accepts flat entry bodies", () => {
+    expect(unwrapSystemAuditLogEntry(sampleEntry)?.actor).toBe("Admin");
+  });
+
+  it("returns null for empty/mis-shaped", () => {
+    expect(unwrapSystemAuditLogEntry(null)).toBeNull();
+    expect(unwrapSystemAuditLogEntry({})).toBeNull();
+  });
+});
+
+describe("queryAuditLogEntries / getAuditLogEntry", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("queryAuditLogEntries unwraps wrapped GET payload", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      [SYSTEM_AUDIT_LOG_PAGE_ROOT]: {
+        entries: [sampleEntry],
+        total: 1,
+        offset: 0,
+        limit: 50,
+      },
+    });
+    const page = await queryAuditLogEntries({ module: "AUTH" });
+    expect(page.total).toBe(1);
+    expect(page.entries?.[0]?.moduleCode).toBe("AUTH");
+    expect(client.get).toHaveBeenCalled();
+  });
+
+  it("getAuditLogEntry unwraps wrapped detail payload", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      [SYSTEM_AUDIT_LOG_ENTRY_ROOT]: sampleEntry,
+    });
+    const entry = await getAuditLogEntry(sampleEntry.auditId);
+    expect(entry.auditId).toBe(sampleEntry.auditId);
+    expect(entry.logMessage).toContain("AUTH-1001");
+  });
+});

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
@@ -170,8 +170,12 @@ public final class DefaultAuditLogService implements AuditLogService {
         sink.write(record);
       } catch (RuntimeException ex) {
         sinkFailureCount.incrementAndGet();
+        // Dual-write split-brain: other sinks (e.g. Log4j) may have already succeeded. Operators
+        // must see ERROR when the durable repository leg fails while server.log still has AUTH
+        // lines (#3089 / AU-5 fail-safe logging).
         FAILURE_LOG.error(
-            "AUDIT_SINK_FAILURE sink={} logId={} code={}: {}",
+            "AUDIT_SINK_FAILURE sink={} logId={} code={} — other sinks may have succeeded"
+                + " (dual-write split-brain risk if this is the durable repository): {}",
             sink.name(),
             logId.value(),
             code.qualifiedCode(),

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
@@ -78,10 +78,11 @@ class DefaultAuditLogServiceTest {
 
   @Test
   void sinkFailureDoesNotPreventOtherSinks() {
-    CapturingAuditLogSink ok = new CapturingAuditLogSink("ok");
-    CapturingAuditLogSink bad = new CapturingAuditLogSink("bad", true);
+    // Log4j-like sink still receives the event when durable repository sink fails (#3089).
+    CapturingAuditLogSink log4j = new CapturingAuditLogSink("log4j");
+    CapturingAuditLogSink repository = new CapturingAuditLogSink("repository", true);
     DefaultAuditLogService svc =
-        DefaultAuditLogService.builder().addSink(bad).addSink(ok).build();
+        DefaultAuditLogService.builder().addSink(log4j).addSink(repository).build();
 
     AuditLogId id =
         svc.log(
@@ -91,12 +92,12 @@ class DefaultAuditLogServiceTest {
             "password=hunter2",
             "1.2.3.4");
 
-    assertEquals(1, ok.records().size());
-    assertEquals(0, bad.records().size());
-    assertEquals(id, ok.records().get(0).logId());
+    assertEquals(1, log4j.records().size());
+    assertEquals(0, repository.records().size());
+    assertEquals(id, log4j.records().get(0).logId());
     assertEquals(1, svc.sinkFailureCount());
     assertTrue(
-        !ok.records().get(0).logMessage().contains("hunter2"),
+        !log4j.records().get(0).logMessage().contains("hunter2"),
         "secret must be redacted even when one sink fails");
   }
 

--- a/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogEntry.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogEntry.java
@@ -17,12 +17,19 @@
 package com.percussion.rest.auditlog;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.time.Instant;
 
-/** Wire DTO for one row from {@code PSX_SYSTEM_AUDIT_LOG}. */
+/**
+ * Wire DTO for one row from {@code PSX_SYSTEM_AUDIT_LOG}.
+ *
+ * <p>Wire root {@code SystemAuditLogEntry} matches {@code WRAP_ROOT_VALUE}/{@code
+ * UNWRAP_ROOT_VALUE} (JacksonContextResolver). SPA detail panel must unwrap (#3089).
+ */
 @XmlRootElement(name = "SystemAuditLogEntry")
+@JsonRootName("SystemAuditLogEntry")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "System security audit log entry")
 public class SystemAuditLogEntry {

--- a/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogPage.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogPage.java
@@ -17,13 +17,21 @@
 package com.percussion.rest.auditlog;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Paged query result for system audit log entries. */
+/**
+ * Paged query result for system audit log entries.
+ *
+ * <p>Wire root {@code SystemAuditLogPage} matches {@code WRAP_ROOT_VALUE}/{@code
+ * UNWRAP_ROOT_VALUE} (JacksonContextResolver). SPA clients must unwrap before reading {@code
+ * entries}/{@code total} (#3089).
+ */
 @XmlRootElement(name = "SystemAuditLogPage")
+@JsonRootName("SystemAuditLogPage")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Paged system security audit log query result")
 public class SystemAuditLogPage {

--- a/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogPageSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogPageSerialDeserialTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link SystemAuditLogPage} / {@link SystemAuditLogEntry} under WRAP_ROOT_VALUE
+ * / UNWRAP_ROOT_VALUE (#3089).
+ *
+ * <p>SPA clients must unwrap {@code {"SystemAuditLogPage":{…}}} or the Security Audit Log viewer
+ * always shows 0 rows even when PSX_SYSTEM_AUDIT_LOG and Log4j dual-write succeeded.
+ */
+@Tag("UnitTest")
+public class SystemAuditLogPageSerialDeserialTest {
+
+  private final ObjectMapper pageMapper =
+      new JacksonContextResolver().getContext(SystemAuditLogPage.class);
+
+  private final ObjectMapper entryMapper =
+      new JacksonContextResolver().getContext(SystemAuditLogEntry.class);
+
+  @Test
+  public void serializesPageUnderSystemAuditLogPageRoot() {
+    SystemAuditLogEntry e = sampleEntry();
+    SystemAuditLogPage page = new SystemAuditLogPage(List.of(e), 1L, 0, 50);
+
+    String json = pageMapper.writeValueAsString(page);
+
+    assertTrue(json.contains("\"SystemAuditLogPage\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"entries\""), json);
+    assertTrue(json.contains("\"total\""), json);
+    assertTrue(json.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), json);
+    assertTrue(json.contains("AUTH"), json);
+  }
+
+  @Test
+  public void deserializesWrappedPageWithEntries() {
+    String json =
+        "{\"SystemAuditLogPage\":{"
+            + "\"entries\":[{"
+            + "\"auditId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\","
+            + "\"moduleCode\":\"AUTH\","
+            + "\"eventType\":\"AUTH_LOGIN\","
+            + "\"outcome\":\"SUCCESS\","
+            + "\"actor\":\"Admin\""
+            + "}],"
+            + "\"total\":1,"
+            + "\"offset\":0,"
+            + "\"limit\":50"
+            + "}}";
+
+    SystemAuditLogPage page = pageMapper.readValue(json, SystemAuditLogPage.class);
+    assertEquals(1L, page.getTotal());
+    assertEquals(0, page.getOffset());
+    assertEquals(50, page.getLimit());
+    assertNotNull(page.getEntries());
+    assertEquals(1, page.getEntries().size());
+    assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", page.getEntries().get(0).getAuditId());
+    assertEquals("AUTH", page.getEntries().get(0).getModuleCode());
+  }
+
+  @Test
+  public void serializesEntryUnderSystemAuditLogEntryRoot() {
+    SystemAuditLogEntry e = sampleEntry();
+    String json = entryMapper.writeValueAsString(e);
+
+    assertTrue(json.contains("\"SystemAuditLogEntry\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"auditId\""), json);
+    assertTrue(json.contains("User Admin logged in"), json);
+  }
+
+  @Test
+  public void deserializesWrappedEntry() {
+    String json =
+        "{\"SystemAuditLogEntry\":{"
+            + "\"auditId\":\"bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee\","
+            + "\"moduleCode\":\"AUTH\","
+            + "\"userMessage\":\"User Admin logged out\""
+            + "}}";
+
+    SystemAuditLogEntry e = entryMapper.readValue(json, SystemAuditLogEntry.class);
+    assertEquals("bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee", e.getAuditId());
+    assertEquals("AUTH", e.getModuleCode());
+    assertEquals("User Admin logged out", e.getUserMessage());
+  }
+
+  @Test
+  public void roundTripPagePreservesTotalAndActor() {
+    SystemAuditLogPage page = new SystemAuditLogPage(List.of(sampleEntry()), 7L, 5, 25);
+    String json = pageMapper.writeValueAsString(page);
+    SystemAuditLogPage back = pageMapper.readValue(json, SystemAuditLogPage.class);
+    assertEquals(7L, back.getTotal());
+    assertEquals(5, back.getOffset());
+    assertEquals(25, back.getLimit());
+    assertEquals(1, back.getEntries().size());
+    assertEquals("Admin", back.getEntries().get(0).getActor());
+  }
+
+  private static SystemAuditLogEntry sampleEntry() {
+    SystemAuditLogEntry e = new SystemAuditLogEntry();
+    e.setAuditId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    e.setEventTime(Instant.parse("2026-08-09T15:00:00Z"));
+    e.setModuleCode("AUTH");
+    e.setMessageCode(1001);
+    e.setEventType("AUTH_LOGIN");
+    e.setOutcome("SUCCESS");
+    e.setActor("Admin");
+    e.setUserMessage("User Admin logged in");
+    e.setLogMessage("[AUTH-1001]-[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] login ok");
+    return e;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes Admin **Security Audit Log** viewer showing **0 results** while login/logout AUTH lines still appear in `server.log` (#3089).

### Root cause
Not dual-write split-brain (REQUIRES_NEW + seed from #2727 remain sound). REST `JacksonContextResolver` enables **`WRAP_ROOT_VALUE`**, so list/detail JSON is:

```json
{"SystemAuditLogPage":{"entries":[...],"total":N,...}}
{"SystemAuditLogEntry":{...}}
```

WebUI `asPage` read top-level `entries`/`total` only → always empty while durable rows and Log4j dual-write succeeded (same class as #2708 / #3039).

### Fix
- **WebUI:** `unwrapSystemAuditLogPage` / `unwrapSystemAuditLogEntry` before binding filters/table/detail; flat-body fallback for tests.
- **rest:** `@JsonRootName` on page/entry DTOs; WRAP_ROOT wire serial/deserial tests.
- **perc-auditlog:** clearer `AUDIT_SINK_FAILURE` ERROR when a sink fails (dual-write split-brain risk if durable repository fails while Log4j succeeds).

### Modules
- `WebUI`
- `rest`
- `modules/perc-auditlog`

## Test plan
1. Deploy build with this PR (or rebuild QA H2 image + WebUI).
2. Log in as Admin; optionally log out/in again.
3. Confirm `server.log` still has AUTH dual-write lines (unchanged).
4. Admin → Tools → Security Audit Log (or `spa.jsp?entry=admin&tab=tools`).
5. Expect **non-empty** table (seed and/or login dual-write); not `0 of 0`.
6. Leave filters blank → Apply; Module `AUTH` → Apply; open a row for user/log message detail.
7. Optional network tab: `GET /services/auditlog/entries` body has `SystemAuditLogPage` root; UI still shows rows.

## Gates evidence
- `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; `DefaultAuditLogServiceTest` Tests run: **6**, Failures: **0**; module total Tests run: **291**
- `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **324**, Failures: **0**; `SystemAuditLogPageSerialDeserialTest` Tests run: **5**, Failures: **0**
- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; focused Vitest auditlog suites: **21** passed (auditLogApi 9 + buildQuery 6 + SecurityAuditLogViewer 6)
- Playwright surface already asserts non-empty rows: `modules/perc-qa-automation/frontend/tests/admin-security-audit-log.spec.js`
- Erlang-style self-review: WRAP_ROOT unwrap peer pattern; no portable-path issues; behavioral unit tests present
- API shape C2: annotation-only DTO + client unwrap; no public method signature / final/sealed blast radius → **downstream_checked=none**
- Product documentation: **N/A** (bugfix restoring existing Admin viewer behavior; no new operator config/surface)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Related
- Fixes #3089
- Prior durable dual-write: #2727 / PR #2747
- WRAP_ROOT peers: #2708, #3039, #2689

> Co-Authored by Grok Build using grok-4.5 with agent main.
