### PR TITLE
fix(i18n): resume nightly refresh and skip URL-only segments

### DIFF
--- a/docs/ai-generated/code-reviews/fix-nightly-i18n-resume-url-identity-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-nightly-i18n-resume-url-identity-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review: fix/nightly-i18n-resume-url-identity
+
+**Date:** 2026-08-11  
+**Scope:** uncommitted tooling for nightly i18n resume + URL-only identity  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for non-trivial logic; false-green / ignored exit codes (resume checkout return codes checked)
+
+## Summary
+
+Small developer-tooling change only (Python scripts + unit tests + READMEs). No product runtime Java, no Maven modules, no product-docs surface.
+
+1. **URL-only identity** in `i18n_translate.py` / `i18n_translate_direct.py` — bare `http(s)://…` segments pass through like placeholders; mixed prose still translates. Prevents hang/rewrite of help-doc href keys via translate-shell.
+2. **`--resume`** on `nightly_i18n_refresh.py` — keeps dirty worktree/locale branch, skips clean-tree and main preflight, requires `--locale`. Proven in production resume of `tr` (#3120).
+
+## Issues
+
+None (no bugs, no missing behavioral tests for new logic).
+
+## Cross-platform path checklist
+
+N/A for product path I/O. Changes use `pathlib.Path` for worktree registration only (existing pattern). Nightly wrapper remains Linux/macOS + `fcntl` (documented).
+
+## Tests run
+
+- `python3 modules/perc-i18n/scripts/test_i18n_translate_direct.py` — 22 OK  
+- `python3 modules/perc-i18n/scripts/test_i18n_translate.py` — 13 OK  
+- `python3 scripts/test_nightly_i18n_refresh.py` — 37 OK  
+
+## Product documentation
+
+N/A — developer/cron tooling only.

--- a/modules/perc-i18n/scripts/README.md
+++ b/modules/perc-i18n/scripts/README.md
@@ -64,6 +64,11 @@ python3 modules/perc-i18n/scripts/i18n_translate.py \
 - **Placeholder-only segments** (e.g. `{0}`, `{1,2,3}`) are skipped — they
   pass through to the output unchanged so parameter substitution still
   works.
+- **URL-only segments** (the entire string is `http://…` or `https://…`)
+  also pass through unchanged. Sending bare URLs to translate-shell can
+  hang or rewrite them into `translate.google.com` wrapper URLs (bad for
+  help-doc href keys). Mixed prose that merely *contains* a URL is still
+  translated.
 - **Cache**: results are keyed by `sha256(target || \0 || text)` and
   stored at the **shared checked-in** file
   `scripts/cache/i18n_translate.json` (both Docker and direct CLIs).

--- a/modules/perc-i18n/scripts/i18n_translate.py
+++ b/modules/perc-i18n/scripts/i18n_translate.py
@@ -66,6 +66,20 @@ DEFAULT_FILES = ('CmsUi.tmx', 'SystemResources.tmx', 'DeveloperUi.tmx')
 # existing translate_tmx.py rule from update_tmx_limited.py:40.
 PLACEHOLDER_RE = re.compile(r'^\s*\{[0-9]+(,[0-9]+)*\}\s*$')
 
+# URL-only segments (e.g. help-doc hrefs). translate-shell often hangs or
+# rewrites these into google-translate wrapper URLs; keep them identity.
+URL_ONLY_RE = re.compile(r'^\s*https?://\S+\s*$', re.IGNORECASE)
+
+
+def is_identity_segment(text: str) -> bool:
+    """True when the source segment must pass through untranslated.
+
+    Covers placeholder-only keys (``{0}``) and bare URL keys. Mixed prose
+    that merely *contains* a URL is translated normally.
+    """
+    return bool(PLACEHOLDER_RE.match(text) or URL_ONLY_RE.match(text))
+
+
 # Exponential-backoff parameters.
 BACKOFF_START_SEC = 2.0
 BACKOFF_MAX_SEC = 60.0
@@ -193,8 +207,8 @@ def translate(text: str, target: str, *,
               cache: dict[str, str] | None = None,
               force: bool = False) -> str:
     """Translate ``text`` to ``target``, honoring the on-disk cache."""
-    if PLACEHOLDER_RE.match(text):
-        return text  # leave placeholders verbatim
+    if is_identity_segment(text):
+        return text  # placeholders and bare URLs pass through
     if cache is None:
         cache = load_cache()
     key = cache_key(text, target)

--- a/modules/perc-i18n/scripts/i18n_translate_direct.py
+++ b/modules/perc-i18n/scripts/i18n_translate_direct.py
@@ -64,7 +64,20 @@ DEFAULT_FILES = ('CmsUi.tmx', 'SystemResources.tmx', 'DeveloperUi.tmx')
 
 PLACEHOLDER_RE = re.compile(r'^\s*\{[0-9]+(,[0-9]+)*\}\s*$')
 
+# URL-only segments (e.g. help-doc hrefs). translate-shell often hangs or
+# rewrites these into google-translate wrapper URLs; keep them identity.
+URL_ONLY_RE = re.compile(r'^\s*https?://\S+\s*$', re.IGNORECASE)
+
 SOURCE_LANG = 'en-us'
+
+
+def is_identity_segment(text: str) -> bool:
+    """True when the source segment must pass through untranslated.
+
+    Covers placeholder-only keys (``{0}``) and bare URL keys. Mixed prose
+    that merely *contains* a URL is translated normally.
+    """
+    return bool(PLACEHOLDER_RE.match(text) or URL_ONLY_RE.match(text))
 
 # Exponential-backoff parameters (shared contract with i18n_translate.py).
 BACKOFF_START_SEC = 2.0
@@ -302,7 +315,7 @@ def _preview(s: str, n: int = 50) -> str:
 
 def translate(text: str, target: str, *, cache: dict[str, str] | None = None, force: bool = False) -> str:
     """Translate text to target, honoring cache."""
-    if PLACEHOLDER_RE.match(text):
+    if is_identity_segment(text):
         return text
     if cache is None:
         cache = load_cache()

--- a/modules/perc-i18n/scripts/test_i18n_translate.py
+++ b/modules/perc-i18n/scripts/test_i18n_translate.py
@@ -60,6 +60,20 @@ class TranslateTest(unittest.TestCase):
         self.assertEqual(result, '{0}')
         self.assertEqual(invoked, [])
 
+    def test_url_only_skipped(self):
+        url = (
+            'https://percussioncmshelp.intsof.com/percussion-cm1/'
+            'install-setup/installing-cm1/system-requirements#browsers'
+        )
+        invoked = []
+        orig_invoke = it.invoke_translate
+        it.invoke_translate = lambda text, target: invoked.append((text, target)) or 'oops'
+        try:
+            self.assertEqual(it.translate(url, 'tr', cache={}), url)
+        finally:
+            it.invoke_translate = orig_invoke
+        self.assertEqual(invoked, [])
+
     def test_uses_cache_without_invoking(self):
         cache = {it.cache_key('Hello', 'de-de'): 'Hallo'}
         invoked = []

--- a/modules/perc-i18n/scripts/test_i18n_translate_direct.py
+++ b/modules/perc-i18n/scripts/test_i18n_translate_direct.py
@@ -40,6 +40,33 @@ class TranslateTest(unittest.TestCase):
     def test_placeholder_skipped(self):
         self.assertEqual(itd.translate("{0}", "ar", cache={}), "{0}")
 
+    def test_url_only_skipped(self):
+        url = (
+            "https://percussioncmshelp.intsof.com/percussion-cm1/"
+            "install-setup/installing-cm1/system-requirements#browsers"
+        )
+        invoked = []
+        orig = itd.invoke_translate
+        itd.invoke_translate = lambda text, target: invoked.append((text, target)) or "nope"
+        try:
+            self.assertEqual(itd.translate(url, "tr", cache={}), url)
+            self.assertEqual(itd.translate("  " + url + "  ", "tr", cache={}), "  " + url + "  ")
+        finally:
+            itd.invoke_translate = orig
+        self.assertEqual(invoked, [])
+
+    def test_prose_with_url_still_translates(self):
+        text = "See https://example.com/docs for details"
+        orig = itd.invoke_translate
+        orig_sleep = itd.time.sleep
+        itd.invoke_translate = lambda text, target: "translated"
+        itd.time.sleep = lambda s: None
+        try:
+            self.assertEqual(itd.translate(text, "tr", cache={}), "translated")
+        finally:
+            itd.invoke_translate = orig
+            itd.time.sleep = orig_sleep
+
     def test_uses_cache_without_invoking(self):
         cache = {itd.cache_key("Hello", "ar"): "مرحبا"}
         invoked = []

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -157,15 +157,20 @@ Automated nightly i18n translation refresh for the 16 base locales.
 
   # Verbose logging
   python3 scripts/nightly_i18n_refresh.py --verbose
+
+  # Resume an interrupted run (keeps dirty TMX/cache on the locale branch)
+  python3 scripts/nightly_i18n_refresh.py --locale tr --resume
   ```
 
   Or via the shell wrapper (recommended for cron):
 
   ```bash
   ./scripts/nightly-i18n-refresh.sh --locale de
+  ./scripts/nightly-i18n-refresh.sh --locale tr --resume
   ```
 
-- **Pre-flight checks**: Verifies `trans` (translate-shell) is on PATH, working tree is clean (in the worktree), on `main` branch (or detached HEAD at `origin/main` — git disallows two worktrees on the same branch), and the **active** `gh` account is authenticated (`gh auth status --active`). Inactive multi-account tokens that are expired do not fail this check.
+- **Pre-flight checks**: Verifies `trans` (translate-shell) is on PATH, working tree is clean (in the worktree), on `main` branch (or detached HEAD at `origin/main` — git disallows two worktrees on the same branch), and the **active** `gh` account is authenticated (`gh auth status --active`). Inactive multi-account tokens that are expired do not fail this check. With **`--resume`**, the clean-tree and main-branch checks are skipped so partial work can continue; `trans` and `gh` are still required. `--resume` also requires `--locale`.
+- **Resume**: After a hang or kill mid-translation, re-run with `--locale <code> --resume` from the same worktree. The wrapper leaves the dirty tree alone; `i18n_translate_direct.py` fills only missing `<tuv>`s and hits the on-disk cache for already-translated strings. Bare URL-only segments pass through without calling `trans` (avoids hangs on help-doc href keys).
 - **Pipeline**: Ensures worktree exists → fetches origin/main → checks for existing PR → creates branch → runs `i18n_translate_direct.py --target <locale>` → runs `i18n_translate_direct.py --target <locale> --fix-matching-en` → commits → pushes → creates PR.
 - **No spotless**: This wrapper does **not** invoke `mvnw spotless:apply`. The perc-i18n spotless config targets JSON (which we exclude due to the 4 MB translation cache) and the eclipseWtp XML formatter hangs on this environment's Eclipse OSGi classloader. TMX formatting is left to the translation script itself per `modules/perc-i18n/AGENTS.md`. The `scripts/cache/**` exclude in `modules/perc-i18n/pom.xml` is kept as defense in depth for manual spotless runs.
 - **Locking**: Uses `flock` on `tmp/nightly-i18n.lock` to prevent concurrent runs.

--- a/scripts/nightly_i18n_refresh.py
+++ b/scripts/nightly_i18n_refresh.py
@@ -9,6 +9,13 @@ Usage:
     python3 scripts/nightly_i18n_refresh.py --locale de
     python3 scripts/nightly_i18n_refresh.py --locale ar --dry-run
     python3 scripts/nightly_i18n_refresh.py --locale fr --verbose
+    python3 scripts/nightly_i18n_refresh.py --locale tr --resume
+
+``--resume`` continues an interrupted locale run: it keeps the worktree on
+the existing ``chore/nightly-i18n-refresh-<locale>`` branch (including a
+dirty tree / partial TMX + cache), skips the clean-tree and main-branch
+preflight, and re-runs translation. The translate scripts already resume
+via the on-disk cache and by only filling missing ``<tuv>`` rows.
 
 Note: This wrapper intentionally does NOT run ``mvnw spotless:apply``. The
 perc-i18n spotless config targets JSON (which we excluded due to the 4 MB
@@ -127,8 +134,43 @@ def run(
     )
 
 
-def ensure_worktree(worktree: Path, logger: logging.Logger) -> bool:
-    """Ensure the dedicated worktree exists and is on main branch."""
+def worktree_registered(worktree: Path) -> bool:
+    """Return True if ``worktree`` exists and is registered with git."""
+    if not worktree.exists():
+        return False
+    worktree_list = run(["git", "worktree", "list", "--porcelain"])
+    resolved = worktree.resolve()
+    for line in worktree_list.stdout.splitlines():
+        if line.startswith("worktree ") and resolved == Path(line[9:]).resolve():
+            return True
+    return False
+
+
+def ensure_worktree(
+    worktree: Path,
+    logger: logging.Logger,
+    *,
+    resume: bool = False,
+) -> bool:
+    """Ensure the dedicated worktree exists and is ready for a fresh run.
+
+    Fresh runs (``resume=False``) fetch ``origin/main`` and move the worktree
+    to detached HEAD at ``origin/main`` so the job starts clean.
+
+    Resume mode only verifies the worktree path is a registered git worktree
+    and leaves the current branch + dirty tree untouched (partial TMX/cache
+    progress from an interrupted translation).
+    """
+    if resume:
+        if not worktree_registered(worktree):
+            if worktree.exists():
+                logger.warning(f"Path {worktree} exists but is not a git worktree")
+            else:
+                logger.error(f"Resume worktree does not exist: {worktree}")
+            return False
+        logger.info(f"Resume mode: keeping worktree state at {worktree}")
+        return True
+
     worktree_list = run(["git", "worktree", "list", "--porcelain"])
 
     if worktree.exists():
@@ -622,14 +664,31 @@ def is_on_main_or_detached(worktree: Path) -> bool:
     return False
 
 
-def run_preflight_checks(logger: logging.Logger, worktree: Path) -> bool:
-    """Run all pre-flight checks. Returns True if all pass."""
+def run_preflight_checks(
+    logger: logging.Logger,
+    worktree: Path,
+    *,
+    resume: bool = False,
+) -> bool:
+    """Run all pre-flight checks. Returns True if all pass.
+
+    Resume mode skips the clean-tree and main-branch checks so an interrupted
+    locale run (dirty TMX/cache on ``chore/nightly-i18n-refresh-<locale>``)
+    can continue.
+    """
     checks: list[tuple[str, "callable[[], bool]"]] = [
         ("trans on PATH", check_trans_available),
-        (f"working tree clean ({worktree})", lambda: is_working_tree_clean_worktree(worktree)),
-        (f"on main branch ({worktree})", lambda: is_on_main_or_detached(worktree)),
         ("gh authenticated", check_gh_auth),
     ]
+    if not resume:
+        checks.insert(
+            1,
+            (f"working tree clean ({worktree})", lambda: is_working_tree_clean_worktree(worktree)),
+        )
+        checks.insert(
+            2,
+            (f"on main branch ({worktree})", lambda: is_on_main_or_detached(worktree)),
+        )
     all_passed, _failures = _evaluate_preflight_checks(
         checks,
         log=lambda msg, *a, **kw: (
@@ -688,11 +747,24 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=DEFAULT_WORKTREE,
         help="Path to the dedicated worktree (default: ~/.kilo/worktrees/nightly-i18n-refresh)",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Continue an interrupted locale run: do not reset the worktree to "
+            "origin/main, allow a dirty tree, and stay on "
+            "chore/nightly-i18n-refresh-<locale> (requires --locale)"
+        ),
+    )
 
     args = parser.parse_args(argv)
 
     logger = setup_logging(args.verbose)
     logger.info("Starting nightly i18n refresh")
+
+    if args.resume and not args.locale:
+        logger.error("--resume requires --locale <code> (e.g. --locale tr)")
+        return 1
 
     lock_fd = acquire_lock(LOCK_FILE)
     if lock_fd is None:
@@ -702,11 +774,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         worktree = args.worktree.resolve()
         logger.info(f"Using worktree: {worktree}")
+        if args.resume:
+            logger.info("Resume mode enabled")
 
-        if not ensure_worktree(worktree, logger):
+        if not ensure_worktree(worktree, logger, resume=args.resume):
             return 1
 
-        if not run_preflight_checks(logger, worktree):
+        if not run_preflight_checks(logger, worktree, resume=args.resume):
             logger.error("Pre-flight checks failed, aborting")
             return 1
 
@@ -716,7 +790,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         locale = select_locale(args.locale)
         logger.info(f"Selected locale: {locale}")
 
-        run(["git", "fetch", "origin", "main"], cwd=worktree)
+        if not args.resume:
+            run(["git", "fetch", "origin", "main"], cwd=worktree)
 
         branch_name = f"chore/nightly-i18n-refresh-{locale}"
 
@@ -725,27 +800,52 @@ def main(argv: Optional[list[str]] = None) -> int:
             logger.info(f"Open PR #{open_pr} exists for {branch_name}, skipping")
             return 0
 
-        local_branch_exists = get_branch_head_commit(branch_name, worktree) is not None
-        if local_branch_exists:
-            age = branch_age_days(branch_name, worktree)
-            logger.debug(f"Branch {branch_name} exists, age: {age} days")
-            if is_branch_stale(age, threshold_days=7):
-                if has_unpushed_commits(branch_name, worktree):
-                    logger.warning(
-                        f"Branch {branch_name} is stale (>7 days) but has unpushed "
-                        f"commits; keeping for manual recovery"
-                    )
+        if args.resume:
+            current = get_current_branch_worktree(worktree)
+            if current == branch_name:
+                logger.info(f"Resume: already on {branch_name}")
+            else:
+                local_exists = get_branch_head_commit(branch_name, worktree) is not None
+                if local_exists:
+                    logger.info(f"Resume: checking out existing branch {branch_name}")
+                    cp = run(["git", "checkout", branch_name], cwd=worktree)
+                    if cp.returncode != 0:
+                        logger.error(
+                            f"Resume: cannot checkout {branch_name} (dirty tree may "
+                            f"conflict): {cp.stderr}"
+                        )
+                        return 1
                 else:
-                    logger.info(f"Branch {branch_name} is stale (>7 days), deleting")
-                    delete_branch(branch_name, worktree)
-                    local_branch_exists = False
-
-        if local_branch_exists:
-            logger.info(f"Reusing existing branch: {branch_name}")
-            run(["git", "checkout", branch_name], cwd=worktree)
+                    logger.info(
+                        f"Resume: creating {branch_name} from current HEAD "
+                        f"(preserving uncommitted progress)"
+                    )
+                    cp = run(["git", "checkout", "-b", branch_name], cwd=worktree)
+                    if cp.returncode != 0:
+                        logger.error(f"Resume: failed to create branch: {cp.stderr}")
+                        return 1
         else:
-            logger.info(f"Creating new branch: {branch_name}")
-            run(["git", "checkout", "-b", branch_name, "origin/main"], cwd=worktree)
+            local_branch_exists = get_branch_head_commit(branch_name, worktree) is not None
+            if local_branch_exists:
+                age = branch_age_days(branch_name, worktree)
+                logger.debug(f"Branch {branch_name} exists, age: {age} days")
+                if is_branch_stale(age, threshold_days=7):
+                    if has_unpushed_commits(branch_name, worktree):
+                        logger.warning(
+                            f"Branch {branch_name} is stale (>7 days) but has unpushed "
+                            f"commits; keeping for manual recovery"
+                        )
+                    else:
+                        logger.info(f"Branch {branch_name} is stale (>7 days), deleting")
+                        delete_branch(branch_name, worktree)
+                        local_branch_exists = False
+
+            if local_branch_exists:
+                logger.info(f"Reusing existing branch: {branch_name}")
+                run(["git", "checkout", branch_name], cwd=worktree)
+            else:
+                logger.info(f"Creating new branch: {branch_name}")
+                run(["git", "checkout", "-b", branch_name, "origin/main"], cwd=worktree)
 
         logger.info(f"Running translation (target: {locale})")
         result1 = run_translate(locale, args.dry_run, worktree, fix_matching=False)

--- a/scripts/test_nightly_i18n_refresh.py
+++ b/scripts/test_nightly_i18n_refresh.py
@@ -270,6 +270,39 @@ class TestPreflightChecks(unittest.TestCase):
         self.assertFalse(all_pass)
         self.assertEqual(failures, ["b"])
 
+    def test_resume_skips_clean_and_main_checks(self):
+        """Resume preflight must not require a clean tree or main branch."""
+        import logging
+        logger = logging.getLogger("test_resume_preflight")
+        logger.addHandler(logging.NullHandler())
+
+        original_trans = m.check_trans_available
+        original_gh = m.check_gh_auth
+        original_clean = m.is_working_tree_clean_worktree
+        original_main = m.is_on_main_or_detached
+
+        m.check_trans_available = lambda: True  # type: ignore[assignment]
+        m.check_gh_auth = lambda: True  # type: ignore[assignment]
+        m.is_working_tree_clean_worktree = lambda wt: False  # type: ignore[assignment]
+        m.is_on_main_or_detached = lambda wt: False  # type: ignore[assignment]
+        try:
+            self.assertTrue(
+                m.run_preflight_checks(logger, Path("/tmp/fake"), resume=True)
+            )
+            self.assertFalse(
+                m.run_preflight_checks(logger, Path("/tmp/fake"), resume=False)
+            )
+        finally:
+            m.check_trans_available = original_trans  # type: ignore[assignment]
+            m.check_gh_auth = original_gh  # type: ignore[assignment]
+            m.is_working_tree_clean_worktree = original_clean  # type: ignore[assignment]
+            m.is_on_main_or_detached = original_main  # type: ignore[assignment]
+
+    def test_resume_cli_requires_locale(self):
+        """--resume without --locale must exit non-zero before locking."""
+        code = m.main(["--resume"])
+        self.assertEqual(code, 1)
+
 
 class TestCheckGhAuth(unittest.TestCase):
     """check_gh_auth must probe only the active gh account (--active)."""


### PR DESCRIPTION
## Summary

Follow-up tooling after the Turkish nightly hang/resume (#3120):

- **URL-only identity** in `i18n_translate.py` / `i18n_translate_direct.py`: bare `http(s)://…` segments pass through untranslated (same idea as `{0}` placeholders). Prevents translate-shell hangs and `translate.google.com` wrapper rewrites on help-doc href keys.
- **`--resume`** on `scripts/nightly_i18n_refresh.py`: keeps the dirty worktree + `chore/nightly-i18n-refresh-<locale>` branch, skips clean-tree/main preflight, requires `--locale`. Re-runs translation so cache hits and already-present `<tuv>`s skip work.
- Docs + unit tests for both behaviors; short Erlang review under `docs/ai-generated/code-reviews/`.

## Usage

```bash
# After an interrupted run (dirty TMX/cache on the locale branch):
scripts/nightly-i18n-refresh.sh --locale tr --resume
```

## Test plan

- [x] `python3 modules/perc-i18n/scripts/test_i18n_translate_direct.py` (22 OK)
- [x] `python3 modules/perc-i18n/scripts/test_i18n_translate.py` (13 OK)
- [x] `python3 scripts/test_nightly_i18n_refresh.py` (37 OK)
- [x] Erlang review: approve (tooling-only; no Maven modules)

## Product documentation

- [x] N/A — developer/cron tooling only; no operator/user-facing product behavior.

## Pre-PR Maven

- [x] N/A — Python scripts only (no module source/POM changes).

Co-Authored by Grok using grok-4.5 with agent coding.