### PR TITLE
feat(#3094): Architecture SPA shell + routing (Slice B)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -58,6 +58,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
           "widget-builder",
           "developer",
           "design",
+          "architecture",
           "explorer",
           "profile",
           "unavailable");
@@ -209,6 +210,9 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     if ("widgetbuilder".equals(entry)) {
       entry = "widget-builder";
     }
+    if ("arch".equals(entry)) {
+      entry = "architecture";
+    }
     if (!SPA_ENTRIES.contains(entry)) {
       return null;
     }
@@ -225,6 +229,9 @@ public class PSWebUiSpaFallbackFilter implements Filter {
         forward.append("&section=").append(urlEncode(second));
       } else if ("workflow".equals(entry) || "admin".equals(entry)) {
         forward.append("&tab=").append(urlEncode(second));
+      } else if ("architecture".equals(entry)) {
+        // Site name path segment (#3094) → query site=
+        forward.append("&site=").append(urlEncode(second));
       }
       // explorer / widget-builder / unavailable: ignore extra path segments
     }

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -24,6 +24,7 @@ export const SPA_ENTRIES = [
   "widget-builder",
   "developer",
   "design",
+  "architecture",
   "explorer",
   "profile",
   "unavailable",
@@ -266,6 +267,25 @@ export function normalizeDesignSection(
     return n as DesignSection;
   }
   return DESIGN_SECTION_ALIASES[n];
+}
+
+/**
+ * Site name for Architecture deep links / path segments (#3094).
+ * Allows common CMS site name characters; rejects traversal and schemes.
+ */
+export function normalizeArchitectureSite(
+  raw: string | null | undefined,
+): string | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const t = raw.trim();
+  if (t.length > 128 || t.includes("://") || t.includes("..") || t.includes("/")) {
+    return undefined;
+  }
+  // Letters, digits, spaces, common punctuation used in demo site names
+  if (!/^[A-Za-z0-9._ -]{1,128}$/.test(t)) {
+    return undefined;
+  }
+  return t;
 }
 
 export function normalizeId(raw: string | null | undefined): string | undefined {

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -18,6 +18,7 @@
 import {
   isSpaEntry,
   normalizeAdminTab,
+  normalizeArchitectureSite,
   normalizeDesignSection,
   normalizeDeveloperSection,
   normalizeExplorerPath,
@@ -41,6 +42,8 @@ export interface ParsedSpaEntry {
   siteId?: string;
   serverId?: string;
   path?: string;
+  /** Architecture site name (path or query; #3094). */
+  site?: string;
 }
 
 /**
@@ -54,9 +57,12 @@ export function parseEntryQuery(
   const params = new URLSearchParams(q);
 
   let entryRaw = (params.get("entry") || "home").trim().toLowerCase();
-  // Legacy alias
+  // Legacy aliases
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
+  }
+  if (entryRaw === "arch") {
+    entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
 
@@ -65,6 +71,7 @@ export function parseEntryQuery(
   const siteId = normalizeId(params.get("siteId"));
   const serverId = normalizeId(params.get("serverId"));
   const path = normalizeExplorerPath(params.get("path"));
+  const site = normalizeArchitectureSite(params.get("site"));
 
   switch (entry) {
     case "home": {
@@ -120,6 +127,17 @@ export function parseEntryQuery(
         clientPath: section ? `/design/${section}` : "/design",
       };
     }
+    case "architecture": {
+      // Prefer path segment when site is a simple token; else query site=
+      if (site) {
+        return {
+          entry,
+          site,
+          clientPath: `/architecture/${encodeURIComponent(site)}`,
+        };
+      }
+      return { entry, clientPath: "/architecture" };
+    }
     case "explorer": {
       let clientPath = "/explorer";
       if (path) {
@@ -148,6 +166,7 @@ export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
   if (parsed.siteId) params.set("siteId", parsed.siteId);
   if (parsed.serverId) params.set("serverId", parsed.serverId);
   if (parsed.path) params.set("path", parsed.path);
+  if (parsed.site) params.set("site", parsed.site);
   return `/cm/app/spa.jsp?${params.toString()}`;
 }
 
@@ -181,6 +200,9 @@ export function parseClientPath(
   let entryRaw = (segments[0] || "home").toLowerCase();
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
+  }
+  if (entryRaw === "arch") {
+    entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
   const second = segments[1];
@@ -238,6 +260,21 @@ export function parseClientPath(
         section,
         clientPath: section ? `/developer/${section}` : "/developer",
       };
+    }
+    case "architecture": {
+      const siteFromPath = normalizeArchitectureSite(
+        second != null ? decodeURIComponent(second) : undefined,
+      );
+      const siteFromQuery = normalizeArchitectureSite(params.get("site"));
+      const site = siteFromPath ?? siteFromQuery;
+      if (site) {
+        return {
+          entry,
+          site,
+          clientPath: `/architecture/${encodeURIComponent(site)}`,
+        };
+      }
+      return { entry, clientPath: "/architecture" };
     }
     case "explorer": {
       let cp = "/explorer";

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -99,16 +99,18 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "architecture":
+              // SPA Architecture shell (#3094 / parent #3092) — not legacy view=arch
               return (
                 <li key={id}>
-                  <a
-                    className={styles.navLink}
-                    href="/cm/app/?view=arch"
+                  <NavLink
+                    to="/architecture"
+                    className={linkClass}
                     data-testid="nav-architecture"
+                    title={message(MSG.NAV_ARCHITECTURE_TITLE)}
                     {...i18nKeyAttr(MSG.NAV_ARCHITECTURE)}
                   >
                     {message(MSG.NAV_ARCHITECTURE)}
-                  </a>
+                  </NavLink>
                 </li>
               );
             case "design":

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -51,6 +51,12 @@ export interface TopNavGates {
 export const ADMIN_NAV_LANDING = "/admin";
 
 /**
+ * Client path for Architecture top-nav NavLink and homepage SPA landing (#3094).
+ * Replaces primary legacy {@code ?view=arch} / {@code siteArchitecture.jsp} entry.
+ */
+export const ARCHITECTURE_NAV_LANDING = "/architecture";
+
+/**
  * Ordered top-nav item ids for the given role / feature gates.
  * Explorer is always immediately after Home.
  */

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -20,6 +20,7 @@ import { Navigate, Route, Routes } from "react-router";
 import { FeaturePlaceholder } from "./FeaturePlaceholder";
 import { AppLayout } from "./layout/AppLayout";
 import { AdminRoute } from "./routes/AdminRoute";
+import { ArchitectureRoute } from "./routes/ArchitectureRoute";
 import { DesignRoute } from "./routes/DesignRoute";
 import { DeveloperRoute } from "./routes/DeveloperRoute";
 import { ExplorerRoute } from "./routes/ExplorerRoute";
@@ -52,6 +53,8 @@ export function AppRoutes(): React.ReactElement {
         <Route path="developer/:section" element={<DeveloperRoute />} />
         <Route path="design" element={<DesignRoute />} />
         <Route path="design/:section" element={<DesignRoute />} />
+        <Route path="architecture" element={<ArchitectureRoute />} />
+        <Route path="architecture/:site" element={<ArchitectureRoute />} />
         <Route path="explorer" element={<ExplorerRoute />} />
         <Route path="profile" element={<ProfileRoute />} />
         <Route

--- a/WebUI/src/main/ts/app/routes/ArchitectureRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ArchitectureRoute.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { lazy } from "react";
+import { useParams, useSearchParams } from "react-router";
+import { loadComponent } from "../../registry";
+import { ARCH_MSG } from "../../architecture/messages";
+import { normalizeArchitectureSite } from "../deepLinks/allowlists";
+import { LazyRouteFrame } from "./RouteErrorBoundary";
+import { RequireRole } from "./RequireRole";
+
+const ArchitectureShellLazy = lazy(() =>
+  loadComponent("ArchitectureShell").then((C) => ({ default: C })),
+);
+
+/**
+ * SPA Architecture / Navigation module — Admin or Designer (#3094).
+ * Slice B: shell + empty state; tree editing lands in later slices.
+ */
+export function ArchitectureRoute(): React.ReactElement {
+  const { site: siteParam } = useParams();
+  const [searchParams] = useSearchParams();
+  const siteFromQuery = normalizeArchitectureSite(searchParams.get("site"));
+  const siteFromPath = normalizeArchitectureSite(siteParam);
+  const site = siteFromPath ?? siteFromQuery ?? null;
+
+  return (
+    <RequireRole gate="adminOrDesigner">
+      <LazyRouteFrame
+        label={ARCH_MSG.TITLE}
+        fallback={
+          <div
+            data-testid="route-architecture-loading"
+            style={{ padding: "1.5rem" }}
+          >
+            {ARCH_MSG.SHELL_LOADING}
+          </div>
+        }
+      >
+        <ArchitectureShellLazy embedded initialSite={site} />
+      </LazyRouteFrame>
+    </RequireRole>
+  );
+}

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { catalogColors } from "../developer/catalogStyles";
+import { ARCH_MSG } from "./messages";
+
+export interface ArchitectureShellProps {
+  /**
+   * Optional site name from SPA path {@code /architecture/:site} or deep-link
+   * query. Tree browsing lands in Slice C; this shell only surfaces context.
+   */
+  initialSite?: string | null;
+  /**
+   * When true (SPA AppLayout), shell is under product chrome — tighter padding.
+   */
+  embedded?: boolean;
+}
+
+/**
+ * Architecture / Navigation SPA shell (#3094 / parent #3092).
+ *
+ * <p>Slice B: product chrome + route only. Empty / in-progress state until
+ * read-only nav tree (Slice C) and structure editing (D–E) land. Primary
+ * top-nav entry is SPA {@code /architecture} — not legacy
+ * {@code siteArchitecture.jsp}.</p>
+ */
+export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
+  initialSite = null,
+  embedded = false,
+}) => {
+  const site =
+    initialSite != null && String(initialSite).trim().length > 0
+      ? String(initialSite).trim()
+      : null;
+
+  const siteHint = site
+    ? ARCH_MSG.SITE_HINT.replace("{0}", site)
+    : ARCH_MSG.SITE_NONE;
+
+  return (
+    <div
+      className="perc-architecture-shell"
+      data-testid="perc-architecture-shell"
+      data-embedded={embedded ? "true" : "false"}
+      data-site={site ?? ""}
+      style={{
+        fontFamily: "var(--perc-font-family, sans-serif)",
+        padding: embedded ? "8px 12px 20px" : "20px",
+        maxWidth: "960px",
+        margin: "0 auto",
+      }}
+    >
+      <header style={{ marginBottom: "16px" }}>
+        <h1
+          style={{ marginBottom: "8px" }}
+          data-testid="architecture-shell-title"
+        >
+          {ARCH_MSG.TITLE}
+        </h1>
+        <p
+          style={{ margin: 0, color: catalogColors.muted, maxWidth: "48rem" }}
+          data-testid="architecture-shell-intro"
+        >
+          {ARCH_MSG.INTRO}
+        </p>
+      </header>
+
+      <section
+        aria-labelledby="architecture-empty-title"
+        data-testid="architecture-empty-state"
+        style={{
+          border: `1px solid ${catalogColors.headerBorder}`,
+          borderRadius: "8px",
+          padding: "1.25rem 1.5rem",
+          background: "#f8fafc",
+        }}
+      >
+        <h2
+          id="architecture-empty-title"
+          style={{
+            marginTop: 0,
+            marginBottom: "0.5rem",
+            fontSize: "1.1rem",
+            color: "#1a202c",
+          }}
+          data-testid="architecture-empty-title"
+        >
+          {ARCH_MSG.EMPTY_TITLE}
+        </h2>
+        <p
+          style={{
+            margin: "0 0 0.75rem",
+            color: catalogColors.muted,
+            lineHeight: 1.5,
+          }}
+          data-testid="architecture-empty-body"
+        >
+          {ARCH_MSG.EMPTY_BODY}
+        </p>
+        <p
+          style={{ margin: 0, color: catalogColors.empty, fontSize: "0.95rem" }}
+          data-testid="architecture-site-hint"
+        >
+          {siteHint}
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default ArchitectureShell;

--- a/WebUI/src/main/ts/architecture/index.ts
+++ b/WebUI/src/main/ts/architecture/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ArchitectureShell } from "./ArchitectureShell";
+export type { ArchitectureShellProps } from "./ArchitectureShell";
+export { ARCH_MSG, ARCH_MSG_KEYS } from "./messages";
+export type { ArchitectureMsgKey } from "./messages";

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { message } from "../i18n/message";
+
+/**
+ * Architecture / Navigation SPA chrome keys (#3094 / parent #3092).
+ * English after {@code @} is the source fallback when TMX is not loaded.
+ * Small key set only — no multi-locale mass TMX backfill in this slice.
+ */
+const KEYS = {
+  TITLE: "perc.ui.architecture.modern@Architecture",
+  INTRO:
+    "perc.ui.architecture.modern@Manage site navigation trees (navons / sections). The modern navigation editor is rolling out under this product shell.",
+  SHELL_LOADING: "perc.ui.architecture.modern@Loading Architecture…",
+  EMPTY_TITLE: "perc.ui.architecture.modern@Navigation editor coming soon",
+  EMPTY_BODY:
+    "perc.ui.architecture.modern@This SPA shell replaces the legacy Architecture page as the primary product entry. Browse and edit navigation trees will land in follow-on slices. Select Architecture from the top nav or open a site deep link when the tree is ready.",
+  SITE_HINT: "perc.ui.architecture.modern@Site context: {0}",
+  SITE_NONE:
+    "perc.ui.architecture.modern@No site selected yet. Site picker and nav tree land in the next Architecture slices.",
+} as const;
+
+export type ArchitectureMsgKey = keyof typeof KEYS;
+
+/** Stable message-key map (tests / i18n key attributes). */
+export const ARCH_MSG_KEYS = KEYS;
+
+/** Resolved English-fallback strings for Architecture shell chrome. */
+export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
+  TITLE: message(KEYS.TITLE),
+  INTRO: message(KEYS.INTRO),
+  SHELL_LOADING: message(KEYS.SHELL_LOADING),
+  EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
+  EMPTY_BODY: message(KEYS.EMPTY_BODY),
+  SITE_HINT: message(KEYS.SITE_HINT),
+  SITE_NONE: message(KEYS.SITE_NONE),
+};

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -207,6 +207,9 @@ export const MSG = {
   NAV_DASHBOARD: "perc.ui.navMenu.dashboard@Dashboard",
   NAV_EDITOR: "perc.ui.navMenu.webmgt@Editor",
   NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Architecture",
+  /** Architecture SPA top-nav tooltip (#3094). */
+  NAV_ARCHITECTURE_TITLE:
+    "perc.ui.architecture.modern@Site navigation (Architecture)",
   /** Design SPA top-nav (#2808) — classic key already en-us "Design". */
   NAV_DESIGN: "perc.ui.navMenu.design@Design",
   NAV_DESIGN_TITLE:

--- a/WebUI/src/main/ts/login/redirect.ts
+++ b/WebUI/src/main/ts/login/redirect.ts
@@ -31,6 +31,9 @@ const ALLOWED_ENTRIES = new Set([
   "explorer",
   "profile",
   "unavailable",
+  "design",
+  "developer",
+  "architecture",
 ]);
 
 /**

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -53,6 +53,7 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
+    // SPA path /architecture (#3094); homepage type remains "Architecture"
     labelKey: "perc.ui.navMenu.architecture@Architecture",
   },
   {

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -111,6 +111,8 @@ const loaders: Record<string, Loader> = {
     import("./developer").then((m) => ({ default: m.DeveloperShell })),
   DesignShell: () =>
     import("./design").then((m) => ({ default: m.DesignShell })),
+  ArchitectureShell: () =>
+    import("./architecture").then((m) => ({ default: m.ArchitectureShell })),
 };
 
 const cache = new Map<string, Promise<ComponentType<any>>>();

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -55,7 +55,7 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // Product "Navigation" / Architecture module
+    // Product "Navigation" / Architecture SPA (#3094 → /architecture)
     labelKey: "perc.ui.navMenu.architecture@Architecture",
   },
   {

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -64,12 +64,13 @@
     Map<String, String> legacyViews = new HashMap<String, String>();
     legacyViews.put("editAsset", "editAsset.jsp");
     legacyViews.put("design", "admin.jsp");
-    legacyViews.put("arch", "siteArchitecture.jsp");
+    // arch / Architecture → SPA entry=architecture (#3094); JSP retained for Slice G only
     legacyViews.put("editor", "webmgt.jsp");
     legacyViews.put("editTemplate", "editTemplate.jsp");
 
     // Modern SPA entries (query contract — never hash). *Modern.jsp is not product path.
     // "dash" is handled as SPA Home gadgets (PR-7 product lock).
+    // "arch" / "architecture" → Architecture SPA shell (#3094).
     String[] spaViews = new String[]{
             "home",
             "publish",
@@ -77,6 +78,8 @@
             "admin",
             "widgetbuilder",
             "developer",
+            "arch",
+            "architecture",
             "dash"
     };
 
@@ -230,6 +233,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
+        else if ("arch".equals(view) || "architecture".equals(view))
+            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+            entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
                 || "developer".equals(view))
@@ -301,6 +307,16 @@
                     DEVELOPER_SECTION_ALIASES);
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
+        }
+        else if ("arch".equals(view) || "architecture".equals(view))
+        {
+            // Optional site context for Architecture SPA (#3094)
+            String site = request.getParameter("site");
+            if (site != null && !site.isBlank() && site.length() <= 128
+                    && !site.contains("://") && !site.contains("..") && !site.contains("/"))
+            {
+                qs.append("&site=").append(URLEncoder.encode(site.trim(), "UTF-8"));
+            }
         }
 
         // Canonical SPA document lives under /cm/app/ (both trees redirect here)

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -52,9 +52,13 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
+        if ("arch".equals(n)) {
+            return "architecture";
+        }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
+                || "design".equals(n) || "architecture".equals(n)
                 || "profile".equals(n)
                 || "unavailable".equals(n)) {
             return n;
@@ -119,7 +123,8 @@
         entry = "home";
     }
     if (("publish".equals(entry) || "widget-builder".equals(entry)
-            || "developer".equals(entry))
+            || "developer".equals(entry) || "design".equals(entry)
+            || "architecture".equals(entry))
             && !(isAdmin || isDesigner)) {
         entry = "home";
     }

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -64,12 +64,13 @@
     Map<String, String> legacyViews = new HashMap<String, String>();
     legacyViews.put("editAsset", "editAsset.jsp");
     legacyViews.put("design", "admin.jsp");
-    legacyViews.put("arch", "siteArchitecture.jsp");
+    // arch / Architecture → SPA entry=architecture (#3094); JSP retained for Slice G only
     legacyViews.put("editor", "webmgt.jsp");
     legacyViews.put("editTemplate", "editTemplate.jsp");
 
     // Modern SPA entries (query contract — never hash). *Modern.jsp is not product path.
     // "dash" is handled as SPA Home gadgets (PR-7 product lock).
+    // "arch" / "architecture" → Architecture SPA shell (#3094).
     String[] spaViews = new String[]{
             "home",
             "publish",
@@ -77,6 +78,8 @@
             "admin",
             "widgetbuilder",
             "developer",
+            "arch",
+            "architecture",
             "dash"
     };
 
@@ -230,6 +233,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
+        else if ("arch".equals(view) || "architecture".equals(view))
+            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+            entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
                 || "developer".equals(view))
@@ -301,6 +307,16 @@
                     DEVELOPER_SECTION_ALIASES);
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
+        }
+        else if ("arch".equals(view) || "architecture".equals(view))
+        {
+            // Optional site context for Architecture SPA (#3094)
+            String site = request.getParameter("site");
+            if (site != null && !site.isBlank() && site.length() <= 128
+                    && !site.contains("://") && !site.contains("..") && !site.contains("/"))
+            {
+                qs.append("&site=").append(URLEncoder.encode(site.trim(), "UTF-8"));
+            }
         }
 
         // Canonical SPA document lives under /cm/app/ (both trees redirect here)

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -52,9 +52,13 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
+        if ("arch".equals(n)) {
+            return "architecture";
+        }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
+                || "design".equals(n) || "architecture".equals(n)
                 || "profile".equals(n)
                 || "unavailable".equals(n)) {
             return n;
@@ -119,7 +123,8 @@
         entry = "home";
     }
     if (("publish".equals(entry) || "widget-builder".equals(entry)
-            || "developer".equals(entry))
+            || "developer".equals(entry) || "design".equals(entry)
+            || "architecture".equals(entry))
             && !(isAdmin || isDesigner)) {
         entry = "home";
     }

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -95,6 +95,20 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void forwardsArchitectureWithOptionalSite() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=architecture",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/architecture", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=architecture&site=Demo",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/architecture/Demo", null));
+    // Legacy first segment alias
+    assertEquals(
+        "/cm/app/spa.jsp?entry=architecture",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/arch", null));
+  }
+
+  @Test
   public void dualTreePagesAppSupported() {
     assertEquals(
         "/cm/pages/app/spa.jsp?entry=home&section=recent",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -79,6 +79,23 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/design/templates").section).toBe("templates");
   });
 
+  it("maps architecture entry, arch alias, and site (#3094)", () => {
+    expect(parseEntryQuery("?entry=architecture").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=architecture").clientPath).toBe(
+      "/architecture",
+    );
+    expect(parseEntryQuery("?entry=arch").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=architecture&site=Demo").site).toBe("Demo");
+    expect(parseEntryQuery("?entry=architecture&site=Demo").clientPath).toBe(
+      "/architecture/Demo",
+    );
+    expect(parseClientPath("/architecture").entry).toBe("architecture");
+    expect(parseClientPath("/architecture/Demo").site).toBe("Demo");
+    expect(parseClientPath("/architecture/Demo").clientPath).toBe(
+      "/architecture/Demo",
+    );
+  });
+
   it("unknown entry falls back to home", () => {
     expect(parseEntryQuery("?entry=nope").entry).toBe("home");
   });

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -85,6 +85,18 @@ describe("TopNav (#2702)", () => {
     expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
   });
 
+  it("Architecture is SPA NavLink to /architecture (#3094)", () => {
+    renderNav();
+    const arch = screen.getByTestId("nav-architecture");
+    const href = arch.getAttribute("href") || "";
+    expect(href === "/architecture" || href.endsWith("/architecture")).toBe(
+      true,
+    );
+    // Must not be a full-page legacy exit
+    expect(href).not.toMatch(/view=arch/);
+    expect(arch.tagName.toLowerCase()).toBe("a");
+  });
+
   it("hides Admin for non-admin", () => {
     bootstrapState.isAdmin = false;
     bootstrapState.isDesigner = false;

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ADMIN_NAV_LANDING,
+  ARCHITECTURE_NAV_LANDING,
   isAdminNavPath,
   topNavItemIds,
 } from "../../../../main/ts/app/layout/topNavConfig";
@@ -85,6 +86,12 @@ describe("ADMIN_NAV_LANDING (#2784)", () => {
   it("points consolidated Admin top-nav at Admin tools shell", () => {
     expect(ADMIN_NAV_LANDING).toBe("/admin");
     expect(isAdminNavPath(ADMIN_NAV_LANDING)).toBe(true);
+  });
+});
+
+describe("ARCHITECTURE_NAV_LANDING (#3094)", () => {
+  it("points Architecture top-nav at SPA shell path", () => {
+    expect(ARCHITECTURE_NAV_LANDING).toBe("/architecture");
   });
 });
 

--- a/WebUI/src/test/ts/app/routes/ArchitectureRoute.test.tsx
+++ b/WebUI/src/test/ts/app/routes/ArchitectureRoute.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArchitectureRoute } from "../../../../main/ts/app/routes/ArchitectureRoute";
+
+const bootstrapState = {
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: false,
+  userName: "Admin",
+  locale: "en-us",
+  entry: "architecture",
+  allowExternalAvatarFetch: true,
+};
+
+vi.mock("../../../../main/ts/app/bootstrap/BootstrapContext", () => ({
+  useSpaBootstrap: () => bootstrapState,
+}));
+
+vi.mock("../../../../main/ts/registry", () => ({
+  loadComponent: async (name: string) => {
+    if (name !== "ArchitectureShell") {
+      throw new Error(`unexpected component: ${name}`);
+    }
+    const mod = await import("../../../../main/ts/architecture/ArchitectureShell");
+    return mod.ArchitectureShell;
+  },
+}));
+
+describe("ArchitectureRoute (#3094)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+    bootstrapState.isAdmin = true;
+    bootstrapState.isDesigner = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderAt(path: string) {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/architecture" element={<ArchitectureRoute />} />
+          <Route path="/architecture/:site" element={<ArchitectureRoute />} />
+          <Route path="/home" element={<div data-testid="home-redirect" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it("mounts shell for Admin/Designer with empty state", async () => {
+    renderAt("/architecture");
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-architecture-shell")).toBeTruthy();
+    });
+    expect(screen.getByTestId("architecture-empty-state")).toBeTruthy();
+  });
+
+  it("passes path site param into shell", async () => {
+    renderAt("/architecture/DemoSite");
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-architecture-shell")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("perc-architecture-shell").getAttribute("data-site"),
+    ).toBe("DemoSite");
+  });
+
+  it("role gate redirects non-designer/non-admin to home", async () => {
+    bootstrapState.isAdmin = false;
+    bootstrapState.isDesigner = false;
+    renderAt("/architecture");
+    await waitFor(() => {
+      expect(screen.getByTestId("home-redirect")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("perc-architecture-shell")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -90,9 +90,13 @@ describe("PR-5 aggressive index.jsp SPA cutover (retained)", () => {
       // Legacy exits preserved (dash moved to SPA Home gadgets in PR-7)
       expect(text).toMatch(/legacyViews\.put\("editor",\s*"webmgt\.jsp"\)/);
       expect(text).toMatch(/legacyViews\.put\("design",\s*"admin\.jsp"\)/);
-      expect(text).toMatch(
+      // #3094: Architecture is SPA entry, not legacyViews arch → siteArchitecture.jsp
+      expect(text).not.toMatch(
         /legacyViews\.put\("arch",\s*"siteArchitecture\.jsp"\)/,
       );
+      expect(text).toMatch(/"arch"/);
+      expect(text).toMatch(/"architecture"/);
+      expect(text).toMatch(/entry\s*=\s*"architecture"|entry = "architecture"/);
     }
   });
 

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ArchitectureShell } from "../../../main/ts/architecture/ArchitectureShell";
+
+describe("ArchitectureShell (#3094)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders shell chrome and empty/in-progress state", () => {
+    render(<ArchitectureShell embedded />);
+    const shell = screen.getByTestId("perc-architecture-shell");
+    expect(shell).toBeTruthy();
+    expect(shell.getAttribute("data-embedded")).toBe("true");
+    expect(shell.getAttribute("data-site")).toBe("");
+    expect(screen.getByTestId("architecture-shell-title").textContent).toMatch(
+      /Architecture/i,
+    );
+    expect(screen.getByTestId("architecture-empty-state")).toBeTruthy();
+    expect(screen.getByTestId("architecture-empty-title").textContent).toMatch(
+      /coming soon/i,
+    );
+    expect(screen.getByTestId("architecture-site-hint").textContent).toMatch(
+      /No site selected/i,
+    );
+  });
+
+  it("surfaces optional site context from props", () => {
+    render(<ArchitectureShell embedded initialSite="Corporate Investments" />);
+    expect(
+      screen.getByTestId("perc-architecture-shell").getAttribute("data-site"),
+    ).toBe("Corporate Investments");
+    expect(screen.getByTestId("architecture-site-hint").textContent).toContain(
+      "Corporate Investments",
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture SPA shell + top-nav routing (#3094 / parent #3092).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-shell-smoke.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Entry: spa.jsp?entry=architecture (empty/in-progress shell until Slice C).
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Architecture SPA shell (#3094)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("deep link and TopNav open shell empty state @smoke @ui", async ({
+    page,
+  }) => {
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("nav-architecture")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("architecture-empty-state")).toBeVisible();
+    await expect(page.getByTestId("architecture-shell-title")).toContainText(
+      /Architecture/i,
+    );
+
+    // Top-nav Architecture is SPA NavLink (not legacy ?view=arch)
+    const href = await page
+      .getByTestId("nav-architecture")
+      .getAttribute("href");
+    expect(href || "").toMatch(/architecture/);
+    expect(href || "").not.toMatch(/view=arch/);
+
+    // Re-enter via top nav
+    await page.getByTestId("nav-home").click();
+    await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByTestId("nav-architecture").click();
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -1,0 +1,45 @@
+---
+id: admin-architecture-navigation
+title: Architecture & site navigation
+description: Modern Architecture SPA shell for managing site navigation trees (migration in progress)
+version: "8.2"
+order: 43
+tags: [admin, architecture, navigation, ui]
+---
+
+# Architecture & site navigation
+
+**Architecture** (site navigation / navon tree editor) is migrating into the modern SPA
+product chrome. In Percussion CMS 8.2 the primary entry is the SPA shell — not the
+legacy CM1 Architecture page.
+
+## Open Architecture (SPA)
+
+1. Sign in as an **Admin** or **Designer**.
+2. Choose **Architecture** in the product top navigation, or open the SPA entry:
+   - Query contract: `spa.jsp?entry=architecture`
+   - Path route: `/cm/app/architecture` (optional site segment or `?site=` for context)
+3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
+
+Default landing can also be set to **Architecture** for a user or role (homepage type
+`Architecture`); login then resolves to the SPA Architecture entry.
+
+## Current status (migration)
+
+| Capability | Status |
+|------------|--------|
+| SPA route + top-nav entry under product chrome | **Available** |
+| Role gate (Admin / Designer) | **Available** |
+| Site navigation tree browse / edit (navons) | **Coming soon** (follow-on slices) |
+| Landing page / section-link parity | **Coming soon** |
+| Legacy `siteArchitecture.jsp` retirement | **Planned** after SPA parity |
+
+Until the navigation tree editor ships, the Architecture shell shows an in-progress
+message. Operators should use this SPA entry as the primary path; the legacy JSP is
+no longer the top-nav destination.
+
+## Related
+
+- [Sites & content structure](id:admin-sites)
+- [Content Explorer](id:admin-content-explorer)
+- [Users, roles & security](id:admin-users-roles) (default landing options include Architecture)

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -38,6 +38,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
+- [Architecture & site navigation](id:admin-architecture-navigation)
 - [Users, roles & security](id:admin-users-roles)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)


### PR DESCRIPTION
## Summary

Slice B of epic #3092: first-class **Architecture / Navigation** SPA shell and routing so top nav no longer depends on the non-functional legacy `siteArchitecture.jsp` as the primary entry.

### Changes
- SPA routes `/architecture` and `/architecture/:site` under `AppLayout`
- `ArchitectureShell` empty/in-progress chrome (tree editing out of scope — Slices C–E)
- `ArchitectureRoute` with `RequireRole` **adminOrDesigner**
- `TopNav` Architecture: legacy `href="/cm/app/?view=arch"` → SPA `NavLink` `/architecture`
- Deep links: `entry=architecture` (+ `arch` alias), optional `site`; dual-tree `index.jsp` / `spa.jsp` + `PSWebUiSpaFallbackFilter`
- Homepage `view=arch` / type Architecture → SPA `entry=architecture` (JSP retained for Slice G only)
- `landingOptions` comments aligned with SPA path
- product-docs stub: Architecture migration note
- Vitest shell/route/TopNav/deep-link smoke; Playwright surface smoke
- Registry lazy load `ArchitectureShell`

Parent: #3092

## Test plan

- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
  - Surefire: Tests run: 44, Failures: 0 (includes PSWebUiSpaFallbackFilterTest 11)
  - Vitest: Test Files 278 passed; Tests 1977 passed
- [x] ArchitectureRoute / ArchitectureShell Vitest (role gate redirect; empty state; site prop)
- [x] product-docs `ci-smoke-product-docs.bat` OK (21 pages)
- [ ] Live CMS (human QA): Admin opens Architecture top-nav → SPA shell empty state; `spa.jsp?entry=architecture`; non-designer cannot use route

### Gates evidence

- **modules_built:** WebUI
- **build_evidence:** `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS; Surefire Tests run: 44; Vitest 1977 passed (278 files); architecture chunk built
- **downstream_checked:** none (no public API final/signature blast radius beyond SPA entry allowlist lockstep dual-tree)

## Product documentation

- [x] Updated product-docs: `product-docs/8.2/admin/architecture-navigation.md` + admin index link

## Fixes

Fixes #3094

Part of #3092

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
