### PR TITLE
fix(rest): SiteList @XmlSeeAlso for Developer Sites (#3090)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/sites/SiteList.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteList.java
@@ -20,12 +20,22 @@ package com.percussion.rest.sites;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 
-/** List wrapper for Site objects. Sunny Sal: "Site list ka boss!" */
+/**
+ * List wrapper for Site objects. Sunny Sal: "Site list ka boss!"
+ *
+ * <p>{@link XmlSeeAlso} registers {@link Site} in the JAXB context so GET {@code /services/sites}
+ * can marshal list elements. Without it, the Developer Sites catalog fails with {@code
+ * JAXBException}: {@code Site nor any of its super class is known to this context} (#3090). Peer
+ * pattern: {@code UserPreferenceList} (#2746), {@code RoleList}, {@code CommunityList}, ACL list
+ * wrappers.
+ */
 @XmlRootElement(name = "SiteList")
 @ArraySchema(schema = @Schema(implementation = Site.class))
+@XmlSeeAlso(Site.class)
 public class SiteList extends ArrayList<Site> {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.sites;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Wire shape for SitesResource list GET must marshal {@link SiteList} elements.
+ *
+ * <p>List GET {@code /services/sites} requires {@link SiteList} JAXB context registration of {@link
+ * Site} via {@code @XmlSeeAlso} (#3090). Mirrors {@code UserPreferenceSerialDeserialTest} (#2746).
+ */
+@Tag("UnitTest")
+public class SiteListSerialDeserialTest {
+
+  private static Site sampleSite() {
+    var site = new Site();
+    site.setName("Help");
+    site.setDescription("Help site");
+    site.setBaseUrl("https://help.example.com");
+    return site;
+  }
+
+  private static JsonMapper wrapRootMapper() {
+    return JsonMapper.builder()
+        .enable(SerializationFeature.WRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+        .build();
+  }
+
+  /**
+   * Developer Sites catalog uses GET all → {@link SiteList}. Jackson root wrap must round-trip
+   * list envelope + element fields (#3090 load path).
+   */
+  @Test
+  public void serializeAndDeserializeSiteList() throws JacksonException {
+    var mapper = wrapRootMapper();
+    var list = new SiteList();
+    list.add(sampleSite());
+
+    var json = mapper.writeValueAsString(list);
+    assertTrue(
+        json.contains("SiteList") || json.contains("["),
+        "expected list wire shape, got: " + json);
+    assertTrue(json.contains("Help"), "list JSON must include site name, got: " + json);
+
+    var roundTrip = mapper.readValue(json, SiteList.class);
+    assertEquals(1, roundTrip.size(), "list size after round-trip");
+    assertEquals("Help", roundTrip.get(0).getName().orElse(null));
+    assertEquals("Help site", roundTrip.get(0).getDescription().orElse(null));
+    assertEquals("https://help.example.com", roundTrip.get(0).getBaseUrl().orElse(null));
+  }
+
+  /**
+   * Regression for #3090: without {@code @XmlSeeAlso(Site.class)} on {@link SiteList}, JAXB context
+   * for the list does not know {@link Site} and GET /services/sites fails with "nor any of its
+   * super class is known to this context".
+   */
+  @Test
+  public void jaxbContextKnowsSiteFromList() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(SiteList.class);
+    // Context creation alone is not enough on all providers — marshal a non-empty list.
+    var list = new SiteList();
+    list.add(sampleSite());
+
+    Marshaller marshaller = ctx.createMarshaller();
+    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
+    var writer = new StringWriter();
+    try {
+      marshaller.marshal(list, writer);
+    } catch (Exception e) {
+      fail(
+          "JAXB must marshal SiteList containing Site (#3090); got: " + e.getMessage(), e);
+    }
+    var xml = writer.toString();
+    assertFalse(xml.isBlank(), "marshalled XML must not be empty");
+    assertTrue(
+        xml.contains("SiteList") || xml.contains("siteList"),
+        "expected SiteList root in XML, got: " + xml);
+    // Element type registration is the critical #3090 gate; name may appear as attribute or
+    // child depending on property accessors / XmlAccessType defaults.
+    assertTrue(
+        xml.contains("Help") || xml.toLowerCase().contains("site"),
+        "marshalled payload should reference site content, got: " + xml);
+  }
+
+  /** Empty list remains valid for sites-none catalogs. */
+  @Test
+  public void jaxbContextMarshalsEmptySiteList() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(SiteList.class);
+    Marshaller marshaller = ctx.createMarshaller();
+    var writer = new StringWriter();
+    marshaller.marshal(new SiteList(), writer);
+    assertFalse(writer.toString().isBlank());
+  }
+}


### PR DESCRIPTION
## Summary

Developer → Sites fails because `SiteList` (extends `ArrayList<Site>`) was missing `@XmlSeeAlso(Site.class)`. Providers that build the JAXB context from the list root did not register `Site`, producing:

`class com.percussion.rest.sites.Site nor any of its super class is known to this context`

Same failure mode as Preferences list (#2746 / `UserPreferenceList`).

### Changes

- `rest/.../sites/SiteList.java` — add `@XmlSeeAlso(Site.class)` + peer-pattern javadoc
- `rest/.../sites/SiteListSerialDeserialTest.java` — Jackson list round-trip + JAXB marshal of non-empty/empty lists

### Audit note (siblings)

Other `*List extends ArrayList` under `rest/` without `@XmlSeeAlso` (not changed here; no reported break): `ActionMenuList`, `ContentTypeList`, `ContentListList`, `ExtensionList`, `GuidList`, `ObjectSummaryList`, `AssetFieldList`, `LocationSchemeParameterList`, `PermissionList`. String-element lists (`ValueList`, `AllowedCommunityList`) do not need the annotation. Fix only when a concrete failure is reported (same one-liner + regression test pattern).

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` (tests on)
- [x] `SiteListSerialDeserialTest` — 3 tests green
- [ ] Human smoke: Developer → Sites loads catalog (see QA issue)

## Gates evidence

- **modules_built:** `rest`
- **command:** `cd rest; ..\mvnw.cmd clean install`
- **result:** BUILD SUCCESS (exit 0)
- **Tests run:** 327, Failures: 0, Errors: 0 (Surefire)
- **SiteListSerialDeserialTest:** Tests run: 3, Failures: 0, Errors: 0
- **downstream_checked:** none (annotation-only; no public method signature / final / sealed change)

## Product documentation

- [x] N/A — internal JAXB list registration fix restoring expected Sites list serialization; no new operator/API contract or UX

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3090

> Co-Authored by Grok Build using grok-4.5 with agent main.
