### PR TITLE
docs(#3132): criteria M2 snapshot + operator dual-run checklist

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Criteria **not met** (snapshot 2026-08-11) — shim **must remain** |
-| **Issue** | [#2835](https://github.com/intersoftdatalabs-in/percussioncms/issues/2835) (slice 3 of [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632)) |
-| **Parent** | [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) Phase 5 · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Status** | Criteria **not met** (snapshot **2026-08-12**) — shim **must remain**; [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) **blocked** until M1–M3 + G1–G6 |
+| **Issue** | Criteria lock [#2835](https://github.com/intersoftdatalabs-in/percussioncms/issues/2835); M2 snapshot refresh [#3132](https://github.com/intersoftdatalabs-in/percussioncms/issues/3132); removal residual [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) |
+| **Parent** | [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) Phase 5 · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) · Phase 3 tracker [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) |
 | **Depends on** | Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) product off definition XML; dual-run policy [#2752](https://github.com/intersoftdatalabs-in/percussioncms/issues/2752) |
 | **Policy / selection** | [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) |
 | **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
@@ -21,14 +21,33 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 
 **Hard ban:** unattended mass deletion of the customer-facing shim without evidence that every criterion below is met. Thin removal is allowed **only** for paths proven dead with tests (none found in this snapshot).
 
-## Decision (this slice)
+**Hard ban (removal residual):** do **not** start implementation on [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) (shim / dual-run deletion) until **every** row in the Status snapshot table below is **PASS** (or explicitly waived with owner + sunset). Partial M2 infrastructure is **not** “ready to remove.”
 
-| Question | Answer (2026-08-11) |
-|----------|---------------------|
+## Status snapshot (2026-08-12) — `main` + open evidence PRs
+
+Re-verify against current `main` before any removal PR. Counts below were taken from this worktree after `git fetch origin main` / hard reset to `origin/main` on **2026-08-12**.
+
+| ID | Criterion | Status | Evidence on `main` / links | What still blocks |
+|----|-----------|--------|----------------------------|-------------------|
+| **M1** | Zero product package definition-XML as ship format (ADR-004) | **PASS** (Widget non-waived) | Cluster [#2897](https://github.com/intersoftdatalabs-in/percussioncms/pull/2897) (batches A+B+C #2883/#2884/#2885): **1** remaining Widget def XML under Packages (`perc.Test` waiver only; was **48**). **77** `component-package.json` under Packages. G4 Widget gate [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051) / #3026 | Pages/Gadgets broader ship-path wording residual; waived Test package only |
+| **M2** | Zero (or waived) runtime legacy definition-XML loads | **PARTIAL / FAIL overall** | **Merged:** [#3045](https://github.com/intersoftdatalabs-in/percussioncms/pull/3045) #3024 (`PSWidgetDao` modern-first + INFO `modern=` / `legacyWidgetXml=` + selection kinds); [#3071](https://github.com/intersoftdatalabs-in/percussioncms/pull/3071) #3025 (`GadgetRegistry` dual-load metrics + last source/entry count). **Open (not on main yet):** [#3134](https://github.com/intersoftdatalabs-in/percussioncms/pull/3134) #3130 product/H2 `modernPackageRoots` defaults; [#3136](https://github.com/intersoftdatalabs-in/percussioncms/pull/3136) #3131 cumulative counters + CI harness | Product installs on current main still default blank `widgetDao.modernPackageRoots` → legacy-only selection unless configured; no process-lifetime zero-legacy proof window; customer XML still valid fallback |
+| **M3** | Customer upgrade window closed or residual waived | **FAIL** | Compilers + dual-run checklist exist; 8.2 dual-run window **open by design** | Need support inventory / waived residual list + closed upgrade window (or documented residual customers) |
+| **G1** | `modules/perc-packages` clean install green after removal | **N/A (pre-removal)** | Module green on current dual-run code; deletion not started | Required only on the future removal PR |
+| **G2** | Behavioral modern-only selection tests | **PARTIAL** | `PSLegacyDefinitionXmlShimTest` + `PSWidgetDaoTest` modern/legacy/neither on main | Modern-only (no legacy fallback) tests belong on removal PR |
+| **G3** | No production refs to deleted dual-run APIs after removal | **N/A (pre-removal)** | Callers still **required**: `PSWidgetDao`, `GadgetRegistry` fallback | Pass only after deletion rewires consumers |
+| **G4** | CI fails if product definition XML reappears under Packages ship paths | **PASS (Widget path)** | `PSWidgetDefinitionXmlInventory` + Surefire [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051) #3026; waive `perc.Test` only | Pages/Gadgets ship-path inventory residual under broader G4 wording |
+| **G5** | Reverse-dep consumers green after removal | **N/A (pre-removal)** | sitemanage / WebUI dual-run tests green with shim present | Re-run sitemanage + WebUI on removal PR |
+| **G6** | Cross-platform Path/Files only in load paths | **PASS (current surfaces)** | Widget inventory + shim use `Path`/`Files`; DAO roots use `Path.of` | Re-check any replacement load path on removal PR |
+
+### Decision (2026-08-12)
+
+| Question | Answer |
+|----------|--------|
 | Are removal criteria met? | **No** |
 | May agents delete `PSLegacyDefinitionXmlShim` / related dual-run loaders now? | **No** — leave shim |
-| Thin proven-dead removal in this PR? | **None** — no dead production path safe to drop |
-| Residual? | File residual for **shim removal when metrics allow** (see Residual work) |
+| Is [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) ready to implement? | **No — blocked** until **M1–M3 + G1–G6** all PASS (or waived with evidence) |
+| Thin proven-dead removal now? | **None** |
+| False “ready to remove” claims allowed? | **No** — PARTIAL M2 infrastructure ≠ M2 PASS |
 
 ---
 
@@ -43,7 +62,9 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 | Product Gadget definition XML | **0** product per-gadget OpenSocial-style definition XML required at runtime | [gadget-definition-inventory.md](./gadget-definition-inventory.md) |
 | ADR-004 ship bar | Product packages author **only** modern `component-package.json` (+ CT / template / slot / catalog artifacts) | Package tree review + package-compile CI |
 
-**Snapshot 2026-08-11 (cluster #2883+#2884+#2885 A+B+C ship-exit):** **PASS M1 for product non-waived Widget XML** — only **1** Widget definition XML remains under `Packages/**/sys__UserDependency--rxconfig/Widgets/` (`perc.Test`, explicit waiver; was **48**). Batches A/B/C removed **8+20+19** committed install XMLs; install wire format is materialized at package-build via `PSWidgetXmlInstallEmitter`. Modern widget `component-package.json` roots: **47** (full product excl. Test). Overall Phase 5 removal criteria still **not met** (M2/M3 and shim still required).
+**Snapshot 2026-08-11 (cluster #2883+#2884+#2885 A+B+C ship-exit / merged cluster PR [#2897](https://github.com/intersoftdatalabs-in/percussioncms/pull/2897)):** **PASS M1 for product non-waived Widget XML** — only **1** Widget definition XML remains under `Packages/**/sys__UserDependency--rxconfig/Widgets/` (`perc.Test`, explicit waiver; was **48**). Batches A/B/C removed **8+20+19** committed install XMLs; install wire format is materialized at package-build via `PSWidgetXmlInstallEmitter`. Modern widget `component-package.json` roots: **47** (full product excl. Test). Overall Phase 5 removal criteria still **not met** (M2/M3 and shim still required).
+
+**Snapshot 2026-08-12 (#3132 re-check on `origin/main`):** **PASS M1 (Widget non-waived)** reaffirmed — Widget def XML count still **1** (`perc.Test` only); **77** `component-package.json` under Packages tree (includes non-widget modern packages). G4 Widget inventory gate remains on main (#3026 / PR #3051).
 
 ### M2 — Zero (or waived) runtime legacy definition-XML loads
 
@@ -56,9 +77,79 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 
 **Snapshot 2026-08-11:** **FAIL M2** — selection API existed and was unit-tested, but **no production caller** outside `modules/perc-packages` shim package + javadoc cross-refs wired `PSLegacyDefinitionXmlShim` into live load paths. `PSWidgetDao` still bound only `@Value("${rxdeploydir}/rxconfig/Widgets")`. `GadgetRegistry` dual-load (modern catalog preferred, legacy `GadgetRegistry.xml` fallback) is still active.
 
-**Snapshot 2026-08-11 (slice #3024):** **PARTIAL M2** — `PSWidgetDao` now wires `PSLegacyDefinitionXmlShim.selectDefinition` (modern-first) with test-visible `getLastSelectionKind()` / `getSelectionKindsById()` and INFO metrics `modern=` / `legacyWidgetXml=`. Optional Spring property `widgetDao.modernPackageRoots` (`File.pathSeparator` list). Content still loads install Widget XML (materialized wire format); selection kind reports MODERN when a modern package root is present for the id. **M2 still FAIL overall** until production installs configure modern roots and runtime metrics show zero (or waived) `LEGACY_WIDGET_XML` over the time-box. Shim **must remain** (#2852).
+**Snapshot 2026-08-11 (slice #3024 / PR [#3045](https://github.com/intersoftdatalabs-in/percussioncms/pull/3045)):** **PARTIAL M2** — `PSWidgetDao` now wires `PSLegacyDefinitionXmlShim.selectDefinition` (modern-first) with test-visible `getLastSelectionKind()` / `getSelectionKindsById()` and INFO metrics `modern=` / `legacyWidgetXml=`. Optional Spring property `widgetDao.modernPackageRoots` (`File.pathSeparator` list). Content still loads install Widget XML (materialized wire format); selection kind reports MODERN when a modern package root is present for the id. **M2 still FAIL overall** until production installs configure modern roots and runtime metrics show zero (or waived) `LEGACY_WIDGET_XML` over the time-box. Shim **must remain** (#2852).
 
-**Snapshot 2026-08-11 (slice #3025):** **PARTIAL M2 (gadget dual-load hardened)** — WebUI `GadgetRegistry` dual-load already preferred `gadget-catalog.json` with `GadgetRegistry.xml` fallback (#2788). Hardening adds INFO selection metrics `modern=` / `legacyRegistryXml=` / `none=` / `entries=` (parity with `PSWidgetDao`), test-visible `getLastLoadEntryCount()`, and edge-case tests (empty/unreadable modern → legacy; blank/null modern resource; successive last-load updates). Product classpath still reports `MODERN_CATALOG`. **Legacy fallback retained** (#2852). **M2 still FAIL overall** until widget modern roots + runtime legacy rate criteria and remaining dual-run exit evidence land.
+**Snapshot 2026-08-11 (slice #3025 / PR [#3071](https://github.com/intersoftdatalabs-in/percussioncms/pull/3071)):** **PARTIAL M2 (gadget dual-load hardened)** — WebUI `GadgetRegistry` dual-load already preferred `gadget-catalog.json` with `GadgetRegistry.xml` fallback (#2788). Hardening adds INFO selection metrics `modern=` / `legacyRegistryXml=` / `none=` / `entries=` (parity with `PSWidgetDao`), test-visible `getLastLoadEntryCount()`, and edge-case tests (empty/unreadable modern → legacy; blank/null modern resource; successive last-load updates). Product classpath still reports `MODERN_CATALOG`. **Legacy fallback retained** (#2852). **M2 still FAIL overall** until widget modern roots + runtime legacy rate criteria and remaining dual-run exit evidence land.
+
+**Snapshot 2026-08-12 (criteria refresh #3132 — code on `main`):** **PARTIAL M2 / FAIL overall** — reaffirmed against `origin/main`:
+
+| Surface | On `main` today | Metric visibility | Legacy still required? |
+|---------|-----------------|-------------------|------------------------|
+| Widget selection wire | #3024 / PR #3045 | Per-poll INFO `modern=` / `legacyWidgetXml=` + `getLastSelectionKind()` / `getSelectionKindsById()` | **Yes** — blank `widgetDao.modernPackageRoots` ⇒ legacy-only kinds for install Widgets XML |
+| Gadget dual-load | #3025 / PR #3071 | INFO `modern=` / `legacyRegistryXml=` / `none=` + `getLastLoadSource()` / `getLastLoadEntryCount()` | **Yes** — classpath fallback retained |
+| Product modern roots default | **Not on main** (open [#3134](https://github.com/intersoftdatalabs-in/percussioncms/pull/3134) / #3130) | N/A until merge | Product/H2 still need explicit property or later defaults PR |
+| Cumulative counters + CI harness | **Not on main** (open [#3136](https://github.com/intersoftdatalabs-in/percussioncms/pull/3136) / #3131) | Per-call / per-poll INFO only | Process-lifetime rate still operator-log based |
+
+**Do not claim M2 PASS** from merged wiring alone. **#2852 remains blocked.**
+
+**Pending (open PRs — do not treat as main until merged):**
+
+- **#3130 / PR [#3134](https://github.com/intersoftdatalabs-in/percussioncms/pull/3134):** product/H2 blank property → `${rxdeploydir}/Packages/Modern` (+ classpath materialize). Would move widget path to “defaults land; still need zero-legacy rate.”
+- **#3131 / PR [#3136](https://github.com/intersoftdatalabs-in/percussioncms/pull/3136):** cumulative counters + `formatSelectionMetricsSummary()` + harness tests; documents **How to measure M2** in more detail after merge.
+
+### How to measure M2 (operator / CI — on `main` today)
+
+Use these probes when collecting evidence. Full cumulative-counter APIs land with #3131; until then use INFO lines + last-kind APIs below. Operator steps for H2 `qa-up` and product install: [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) § **Operator dual-run checklist**.
+
+#### Widget DAO (`projects/sitemanage` — `PSWidgetDao`) — on main via #3024
+
+| Probe | API / surface | What it proves |
+|-------|---------------|----------------|
+| Last kind | `getLastSelectionKind()` | Most recent modern vs `LEGACY_WIDGET_XML` |
+| Per-id poll map | `getSelectionKindsById()` | Kind for every id on last repository poll |
+| INFO log | `Widget definition dual-run selection: modern=…, legacyWidgetXml=…, total=…` | Per-poll modern vs legacy counts |
+| Modern roots | `getModernPackageRoots()` / Spring `widgetDao.modernPackageRoots` | Empty list ⇒ expect legacy kinds for product Widgets XML on disk |
+
+**CI tests (must stay green):**
+
+```text
+# from projects/sitemanage (repo-root mvnw)
+..\..\mvnw.cmd -Dtest=PSWidgetDaoTest test
+# or full module gate:
+..\..\mvnw.cmd clean install
+```
+
+- `com.percussion.pagemanagement.dao.PSWidgetDaoTest` — modern preferred when roots set, legacy fallback, neither throws (#3024)
+
+**M2 pass signal (widget path):** over the agreed time-box window, log/`legacyWidgetXml` rate is **0** (or waived list with owner + sunset), and product widgets select `MODERN_COMPONENT_PACKAGE` when modern roots are configured (or product-defaulted after #3130 merges).
+
+#### Gadget registry (`WebUI` — `GadgetRegistry`) — on main via #3025
+
+| Probe | API / surface | What it proves |
+|-------|---------------|----------------|
+| Last source | `getLastLoadSource()` | `MODERN_CATALOG` / `LEGACY_REGISTRY_XML` / `NONE` |
+| Last entries | `getLastLoadEntryCount()` | Size of last dual-load map |
+| INFO log | `Gadget registry dual-load selection: modern=…, legacyRegistryXml=…, none=…, entries=…, source=…` | Per-load modern vs legacy |
+
+**CI tests (must stay green):**
+
+```text
+# from WebUI (repo-root mvnw)
+..\mvnw.cmd -Dtest=GadgetRegistryTest test
+# or full module gate:
+..\mvnw.cmd clean install
+```
+
+- `com.percussion.webui.gadget.servlets.GadgetRegistryTest` — dual-load preference + edges (#3025)
+
+**M2 pass signal (gadget path):** product installs report `lastSource=MODERN_CATALOG` and no required production dependence on `LEGACY_REGISTRY_XML` (or waived customer classpaths only).
+
+#### Support / operator collection recipe
+
+1. Run the Surefire classes above (or full module `clean install`) in CI or locally.
+2. On a live/QA CMS after widget/gadget traffic: capture INFO lines containing `dual-run selection` / `dual-load selection` (and after #3131 merges, `formatSelectionMetricsSummary()` / cumulative counters).
+3. Attach counter snapshots (or log excerpts) to [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) when claiming M2 — never claim ready-to-remove without that evidence.
+4. **Hard ban:** do not delete the shim or legacy fallback based only on product classpath modern preference or PARTIAL snapshots above.
 
 ### M3 — Customer upgrade window closed (or accepted residual)
 
@@ -69,6 +160,8 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 | Upgrade docs | Operators have a documented convert → deploy modern → remove XML path | Dual-run checklist in [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) + product-docs when operator-facing steps freeze |
 
 **Snapshot 2026-08-11:** **FAIL M3** — compilers and dual-run operator checklist exist; customer upgrade window is **still open** by design for 8.2 dual-run. No production metric stream yet to prove “zero loads.”
+
+**Snapshot 2026-08-12 (#3132):** **FAIL M3** — unchanged. Compilers, dual-run operator checklist (expanded for H2 `qa-up` + product install), and M2 measurement recipes exist; customer upgrade window remains **open**. Support residual list not closed. **#2852 still blocked** on M3 (and remaining M2 evidence) even if M1 stays PASS.
 
 ---
 
@@ -85,7 +178,7 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 
 **Snapshot 2026-08-11:** G2 partially satisfied for the **selection API** (`PSLegacyDefinitionXmlShimTest`). G1/G3–G6 for **deletion** are N/A until M1–M3 pass.
 
-**Snapshot 2026-08-11 (G4 Widget inventory gate #3026):** **PASS G4 for product Widget definition XML** — automated assertion in `modules/perc-packages`:
+**Snapshot 2026-08-11 (G4 Widget inventory gate #3026 / PR [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051)):** **PASS G4 for product Widget definition XML** — automated assertion in `modules/perc-packages`:
 
 | Piece | Location |
 |-------|----------|
@@ -95,6 +188,8 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 | Path I/O | `Path.resolve` / `Files` only (G6-aligned) |
 
 Pages/Gadgets ship-path inventory remains residual under the broader G4 wording; Widget path is the Phase 3 residual closed by #3026.
+
+**Snapshot 2026-08-12 (#3132):** G-status summary matches the **Status snapshot** table above: G4 Widget **PASS** on main; G2 **PARTIAL** (dual-run selection tests, not modern-only deletion tests); G1/G3/G5 **N/A** until removal PR; G6 **PASS** for current Path/Files surfaces. **None of this unlocks #2852** without M2/M3.
 
 ---
 
@@ -116,7 +211,9 @@ Pages/Gadgets ship-path inventory remains residual under the broader G4 wording;
 
 ---
 
-## 4. Inventory snapshot (grep / tree) — 2026-08-11
+## 4. Inventory snapshot (grep / tree) — 2026-08-11 (reaffirmed 2026-08-12 on `main`)
+
+**2026-08-12 re-check on `origin/main`:** product Packages Widget def XML count still **1** (`perc.Test` only); `PSWidgetDao` still the sole production caller of `PSLegacyDefinitionXmlShim`; `GadgetRegistry` dual-load still live with metrics. No thin dead-path deletion candidate.
 
 ### 4.1 Selection API package (`modules/perc-packages`)
 
@@ -203,19 +300,21 @@ Copy into the residual issue / PR when M1–M3 evidence exists:
 
 | Work | Form | Notes |
 |------|------|-------|
-| Runtime dual-run shim deletion + consumer rewiring when criteria met | Residual GitHub issue (p2, unassigned) | Modules: `modules/perc-packages`, likely `projects/sitemanage` (widget DAO), possibly `WebUI` gadget dual-load |
-| Product Widget XML deletion from Packages after modern ship | Owned under Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) residuals — **do not** invent mega-delete here | Prerequisite for M1 |
+| Runtime dual-run shim deletion + consumer rewiring when criteria met | **[#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852)** (p2, unassigned) — **BLOCKED** until M1–M3 + G1–G6 | Modules: `modules/perc-packages`, likely `projects/sitemanage` (widget DAO), possibly `WebUI` gadget dual-load |
+| Product/H2 default modern package roots | Open [#3130](https://github.com/intersoftdatalabs-in/percussioncms/issues/3130) / PR [#3134](https://github.com/intersoftdatalabs-in/percussioncms/pull/3134) | M2 infrastructure; **not** shim deletion |
+| Dual-run selection metrics evidence harness | Open [#3131](https://github.com/intersoftdatalabs-in/percussioncms/issues/3131) / PR [#3136](https://github.com/intersoftdatalabs-in/percussioncms/pull/3136) | M2 measurement; **not** shim deletion |
+| Criteria M2 snapshot + operator checklist | [#3132](https://github.com/intersoftdatalabs-in/percussioncms/issues/3132) (this refresh) | Docs only; keeps #2852 correctly blocked |
 | Page dual-ship code retirement | [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) | Parallel, not identical |
 
-Residual issue for this slice is filed from the night-issue-prs run of #2835 (link in issue/PR comments and parent Agent progress).
+**#2852 gate statement (authoritative for agents):** implement shim/fallback deletion **only** after this doc’s Status snapshot shows **M1 PASS**, **M2 PASS** (zero or waived legacy rate with attached evidence), **M3 PASS** (or waived residual customers), and **G1–G6 PASS** on the removal PR. Until then leave dual-run code in place.
 
 ---
 
 ## See also
 
-- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) — operator dual-run policy
+- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) — operator dual-run policy + H2/product checklist
 - [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) — package-build dual-ship
 - [widget-xml-inventory.md](./widget-xml-inventory.md) / [page-definition-inventory.md](./page-definition-inventory.md) / [gadget-definition-inventory.md](./gadget-definition-inventory.md)
 - [component-package-manifest.md](./component-package-manifest.md) / [adr/004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md)
 - [plan.md](./plan.md) § Phase 5
-- Epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) · Phase 5 [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) · Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630)
+- Epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) · Phase 5 [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) · Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Removal residual [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) · Criteria refresh [#3132](https://github.com/intersoftdatalabs-in/percussioncms/issues/3132)

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Accepted for Phase 3 slice 3 (#2752); **shim still required** (criteria not met — see Phase 5 criteria) |
+| **Status** | Accepted for Phase 3 slice 3 (#2752); **shim still required** (criteria not met — snapshot **2026-08-12**); [#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852) **blocked** until M1–M3 + G1–G6 |
 | **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) (Phase 3) |
 | **Epic** | [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
-| **Phase 5 criteria** | [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (#2835 / #2632) |
+| **Phase 5 criteria** | [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (#2835 / #2632 / criteria refresh #3132) |
 | **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
 | **Code** | `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (`modules/perc-packages`) |
-| **Related slices** | Manifest model #2750 / PR #2754; Widget XML compiler #2751 / PR #2755 |
+| **Related slices** | Manifest model #2750; Widget XML compiler #2751; modern-first wire #3024 / PR #3045; gadget metrics #3025 / PR #3071; G4 inventory #3026 / PR #3051; defaults open #3130 / PR #3134; harness open #3131 / PR #3136 |
 
 ## Purpose
 
@@ -77,24 +77,96 @@ Hard order for a package root or definition id:
 
 ## Operator dual-run checklist
 
+High-level convert path (all environments):
+
 1. **Inventory** customer Widget XML under install `rxconfig/Widgets` (and package archives if applicable).
 2. **Convert** using the Widget XML → Component Package Manifest compiler when available (#2751).
 3. **Deploy** modern packages (`component-package.json` + artifacts) beside or instead of XML.
 4. **Verify** selection: modern present ⇒ modern wins even if old XML remains on disk.
 5. **Remove** legacy XML after smoke/parity for converted definitions.
-6. **Exit dual-run** when no required customer definitions rely on the XML path (Phase 5).
+6. **Exit dual-run** when no required customer definitions rely on the XML path (Phase 5) — only after [criteria](./definition-xml-shim-removal-criteria.md) M1–M3 + G1–G6.
+
+### When the shim **must stay**
+
+Keep `PSLegacyDefinitionXmlShim` and gadget legacy fallback when **any** of the following is true:
+
+| Condition | Why |
+|-----------|-----|
+| Criteria Status snapshot shows M2 **FAIL** or **PARTIAL** | No zero-legacy runtime evidence yet |
+| Criteria M3 **FAIL** | Customer upgrade window still open |
+| Install has Widget XML without a matching modern package root | Customer / residual defs still load via legacy |
+| `widgetDao.modernPackageRoots` is blank **and** product defaults PR (#3130) is not on the build | On current `main`, blank property ⇒ legacy-only selection kinds |
+| Gadget classpath missing `gadget-catalog.json` | Product prefers modern; fallback is the safety net |
+| Agent or human is tempted to “finish Phase 5 early” | **#2852 is blocked** — deletion is not the dual-run checklist |
+
+### How to read metrics (on `main` today)
+
+| Surface | Log / API | How to interpret |
+|---------|-----------|------------------|
+| Widgets | INFO `Widget definition dual-run selection: modern=N, legacyWidgetXml=M, total=T` | After a repository poll: `M > 0` means at least some loaded ids classified as legacy (expected when modern roots empty or customer-only XML). `N` rises when modern package roots match ids. |
+| Widgets | `PSWidgetDao.getLastSelectionKind()` / `getSelectionKindsById()` | Last single selection / per-id map — use from tests or support probes |
+| Widgets | `PSWidgetDao.getModernPackageRoots()` | Empty ⇒ expect legacy kinds for install Widgets XML on disk |
+| Gadgets | INFO `Gadget registry dual-load selection: modern=…, legacyRegistryXml=…, none=…, entries=…, source=…` | Product classpath should show modern preferred; `legacyRegistryXml=1` means fallback fired |
+| Gadgets | `GadgetRegistry.getLastLoadSource()` / `getLastLoadEntryCount()` | Diagnostics / unit tests |
+
+**After open PRs merge (not yet on main):**
+
+- #3130 / PR #3134 — blank `widgetDao.modernPackageRoots` discovers `${rxdeploydir}/Packages/Modern` (+ classpath materialize).
+- #3131 / PR #3136 — cumulative counters, `formatSelectionMetricsSummary()`, harness tests; see criteria § **How to measure M2**.
+
+### What evidence **closes M2**
+
+M2 becomes **PASS** only when **all** hold (document on #2852 when claiming):
+
+1. Product / QA installs have modern roots available (explicit property **or** product defaults after #3130 merges).
+2. Over the agreed time-box, widget `legacyWidgetXml` rate is **0** (or an explicit waiver list with owner + sunset date).
+3. Gadget product path reports modern catalog with **no** required production dependence on `LEGACY_REGISTRY_XML` (or waived classpaths only).
+4. Evidence is attached (log excerpts and/or counter snapshots) — not chat assertion alone.
+
+Until then: **shim stays; #2852 stays blocked.**
+
+### H2 `qa-up` (docker / local QA)
+
+| Step | Action | Pass signal |
+|------|--------|-------------|
+| 1 | Bring up CMS via project H2 `qa-up` / docker compose path used by the team | Server starts; widgets load |
+| 2 | Confirm install Widgets dir exists (`${rxdeploydir}/rxconfig/Widgets`) | Product widgets present as install wire XML (materialized) |
+| 3 | **On current main:** set `widgetDao.modernPackageRoots` to a `File.pathSeparator` list of package roots that contain `component-package.json` **or** accept legacy-only kinds until #3130 merges. Prefer roots under staged modern package trees when available | `getModernPackageRoots()` non-empty when testing modern path |
+| 4 | Exercise widget list / page edit that loads definitions (poll triggers `recordSelectionKinds`) | INFO line appears with `modern=` / `legacyWidgetXml=` |
+| 5 | Open dashboard (gadget type map load) | INFO gadget dual-load line; product classpath typically `source=MODERN_CATALOG` |
+| 6 | Capture log excerpts for any M2 discussion | Attach to #2852 only when claiming zero-legacy — do **not** open deletion work from PARTIAL metrics |
+
+### Product install (full installer / upgrade)
+
+| Step | Action | Pass signal |
+|------|--------|-------------|
+| 1 | Install or upgrade using product distribution | `rxconfig/Widgets` populated for install wire format |
+| 2 | Inventory customer residual Widget XML (support path) | List of non-product ids retained under Widgets |
+| 3 | Configure modern roots (property list of package roots with `component-package.json`) until #3130 product defaults ship | Selection kinds show MODERN for converted product ids |
+| 4 | Convert remaining customer XML via Widget XML compiler → deploy modern packages | Customer defs selectable as modern |
+| 5 | Smoke pages/widgets; read dual-run INFO metrics | No unexpected `none` / mass legacy for product ids after modern roots configured |
+| 6 | Only after criteria M1–M3 + G1–G6: allow #2852 deletion work | Criteria Status snapshot all PASS |
+
+### Spring / property knobs (portable)
+
+| Knob | Behavior on `main` (2026-08-12) |
+|------|----------------------------------|
+| `widgetDao.modernPackageRoots` | `File.pathSeparator`-separated absolute or resolvable paths. **Blank default** → no modern roots (legacy-only selection kinds). |
+| Widgets repository | `${rxdeploydir}/rxconfig/Widgets` (existing DAO repository directory) |
+| Gadget modern resource | Classpath `com/percussion/webui/gadget/servlets/gadget-catalog.json` |
+| Gadget legacy resource | Classpath `…/GadgetRegistry.xml` (fallback; **do not delete** until #2852 criteria met) |
 
 ## Exit criteria (shim retirement)
 
-The dual-run window ends when **all** of the following hold. **Authoritative metrics, test gates, time-box, and 2026-08-10 inventory:** [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (#2835).
+The dual-run window ends when **all** of the following hold. **Authoritative metrics, test gates, time-box, and inventory:** [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (Status snapshot **2026-08-12**, #2835 / #3132).
 
 - [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
-- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install. **Inventory detail:** product Widget definition XMLs under Packages (`sys__UserDependency--rxconfig/Widgets`) — see [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md).
-- [ ] Customer upgrade path documented and used for remaining XML (window still open for 8.2 dual-run).
-- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived. **Snapshot (#3024):** `PSWidgetDao` logs dual-run counts and exposes selection kinds; M2 still open until modern roots are configured in product installs and legacy rate is zero/waived. **Snapshot (#3025):** WebUI `GadgetRegistry` logs INFO dual-load metrics (`modern=` / `legacyRegistryXml=` / `none=`) and exposes `getLastLoadSource()` / `getLastLoadEntryCount()`; product classpath prefers modern; legacy fallback retained until #2852.
-- [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help — **blocked** until criteria doc M1–M3 + G1–G6 pass; residual tracks the deletion PR.
+- [x] Product **Widget** packages (non-waived) no longer ship definition XML as source of truth under Packages — cluster [#2897](https://github.com/intersoftdatalabs-in/percussioncms/pull/2897) (A+B+C); only `perc.Test` waived residual; G4 gate [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051). Install wire XML may still be **materialized** at package-build for runtime load — that is not ADR-004 authoring regression. **Broader M1 (Pages/Gadgets wording):** see criteria M1 row.
+- [ ] Customer upgrade path documented and used for remaining XML (window still open for 8.2 dual-run) — **M3 FAIL**.
+- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived. **Snapshot 2026-08-12:** #3024 / #3025 on main (PARTIAL M2); #3130 / #3131 open for defaults + harness; overall **M2 FAIL**. See criteria § How to measure M2.
+- [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help — **blocked** until criteria doc **M1–M3 + G1–G6** pass; residual **[#2852](https://github.com/intersoftdatalabs-in/percussioncms/issues/2852)** tracks the deletion PR and must **not** start early.
 
-**Do not** mass-delete the customer-facing shim while any box above is open.
+**Do not** mass-delete the customer-facing shim while any box above is open. **Do not** treat PARTIAL M2 as “ready to remove.”
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Docs-only criteria closeout for Phase 3 residual **#3132** (parent **#2630**): refresh dual-run removal criteria Status snapshot and expand the operator dual-run checklist so **#2852 stays blocked** until real M1–M3 + G1–G6 evidence — not agent guesswork.

### Changes
- `definition-xml-shim-removal-criteria.md`
  - Status **2026-08-12** table: M1/M2/M3/G1–G6 PASS/FAIL/PARTIAL/N/A with dated evidence
  - Merged PR links: #3024/#3045, #3025/#3071, #3026/#3051, cluster #2897 (M1 Widget PASS)
  - Open (not on main) evidence PRs: #3130/#3134, #3131/#3136
  - How to measure M2 on current `main` (INFO logs + last-kind APIs)
  - Explicit **#2852 blocked** until M1–M3 + G1–G6
- `dual-run-legacy-definition-xml-shim.md`
  - Operator checklist: when shim must stay, how to read metrics, what closes M2
  - H2 `qa-up` + product install steps
  - Exit criteria boxes aligned with 2026-08-12 snapshot

### Out of scope
- Code deletion of shim / dual-run fallbacks
- Inventing product OUT or customer waiver without evidence

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2630 · Grandparent: #2626 · Related blocked residual: #2852 · Fixes #3132

## Test plan
- [x] Re-count on `origin/main`: Widget def XML under Packages = 1 (`perc.Test` only); component-package.json count = 77
- [x] Criteria Status table consistent with merged #3024/#3025/#3026 and open #3134/#3136 (not claimed merged)
- [x] Dual-run checklist actionable for H2 qa-up + product install; no false ready-to-remove claim
- [x] #2852 gate restated in both docs

## Product documentation
- [x] N/A — engineering criteria + dual-run operator notes under `docs/ai-generated/...` only; no customer product-docs surface change

## Build evidence (C3)
- **modules_built:** none (docs-only; no Maven module sources changed)
- **build_evidence:** N/A — documentation only; no `mvnw clean install` required for pure markdown under `docs/ai-generated/`
- **downstream_checked:** none (C2 N/A — no API/type changes)

> Co-Authored by Grok Build using grok-4.5 with agent main.