### PR TITLE
fix(perc-system): type install upgrade-plugin raw collections (#2995)

### DIFF
--- a/system/src/main/java/com/percussion/install/PSOraConvertLONG2LOBTool.java
+++ b/system/src/main/java/com/percussion/install/PSOraConvertLONG2LOBTool.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Vector;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -136,18 +136,15 @@ public class PSOraConvertLONG2LOBTool {
             + "ORDER BY table_name";
 
     ResultSet rs = performQuery(filterLongTablesSql);
-    Vector vTables = new Vector();
+    List<String> vTables = new ArrayList<>();
 
     while (rs.next()) {
       vTables.add(rs.getString("table_name"));
     }
 
-    if (vTables.size() <= 0) return null;
+    if (vTables.isEmpty()) return null;
 
-    String[] arrTableNames = new String[vTables.size()];
-    for (int i = 0; i < arrTableNames.length; i++) arrTableNames[i] = (String) vTables.elementAt(i);
-
-    return arrTableNames;
+    return vTables.toArray(new String[0]);
   }
 
   /**
@@ -259,7 +256,7 @@ public class PSOraConvertLONG2LOBTool {
       return true;
     }
 
-    Collection coll = Arrays.asList(arrTablesToConvert);
+    Collection<String> coll = Arrays.asList(arrTablesToConvert);
 
     return executeConversion2(coll);
   }
@@ -275,7 +272,7 @@ public class PSOraConvertLONG2LOBTool {
    * @throws SQLException on any ORA error
    * @throws PSJdbcTableFactoryException
    */
-  private boolean executeConversion2(Collection collLongTableNames)
+  private boolean executeConversion2(Collection<String> collLongTableNames)
       throws SQLException, PSJdbcTableFactoryException {
     if (collLongTableNames == null) throw new IllegalArgumentException("collLongTableNames==null");
 
@@ -283,18 +280,14 @@ public class PSOraConvertLONG2LOBTool {
 
     // create a table instance for each LONG table and gather all the info we
     // need to convert this table, which includes detailed column info, etc.
-    Iterator itTableNames = collLongTableNames.iterator();
-
-    Collection collLongTables = new ArrayList();
+    Collection<OraTable> collLongTables = new ArrayList<>();
     OraTable curTable = null;
 
     try {
       // first gather all the info needed to convert given tables
       logIt("Gathering table information..");
 
-      while (itTableNames.hasNext()) {
-        String tableName = (String) itTableNames.next();
-
+      for (String tableName : collLongTableNames) {
         curTable = new OraTable(m_conn, schemaName, tableName);
 
         curTable.queryTableInfo();
@@ -304,10 +297,8 @@ public class PSOraConvertLONG2LOBTool {
 
       logIt("About to convert " + collLongTables.size() + " LONG tables.");
 
-      Iterator itTables = collLongTables.iterator();
-
-      while (itTables.hasNext()) {
-        curTable = (OraTable) itTables.next();
+      for (OraTable table : collLongTables) {
+        curTable = table;
 
         logIt("About to convert table: " + curTable.getOwner() + "." + curTable.getName());
 
@@ -364,10 +355,11 @@ public class PSOraConvertLONG2LOBTool {
    * @return a collection of table names under a given schema that use LONGs
    * @throws SQLException
    */
-  public Collection querySchemaLONGTables() throws SQLException, PSJdbcTableFactoryException {
+  public Collection<String> querySchemaLONGTables()
+      throws SQLException, PSJdbcTableFactoryException {
     String schemaName = m_databaseDef.getSchema();
 
-    ArrayList al = new ArrayList();
+    ArrayList<String> al = new ArrayList<>();
 
     /* get list of tables that use LONG or LONG RAW datatype
     input: schema name
@@ -456,16 +448,13 @@ public class PSOraConvertLONG2LOBTool {
 
       if (cmd.equalsIgnoreCase(CMD_LIST)) {
         // get a list of LONG tables found is user's schema
-        Collection collLongTables = convertTool.querySchemaLONGTables();
+        Collection<String> collLongTables = convertTool.querySchemaLONGTables();
 
-        if (collLongTables.size() <= 0)
+        if (collLongTables.isEmpty())
           System.out.println("No tables in a given schema use LONG column type.");
         else System.out.println("List of table names that use LONG column type:");
 
-        Iterator iter = collLongTables.iterator();
-        while (iter.hasNext()) {
-          String tName = (String) iter.next();
-
+        for (String tName : collLongTables) {
           System.out.println(tName);
         }
       } else if (cmd.equalsIgnoreCase(CMD_TEST)) {
@@ -541,7 +530,7 @@ public class PSOraConvertLONG2LOBTool {
     private String m_name;
 
     // all column definitions
-    private Collection m_collColumns = new ArrayList();
+    private Collection<OraColumn> m_collColumns = new ArrayList<>();
 
     private OraTable m_backupTable = null;
 
@@ -638,12 +627,7 @@ public class PSOraConvertLONG2LOBTool {
     }
 
     private OraColumn getLongColumn() {
-      String colName = null;
-      Iterator it = m_collColumns.iterator();
-
-      while (it.hasNext()) {
-        OraColumn col = (OraColumn) it.next();
-
+      for (OraColumn col : m_collColumns) {
         if (col.isLongType()) {
           return col;
         }
@@ -733,10 +717,10 @@ public class PSOraConvertLONG2LOBTool {
       OraColumn lobCol = null;
 
       // append all columns
-      Iterator itcol = m_collColumns.iterator();
+      Iterator<OraColumn> itcol = m_collColumns.iterator();
 
       for (; itcol.hasNext(); ) {
-        OraColumn col = (OraColumn) itcol.next();
+        OraColumn col = itcol.next();
 
         if (col.isLongType()) {
           lobCol = col;
@@ -803,10 +787,10 @@ public class PSOraConvertLONG2LOBTool {
       buf.append("\" SELECT ");
 
       // append all columns
-      Iterator itcol = m_collColumns.iterator();
+      Iterator<OraColumn> itcol = m_collColumns.iterator();
 
       for (; itcol.hasNext(); ) {
-        OraColumn col = (OraColumn) itcol.next();
+        OraColumn col = itcol.next();
 
         buf.append(col.formatForInsertIntoBackup(true));
 
@@ -930,10 +914,10 @@ public class PSOraConvertLONG2LOBTool {
       buf.append(new_table_name);
       buf.append("\" (");
 
-      Iterator itcol = m_collColumns.iterator();
+      Iterator<OraColumn> itcol = m_collColumns.iterator();
 
       for (; itcol.hasNext(); ) {
-        OraColumn col = (OraColumn) itcol.next();
+        OraColumn col = itcol.next();
 
         buf.append(col.formatForCreate(convertLong2Lob));
 

--- a/system/src/main/java/com/percussion/install/PSUpgradeDbAndHtmlAndXslFilesForSlotNames.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradeDbAndHtmlAndXslFilesForSlotNames.java
@@ -443,14 +443,13 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     source.setLogWriter(new OutputStreamWriter(logStream));
     StringBuilder sbOld = new StringBuilder();
     StringBuilder sbNew = new StringBuilder();
-    List allStartTags = source.findAllStartTags();
-    for (Object tagObj : allStartTags) {
-      StartTag sTag = (StartTag) tagObj;
+    List<StartTag> allStartTags = source.findAllStartTags();
+    for (StartTag sTag : allStartTags) {
       Attributes attributes = sTag.getAttributes();
 
       if (attributes == null) continue;
 
-      Iterator attrs = attributes.iterator();
+      Iterator<Attribute> attrs = attributes.iterator();
 
       sbOld.setLength(0);
       sbNew.setLength(0);
@@ -463,7 +462,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
 
       boolean modifiedAttrs = false;
       while (attrs.hasNext()) {
-        Attribute attr = (Attribute) attrs.next();
+        Attribute attr = attrs.next();
         String value = getModifiedValue(attr, sTag);
         if (value == null) value = attr.getValue();
         else modifiedAttrs = true;

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginConvertContentTypes.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginConvertContentTypes.java
@@ -53,7 +53,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set; // Removed unused import
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -693,7 +693,7 @@ public class PSUpgradePluginConvertContentTypes extends PSSpringUpgradePluginBas
   private static Properties m_resourceMapProps = new Properties();
 
   /** Content type name storage. */
-  private static Set m_contentNames = new HashSet();
+  private static Set<String> m_contentNames = new HashSet<>();
 
   private static IPSUpgradeModule m_config;
 }

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCopyImagesToLocales.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCopyImagesToLocales.java
@@ -42,25 +42,20 @@ public class PSUpgradePluginCopyImagesToLocales implements IPSUpgradePlugin {
     m_config = config;
     log("Performing locale image copy");
 
-    List localeDirs = new ArrayList();
     File en_usImagesDir = new File(RxUpgrade.getRxRoot() + ENGLISH_LOCALE_IMAGES);
     File imagesDir = en_usImagesDir.getParentFile();
     File[] imagesFiles = imagesDir.listFiles();
-    for (int i = 0; i < imagesFiles.length; i++) {
-      File f = imagesFiles[i];
-      if (f.isDirectory() && !f.getName().equals("en-us")) {
-        log("Additional image directory found for locale " + f.getName());
-        localeDirs.add(f);
-      }
+    List<File> localeDirs = collectNonEnglishLocaleDirs(imagesFiles);
+    for (File f : localeDirs) {
+      log("Additional image directory found for locale " + f.getName());
     }
 
-    if (localeDirs.size() == 0) {
+    if (localeDirs.isEmpty()) {
       log("No additional locales were found, image copy not required");
     } else {
       log("Copying images from locale en-us to additional locale image " + "directories");
 
-      for (int i = 0; i < localeDirs.size(); i++) {
-        File localeDir = (File) localeDirs.get(i);
+      for (File localeDir : localeDirs) {
         copyImageFiles(en_usImagesDir, localeDir);
       }
 
@@ -68,6 +63,26 @@ public class PSUpgradePluginCopyImagesToLocales implements IPSUpgradePlugin {
     }
 
     return null;
+  }
+
+  /**
+   * Collects image subdirectories that are not the English locale folder. Package-visible for unit
+   * tests.
+   *
+   * @param imagesFiles children of the images directory, may be <code>null</code>
+   * @return non-English locale directories, never <code>null</code>
+   */
+  static List<File> collectNonEnglishLocaleDirs(File[] imagesFiles) {
+    List<File> localeDirs = new ArrayList<>();
+    if (imagesFiles == null) {
+      return localeDirs;
+    }
+    for (File f : imagesFiles) {
+      if (f != null && f.isDirectory() && !f.getName().equals("en-us")) {
+        localeDirs.add(f);
+      }
+    }
+    return localeDirs;
   }
 
   /**

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginGeneralTables.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginGeneralTables.java
@@ -157,7 +157,7 @@ public class PSUpgradePluginGeneralTables implements IPSUpgradePlugin {
     PSJdbcTableSchemaCollection collSchema = new PSJdbcTableSchemaCollection();
     PSJdbcTableSchema tableSchema = null;
     PSJdbcTableData tableData = null;
-    ArrayList<PSJdbcTableSchema> schemasToSort = new ArrayList();
+    ArrayList<PSJdbcTableSchema> schemasToSort = new ArrayList<>();
     for (int i = 0; i < tableList.size(); i++) {
       config.getLogStream().println("catalogging table: " + tableList.get(i).toString());
       tableSchema =

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginMigrateControlDependencies.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginMigrateControlDependencies.java
@@ -117,7 +117,7 @@ public class PSUpgradePluginMigrateControlDependencies implements IPSUpgradePlug
       String control = PSControlDependencyMap.CONTROL;
       String dep = PSControlDependencyMap.DEP;
       String ctrlRegEx = control + ".*" + dep + ".*";
-      List controlDepends = new ArrayList();
+      List<Element> controlDepends = new ArrayList<>();
 
       NodeList userPropNodes = doc.getElementsByTagName(PSContentEditorPipe.USER_PROPERTY);
 
@@ -130,13 +130,13 @@ public class PSUpgradePluginMigrateControlDependencies implements IPSUpgradePlug
 
         String name = property.getAttribute(PSContentEditorPipe.USER_PROP_NAME_ATTR);
 
-        if (name.matches(ctrlRegEx)) controlDepends.add(property);
+        if (isControlDependencyName(name, ctrlRegEx)) controlDepends.add(property);
       }
 
       // Add control dependencies to each content editor pipe if any
       NodeList contentEditorPipes = doc.getElementsByTagName(PSContentEditorPipe.XML_NODE_NAME);
 
-      if (controlDepends.size() > 0) {
+      if (!controlDepends.isEmpty()) {
         for (int i = 0; i < contentEditorPipes.getLength(); i++) {
           Element cePipe = (Element) contentEditorPipes.item(i);
           NodeList userPropsNodes =
@@ -151,8 +151,7 @@ public class PSUpgradePluginMigrateControlDependencies implements IPSUpgradePlug
                 PSXmlDocumentBuilder.addEmptyElement(
                     doc, cePipe, PSContentEditorPipe.USER_PROPERTIES);
 
-          for (int j = 0; j < controlDepends.size(); j++) {
-            Element controlDep = (Element) controlDepends.get(j);
+          for (Element controlDep : controlDepends) {
             String name = controlDep.getAttribute(PSContentEditorPipe.USER_PROP_NAME_ATTR);
             String value = controlDep.getTextContent();
 
@@ -169,8 +168,7 @@ public class PSUpgradePluginMigrateControlDependencies implements IPSUpgradePlug
       Element root = doc.getDocumentElement();
 
       if (root != null) {
-        for (int i = 0; i < controlDepends.size(); i++) {
-          Element controlDep = (Element) controlDepends.get(i);
+        for (Element controlDep : controlDepends) {
           String name = controlDep.getAttribute(PSContentEditorPipe.USER_PROP_NAME_ATTR);
 
           log("Removing dependency " + name + " from application user properties");
@@ -180,6 +178,18 @@ public class PSUpgradePluginMigrateControlDependencies implements IPSUpgradePlug
     } catch (Exception e) {
       log("Migration failed due to the following error: " + e.getMessage());
     }
+  }
+
+  /**
+   * Whether a user-property name matches the control-dependency naming pattern. Package-visible for
+   * unit tests.
+   *
+   * @param name property name, may be <code>null</code>
+   * @param ctrlRegEx regex built from control/dep constants, never <code>null</code>
+   * @return <code>true</code> when the name matches the control-dependency pattern
+   */
+  static boolean isControlDependencyName(String name, String ctrlRegEx) {
+    return name != null && name.matches(ctrlRegEx);
   }
 
   /**

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginPsxCTTemplate.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginPsxCTTemplate.java
@@ -29,7 +29,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -348,18 +347,14 @@ public class PSUpgradePluginPsxCTTemplate implements IPSUpgradePlugin {
 
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery(queryStmt);
-    Map labelsIds = new HashMap();
+    Map<Integer, String> labelsIds = new HashMap<>();
 
     while (rs.next()) labelsIds.put(Integer.valueOf(rs.getInt(2)), rs.getString(1));
 
     int rowsUpdated = 0;
-    Iterator keyIter = labelsIds.keySet().iterator();
-    while (keyIter.hasNext()) {
-      Integer id = (Integer) keyIter.next();
-      String label = (String) labelsIds.get(id);
-      String name = InstallUtil.modifyName(label);
-
-      name = name.replaceAll("'", "''");
+    for (Map.Entry<Integer, String> entry : labelsIds.entrySet()) {
+      Integer id = entry.getKey();
+      String name = sqlEscapedTemplateName(entry.getValue());
 
       String updateStmt =
           "UPDATE "
@@ -377,6 +372,22 @@ public class PSUpgradePluginPsxCTTemplate implements IPSUpgradePlugin {
       rowsUpdated++;
     }
     log("Updated " + rowsUpdated + " names");
+  }
+
+  /**
+   * Builds a SQL-safe template NAME from a LABEL via {@link InstallUtil#modifyName(String)} and
+   * single-quote escaping. Package-visible for unit tests.
+   *
+   * @param label the template label, may be <code>null</code>
+   * @return name suitable for embedding in a SQL string literal, never <code>null</code> if label
+   *     was non-null (follows modifyName null handling)
+   */
+  static String sqlEscapedTemplateName(String label) {
+    String name = InstallUtil.modifyName(label);
+    if (name == null) {
+      return null;
+    }
+    return name.replace("'", "''");
   }
 
   /**

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginRelationship.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginRelationship.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import org.w3c.dom.Document;
@@ -243,7 +242,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
 
     // fix up relationship configurations & gets the mapper
     // which maps new to old relationship name
-    Map configNames = fixupRelationshipConfigNameIds(logger, configSet, 50);
+    Map<String, String> configNames = fixupRelationshipConfigNameIds(logger, configSet, 50);
 
     addKnownExecutionContexts(logger, configSet);
     removeExpirationProperty(logger, configSet);
@@ -279,17 +278,11 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param configNames the map of new to old configuration names, assumed never <code>null</code>
    */
   private void fixProcessChecks(
-      PrintStream logger, PSRelationshipConfigSet configSet, Map configNames) {
+      PrintStream logger, PSRelationshipConfigSet configSet, Map<String, String> configNames) {
     // Reverse the config name map
-    Map oldToNew = new HashMap();
-    Iterator eiter = configNames.entrySet().iterator();
-    while (eiter.hasNext()) {
-      Entry entry = (Entry) eiter.next();
-      oldToNew.put(entry.getValue(), entry.getKey());
-    }
-    Iterator citer = configSet.getConfigList().iterator();
-    while (citer.hasNext()) {
-      fixProcessChecks(logger, (PSRelationshipConfig) citer.next(), oldToNew);
+    Map<String, String> oldToNew = reverseConfigNameMap(configNames);
+    for (PSRelationshipConfig config : configSet.getConfigList()) {
+      fixProcessChecks(logger, config, oldToNew);
     }
   }
 
@@ -301,8 +294,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param config the configuration, assumed never <code>null</code>
    * @param oldToNew the map of old to new configuration names, assumed never <code>null</code>
    */
-  private void fixProcessChecks(PrintStream logger, PSRelationshipConfig config, Map oldToNew) {
-    Iterator iter = config.getProcessChecks();
+  private void fixProcessChecks(
+      PrintStream logger, PSRelationshipConfig config, Map<String, String> oldToNew) {
+    Iterator<?> iter = config.getProcessChecks();
     while (iter.hasNext()) {
       fixProcessCheck(logger, (PSProcessCheck) iter.next(), oldToNew);
     }
@@ -316,8 +310,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param check the process check, assumed never <code>null</code>
    * @param oldToNew the map of old to new configuration names, assumed never <code>null</code>
    */
-  private void fixProcessCheck(PrintStream logger, PSProcessCheck check, Map oldToNew) {
-    Iterator ruleiter = check.getConditions();
+  private void fixProcessCheck(
+      PrintStream logger, PSProcessCheck check, Map<String, String> oldToNew) {
+    Iterator<?> ruleiter = check.getConditions();
     while (ruleiter.hasNext()) {
       fixRule(logger, (PSRule) ruleiter.next(), oldToNew);
     }
@@ -330,15 +325,15 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param rule the rule, assumed never <code>null</code>
    * @param oldToNew the map of old to new configuration names, assumed never <code>null</code>
    */
-  private void fixRule(PrintStream logger, PSRule rule, Map oldToNew) {
+  private void fixRule(PrintStream logger, PSRule rule, Map<String, String> oldToNew) {
     PSExtensionCallSet callSet = rule.getExtensionRules();
     if (callSet != null) {
-      Iterator call = callSet.iterator();
+      Iterator<?> call = callSet.iterator();
       while (call.hasNext()) {
         fixCall(logger, (PSExtensionCall) call.next(), oldToNew);
       }
     }
-    Iterator citer = rule.getConditionalRules();
+    Iterator<?> citer = rule.getConditionalRules();
     while (citer.hasNext()) {
       fixConditional(logger, (PSConditional) citer.next(), oldToNew);
     }
@@ -351,7 +346,8 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param conditional the conditional, assumed never <code>null</code>
    * @param oldToNew the map of old to new configuration names, assumed never <code>null</code>
    */
-  private void fixConditional(PrintStream logger, PSConditional conditional, Map oldToNew) {
+  private void fixConditional(
+      PrintStream logger, PSConditional conditional, Map<String, String> oldToNew) {
     fixReplacementValue(logger, oldToNew, conditional.getValue());
     fixReplacementValue(logger, oldToNew, conditional.getVariable());
   }
@@ -363,7 +359,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param call the call, assumed never <code>null</code>
    * @param oldToNew the map of old to new configuration names, assumed never <code>null</code>
    */
-  private void fixCall(PrintStream logger, PSExtensionCall call, Map oldToNew) {
+  private void fixCall(PrintStream logger, PSExtensionCall call, Map<String, String> oldToNew) {
     PSExtensionParamValue values[] = call.getParamValues();
     for (int i = 0; i < values.length; i++) {
       fixReplacementValue(logger, oldToNew, values[i].getValue());
@@ -378,10 +374,11 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param value the value that may reference an old relationship name, assumed never <code>null
    *     </code>
    */
-  private void fixReplacementValue(PrintStream logger, Map oldToNew, IPSReplacementValue value) {
+  private void fixReplacementValue(
+      PrintStream logger, Map<String, String> oldToNew, IPSReplacementValue value) {
     if (value instanceof PSTextLiteral) {
       PSTextLiteral tl = (PSTextLiteral) value;
-      String mapped = (String) oldToNew.get(tl.getText());
+      String mapped = oldToNew.get(tl.getText());
       if (mapped != null) {
         logger.println(
             "Updating relationship config, replaced old "
@@ -419,7 +416,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param nameMap it maps the new relationship name to its old one, assumed not <code>null</code>.
    * @throws Exception if an error occurs.
    */
-  private void upgradeSystemDef(PrintStream logger, Map nameMap) throws Exception {
+  private void upgradeSystemDef(PrintStream logger, Map<String, String> nameMap) throws Exception {
     FileInputStream in = null;
     FileOutputStream out = null;
     Document doc = null;
@@ -532,14 +529,21 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @return the new relationship name, it may be <code>null</code> if cannot find the related new
    *     name.
    */
-  private String getNewRelName(String oldName, Map nameMap) {
-    Iterator entries = nameMap.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry entry = (Map.Entry) entries.next();
-      if (oldName.equalsIgnoreCase((String) entry.getValue())) return (String) entry.getKey();
+  /** Package-visible for unit tests: maps old relationship name to new (case-insensitive). */
+  static String getNewRelName(String oldName, Map<String, String> nameMap) {
+    for (Map.Entry<String, String> entry : nameMap.entrySet()) {
+      if (oldName.equalsIgnoreCase(entry.getValue())) return entry.getKey();
     }
-
     return null;
+  }
+
+  /** Package-visible for unit tests: reverse new->old map to old->new. */
+  static Map<String, String> reverseConfigNameMap(Map<String, String> configNames) {
+    Map<String, String> oldToNew = new HashMap<>();
+    for (Map.Entry<String, String> entry : configNames.entrySet()) {
+      oldToNew.put(entry.getValue(), entry.getKey());
+    }
+    return oldToNew;
   }
 
   /**
@@ -550,13 +554,11 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param nameMap it maps the new relationship name to its old one, assumed not <code>null</code>.
    * @throws Exception if an error occurs.
    */
-  private void updateSlotTable(PrintStream logger, Connection conn, Map configNames)
-      throws Exception {
-    Iterator names = configNames.entrySet().iterator();
-    while (names.hasNext()) {
-      Map.Entry entry = (Map.Entry) names.next();
-      String newName = (String) entry.getKey();
-      String oldName = (String) entry.getValue();
+  private void updateSlotTable(
+      PrintStream logger, Connection conn, Map<String, String> configNames) throws Exception {
+    for (Map.Entry<String, String> entry : configNames.entrySet()) {
+      String newName = entry.getKey();
+      String oldName = entry.getValue();
       if (!oldName.equals(newName)) {
         String sqlStmt =
             "update "
@@ -581,7 +583,8 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param nameMap it maps the new relationship name to its old one, assumed not <code>null</code>.
    * @throws Exception if an error occurs.
    */
-  private void updateMenuActionTable(PrintStream logger, Connection conn, Map configNames)
+  private void updateMenuActionTable(
+      PrintStream logger, Connection conn, Map<String, String> configNames)
       throws Exception {
     PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(m_dbProps);
     PSJdbcTableSchema tableSchema = getTableSchema(conn, dbmsDef, MENUACTION_TABLE);
@@ -601,8 +604,8 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
       return; // do nothing if there is no action defined
     }
 
-    List updatedRows = new ArrayList();
-    Iterator rows = tableData.getRows();
+    List<PSJdbcRowData> updatedRows = new ArrayList<>();
+    Iterator<?> rows = tableData.getRows();
     while (rows.hasNext()) {
       PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
       PSJdbcRowData tgtRow = getUpdatedRow(srcRow, configNames, MENUACTION_TABLE);
@@ -640,7 +643,8 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @return the updated row. It may be <code>null</code> if the source row does not need to be
    *     updated.
    */
-  private PSJdbcRowData getUpdatedRow(PSJdbcRowData srcRow, Map configNames, String table) {
+  private PSJdbcRowData getUpdatedRow(
+      PSJdbcRowData srcRow, Map<String, String> configNames, String table) {
     PSJdbcColumnData col = srcRow.getColumn("URL");
     String url = col.getValue();
     if (url == null || url.trim().length() == 0) return null;
@@ -664,7 +668,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
     url = url.replaceAll(SYS_RELATIONSHIP_TYPE_EQ + name, SYS_RELATIONSHIP_TYPE_EQ + newName);
     col.setValue(url);
 
-    List columns = new ArrayList();
+    List<PSJdbcColumnData> columns = new ArrayList<>();
     columns.add(srcRow.getColumn("ACTIONID"));
     columns.add(col);
 
@@ -685,7 +689,10 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @throws Exception if an error occurs.
    */
   private void createRelationshipViews(
-      PrintStream logger, Connection conn, PSRelationshipConfigSet configSet, Map nameMap)
+      PrintStream logger,
+      Connection conn,
+      PSRelationshipConfigSet configSet,
+      Map<String, String> nameMap)
       throws Exception {
     // create the view to map to the old relationship main table
 
@@ -759,16 +766,16 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param nameMap it maps new relationship name to old once, never <code>null</code>.
    * @return the created partial SELECT clause, never <code>null</code> or empty.
    */
-  private String getSelectConfigName(PSRelationshipConfigSet configSet, Map nameMap) {
+  private String getSelectConfigName(
+      PSRelationshipConfigSet configSet, Map<String, String> nameMap) {
     StringBuilder caseBuf = new StringBuilder();
     boolean hasMismatchName = false;
     caseBuf.append("CASE RN.CONFIG_NAME ");
-    String cname;
-    Iterator configs = configSet.iterator();
+    Iterator<?> configs = configSet.iterator();
     while (configs.hasNext()) {
-      cname = ((PSRelationshipConfig) configs.next()).getName();
+      String cname = ((PSRelationshipConfig) configs.next()).getName();
 
-      if (!cname.equals((String) nameMap.get(cname))) {
+      if (!cname.equals(nameMap.get(cname))) {
         hasMismatchName = true;
         caseBuf.append("WHEN '" + cname + "' ");
         caseBuf.append("THEN '" + nameMap.get(cname) + "' ");
@@ -887,14 +894,10 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    */
   private void updateCustomProperties(
       PrintStream logger, Connection conn, PSRelationshipConfigSet configSet) throws Exception {
-    Iterator configs = configSet.iterator();
-    PSRelationshipConfig config;
-    Iterator propNames;
+    Iterator<?> configs = configSet.iterator();
     while (configs.hasNext()) {
-      config = (PSRelationshipConfig) configs.next();
-      propNames = config.getCustomPropertyNames().iterator();
-      while (propNames.hasNext()) {
-        String propName = (String) propNames.next();
+      PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
+      for (String propName : config.getCustomPropertyNames()) {
         String sqlStmt =
             "INSERT INTO "
                 + getNewRelPropTable()
@@ -1319,14 +1322,15 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @throws Exception if an error occurs.
    */
   private void saveRelationshipConfigNameIds(
-      PrintStream logger, Connection conn, PSRelationshipConfigSet configSet, Map configNames)
+      PrintStream logger,
+      Connection conn,
+      PSRelationshipConfigSet configSet,
+      Map<String, String> configNames)
       throws Exception {
     // \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
     // Modify the config names in (old) PSX_RELATIONSHIPS table for later use
     // \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
-    Iterator entries = configNames.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry entry = (Map.Entry) entries.next();
+    for (Map.Entry<String, String> entry : configNames.entrySet()) {
       if (!entry.getKey().equals(entry.getValue())) {
         String sqlStmt =
             "UPDATE "
@@ -1345,7 +1349,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
     // Add a list of unknown ids & names into the name table
     // \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
 
-    Iterator configs = configSet.iterator();
+    Iterator<?> configs = configSet.iterator();
     while (configs.hasNext()) {
       PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
       if (config.getId() > PSRelationshipConfig.ID_TRANSLATION_MANDATORY) {
@@ -1374,18 +1378,17 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param configSet all relationship configurations, assumed not <code>null</code>.
    */
   private void addKnownExecutionContexts(PrintStream logger, PSRelationshipConfigSet configSet) {
-    Iterator configs = configSet.iterator();
-    PSRelationshipConfig config;
+    Iterator<?> configs = configSet.iterator();
     while (configs.hasNext()) {
-      config = (PSRelationshipConfig) configs.next();
-      Iterator effects = config.getEffects();
+      PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
+      Iterator<?> effects = config.getEffects();
       while (effects.hasNext()) {
         PSConditionalEffect effect = (PSConditionalEffect) effects.next();
         PSExtensionCall ext = effect.getEffect();
         String fullName = ext.getExtensionRef().getFQN();
 
         if (ms_knownExeCtx.get(fullName) != null) {
-          effect.setExecutionContexts((Collection) ms_knownExeCtx.get(fullName));
+          effect.setExecutionContexts(ms_knownExeCtx.get(fullName));
           logger.println(
               "Added known execution contexts for '"
                   + fullName
@@ -1406,10 +1409,10 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @return a mapper that maps new relationship name to its original (old) name, never <code>null
    *     </code>.
    */
-  private Map fixupRelationshipConfigNameIds(
+  private Map<String, String> fixupRelationshipConfigNameIds(
       PrintStream logger, PSRelationshipConfigSet configSet, int startId) {
-    Map configName = new HashMap();
-    Iterator configs = configSet.iterator();
+    Map<String, String> configName = new HashMap<>();
+    Iterator<?> configs = configSet.iterator();
     PSRelationshipConfig config;
     while (configs.hasNext()) {
       config = (PSRelationshipConfig) configs.next();
@@ -1471,10 +1474,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    * @param configSet all relationship configurations, assumed not <code>null</code>.
    */
   private void removeExpirationProperty(PrintStream logger, PSRelationshipConfigSet configSet) {
-    Iterator configs = configSet.iterator();
-    PSRelationshipConfig config;
+    Iterator<?> configs = configSet.iterator();
     while (configs.hasNext()) {
-      config = (PSRelationshipConfig) configs.next();
+      PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
       if (config.removeSysProperty("rs_expirationtime"))
         logger.println(
             "Removed 'rs_expirationtime' system property from '"
@@ -1485,47 +1487,47 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
 
   /** Populate {@link #ms_knownExeCtx} */
   private static void initKnownExeCtx() {
-    ms_knownExeCtx = new HashMap();
+    ms_knownExeCtx = new HashMap<>();
 
     String name = "Java/global/percussion/relationship/effect/sys_TouchParentFolderEffect";
-    List exeCtxs = new ArrayList();
+    List<Integer> exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_CONSTRUCTION));
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_DESTRUCTION));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/fastforward/managednav/rxs_NavFolderEffect";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_CONSTRUCTION));
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_DESTRUCTION));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_isCloneExists";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_CLONE));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_PublishMandatory";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_WORKFLOW));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_UnpublishMandatory";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_WORKFLOW));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_AttachTranslatedFolder";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_CONSTRUCTION));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_Promote";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_POST_WORKFLOW));
     ms_knownExeCtx.put(name, exeCtxs);
 
     name = "Java/global/percussion/relationship/effect/sys_AddCloneToFolder";
-    exeCtxs = new ArrayList();
+    exeCtxs = new ArrayList<>();
     exeCtxs.add(Integer.valueOf(IPSExecutionContext.RS_PRE_CONSTRUCTION));
     ms_knownExeCtx.put(name, exeCtxs);
   }
@@ -1546,11 +1548,10 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
     PSCloneOverrideFieldList src = newCopy.getCloneOverrideFieldList();
     PSCloneOverrideFieldList target = new PSCloneOverrideFieldList();
 
-    Iterator srcIt = src.iterator();
-    PSCloneOverrideField overrideField;
+    Iterator<?> srcIt = src.iterator();
     boolean isAdded = false;
     while (srcIt.hasNext()) {
-      overrideField = (PSCloneOverrideField) srcIt.next();
+      PSCloneOverrideField overrideField = (PSCloneOverrideField) srcIt.next();
       if (overrideField.getName().equalsIgnoreCase(IPSHtmlParameters.SYS_COMMUNITYID)) {
         // replacing 1st and skip the rest.
         if (!isAdded) {
@@ -1609,27 +1610,23 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    */
   protected void updateActiveAssemblyProperties(
       PrintStream logger, PSRelationshipConfigSet configSet) {
-    final Collection rqdNames = PSRelationshipConfig.getPreDefinedUserPropertyNames();
+    final Collection<String> rqdNames = PSRelationshipConfig.getPreDefinedUserPropertyNames();
 
-    Iterator aaConfigs =
-        configSet.getConfigListByCategory(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY).iterator();
-    while (aaConfigs.hasNext()) {
-      PSRelationshipConfig config = (PSRelationshipConfig) aaConfigs.next();
-      Set userPropNames = config.getUserProperties().keySet();
+    for (PSRelationshipConfig config :
+        configSet.getConfigListByCategory(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY)) {
+      Set<String> userPropNames = config.getUserProperties().keySet();
       if (!userPropNames.containsAll(rqdNames)) {
         // get the missing names
-        List missingNames = new ArrayList(rqdNames);
+        List<String> missingNames = new ArrayList<>(rqdNames);
         missingNames.removeAll(userPropNames);
 
         // get the current properties
         PSPropertySet userProps = new PSPropertySet();
-        Iterator props = config.getUserDefProperties();
+        Iterator<?> props = config.getUserDefProperties();
         while (props.hasNext()) userProps.add(props.next());
 
         // add the missing properties
-        Iterator names = missingNames.iterator();
-        while (names.hasNext()) {
-          String propName = (String) names.next();
+        for (String propName : missingNames) {
           PSProperty prop = new PSProperty(propName);
           userProps.add(prop);
 
@@ -1660,7 +1657,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    */
   private void removeNonNumericPropertyValues(PrintStream logger, Connection conn, String property)
       throws Exception {
-    List invalidRows = new ArrayList();
+    List<Integer> invalidRows = new ArrayList<>();
     PreparedStatement stmt = null;
     ResultSet rs = null;
     int rowCount = 0;
@@ -1694,8 +1691,8 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
         }
       }
 
-      for (int i = 0; i < invalidRows.size(); i++) {
-        int invalidRID = ((Integer) invalidRows.get(i)).intValue();
+      for (Integer ridObj : invalidRows) {
+        int invalidRID = ridObj.intValue();
         sqlStmt =
             "DELETE FROM "
                 + getOldRelPropTable()
@@ -1744,9 +1741,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    *     </code>.
    * @throws Exception if an error occurs.
    */
-  private void updateMenuActionParamTable(PrintStream logger, Connection conn, Map configNames)
-      throws Exception {
-    Map updateVals = new HashMap();
+  private void updateMenuActionParamTable(
+      PrintStream logger, Connection conn, Map<String, String> configNames) throws Exception {
+    Map<Integer, String> updateVals = new HashMap<>();
     PreparedStatement stmt = null;
     ResultSet rs = null;
     int rowCount = 0;
@@ -1778,11 +1775,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
         updateVals.put(Integer.valueOf(actionid), newValue);
       }
 
-      Set keys = updateVals.keySet();
-      Iterator iter = keys.iterator();
-      while (iter.hasNext()) {
-        Integer aid = (Integer) iter.next();
-        String val = (String) updateVals.get(aid);
+      for (Map.Entry<Integer, String> e : updateVals.entrySet()) {
+        Integer aid = e.getKey();
+        String val = e.getValue();
         sqlStmt =
             "UPDATE "
                 + getMenuActionParamTable()
@@ -1828,7 +1823,7 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
   /**
    * It maps the effect (full) name to its known execution contexts. Init when the class is loaded.
    */
-  private static Map ms_knownExeCtx;
+  private static Map<String, List<Integer>> ms_knownExeCtx;
 
   static {
     initKnownExeCtx();

--- a/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
@@ -190,4 +190,90 @@ class PSInstallPackageTypedTest {
         IllegalArgumentException.class,
         () -> PSUpgradeDbAndHtmlAndXslFilesForSlotNames.convertSlotName(null));
   }
+
+  @Test
+  @DisplayName("PsxCTTemplate sqlEscapedTemplateName escapes quotes after modifyName")
+  void psxCtTemplateSqlEscapedName() {
+    assertEquals("My_Template", PSUpgradePluginPsxCTTemplate.sqlEscapedTemplateName("My Template"));
+    assertEquals("O''Brien_Tpl", PSUpgradePluginPsxCTTemplate.sqlEscapedTemplateName("O'Brien Tpl"));
+    assertEquals(null, PSUpgradePluginPsxCTTemplate.sqlEscapedTemplateName(null));
+  }
+
+  @Test
+  @DisplayName("CopyImagesToLocales collects non-English locale dirs")
+  void copyImagesCollectsNonEnglishLocaleDirs() throws Exception {
+    java.nio.file.Path root = java.nio.file.Files.createTempDirectory("img-locales");
+    try {
+      java.io.File en = root.resolve("en-us").toFile();
+      java.io.File fr = root.resolve("fr-fr").toFile();
+      java.io.File de = root.resolve("de-de").toFile();
+      java.io.File notDir = root.resolve("readme.txt").toFile();
+      assertTrue(en.mkdirs());
+      assertTrue(fr.mkdirs());
+      assertTrue(de.mkdirs());
+      assertTrue(notDir.createNewFile());
+
+      List<java.io.File> locales =
+          PSUpgradePluginCopyImagesToLocales.collectNonEnglishLocaleDirs(root.toFile().listFiles());
+      assertEquals(2, locales.size());
+      Set<String> names = new HashSet<>();
+      for (java.io.File f : locales) {
+        names.add(f.getName());
+      }
+      assertTrue(names.contains("fr-fr"));
+      assertTrue(names.contains("de-de"));
+      assertFalse(names.contains("en-us"));
+    } finally {
+      java.nio.file.Files.walk(root)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  java.nio.file.Files.deleteIfExists(p);
+                } catch (Exception ignored) {
+                }
+              });
+    }
+  }
+
+  @Test
+  @DisplayName("CopyImagesToLocales handles null listing")
+  void copyImagesNullListing() {
+    assertTrue(PSUpgradePluginCopyImagesToLocales.collectNonEnglishLocaleDirs(null).isEmpty());
+  }
+
+  @Test
+  @DisplayName("MigrateControlDependencies matches control dep name regex")
+  void migrateControlDependencyName() {
+    String control = com.percussion.design.objectstore.PSControlDependencyMap.CONTROL;
+    String dep = com.percussion.design.objectstore.PSControlDependencyMap.DEP;
+    String ctrlRegEx = control + ".*" + dep + ".*";
+    assertTrue(
+        PSUpgradePluginMigrateControlDependencies.isControlDependencyName(
+            control + "foo" + dep + "bar", ctrlRegEx));
+    assertFalse(
+        PSUpgradePluginMigrateControlDependencies.isControlDependencyName("plainProp", ctrlRegEx));
+    assertFalse(PSUpgradePluginMigrateControlDependencies.isControlDependencyName(null, ctrlRegEx));
+  }
+
+  @Test
+  @DisplayName("Relationship reverseConfigNameMap and getNewRelName are typed")
+  void relationshipConfigNameHelpers() {
+    java.util.Map<String, String> newToOld = new java.util.HashMap<>();
+    newToOld.put("ActiveAssembly", "Active Assembly");
+    newToOld.put("FolderContent", "Folder Content");
+
+    java.util.Map<String, String> oldToNew =
+        PSUpgradePluginRelationship.reverseConfigNameMap(newToOld);
+    assertEquals("ActiveAssembly", oldToNew.get("Active Assembly"));
+    assertEquals("FolderContent", oldToNew.get("Folder Content"));
+
+    assertEquals(
+        "ActiveAssembly",
+        PSUpgradePluginRelationship.getNewRelName("Active Assembly", newToOld));
+    assertEquals(
+        "ActiveAssembly",
+        PSUpgradePluginRelationship.getNewRelName("active assembly", newToOld));
+    assertEquals(null, PSUpgradePluginRelationship.getNewRelName("Unknown", newToOld));
+  }
 }


### PR DESCRIPTION
## Summary
PR-sized install upgrade-plugin `-Xlint` residual for **#2995** (parent **#2877**, grandparent **#2022**), after #2942 / PR #2994.

Real generics on remaining install upgrade raw collections:

- `PSUpgradePluginPsxCTTemplate` — `Map<Integer,String>` labels + `sqlEscapedTemplateName` helper
- `PSUpgradePluginCopyImagesToLocales` — `List<File>` + `collectNonEnglishLocaleDirs`
- `PSUpgradePluginMigrateControlDependencies` — `List<Element>` + `isControlDependencyName`
- `PSUpgradePluginConvertContentTypes` — `Set<String> m_contentNames`
- `PSUpgradePluginGeneralTables` — diamond `ArrayList<>`
- `PSUpgradeDbAndHtmlAndXslFilesForSlotNames` residual — typed Jericho `StartTag` / `Attribute` iteration
- `PSOraConvertLONG2LOBTool` — typed `Collection`/`List`/`Iterator` (LONG→LOB converter)
- `PSUpgradePluginRelationship` — residual `Map`/`List` rawtypes after #2952 merge (config name maps, menu/slot updates, known execution contexts, AA properties)

Workflow transition plugins already typed; no thrash with #2952 (merged).

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` (tests included, no skip)
- [x] `PSInstallPackageTypedTest` — 15 tests (new helpers + prior #2942 coverage)
- [x] Full system surefire: **1899** tests, **0** failures/errors
- [x] Product documentation: **N/A** — pure generics tech-debt, no operator/user-facing behavior change

## Gates evidence
- **modules_built:** `system`
- **build_evidence:** `cd system; ../mvnw.cmd clean install` → jar install green; Tests run: 1899, Failures: 0, Errors: 0; `PSInstallPackageTypedTest`: Tests run: 15, Failures: 0, Errors: 0
- **downstream_checked:** none — private method generics + package-visible static helpers; public `querySchemaLONGTables` return type only reified to `Collection<String>` (erasure-compatible); no `final`/`sealed` or public signature removal
- **C2 reverse-deps:** not required for this change class

## Fixes
Fixes #2995

Parent tracker: #2877 / grandparent #2022

> Co-Authored by Grok Build using grok-4.5 with agent main.
