### PR TITLE
fix(installer): installSampleSites applies RXSITES sample rows (#3133)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3133-install-sample-sites-rxsites-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3133-install-sample-sites-rxsites-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review: #3133 installSampleSites RXSITES
+
+**Branch:** `fix/issue-3133-install-sample-sites-rxsites`  
+**Scope:** uncommitted changes vs HEAD  
+**Date:** 2026-08-12  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+
+## Summary
+
+`installSampleSites` only passed `RxffTableDef.xml` to `PSTableAction`. That task iterates **schema** entries and looks up data by name; `RxffTableDef` is only `RXS_CT_*` while sample graph data (including `RXSITES`) lives in `RxffTableData.xml`. Fix restores legacy FastForward dual def: `cmsTableDef.xml,RxffTableDef.xml`.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable paths).
+
+## Cross-platform path checklist
+
+- ANT `${data.dir}/…` properties only — portable  
+- Tests use `java.nio.file.Path` relative to module CWD (peer pattern)  
+- No hardcoded separators or OS-specific paths  
+
+## Tests
+
+`InstallSampleSitesWiringTest` (3): dual tableDef wiring; RXSITES replace rows + site names; every sample data table has schema in combined defs.
+
+## Memory patterns hit
+
+- Installer/packaging companions: lockstep wiring test + historic peer (`installFastForward.xml`)  
+- Behavioral regression for silent success path  
+
+## Build
+
+`modules/perc-distribution-tree`: `mvnw clean install` — BUILD SUCCESS; InstallSampleSitesWiringTest 3/3; module surefire totals 251 tests, 0 failures.

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -724,7 +724,7 @@
 			(RXSITES, PSX_FOLDER, ACLs, editions, …) with no CT extension rows.
 			Without cmsTableDef, installSampleSites "succeeds" while never inserting
 			RXSITES (#3133 residual of #2989). Match legacy FastForward install:
-			sys_cmstableDef + RxffTableDef (see installFastForward.xml). -->
+			cmsTableDef + RxffTableDef (see installFastForward.xml). -->
 		<PSTableAction rootDir="${install.dir}"
 			repositoryLocation="${rxrepository.properties}"
 			tableFactoryLogFile="${install.dir}/rxconfig/Installer/tableFactory.log"

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -210,11 +210,12 @@
 		<!-- Optional sample sites (Corporate Investments / Enterprise Investments).
 			Driven by the Java preinstall's demo-sites flag, propagated to ANT as -Dinstall.demo.sites=true
 			from Phase-1 options (wizard Yes / demo-sites CLI flag) via Main.execJar (#2192).
-			When true on new installs and upgrades: antcall installSampleSites chains an
-			RxffTableData/RxffTableDef PSTableAction pass that seeds the two sample sites plus
-			their ACLs, content types, nav, etc. RXLOCALE / RXLOCALEFORMAT are protected by
-			stripSampleLocales, not by install-type gating. This in-target guard is defensive
-			so the chain wiring and the system property remain in sync. -->
+			When true on new installs and upgrades: antcall installSampleSites chains a
+			PSTableAction over cmsTableDef+RxffTableDef with RxffTableData (locale-stripped
+			staging) so RXSITES and the dependent sample graph are inserted (#3133).
+			RXLOCALE / RXLOCALEFORMAT are protected by stripSampleLocales, not by
+			install-type gating. This in-target guard is defensive so the chain wiring
+			and the system property remain in sync. -->
 		<if>
 			<equals arg1="${install.demo.sites}" arg2="true" />
 			<then>
@@ -716,13 +717,20 @@
 		</antcall>
 
 		<!-- Run the schema + data load using the stripped staging copy. The original
-			shipped file is never modified. -->
+			shipped file is never modified.
+			PSTableAction only processes tables present in tableDef (schema collection
+			is the outer loop; data is looked up by table name). RxffTableDef.xml lists
+			only RXS_CT_* extension schemas; RxffTableData has the sample graph
+			(RXSITES, PSX_FOLDER, ACLs, editions, …) with no CT extension rows.
+			Without cmsTableDef, installSampleSites "succeeds" while never inserting
+			RXSITES (#3133 residual of #2989). Match legacy FastForward install:
+			sys_cmstableDef + RxffTableDef (see installFastForward.xml). -->
 		<PSTableAction rootDir="${install.dir}"
 			repositoryLocation="${rxrepository.properties}"
 			tableFactoryLogFile="${install.dir}/rxconfig/Installer/tableFactory.log"
 			tableData="${data.dir}/RxffTableData.staging.xml"
-			tableDef="${data.dir}/RxffTableDef.xml" failonerror="true"
-			silenceerrors="false" />
+			tableDef="${data.dir}/cmsTableDef.xml,${data.dir}/RxffTableDef.xml"
+			failonerror="true" silenceerrors="false" />
 
 		<echo>Sample sites seeded.</echo>
 	</target>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
@@ -62,19 +62,23 @@ class InstallSampleSitesWiringTest {
   private static final Path SAMPLE_DEF = INSTALLER_DATA.resolve("RxffTableDef.xml");
   private static final Path CMS_TABLE_DEF = INSTALLER_DATA.resolve("cmsTableDef.xml");
 
+  /** Matches {@code name} anywhere on a {@code <table ...>} start tag (not only first attr). */
   private static final Pattern TABLE_NAME_ATTR =
-      Pattern.compile("<table\\s+name\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "<table\\s+[^>]*?name\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
 
   @Test
-  void installSampleSitesTableDefIncludesCmsAndRxffDefs() throws IOException {
+  void installSampleSitesTableDefIncludesCmsAndRxffDefs()
+      throws IOException, ParserConfigurationException, SAXException {
     assertTrue(Files.isRegularFile(INSTALL_REPOSITORY_XML), "missing " + INSTALL_REPOSITORY_XML);
-    String body = Files.readString(INSTALL_REPOSITORY_XML, StandardCharsets.UTF_8);
-
-    int targetStart = body.indexOf("name=\"installSampleSites\"");
-    assertTrue(targetStart >= 0, "installSampleSites target must exist");
-    int targetEnd = body.indexOf("</target>", targetStart);
-    assertTrue(targetEnd > targetStart, "installSampleSites target must be closed");
-    String targetBody = body.substring(targetStart, targetEnd);
+    Document installDoc = parseXml(INSTALL_REPOSITORY_XML);
+    Element sampleSitesTarget = findNamedTarget(installDoc, "installSampleSites");
+    if (sampleSitesTarget == null) {
+      fail("installSampleSites target must exist in installRepository.xml");
+    }
+    // Serialize just this target's attributes/children via getTextContent + attribute checks
+    // on the Element tree (avoids brittle first-</target> string scan).
+    String targetBody = elementTextSnapshot(sampleSitesTarget);
 
     assertTrue(
         targetBody.contains("RxffTableData.staging.xml"),
@@ -197,6 +201,47 @@ class InstallSampleSitesWiringTest {
       }
     }
     return null;
+  }
+
+  /** Ant project targets are flat; select by {@code name} attribute. */
+  private static Element findNamedTarget(Document doc, String targetName) {
+    NodeList targets = doc.getElementsByTagName("target");
+    for (int i = 0; i < targets.getLength(); i++) {
+      Element target = (Element) targets.item(i);
+      if (targetName.equals(target.getAttribute("name"))) {
+        return target;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Flatten element attributes and descendant attributes/text into one string for contains /
+   * regex checks. Preferable to string-slicing on the first {@code </target>} in the file.
+   */
+  private static String elementTextSnapshot(Element root) {
+    StringBuilder sb = new StringBuilder();
+    appendElementSnapshot(root, sb);
+    return sb.toString();
+  }
+
+  private static void appendElementSnapshot(Element el, StringBuilder sb) {
+    var attrs = el.getAttributes();
+    for (int i = 0; i < attrs.getLength(); i++) {
+      sb.append(' ').append(attrs.item(i).getNodeName()).append('=');
+      sb.append('"').append(attrs.item(i).getNodeValue()).append('"');
+    }
+    NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      var child = children.item(i);
+      if (child instanceof Element childEl) {
+        appendElementSnapshot(childEl, sb);
+      } else if (child.getNodeType() == org.w3c.dom.Node.TEXT_NODE
+          || child.getNodeType() == org.w3c.dom.Node.CDATA_SECTION_NODE
+          || child.getNodeType() == org.w3c.dom.Node.COMMENT_NODE) {
+        sb.append(child.getNodeValue());
+      }
+    }
   }
 
   private static String columnValue(Element row, String columnName) {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Regression for #3133 / #2989: {@code installSampleSites} must apply sample site rows
+ * (including {@code RXSITES}) rather than only RXS_CT_* content-type extension schemas.
+ *
+ * <p>{@code PSTableAction} iterates the schema collection from {@code tableDef} and looks up
+ * matching data by table name. {@code RxffTableDef.xml} only lists RXS_CT_* tables while {@code
+ * RxffTableData.xml} holds the sample graph (RXSITES, folders, ACLs, …) with no CT rows. Using
+ * RxffTableDef alone therefore "succeeds" without ever inserting RXSITES. Legacy FastForward
+ * install used {@code cmsTableDef + RxffTableDef}; installSampleSites must do the same.
+ */
+@Tag("UnitTest")
+class InstallSampleSitesWiringTest {
+
+  private static final Path INSTALLER_DATA =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/data");
+
+  private static final Path INSTALL_REPOSITORY_XML =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/installRepository.xml");
+
+  private static final Path SAMPLE_DATA = INSTALLER_DATA.resolve("RxffTableData.xml");
+  private static final Path SAMPLE_DEF = INSTALLER_DATA.resolve("RxffTableDef.xml");
+  private static final Path CMS_TABLE_DEF = INSTALLER_DATA.resolve("cmsTableDef.xml");
+
+  private static final Pattern TABLE_NAME_ATTR =
+      Pattern.compile("<table\\s+name\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+
+  @Test
+  void installSampleSitesTableDefIncludesCmsAndRxffDefs() throws IOException {
+    assertTrue(Files.isRegularFile(INSTALL_REPOSITORY_XML), "missing " + INSTALL_REPOSITORY_XML);
+    String body = Files.readString(INSTALL_REPOSITORY_XML, StandardCharsets.UTF_8);
+
+    int targetStart = body.indexOf("name=\"installSampleSites\"");
+    assertTrue(targetStart >= 0, "installSampleSites target must exist");
+    int targetEnd = body.indexOf("</target>", targetStart);
+    assertTrue(targetEnd > targetStart, "installSampleSites target must be closed");
+    String targetBody = body.substring(targetStart, targetEnd);
+
+    assertTrue(
+        targetBody.contains("RxffTableData.staging.xml"),
+        "installSampleSites must load locale-stripped staging data");
+    assertTrue(
+        targetBody.contains("cmsTableDef.xml"),
+        "installSampleSites tableDef must include cmsTableDef so RXSITES and other sample-graph"
+            + " tables are processed (#3133). RxffTableDef alone only covers RXS_CT_*.");
+    assertTrue(
+        targetBody.contains("RxffTableDef.xml"),
+        "installSampleSites tableDef must still include RxffTableDef for CT extension schemas");
+
+    // Order matches legacy FastForward: cms first, then Rxff CT defs.
+    Pattern dualDef =
+        Pattern.compile(
+            "tableDef\\s*=\\s*[\"'][^\"']*cmsTableDef\\.xml\\s*,\\s*[^\"']*RxffTableDef\\.xml",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    assertTrue(
+        dualDef.matcher(targetBody).find(),
+        "installSampleSites must set tableDef to cmsTableDef.xml,RxffTableDef.xml (comma-separated);"
+            + " found target fragment:\n"
+            + targetBody);
+  }
+
+  @Test
+  void sampleDataDeclaresRxsitesReplaceRows()
+      throws IOException, ParserConfigurationException, SAXException {
+    assertTrue(Files.isRegularFile(SAMPLE_DATA), "missing " + SAMPLE_DATA);
+    Document doc = parseXml(SAMPLE_DATA);
+    Element rxsites = findTable(doc, "RXSITES");
+    if (rxsites == null) {
+      fail("RxffTableData.xml must declare a RXSITES table for demo-sites seed");
+    }
+
+    String onCreateOnly = rxsites.getAttribute("onCreateOnly");
+    assertFalse(
+        "yes".equalsIgnoreCase(onCreateOnly) || "y".equalsIgnoreCase(onCreateOnly),
+        "RXSITES sample rows must use onCreateOnly=no so they apply when the table already exists"
+            + " from cmsTableDef (actual onCreateOnly="
+            + onCreateOnly
+            + ")");
+
+    NodeList rows = rxsites.getElementsByTagName("row");
+    assertTrue(rows.getLength() >= 1, "RXSITES must have at least one sample row");
+
+    Set<String> siteNames = new LinkedHashSet<>();
+    for (int i = 0; i < rows.getLength(); i++) {
+      Element row = (Element) rows.item(i);
+      String action = row.getAttribute("action");
+      assertTrue(
+          action == null
+              || action.isEmpty()
+              || "r".equalsIgnoreCase(action)
+              || "i".equalsIgnoreCase(action)
+              || "u".equalsIgnoreCase(action),
+          "RXSITES row action should be replace/insert/update compatible, was: " + action);
+      String name = columnValue(row, "SITENAME");
+      if (name != null && !name.isBlank()) {
+        siteNames.add(name.trim());
+      }
+    }
+
+    assertTrue(
+        siteNames.stream().anyMatch(n -> n.toLowerCase(Locale.ROOT).contains("enterprise")),
+        "expected Enterprise Investments sample site name in RXSITES, found " + siteNames);
+    assertTrue(
+        siteNames.stream().anyMatch(n -> n.toLowerCase(Locale.ROOT).contains("corporate")),
+        "expected Corporate Investments sample site name in RXSITES, found " + siteNames);
+  }
+
+  @Test
+  void everySampleDataTableHasSchemaInCombinedDefs() throws IOException {
+    assertTrue(Files.isRegularFile(SAMPLE_DATA), "missing " + SAMPLE_DATA);
+    assertTrue(Files.isRegularFile(SAMPLE_DEF), "missing " + SAMPLE_DEF);
+    assertTrue(Files.isRegularFile(CMS_TABLE_DEF), "missing " + CMS_TABLE_DEF);
+
+    Set<String> dataTables = tableNamesFromXmlText(Files.readString(SAMPLE_DATA, StandardCharsets.UTF_8));
+    Set<String> defTables = tableNamesFromXmlText(Files.readString(SAMPLE_DEF, StandardCharsets.UTF_8));
+    Set<String> cmsTables = tableNamesFromXmlText(Files.readString(CMS_TABLE_DEF, StandardCharsets.UTF_8));
+
+    assertTrue(dataTables.contains("RXSITES"), "sample data must include RXSITES");
+    assertFalse(
+        defTables.contains("RXSITES"),
+        "RxffTableDef must not be the sole place RXSITES could live — it historically only has"
+            + " RXS_CT_*; cmsTableDef is required for site rows");
+    assertTrue(cmsTables.contains("RXSITES"), "cmsTableDef must define RXSITES schema");
+
+    Set<String> missing = new LinkedHashSet<>();
+    for (String table : dataTables) {
+      if (!defTables.contains(table) && !cmsTables.contains(table)) {
+        missing.add(table);
+      }
+    }
+    assertTrue(
+        missing.isEmpty(),
+        "Every RxffTableData table must appear in cmsTableDef or RxffTableDef so PSTableAction can"
+            + " process it. Missing schema for: "
+            + missing);
+  }
+
+  private static Document parseXml(Path path)
+      throws IOException, ParserConfigurationException, SAXException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setValidating(false);
+    // Avoid XXE; seed files are trusted repo assets but keep parser tight.
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    try (InputStream in = Files.newInputStream(path)) {
+      return builder.parse(in);
+    }
+  }
+
+  private static Element findTable(Document doc, String tableName) {
+    NodeList tables = doc.getElementsByTagName("table");
+    for (int i = 0; i < tables.getLength(); i++) {
+      Element table = (Element) tables.item(i);
+      if (tableName.equalsIgnoreCase(table.getAttribute("name"))) {
+        return table;
+      }
+    }
+    return null;
+  }
+
+  private static String columnValue(Element row, String columnName) {
+    NodeList cols = row.getElementsByTagName("column");
+    for (int i = 0; i < cols.getLength(); i++) {
+      Element col = (Element) cols.item(i);
+      if (columnName.equalsIgnoreCase(col.getAttribute("name"))) {
+        return col.getTextContent();
+      }
+    }
+    return null;
+  }
+
+  private static Set<String> tableNamesFromXmlText(String xml) {
+    Set<String> names = new LinkedHashSet<>();
+    Matcher m = TABLE_NAME_ATTR.matcher(xml);
+    while (m.find()) {
+      names.add(m.group(1));
+    }
+    return names;
+  }
+}


### PR DESCRIPTION
## Summary

Parent tracker: #2989. Residual: #3133.

After #3001–#3003, `install.demo.sites=true` correctly entered `installSampleSites` and printed "Sample sites seeded," but **RXSITES stayed empty**. Root cause: `PSTableAction` iterates **tableDef schemas** and only loads matching data by name. `RxffTableDef.xml` lists only `RXS_CT_*` extension tables; `RxffTableData.xml` holds the sample graph (`RXSITES`, folders, ACLs, editions, …) with **no** CT rows. Def-only pass was a silent no-op for site rows.

**Fix:** Use dual `tableDef` like legacy FastForward (`system/installResources/installFastForward.xml`):

`cmsTableDef.xml,RxffTableDef.xml` + locale-stripped `RxffTableData.staging.xml`.

## Test plan

- [x] `cd modules/perc-distribution-tree && ../../mvnw clean install` — BUILD SUCCESS; `InstallSampleSitesWiringTest` 3/3; module suite 251 tests, 0 failures
- [x] Erlang review approve (`docs/ai-generated/code-reviews/issue-3133-install-sample-sites-rxsites-erlang.md`)
- [ ] Human / matrix: fresh `python docker/scripts/perc-devctl.py qa-up` with package containing this change → `SELECT COUNT(*) FROM RXSITES` ≥ 1; pathmanagement `/Sites` and sitemanage/site non-empty; Playwright `EXPECT_DEMO_SITES=1` list green

## Gates evidence

- **modules_built:** `modules/perc-distribution-tree`
- **build_evidence:** `../../mvnw clean install` from `modules/perc-distribution-tree` → BUILD SUCCESS; Tests run: InstallSampleSitesWiringTest 3, Failures: 0; module surefire total tests=251 failures=0 errors=0
- **downstream_checked:** none (no public Java API / final/sealed change; ANT XML + wiring unit tests only)
- **C5 UI live proof:** N/A for frontend code (installer seed wiring only; no WebUI/SPA change). End-to-end H2 cell proof deferred to QA handoff (requires distribution package + matrix image rebuild).

## Product documentation

- [x] N/A — behavior already documented under product-docs for `--demo-sites` / sample sites; this restores intended seed behavior.

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3133

> Co-Authored by Grok Build using grok-4.5 with agent main.
