### PR TITLE
fix(DesktopContentExplorer): type PSNode ObjectStoreErrorCodes (#3141)

### DIFF
--- a/modules/DesktopContentExplorer/pom.xml
+++ b/modules/DesktopContentExplorer/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- Direct typed ObjectStoreErrorCodes (issue #3141); was transitive via perc-system. -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
             <artifactId>webservices</artifactId>

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/objectstore/PSNode.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/objectstore/PSNode.java
@@ -16,11 +16,11 @@
  */
 package com.percussion.cx.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.objectstore.PSFolderPermissions;
 import com.percussion.cms.objectstore.PSObjectPermissions;
 import com.percussion.cx.IPSConstants;
 import com.percussion.cx.PSNavigationTree;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.util.PSEntrySet;
@@ -127,7 +127,7 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_name = sourceNode.getAttribute(NAME_ATTR);
@@ -139,7 +139,7 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
     if (hint != null && hint.length() > 0) {
       if (!ms_helpTypeHints.contains(hint)) {
         Object[] args = {XML_NODE_NAME, HELP_TYPE_HINT_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       m_helpTypeHint = hint;
     }
@@ -151,14 +151,14 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
       String permissions = sourceNode.getAttribute(PERMISSIONS_ATTR);
       if ((permissions == null) || (permissions.trim().length() < 1)) {
         Object[] args = {XML_NODE_NAME, PERMISSIONS_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       try {
         m_permissions = new PSFolderPermissions(Integer.parseInt(permissions.trim()));
       } catch (NumberFormatException e) {
         String[] args = {XML_NODE_NAME, PERMISSIONS_ATTR, permissions};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -1094,14 +1094,14 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
 
       if (!TABLEMETA_NODE.equals(sourceNode.getNodeName())) {
         Object[] args = {TABLEMETA_NODE, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       // PSComponentUtils.getChildElements returns a raw Iterator of Element nodes.
       Iterator<?> columns = PSComponentUtils.getChildElements(sourceNode, COLUMN_NODE);
       if (!columns.hasNext()) {
         Object[] args = {TABLEMETA_NODE, COLUMN_NODE, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       while (columns.hasNext()) {
@@ -1236,14 +1236,14 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
 
       if (!ROWDATA_NODE.equals(sourceNode.getNodeName())) {
         Object[] args = {ROWDATA_NODE, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       // PSComponentUtils.getChildElements returns a raw Iterator of Element nodes.
       Iterator<?> columns = PSComponentUtils.getChildElements(sourceNode, COLDATA_NODE);
       if (!columns.hasNext()) {
         Object[] args = {ROWDATA_NODE, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       while (columns.hasNext()) {

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
@@ -241,6 +241,7 @@ public class PSNodeTest {
         assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   @Test
@@ -255,6 +256,7 @@ public class PSNodeTest {
         assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   @Test
@@ -283,6 +285,7 @@ public class PSNodeTest {
         assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   @Test

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
@@ -18,7 +18,11 @@ package com.percussion.cx.objectstore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSEntrySet;
+import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,9 +30,18 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
-/** Test case for the {@link PSNode} class. */
+/**
+ * Test case for the {@link PSNode} class.
+ *
+ * <p>Includes typed {@link ObjectStoreErrorCodes} regression coverage for issue #3141 / parent
+ * #2616 (DesktopContentExplorer residual after ObjectStore batches F–M).
+ */
+@Tag("UnitTest")
 public class PSNodeTest {
   /**
    * Test the clone method to ensure child collections are properly supported.
@@ -190,5 +203,104 @@ public class PSNodeTest {
     assertNotNull(found);
     assertEquals("i1", found.getName());
     assertNull(parent.findChildNode("nope", PSNode.TYPE_ITEM, false));
+  }
+
+  @Test
+  public void fromXmlWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotANode");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertEquals(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void fromXmlInvalidHelpTypeHintUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = itemNode(doc, "n1", "Label");
+    root.setAttribute("helptypehint", "not-a-valid-hint");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void fromXmlFolderMissingPermissionsUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, PSNode.XML_NODE_NAME);
+    root.setAttribute("name", "folder1");
+    root.setAttribute("label", "Folder 1");
+    root.setAttribute("type", PSNode.TYPE_FOLDER);
+    // permissions intentionally omitted
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void fromXmlFolderNonNumericPermissionsUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, PSNode.XML_NODE_NAME);
+    root.setAttribute("name", "folder1");
+    root.setAttribute("label", "Folder 1");
+    root.setAttribute("type", PSNode.TYPE_FOLDER);
+    root.setAttribute("permissions", "not-an-int");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void fromXmlEmptyRowDataUsesTypedInvalidChild() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = itemNode(doc, "i1", "Item");
+    // Empty RowData child triggers RowData.fromXml invalid-child path
+    root.appendChild(doc.createElement("RowData"));
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), ex.getErrorCode());
+    assertEquals(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void fromXmlTableMetaWithoutColumnsUsesTypedInvalidChild() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = itemNode(doc, "i1", "Item");
+    // hasChildNodes() true via whitespace/text so TableMeta.fromXml runs; no Column children
+    Element tableMeta = doc.createElement(PSNode.TABLEMETA_NODE);
+    tableMeta.appendChild(doc.createTextNode(" "));
+    root.appendChild(tableMeta);
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNode(root));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void fromXmlValidItemRoundTripPreservesName() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = itemNode(doc, "ok", "OK Label");
+    PSNode node = new PSNode(root);
+    assertEquals("ok", node.getName());
+    assertEquals("OK Label", node.getLabel());
+    assertEquals(PSNode.TYPE_ITEM, node.getType());
+  }
+
+  /** Minimal valid Item {@code Node} element for fromXml success/error cases. */
+  private static Element itemNode(Document doc, String name, String label) {
+    Element root = PSXmlDocumentBuilder.createRoot(doc, PSNode.XML_NODE_NAME);
+    root.setAttribute("name", name);
+    root.setAttribute("label", label);
+    root.setAttribute("type", PSNode.TYPE_ITEM);
+    return root;
   }
 }


### PR DESCRIPTION
## Summary
- Retype all production `IPSObjectStoreErrors` throw sites in `modules/DesktopContentExplorer` (`PSNode` + nested `TableMeta` / `RowData`) to typed `ObjectStoreErrorCodes` with `IPSErrorCode`-aware `PSUnknownNodeTypeException` constructors (parent residual of #2616 after batches F–M).
- Add explicit `audit-log` dependency for the direct import.
- Extend `PSNodeTest` with typed-code regressions (wrong type, invalid attr, invalid child) and a valid fromXml round-trip.

Fixes #3141  
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `modules/DesktopContentExplorer` standalone `mvnw clean install` (includes tests)
- [x] `PSNodeTest`: 16 tests (typed path coverage + existing behavior)
- [x] Module suite: Tests run: 172, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
- [x] Inventory: zero production bare `IPSObjectStoreErrors` under DesktopContentExplorer after change
- [ ] Product documentation: N/A (internal typed error-code tech-debt; no operator/UX/API surface change)
- [ ] C5 UI live proof: N/A (pure Java exception typing; no UI surface)

## Gates evidence
- modules_built=modules/DesktopContentExplorer
- build_evidence=`cd modules/DesktopContentExplorer; ../../mvnw clean install` → BUILD SUCCESS; Tests run: 172, Failures: 0, Errors: 0, Skipped: 0; PSNodeTest Tests run: 16
- downstream_checked=none (no public/protected API signature change; ctor throw codes only)
- C2 not applicable: no final/sealed, no public method/ctor signature changes

> Co-Authored by Grok Build using grok-4.5 with agent main.