### PR TITLE
fix(system): retype PSAclEntry ACL leftovers to DesignErrorCodes (#3142)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
@@ -18,6 +18,7 @@
 package com.percussion.design.objectstore;
 
 
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -617,7 +618,7 @@ public class PSAclEntry extends PSComponent {
       sTemp = tree.getElementData("modifyAcl", false);
       if ((sTemp != null) && sTemp.equalsIgnoreCase("yes")) m_accessLevel |= AACE_DESIGN_MODIFY_ACL;
     } else {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.ACL_ENTRY_LEVEL_NOT_FOUND);
+      throw new PSUnknownNodeTypeException(DesignErrorCodes.ACL_ENTRY_LEVEL_NOT_FOUND);
     }
   }
 
@@ -658,7 +659,7 @@ public class PSAclEntry extends PSComponent {
 
       if (0 != (m_accessLevel & all_flags_compliment)) {
         Object[] args = {"" + m_accessLevel};
-        cxt.validationError(this, IPSObjectStoreErrors.ACL_SECURITY_LEVEL_INVALID, args);
+        cxt.validationError(this, DesignErrorCodes.ACL_SECURITY_LEVEL_INVALID, args);
       }
     } else {
       // turn on all invalid bits
@@ -672,7 +673,7 @@ public class PSAclEntry extends PSComponent {
 
       if (0 != (m_accessLevel & all_flags_compliment)) {
         Object[] args = {"" + m_accessLevel};
-        cxt.validationError(this, IPSObjectStoreErrors.ACL_SECURITY_LEVEL_INVALID, args);
+        cxt.validationError(this, DesignErrorCodes.ACL_SECURITY_LEVEL_INVALID, args);
       }
     }
 
@@ -685,7 +686,7 @@ public class PSAclEntry extends PSComponent {
         break; // end valid types
       default:
         cxt.validationError(
-            this, IPSObjectStoreErrors.ACL_TYPE_INVALID, new Object[] {m_name, "" + m_type});
+            this, DesignErrorCodes.ACL_TYPE_INVALID, new Object[] {m_name, "" + m_type});
     }
 
     IllegalArgumentException ex = validateName(m_name);

--- a/system/src/test/java/com/percussion/design/objectstore/PSAclEntryTypedErrorCodeTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSAclEntryTypedErrorCodeTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.percussion.design.objectstore.server.PSValidatorAdapter;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3142: {@link PSAclEntry} production call sites must use typed {@link DesignErrorCodes}
+ * (not bare {@code IPSObjectStoreErrors} ints) for ACL level / type validation leftovers.
+ */
+public class PSAclEntryTypedErrorCodeTest {
+
+  @Test
+  public void fromXmlMissingAccessLevelUsesTypedDesignCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, PSAclEntry.ms_NodeType);
+    root.setAttribute("id", "1");
+    root.setAttribute("type", "user");
+    PSXmlDocumentBuilder.addElement(doc, root, "name", "admin1");
+    // no serverAccessLevel / applicationAccessLevel child
+
+    PSAclEntry entry = new PSAclEntry();
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> entry.fromXml(root, null, null));
+    assertEquals(DesignErrorCodes.ACL_ENTRY_LEVEL_NOT_FOUND.numericCode(), ex.getErrorCode());
+    assertSame(DesignErrorCodes.ACL_ENTRY_LEVEL_NOT_FOUND, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void validateServerAclWithAppFlagsUsesSecurityLevelDesignCode() throws Exception {
+    PSAclEntry entry = new PSAclEntry("admin1", PSAclEntry.ACE_TYPE_USER);
+    // Corrupt state: server ACL flag with application access bits
+    setPrivate(entry, "m_isServerAcl", true);
+    setPrivate(entry, "m_accessLevel", PSAclEntry.AACE_DATA_QUERY);
+
+    PSValidatorAdapter validator = new PSValidatorAdapter(null);
+    PSSystemValidationException ex =
+        assertThrows(PSSystemValidationException.class, () -> entry.validate(validator));
+    assertEquals(DesignErrorCodes.ACL_SECURITY_LEVEL_INVALID.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void validateAppAclWithServerFlagsUsesSecurityLevelDesignCode() throws Exception {
+    PSAclEntry entry = new PSAclEntry("editor", PSAclEntry.ACE_TYPE_ROLE);
+    setPrivate(entry, "m_isServerAcl", false);
+    setPrivate(entry, "m_accessLevel", PSAclEntry.SACE_ACCESS_DATA);
+
+    PSValidatorAdapter validator = new PSValidatorAdapter(null);
+    PSSystemValidationException ex =
+        assertThrows(PSSystemValidationException.class, () -> entry.validate(validator));
+    assertEquals(DesignErrorCodes.ACL_SECURITY_LEVEL_INVALID.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void validateInvalidTypeUsesTypeDesignCode() throws Exception {
+    PSAclEntry entry = new PSAclEntry("orphan", PSAclEntry.ACE_TYPE_USER);
+    setPrivate(entry, "m_type", 99);
+
+    PSValidatorAdapter validator = new PSValidatorAdapter(null);
+    PSSystemValidationException ex =
+        assertThrows(PSSystemValidationException.class, () -> entry.validate(validator));
+    assertEquals(DesignErrorCodes.ACL_TYPE_INVALID.numericCode(), ex.getErrorCode());
+  }
+
+  private static void setPrivate(Object target, String fieldName, Object value) throws Exception {
+    Field field = PSAclEntry.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    if (value instanceof Integer) {
+      field.setInt(target, ((Integer) value).intValue());
+    } else if (value instanceof Boolean) {
+      field.setBoolean(target, ((Boolean) value).booleanValue());
+    } else {
+      field.set(target, value);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Parent: #2616. Residual slice #3142 — Design ACL / `PSAclEntry` ObjectStore call-site leftovers.

Retypes the last production **qualified** `IPSObjectStoreErrors.*` call sites under `system` design.objectstore ACL (`PSAclEntry`) to typed `DesignErrorCodes`:
- `ACL_ENTRY_LEVEL_NOT_FOUND` (fromXml missing server/application access level)
- `ACL_SECURITY_LEVEL_INVALID` (validate server/app flag mismatch)
- `ACL_TYPE_INVALID` (validate unknown ACE type)

Uses dual-write-safe `IPSErrorCode` ctors / `validationError(IPSErrorCode, …)` overloads already on main.

### Inventory / waivers
| Site | Disposition |
|------|-------------|
| `PSAclEntry` (4 call sites) | **Retyped** this PR |
| `PSDataSet` / `PSFile` / `PSLoginWebPage` commented `IPSObjectStoreErrors` | Dead commented code only — no production throw |
| `PSXmlObjectStoreHandler` / `PSXmlObjectStoreLockManager` `implements IPSObjectStoreErrors` | Constant-interface inheritance (not Design ACL structure); **out of this Design-ACL residual** (sibling focus remains Desktop CX #3141 / monorepo inventory). No product waiver — deferred as non-ACL server-handler inheritance debt under parent #2616 if still desired |

After this PR: zero production `IPSObjectStoreErrors.` qualified references remain under `system/src/main`.

## Test plan
- [x] `system` standalone `mvnw clean install` (tests included)
- [x] New `PSAclEntryTypedErrorCodeTest` (4 tests): missing level typed code; security-level invalid server/app; invalid type
- [x] Existing `PSAclEntryTest` still green

## Gates evidence
- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1955**, Failures: 0, Errors: 0, Skipped: 241
- **downstream_checked:** none (no public API shape change; only error-code enum constants at existing call sites)
- **C5 UI proof:** N/A — pure Java tech-debt, no UI surface
- **Product documentation:** N/A — internal error-code typing only; no operator/user-visible behavior change

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3142

> Co-Authored by Grok Build using grok-4.5 with agent main.