### PR TITLE
fix(sitemanage): main-source misc Xlint residual to zero (#3107)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3107-sitemanage-xlint-misc-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3107-sitemanage-xlint-misc-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review: issue #3107 sitemanage misc Xlint residual
+
+## Summary
+
+PR-sized cleanup of remaining **main-source** `-Xlint` diagnostics in `projects/sitemanage` after #3061 / PR #3106. Real fixes preferred: static qualification, Hibernate `Session.find`, equals/hashCode pairs, fall-through rewrite, typed collection copies, serial-field concrete types, and targeted `@SuppressWarnings("removal")` only for intentional legacy (PSAesCBC decrypt fallback, ThreadDeath stop, GenericGenerator custom id).
+
+## Scope
+
+- Branch: `fix/issue-3107-sitemanage-xlint-misc`
+- Base: `origin/main`
+- Module: `projects/sitemanage` only
+- Prior: #2032 / #2200 / #3061 serial-field + this-escape batches
+- Cross-platform path review: **N/A** — no path/file I/O changes
+- Memory patterns: prefer real Xlint fixes over blanket suppress; Session.get → find peer pattern from taxonomy/DTS DAOs
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Behavioral tests: `PSXlintMiscResidualTest` (8) for equals/hashCode + DTO copies; existing serial-field tests still green
+- Build: `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1098, Failures: 0, Errors: 0, Skipped: 125
+- Main-source Xlint: **40 → 0** (project compiler args)
+
+## Issues
+
+None at bug severity.
+
+### suggestion
+
+1. **Test-source residual (~60)** — file follow-up under #2032 for test-source serialVersionUID / this-escape / unchecked / Unsafe path-injection tests. Out of scope for this main-source batch.
+
+### nit
+
+1. `PSAnalyticsProviderConfig.setExtraParamsMap` still does not sync `ExtraParamsClass` (pre-existing); getter rebuilds from `extraParams`. Left unchanged to avoid behavior change.
+
+## Inventory
+
+| Cluster | Before | After | Approach |
+|---------|--------|-------|----------|
+| static qualification | ~12 | 0 | Type-name qualification |
+| Session.get removal | 6 | 0 | `session.find` |
+| equals without hashCode | 3 | 0 | Add hashCode |
+| fall-through | 2 | 0 | Explicit break + set dirty |
+| unchecked conversion | 5 | 0 | Always copy into HashMap/ArrayList |
+| serial-field leftovers | 3 | 0 | HashMap/ArrayList field types; transient collaborator |
+| try-with-resources unused | 1 | 0 | Drop unused Reader |
+| redundant cast | 1 | 0 | Remove cast |
+| missing @Deprecated | 1 | 0 | Annotate |
+| removal (PSAesCBC/ThreadDeath/GenericGenerator) | ~6 | 0 | Targeted suppress / type= form |
+
+## Residual
+
+Test-source Xlint (~60) — separate PR-sized residual under parent #2032 / #2200.

--- a/projects/sitemanage/src/main/java/com/percussion/analytics/data/PSAnalyticsProviderConfig.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/data/PSAnalyticsProviderConfig.java
@@ -62,13 +62,8 @@ public class PSAnalyticsProviderConfig implements Serializable {
     this.userid = userid;
     this.password = password;
     this.isEncrypted = isEncrypted;
-    if (extraParamsMap == null) {
-      this.extraParamsMap = null;
-    } else if (extraParamsMap instanceof HashMap) {
-      this.extraParamsMap = (HashMap) extraParamsMap;
-    } else {
-      this.extraParamsMap = new HashMap<>(extraParamsMap);
-    }
+    this.extraParamsMap =
+        extraParamsMap == null ? null : new HashMap<>(extraParamsMap);
     this.uid = userid;
 
     // Build ExtraParamsClass from extraParamsMap
@@ -140,15 +135,9 @@ public class PSAnalyticsProviderConfig implements Serializable {
     return map;
   }
 
-  @SuppressWarnings("unchecked")
   public void setExtraParamsMap(Map<String, String> extraParamsMap) {
-    if (extraParamsMap == null) {
-      this.extraParamsMap = null;
-    } else if (extraParamsMap instanceof HashMap) {
-      this.extraParamsMap = (HashMap<String, String>) extraParamsMap;
-    } else {
-      this.extraParamsMap = new HashMap<>(extraParamsMap);
-    }
+    this.extraParamsMap =
+        extraParamsMap == null ? null : new HashMap<>(extraParamsMap);
   }
 
   public ExtraParamsClass getExtraParams() {

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
@@ -184,5 +184,5 @@ public class PSAssetUploadServlet extends HttpServlet {
   private static final Logger logger = LogManager.getLogger("PSAssetUploadServlet");
 
   /** Runtime collaborator — not part of servlet Java serialization. */
-  private final PSAssetCreator assetCreator = new PSAssetCreator();
+  private final transient PSAssetCreator assetCreator = new PSAssetCreator();
 }

--- a/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
@@ -27,8 +27,6 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import java.io.File;
-import java.io.Reader;
-import java.io.StringReader;
 import java.util.ArrayList;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -105,7 +103,7 @@ public class PSCategoryUnMarshaller {
     if (StringUtils.isBlank(categoryJson)) {
       return null;
     }
-    try (Reader reader = new StringReader(categoryJson)) {
+    try {
       var mapper =
           JsonMapper.builder()
               .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
@@ -38,14 +38,6 @@ public class PSContentMigrationException extends Exception {
   }
 
   public void setFailedItems(Map<String, String> failedItems) {
-    if (failedItems != null) {
-      if (failedItems == null) {
-        this.failedItems = null;
-      } else if (failedItems instanceof HashMap) {
-        this.failedItems = (HashMap) failedItems;
-      } else {
-        this.failedItems = new HashMap<>(failedItems);
-      }
-    }
+    this.failedItems = failedItems == null ? null : new HashMap<>(failedItems);
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
@@ -38,27 +38,14 @@ public class PSFolders extends PSAbstractDataObject {
   }
 
   public PSFolders(List<PSFolderItem> children) {
-    if (children == null) {
-      this.children = null;
-    } else if (children instanceof ArrayList) {
-      this.children = (ArrayList) children;
-    } else {
-      this.children = new ArrayList<>(children);
-    }
+    this.children = children == null ? null : new ArrayList<>(children);
   }
 
   public List<PSFolderItem> getChildren() {
     return children == null ? new ArrayList<>() : children;
   }
 
-  @SuppressWarnings("unchecked")
   public void setChildren(List<PSFolderItem> children) {
-    if (children == null) {
-      this.children = null;
-    } else if (children instanceof ArrayList) {
-      this.children = (ArrayList<PSFolderItem>) children;
-    } else {
-      this.children = new ArrayList<>(children);
-    }
+    this.children = children == null ? null : new ArrayList<>(children);
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/metadata/dao/impl/PSMetadataDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/metadata/dao/impl/PSMetadataDao.java
@@ -98,7 +98,7 @@ public class PSMetadataDao implements com.percussion.metadata.dao.IPSMetadataDao
     var session = getSession();
     try {
       var key = data.getKey();
-      var existing = session.get(PSMetadata.class, key);
+      var existing = session.find(PSMetadata.class, key);
       if (existing == null) {
         var emsg = "Attempt to modify non-existent record " + key;
         log.error(emsg);
@@ -124,7 +124,7 @@ public class PSMetadataDao implements com.percussion.metadata.dao.IPSMetadataDao
   public PSMetadata find(String key) throws IPSGenericDao.LoadException {
     var session = getSession();
     try {
-      return session.get(PSMetadata.class, key);
+      return session.find(PSMetadata.class, key);
     } catch (HibernateException e) {
       var msg = "find(String key) database error " + e.getMessage();
       log.error(msg);

--- a/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSSearchIndexProcessMonitor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSSearchIndexProcessMonitor.java
@@ -112,10 +112,13 @@ public final class PSSearchIndexProcessMonitor implements IPSNotificationListene
             }
           }
         }
-      // fall through
+        // Same as item queued/processed: mark monitor dirty so the timer refreshes the message.
+        changed.compareAndSet(false, true);
+        break;
       case SEARCH_INDEX_ITEM_QUEUED:
       case SEARCH_INDEX_ITEM_PROCESSED:
         changed.compareAndSet(false, true);
+        break;
       default:
         break;
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
@@ -845,7 +845,7 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
     private static final long serialVersionUID = 1L;
 
     @XmlElement(name = "Icon")
-    protected List<Icon> icon;
+    protected ArrayList<Icon> icon;
 
     @XmlAttribute(name = "contenttype_name")
     protected String contenttypeName;
@@ -905,6 +905,15 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
         icon = new ArrayList<>();
       }
       return icon;
+    }
+
+    /**
+     * JAXB / callers may pass any List; store as concrete ArrayList for serialization.
+     *
+     * @param icon icon list, may be null
+     */
+    public void setIcon(List<Icon> icon) {
+      this.icon = icon == null ? null : new ArrayList<>(icon);
     }
 
     /**

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
@@ -842,7 +842,11 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
       propOrder = {"icon"})
   public static class WidgetPrefs implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    /**
+     * Bumped from 1L when {@code icon} field type changed from {@code List} to {@code ArrayList}
+     * and {@link #setIcon} was added (JAXB / serialization contract).
+     */
+    private static final long serialVersionUID = 2L;
 
     @XmlElement(name = "Icon")
     protected ArrayList<Icon> icon;
@@ -886,8 +890,9 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
      * Gets the value of the icon property.
      *
      * <p>This accessor method returns a reference to the live list, not a snapshot. Therefore any
-     * modification you make to the returned list will be present inside the JAXB object. This is
-     * why there is not a <CODE>set</CODE> method for the icon property.
+     * modification you make to the returned list will be present inside the JAXB object. Callers may
+     * also use {@link #setIcon(List)} (e.g. JAXB unmarshalling) to replace the list; that method
+     * always stores a concrete {@link ArrayList}.
      *
      * <p>For example, to add a new item, do as follows:
      *
@@ -908,7 +913,8 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
     }
 
     /**
-     * JAXB / callers may pass any List; store as concrete ArrayList for serialization.
+     * Sets the icon list (JAXB / callers). Any {@link List} is copied into a concrete {@link
+     * ArrayList} for a stable serialization type.
      *
      * @param icon icon list, may be null
      */

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -242,6 +242,7 @@ public class PSTemplateService implements IPSTemplateService {
   /**
    * @deprecated This is used by unit test only. It cannot be used by production code
    */
+  @Deprecated
   public PSTemplateSummary findUserTemplateByName_UsedByUnitTestOnly(String name)
       throws PSDataServiceException {
     rejectIfBlank("findUserTemplateByName", "name", name);

--- a/projects/sitemanage/src/main/java/com/percussion/pageoptimizer/impl/PSPageOptimizerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pageoptimizer/impl/PSPageOptimizerService.java
@@ -53,7 +53,7 @@ public class PSPageOptimizerService extends PSCloudService implements IPSPageOpt
       IPSPageService pageService,
       PSLicenseService licenseService) {
     super(folderHelper, renderService, pageService, licenseService);
-    this.log = LogManager.getLogger(PSPageOptimizerService.class);
+    PSCloudService.log = LogManager.getLogger(PSPageOptimizerService.class);
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
@@ -2085,6 +2085,7 @@ public class PSPubServerService implements IPSPubServerService {
           PSExceptionUtils.getMessageForLog(e));
       try {
         // Decrypt-only upgrade fallback (accepted-risk T047/T048) — do not encrypt with PSAesCBC
+        @SuppressWarnings("removal")
         PSAesCBC aes = new PSAesCBC();
         return aes.decrypt(dstr, IPSPubServerDao.ENCRYPTION_KEY);
       } catch (PSEncryptionException psEncryptionException) {

--- a/projects/sitemanage/src/main/java/com/percussion/queue/impl/PSPageImportQueue.java
+++ b/projects/sitemanage/src/main/java/com/percussion/queue/impl/PSPageImportQueue.java
@@ -226,7 +226,7 @@ public class PSPageImportQueue extends PSAbstractEventQueue<PSSiteQueue>
         Thread.currentThread().interrupt();
         return false;
       } catch (Throwable t) {
-        if (t instanceof ThreadDeath) {
+        if (isThreadDeath(t)) {
           return false;
         }
         return true;
@@ -249,7 +249,7 @@ public class PSPageImportQueue extends PSAbstractEventQueue<PSSiteQueue>
         Thread.currentThread().interrupt();
         return false;
       } catch (Throwable t) {
-        if (t instanceof ThreadDeath) {
+        if (isThreadDeath(t)) {
           return false;
         }
         log.error(
@@ -264,6 +264,15 @@ public class PSPageImportQueue extends PSAbstractEventQueue<PSSiteQueue>
     } catch (Exception e) {
       return true;
     }
+  }
+
+  /**
+   * {@link ThreadDeath} is deprecated for removal; keep historical stop-thread behavior without
+   * littering call sites with removal warnings.
+   */
+  @SuppressWarnings("removal")
+  private static boolean isThreadDeath(Throwable t) {
+    return t instanceof ThreadDeath;
   }
 
   private void setRequestInfo(PSSiteQueue importingSite) {

--- a/projects/sitemanage/src/main/java/com/percussion/recent/data/PSRecent.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recent/data/PSRecent.java
@@ -72,9 +72,12 @@ public class PSRecent extends PSAbstractDataObject {
   }
 
   @Id
+  // Custom next-number generator; GenericGenerator is deprecated for removal in Hibernate 7 —
+  // keep until entity generators migrate monorepo-wide (tracked under Hibernate migration plans).
+  @SuppressWarnings("removal")
   @GenericGenerator(
       name = "id",
-      strategy = "com.percussion.data.utils.PSNextNumberHibernateGenerator")
+      type = com.percussion.data.utils.PSNextNumberHibernateGenerator.class)
   @GeneratedValue(generator = "id")
   @Column(name = "ID", nullable = false)
   private int id;

--- a/projects/sitemanage/src/main/java/com/percussion/redirect/service/impl/PSRedirectService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/redirect/service/impl/PSRedirectService.java
@@ -201,7 +201,7 @@ public class PSRedirectService implements IPSRedirectService {
     // Assume failure
     var ret = new PSRedirectStatus(PSRedirectStatus.SERVICE_ERROR, "Error.");
 
-    var client = ClientBuilder.newBuilder().newClient();
+    var client = ClientBuilder.newClient();
     var lic = getLicense();
 
     if (lic != null) {

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -98,7 +98,7 @@ public class PSSearchService implements IPSSearchService {
     this.itemWorkflowService = itemWorkflowService;
     this.listViewHelper = listViewHelper;
     this.workflowService = PSWorkflowServiceLocator.getWorkflowService();
-    this.uiService = uiService;
+    PSSearchService.uiService = uiService;
     this.recycleService = recycleService;
     this.systemService =
         Optional.ofNullable(systemService).orElseGet(PSSystemServiceLocator::getSystemService);

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSMapWrapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSMapWrapper.java
@@ -31,7 +31,8 @@ public class PSMapWrapper implements Serializable {
 
   private static final long serialVersionUID = 8252999104256582955L;
 
-  private Map<String, String> entries = new HashMap<>();
+  /** Concrete serializable map type (not the Map interface) for serial-field compliance. */
+  private HashMap<String, String> entries = new HashMap<>();
 
   public Map<String, String> getEntries() {
     return entries;

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSUnassignedResults.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSUnassignedResults.java
@@ -76,13 +76,8 @@ public class PSUnassignedResults extends PSAbstractDataObject {
         Integer startIndex, Integer childrenCount, List<UnassignedItem> childrenInPage) {
       this.startIndex = startIndex;
       this.childrenCount = childrenCount;
-      if (childrenInPage == null) {
-        this.childrenInPage = new ArrayList<>();
-      } else if (childrenInPage instanceof ArrayList) {
-        this.childrenInPage = (ArrayList) childrenInPage;
-      } else {
-        this.childrenInPage = new ArrayList<>(childrenInPage);
-      }
+      this.childrenInPage =
+          childrenInPage == null ? new ArrayList<>() : new ArrayList<>(childrenInPage);
     }
 
     /**

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSUserLoginDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSUserLoginDao.java
@@ -60,7 +60,7 @@ public class PSUserLoginDao implements IPSUserLoginDao {
     String emsg;
     var session = getSession();
     try {
-      var login = session.get(PSUserLogin.class, name);
+      var login = session.find(PSUserLogin.class, name);
       log.debug("deleting userlogin for {}", login);
       if (login == null) {
         emsg = "Attempt to delete non-existent user " + name;
@@ -106,7 +106,7 @@ public class PSUserLoginDao implements IPSUserLoginDao {
     var session = getSession();
     PSUserLogin result = null;
     try {
-      result = session.get(PSUserLogin.class, id);
+      result = session.find(PSUserLogin.class, id);
       if (result == null) {
         emsg = "no such user " + id;
         log.debug(emsg);
@@ -173,7 +173,7 @@ public class PSUserLoginDao implements IPSUserLoginDao {
     var session = getSession();
     try {
       var uid = login.getUserid();
-      var l2 = session.get(PSUserLogin.class, uid);
+      var l2 = session.find(PSUserLogin.class, uid);
       if (l2 == null) {
         emsg = "Attempt to modify non-existent user " + uid;
         log.error(emsg);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/dao/impl/PSImportLogDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/dao/impl/PSImportLogDao.java
@@ -110,7 +110,7 @@ public class PSImportLogDao implements IPSImportLogDao {
   @Override
   public PSImportLogEntry findLogEntryById(long pageLogId) {
     var session = getSession();
-    return session.get(PSImportLogEntry.class, pageLogId);
+    return session.find(PSImportLogEntry.class, pageLogId);
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/utils/PSFileDownLoadJobRunner.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/utils/PSFileDownLoadJobRunner.java
@@ -68,6 +68,20 @@ public class PSFileDownLoadJobRunner implements Runnable {
     return false;
   }
 
+  @Override
+  public int hashCode() {
+    var j = getJob();
+    if (j == null) {
+      return 0;
+    }
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (j.getFile() == null ? 0 : j.getFile().hashCode());
+    result = prime * result + (j.getUrl() == null ? 0 : j.getUrl().hashCode());
+    result = prime * result + (j.getCreateAsset() == null ? 0 : j.getCreateAsset().hashCode());
+    return result;
+  }
+
   public void setRequestInfo(Map<String, Object> requestInfoMap) {
     if (PSRequestInfo.isInited()) {
       PSRequestInfo.resetRequestInfo();

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionMetaDataService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionMetaDataService.java
@@ -205,6 +205,11 @@ public class PSSiteSectionMetaDataService implements IPSSiteSectionMetaDataServi
     }
 
     @Override
+    public int hashCode() {
+      return folderPath == null ? 0 : folderPath.hashCode();
+    }
+
+    @Override
     public String toString() {
       final StringBuffer sb = new StringBuffer("SectionPath{");
       sb.append("folderPath='").append(folderPath).append('\'');

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSAntEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSAntEditionTask.java
@@ -134,7 +134,7 @@ public class PSAntEditionTask implements IPSEditionTask {
         pubServer = pubOpt.get();
         root =
             pubServer
-                .getProperty(pubServerMgr.PUBLISH_FOLDER_PROPERTY)
+                .getProperty(IPSPubServerDao.PUBLISH_FOLDER_PROPERTY)
                 .map(PSPubServerProperty::getValue)
                 .orElse(EMPTY);
       }

--- a/projects/sitemanage/src/main/java/com/percussion/ui/service/impl/PSUiService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/ui/service/impl/PSUiService.java
@@ -78,7 +78,7 @@ public class PSUiService implements IPSUiService {
     var cols = df.getColumns();
     var temp = new ArrayList<PSDisplayColumn>();
     while (cols.hasNext()) {
-      temp.add((PSDisplayColumn) cols.next());
+      temp.add(cols.next());
     }
     temp.sort(Comparator.comparingInt(PSDisplayColumn::getPosition));
 

--- a/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSSiteConfigUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSSiteConfigUtils.java
@@ -873,8 +873,8 @@ public class PSSiteConfigUtils {
    */
   private static void appendLogoutElement(SecureXmlData securityData, Document doc, Node http) {
     Element logout = doc.createElement("security:logout");
-    logout.setAttribute("logout-url", securityData.LOGOUT_PROCESSING_URL);
-    logout.setAttribute("success-handler-ref", securityData.LOGOUT_SUCCESS_HANDLER_REF);
+    logout.setAttribute("logout-url", SecureXmlData.LOGOUT_PROCESSING_URL);
+    logout.setAttribute("success-handler-ref", SecureXmlData.LOGOUT_SUCCESS_HANDLER_REF);
 
     http.appendChild(logout);
   }
@@ -998,12 +998,13 @@ public class PSSiteConfigUtils {
     if (!isBlank(loginPage)) {
       formLogin.setAttribute("login-page", loginPage);
       formLogin.setAttribute(
-          "authentication-failure-url", loginPage + securityData.AUTHENTICATION_FAILURE_URL_SUFFIX);
+          "authentication-failure-url",
+          loginPage + SecureXmlData.AUTHENTICATION_FAILURE_URL_SUFFIX);
     }
 
-    formLogin.setAttribute("login-processing-url", securityData.LOGING_PROCESSING_URL);
+    formLogin.setAttribute("login-processing-url", SecureXmlData.LOGING_PROCESSING_URL);
     formLogin.setAttribute(
-        "authentication-success-handler-ref", securityData.AUTHENTICATION_SUCCESS_HANDLER_REF);
+        "authentication-success-handler-ref", SecureXmlData.AUTHENTICATION_SUCCESS_HANDLER_REF);
 
     http.appendChild(formLogin);
   }
@@ -1063,8 +1064,8 @@ public class PSSiteConfigUtils {
   private static void appendFormLoginProcessor(
       SecureXmlData securityData, Document doc, Node http) {
     Element logout = doc.createElement("security:custom-filter");
-    logout.setAttribute("before", securityData.FORM_LOGIN_FILTER);
-    logout.setAttribute("ref", securityData.FORM_LOGIN_PROCESSOR);
+    logout.setAttribute("before", SecureXmlData.FORM_LOGIN_FILTER);
+    logout.setAttribute("ref", SecureXmlData.FORM_LOGIN_PROCESSOR);
 
     http.appendChild(logout);
   }
@@ -1275,6 +1276,21 @@ public class PSSiteConfigUtils {
       } else if (!sitename.equals(other.sitename)) return false;
       if (useHttpsForSecureSite != other.useHttpsForSecureSite) return false;
       return true;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((loginPage == null) ? 0 : loginPage.hashCode());
+      result =
+          prime * result
+              + ((secureAndMemberSectionsUrls == null)
+                  ? 0
+                  : secureAndMemberSectionsUrls.hashCode());
+      result = prime * result + ((sitename == null) ? 0 : sitename.hashCode());
+      result = prime * result + (useHttpsForSecureSite ? 1231 : 1237);
+      return result;
     }
 
     public String getRequiresChannelAttributeValue() {

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/service/PSWidgetBuilderService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/service/PSWidgetBuilderService.java
@@ -218,8 +218,7 @@ public class PSWidgetBuilderService implements IPSWidgetBuilderService {
   public PSWidgetBuilderValidationResults validate(PSWidgetBuilderDefinitionData definition) {
     Validate.notNull(definition, "definition must not be null");
     var results = new PSWidgetBuilderValidationResults();
-    var validator = new PSWidgetBuilderDefinitionValidator();
-    results.setResults(validator.validate(definition, loadAll()));
+    results.setResults(PSWidgetBuilderDefinitionValidator.validate(definition, loadAll()));
     return results;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflow.java
+++ b/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflow.java
@@ -51,13 +51,7 @@ public class PSUiWorkflow extends PSAbstractDataObject {
 
   public PSUiWorkflow(String workflowName, List<PSUiWorkflowStep> workflowSteps) {
     this.workflowName = workflowName;
-    if (workflowSteps == null) {
-      this.workflowSteps = null;
-    } else if (workflowSteps instanceof ArrayList) {
-      this.workflowSteps = (ArrayList) workflowSteps;
-    } else {
-      this.workflowSteps = new ArrayList<>(workflowSteps);
-    }
+    this.workflowSteps = workflowSteps == null ? null : new ArrayList<>(workflowSteps);
   }
 
   public String getWorkflowName() {
@@ -81,15 +75,8 @@ public class PSUiWorkflow extends PSAbstractDataObject {
     return workflowSteps;
   }
 
-  @SuppressWarnings("unchecked")
   public void setWorkflowSteps(List<PSUiWorkflowStep> workflowSteps) {
-    if (workflowSteps == null) {
-      this.workflowSteps = null;
-    } else if (workflowSteps instanceof ArrayList) {
-      this.workflowSteps = (ArrayList<PSUiWorkflowStep>) workflowSteps;
-    } else {
-      this.workflowSteps = new ArrayList<>(workflowSteps);
-    }
+    this.workflowSteps = workflowSteps == null ? null : new ArrayList<>(workflowSteps);
   }
 
   public String getPreviousWorkflowName() {

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSXlintMiscResidualTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSXlintMiscResidualTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.analytics.data.PSAnalyticsProviderConfig;
+import com.percussion.contentmigration.service.PSContentMigrationException;
+import com.percussion.foldermanagement.data.PSFolderItem;
+import com.percussion.foldermanagement.data.PSFolders;
+import com.percussion.sitemanage.importer.utils.PSFileDownLoadJobRunner;
+import com.percussion.sitemanage.importer.utils.PSFileDownloadJob;
+import com.percussion.sitemanage.service.impl.PSSiteSectionMetaDataService.SectionPath;
+import com.percussion.utils.service.impl.PSSiteConfigUtils.SecureXmlData;
+import com.percussion.workflow.data.PSUiWorkflow;
+import com.percussion.workflow.data.PSUiWorkflowStep;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for sitemanage main-source misc Xlint residual (#3107): equals/hashCode
+ * contracts, concrete serializable collection fields, and typed list/map copy constructors.
+ */
+@Tag("UnitTest")
+class PSXlintMiscResidualTest {
+
+  @Test
+  void secureXmlDataEqualsHashCodeContract() {
+    var a = new SecureXmlData();
+    a.setSitename("site-a");
+    a.setLoginPage("/login");
+    a.setUseHttpsForSecureSite(true);
+    a.addSecureOrMemberSection("/members/", "editors");
+
+    var b = new SecureXmlData();
+    b.setSitename("site-a");
+    b.setLoginPage("/login");
+    b.setUseHttpsForSecureSite(true);
+    b.addSecureOrMemberSection("/members/", "editors");
+
+    var c = new SecureXmlData();
+    c.setSitename("site-b");
+    c.setLoginPage("/login");
+    c.setUseHttpsForSecureSite(true);
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  void sectionPathEqualsHashCodeContract() {
+    var a = new SectionPath("//Sites/a");
+    var b = new SectionPath("//Sites/a");
+    var c = new SectionPath("//Sites/b");
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  void fileDownloadJobRunnerEqualsHashCodeContract() {
+    // Protected ctor — anonymous subclass from test package.
+    var job = new PSFileDownloadJob("file.css", "https://example.test/file.css", false) {};
+    var a = new PSFileDownLoadJobRunner(job, Map.of());
+    var b =
+        new PSFileDownLoadJobRunner(
+            new PSFileDownloadJob("file.css", "https://example.test/file.css", false) {}, Map.of());
+    var c =
+        new PSFileDownLoadJobRunner(
+            new PSFileDownloadJob("other.css", "https://example.test/other.css", true) {}, Map.of());
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  void mapWrapperEntriesFieldIsConcreteHashMap() throws Exception {
+    var field = PSMapWrapper.class.getDeclaredField("entries");
+    assertEquals(HashMap.class, field.getType());
+    assertFalse(Modifier.isTransient(field.getModifiers()));
+
+    var wrap = new PSMapWrapper();
+    wrap.setEntries(Map.of("k", "v"));
+    assertInstanceOf(HashMap.class, wrap.getEntries());
+    assertEquals("v", wrap.getEntries().get("k"));
+  }
+
+  @Test
+  void foldersCopiesListIntoArrayList() {
+    List<PSFolderItem> src = List.of(new PSFolderItem());
+    var folders = new PSFolders(src);
+    assertInstanceOf(ArrayList.class, folders.getChildren());
+    assertEquals(1, folders.getChildren().size());
+
+    folders.setChildren(null);
+    // getter returns empty list when field is null
+    assertTrue(folders.getChildren().isEmpty());
+  }
+
+  @Test
+  void analyticsConfigCopiesExtraParamsMap() {
+    Map<String, String> params = Map.of("account", "123");
+    var cfg = new PSAnalyticsProviderConfig("user", "pass", false, params);
+    // getExtraParamsMap rebuilds from ExtraParamsClass populated by the ctor.
+    assertInstanceOf(HashMap.class, cfg.getExtraParamsMap());
+    assertEquals("123", cfg.getExtraParamsMap().get("account"));
+    cfg.setExtraParams(null);
+    assertTrue(cfg.getExtraParamsMap().isEmpty());
+  }
+
+  @Test
+  void contentMigrationExceptionCopiesFailedItems() {
+    var ex = new PSContentMigrationException("fail");
+    ex.setFailedItems(Map.of("page-1", "missing template"));
+    assertInstanceOf(HashMap.class, ex.getFailedItems());
+    assertEquals("missing template", ex.getFailedItems().get("page-1"));
+    ex.setFailedItems(null);
+    assertNull(ex.getFailedItems());
+  }
+
+  @Test
+  void uiWorkflowCopiesStepsIntoArrayList() {
+    var step = new PSUiWorkflowStep();
+    var wf = new PSUiWorkflow("Default", List.of(step));
+    assertInstanceOf(ArrayList.class, wf.getWorkflowSteps());
+    assertEquals(1, wf.getWorkflowSteps().size());
+    wf.setWorkflowSteps(null);
+    assertNull(wf.getWorkflowSteps());
+  }
+}


### PR DESCRIPTION
## Summary

Partial→complete main-source Xlint cleanup for **sitemanage** residual issue **#3107** (parent module **#2032**, monorepo tracker **#2200**). After this-escape/serial-field (#3061 / PR #3106), this PR clears the **misc main-source residual** to **zero**.

### Main changes
- **Static qualification:** `PSCloudService.log`, `PSSearchService.uiService`, `SecureXmlData.*` constants, `ClientBuilder.newClient()`, `IPSPubServerDao.PUBLISH_FOLDER_PROPERTY`, `PSWidgetBuilderDefinitionValidator.validate(...)`
- **Hibernate:** `Session.get` → `Session.find` (PSMetadataDao, PSUserLoginDao, PSImportLogDao)
- **equals/hashCode:** `SecureXmlData`, `PSFileDownLoadJobRunner`, `SectionPath`
- **Fall-through:** `PSSearchIndexProcessMonitor` rewrite with explicit `break`
- **Unchecked:** always copy into `HashMap`/`ArrayList` (PSFolders, PSUiWorkflow, PSUnassignedResults, PSAnalyticsProviderConfig, PSContentMigrationException)
- **serial-field leftovers:** concrete `HashMap`/`ArrayList` fields; `transient` assetCreator on servlet
- **Misc:** unused try-with-resources Reader removed; redundant cast; `@Deprecated` on unit-test-only template finder
- **Removal deprecations:** targeted suppress for legacy PSAesCBC decrypt fallback, ThreadDeath helper, GenericGenerator custom id (`type=` form)

### Tests
- New `PSXlintMiscResidualTest` (8): equals/hashCode contracts + DTO copy constructors

### Inventory (main-source)
| Metric | Before | After |
|--------|--------|-------|
| total main Xlint warnings | **40** | **0** |

### Residual
Test-source Xlint (~60: this-escape, serialVersionUID, unchecked, sun.misc.Unsafe in path-injection tests) — filed as follow-up under #2032 / #2200.

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1098**, Failures: **0**, Errors: **0**, Skipped: **125**
- [x] Focused: `PSXlintMiscResidualTest` — 8 green
- [x] Main compile showWarnings: 0 `[WARNING] *.java:` lines
- [x] C2: no types made `final`/sealed; no public signature removals — greps N/A

## Product documentation
- [x] N/A — pure compiler lint tech debt; no operator/user/API surface change

## Gates / evidence (C3)
- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1098, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** none (C2 did not apply — no final/signature/package API shape changes)
- **C5 UI:** N/A — no UI surface

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent: #2032 / #2200  
Fixes #3107 (sitemanage main-source misc Xlint residual).

> Co-Authored by Grok Build using grok-4.5 with agent main.
