### PR TITLE
fix(deployer): ObjectStoreErrorCodes slice 1 — objectstore non-idtypes (#3163)

### DIFF
--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- Direct ObjectStoreErrorCodes imports (typed IPSObjectStoreErrors peers) -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
             <artifactId>tablefactory</artifactId>

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySetting.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySetting.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -102,7 +102,7 @@ public abstract class PSAppPolicySetting implements IPSDeployComponent {
 
     if (!xmlNodeName.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {xmlNodeName, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySettings.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySettings.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -101,7 +101,7 @@ public final class PSAppPolicySettings implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
@@ -20,7 +20,7 @@ package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIDContextFactory;
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIdContext;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -238,7 +238,7 @@ public final class PSApplicationIDTypeMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -258,7 +258,7 @@ public final class PSApplicationIDTypeMapping implements IPSDeployComponent {
     var ctxEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (ctxEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, "ANY", "null"});
     }
     m_ctx = PSApplicationIDContextFactory.fromXml(ctxEl);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIdContext;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -538,7 +538,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -546,7 +546,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     Element depEl = tree.getNextElement(FIRST_FLAGS);
     String expected = "PSXDeployableElement | PSXDeployableObject";
     if (depEl == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, expected);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, expected);
 
     String nodeName = depEl.getNodeName();
     if (nodeName.equals(PSDeployableElement.XML_NODE_NAME)) m_dep = new PSDeployableElement(depEl);
@@ -554,7 +554,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
       m_dep = new PSDeployableObject(depEl);
     else {
       Object[] args = {expected, nodeName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     tree.setCurrent(sourceNode); // roll back to the root
@@ -718,7 +718,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // need to have at least one
     if (elemEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_MAPPING_ELEMENT);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_MAPPING_ELEMENT);
     }
     Map<String, List<PSApplicationIDTypeMapping>> elemMap = new HashMap<>();
 
@@ -747,7 +747,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // need to have at least one
     if (mappingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSApplicationIDTypeMapping.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSApplicationIDTypeMapping.XML_NODE_NAME);
     }
     List<PSApplicationIDTypeMapping> mappingList = new ArrayList<>();
 
@@ -777,7 +777,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // must have at least one filter
     Element filterEl = tree.getNextElement(XML_NODE_FILTER, FIRST_FLAGS);
     if (filterEl == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_FILTER);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_FILTER);
     }
 
     while (filterEl != null) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.utils.collections.PSMapUtils;
@@ -177,7 +177,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -190,7 +190,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     Element descEl = tree.getNextElement(PSExportDescriptor.XML_NODE_NAME, firstFlags);
     if (descEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSExportDescriptor.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSExportDescriptor.XML_NODE_NAME);
     }
     m_exportDescriptor = new PSExportDescriptor(descEl);
 
@@ -202,7 +202,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     Element mapEl = tree.getNextElement(XML_EL_DBMS_INFO_MAP, firstFlags);
     if (mapEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAP);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAP);
     }
 
     // walk the mappings
@@ -210,7 +210,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     // need to have at least one
     if (mappingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAPPING);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAPPING);
     }
 
     while (mappingEl != null) {
@@ -221,7 +221,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
       List<PSDatasourceMap> dbmsList = m_externalDbmsMap.get(pkgKey);
       if (dbmsList == null) {
         Object[] args = {XML_EL_DBMS_INFO_MAPPING, XML_ATTR_PKGKEY, pkgKey};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // restore each dbms info and add to that map entry's list

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveInfo.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.system.utils.PSFormatVersion;
@@ -279,7 +279,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -302,7 +302,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSFormatVersion.NODE_TYPE));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSFormatVersion.NODE_TYPE));
     m_serverInfo = PSFormatVersion.createFromXml(serverInfoEl);
 
     var repositoryEl =
@@ -313,7 +313,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDbmsInfo.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDbmsInfo.XML_NODE_NAME));
     m_repository = new PSDbmsInfo(repositoryEl);
 
     var detailEl =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -224,7 +224,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_depMap.clear(); // initialize internal data.
@@ -384,7 +384,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
 
       if (!XML_CHILD_NODE.equals(sourceNode.getNodeName())) {
         Object[] args = {XML_CHILD_NODE, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
       m_key = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_CHILD_NODE_ATTR);
 
@@ -399,7 +399,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
       if (childEl == null) // no child element
       {
         Object[] args = {XML_CHILD_NODE + " DependencyKey=\"" + m_key + "\"", "first", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (childEl != null) {
         if (childEl.getNodeName().equals(PSApplicationIDTypes.XML_NODE_NAME)) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -174,7 +174,7 @@ public final class PSArchivePackage implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode should not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_name = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_NAME);
     m_type = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.util.PSDateFormatISO8601;
@@ -209,7 +209,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     // get the attributes
     m_id = Integer.parseInt(PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_ID));
@@ -219,7 +219,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     m_installDate = dateFormat.parse(sDate, new ParsePosition(0));
     if (m_installDate == null) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_INSTALL_DATE, sDate};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get the child elements
@@ -229,7 +229,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     Element childEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (childEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME);
     }
     m_archiveInfo = new PSArchiveInfo(childEl);
 
@@ -238,7 +238,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     childEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
     if (childEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchivePackage.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchivePackage.XML_NODE_NAME);
     }
     while (childEl != null && childEl.getNodeName().equals(PSArchivePackage.XML_NODE_NAME)) {
       m_packageList.add(new PSArchivePackage(childEl));

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDatasourceMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDatasourceMap.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import java.util.Objects;
 import java.util.Optional;
@@ -129,7 +129,7 @@ public final class PSDatasourceMap implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode should not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_srcDataSource =
         PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SOURCE_DATASRC);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsInfo.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.server.PSDbmsHelper;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.legacy.security.deprecated.PSCryptographer;
@@ -383,7 +383,7 @@ public final class PSDbmsInfo implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     var tree = new PSXmlTreeWalker(sourceNode);
     String ds;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -162,7 +162,7 @@ public final class PSDbmsMap implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -149,7 +149,7 @@ public final class PSDbmsMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -161,7 +161,7 @@ public final class PSDbmsMapping implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDatasourceMap.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDatasourceMap.XML_NODE_NAME));
 
     m_datasrcMap = new PSDatasourceMap(srcEl);
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.services.system.IPSDependencyBaseline;
@@ -1174,7 +1174,7 @@ public abstract class PSDependency
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // static helper — avoid overridable getRequiredAttribute this-escape from Element ctor
@@ -1186,7 +1186,7 @@ public abstract class PSDependency
     }
     if (m_dependencyType == -1) {
       Object[] args = {sourceNode.getTagName(), XML_ATT_DEPENDENCY_TYPE, sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_dependencyId =
@@ -1242,7 +1242,7 @@ public abstract class PSDependency
             PSDeployableElement.XML_NODE_NAME + ", " + PSDeployableObject.XML_NODE_NAME,
             dep.getNodeName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
         }
         m_dependencies.add(depObj);
         depObj.setParentDependency(this); // support a doubly-linked list
@@ -1267,7 +1267,7 @@ public abstract class PSDependency
             PSDeployableElement.XML_NODE_NAME + ", " + PSDeployableObject.XML_NODE_NAME,
             dep.getNodeName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
         }
         m_ancestors.add(depObj);
         dep = tree.getNextElement(nextFlags);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcTableData;
@@ -155,7 +155,7 @@ public final class PSDependencyData implements IPSDeployComponent {
       m_data = new PSJdbcTableData(dataEl);
     } catch (PSJdbcTableFactoryException e) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, e.getMessage()});
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -179,7 +179,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -194,7 +194,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
     }
     if (m_type == UNDEFINED) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {sourceNode.getTagName(), XML_ATTR_FILE_TYPE, fileTypeAttr});
     }
 
@@ -209,7 +209,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
         PSDeployComponentUtils.getRequiredElement(tree, XML_NODE_NAME, XML_EL_ARCHIVE_FILE, false);
     if (archiveLocation.trim().isEmpty()) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, XML_EL_ARCHIVE_FILE, "null"});
     }
     m_archiveLocation = new File(archiveLocation);
@@ -222,7 +222,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
       String origPath = PSXmlTreeWalker.getElementData(origFileEl);
       if (origPath == null || origPath.trim().isEmpty()) {
         throw new PSUnknownNodeTypeException(
-            IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+            ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
             new Object[] {XML_NODE_NAME, XML_EL_ORIG_FILE, "null"});
       }
       m_originalFile = new File(PSDeployComponentUtils.getNormalizedPath(origPath));

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployComponentUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployComponentUtils.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -64,7 +64,7 @@ public class PSDeployComponentUtils {
     String val = source.getAttribute(attName);
     if (val == null || val.trim().length() == 0) {
       Object[] args = {source.getTagName(), attName, "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     return val;
@@ -97,7 +97,7 @@ public class PSDeployComponentUtils {
     String temp = tree.getElementData(node);
     if (temp == null || (notEmpty && temp.trim().length() == 0)) {
       Object[] args = {parent, node, temp == null ? "null" : temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     return temp;
@@ -140,7 +140,7 @@ public class PSDeployComponentUtils {
     Element element = tree.getNextElement(flags);
 
     if (element == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, nodeName);
     }
     return element;
   }
@@ -189,7 +189,7 @@ public class PSDeployComponentUtils {
       if (!found) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return index;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -190,7 +190,7 @@ public final class PSDeployableElement extends PSDependency {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);
@@ -198,7 +198,7 @@ public final class PSDeployableElement extends PSDependency {
         tree.getNextElement(PSDependency.XML_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (dep == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
     // final helper — avoid overridable super.fromXml this-escape from Element ctor
     restoreDependencyFromXml(dep);
@@ -207,7 +207,7 @@ public final class PSDeployableElement extends PSDependency {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DESC));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DESC));
   }
 
   // see IPSDeployComponent

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -187,7 +187,7 @@ public class PSDeployableObject extends PSDependency {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);
@@ -195,7 +195,7 @@ public class PSDeployableObject extends PSDependency {
         tree.getNextElement(PSDependency.XML_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (dep == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
     // final helper — avoid overridable super.fromXml this-escape from Element ctor
     restoreDependencyFromXml(dep);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -115,7 +115,7 @@ public final class PSDeploymentServerConnectionInfo implements IPSDeployComponen
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.rx.config.IPSConfigService;
@@ -200,7 +200,7 @@ public abstract class PSDescriptor implements IPSDeployComponent {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -323,7 +323,7 @@ public final class PSExportDescriptor extends PSDescriptor {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -341,14 +341,14 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element descEl = tree.getNextElement(PSDescriptor.XML_NODE_NAME, firstFlags);
     if (descEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME);
     }
     super.fromXml(descEl);
 
     // restore packages
     Element packagesEl = tree.getNextElement(XML_EL_PACKAGES, nextFlags);
     if (packagesEl == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_PACKAGES);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_PACKAGES);
     }
 
     m_packages.clear();
@@ -364,7 +364,7 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element modsEl = tree.getNextElement(XML_EL_MODIFIED_PACKAGES, nextFlags);
     if (modsEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_MODIFIED_PACKAGES);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_MODIFIED_PACKAGES);
     }
     Element modName = tree.getNextElement(XML_EL_PACKAGE_NAME, firstFlags);
     while (modName != null) {
@@ -379,7 +379,7 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element missingEl = tree.getNextElement(XML_EL_MISSING_PACKAGES, nextFlags);
     if (missingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_MISSING_PACKAGES);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_MISSING_PACKAGES);
     }
     Element missingName = tree.getNextElement(XML_EL_PACKAGE_NAME, firstFlags);
     while (missingName != null) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
@@ -445,7 +445,7 @@ public final class PSIdMap implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_sourceServer = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SRC_SERVER);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMapping.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -386,7 +386,7 @@ public final class PSIdMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_sourceId = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SRC_ID);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -185,7 +185,7 @@ public final class PSImportDescriptor extends PSDescriptor {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -197,7 +197,7 @@ public final class PSImportDescriptor extends PSDescriptor {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME));
     super.fromXml(descEl);
 
     var archiveInfoEl =
@@ -207,7 +207,7 @@ public final class PSImportDescriptor extends PSDescriptor {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME));
     m_archiveInfo = new PSArchiveInfo(archiveInfoEl);
 
     m_packages.clear();

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -122,7 +122,7 @@ public final class PSImportPackage implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -134,7 +134,7 @@ public final class PSImportPackage implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSImportPackage.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSImportPackage.XML_NODE_NAME));
     m_pkg = new PSDeployableElement(pkgEl);
 
     var valEl =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -134,7 +134,7 @@ public final class PSLogDetail implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -145,7 +145,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDbmsMap.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDbmsMap.XML_NODE_NAME));
     m_dbmsMap = new PSDbmsMap(dbmsEl);
 
     var txnEl =
@@ -153,7 +153,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL,
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL,
                         PSTransactionLogSummary.XML_NODE_NAME));
     m_txnLog = new PSTransactionLogSummary(txnEl);
 
@@ -162,7 +162,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSValidationResults.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSValidationResults.XML_NODE_NAME));
     m_validationResults = new PSValidationResults(valEl);
 
     var idEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
@@ -179,7 +179,7 @@ public final class PSLogDetail implements IPSDeployComponent {
   private void checkNullXmlELement(Element element, String nodeName)
       throws PSUnknownNodeTypeException {
     if (element == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, nodeName);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -175,7 +175,7 @@ public final class PSLogSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -99,7 +99,7 @@ public final class PSTransactionLogSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -153,7 +153,7 @@ public final class PSTransactionSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -168,7 +168,7 @@ public final class PSTransactionSummary implements IPSDeployComponent {
 
     if (!validateElementType(m_elementType) || !isActionValid(m_action)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_EL_TYPE, m_elementType});
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSUserDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSUserDependency.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -182,7 +182,7 @@ public final class PSUserDependency extends PSDeployableObject {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -199,7 +199,7 @@ public final class PSUserDependency extends PSDeployableObject {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDeployableObject.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDeployableObject.XML_NODE_NAME));
     super.fromXml(dep);
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Collections;
@@ -177,7 +177,7 @@ public final class PSValidationResult implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -186,7 +186,7 @@ public final class PSValidationResult implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {sourceNode.getTagName(), XML_ATTR_MSG, "null"}));
 
     m_isError = getRequiredBoolAttr(sourceNode, XML_ATTR_IS_ERROR);
@@ -199,7 +199,7 @@ public final class PSValidationResult implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME));
 
     switch (depEl.getNodeName()) {
       case PSDeployableObject.XML_NODE_NAME -> m_dep = new PSDeployableObject(depEl);
@@ -207,7 +207,7 @@ public final class PSValidationResult implements IPSDeployComponent {
       case PSUserDependency.XML_NODE_NAME -> m_dep = new PSUserDependency(depEl);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {
                 "(PSXDeployableElement | PSXDeployableObject | PSXUserDependency)",
                 depEl.getNodeName()

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -160,7 +160,7 @@ public final class PSValidationResults implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDeployerObjectstoreTypedErrorCodeSlice1Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDeployerObjectstoreTypedErrorCodeSlice1Test.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import com.percussion.xml.PSXmlTreeWalker;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3163 (parent #3149 slice 1): deployer objectstore (non-idtypes) call sites must throw
+ * typed {@link ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare
+ * {@code IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerObjectstoreTypedErrorCodeSlice1Test {
+
+  @Test
+  public void archivePackageWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotArchivePackage");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSArchivePackage(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void datasourceMapWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDatasourceMap");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDatasourceMap(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployComponentUtilsRequiredAttributeUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, "PSXTest");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> PSDeployComponentUtils.getRequiredAttribute(el, "missingAttr"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployComponentUtilsNextRequiredElementUsesTypedNull() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXParent");
+    PSXmlTreeWalker tree = new PSXmlTreeWalker(root);
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () ->
+                PSDeployComponentUtils.getNextRequiredElement(
+                    tree, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN, "ExpectedChild"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployableObjectWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDeployableObject");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDeployableObject(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}


### PR DESCRIPTION
## Summary
Slice 1 of #3149 (grandparent #2616): retype bare `IPSObjectStoreErrors` ints under `deployer/src/main/java/com/percussion/deployer/objectstore/**` **excluding** `objectstore/idtypes/**` (33 production files, ~79 call sites) to typed `ObjectStoreErrorCodes` via IPSErrorCode-aware `PSUnknownNodeTypeException` constructors.

Matches ObjectStore call-site batches F–M (e.g. design.objectstore A–C / K3).

### Changes
- Replace `import IPSObjectStoreErrors` + bare int throws with `ObjectStoreErrorCodes` on structural XML codes (`XML_ELEMENT_NULL`, `WRONG_TYPE`, `INVALID_ATTR`, `INVALID_CHILD`)
- Declare direct `audit-log` dependency on `perc-deployer` for the typed catalog import
- Add `PSDeployerObjectstoreTypedErrorCodeSlice1Test` (5 cases) asserting `getTypedErrorCode()` / numeric codes / non-auditable
- **Gate allow-list unchanged** (`scripts/verify-no-bare-ipsobjectstoreerrors.py` residual prefixes stay for slices 2–3 / #3164–#3165)
- **idtypes/** left bare intentionally (slice 2)

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — BUILD SUCCESS
- [x] New unit test: Tests run: 5, Failures: 0
- [x] Full deployer suite: Tests run: 245, Failures: 0, Errors: 0, Skipped: 19
- [x] Product documentation: N/A — pure tech-debt retype; no product/operator-facing behavior change
- [x] UI live proof (C5): N/A — no WebUI / browser surface

## Gates evidence
- **modules_built:** `deployer`
- **build_evidence:** `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 245, Failures: 0, Errors: 0, Skipped: 19; new `PSDeployerObjectstoreTypedErrorCodeSlice1Test` Tests run: 5
- **downstream_checked:** none (no API shape / final / signature change — int → IPSErrorCode overload peers already present; exception message codes unchanged numerically)
- **C2:** not applicable (no type sealed/final; no public signature change)

## Links
- Fixes #3163
- Parent: #3149
- Grandparent: #2616
- Related freeze gate: #3143 / PR #3148

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.