### PR TITLE
fix(deployer): ObjectStoreErrorCodes slice 2 — objectstore idtypes (#3164)

### DIFF
--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- Direct ObjectStoreErrorCodes imports (typed IPSObjectStoreErrors peers) -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
             <artifactId>tablefactory</artifactId>

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppCEItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppCEItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -116,7 +116,7 @@ public final class PSAppCEItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -129,7 +129,7 @@ public final class PSAppCEItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppConditionalIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppConditionalIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -212,7 +212,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -225,7 +225,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 
@@ -233,7 +233,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
     var condEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (condEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, "null", "null"});
     }
 
@@ -242,7 +242,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
       case PSWhereClause.ms_NodeType -> m_cond = new PSWhereClause(condEl, null, null);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {PSConditional.ms_NodeType, condEl.getNodeName()});
     }
     m_origCond = (PSConditional) m_cond.clone();

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDataMappingIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDataMappingIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSDataMapping;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -206,7 +206,7 @@ public final class PSAppDataMappingIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -222,7 +222,7 @@ public final class PSAppDataMappingIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDisplayMapperIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDisplayMapperIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -129,7 +129,7 @@ public final class PSAppDisplayMapperIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -139,7 +139,7 @@ public final class PSAppDisplayMapperIdContext extends PSApplicationIdContext {
       m_id = Integer.parseInt(strId);
     } catch (NumberFormatException e) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_ID, strId});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppEntryIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppEntryIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -142,7 +142,7 @@ public final class PSAppEntryIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -152,7 +152,7 @@ public final class PSAppEntryIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
     m_entry = new PSEntry(entryEl, null, null);
     m_origEntry = m_entry;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionCallIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionCallIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -154,7 +154,7 @@ public final class PSAppExtensionCallIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -169,7 +169,7 @@ public final class PSAppExtensionCallIdContext extends PSApplicationIdContext {
 
     if (!validateIndex(m_index) && strIndex != null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionParamIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionParamIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSAbstractParamValue;
 import com.percussion.design.objectstore.PSExtensionParamValue;
@@ -182,7 +182,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -194,7 +194,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     m_paramName =
@@ -208,7 +208,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
 
     m_param =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppIndexedItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppIndexedItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -133,7 +133,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -145,7 +145,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     var strType = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_TYPE);
@@ -161,7 +161,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(typeVal)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
     m_type = typeVal;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppNamedItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppNamedItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -151,7 +151,7 @@ public final class PSAppNamedItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -165,7 +165,7 @@ public final class PSAppNamedItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUISetIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUISetIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUISet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -120,7 +120,7 @@ public final class PSAppUISetIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUrlRequestIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUrlRequestIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -158,7 +158,7 @@ public final class PSAppUrlRequestIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIDContextFactory.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIDContextFactory.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore.idtypes;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Element;
 
@@ -60,7 +60,7 @@ public class PSApplicationIDContextFactory {
       case PSBindingIdContext.XML_NODE_NAME -> new PSBindingIdContext(sourceNode);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {"PSXApplicationIDContext", nodeName});
     };
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingIdContext.java
@@ -18,7 +18,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -182,7 +182,7 @@ public final class PSBindingIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -203,7 +203,7 @@ public final class PSBindingIdContext extends PSApplicationIdContext {
 
     if (!validateIndex(m_index) && strIndex != null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingParamIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingParamIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -201,7 +201,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -213,7 +213,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     var strOccur = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_OCCUR);
@@ -224,7 +224,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_OCCUR, strOccur}));
 
     m_paramName =
@@ -238,7 +238,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
     m_param = new PSTextLiteral(paramEl, null, null);
 

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.objectstore.idtypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3164 (parent #3149 slice 2): deployer objectstore idtypes call sites must throw typed
+ * {@link ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare {@code
+ * IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test {
+
+  @Test
+  public void uiSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotUISetIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppUISetIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void ceItemWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCEItemIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppCEItemIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void ceItemInvalidTypeAttrUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, PSAppCEItemIdContext.XML_NODE_NAME);
+    el.setAttribute("type", "not-a-valid-ce-item-type");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppCEItemIdContext(el));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void factoryUnknownNodeUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "PSXNotAnIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> PSApplicationIDContextFactory.fromXml(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void namedItemInvalidTypeAttrUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, PSAppNamedItemIdContext.XML_NODE_NAME);
+    el.setAttribute("name", "someName");
+    el.setAttribute("type", "not-a-valid-named-item-type");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppNamedItemIdContext(el));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
@@ -92,4 +92,84 @@ public class PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test {
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
   }
+
+  @Test
+  public void namedItemWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotNamedItemIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppNamedItemIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void conditionalWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppConditionalIdContext(wrong));
+  }
+
+  @Test
+  public void dataMappingWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppDataMappingIdContext(wrong));
+  }
+
+  @Test
+  public void displayMapperWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppDisplayMapperIdContext(wrong));
+  }
+
+  @Test
+  public void entryWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppEntryIdContext(wrong));
+  }
+
+  @Test
+  public void extensionCallWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppExtensionCallIdContext(wrong));
+  }
+
+  @Test
+  public void extensionParamWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppExtensionParamIdContext(wrong));
+  }
+
+  @Test
+  public void indexedItemWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppIndexedItemIdContext(wrong));
+  }
+
+  @Test
+  public void urlRequestWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppUrlRequestIdContext(wrong));
+  }
+
+  @Test
+  public void bindingWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSBindingIdContext(wrong));
+  }
+
+  @Test
+  public void bindingParamWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSBindingParamIdContext(wrong));
+  }
+
+  /**
+   * Wrong-root path for each remaining idtypes context: constructor must throw typed {@link
+   * ObjectStoreErrorCodes#XML_ELEMENT_WRONG_TYPE}, not a bare int code.
+   */
+  private static void assertWrongRootTyped(XmlCtor ctor) throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAnIdtypesContextRoot");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> ctor.construct(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @FunctionalInterface
+  private interface XmlCtor {
+    void construct(Element el) throws PSUnknownNodeTypeException;
+  }
 }


### PR DESCRIPTION
## Summary
Slice 2 of #3149 (grandparent #2616): retype bare `IPSObjectStoreErrors` ints under `deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/**` (14 production files, ~45 call sites) to typed `ObjectStoreErrorCodes` via IPSErrorCode-aware `PSUnknownNodeTypeException` constructors.

Matches ObjectStore call-site batches F–M and sibling slice 1 (#3163 / PR #3166).

### Changes
- Replace `import IPSObjectStoreErrors` + bare int throws with `ObjectStoreErrorCodes` on structural XML codes (`XML_ELEMENT_WRONG_TYPE`, `INVALID_ATTR`, `INVALID_CHILD`)
- Declare direct `audit-log` dependency on `perc-deployer` for the typed catalog import (same as slice 1; merges cleanly if both land)
- Add `PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test` (5 cases) asserting `getTypedErrorCode()` / numeric codes / non-auditable
- **Gate allow-list unchanged** (`RESIDUAL_ALLOW_PREFIXES` stays for slice 3 / #3165)

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — BUILD SUCCESS
- [x] New unit test: Tests run: 5, Failures: 0
- [x] Full deployer suite: Tests run: 245, Failures: 0, Errors: 0, Skipped: 19
- [x] Product documentation: N/A — pure tech-debt retype; no product/operator-facing behavior change
- [x] UI live proof (C5): N/A — no WebUI / browser surface

## Gates evidence
- **modules_built:** `deployer`
- **build_evidence:** `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 245, Failures: 0, Errors: 0, Skipped: 19; new `PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test` Tests run: 5
- **downstream_checked:** none (no API shape / final / signature change — int → IPSErrorCode overload peers already present; exception message codes unchanged numerically)
- **C2:** not applicable (no type sealed/final; no public signature change)

## Links
- Fixes #3164
- Parent: #3149
- Grandparent: #2616
- Sibling slice 1: #3163 / PR #3166
- Related freeze gate: #3143 / PR #3148

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
