### PR TITLE
fix(sitemanage): clear test-source Xlint residual (#3159)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3159-sitemanage-test-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3159-sitemanage-test-xlint-erlang.md
@@ -1,0 +1,51 @@
+# Erlang review — issue #3159 sitemanage test-source Xlint residual
+
+**Date:** 2026-08-12  
+**Branch:** `fix/issue-3159-sitemanage-test-xlint`  
+**Scope:** `projects/sitemanage` **test-source only** project `-Xlint` residual after main-source misc zero (#3107 / open PR #3158)  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Clears **all 60** test-source project `-Xlint` diagnostics for `projects/sitemanage` with real fixes preferred over blanket suppress. Main sources untouched (open #3158 owns remaining main-source residual on this base). Path-injection security assertions preserved after dropping `sun.misc.Unsafe`.
+
+| Metric | Before | After |
+|--------|--------|-------|
+| test-source project Xlint | **60** | **0** |
+| main-source project Xlint on this base | 40 (owned by #3158) | 40 (untouched) |
+
+## Clusters cleared
+
+| Cluster | Approach |
+|---------|----------|
+| **this-escape** (REST clients) | Final/safe setters; protected `requestHeaders` / `postContentType` field seeds; `PSRestClient(String)` ctor chain; remove redundant `fillInStackTrace`; justified `@SuppressWarnings("this-escape")` only on intentional Throwable parse ctors |
+| **serialVersionUID** | Nested concurrency/exception stubs + dummy validation exceptions |
+| **serial-field** | `transient` on parsed `PSErrors` / `PSValidationErrors` exception payloads |
+| **unchecked** | Typed `TypeReference` JSON; `Class.cast` / `@SuppressWarnings` on ArgumentCaptor generics; chained `thenReturn` (no generic varargs arrays); typed `IPSGenericDao` mock |
+| **heap-pollution** | `@SafeVarargs` + `@SuppressWarnings("varargs")` on `PSTestDataCleaner` |
+| **sun.misc.Unsafe** | Real ctors + Mockito for path-injection tests (`PSCloudService` public API; `PSCSSParser` public ctor; `PSSiteDataService` mock shell + private Method.invoke) |
+| **static** | `PSThumbnailProcessMonitor.incrementCount/decrementCount` qualified by type name |
+
+## Findings
+
+- **Bugs:** none. Security tests still assert `IllegalArgumentException` for traversal/NUL/separator payloads before File I/O.
+- **Behavior:** test-only; no production main-source change; REST client header seeding equivalent.
+- **Cross-platform:** path-injection tests keep portable path construction; no hardcoded separators introduced.
+- **C2 API shape:** no production types made `final`/sealed; no public production signature changes. Test REST helper visibility changes (`protected` fields, `final` helpers) are test-classpath only.
+
+## Build evidence
+
+```text
+cd projects/sitemanage && ../../mvnw.cmd clean install
+BUILD SUCCESS
+Tests run: 1090, Failures: 0, Errors: 0, Skipped: 125
+
+cd projects/sitemanage && ../../mvnw.cmd test-compile -Dmaven.compiler.showWarnings=true
+test-source [WARNING] *.java: 0
+```
+
+## Verdict
+
+**PASS** for commit/PR. Residual: none for test-source Xlint on sitemanage; main-source remains #3158 / #3107.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
@@ -140,7 +140,9 @@ class ContentTranslationsAdaptorTest {
     assertEquals(ContentTranslationsAdaptor.ROLE_TRANSLATION, out.getCreated().get(0).getRole());
     assertEquals(Long.valueOf(100L), out.getCreated().get(0).getSourceContentId());
 
+    @SuppressWarnings("unchecked")
     ArgumentCaptor<List<IPSGuid>> guidsCap = ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
     ArgumentCaptor<List<PSAutoTranslation>> settingsCap = ArgumentCaptor.forClass(List.class);
     verify(contentWs)
         .newTranslations(guidsCap.capture(), settingsCap.capture(), isNull(), eq(true));

--- a/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipServiceClearOnRecycleTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipServiceClearOnRecycleTest.java
@@ -105,9 +105,11 @@ class PSWidgetAssetRelationshipServiceClearOnRecycleTest {
         mockRelationship(false, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
     PSRelationship localRel = mockRelationship(false, PSRelationshipConfig.TYPE_LOCAL_CONTENT);
 
-    // loadRelationships is called twice (shared filter then local filter)
+    // loadRelationships is called twice (shared filter then local filter).
+    // Chain thenReturn to avoid unchecked generic array creation for varargs.
     when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
-        .thenReturn(List.of(sharedWidgetRel), List.of(localRel));
+        .thenReturn(List.of(sharedWidgetRel))
+        .thenReturn(List.of(localRel));
 
     int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
 
@@ -130,7 +132,8 @@ class PSWidgetAssetRelationshipServiceClearOnRecycleTest {
 
     // Shared path: both returned from AA filter; service keeps only non-inline
     when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
-        .thenReturn(List.of(inline, widget), Collections.emptyList());
+        .thenReturn(List.of(inline, widget))
+        .thenReturn(Collections.emptyList());
 
     int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
 
@@ -146,7 +149,8 @@ class PSWidgetAssetRelationshipServiceClearOnRecycleTest {
   void clear_whenNoBindings_isIdempotent() throws Exception {
     stubAssetGuid();
     when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
-        .thenReturn(Collections.emptyList(), Collections.emptyList());
+        .thenReturn(Collections.emptyList())
+        .thenReturn(Collections.emptyList());
 
     int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
 
@@ -160,7 +164,8 @@ class PSWidgetAssetRelationshipServiceClearOnRecycleTest {
 
     PSRelationship shared = mockRelationship(false, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
     when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
-        .thenReturn(List.of(shared), Collections.emptyList());
+        .thenReturn(List.of(shared))
+        .thenReturn(Collections.emptyList());
 
     int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
 

--- a/projects/sitemanage/src/test/java/com/percussion/cloudservice/impl/PSCloudServicePathInjectionTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/cloudservice/impl/PSCloudServicePathInjectionTest.java
@@ -17,62 +17,41 @@ package com.percussion.cloudservice.impl;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import com.percussion.licensemanagement.service.impl.PSLicenseService;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.IPSRenderService;
+import com.percussion.share.dao.IPSFolderHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import sun.misc.Unsafe;
 
 /**
  * Path-injection regression for {@link PSCloudService#generateThumbUrl}: siteName and pageId are
  * validated with {@code requireSafeFileName} before any File I/O under {@code PSServer.getRxDir()}.
  *
- * <p>Uses {@link Unsafe#allocateInstance} so validation runs without constructing Spring deps or
- * requiring a live server (same pattern as {@code PSSiteDataServicePathInjectionTest}).
+ * <p>Instantiates {@link PSCloudService} via its public constructor with Mockito-mocked
+ * dependencies (same pattern as {@code PSImportThemeHelperPathInjectionTest}) — no {@code
+ * sun.misc.Unsafe}.
  */
 public class PSCloudServicePathInjectionTest {
 
-  private static final Unsafe UNSAFE;
-  private static final Method GENERATE_THUMB_URL;
-
-  static {
-    try {
-      Field f = Unsafe.class.getDeclaredField("theUnsafe");
-      f.setAccessible(true);
-      UNSAFE = (Unsafe) f.get(null);
-      GENERATE_THUMB_URL =
-          PSCloudService.class.getDeclaredMethod("generateThumbUrl", String.class, String.class);
-      GENERATE_THUMB_URL.setAccessible(true);
-    } catch (ReflectiveOperationException e) {
-      throw new ExceptionInInitializerError(e);
-    }
-  }
-
-  private static String invokeGenerateThumbUrl(String pageId, String siteName) throws Exception {
-    Object instance = UNSAFE.allocateInstance(PSCloudService.class);
-    try {
-      return (String) GENERATE_THUMB_URL.invoke(instance, pageId, siteName);
-    } catch (InvocationTargetException ite) {
-      Throwable cause = ite.getCause();
-      if (cause instanceof Exception) {
-        throw (Exception) cause;
-      }
-      if (cause instanceof Error) {
-        throw (Error) cause;
-      }
-      throw ite;
-    }
+  private static PSCloudService service() {
+    return new PSCloudService(
+        mock(IPSFolderHelper.class),
+        mock(IPSRenderService.class),
+        mock(IPSPageService.class),
+        mock(PSLicenseService.class));
   }
 
   @Test
   @DisplayName("generateThumbUrl rejects parent traversal in siteName before File I/O")
   void rejectsTraversalInSiteName() {
+    PSCloudService svc = service();
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
-            () -> invokeGenerateThumbUrl("page1", "../escape"),
+            () -> svc.generateThumbUrl("page1", "../escape"),
             "siteName traversal must be rejected by requireSafeFileName");
     assertTrue(
         ex.getMessage() != null && !ex.getMessage().isBlank(),
@@ -82,32 +61,36 @@ public class PSCloudServicePathInjectionTest {
   @Test
   @DisplayName("generateThumbUrl rejects parent traversal in pageId before File I/O")
   void rejectsTraversalInPageId() {
+    PSCloudService svc = service();
     assertThrows(
         IllegalArgumentException.class,
-        () -> invokeGenerateThumbUrl("../escape", "goodSite"),
+        () -> svc.generateThumbUrl("../escape", "goodSite"),
         "pageId traversal must be rejected by requireSafeFileName");
   }
 
   @Test
   @DisplayName("generateThumbUrl rejects path separators in siteName")
   void rejectsSlashInSiteName() {
+    PSCloudService svc = service();
     assertThrows(
-        IllegalArgumentException.class, () -> invokeGenerateThumbUrl("page1", "site/name"));
+        IllegalArgumentException.class, () -> svc.generateThumbUrl("page1", "site/name"));
     assertThrows(
-        IllegalArgumentException.class, () -> invokeGenerateThumbUrl("page1", "site\\name"));
+        IllegalArgumentException.class, () -> svc.generateThumbUrl("page1", "site\\name"));
   }
 
   @Test
   @DisplayName("generateThumbUrl rejects path separators in pageId")
   void rejectsSlashInPageId() {
+    PSCloudService svc = service();
     assertThrows(
-        IllegalArgumentException.class, () -> invokeGenerateThumbUrl("page/id", "goodSite"));
+        IllegalArgumentException.class, () -> svc.generateThumbUrl("page/id", "goodSite"));
   }
 
   @Test
   @DisplayName("generateThumbUrl rejects NUL in siteName")
   void rejectsNulInSiteName() {
+    PSCloudService svc = service();
     assertThrows(
-        IllegalArgumentException.class, () -> invokeGenerateThumbUrl("page1", "site\0name"));
+        IllegalArgumentException.class, () -> svc.generateThumbUrl("page1", "site\0name"));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/foldermanagement/service/PSFolderServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/foldermanagement/service/PSFolderServiceRestClient.java
@@ -33,7 +33,8 @@ public class PSFolderServiceRestClient extends PSDataServiceRestClient<PSFolderI
 
   public PSFolderServiceRestClient(String url) {
     super(PSFolderItem.class, url, "/Rhythmyx/services/foldermanagement/folders");
-    setPostContentType(MediaType.APPLICATION_XML);
+    // Direct field seed — avoids this-escape on overridable/setter path.
+    this.postContentType = MediaType.APPLICATION_XML;
   }
 
   public List<PSFolderItem> getAssociatedFolders(

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
@@ -124,48 +124,64 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
    * simple-name equality without putting those libraries on the test compile classpath.
    */
   static final class LockAcquisitionException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     LockAcquisitionException(String m) {
       super(m);
     }
   }
 
   static final class OptimisticLockException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     OptimisticLockException(String m) {
       super(m);
     }
   }
 
   static final class PessimisticLockException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     PessimisticLockException(String m) {
       super(m);
     }
   }
 
   static final class ConcurrencyFailureException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     ConcurrencyFailureException(String m) {
       super(m);
     }
   }
 
   static final class CannotAcquireLockException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     CannotAcquireLockException(String m) {
       super(m);
     }
   }
 
   static final class ObjectOptimisticLockingFailureException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     ObjectOptimisticLockingFailureException(String m) {
       super(m);
     }
   }
 
   static final class StaleObjectStateException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     StaleObjectStateException(String m) {
       super(m);
     }
   }
 
   static final class StaleStateException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     StaleStateException(String m) {
       super(m);
     }

--- a/projects/sitemanage/src/test/java/com/percussion/metadata/web/service/PSMetadataServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/metadata/web/service/PSMetadataServiceRestClient.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
 /** REST client for metadata service. Sunny Sal says: "Metadata management, Java 11 style!" */
@@ -52,9 +53,10 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
       var response = GET(concatPath(getPath(), GADGETS_KEY));
       var metadata = PSSerializerUtils.unmarshal(response, PSMetadata.class);
       var mapper = JsonMapper.builder().build();
-      var dataMap = mapper.readValue(metadata.getData(), java.util.Map.class);
-      var dashboardConfigMap = (java.util.Map<String, Object>) dataMap.get("DashboardConfig");
-      config = mapper.convertValue(dashboardConfigMap, PSDashboardConfiguration.class);
+      Map<String, Object> dataMap =
+          mapper.readValue(metadata.getData(), new TypeReference<Map<String, Object>>() {});
+      Object dashboardConfigObj = dataMap.get("DashboardConfig");
+      config = mapper.convertValue(dashboardConfigObj, PSDashboardConfiguration.class);
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));

--- a/projects/sitemanage/src/test/java/com/percussion/monitor/process/PSThumbnailProcessMonitorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/monitor/process/PSThumbnailProcessMonitorTest.java
@@ -31,18 +31,19 @@ public class PSThumbnailProcessMonitorTest {
   void testThumbnailMonitor() {
     var mon = new PSThumbnailProcessMonitor();
     assertEquals(0L, mon.getCurrentCount());
-    mon.incrementCount();
+    // Static counters: qualify by type name (not via instance expression).
+    PSThumbnailProcessMonitor.incrementCount();
     assertEquals(1L, mon.getCurrentCount());
-    mon.incrementCount();
+    PSThumbnailProcessMonitor.incrementCount();
     assertEquals(2L, mon.getCurrentCount());
-    mon.decrementCount();
+    PSThumbnailProcessMonitor.decrementCount();
     assertEquals(1L, mon.getCurrentCount());
-    mon.incrementCount(5);
+    PSThumbnailProcessMonitor.incrementCount(5);
     assertEquals(6L, mon.getCurrentCount());
-    mon.decrementCount(4);
+    PSThumbnailProcessMonitor.decrementCount(4);
     assertEquals(2L, mon.getCurrentCount());
-    mon.decrementCount(2);
+    PSThumbnailProcessMonitor.decrementCount(2);
     assertEquals(0L, mon.getCurrentCount());
-    mon.decrementCount();
+    PSThumbnailProcessMonitor.decrementCount();
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/PSSiteDataServletTestCaseFixture.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/PSSiteDataServletTestCaseFixture.java
@@ -104,7 +104,7 @@ public class PSSiteDataServletTestCaseFixture {
     PSSpringWebApplicationContextUtils.injectDependencies(this);
     PSRequestInfo.resetRequestInfo();
     PSRequest req = PSRequest.getContextForRequest();
-    PSRequestInfo.initRequestInfo((Map) null);
+    PSRequestInfo.initRequestInfo(new java.util.HashMap<String, Object>());
     PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_PSREQUEST, req);
     setSecurityWs(PSSecurityWsLocator.getSecurityWebservice());
     securityWs.login(request, response, uid, pwd, null, community, null);

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/web/service/PSRenderLinkServiceClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/web/service/PSRenderLinkServiceClient.java
@@ -28,9 +28,24 @@ import java.io.InputStream;
 public class PSRenderLinkServiceClient extends PSObjectRestClient {
   private final String path = "/Rhythmyx/services/pagemanagement/renderlink";
 
-  {
-    addAccept("text/html");
-    addAccept("image/*");
+  public PSRenderLinkServiceClient() {
+    super();
+    seedAccepts();
+  }
+
+  public PSRenderLinkServiceClient(String baseUrl) {
+    super(baseUrl);
+    seedAccepts();
+  }
+
+  private void seedAccepts() {
+    // Direct header mutation after super — no this-escape method dispatch.
+    String accept = requestHeaders.get("Accept");
+    if (accept == null || accept.isBlank()) {
+      requestHeaders.put("Accept", "text/html,image/*");
+    } else {
+      requestHeaders.put("Accept", accept + ",text/html,image/*");
+    }
   }
 
   public String getPath() {

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/web/service/PSRenderServiceClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/web/service/PSRenderServiceClient.java
@@ -27,8 +27,24 @@ import com.percussion.share.test.PSObjectRestClient;
 public class PSRenderServiceClient extends PSObjectRestClient {
   private final String path = "/Rhythmyx/services/pagemanagement/render";
 
-  {
-    addAccept("text/html");
+  public PSRenderServiceClient() {
+    super();
+    seedAccepts();
+  }
+
+  public PSRenderServiceClient(String baseUrl) {
+    super(baseUrl);
+    seedAccepts();
+  }
+
+  private void seedAccepts() {
+    // Direct header mutation after super — no this-escape method dispatch.
+    String accept = requestHeaders.get("Accept");
+    if (accept == null || accept.isBlank()) {
+      requestHeaders.put("Accept", "text/html");
+    } else {
+      requestHeaders.put("Accept", accept + ",text/html");
+    }
   }
 
   public String getPath() {

--- a/projects/sitemanage/src/test/java/com/percussion/recent/service/PSRecentServiceFixture.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recent/service/PSRecentServiceFixture.java
@@ -115,7 +115,7 @@ public class PSRecentServiceFixture {
     PSSpringWebApplicationContextUtils.injectDependencies(this);
     PSRequestInfo.resetRequestInfo();
     var req = PSRequest.getContextForRequest();
-    PSRequestInfo.initRequestInfo((Map) null);
+    PSRequestInfo.initRequestInfo(new java.util.HashMap<String, Object>());
     PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_PSREQUEST, req);
     setSecurityWs(PSSecurityWsLocator.getSecurityWebservice());
     securityWs.login(request, response, uid, pwd, null, community, null);

--- a/projects/sitemanage/src/test/java/com/percussion/share/service/PSAbstractFullDataServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/service/PSAbstractFullDataServiceTest.java
@@ -38,8 +38,9 @@ public class PSAbstractFullDataServiceTest {
   IPSDataItemSummaryService dataItemSummaryService;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   void setUp() {
-    dao = Mockito.mock(IPSGenericDao.class);
+    dao = (IPSGenericDao<Object, String>) Mockito.mock(IPSGenericDao.class);
     dataItemSummaryService = Mockito.mock(IPSDataItemSummaryService.class);
     sut = new TestFullDataService(dataItemSummaryService, dao);
   }

--- a/projects/sitemanage/src/test/java/com/percussion/share/test/PSDataObjectTestUtils.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/test/PSDataObjectTestUtils.java
@@ -39,9 +39,11 @@ public class PSDataObjectTestUtils {
     public T actualSerialized;
   }
 
+  @SuppressWarnings("unchecked")
   public static <T> DataObjectXmlTestResults<T> doXmlSerialization(T object) {
     var s = PSSerializerUtils.marshal(object);
-    var klass = (Class<T>) object.getClass();
+    // object.getClass() is Class<? extends T>; cast is required for typed unmarshal.
+    Class<T> klass = (Class<T>) object.getClass();
     var copy = PSSerializerUtils.unmarshal(s, klass);
     var sCopy = PSSerializerUtils.marshal(copy);
 
@@ -83,7 +85,8 @@ public class PSDataObjectTestUtils {
       var defaults = new HashMap<String, P>();
       for (var pd : props) {
         if (pt.equals(pd.getPropertyType())) {
-          defaults.put(pd.getName(), (P) map.get(pd.getName()));
+          Object raw = map.get(pd.getName());
+          defaults.put(pd.getName(), raw == null ? null : pt.cast(raw));
         }
       }
       return defaults;

--- a/projects/sitemanage/src/test/java/com/percussion/share/test/PSObjectRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/test/PSObjectRestClient.java
@@ -42,12 +42,14 @@ public class PSObjectRestClient extends PSRestClient {
 
   public PSObjectRestClient() {
     super();
-    getRequestHeaders().put("Accept", "text/xml");
+    // Direct field seed (protected requestHeaders) — avoids this-escape method calls.
+    requestHeaders.put("Accept", "text/xml");
   }
 
   public PSObjectRestClient(String baseUrl) {
-    this();
-    setUrl(baseUrl);
+    super(baseUrl);
+    // Headers map is shared with the client created in super(baseUrl).
+    requestHeaders.put("Accept", "text/xml");
   }
 
   public void switchCommunity(Integer id) {
@@ -162,7 +164,7 @@ public class PSObjectRestClient extends PSRestClient {
     try {
       var context = JAXBContext.newInstance(type);
       var u = context.createUnmarshaller();
-      return (T) u.unmarshal(new StringReader(response));
+      return type.cast(u.unmarshal(new StringReader(response)));
     } catch (JAXBException e) {
       throw new DataRestClientMarshalException("Error unmarshaling", e);
     }
@@ -195,15 +197,16 @@ public class PSObjectRestClient extends PSRestClient {
 
   public static class DataValidationRestClientException extends DataRestClientException {
     private static final long serialVersionUID = 1L;
-    private PSValidationErrors errors;
+    /** Parsed validation payload; not part of Java serialization of the exception. */
+    private transient PSValidationErrors errors;
 
     public DataValidationRestClientException(RestClientException cause) {
       super(cause);
     }
 
     @Override
-    protected void setErrorResponse(String response) {
-      setErrors(fromXml(response));
+    protected final void setErrorResponse(String response) {
+      setValidationErrors(fromValidationXml(response));
     }
 
     @Override
@@ -211,12 +214,11 @@ public class PSObjectRestClient extends PSRestClient {
       return errors;
     }
 
-    public void setErrors(PSValidationErrors errors) {
+    public final void setValidationErrors(PSValidationErrors errors) {
       this.errors = errors;
     }
 
-    @Override
-    protected PSValidationErrors fromXml(String xml) {
+    protected final PSValidationErrors fromValidationXml(String xml) {
       try {
         return JAXB.unmarshal(new StringReader(xml), PSValidationErrors.class);
       } catch (Exception e) {
@@ -230,37 +232,56 @@ public class PSObjectRestClient extends PSRestClient {
 
   public static class DataRestClientException extends RestClientException {
     private static final long serialVersionUID = 1L;
-    private PSErrors errors;
+    /** Parsed error payload; not part of Java serialization of the exception. */
+    private transient PSErrors errors;
     private RestClientException restClientException;
 
+    /**
+     * Parses response body into structured errors. Polymorphic parse hook may run before subclass
+     * fields finish init — justified for intentional Throwable construction (same pattern as main
+     * PSErrorsExceptionDecorator).
+     */
+    @SuppressWarnings("this-escape")
     public DataRestClientException(RestClientException cause) {
       super(cause);
       restClientException = cause;
       if (cause.getResponseBody() != null) {
         setErrorResponse(cause.getResponseBody());
-      } else {
-        fillInStackTrace();
+      }
+      // else: super() already filled the stack; do not call fillInStackTrace() (this-escape).
+    }
+
+    /** Chains nested error causes; {@code initCause} is intentional Throwable API use. */
+    @SuppressWarnings("this-escape")
+    public DataRestClientException(DataRestClientException parent, PSErrorCause ec) {
+      restClientException = parent.restClientException;
+      initFromErrorCause(ec);
+    }
+
+    protected final void initFromErrorCause(PSErrorCause ec) {
+      applyStackTrace(ec.getStackTrace());
+      var child = ec.getErrorCause();
+      initFromChildCause(child);
+    }
+
+    protected final void initFromChildCause(PSErrorCause child) {
+      if (child != null) {
+        initCause(new DataRestClientException(this, child));
+      } else if (restClientException != null) {
+        initCause(restClientException);
       }
     }
 
-    public DataRestClientException(DataRestClientException parent, PSErrorCause ec) {
-      restClientException = parent.restClientException;
-      init(ec);
+    protected final void applyStackTrace(PSErrorCause ec) {
+      if (ec != null) {
+        setStackTrace(ec.getStackTrace());
+      }
     }
 
-    protected void init(PSErrorCause ec) {
-      setStackTrace(ec.getStackTrace());
-      var child = ec.getErrorCause();
-      initCause(child);
-    }
-
-    protected void initCause(PSErrorCause child) {
-      if (child != null) initCause(new DataRestClientException(this, child));
-      else if (restClientException != null) initCause(restClientException);
-    }
-
-    protected void setStackTrace(PSErrorCause ec) {
-      if (ec != null) setStackTrace(ec.getStackTrace());
+    protected final void applyStackTrace(StackTraceElement[] stack) {
+      if (stack != null) {
+        setStackTrace(stack);
+      }
     }
 
     @Override
@@ -285,15 +306,15 @@ public class PSObjectRestClient extends PSRestClient {
       return errors;
     }
 
-    protected void setErrors(PSErrors errors) {
+    protected final void setErrors(PSErrors errors) {
       this.errors = errors;
       if (hasException()) {
-        setStackTrace(errors.getGlobalError().getCause());
-        initCause(errors.getGlobalError().getCause().getErrorCause());
+        applyStackTrace(errors.getGlobalError().getCause());
+        initFromChildCause(errors.getGlobalError().getCause().getErrorCause());
       }
     }
 
-    protected PSErrors fromXml(String xml) {
+    protected final PSErrors fromXml(String xml) {
       try {
         return JAXB.unmarshal(new StringReader(xml), PSErrors.class);
       } catch (Exception e) {

--- a/projects/sitemanage/src/test/java/com/percussion/share/test/PSRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/test/PSRestClient.java
@@ -51,10 +51,25 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSRestClient {
   private String url;
-  private Map<String, String> requestHeaders = new HashMap<String, String>();
-  private String postContentType = "text/xml";
+  /** Protected so subclasses can seed headers in ctors without this-escape method calls. */
+  protected final Map<String, String> requestHeaders = new HashMap<String, String>();
+  /** Protected so subclasses can seed content type in ctors without this-escape method calls. */
+  protected String postContentType = "text/xml";
 
   private PSModernHttpClient client;
+
+  public PSRestClient() {}
+
+  /**
+   * Seeds base URL and HTTP client during construction without overridable method dispatch
+   * (clears subclass this-escape when chaining {@code super(baseUrl)}).
+   */
+  public PSRestClient(String baseUrl) {
+    this.url = baseUrl;
+    if (baseUrl != null) {
+      this.client = new PSModernHttpClient(baseUrl, requestHeaders);
+    }
+  }
 
   public List<String> parseAcceptHeader(String acceptHeader) {
     return new ArrayList<String>(asList(acceptHeader.split(",")));
@@ -64,19 +79,19 @@ public class PSRestClient {
     return StringUtils.join(accepts, ",");
   }
 
-  protected void addAccept(String mime) {
+  protected final void addAccept(String mime) {
     List<String> accepts = parseAcceptHeader(getAcceptHeader());
     accepts.add(mime);
     setAcceptHeader(outputAcceptHeader(accepts));
   }
 
-  protected String getAcceptHeader() {
+  protected final String getAcceptHeader() {
     String accept = getRequestHeaders().get("Accept");
     if (accept == null) return "";
     return accept;
   }
 
-  protected void setAcceptHeader(String header) {
+  protected final void setAcceptHeader(String header) {
     notNull(header, "header");
     getRequestHeaders().put("Accept", header);
   }
@@ -85,7 +100,7 @@ public class PSRestClient {
     return url;
   }
 
-  public void setUrl(String url) {
+  public final void setUrl(String url) {
     this.url = url;
     // Initialize the modern HTTP client with the base URL
     if (url != null) {
@@ -242,22 +257,27 @@ public class PSRestClient {
     public RestClientException() {}
 
     public RestClientException(RestClientException cause) {
-      setStatus(cause.getStatus());
-      setUri(cause.getUri());
-      setResponseBody(cause.getResponseBody());
-      setMessage(cause.getMessage());
+      // Direct field copies (not overridable setters) avoid -Xlint:this-escape.
+      this.status = cause.getStatus();
+      this.uri = cause.getUri();
+      this.responseBody = cause.getResponseBody();
+      this.message = cause.getMessage();
     }
 
     public RestClientException(int status, String uri, InputStream responseBody) {
-      init(status, uri, null);
-      setMessage(getRestErrorMessage());
-      fillInStackTrace();
+      // super() already fills the stack; do not call fillInStackTrace() again.
+      this.status = status;
+      this.uri = uri;
+      this.responseBody = null;
+      this.message =
+          format("HTTP Error code: {0}\nURI: {1}\nResponse: {2}", status, uri, (Object) null);
     }
 
     public RestClientException(int status, String uri, String responseBody) {
-      init(status, uri, responseBody);
-      setMessage(getRestErrorMessage());
-      fillInStackTrace();
+      this.status = status;
+      this.uri = uri;
+      this.responseBody = responseBody;
+      this.message = format("HTTP Error code: {0}\nURI: {1}\nResponse: {2}", status, uri, responseBody);
     }
 
     @Override
@@ -268,62 +288,68 @@ public class PSRestClient {
       return super.getMessage();
     }
 
-    protected void setMessage(String message) {
+    protected final void setMessage(String message) {
       this.message = message;
     }
 
-    protected String getRestErrorMessage() {
+    protected final String getRestErrorMessage() {
       return format(
           "HTTP Error code: {0}\nURI: {1}\nResponse: {2}",
           getStatus(), getUri(), getResponseBody());
     }
 
-    protected void init(int status, String uri, String responseBody) {
+    protected final void init(int status, String uri, String responseBody) {
       this.status = status;
       this.uri = uri;
       this.responseBody = responseBody;
     }
 
-    public String getUri() {
+    public final String getUri() {
       return uri;
     }
 
-    public void setUri(String uri) {
+    public final void setUri(String uri) {
       this.uri = uri;
     }
 
-    public int getStatus() {
+    public final int getStatus() {
       return status;
     }
 
-    public void setStatus(int status) {
+    public final void setStatus(int status) {
       this.status = status;
     }
 
-    public String getResponseBody() {
+    public final String getResponseBody() {
       return responseBody;
     }
 
-    public void setResponseBody(String responseBody) {
+    public final void setResponseBody(String responseBody) {
       this.responseBody = responseBody;
     }
   }
 
   protected static final Logger log = LogManager.getLogger(PSRestClient.class);
 
-  public String getPostContentType() {
+  public final String getPostContentType() {
     return postContentType;
   }
 
-  public void setPostContentType(String postContentType) {
+  public final void setPostContentType(String postContentType) {
     this.postContentType = postContentType;
   }
 
-  public Map<String, String> getRequestHeaders() {
+  public final Map<String, String> getRequestHeaders() {
     return requestHeaders;
   }
 
-  public void setRequestHeaders(Map<String, String> requestHeaders) {
-    this.requestHeaders = requestHeaders;
+  /**
+   * Replaces header entries in place (map is final). Prefer mutating {@link #requestHeaders}
+   * directly from subclass constructors to avoid this-escape diagnostics.
+   */
+  public final void setRequestHeaders(Map<String, String> requestHeaders) {
+    notNull(requestHeaders, "requestHeaders");
+    this.requestHeaders.clear();
+    this.requestHeaders.putAll(requestHeaders);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/test/PSTestDataCleaner.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/test/PSTestDataCleaner.java
@@ -57,11 +57,15 @@ public abstract class PSTestDataCleaner<ID> {
    *
    * @param ids never any <code>null</code> elements.
    */
-  public void add(ID... ids) {
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final void add(ID... ids) {
     noNullElements(ids, "one of the ids passed to the cleaner was null");
     for (ID id : ids) {
       boolean shouldAdd = !(isRemoveDuplicates() && getDataIds().contains(id));
-      if (shouldAdd) dataIds.add(id);
+      if (shouldAdd) {
+        dataIds.add(id);
+      }
     }
   }
 
@@ -70,7 +74,9 @@ public abstract class PSTestDataCleaner<ID> {
    *
    * @param ids never any <code>null</code> elements.
    */
-  public void remove(ID... ids) {
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final void remove(ID... ids) {
     noNullElements(ids, "one of the ids passed to the cleaner was null");
     dataIds.removeAll(asList(ids));
   }

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSValidationExceptionMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSValidationExceptionMapperTest.java
@@ -18,12 +18,16 @@ class PSValidationExceptionMapperTest {
       new PSSpringValidationExceptionMapper();
 
   private static final class DummyValidationException extends PSValidationException {
+    private static final long serialVersionUID = 1L;
+
     DummyValidationException(String message) {
       super(message);
     }
   }
 
   private static final class DummySpringValidationException extends PSSpringValidationException {
+    private static final long serialVersionUID = 1L;
+
     DummySpringValidationException(String message) {
       super(message);
     }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/importer/theme/PSCSSParserPathInjectionTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/importer/theme/PSCSSParserPathInjectionTest.java
@@ -20,15 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import com.percussion.sitemanage.importer.IPSSiteImportLogger;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import sun.misc.Unsafe;
 
 /**
  * Regression tests for {@link PSCSSParser} focused on the three {@code java/path-injection}
@@ -46,25 +46,19 @@ import sun.misc.Unsafe;
  * every path BEFORE any File / FileWriter / FileInputStream construction, with the theme root as
  * the canonical base.
  *
- * <p>Tests use {@link sun.misc.Unsafe#allocateInstance} to bypass the PSCSSParser constructor
- * (which has a {@code @notNull} precondition and a real logger dependency) and reflectively invoke
- * the three private sink methods. The same pattern is used by {@code
- * PSSiteDataServicePathInjectionTest} (T043).
+ * <p>Tests construct {@link PSCSSParser} via its public constructor with a Mockito-mocked logger
+ * (no {@code sun.misc.Unsafe}) and reflectively invoke the three private sink methods.
  */
 public class PSCSSParserPathInjectionTest {
 
   @TempDir File themeRoot;
 
-  private static final Unsafe UNSAFE;
   private static final Method FILE_EXISTS_METHOD;
   private static final Method SAVE_FILE_METHOD;
   private static final Method LOAD_FILE_METHOD;
 
   static {
     try {
-      Field f = Unsafe.class.getDeclaredField("theUnsafe");
-      f.setAccessible(true);
-      UNSAFE = (Unsafe) f.get(null);
       FILE_EXISTS_METHOD = PSCSSParser.class.getDeclaredMethod("fileExists", String.class);
       FILE_EXISTS_METHOD.setAccessible(true);
       SAVE_FILE_METHOD =
@@ -78,24 +72,13 @@ public class PSCSSParserPathInjectionTest {
   }
 
   /**
-   * Constructs an uninitialized PSCSSParser instance and sets the {@code themeRootDirectory} field
-   * via reflection so the validator has a real base directory to check against.
+   * Constructs a real PSCSSParser with a mocked logger so private sinks can be invoked without
+   * JDK-internal {@code Unsafe.allocateInstance}.
    */
-  private PSCSSParser parser() throws Exception {
-    PSCSSParser p = (PSCSSParser) UNSAFE.allocateInstance(PSCSSParser.class);
-    setField(p, "themeRootDirectory", themeRoot.getAbsolutePath());
-    // logger is unused by the three sink methods being tested (they do
-    // not log on success), so leave it null. setFileDownloader would
-    // require a real downloader; not needed for these tests.
-    setField(p, "logger", null);
-    return p;
-  }
-
-  private static void setField(Object target, String name, Object value)
-      throws ReflectiveOperationException {
-    Field f = PSCSSParser.class.getDeclaredField(name);
-    f.setAccessible(true);
-    f.set(target, value);
+  private PSCSSParser parser() {
+    IPSSiteImportLogger logger = mock(IPSSiteImportLogger.class);
+    return new PSCSSParser(
+        "test-site", themeRoot.getAbsolutePath(), "http://test.example/theme/", logger);
   }
 
   private static Object invokeFileExists(PSCSSParser p, String path) throws Throwable {

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServicePathInjectionTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServicePathInjectionTest.java
@@ -18,14 +18,13 @@ package com.percussion.sitemanage.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.percussion.security.io.PSPathInjectionGuard;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import sun.misc.Unsafe;
 
 /**
  * Regression tests for {@link PSSiteDataService} focused on the {@code java/path-injection} finding
@@ -37,25 +36,23 @@ import sun.misc.Unsafe;
  * the cache directory and reach File construction with attacker-controlled traversal sequences.
  *
  * <p>The fix adds {@link PSPathInjectionGuard#requireSafeFileName} on both names BEFORE any File
- * construction. To invoke the private {@code updateThumbnailCache} without the 21-arg public
- * constructor we use {@link Unsafe#allocateInstance} (which skips constructors and field
- * initializers), then reflectively call the method. Because the validator runs FIRST in the
- * post-fix code, malicious payloads surface as {@link IllegalArgumentException} from the validator,
- * not as a later {@link NullPointerException} from the un-initialized {@code PSServer.getRxDir()}
- * call.
+ * construction. To invoke the private {@code updateThumbnailCache} without the multi-arg public
+ * constructor we use a Mockito mock shell (constructor not invoked) and reflectively call the
+ * method. Because the validator runs after static logging and before {@code PSServer.getRxDir()},
+ * malicious payloads surface as {@link IllegalArgumentException} from the validator, not as a later
+ * {@link NullPointerException} from un-initialized collaborators.
+ *
+ * <p>No {@code sun.misc.Unsafe} — private methods are not intercepted by Mockito, so {@code
+ * Method.invoke} runs the real production body on the mock instance.
  */
 public class PSSiteDataServicePathInjectionTest {
 
   private static final String METHOD_NAME = "updateThumbnailCache";
 
-  private static final Unsafe UNSAFE;
   private static final Method UPDATE_METHOD;
 
   static {
     try {
-      Field f = Unsafe.class.getDeclaredField("theUnsafe");
-      f.setAccessible(true);
-      UNSAFE = (Unsafe) f.get(null);
       UPDATE_METHOD =
           PSSiteDataService.class.getDeclaredMethod(METHOD_NAME, String.class, String.class);
       UPDATE_METHOD.setAccessible(true);
@@ -65,13 +62,13 @@ public class PSSiteDataServicePathInjectionTest {
   }
 
   /**
-   * Reflectively invokes the private {@code updateThumbnailCache} on an uninitialized instance
-   * (skipping the 21-arg public constructor). The validator must run BEFORE any PSServer.getRxDir()
-   * call, so traversal payloads must surface as IllegalArgumentException.
+   * Reflectively invokes the private {@code updateThumbnailCache} on a Mockito shell instance
+   * (constructor skipped). The validator must run BEFORE any PSServer.getRxDir() call, so traversal
+   * payloads must surface as IllegalArgumentException.
    */
   private static void invokeUpdateThumbnailCache(String oldSiteName, String newSiteName)
       throws Exception {
-    Object instance = UNSAFE.allocateInstance(PSSiteDataService.class);
+    PSSiteDataService instance = mock(PSSiteDataService.class);
     try {
       UPDATE_METHOD.invoke(instance, oldSiteName, newSiteName);
     } catch (InvocationTargetException ite) {

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
@@ -64,6 +64,8 @@ class PSWorkflowEditionTaskConcurrencyTest {
 
   /** Simple name must equal {@code CannotAcquireLockException} for exact-name detection. */
   static final class CannotAcquireLockException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     CannotAcquireLockException(String m) {
       super(m);
     }


### PR DESCRIPTION
## Summary

Clears **all 60** `projects/sitemanage` **test-source** project `-Xlint` diagnostics after main-source misc residual (#3107 / open PR #3158). Real fixes preferred; main sources untouched.

### Clusters
| Cluster | Approach |
|---------|----------|
| this-escape REST clients | Final/safe helpers; protected `requestHeaders`/`postContentType` seeds; `PSRestClient(String)` ctor chain; no redundant `fillInStackTrace` |
| serialVersionUID | Nested concurrency/exception stubs + dummy validation exceptions |
| serial-field | `transient` parsed error payloads on REST client exceptions |
| unchecked | `TypeReference` JSON; typed ArgumentCaptor; chained `thenReturn`; typed dao mock |
| heap-pollution | `@SafeVarargs` on `PSTestDataCleaner` |
| sun.misc.Unsafe | Real constructors / Mockito shells for path-injection tests (security asserts preserved) |
| static | `PSThumbnailProcessMonitor.*` qualified by type name |

### Inventory
| Metric | Before | After |
|--------|--------|-------|
| test-source Xlint | **60** | **0** |

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1090**, Failures: **0**, Errors: **0**, Skipped: **125**
- [x] `test-compile -Dmaven.compiler.showWarnings=true` — test-source `[WARNING] *.java:` **0**
- [x] Path-injection suites still reject traversal/NUL/separator payloads
- [x] C2: no production final/signature changes — N/A

## Product documentation
- [x] N/A — pure compiler lint tech debt; no operator/user/API surface change

## Gates / evidence (C3)
- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1090, Failures: 0, Errors: 0, Skipped: 125; test-source Xlint 60→0
- **downstream_checked:** none (C2 did not apply — test-source only; no production final/signature/package API shape changes)
- **C5 UI:** N/A — no UI surface

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent: #2032 / #2200  
Fixes #3159 (sitemanage test-source Xlint residual after #3107).

> Co-Authored by Grok Build using grok-4.5 with agent main.
