### PR TITLE
fix(utils): batch 8 real generics Jexl + PSCollection suppress strip (#3015)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3015-utils-javac-residual-batch8-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3015-utils-javac-residual-batch8-erlang.md
@@ -1,0 +1,61 @@
+# Erlang review: fix/issue-3015-utils-javac-batch8-real-generics
+
+## Summary
+
+Batch 8 residual after utils batch 7 (#2969 / PR #3014). Clears **class-level** suppressions on `PSJexlEvaluator` and `PSCollection` with real generics; hardens `PSConcurrentList` deserialization; consolidates CRTP unchecked sites on `ConfigurationContextAbstract`. Does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API. Module `mvnw clean install` green.
+
+## Scope
+
+- Branch: `fix/issue-3015-utils-javac-batch8-real-generics`
+- Module: `modules/utils` only
+- Parent tracker: #2200 / module #2016 / residual #3015
+- Prior: batch 7 #2969 / PR #3014
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+- No new filesystem path construction or path string handling.
+- Serialization and binder tests use in-memory streams / maps only.
+
+## Change map
+
+| Area | Fix |
+|------|-----|
+| `PSJexlEvaluator` | Real `Map<String,Object>` / `List<Object>` binder path; strip class-level suppress; scoped helpers `asStringObjectMap` / `asMutableObjectList` |
+| `PSCollection` | `extends PSConcurrentList<Object>`; `Class<?>` / `Collection<?>` / `Iterator<?>`; strip class-level rawtypes/unchecked/this-escape suppress |
+| `PSConcurrentList` | `restoreList` with `instanceof List` + `InvalidObjectException`; single scoped unchecked residual |
+| `ConfigurationContextAbstract` | CRTP `self()` + `cloneConfig()` helpers; no multi-site method suppress scatter |
+
+## Behavioral tests
+
+- `PSCollectionTypedTest` (4) — member class, addAll type reject, iterator ctor, capacity ctor
+- `PSConcurrentListSerializationTest` (+2) — restoreList rejects non-list; null → empty
+- Existing `PSJexlEvaluatorTest` binder/eval suite still green
+
+## Residual (intentional — file child)
+
+| Area | Notes |
+|------|-------|
+| `PSWorkflowUtilsBase` raw List/Map API | Source-compat; do **not** reparameterize without explicit policy |
+| `PSXmlSerializationHelper` class rawtypes/unchecked | Serialization helpers; larger redesign |
+| `PSItemIterator` method unchecked | Map value / multi-map Collection casts inherent to `Map<?,?>` |
+| `PSCopier` nested Map-as-V unchecked | Documented method-scoped residual |
+| `PSConcurrentList.restoreList` | Serialization cast residual (scoped) |
+| `ConfigurationContextAbstract` CRTP helpers | `(T) this` / BeanUtils clone residual (scoped) |
+
+## Verification
+
+- `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests: **380** run, **0** failures, **9** skips
+- Grep: monorepo `extends PSCollection` remains product subclasses (TableFactory etc.); no API reparameterization of WorkflowUtilsBase
+
+## Issues
+
+None (bug).

--- a/modules/utils/src/main/java/com/percussion/util/PSCollection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSCollection.java
@@ -25,12 +25,15 @@ import java.util.Objects;
  * The PSCollection class is used to maintain a collection of objects. Objects can be added, changed
  * or removed from the collection. All objects in the collection must be of the same class.
  *
+ * <p>Element type is {@link Object} at the list API surface (historical heterogeneous product use);
+ * runtime membership is still enforced via {@link #m_memberClass}. Parameterized as {@code
+ * PSConcurrentList<Object>} so callers and subclasses no longer sit on a raw concurrent list.
+ *
  * @author Tas Giakouminakis
  * @version 1.0
  * @since 1.0
  */
-@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
-public class PSCollection extends PSConcurrentList {
+public class PSCollection extends PSConcurrentList<Object> {
 
   /**
    * Serialization id. Parent {@link PSConcurrentList} owns list payload serialization; this class
@@ -64,7 +67,8 @@ public class PSCollection extends PSConcurrentList {
    * @param cl the class which this collection's members must be or extend.
    * @param initialCapacity the initial capacity of the collection.
    */
-  public PSCollection(Class cl, int initialCapacity) {
+  public PSCollection(Class<?> cl, int initialCapacity) {
+    super(Object.class, initialCapacity);
     m_memberClass = cl;
   }
 
@@ -75,7 +79,7 @@ public class PSCollection extends PSConcurrentList {
    *     type. May not be <code>null</code>.
    * @throws ClassCastException if all of the objects under the iterator are not of the same type.
    */
-  public PSCollection(Iterator i) throws ClassCastException {
+  public PSCollection(Iterator<?> i) throws ClassCastException {
     m_memberClass = null;
 
     while (i.hasNext()) {
@@ -100,6 +104,7 @@ public class PSCollection extends PSConcurrentList {
    * @param o the object to add to the collection
    * @throws ClassCastException if the object is not of the appropriate class
    */
+  @Override
   public void add(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
@@ -115,6 +120,7 @@ public class PSCollection extends PSConcurrentList {
    * @return <code>true</code> if the object was added, throws ClassCastException otherwise
    * @throws ClassCastException if the object is not of the appropriate class
    */
+  @Override
   public boolean add(Object o) throws ClassCastException {
     checkType(o);
 
@@ -142,7 +148,9 @@ public class PSCollection extends PSConcurrentList {
    * @return <code>true</code> if the collection was added, throws ClassCastException otherwise
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public boolean addAll(Collection c) throws ArrayIndexOutOfBoundsException, ClassCastException {
+  @Override
+  public boolean addAll(Collection<?> c)
+      throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
     return super.addAll(c);
@@ -153,11 +161,13 @@ public class PSCollection extends PSConcurrentList {
    * collection must be of the class or extend the class which was defined at construction of the
    * collection. If the object is of an incorrect type, an exception will be thrown.
    *
+   * @param index the insert position
    * @param c the collection to add to this collection
    * @return <code>true</code> if the collection was added, throws ClassCastException otherwise
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public boolean addAll(int index, Collection c)
+  @Override
+  public boolean addAll(int index, Collection<?> c)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
@@ -175,6 +185,7 @@ public class PSCollection extends PSConcurrentList {
    * @throws ArrayIndexOutOfBoundsException if index is out of range
    * @throws ClassCastException if the object is not of the appropriate class
    */
+  @Override
   public Object set(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
@@ -207,7 +218,7 @@ public class PSCollection extends PSConcurrentList {
    *
    * @return the class type
    */
-  public Class getMemberClassType() {
+  public Class<?> getMemberClassType() {
     return m_memberClass;
   }
 
@@ -223,9 +234,8 @@ public class PSCollection extends PSConcurrentList {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PSCollection)) return false;
-    PSCollection that = (PSCollection) o;
-    return m_memberClass.equals(that.m_memberClass);
+    if (!(o instanceof PSCollection that)) return false;
+    return Objects.equals(m_memberClass, that.m_memberClass);
   }
 
   @Override
@@ -255,10 +265,8 @@ public class PSCollection extends PSConcurrentList {
    * @param c the collection to check
    * @exception ClassCastException if any object in the provided collection is of the wrong type.
    */
-  private void checkType(Collection c) throws ClassCastException {
-    Iterator i = c.iterator();
-    while (i.hasNext()) {
-      Object o = i.next();
+  private void checkType(Collection<?> c) throws ClassCastException {
+    for (Object o : c) {
       if (!(m_memberClass.isInstance(o)))
         throw new ClassCastException(
             "Cannot add an object of class "
@@ -313,5 +321,5 @@ public class PSCollection extends PSConcurrentList {
   }
 
   /** The one and only valid class type for this collection. */
-  private Class m_memberClass;
+  private Class<?> m_memberClass;
 }

--- a/modules/utils/src/main/java/com/percussion/util/PSConcurrentList.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSConcurrentList.java
@@ -18,6 +18,7 @@
 package com.percussion.util;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -107,17 +108,32 @@ public class PSConcurrentList<T> implements List<T>, Serializable {
    * @throws IOException on read failure
    * @throws ClassNotFoundException if an element class is missing
    */
-  @SuppressWarnings("unchecked")
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     readWriteLock = new ReentrantReadWriteLock();
     rentrantLock = new ReentrantLock();
-    Object raw = in.readObject();
+    list = restoreList(in.readObject());
+  }
+
+  /**
+   * Rebuild the backing list from the serialized payload. The stream is trusted to contain a {@link
+   * List} of {@code T} elements written by {@link #writeObject(ObjectOutputStream)}; the single
+   * unchecked cast is inherent to Java generic deserialization and is isolated here.
+   *
+   * @param raw payload from the stream, may be {@code null}
+   * @return a new mutable list, never {@code null}
+   * @throws InvalidObjectException if the payload is present but not a list
+   */
+  @SuppressWarnings("unchecked")
+  private static <E> List<E> restoreList(Object raw) throws InvalidObjectException {
     if (raw == null) {
-      list = new ArrayList<>();
-    } else {
-      list = new ArrayList<>((List<T>) raw);
+      return new ArrayList<>();
     }
+    if (!(raw instanceof List<?>)) {
+      throw new InvalidObjectException(
+          "PSConcurrentList expected List payload, found " + raw.getClass().getName());
+    }
+    return new ArrayList<>((List<E>) raw);
   }
 
   public boolean remove(Object o) {

--- a/modules/utils/src/main/java/com/percussion/utils/container/ConfigurationContextAbstract.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/ConfigurationContextAbstract.java
@@ -71,15 +71,15 @@ public abstract class ConfigurationContextAbstract<
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void load() {
-    load((T) this);
+    // CRTP residual: subclasses are typed as ConfigurationContextAbstract<Self, U>
+    load(self());
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void save() {
-    save((T) this);
+    // CRTP residual: subclasses are typed as ConfigurationContextAbstract<Self, U>
+    save(self());
   }
 
   /**
@@ -87,12 +87,36 @@ public abstract class ConfigurationContextAbstract<
    *
    * @param from the source context to copy from
    */
-  @SuppressWarnings("unchecked")
   public void copyFrom(ConfigurationContextAbstract<T, U> from) {
     try {
-      this.config = (U) BeanUtils.cloneBean(from.getConfig());
+      // BeanUtils.cloneBean returns Object; config type is U by construction of this hierarchy.
+      this.config = cloneConfig(from.getConfig());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * CRTP self-view. Concrete contexts extend {@code ConfigurationContextAbstract<Self, U>} so this
+   * cast is the single residual for load/save without a class-level blanket suppress.
+   *
+   * @return {@code this} as {@code T}
+   */
+  @SuppressWarnings("unchecked")
+  private T self() {
+    return (T) this;
+  }
+
+  /**
+   * Clone a config bean. {@link BeanUtils#cloneBean(Object)} returns {@link Object}; the cast is
+   * scoped here.
+   *
+   * @param source config to clone, never {@code null}
+   * @return cloned config as {@code U}
+   * @throws Exception if BeanUtils fails
+   */
+  @SuppressWarnings("unchecked")
+  private U cloneConfig(U source) throws Exception {
+    return (U) BeanUtils.cloneBean(source);
   }
 }

--- a/modules/utils/src/main/java/com/percussion/utils/jexl/PSJexlEvaluator.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jexl/PSJexlEvaluator.java
@@ -32,9 +32,13 @@ import org.apache.logging.log4j.Logger;
  * the context for use in expressions. After a number of expressions are evaluated using {@link
  * #evaluate(String, IPSScript)} , the results can be extracted by calling {@link #getVars()}.
  *
+ * <p>The binder walks a tree of {@code Map<String, Object>} and {@code List<Object>} values created
+ * on demand. Re-entering an existing node requires a single unchecked cast per node (the graph is
+ * only ever populated with those types by this class); those casts live on private helpers rather
+ * than a class-level blanket suppress.
+ *
  * @author dougrand
  */
-@SuppressWarnings(value = {"unchecked", "rawtypes"})
 public class PSJexlEvaluator {
   /** Commons logger for evaluator */
   private static final Logger log = LogManager.getLogger(PSJexlEvaluator.class);
@@ -185,7 +189,7 @@ public class PSJexlEvaluator {
 
     for (int i = 0; i < components.length; i++) {
       boolean last = (components.length - i) == 1;
-      Object next = null;
+      Object next;
       component = components[i];
       int square = component.indexOf("[");
       index = -1;
@@ -206,7 +210,7 @@ public class PSJexlEvaluator {
       if (!last) {
         next = dereferenceMap(current, component);
         if (index >= 0) {
-          if (next != null && !(next instanceof List)) {
+          if (next != null && !(next instanceof List<?>)) {
             throw new IllegalStateException(
                 "While trying to bind variable "
                     + var
@@ -214,22 +218,22 @@ public class PSJexlEvaluator {
                     + next.getClass().getCanonicalName()
                     + " was found");
           }
-          List nlist = (List) next;
+          List<Object> nlist = asMutableObjectList(next);
           if (nlist == null) {
             nlist = new ArrayList<>();
-            ((Map<String, Object>) current).put(component, nlist);
+            asStringObjectMap(current).put(component, nlist);
           }
-          matchLength((ArrayList<Object>) nlist, index);
+          matchLength(nlist, index);
           next = nlist.get(index);
           if (next == null) {
-            next = new HashMap<>();
+            next = new HashMap<String, Object>();
             nlist.set(index, next);
           }
           current = next;
         } else {
           if (next == null) {
-            next = new HashMap();
-            ((Map) current).put(component, next);
+            next = new HashMap<String, Object>();
+            asStringObjectMap(current).put(component, next);
           }
           current = next;
         }
@@ -238,7 +242,7 @@ public class PSJexlEvaluator {
     // At this point we have either a map, or a map and an index
     if (index >= 0) {
       Object val = dereferenceMap(current, component);
-      if (val != null && !(val instanceof List)) {
+      if (val != null && !(val instanceof List<?>)) {
         throw new IllegalStateException(
             "While trying to bind variable "
                 + var
@@ -246,19 +250,19 @@ public class PSJexlEvaluator {
                 + val.getClass().getCanonicalName()
                 + " was found");
       }
-      ArrayList setval = (ArrayList) val;
+      List<Object> setval = asMutableObjectList(val);
       if (setval == null) {
         setval = new ArrayList<>();
-        ((Map) current).put(component, setval);
+        asStringObjectMap(current).put(component, setval);
       }
       matchLength(setval, index);
       setval.set(index, value);
     } else {
-      if (!(current instanceof Map)) {
+      if (!(current instanceof Map<?, ?>)) {
         log.debug("Did not find a Map when setting component {}", component);
         return;
       }
-      ((Map) current).put(component, value);
+      asStringObjectMap(current).put(component, value);
     }
   }
 
@@ -288,10 +292,10 @@ public class PSJexlEvaluator {
     }
     if (value == null) {
       value = new HashMap<String, Object>();
-    } else if (!(value instanceof Map)) {
+    } else if (!(value instanceof Map<?, ?>)) {
       throw new IllegalStateException("var " + var + " did not evaluate to a Map");
     }
-    Map varmap = (Map) value;
+    Map<String, Object> varmap = asStringObjectMap(value);
     for (Map.Entry<String, Object> binding : bindings.entrySet()) {
       varmap.put(binding.getKey(), binding.getValue());
     }
@@ -299,15 +303,17 @@ public class PSJexlEvaluator {
   }
 
   /**
-   * Make sure that the array list is of the right size
+   * Make sure that the list is of the right size for the given index.
    *
    * @param list list, assumed never <code>null</code>
    * @param index index, assumed zero or positive
    */
-  private static void matchLength(ArrayList list, int index) {
+  private static void matchLength(List<Object> list, int index) {
     if (list.size() > index) return;
 
-    list.ensureCapacity(index + 1);
+    if (list instanceof ArrayList<?> arrayList) {
+      arrayList.ensureCapacity(index + 1);
+    }
     for (int i = list.size(); i <= index; i++) {
       list.add(null);
     }
@@ -321,13 +327,39 @@ public class PSJexlEvaluator {
    * @return the dereferenced value
    */
   private static Object dereferenceMap(Object obj, String component) {
-    if (obj instanceof Map) {
-      obj = ((Map) obj).get(component);
-    } else {
-      throw new IllegalStateException(
-          "Expected map but found " + obj.getClass() + " at component " + component);
+    if (obj instanceof Map<?, ?> map) {
+      return map.get(component);
     }
-    return obj;
+    throw new IllegalStateException(
+        "Expected map but found " + obj.getClass() + " at component " + component);
+  }
+
+  /**
+   * Reinterpret a binder tree node as a mutable {@code Map<String, Object>}. The binder only ever
+   * inserts such maps (or the root {@link #m_vars}); the cast is the single residual needed to
+   * re-enter an existing node without copying.
+   *
+   * @param obj existing map node, never {@code null}
+   * @return the same map typed for mutation
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asStringObjectMap(Object obj) {
+    return (Map<String, Object>) obj;
+  }
+
+  /**
+   * Reinterpret a binder tree list node as a mutable {@code List<Object>}, or {@code null} when the
+   * slot has not been created yet. Same residual contract as {@link #asStringObjectMap(Object)}.
+   *
+   * @param obj existing list node, or {@code null}
+   * @return the same list typed for mutation, or {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  private static List<Object> asMutableObjectList(Object obj) {
+    if (obj == null) {
+      return null;
+    }
+    return (List<Object>) obj;
   }
 
   @Override
@@ -364,8 +396,10 @@ public class PSJexlEvaluator {
     for (String key : data.keySet()) {
       if (key.equals("$rx") || key.equals("$tools")) continue;
       Object value = data.get(key);
-      if (value instanceof Map) {
-        rval.append(bindingsToString((Map) value, prefix.length() > 0 ? prefix + "." + key : key));
+      if (value instanceof Map<?, ?>) {
+        rval.append(
+            bindingsToString(
+                asStringObjectMap(value), prefix.length() > 0 ? prefix + "." + key : key));
       } else {
         if (prefix.length() > 0) {
           rval.append(prefix);

--- a/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link PSCollection} after parameterizing as {@code
+ * PSConcurrentList<Object>} with {@code Class<?>}/{@code Collection<?>}/{@code Iterator<?>}
+ * surfaces (#3015 batch 8).
+ */
+@Tag("UnitTest")
+public class PSCollectionTypedTest {
+
+  @Test
+  public void memberClassAndElementsRoundTripThroughObjectListApi() {
+    PSCollection coll = new PSCollection(String.class);
+    assertEquals(String.class, coll.getMemberClassType());
+    assertTrue(coll.add("a"));
+    coll.add(0, "b");
+    assertEquals(Arrays.asList("b", "a"), List.copyOf(coll));
+    assertEquals("b", coll.set(0, "c"));
+    assertEquals("c", coll.get(0));
+  }
+
+  @Test
+  public void addAllRejectsWrongElementType() {
+    PSCollection coll = new PSCollection(String.class);
+    coll.add("ok");
+    List<Object> mixed = new ArrayList<>();
+    mixed.add("fine");
+    mixed.add(Integer.valueOf(1));
+    assertThrows(ClassCastException.class, () -> coll.addAll(mixed));
+    assertEquals(1, coll.size());
+  }
+
+  @Test
+  public void iteratorCtorInfersMemberClass() {
+    Iterator<String> it = Arrays.asList("x", "y").iterator();
+    PSCollection coll = new PSCollection(it);
+    assertEquals(String.class, coll.getMemberClassType());
+    assertEquals(2, coll.size());
+    assertEquals("x", coll.get(0));
+    assertThrows(ClassCastException.class, () -> coll.add(Integer.valueOf(3)));
+  }
+
+  @Test
+  public void initialCapacityCtorStillEnforcesType() {
+    PSCollection coll = new PSCollection(Integer.class, 8);
+    assertTrue(coll.add(Integer.valueOf(1)));
+    assertThrows(ClassCastException.class, () -> coll.add("nope"));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
@@ -17,15 +17,20 @@
 package com.percussion.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
@@ -97,6 +102,25 @@ public class PSConcurrentListSerializationTest {
     // Type guard still works after deserialization
     restored.add("three");
     assertEquals(3, restored.size());
+  }
+
+  @Test
+  public void testRestoreListRejectsNonListPayload() throws Exception {
+    Method restore = PSConcurrentList.class.getDeclaredMethod("restoreList", Object.class);
+    restore.setAccessible(true);
+    InvocationTargetException thrown =
+        assertThrows(InvocationTargetException.class, () -> restore.invoke(null, "not-a-list"));
+    assertInstanceOf(InvalidObjectException.class, thrown.getCause());
+  }
+
+  @Test
+  public void testRestoreListAcceptsNullAsEmpty() throws Exception {
+    Method restore = PSConcurrentList.class.getDeclaredMethod("restoreList", Object.class);
+    restore.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Object> empty = (List<Object>) restore.invoke(null, new Object[] {null});
+    assertNotNull(empty);
+    assertTrue(empty.isEmpty());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Partial implement for **#3015** (modules/utils javac residual after batch 7) — **batch 8** real **generics** cluster (no new blanket suppressions; does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API).

| Area | Fix |
|------|-----|
| `PSJexlEvaluator` | Real `Map<String,Object>` / `List<Object>` binder path; strip class-level suppress; scoped helpers `asStringObjectMap` / `asMutableObjectList` |
| `PSCollection` | `extends PSConcurrentList<Object>`; `Class<?>` / `Collection<?>` / `Iterator<?>`; strip class-level rawtypes/unchecked/this-escape suppress |
| `PSConcurrentList` | `restoreList` with `instanceof List` + `InvalidObjectException`; single scoped unchecked residual |
| `ConfigurationContextAbstract` | CRTP `self()` + `cloneConfig()` helpers; no multi-site method suppress scatter |

**Not changed (by design):** `PSWorkflowUtilsBase` raw public API; `PSXmlSerializationHelper` class suppress; `PSItemIterator` / `PSCopier` inherent casts; scoped serialization/CRTP residuals remaining on helpers.

Parent module: **#2016**. Tracker: **#2200**. Residual after this batch: **#3172**.

## Test plan

- [x] Standalone `modules/utils`: `cd modules/utils && ..\..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Suite: **380** tests, **0** failures (9 pre-existing skips)
- [x] New tests: `PSCollectionTypedTest` (4); `PSConcurrentListSerializationTest` restoreList (+2)
- [x] Existing `PSJexlEvaluatorTest` binder suite green

## Product documentation

- [x] N/A — pure compiler hygiene / non-product-facing tech-debt (no operator, admin, integrator, or end-user behavior change)

## Gates evidence (C3)

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 380, Failures: 0, Errors: 0, Skipped: 9
- **downstream_checked:** grepped monorepo for `extends PSCollection` — product subclasses (TableFactory etc.) remain source-compatible (`PSCollection` still non-generic public type, now `PSConcurrentList<Object>`); no public WorkflowUtilsBase signature change; `getMemberClassType()` returns `Class<?>` (erasure-compatible)
- Erlang-style self-review: approve — `docs/ai-generated/code-reviews/issue-3015-utils-javac-residual-batch8-erlang.md`
- C5 UI proof: N/A (no UI surface)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #3015. Parent: #2016. Tracker: #2200. Residual: #3172.

Fixes partial #3015

> Co-Authored by Grok Build using grok-4.5 with agent main.
