### PR TITLE
cluster(night): ObjectStoreErrorCodes deployer slices 1–3 thrash absorb (#3166 #3167 #3168)

### DIFF
--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- Direct ObjectStoreErrorCodes imports (typed IPSObjectStoreErrors peers) -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
             <artifactId>tablefactory</artifactId>

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
@@ -18,7 +18,7 @@ package com.percussion.deployer.catalog;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -175,7 +175,7 @@ public final class PSCatalogResult implements IPSDeployComponent, Comparable<PSC
     // make sure we got the correct root node tag
     if (false == XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -194,7 +194,7 @@ public final class PSCatalogResult implements IPSDeployComponent, Comparable<PSC
       Element column = tree.getNextElement(XML_COLUMN_NODE, firstFlags);
       if (column == null) {
         Object[] args = {XML_COLUMNS_NODE, XML_COLUMN_NODE, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       while (column != null) {
@@ -208,12 +208,12 @@ public final class PSCatalogResult implements IPSDeployComponent, Comparable<PSC
           } else {
             Object[] args = {XML_COLUMNS_NODE, XML_COLUMN_NODE, data};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         } else {
           Object[] args = {XML_COLUMNS_NODE, XML_COLUMN_NODE, typeString};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         column = tree.getNextElement(XML_COLUMN_NODE, nextFlags);
       }

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.catalog;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import java.util.Date;
 import java.util.HashMap;
@@ -157,7 +157,7 @@ public final class PSCatalogResultColumn implements IPSDeployComponent {
     // make sure we got the correct root node tag
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_name = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_NAME_ATTR);
@@ -165,7 +165,7 @@ public final class PSCatalogResultColumn implements IPSDeployComponent {
     m_type = getType(type);
     if (m_type == TYPE_UNKNOWN) {
       Object[] args = {sourceNode, XML_TYPE_ATTR, type};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultSet.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultSet.java
@@ -17,7 +17,7 @@
 package com.percussion.deployer.catalog;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -80,7 +80,7 @@ public final class PSCatalogResultSet implements IPSDeployComponent {
     // make sure we got the correct root node tag
     if (false == XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -95,7 +95,7 @@ public final class PSCatalogResultSet implements IPSDeployComponent {
       Element resultColumn = tree.getNextElement(PSCatalogResultColumn.XML_NODE_NAME, firstFlags);
       if (resultColumn == null) {
         Object[] args = {XML_COLUMN_META, PSCatalogResultColumn.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       var catalogResultColumns = new ArrayList<PSCatalogResultColumn>();
       while (resultColumn != null) {
@@ -114,7 +114,7 @@ public final class PSCatalogResultSet implements IPSDeployComponent {
         m_results.add(result);
       } else {
         throw new PSUnknownNodeTypeException(
-            IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+            ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
             new Object[] {XML_NODE_NAME, PSCatalogResult.XML_NODE_NAME, "invalid column data"});
       }
       catalogResult = tree.getNextElement(PSCatalogResult.XML_NODE_NAME, nextFlags);

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
@@ -38,7 +38,7 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.objectstore.PSUserDependency;
 import com.percussion.deployer.objectstore.PSValidationResults;
 import com.percussion.deployer.server.PSDeploymentHandler;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSFeatureSet;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -1651,7 +1651,7 @@ public class PSDeploymentManager {
       } catch (NumberFormatException e) {
         Object[] msgArgs = {respRoot.getTagName(), statusAttr, strStatus};
         PSUnknownNodeTypeException une =
-            new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+            new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
         throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
@@ -1699,7 +1699,7 @@ public class PSDeploymentManager {
       } catch (NumberFormatException e) {
         Object[] msgArgs = {respRoot.getTagName(), resultAttr, strResult};
         PSUnknownNodeTypeException une =
-            new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+            new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
         throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
@@ -1830,7 +1830,7 @@ public class PSDeploymentManager {
       } catch (NumberFormatException e) {
         Object[] msgArgs = {root.getTagName(), idAttr, strId};
         PSUnknownNodeTypeException une =
-            new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+            new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, root.getTagName(), une.getLocalizedMessage()};
         throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySetting.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySetting.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -102,7 +102,7 @@ public abstract class PSAppPolicySetting implements IPSDeployComponent {
 
     if (!xmlNodeName.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {xmlNodeName, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySettings.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSAppPolicySettings.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -101,7 +101,7 @@ public final class PSAppPolicySettings implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
@@ -20,7 +20,7 @@ package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIDContextFactory;
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIdContext;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -238,7 +238,7 @@ public final class PSApplicationIDTypeMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -258,7 +258,7 @@ public final class PSApplicationIDTypeMapping implements IPSDeployComponent {
     var ctxEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (ctxEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, "ANY", "null"});
     }
     m_ctx = PSApplicationIDContextFactory.fromXml(ctxEl);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIdContext;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -538,7 +538,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -546,7 +546,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     Element depEl = tree.getNextElement(FIRST_FLAGS);
     String expected = "PSXDeployableElement | PSXDeployableObject";
     if (depEl == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, expected);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, expected);
 
     String nodeName = depEl.getNodeName();
     if (nodeName.equals(PSDeployableElement.XML_NODE_NAME)) m_dep = new PSDeployableElement(depEl);
@@ -554,7 +554,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
       m_dep = new PSDeployableObject(depEl);
     else {
       Object[] args = {expected, nodeName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     tree.setCurrent(sourceNode); // roll back to the root
@@ -718,7 +718,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // need to have at least one
     if (elemEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_MAPPING_ELEMENT);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_MAPPING_ELEMENT);
     }
     Map<String, List<PSApplicationIDTypeMapping>> elemMap = new HashMap<>();
 
@@ -747,7 +747,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // need to have at least one
     if (mappingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSApplicationIDTypeMapping.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSApplicationIDTypeMapping.XML_NODE_NAME);
     }
     List<PSApplicationIDTypeMapping> mappingList = new ArrayList<>();
 
@@ -777,7 +777,7 @@ public final class PSApplicationIDTypes implements IPSDeployComponent {
     // must have at least one filter
     Element filterEl = tree.getNextElement(XML_NODE_FILTER, FIRST_FLAGS);
     if (filterEl == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_FILTER);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_FILTER);
     }
 
     while (filterEl != null) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.utils.collections.PSMapUtils;
@@ -177,7 +177,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -190,7 +190,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     Element descEl = tree.getNextElement(PSExportDescriptor.XML_NODE_NAME, firstFlags);
     if (descEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSExportDescriptor.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSExportDescriptor.XML_NODE_NAME);
     }
     m_exportDescriptor = new PSExportDescriptor(descEl);
 
@@ -202,7 +202,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     Element mapEl = tree.getNextElement(XML_EL_DBMS_INFO_MAP, firstFlags);
     if (mapEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAP);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAP);
     }
 
     // walk the mappings
@@ -210,7 +210,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
     // need to have at least one
     if (mappingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAPPING);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DBMS_INFO_MAPPING);
     }
 
     while (mappingEl != null) {
@@ -221,7 +221,7 @@ public final class PSArchiveDetail implements IPSDeployComponent {
       List<PSDatasourceMap> dbmsList = m_externalDbmsMap.get(pkgKey);
       if (dbmsList == null) {
         Object[] args = {XML_EL_DBMS_INFO_MAPPING, XML_ATTR_PKGKEY, pkgKey};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // restore each dbms info and add to that map entry's list

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveInfo.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.system.utils.PSFormatVersion;
@@ -279,7 +279,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -302,7 +302,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSFormatVersion.NODE_TYPE));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSFormatVersion.NODE_TYPE));
     m_serverInfo = PSFormatVersion.createFromXml(serverInfoEl);
 
     var repositoryEl =
@@ -313,7 +313,7 @@ public final class PSArchiveInfo implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDbmsInfo.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDbmsInfo.XML_NODE_NAME));
     m_repository = new PSDbmsInfo(repositoryEl);
 
     var detailEl =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -224,7 +224,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_depMap.clear(); // initialize internal data.
@@ -384,7 +384,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
 
       if (!XML_CHILD_NODE.equals(sourceNode.getNodeName())) {
         Object[] args = {XML_CHILD_NODE, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
       m_key = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_CHILD_NODE_ATTR);
 
@@ -399,7 +399,7 @@ public final class PSArchiveManifest implements IPSDeployComponent {
       if (childEl == null) // no child element
       {
         Object[] args = {XML_CHILD_NODE + " DependencyKey=\"" + m_key + "\"", "first", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (childEl != null) {
         if (childEl.getNodeName().equals(PSApplicationIDTypes.XML_NODE_NAME)) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -174,7 +174,7 @@ public final class PSArchivePackage implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode should not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_name = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_NAME);
     m_type = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.util.PSDateFormatISO8601;
@@ -209,7 +209,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     // get the attributes
     m_id = Integer.parseInt(PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_ID));
@@ -219,7 +219,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     m_installDate = dateFormat.parse(sDate, new ParsePosition(0));
     if (m_installDate == null) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_INSTALL_DATE, sDate};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get the child elements
@@ -229,7 +229,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     Element childEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (childEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME);
     }
     m_archiveInfo = new PSArchiveInfo(childEl);
 
@@ -238,7 +238,7 @@ public final class PSArchiveSummary implements IPSDeployComponent {
     childEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
     if (childEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchivePackage.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchivePackage.XML_NODE_NAME);
     }
     while (childEl != null && childEl.getNodeName().equals(PSArchivePackage.XML_NODE_NAME)) {
       m_packageList.add(new PSArchivePackage(childEl));

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDatasourceMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDatasourceMap.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import java.util.Objects;
 import java.util.Optional;
@@ -129,7 +129,7 @@ public final class PSDatasourceMap implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode should not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_srcDataSource =
         PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SOURCE_DATASRC);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsInfo.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore;
 
 import com.percussion.deployer.server.PSDbmsHelper;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.legacy.security.deprecated.PSCryptographer;
@@ -383,7 +383,7 @@ public final class PSDbmsInfo implements IPSDeployComponent {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     var tree = new PSXmlTreeWalker(sourceNode);
     String ds;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -162,7 +162,7 @@ public final class PSDbmsMap implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -149,7 +149,7 @@ public final class PSDbmsMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -161,7 +161,7 @@ public final class PSDbmsMapping implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDatasourceMap.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDatasourceMap.XML_NODE_NAME));
 
     m_datasrcMap = new PSDatasourceMap(srcEl);
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.services.system.IPSDependencyBaseline;
@@ -1174,7 +1174,7 @@ public abstract class PSDependency
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // static helper — avoid overridable getRequiredAttribute this-escape from Element ctor
@@ -1186,7 +1186,7 @@ public abstract class PSDependency
     }
     if (m_dependencyType == -1) {
       Object[] args = {sourceNode.getTagName(), XML_ATT_DEPENDENCY_TYPE, sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_dependencyId =
@@ -1242,7 +1242,7 @@ public abstract class PSDependency
             PSDeployableElement.XML_NODE_NAME + ", " + PSDeployableObject.XML_NODE_NAME,
             dep.getNodeName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
         }
         m_dependencies.add(depObj);
         depObj.setParentDependency(this); // support a doubly-linked list
@@ -1267,7 +1267,7 @@ public abstract class PSDependency
             PSDeployableElement.XML_NODE_NAME + ", " + PSDeployableObject.XML_NODE_NAME,
             dep.getNodeName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
         }
         m_ancestors.add(depObj);
         dep = tree.getNextElement(nextFlags);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcTableData;
@@ -155,7 +155,7 @@ public final class PSDependencyData implements IPSDeployComponent {
       m_data = new PSJdbcTableData(dataEl);
     } catch (PSJdbcTableFactoryException e) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, e.getMessage()});
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -179,7 +179,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -194,7 +194,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
     }
     if (m_type == UNDEFINED) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {sourceNode.getTagName(), XML_ATTR_FILE_TYPE, fileTypeAttr});
     }
 
@@ -209,7 +209,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
         PSDeployComponentUtils.getRequiredElement(tree, XML_NODE_NAME, XML_EL_ARCHIVE_FILE, false);
     if (archiveLocation.trim().isEmpty()) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, XML_EL_ARCHIVE_FILE, "null"});
     }
     m_archiveLocation = new File(archiveLocation);
@@ -222,7 +222,7 @@ public final class PSDependencyFile implements IPSDeployComponent {
       String origPath = PSXmlTreeWalker.getElementData(origFileEl);
       if (origPath == null || origPath.trim().isEmpty()) {
         throw new PSUnknownNodeTypeException(
-            IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+            ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
             new Object[] {XML_NODE_NAME, XML_EL_ORIG_FILE, "null"});
       }
       m_originalFile = new File(PSDeployComponentUtils.getNormalizedPath(origPath));

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployComponentUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployComponentUtils.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -64,7 +64,7 @@ public class PSDeployComponentUtils {
     String val = source.getAttribute(attName);
     if (val == null || val.trim().length() == 0) {
       Object[] args = {source.getTagName(), attName, "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     return val;
@@ -97,7 +97,7 @@ public class PSDeployComponentUtils {
     String temp = tree.getElementData(node);
     if (temp == null || (notEmpty && temp.trim().length() == 0)) {
       Object[] args = {parent, node, temp == null ? "null" : temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     return temp;
@@ -140,7 +140,7 @@ public class PSDeployComponentUtils {
     Element element = tree.getNextElement(flags);
 
     if (element == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, nodeName);
     }
     return element;
   }
@@ -189,7 +189,7 @@ public class PSDeployComponentUtils {
       if (!found) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return index;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -190,7 +190,7 @@ public final class PSDeployableElement extends PSDependency {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);
@@ -198,7 +198,7 @@ public final class PSDeployableElement extends PSDependency {
         tree.getNextElement(PSDependency.XML_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (dep == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
     // final helper — avoid overridable super.fromXml this-escape from Element ctor
     restoreDependencyFromXml(dep);
@@ -207,7 +207,7 @@ public final class PSDeployableElement extends PSDependency {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_DESC));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_DESC));
   }
 
   // see IPSDeployComponent

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -187,7 +187,7 @@ public class PSDeployableObject extends PSDependency {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);
@@ -195,7 +195,7 @@ public class PSDeployableObject extends PSDependency {
         tree.getNextElement(PSDependency.XML_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (dep == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
     // final helper — avoid overridable super.fromXml this-escape from Element ctor
     restoreDependencyFromXml(dep);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -115,7 +115,7 @@ public final class PSDeploymentServerConnectionInfo implements IPSDeployComponen
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.rx.config.IPSConfigService;
@@ -200,7 +200,7 @@ public abstract class PSDescriptor implements IPSDeployComponent {
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
     var tree = new PSXmlTreeWalker(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -323,7 +323,7 @@ public final class PSExportDescriptor extends PSDescriptor {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -341,14 +341,14 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element descEl = tree.getNextElement(PSDescriptor.XML_NODE_NAME, firstFlags);
     if (descEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME);
     }
     super.fromXml(descEl);
 
     // restore packages
     Element packagesEl = tree.getNextElement(XML_EL_PACKAGES, nextFlags);
     if (packagesEl == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_PACKAGES);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_PACKAGES);
     }
 
     m_packages.clear();
@@ -364,7 +364,7 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element modsEl = tree.getNextElement(XML_EL_MODIFIED_PACKAGES, nextFlags);
     if (modsEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_MODIFIED_PACKAGES);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_MODIFIED_PACKAGES);
     }
     Element modName = tree.getNextElement(XML_EL_PACKAGE_NAME, firstFlags);
     while (modName != null) {
@@ -379,7 +379,7 @@ public final class PSExportDescriptor extends PSDescriptor {
     Element missingEl = tree.getNextElement(XML_EL_MISSING_PACKAGES, nextFlags);
     if (missingEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_EL_MISSING_PACKAGES);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_EL_MISSING_PACKAGES);
     }
     Element missingName = tree.getNextElement(XML_EL_PACKAGE_NAME, firstFlags);
     while (missingName != null) {

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
@@ -445,7 +445,7 @@ public final class PSIdMap implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_sourceServer = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SRC_SERVER);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMapping.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -386,7 +386,7 @@ public final class PSIdMapping implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_sourceId = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_SRC_ID);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportDescriptor.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -185,7 +185,7 @@ public final class PSImportDescriptor extends PSDescriptor {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -197,7 +197,7 @@ public final class PSImportDescriptor extends PSDescriptor {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDescriptor.XML_NODE_NAME));
     super.fromXml(descEl);
 
     var archiveInfoEl =
@@ -207,7 +207,7 @@ public final class PSImportDescriptor extends PSDescriptor {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSArchiveInfo.XML_NODE_NAME));
     m_archiveInfo = new PSArchiveInfo(archiveInfoEl);
 
     m_packages.clear();

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -122,7 +122,7 @@ public final class PSImportPackage implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -134,7 +134,7 @@ public final class PSImportPackage implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSImportPackage.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSImportPackage.XML_NODE_NAME));
     m_pkg = new PSDeployableElement(pkgEl);
 
     var valEl =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -134,7 +134,7 @@ public final class PSLogDetail implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -145,7 +145,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDbmsMap.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDbmsMap.XML_NODE_NAME));
     m_dbmsMap = new PSDbmsMap(dbmsEl);
 
     var txnEl =
@@ -153,7 +153,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL,
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL,
                         PSTransactionLogSummary.XML_NODE_NAME));
     m_txnLog = new PSTransactionLogSummary(txnEl);
 
@@ -162,7 +162,7 @@ public final class PSLogDetail implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSValidationResults.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSValidationResults.XML_NODE_NAME));
     m_validationResults = new PSValidationResults(valEl);
 
     var idEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
@@ -179,7 +179,7 @@ public final class PSLogDetail implements IPSDeployComponent {
   private void checkNullXmlELement(Element element, String nodeName)
       throws PSUnknownNodeTypeException {
     if (element == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, nodeName);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -175,7 +175,7 @@ public final class PSLogSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -99,7 +99,7 @@ public final class PSTransactionLogSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -153,7 +153,7 @@ public final class PSTransactionSummary implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -168,7 +168,7 @@ public final class PSTransactionSummary implements IPSDeployComponent {
 
     if (!validateElementType(m_elementType) || !isActionValid(m_action)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_EL_TYPE, m_elementType});
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSUserDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSUserDependency.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -182,7 +182,7 @@ public final class PSUserDependency extends PSDeployableObject {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -199,7 +199,7 @@ public final class PSUserDependency extends PSDeployableObject {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDeployableObject.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDeployableObject.XML_NODE_NAME));
     super.fromXml(dep);
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Collections;
@@ -177,7 +177,7 @@ public final class PSValidationResult implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -186,7 +186,7 @@ public final class PSValidationResult implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {sourceNode.getTagName(), XML_ATTR_MSG, "null"}));
 
     m_isError = getRequiredBoolAttr(sourceNode, XML_ATTR_IS_ERROR);
@@ -199,7 +199,7 @@ public final class PSValidationResult implements IPSDeployComponent {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME));
+                        ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME));
 
     switch (depEl.getNodeName()) {
       case PSDeployableObject.XML_NODE_NAME -> m_dep = new PSDeployableObject(depEl);
@@ -207,7 +207,7 @@ public final class PSValidationResult implements IPSDeployComponent {
       case PSUserDependency.XML_NODE_NAME -> m_dep = new PSUserDependency(depEl);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {
                 "(PSXDeployableElement | PSXDeployableObject | PSXUserDependency)",
                 depEl.getNodeName()

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -160,7 +160,7 @@ public final class PSValidationResults implements IPSDeployComponent {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppCEItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppCEItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Optional;
@@ -116,7 +116,7 @@ public final class PSAppCEItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -129,7 +129,7 @@ public final class PSAppCEItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppConditionalIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppConditionalIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -212,7 +212,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -225,7 +225,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 
@@ -233,7 +233,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
     var condEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (condEl == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
           new Object[] {XML_NODE_NAME, "null", "null"});
     }
 
@@ -242,7 +242,7 @@ public final class PSAppConditionalIdContext extends PSApplicationIdContext {
       case PSWhereClause.ms_NodeType -> m_cond = new PSWhereClause(condEl, null, null);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {PSConditional.ms_NodeType, condEl.getNodeName()});
     }
     m_origCond = (PSConditional) m_cond.clone();

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDataMappingIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDataMappingIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSDataMapping;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -206,7 +206,7 @@ public final class PSAppDataMappingIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -222,7 +222,7 @@ public final class PSAppDataMappingIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDisplayMapperIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppDisplayMapperIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -129,7 +129,7 @@ public final class PSAppDisplayMapperIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -139,7 +139,7 @@ public final class PSAppDisplayMapperIdContext extends PSApplicationIdContext {
       m_id = Integer.parseInt(strId);
     } catch (NumberFormatException e) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_ID, strId});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppEntryIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppEntryIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -142,7 +142,7 @@ public final class PSAppEntryIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -152,7 +152,7 @@ public final class PSAppEntryIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
     m_entry = new PSEntry(entryEl, null, null);
     m_origEntry = m_entry;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionCallIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionCallIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -154,7 +154,7 @@ public final class PSAppExtensionCallIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -169,7 +169,7 @@ public final class PSAppExtensionCallIdContext extends PSApplicationIdContext {
 
     if (!validateIndex(m_index) && strIndex != null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionParamIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppExtensionParamIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSAbstractParamValue;
 import com.percussion.design.objectstore.PSExtensionParamValue;
@@ -182,7 +182,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -194,7 +194,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     m_paramName =
@@ -208,7 +208,7 @@ public final class PSAppExtensionParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
 
     m_param =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppIndexedItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppIndexedItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -133,7 +133,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -145,7 +145,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     var strType = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_TYPE);
@@ -161,7 +161,7 @@ public final class PSAppIndexedItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(typeVal)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
     m_type = typeVal;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppNamedItemIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppNamedItemIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -151,7 +151,7 @@ public final class PSAppNamedItemIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -165,7 +165,7 @@ public final class PSAppNamedItemIdContext extends PSApplicationIdContext {
     }
     if (!validateType(m_type)) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_TYPE, strType});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUISetIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUISetIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUISet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -120,7 +120,7 @@ public final class PSAppUISetIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUrlRequestIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSAppUrlRequestIdContext.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -158,7 +158,7 @@ public final class PSAppUrlRequestIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIDContextFactory.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIDContextFactory.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore.idtypes;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Element;
 
@@ -60,7 +60,7 @@ public class PSApplicationIDContextFactory {
       case PSBindingIdContext.XML_NODE_NAME -> new PSBindingIdContext(sourceNode);
       default ->
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+              ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
               new Object[] {"PSXApplicationIDContext", nodeName});
     };
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingIdContext.java
@@ -18,7 +18,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.text.MessageFormat;
@@ -182,7 +182,7 @@ public final class PSBindingIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -203,7 +203,7 @@ public final class PSBindingIdContext extends PSApplicationIdContext {
 
     if (!validateIndex(m_index) && strIndex != null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
           new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex});
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingParamIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSBindingParamIdContext.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.objectstore.idtypes;
 
 import com.percussion.deployer.objectstore.IPSDeployComponent;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -201,7 +201,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE,
+          ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE,
           new Object[] {XML_NODE_NAME, sourceNode.getNodeName()});
     }
 
@@ -213,7 +213,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_INDEX, strIndex}));
 
     var strOccur = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_OCCUR);
@@ -224,7 +224,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR,
                         new Object[] {XML_NODE_NAME, XML_ATTR_OCCUR, strOccur}));
 
     m_paramName =
@@ -238,7 +238,7 @@ public final class PSBindingParamIdContext extends PSApplicationIdContext {
             .orElseThrow(
                 () ->
                     new PSUnknownNodeTypeException(
-                        IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+                        ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
                         new Object[] {XML_NODE_NAME, "null", "null"}));
     m_param = new PSTextLiteral(paramEl, null, null);
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDependencyDef.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDependencyDef.java
@@ -18,7 +18,7 @@
 package com.percussion.deployer.server;
 
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -118,7 +118,7 @@ public class PSDependencyDef {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       var args = new Object[] {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_objectType = PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATTR_OBJECT_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDependencyMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDependencyMap.java
@@ -19,7 +19,7 @@ package com.percussion.deployer.server;
 
 import com.percussion.cms.IPSConstants;
 import com.percussion.deployer.server.dependencies.PSDependencyHandler;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
@@ -98,7 +98,7 @@ public final class PSDependencyMap {
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
@@ -44,7 +44,7 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.objectstore.PSUserDependency;
 import com.percussion.deployer.server.uninstall.IPSUninstallResult;
 import com.percussion.deployer.server.uninstall.PSPackageUninstaller;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSFeatureSet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -241,7 +241,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (type == null || type.trim().length() == 0) {
       Object[] msgArgs = {root.getTagName(), "type", ""};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
       throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
@@ -536,7 +536,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (idTypeEl == null) {
       Object[] msgArgs = {PSApplicationIDTypes.XML_NODE_NAME};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, msgArgs);
 
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
@@ -683,7 +683,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       if (infoEl == null) {
         Object[] msgArgs = {PSArchiveInfo.XML_NODE_NAME};
         PSUnknownNodeTypeException une =
-            new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, msgArgs);
+            new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, msgArgs);
 
         Object[] args = {
           doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
@@ -1090,7 +1090,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (attrValue == null || attrValue.trim().length() == 0) {
       Object[] msgArgs = {root.getTagName(), attrName, ""};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
       throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
@@ -1270,7 +1270,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       Element root = req.getInputDocument().getDocumentElement();
       Object[] msgArgs = {root.getTagName(), attrName, sNumber};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
       throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
@@ -1560,7 +1560,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (compEl == null) {
       Object[] msgArgs = {xmlNodeName};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, msgArgs);
 
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
@@ -2515,7 +2515,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       // wrap exception
       Object[] args = {PSExceptionUtils.getMessageForLog(e)};
       PSServerException se =
-          new PSServerException(IPSObjectStoreErrors.FEATURE_SET_LOAD_EXCEPTION, args);
+          new PSServerException(ObjectStoreErrorCodes.FEATURE_SET_LOAD_EXCEPTION.numericCode(), args);
       throw new PSDeployException(se);
     } finally {
       if (fIn != null)
@@ -3032,7 +3032,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       String badEl = depEl == null ? "null" : depEl.getTagName();
       Object[] msgArgs = {PSDependency.XML_NODE_NAME, badEl};
       PSUnknownNodeTypeException une =
-          new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, msgArgs);
+          new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, msgArgs);
 
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)

--- a/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogTypedErrorCodeSlice3Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogTypedErrorCodeSlice3Test.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3165 (parent #3149 slice 3): deployer catalog call sites must throw typed {@link
+ * ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare {@code
+ * IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerCatalogTypedErrorCodeSlice3Test {
+
+  @Test
+  public void catalogResultWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCatalogResult");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSCatalogResult(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void catalogResultColumnWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCatalogResultColumn");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSCatalogResultColumn(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void catalogResultColumnInvalidTypeAttrUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, PSCatalogResultColumn.XML_NODE_NAME);
+    el.setAttribute("name", "col1");
+    el.setAttribute("type", "not-a-real-type");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSCatalogResultColumn(el));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void catalogResultSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCatalogResultSet");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSCatalogResultSet(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDeployerObjectstoreTypedErrorCodeSlice1Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDeployerObjectstoreTypedErrorCodeSlice1Test.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import com.percussion.xml.PSXmlTreeWalker;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3163 (parent #3149 slice 1): deployer objectstore (non-idtypes) call sites must throw
+ * typed {@link ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare
+ * {@code IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerObjectstoreTypedErrorCodeSlice1Test {
+
+  @Test
+  public void archivePackageWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotArchivePackage");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSArchivePackage(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void datasourceMapWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDatasourceMap");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDatasourceMap(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployComponentUtilsRequiredAttributeUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, "PSXTest");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> PSDeployComponentUtils.getRequiredAttribute(el, "missingAttr"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployComponentUtilsNextRequiredElementUsesTypedNull() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXParent");
+    PSXmlTreeWalker tree = new PSXmlTreeWalker(root);
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () ->
+                PSDeployComponentUtils.getNextRequiredElement(
+                    tree, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN, "ExpectedChild"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void deployableObjectWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDeployableObject");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDeployableObject(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.objectstore.idtypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3164 (parent #3149 slice 2): deployer objectstore idtypes call sites must throw typed
+ * {@link ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare {@code
+ * IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test {
+
+  @Test
+  public void uiSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotUISetIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppUISetIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void ceItemWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCEItemIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppCEItemIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void ceItemInvalidTypeAttrUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, PSAppCEItemIdContext.XML_NODE_NAME);
+    el.setAttribute("type", "not-a-valid-ce-item-type");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppCEItemIdContext(el));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void factoryUnknownNodeUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "PSXNotAnIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> PSApplicationIDContextFactory.fromXml(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void namedItemInvalidTypeAttrUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = PSXmlDocumentBuilder.createRoot(doc, PSAppNamedItemIdContext.XML_NODE_NAME);
+    el.setAttribute("name", "someName");
+    el.setAttribute("type", "not-a-valid-named-item-type");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppNamedItemIdContext(el));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test.java
@@ -92,4 +92,84 @@ public class PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test {
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
   }
+
+  @Test
+  public void namedItemWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotNamedItemIdContext");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSAppNamedItemIdContext(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void conditionalWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppConditionalIdContext(wrong));
+  }
+
+  @Test
+  public void dataMappingWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppDataMappingIdContext(wrong));
+  }
+
+  @Test
+  public void displayMapperWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppDisplayMapperIdContext(wrong));
+  }
+
+  @Test
+  public void entryWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppEntryIdContext(wrong));
+  }
+
+  @Test
+  public void extensionCallWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppExtensionCallIdContext(wrong));
+  }
+
+  @Test
+  public void extensionParamWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppExtensionParamIdContext(wrong));
+  }
+
+  @Test
+  public void indexedItemWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppIndexedItemIdContext(wrong));
+  }
+
+  @Test
+  public void urlRequestWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSAppUrlRequestIdContext(wrong));
+  }
+
+  @Test
+  public void bindingWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSBindingIdContext(wrong));
+  }
+
+  @Test
+  public void bindingParamWrongRootUsesTypedWrongType() throws Exception {
+    assertWrongRootTyped(wrong -> new PSBindingParamIdContext(wrong));
+  }
+
+  /**
+   * Wrong-root path for each remaining idtypes context: constructor must throw typed {@link
+   * ObjectStoreErrorCodes#XML_ELEMENT_WRONG_TYPE}, not a bare int code.
+   */
+  private static void assertWrongRootTyped(XmlCtor ctor) throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAnIdtypesContextRoot");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> ctor.construct(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @FunctionalInterface
+  private interface XmlCtor {
+    void construct(Element el) throws PSUnknownNodeTypeException;
+  }
 }

--- a/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerTypedErrorCodeSlice3Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerTypedErrorCodeSlice3Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3165 (parent #3149 slice 3): deployer server call sites must throw typed {@link
+ * ObjectStoreErrorCodes} via IPSErrorCode-aware exception constructors — not bare {@code
+ * IPSObjectStoreErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSDeployerServerTypedErrorCodeSlice3Test {
+
+  @Test
+  public void dependencyDefWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDependencyDef");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDependencyDef(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void dependencyMapWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDependencyMap");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSDependencyMap(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerTypedErrorCodeSlice3Test.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerTypedErrorCodeSlice3Test.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.conn.PSServerException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,26 @@ public class PSDeployerServerTypedErrorCodeSlice3Test {
         assertThrows(PSUnknownNodeTypeException.class, () -> new PSDependencyMap(wrong));
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  /**
+   * Mirrors {@link PSDeploymentHandler#getFeatureSet} exception wrap: {@code PSServerException}
+   * has no {@code IPSErrorCode}-aware constructor, so the call site must pass {@link
+   * ObjectStoreErrorCodes#FEATURE_SET_LOAD_EXCEPTION}{@code .numericCode()}. If the enum's
+   * numeric value drifts, or a typed ctor is added and this bridge is removed without updating
+   * callers, this assertion fails.
+   */
+  @Test
+  public void featureSetLoadExceptionNumericBridgeMatchesTypedEnum() {
+    int expected = ObjectStoreErrorCodes.FEATURE_SET_LOAD_EXCEPTION.numericCode();
+    PSServerException se =
+        new PSServerException(expected, new Object[] {"synthetic feature-set load failure"});
+    assertEquals(expected, se.getErrorCode());
+    // Same wrap shape as getFeatureSet catch: PSDeployException(PSException)
+    PSDeployException de = new PSDeployException(se);
+    assertEquals(expected, de.getErrorCode());
+    // Enum constant remains the typed contract source for the numeric bridge.
+    assertEquals(
+        ObjectStoreErrorCodes.FEATURE_SET_LOAD_EXCEPTION.numericCode(), de.getErrorCode());
   }
 }

--- a/scripts/test_verify_no_bare_ipsobjectstoreerrors.py
+++ b/scripts/test_verify_no_bare_ipsobjectstoreerrors.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""pytest coverage for scripts/verify-no-bare-ipsobjectstoreerrors.py.
+
+Proves:
+* PASS on the real monorepo (allow-listed residuals only)
+* FAIL when a deliberate new bare production call-site is introduced
+  (negative probes use ``tmp_path`` only — never dirties the real tree)
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+SCRIPT = SCRIPT_DIR / "verify-no-bare-ipsobjectstoreerrors.py"
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPT), *args]
+    return subprocess.run(
+        cmd,
+        shell=False,
+        check=False,
+        timeout=90,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def _init_fake_git_repo(fake_root: Path) -> None:
+    """Minimal git repo so ``git grep`` works under a temp root."""
+    fake_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init"],
+        shell=False,
+        check=True,
+        cwd=str(fake_root),
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "gate-test@example.com"],
+        shell=False,
+        check=True,
+        cwd=str(fake_root),
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "ipsobjectstoreerrors-gate-test"],
+        shell=False,
+        check=True,
+        cwd=str(fake_root),
+        capture_output=True,
+    )
+
+
+def _write_and_add(fake_root: Path, rel: str, content: str) -> None:
+    path = fake_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "--", rel.replace("\\", "/")],
+        shell=False,
+        check=True,
+        cwd=str(fake_root),
+        capture_output=True,
+    )
+
+
+def test_help_exits_zero_and_prints_usage() -> None:
+    result = _run("--help")
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout.lower()
+
+
+def test_list_allowlist_exits_zero() -> None:
+    result = _run("--list-allowlist")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "IPSObjectStoreErrors.java" in combined
+    # Deployer production residual cleared in #3165 (parent #3149) — not allow-listed.
+    assert "deployer/src/main/java/" not in combined
+    # Remaining documented residuals (Desktop CX / Design ACL).
+    assert "PSNode.java" in combined
+    assert "PSAclEntry.java" in combined
+
+
+def test_clean_repo_passes() -> None:
+    """Allow-listed tree on current main must pass the freeze gate."""
+    result = _run("--repo-root", str(REPO_ROOT))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+
+
+def test_deliberate_new_bare_production_site_fails(tmp_path: Path) -> None:
+    """Tracked production Java with bare IPSObjectStoreErrors must fail.
+
+    Acceptance for #3143: gate fails on a deliberate new bare production usage.
+    Uses ``tmp_path`` only so interrupted runs never leave the monorepo dirty.
+    """
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+
+    # Interface alone is allow-listed in the real script, but this fake tree
+    # has a brand-new production throw site outside the residual prefixes.
+    _write_and_add(
+        fake_root,
+        "system/src/main/java/com/percussion/example/BareIpsProbe.java",
+        (
+            "package com.percussion.example;\n"
+            "import com.percussion.design.objectstore.IPSObjectStoreErrors;\n"
+            "import com.percussion.design.objectstore.PSUnknownNodeTypeException;\n"
+            "public class BareIpsProbe {\n"
+            "  void boom() throws PSUnknownNodeTypeException {\n"
+            "    throw new PSUnknownNodeTypeException(\n"
+            "        IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, new Object[] {});\n"
+            "  }\n"
+            "}\n"
+        ),
+    )
+
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 1, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "FAIL" in combined
+    assert "BareIpsProbe.java" in combined
+    assert "IPSObjectStoreErrors" in combined
+
+
+def test_allowlisted_interface_alone_passes(tmp_path: Path) -> None:
+    """Only the interface definition under the always-allow path must pass."""
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+    _write_and_add(
+        fake_root,
+        "modules/utils/src/main/java/com/percussion/design/objectstore/"
+        "IPSObjectStoreErrors.java",
+        (
+            "package com.percussion.design.objectstore;\n"
+            "public interface IPSObjectStoreErrors {\n"
+            "  int XML_ELEMENT_WRONG_TYPE = 2012;\n"
+            "}\n"
+        ),
+    )
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+
+
+def test_comment_only_mention_passes(tmp_path: Path) -> None:
+    """Historical comment/javadoc mentions must not trip the gate."""
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+    _write_and_add(
+        fake_root,
+        "system/src/main/java/com/percussion/example/CommentOnly.java",
+        (
+            "package com.percussion.example;\n"
+            "/** Formerly used {@code IPSObjectStoreErrors} ints. */\n"
+            "public class CommentOnly {\n"
+            "  // IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE was here\n"
+            "}\n"
+        ),
+    )
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+
+
+def test_test_source_bare_use_passes(tmp_path: Path) -> None:
+    """Test sources may still reference legacy ints for parity assertions."""
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+    _write_and_add(
+        fake_root,
+        "system/src/test/java/com/percussion/example/ParityTest.java",
+        (
+            "package com.percussion.example;\n"
+            "import com.percussion.design.objectstore.IPSObjectStoreErrors;\n"
+            "import org.junit.jupiter.api.Test;\n"
+            "import static org.junit.jupiter.api.Assertions.assertEquals;\n"
+            "class ParityTest {\n"
+            "  @Test void code() {\n"
+            "    assertEquals(2012, IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE);\n"
+            "  }\n"
+            "}\n"
+        ),
+    )
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+
+
+def test_norm_path_edge_cases() -> None:
+    """``_norm_path`` must not corrupt ``../`` via character-class strip."""
+    # Import from script module (same directory on sys.path via file load).
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("ips_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod._norm_path(r"foo\bar\Baz.java") == "foo/bar/Baz.java"
+    assert mod._norm_path("./system/src/main/java/X.java") == "system/src/main/java/X.java"
+    assert mod._norm_path("././deployer/src/main/java/Y.java") == "deployer/src/main/java/Y.java"
+    # Critical: ``../`` must not collapse to empty/parent-stripped.
+    assert mod._norm_path("../foo/bar.java") == "../foo/bar.java"
+    assert mod._norm_path(r"..\foo\bar.java") == "../foo/bar.java"
+    assert mod._norm_path("system/src/main/java/X.java") == "system/src/main/java/X.java"
+
+
+def test_new_file_under_deployer_tree_not_silently_allowed(tmp_path: Path) -> None:
+    """Broad deployer prefix removed — only exact residual files pass."""
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+    _write_and_add(
+        fake_root,
+        "deployer/src/main/java/com/percussion/deployer/NewBareSite.java",
+        (
+            "package com.percussion.deployer;\n"
+            "import com.percussion.design.objectstore.IPSObjectStoreErrors;\n"
+            "public class NewBareSite {\n"
+            "  int c = IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE;\n"
+            "}\n"
+        ),
+    )
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "NewBareSite.java" in (result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/test_verify_no_bare_ipsobjectstoreerrors.py
+++ b/scripts/test_verify_no_bare_ipsobjectstoreerrors.py
@@ -196,6 +196,26 @@ def test_test_source_bare_use_passes(tmp_path: Path) -> None:
     assert "PASS" in result.stdout
 
 
+def test_repo_root_src_test_bare_use_passes(tmp_path: Path) -> None:
+    """Repo-root ``src/test/`` layout (no module prefix) must still be treated as test."""
+    fake_root = tmp_path / "repo"
+    _init_fake_git_repo(fake_root)
+    _write_and_add(
+        fake_root,
+        "src/test/java/com/percussion/example/RootLayoutParity.java",
+        (
+            "package com.percussion.example;\n"
+            "import com.percussion.design.objectstore.IPSObjectStoreErrors;\n"
+            "public class RootLayoutParity {\n"
+            "  int c = IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE;\n"
+            "}\n"
+        ),
+    )
+    result = _run("--repo-root", str(fake_root))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+
+
 def test_norm_path_edge_cases() -> None:
     """``_norm_path`` must not corrupt ``../`` via character-class strip."""
     # Import from script module (same directory on sys.path via file load).
@@ -213,6 +233,26 @@ def test_norm_path_edge_cases() -> None:
     assert mod._norm_path("../foo/bar.java") == "../foo/bar.java"
     assert mod._norm_path(r"..\foo\bar.java") == "../foo/bar.java"
     assert mod._norm_path("system/src/main/java/X.java") == "system/src/main/java/X.java"
+
+
+def test_is_test_path_segment_detection() -> None:
+    """``src/test`` (and it / testFixtures) as consecutive segments — no leading slash required."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("ips_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod._is_test_path("system/src/test/java/com/example/FooTest.java")
+    assert mod._is_test_path("src/test/java/com/example/RootLayoutTest.java")
+    assert mod._is_test_path("src/it/java/com/example/RootIt.java")
+    assert mod._is_test_path("module/src/testFixtures/java/com/example/Fx.java")
+    assert mod._is_test_path(r"src\test\java\com\example\WinSep.java")
+    assert not mod._is_test_path("system/src/main/java/com/example/Prod.java")
+    assert not mod._is_test_path("src/main/java/com/example/Prod.java")
+    # Name-based fallback still works for *Test.java outside src/test.
+    assert mod._is_test_path("tools/FooTest.java")
 
 
 def test_new_file_under_deployer_tree_not_silently_allowed(tmp_path: Path) -> None:

--- a/scripts/verify-no-bare-ipsobjectstoreerrors.py
+++ b/scripts/verify-no-bare-ipsobjectstoreerrors.py
@@ -133,9 +133,18 @@ def _norm_path(path: str) -> str:
 
 
 def _is_test_path(path: str) -> bool:
+    """True for test / it / testFixtures sources under any module layout.
+
+    Detects ``src/test``, ``src/it``, and ``src/testFixtures`` as consecutive
+    path segments so both module-prefixed paths (``deployer/src/test/...``) and
+    repo-root layouts (``src/test/...``) classify as tests. A leading-slash
+    substring check alone would miss the latter.
+    """
     norm = _norm_path(path)
-    if "/src/test/" in norm or "/src/it/" in norm or "/src/testFixtures/" in norm:
-        return True
+    parts = Path(norm).parts
+    for i in range(len(parts) - 1):
+        if parts[i] == "src" and parts[i + 1] in ("test", "it", "testFixtures"):
+            return True
     name = Path(norm).name
     if name.endswith("Test.java") or name.endswith("Tests.java"):
         return True

--- a/scripts/verify-no-bare-ipsobjectstoreerrors.py
+++ b/scripts/verify-no-bare-ipsobjectstoreerrors.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Grep gate: freeze bare production ``IPSObjectStoreErrors`` call-sites (#3143).
+
+Purpose
+-------
+Phase 2b ObjectStore retype work (#2616 family) moved production throws onto typed
+``ObjectStoreErrorCodes`` / ``ObjectStoreErrorCode`` / ``DesignErrorCodes`` peers.
+This gate fails when **new** production Java sources introduce bare
+``IPSObjectStoreErrors`` imports, ``implements``, or qualified constant uses
+outside an explicit allow-list.
+
+Allow-list classes
+------------------
+1. **Interface definition** — ``IPSObjectStoreErrors`` itself
+2. **Dual-write / typed peer bridge** — utils ``ObjectStoreErrorCode`` enum
+3. **Documented residual production call-sites** until sibling retypes land
+   (Desktop CX #3141, Design ACL #3142,
+   legacy ``implements IPSObjectStoreErrors`` handlers)
+
+Tests and comment/javadoc-only mentions are ignored.
+
+Usage
+-----
+::
+
+    python3 scripts/verify-no-bare-ipsobjectstoreerrors.py [--repo-root <path>]
+    python3 scripts/verify-no-bare-ipsobjectstoreerrors.py --list-allowlist
+
+Exit codes
+----------
+- ``0`` clean (only allow-listed / test / comment hits)
+- ``1`` at least one new bare production usage
+
+Portable: Python 3.9+; uses ``git grep`` (tracked files only) with
+``shell=False``.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+LOGGER = logging.getLogger(__name__)
+
+# Marker substring scanned via git grep -F.
+BANNED_TOKEN = "IPSObjectStoreErrors"
+
+GREP_PATHSPECS = ("*.java",)
+
+# Paths (posix, relative to repo root) always allowed — interface + bridges.
+ALWAYS_ALLOW_EXACT: frozenset[str] = frozenset(
+    {
+        # Legacy constant interface (must remain until full retirement).
+        "modules/utils/src/main/java/com/percussion/design/objectstore/"
+        "IPSObjectStoreErrors.java",
+        # Utils-local typed peers (numeric bridge from interface constants).
+        "modules/utils/src/main/java/com/percussion/design/objectstore/"
+        "ObjectStoreErrorCode.java",
+    }
+)
+
+# Exact residual production call-sites (path == entry). Prefer exact paths so a
+# new file under the same tree fails the gate until explicitly allow-listed with
+# an issue link. Shrink as retypes merge (#3141 / #3142). Deployer (#3149) cleared in #3165.
+RESIDUAL_ALLOW_EXACT: frozenset[str] = frozenset(
+    {
+        # #3141 — Desktop CX PSNode bare sites (PR open at gate land).
+        "modules/DesktopContentExplorer/src/main/java/com/percussion/cx/"
+        "objectstore/PSNode.java",
+        # #3142 — Design ACL PSAclEntry bare sites (PR open at gate land).
+        "system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java",
+        # Legacy implements IPSObjectStoreErrors (unqualified constant use).
+        "system/src/main/java/com/percussion/design/objectstore/server/"
+        "PSXmlObjectStoreHandler.java",
+        "system/src/main/java/com/percussion/design/objectstore/server/"
+        "PSXmlObjectStoreLockManager.java",
+    }
+)
+
+# Optional path prefixes (rare). Prefer RESIDUAL_ALLOW_EXACT. Do not grow without
+# an issue link. Empty at land so new trees are not silently allowed.
+RESIDUAL_ALLOW_PREFIXES: tuple[tuple[str, str], ...] = ()
+
+# This gate and its tests may mention the token.
+SCRIPT_ALLOW_PREFIXES: tuple[str, ...] = (
+    "scripts/verify-no-bare-ipsobjectstoreerrors.py",
+    "scripts/test_verify_no_bare_ipsobjectstoreerrors.py",
+)
+
+# Strip block comments then line comments for a coarse "is this code?" check.
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//.*?$", re.MULTILINE)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="verify-no-bare-ipsobjectstoreerrors.py",
+        description=(
+            "Fail on new bare production IPSObjectStoreErrors call-sites "
+            "outside the documented allow-list (#3143 / parent #2616)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repo root for the checks (default: this script's repo root)",
+    )
+    parser.add_argument(
+        "--list-allowlist",
+        action="store_true",
+        help="Print allow-list paths/prefixes and exit 0",
+    )
+    return parser
+
+
+def _norm_path(path: str) -> str:
+    """Normalize git-grep paths to posix relative form.
+
+    Only strip a leading ``./`` segment (not character-class ``lstrip("./")``,
+    which would corrupt ``../foo`` into ``foo``). Match peer freeze scripts that
+    only rewrite separators.
+    """
+    norm = path.replace("\\", "/")
+    while norm.startswith("./"):
+        norm = norm[2:]
+    return norm
+
+
+def _is_test_path(path: str) -> bool:
+    norm = _norm_path(path)
+    if "/src/test/" in norm or "/src/it/" in norm or "/src/testFixtures/" in norm:
+        return True
+    name = Path(norm).name
+    if name.endswith("Test.java") or name.endswith("Tests.java"):
+        return True
+    return False
+
+
+def _is_script_allowlisted(path: str) -> bool:
+    norm = _norm_path(path)
+    for prefix in SCRIPT_ALLOW_PREFIXES:
+        if norm == prefix or norm.startswith(prefix):
+            return True
+    return False
+
+
+def _is_always_allowlisted(path: str) -> bool:
+    return _norm_path(path) in ALWAYS_ALLOW_EXACT
+
+
+def _residual_reason(path: str) -> str | None:
+    norm = _norm_path(path)
+    if norm in RESIDUAL_ALLOW_EXACT:
+        return "documented residual exact path (#3141/#3142)"
+    for prefix, reason in RESIDUAL_ALLOW_PREFIXES:
+        if norm == prefix or norm.startswith(prefix):
+            return reason
+    return None
+
+
+def _code_mentions_token(source: str) -> bool:
+    """True if non-comment Java code still mentions IPSObjectStoreErrors."""
+    without_blocks = _BLOCK_COMMENT_RE.sub("", source)
+    without_line = _LINE_COMMENT_RE.sub("", without_blocks)
+    return BANNED_TOKEN in without_line
+
+
+def _git_grep_lines(repo_root: Path, pattern: str) -> list[tuple[str, int, str]]:
+    """Return (path, line_no, text) from ``git grep -n -F``."""
+    cmd = ["git", "grep", "-n", "-F", pattern, "--", *GREP_PATHSPECS]
+    result = subprocess.run(
+        cmd,
+        shell=False,
+        check=False,
+        cwd=str(repo_root),
+        timeout=120,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git grep failed for {pattern!r} (rc={result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    hits: list[tuple[str, int, str]] = []
+    for raw in result.stdout.splitlines():
+        if not raw.strip():
+            continue
+        # path:line:text  (path may contain drive letters on Windows — use maxsplit)
+        parts = raw.split(":", 2)
+        if len(parts) < 3:
+            # Some git versions may emit path\0line\0 — not used with default -n.
+            continue
+        path_part, line_s, text = parts
+        try:
+            line_no = int(line_s)
+        except ValueError:
+            # Windows path with drive letter: C:/foo:12:text already split wrong.
+            # Re-parse from the right: last path-ish segment before line number.
+            m = re.match(r"^(.*):(\d+):(.*)$", raw)
+            if not m:
+                continue
+            path_part, line_s, text = m.group(1), m.group(2), m.group(3)
+            line_no = int(line_s)
+        hits.append((_norm_path(path_part), line_no, text))
+    return hits
+
+
+def _paths_with_code_hits(repo_root: Path) -> list[str]:
+    """Unique production paths that mention the token in non-comment code."""
+    hits = _git_grep_lines(repo_root, BANNED_TOKEN)
+
+    # Group lines by path for comment stripping at file granularity (cheaper
+    # than reading every file when git already scoped to tracked *.java).
+    by_path: dict[str, list[tuple[int, str]]] = {}
+    for path, line_no, text in hits:
+        by_path.setdefault(path, []).append((line_no, text))
+
+    offenders: list[str] = []
+    for path, lines in sorted(by_path.items()):
+        if _is_test_path(path):
+            continue
+        if _is_script_allowlisted(path):
+            continue
+        if _is_always_allowlisted(path):
+            continue
+        if _residual_reason(path) is not None:
+            continue
+
+        abs_path = repo_root / path
+        if abs_path.is_file():
+            try:
+                source = abs_path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                LOGGER.warning("could not read %s: %s", path, exc)
+                source = "\n".join(t for _, t in lines)
+        else:
+            # Fake git-only trees in unit tests may not have full file content
+            # if only staged blob is available — fall back to grepped lines.
+            source = "\n".join(t for _, t in lines)
+
+        if _code_mentions_token(source):
+            offenders.append(path)
+
+    return offenders
+
+
+def _print_allowlist() -> None:
+    print("== Always allow (interface + typed bridges) ==")
+    for path in sorted(ALWAYS_ALLOW_EXACT):
+        print(f"  {path}")
+    print("== Residual production allow-list exact (shrink as retypes land) ==")
+    for path in sorted(RESIDUAL_ALLOW_EXACT):
+        print(f"  {path}")
+    if RESIDUAL_ALLOW_PREFIXES:
+        print("== Residual production allow-list prefixes ==")
+        for prefix, reason in RESIDUAL_ALLOW_PREFIXES:
+            print(f"  {prefix}")
+            print(f"    reason: {reason}")
+    print("== Script self-allow ==")
+    for prefix in SCRIPT_ALLOW_PREFIXES:
+        print(f"  {prefix}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.list_allowlist:
+        _print_allowlist()
+        return 0
+
+    repo_root = Path(args.repo_root)
+    print("==> scanning production Java for bare IPSObjectStoreErrors usages")
+    try:
+        offenders = _paths_with_code_hits(repo_root)
+    except RuntimeError as exc:
+        print(f"  FAIL: {exc}", file=sys.stderr)
+        print("verify-no-bare-ipsobjectstoreerrors: FAIL", file=sys.stderr)
+        return 1
+
+    if offenders:
+        print(
+            "  FAIL: new bare IPSObjectStoreErrors production call-site(s) "
+            "outside allow-list:",
+            file=sys.stderr,
+        )
+        for path in offenders:
+            print(f"    {path}", file=sys.stderr)
+        print(
+            "  Prefer typed ObjectStoreErrorCodes / ObjectStoreErrorCode / "
+            "DesignErrorCodes. To document an intentional residual, add the "
+            "exact path to RESIDUAL_ALLOW_EXACT in this script with an issue "
+            "link (#3143 / parent #2616 / deployer #3149).",
+            file=sys.stderr,
+        )
+        print("verify-no-bare-ipsobjectstoreerrors: FAIL", file=sys.stderr)
+        return 1
+
+    print("  OK: no new bare production IPSObjectStoreErrors call-sites")
+    print("verify-no-bare-ipsobjectstoreerrors: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary — same-file thrash absorption

Overnight issue work opened three stacked deployer PRs under parent epic **#3149** (retype bare `IPSObjectStoreErrors` → `ObjectStoreErrorCodes`). They thrash the same production paths and especially **`deployer/pom.xml`** (audit-log dep), so they cannot merge cleanly in parallel:

| PR | Slice | Head |
|----|-------|------|
| #3166 | objectstore non-idtypes | `fix/issue-3163-deployer-objectstore-error-codes` |
| #3167 | objectstore idtypes | `fix/issue-3164-objectstore-idtypes-errorcodes` |
| #3168 | catalog/server/client + freeze-gate shrink | `fix/issue-3165-deployer-catalog-server-client-errorcodes` (CONFLICTING vs main alone) |

This cluster re-absorbs them **oldest-first** onto current `main` with union semantics (gate scripts: took final slice-3 versions that clear all deployer residual allow-list entries).

### Thrash files (shared paths)

- `deployer/pom.xml` (all three)
- 33 objectstore non-idtypes production files (#3166 ∩ #3168)
- 14 objectstore/idtypes production files (#3167 ∩ #3168)
- Slice test sources restated on the stack tip
- `scripts/verify-no-bare-ipsobjectstoreerrors.py` + `scripts/test_verify_no_bare_ipsobjectstoreerrors.py` (main + #3168 add/add; resolved to slice-3)

### Supersedes table

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #3166 | `fix/issue-3163-deployer-objectstore-error-codes` | yes | Slice 1 — 33 objectstore files + Slice1Test |
| yes | #3167 | `fix/issue-3164-objectstore-idtypes-errorcodes` | yes | Slice 2 — 14 idtypes files + Slice2Test |
| yes | #3168 | `fix/issue-3165-deployer-catalog-server-client-errorcodes` | yes | Slice 3 — catalog/server/client + gate shrink; conflicts vs main resolved |

Closes the stack for parent **#3149** once this lands (all three child issues already closed as code-complete).

## Test plan / gates evidence

- `cd deployer && ../mvnw.cmd clean install` after each absorb → **BUILD SUCCESS**
- Final: **Tests run: 268, Failures: 0, Errors: 0, Skipped: 19**
  - Includes `PSDeployerObjectstoreTypedErrorCodeSlice1Test`, `PSDeployerObjectstoreIdtypesTypedErrorCodeSlice2Test`, `PSDeployerCatalogTypedErrorCodeSlice3Test`, `PSDeployerServerTypedErrorCodeSlice3Test`
- `python scripts/verify-no-bare-ipsobjectstoreerrors.py` → **PASS**
- `pytest scripts/test_verify_no_bare_ipsobjectstoreerrors.py` → **11 passed**
- `rg IPSObjectStoreErrors deployer/src/main/java` → **none**

## Operator

Grok: night-issue-prs (model grok-4.5)

Do **not** merge the superseded PRs (#3166 #3167 #3168); this cluster is the single merge unit.