### PR TITLE
fix(perc-system): type server residual raw collections (#3170)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3170-server-residual-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3170-server-residual-xlint-erlang.md
@@ -1,0 +1,53 @@
+# Erlang review — issue #3170 server residual Xlint (non-cache/non-webservices)
+
+**Reviewer persona:** Erlang (pre-commit hard gate)  
+**Branch:** `fix/issue-3170-server-residual-xlint`  
+**Date:** 2026-08-12  
+**Change class:** Legacy raw-collection typing / Xlint residual (no product behavior surface)
+
+## Scope reviewed
+
+| Path | Role |
+|------|------|
+| `PSPersistentPropertyManager.java` | Nested typed caches; public Collection APIs |
+| `PSUserSession.java` | Session maps/lists; property metadata APIs |
+| `PSCompareRequestHandler.java` | Loadable handler roots + user props |
+| `job/PSJobHandler.java`, `PSJobRunner.java`, `PSJobHandlerConfiguration.java` | Job handler maps/listeners/roots |
+| `PSServerResidualTypedTest.java` | Behavioral + API-signature tests |
+
+Out of scope (owned elsewhere): `server.cache` (#2877 / PR #3161), `server.webservices` (#3160 / PR #3171), `services.*` (#3181), `security` residual (#3182).
+
+## Checklist
+
+### Bugs / correctness
+- **resetMetaCache:** previous loop recreated iterators incorrectly; replaced with `keySet().removeIf` (same intent: drop matching user meta cache entries then repopulate). **OK.**
+- **save() null-action loop:** dropped redundant early-return on last null-action element; finally still syncs cache. Behavior equivalent. **OK.**
+- **ConcurrentHashMap null keys/values:** pre-existing CHM constraints (null category / null session values); not introduced. **OK (no change).**
+- **CategoryMap/LeafMap nesting:** matches prior structure username→category→propName→object. **OK.**
+- **getUserProperties typing:** callers (`PSCompareRequestHandler`, `PreferencesAdaptor`) remain binary-compatible; generic refinement only. **OK.**
+
+### Generics / rawtypes
+- Real generics preferred; no new class-level blanket `@SuppressWarnings`.  
+- Narrow unchecked cast retained only for private-object community lists (`List<String>` from Object map). **OK.**
+
+### Portable paths / I/O
+- No path or file I/O changes. **N/A.**
+
+### Tests
+- `PSServerResidualTypedTest` (10): arg validation, compare roots, job config typed maps, job listeners, API generic signatures.  
+- Existing proxy-cast + job config tests still green.  
+- Full module: `mvnw clean install` **BUILD SUCCESS**, Tests run: **1965**, Failures: 0, Errors: 0, Skipped: 241.
+
+### API blast radius (C2)
+- Public return/param types refined to parameterized collections (erasure-compatible).  
+- Grep: no monorepo caller needs recompile beyond `system` for binary; `PreferencesAdaptor` uses raw `.contains` on Collection.  
+- No `final`/`sealed` on types; no reverse-dep module install required.
+
+### Product docs
+- N/A — pure tech-debt typing.
+
+## Verdict
+
+**PASS** — safe to commit and open PR.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/server/PSPersistentPropertyManager.java
+++ b/system/src/main/java/com/percussion/server/PSPersistentPropertyManager.java
@@ -22,11 +22,11 @@ import com.percussion.services.legacy.PSCmsObjectMgrLocator;
 import com.percussion.utils.tools.PSPatternMatcher;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,6 +43,16 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSPersistentPropertyManager {
   private static final Logger log = LogManager.getLogger(PSPersistentPropertyManager.class);
+
+  /** Nested leaf map: property name → value object. */
+  private static final class LeafMap<T> extends ConcurrentHashMap<String, T> {
+    private static final long serialVersionUID = 1L;
+  }
+
+  /** Nested category map: category → leaf map. */
+  private static final class CategoryMap<T> extends ConcurrentHashMap<String, LeafMap<T>> {
+    private static final long serialVersionUID = 1L;
+  }
 
   /** Default constructor; private to disallow instantiation. */
   private PSPersistentPropertyManager() {}
@@ -74,15 +84,14 @@ public class PSPersistentPropertyManager {
    *     search criteria. If a match isn't found, an empty collection is returned.
    * @throws IllegalArgumentException if property name and category is not supplied.
    */
-  public Collection getPersistedPropertyMeta(
+  public Collection<PSPersistentPropertyMeta> getPersistedPropertyMeta(
       String category, PSUserSession userSession, String propertyName) {
     if ((category == null || category.length() == 0)
         && (propertyName == null || propertyName.length() == 0))
       throw new IllegalArgumentException(
           "Category and property name cannot be null at the same time");
-    Collection c = null;
+    Collection<PSPersistentPropertyMeta> c = new ArrayList<>();
     try {
-      c = new ArrayList<>();
       String userName = getUserName(userSession);
       if (userName.length() == 0) return c;
 
@@ -91,25 +100,17 @@ public class PSPersistentPropertyManager {
       // to ensure that no updates are done concurrently.
       synchronized (this) {
         populateCache(userSession, true);
-        ConcurrentHashMap cMap = m_mergedMetaCache.get(userName);
+        CategoryMap<PSPersistentPropertyMeta> cMap = m_mergedMetaCache.get(userName);
         if (cMap == null) return c;
         PSPatternMatcher pm = PSPatternMatcher.SQLPatternMatcher(null);
-        Set cSet = cMap.keySet();
-        Iterator cItr = cSet.iterator();
-        String cat = null;
-        ConcurrentHashMap objMap = null;
         if (category != null && category.length() != 0) {
-          while (cItr.hasNext()) {
-            cat = (String) cItr.next();
-            if (pm.doesMatchPattern(category, cat)) {
-              objMap = (ConcurrentHashMap) cMap.get(cat);
-              matchLeaves(pm, propertyName, objMap, c);
+          for (Map.Entry<String, LeafMap<PSPersistentPropertyMeta>> entry : cMap.entrySet()) {
+            if (pm.doesMatchPattern(category, entry.getKey())) {
+              matchLeaves(pm, propertyName, entry.getValue(), c);
             }
           }
         } else {
-          while (cItr.hasNext()) {
-            cat = (String) cItr.next();
-            objMap = (ConcurrentHashMap) cMap.get(cat);
+          for (LeafMap<PSPersistentPropertyMeta> objMap : cMap.values()) {
             matchLeaves(pm, propertyName, objMap, c);
           }
         }
@@ -127,7 +128,7 @@ public class PSPersistentPropertyManager {
     IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
 
     List<PSPersistentPropertyMeta> ret =
-        mgr.saveAllPersistentMeta(list).collect(java.util.stream.Collectors.toList());
+        mgr.saveAllPersistentMeta(list).collect(Collectors.toList());
     resetMetaCache(user);
     return ret;
   }
@@ -160,14 +161,12 @@ public class PSPersistentPropertyManager {
    * @param rc container in which matched objects will reside.
    * @return collection of matched objects.
    */
-  private Collection matchLeaves(
-      PSPatternMatcher pm, String pattern, ConcurrentHashMap hm, Collection rc) {
-
-    Set objSet = hm.keySet();
-    Iterator objItr = objSet.iterator();
-    while (objItr.hasNext()) {
-      String propName = (String) objItr.next();
-      if (pm.doesMatchPattern(pattern, propName)) rc.add(hm.get(propName));
+  private <T> Collection<T> matchLeaves(
+      PSPatternMatcher pm, String pattern, LeafMap<T> hm, Collection<T> rc) {
+    for (Map.Entry<String, T> entry : hm.entrySet()) {
+      if (pm.doesMatchPattern(pattern, entry.getKey())) {
+        rc.add(entry.getValue());
+      }
     }
     return rc;
   }
@@ -177,14 +176,8 @@ public class PSPersistentPropertyManager {
    * @param user
    */
   public void resetMetaCache(PSUserSession user) {
-
-    while (m_mergedMetaCache.entrySet().iterator().hasNext()) {
-      Map.Entry<String, ConcurrentHashMap> entry = m_mergedMetaCache.entrySet().iterator().next();
-      if (entry.getKey().equalsIgnoreCase(getUserName(user))) {
-        m_mergedMetaCache.entrySet().iterator().remove();
-      }
-    }
-
+    String userName = getUserName(user);
+    m_mergedMetaCache.keySet().removeIf(k -> k.equalsIgnoreCase(userName));
     populateCache(user, true);
   }
 
@@ -198,128 +191,136 @@ public class PSPersistentPropertyManager {
   private void populateCache(PSUserSession userSession, boolean isMeta) {
     String userName = getUserName(userSession);
     if (isMeta) {
-      if (m_mergedMetaCache.get(SYS_USER) == null) load(SYS_USER, true);
+      if (m_mergedMetaCache.get(SYS_USER) == null) loadMeta(SYS_USER);
       if (m_mergedMetaCache.get(userName) == null) {
-        load(userName, true);
-        merge(userName, m_mergedMetaCache, true);
+        loadMeta(userName);
+        mergeMeta(userName);
       }
     } else {
-      if (m_propertyCache.get(SYS_USER) == null) load(SYS_USER, false);
+      if (m_propertyCache.get(SYS_USER) == null) loadProperty(SYS_USER);
       if (m_propertyCache.get(userName) == null) {
-        load(userName, false);
-        if (m_propertyCache.get(SYS_USER) != null) merge(userName, m_propertyCache, false);
+        loadProperty(userName);
+        if (m_propertyCache.get(SYS_USER) != null) mergeProperty(userName);
       }
     }
   }
 
   /**
-   * Merges default entries with the user entries,already existing user entries are left untouched.
+   * Merges default meta entries with the user entries; already existing user entries are left
+   * untouched.
    */
-  private void merge(String userName, Map map, boolean isMeta) {
-    ConcurrentHashMap sysCategoryMap = (ConcurrentHashMap) map.get(SYS_USER);
-    ConcurrentHashMap usrCategoryMap = (ConcurrentHashMap) map.get(userName);
+  private void mergeMeta(String userName) {
+    merge(
+        userName,
+        m_mergedMetaCache,
+        (src, uname) -> new PSPersistentPropertyMeta(src, uname));
+  }
+
+  /**
+   * Merges default property entries with the user entries; already existing user entries are left
+   * untouched.
+   */
+  private void mergeProperty(String userName) {
+    merge(
+        userName,
+        m_propertyCache,
+        (src, uname) -> new PSPersistentProperty(src, uname, PSPersistentPropertyManager.UPDATE));
+  }
+
+  private <T> void merge(
+      String userName,
+      Map<String, CategoryMap<T>> map,
+      BiFunction<T, String, T> copyForUser) {
+    CategoryMap<T> sysCategoryMap = map.get(SYS_USER);
+    CategoryMap<T> usrCategoryMap = map.get(userName);
     if (usrCategoryMap == null) {
-      usrCategoryMap = new ConcurrentHashMap();
+      usrCategoryMap = new CategoryMap<>();
       map.put(userName, usrCategoryMap);
     }
 
-    if (null == sysCategoryMap) return;
-    Set sysCatSet = sysCategoryMap.keySet();
-    Iterator sysCatItr = sysCatSet.iterator();
-    while (sysCatItr.hasNext()) {
-      String sysCategory = (String) sysCatItr.next();
-      if (!usrCategoryMap.containsKey(sysCategory))
-        usrCategoryMap.put(sysCategory, new ConcurrentHashMap<>());
-      mergeLeaves(
-          userName,
-          (ConcurrentHashMap) sysCategoryMap.get(sysCategory),
-          (ConcurrentHashMap) usrCategoryMap.get(sysCategory),
-          isMeta);
+    if (sysCategoryMap == null) return;
+    for (Map.Entry<String, LeafMap<T>> sysCatEntry : sysCategoryMap.entrySet()) {
+      String sysCategory = sysCatEntry.getKey();
+      if (!usrCategoryMap.containsKey(sysCategory)) {
+        usrCategoryMap.put(sysCategory, new LeafMap<>());
+      }
+      mergeLeaves(userName, sysCatEntry.getValue(), usrCategoryMap.get(sysCategory), copyForUser);
     }
   }
 
   /**
-   * Merges the leaf map - the map which maintains meta property name and meta
-   * object(PSPersistentPropertyMeta) mappings.
+   * Merges the leaf map - the map which maintains property name and value object mappings.
    */
-  private Map mergeLeaves(String userName, Map src, Map dest, boolean isMeta) {
-    Set srcSet = src.keySet();
-    Iterator srcItr = srcSet.iterator();
-    while (srcItr.hasNext()) {
-      String srcName = (String) srcItr.next();
+  private <T> void mergeLeaves(
+      String userName, LeafMap<T> src, LeafMap<T> dest, BiFunction<T, String, T> copyForUser) {
+    for (Map.Entry<String, T> srcEntry : src.entrySet()) {
+      String srcName = srcEntry.getKey();
       // checks if the user mapping for a name already exists
       // to prevent overwrites, if exists don't touch it!!.
       if (dest.get(srcName) == null) {
-        if (isMeta) {
-          PSPersistentPropertyMeta obj = (PSPersistentPropertyMeta) src.get(srcName);
-          PSPersistentPropertyMeta newObj = new PSPersistentPropertyMeta(obj, userName);
-          dest.put(srcName, newObj);
-        } else {
-          PSPersistentProperty obj = (PSPersistentProperty) src.get(srcName);
-          PSPersistentProperty newObj =
-              new PSPersistentProperty(obj, userName, PSPersistentPropertyManager.UPDATE);
-          dest.put(srcName, newObj);
-        }
+        dest.put(srcName, copyForUser.apply(srcEntry.getValue(), userName));
       }
     }
-    return src;
   }
 
   /**
-   * Populates <code>m_mergedMetaCache</code> and <code>m_propertyCache</code> for an user.
+   * Populates <code>m_mergedMetaCache</code> for a user.
    *
-   * @param userName
-   * @param loadMetadata indicates whether to load meta properties or properties. Metadata is loaded
-   *     if <code>true</code>, data otherwise.
+   * @param userName the user name key
    */
-  private void load(String userName, boolean loadMetadata) {
+  private void loadMeta(String userName) {
     IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
+    CategoryMap<PSPersistentPropertyMeta> categoryMap = new CategoryMap<>();
+    m_mergedMetaCache.put(userName, categoryMap);
 
-    ConcurrentHashMap categoryMap = new ConcurrentHashMap();
+    List<PSPersistentPropertyMeta> persists =
+        mgr.findAllPersistentMeta()
+            .filter(pm -> pm.getUserName().equals(userName))
+            .collect(Collectors.toList());
 
-    if (loadMetadata) m_mergedMetaCache.put(userName, categoryMap);
-    else m_propertyCache.put(userName, categoryMap);
-
-    List persists;
-    if (loadMetadata) {
-      persists =
-          mgr.findAllPersistentMeta()
-              .filter(pm -> pm.getUserName().equals(userName))
-              .collect(java.util.stream.Collectors.toList());
-    } else {
-      persists = mgr.findPersistentPropertiesByName(userName);
-    }
-
-    Iterator ps = persists.iterator();
-    while (ps.hasNext()) {
-      String propertyName = null;
-      String category = null;
-      Object obj = ps.next();
-      if (loadMetadata) {
-        category = ((PSPersistentPropertyMeta) obj).getCategory();
-        propertyName = ((PSPersistentPropertyMeta) obj).getPropertyName();
-      } else {
-        category = ((PSPersistentProperty) obj).getCategory();
-        propertyName = ((PSPersistentProperty) obj).getName();
-      }
-      // if category is null then the key is null and all the metaobj without
-      // category go there.
-      ConcurrentHashMap map = (ConcurrentHashMap) categoryMap.get(category);
+    for (PSPersistentPropertyMeta meta : persists) {
+      String category = meta.getCategory();
+      String propertyName = meta.getPropertyName();
+      LeafMap<PSPersistentPropertyMeta> map = categoryMap.get(category);
       if (map == null) {
-        map = new ConcurrentHashMap<>();
+        map = new LeafMap<>();
         categoryMap.put(category, map);
       }
-      map.put(propertyName, obj);
+      map.put(propertyName, meta);
+    }
+  }
+
+  /**
+   * Populates <code>m_propertyCache</code> for a user.
+   *
+   * @param userName the user name key
+   */
+  private void loadProperty(String userName) {
+    IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
+    CategoryMap<PSPersistentProperty> categoryMap = new CategoryMap<>();
+    m_propertyCache.put(userName, categoryMap);
+
+    List<PSPersistentProperty> persists = mgr.findPersistentPropertiesByName(userName);
+
+    for (PSPersistentProperty prop : persists) {
+      String category = prop.getCategory();
+      String propertyName = prop.getName();
+      LeafMap<PSPersistentProperty> map = categoryMap.get(category);
+      if (map == null) {
+        map = new LeafMap<>();
+        categoryMap.put(category, map);
+      }
+      map.put(propertyName, prop);
     }
   }
 
   /** Utility method to get PSPersistentPropertyMeta objects from m_mergedMetaCache. */
   private PSPersistentPropertyMeta getFromMetaCache(
       String category, String userName, String propertyName) {
-    Map catMap = (ConcurrentHashMap) m_mergedMetaCache.get(userName);
+    CategoryMap<PSPersistentPropertyMeta> catMap = m_mergedMetaCache.get(userName);
     if (catMap != null) {
-      ConcurrentHashMap objMap = (ConcurrentHashMap) catMap.get(category);
-      if (objMap != null) return (PSPersistentPropertyMeta) objMap.get(propertyName);
+      LeafMap<PSPersistentPropertyMeta> objMap = catMap.get(category);
+      if (objMap != null) return objMap.get(propertyName);
       else return null;
     } else {
       return null;
@@ -382,7 +383,7 @@ public class PSPersistentPropertyManager {
    * @throws IllegalArgumentException If <code>propertyName</code> and <code>category</code> are
    *     both <code>null</code> or empty, or if <code>request</code> is <code>null</code>.
    */
-  public synchronized Collection getPersistedProperty(
+  public synchronized Collection<PSPersistentProperty> getPersistedProperty(
       String category, PSUserSession userSession, String propertyName) {
     if ((category == null || category.length() == 0)
         && (propertyName == null || propertyName.length() == 0))
@@ -391,7 +392,7 @@ public class PSPersistentPropertyManager {
 
     if (userSession == null) throw new IllegalArgumentException("request may not be null");
 
-    Collection c = new ArrayList();
+    Collection<PSPersistentProperty> c = new ArrayList<>();
     try {
       String userName = getUserName(userSession);
       if (userName.length() == 0) return c;
@@ -402,23 +403,17 @@ public class PSPersistentPropertyManager {
       synchronized (this) {
         populateCache(userSession, false);
         if (m_propertyCache.isEmpty()) return c;
-        ConcurrentHashMap cMap = (ConcurrentHashMap) m_propertyCache.get(userName);
+        CategoryMap<PSPersistentProperty> cMap = m_propertyCache.get(userName);
         if (cMap == null) return c;
         PSPatternMatcher pm = PSPatternMatcher.SQLPatternMatcher(null);
-        Set cSet = cMap.keySet();
-        Iterator cItr = cSet.iterator();
         if (category != null && category.length() != 0) {
-          while (cItr.hasNext()) {
-            String cat = (String) cItr.next();
-            if (pm.doesMatchPattern(category, cat)) {
-              ConcurrentHashMap objMap = (ConcurrentHashMap) cMap.get(cat);
-              matchLeaves(pm, propertyName, objMap, c);
+          for (Map.Entry<String, LeafMap<PSPersistentProperty>> entry : cMap.entrySet()) {
+            if (pm.doesMatchPattern(category, entry.getKey())) {
+              matchLeaves(pm, propertyName, entry.getValue(), c);
             }
           }
         } else {
-          while (cItr.hasNext()) {
-            String cat = (String) cItr.next();
-            ConcurrentHashMap objMap = (ConcurrentHashMap) cMap.get(cat);
+          for (LeafMap<PSPersistentProperty> objMap : cMap.values()) {
             matchLeaves(pm, propertyName, objMap, c);
           }
         }
@@ -441,21 +436,18 @@ public class PSPersistentPropertyManager {
    *     null</code>.
    * @throws IllegalArgumentException if any param is invalid.
    */
-  public synchronized void save(Collection c, PSUserSession userSession) {
+  public synchronized void save(Collection<PSPersistentProperty> c, PSUserSession userSession) {
     if (c == null) throw new IllegalArgumentException("c may not be null");
 
     if (userSession == null) throw new IllegalArgumentException("userSession may not be null");
 
     try {
-      Iterator itr = c.iterator();
       String userName = getUserName(userSession);
       if (userName.length() == 0) return;
       IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
-      while (itr.hasNext()) {
-        PSPersistentProperty ps = (PSPersistentProperty) itr.next();
+      for (PSPersistentProperty ps : c) {
         String action = ps.getExtraParam();
         if (action == null) {
-          if (!itr.hasNext()) return;
           continue;
         }
         if (action.equals(INSERT) || action.equals(UPDATE) || action.equals(DELETE)) {
@@ -532,10 +524,8 @@ public class PSPersistentPropertyManager {
    * Synchronize properties in <code>m_propertyCache</code>. Preferably called after backend has
    * updated.
    */
-  private void syncPropertyCache(Collection c) {
-    Iterator itr = c.iterator();
-    while (itr.hasNext()) {
-      PSPersistentProperty ps = (PSPersistentProperty) itr.next();
+  private void syncPropertyCache(Collection<PSPersistentProperty> c) {
+    for (PSPersistentProperty ps : c) {
       setPropertyCache(ps);
     }
   }
@@ -551,21 +541,20 @@ public class PSPersistentPropertyManager {
     synchronized (ps) {
       String userName = ps.getUserName();
       String category = ps.getCategory();
-      Map catMap = (Map) m_propertyCache.get(userName);
+      CategoryMap<PSPersistentProperty> catMap = m_propertyCache.get(userName);
       if (catMap == null) {
-        catMap = new ConcurrentHashMap();
+        catMap = new CategoryMap<>();
         m_propertyCache.put(userName, catMap);
       }
-      Map objMap = null;
       if (category != null && category.length() == 0) category = null;
-      objMap = (Map) catMap.get(category);
+      LeafMap<PSPersistentProperty> objMap = catMap.get(category);
       if (objMap == null) {
-        objMap = new ConcurrentHashMap();
+        objMap = new LeafMap<>();
         catMap.put(category, objMap);
       }
       String propName = ps.getName();
       String action = ps.getExtraParam();
-      PSPersistentProperty obj = (PSPersistentProperty) objMap.get(propName);
+      PSPersistentProperty obj = objMap.get(propName);
       if (action.equals(PSPersistentPropertyManager.INSERT)) {
         objMap.put(propName, ps);
         // reset the action
@@ -590,15 +579,17 @@ public class PSPersistentPropertyManager {
   private static final Logger ms_log = LogManager.getLogger(PSPersistentPropertyManager.class);
 
   /**
-   * Maintains a cache of merged <code> PSPersitentPropertyMeta</code> objects. Note there 2 levels
-   * of indirection. Username key(s) are mapped to ConcurrentHashMap(s), whose keys are categories
-   * and those key(s) are mapped to ConcurrentHashMap(s) whose key(s) are mapped to meta property
-   * objects Pictorially --- (Usernname,(categories,(metaPropertyName,metaObjs)))
+   * Maintains a cache of merged <code>PSPersistentPropertyMeta</code> objects. Note there are 2
+   * levels of indirection. Username key(s) are mapped to category maps, whose keys are categories
+   * and those key(s) are mapped to leaf maps whose keys are meta property names mapped to meta
+   * objects. Pictorially --- (Username,(categories,(metaPropertyName,metaObjs)))
    */
-  private final Map<String, ConcurrentHashMap> m_mergedMetaCache = new ConcurrentHashMap<>();
+  private final Map<String, CategoryMap<PSPersistentPropertyMeta>> m_mergedMetaCache =
+      new ConcurrentHashMap<>();
 
-  /** Cache for <code>PSPersitentProperty</code> objects. */
-  private final Map m_propertyCache = new ConcurrentHashMap();
+  /** Cache for <code>PSPersistentProperty</code> objects (same nesting as meta cache). */
+  private final Map<String, CategoryMap<PSPersistentProperty>> m_propertyCache =
+      new ConcurrentHashMap<>();
 
   public static final String SYS_USER = "**psxsystem";
   public static final String DELETE = "DELETE";

--- a/system/src/main/java/com/percussion/server/PSUserSession.java
+++ b/system/src/main/java/com/percussion/server/PSUserSession.java
@@ -103,9 +103,9 @@ public class PSUserSession {
 
     PSUserSession session = new PSUserSession(request, m_id);
 
-    session.m_privateObjects = new ConcurrentHashMap(m_privateObjects);
+    session.m_privateObjects = new ConcurrentHashMap<>(m_privateObjects);
     session.m_systemObjects = m_systemObjects;
-    session.m_UserEntries = new CopyOnWriteArrayList();
+    session.m_UserEntries = new CopyOnWriteArrayList<>();
     session.m_usrMeta = m_usrMeta;
     session.m_usrProp = m_usrProp;
 
@@ -266,10 +266,8 @@ public class PSUserSession {
    * @return The list, never null, may be empty.
    */
   public List<String> getUserRoles() {
-    List<String> roleList = new ArrayList<String>();
-    Iterator userEntries = m_UserEntries.iterator();
-    while (userEntries.hasNext()) {
-      PSUserEntry userEntry = (PSUserEntry) userEntries.next();
+    List<String> roleList = new ArrayList<>();
+    for (PSUserEntry userEntry : m_UserEntries) {
       PSRoleEntry[] roles = userEntry.getRoles();
       for (int i = 0; i < roles.length; i++) {
         roleList.add(roles[i].getName());
@@ -309,11 +307,11 @@ public class PSUserSession {
    *     null</code> may be empty. List is cached in the user's session after the first call.
    * @throws PSInternalRequestCallException if there is an error retrieving the communities
    */
-  @SuppressWarnings(value = {"unchecked"})
   public List<String> getUserCommunities(PSRequest request) throws PSInternalRequestCallException {
+    @SuppressWarnings("unchecked")
     List<String> list = (List<String>) getPrivateObject(USER_COMMUNITIES);
     if (list == null) {
-      list = new ArrayList<String>();
+      list = new ArrayList<>();
 
       // Make an internal request to get the user roles.
       PSInternalRequest iReq =
@@ -335,7 +333,7 @@ public class PSUserSession {
       setPrivateObject(USER_COMMUNITIES, list);
     }
 
-    return new ArrayList<String>(list);
+    return new ArrayList<>(list);
   }
 
   /**
@@ -345,14 +343,14 @@ public class PSUserSession {
    * @return The list of names, never <code>null</code>.
    * @throws PSInternalRequestCallException if there is an error.
    */
-  @SuppressWarnings(value = {"unchecked"})
   public List<String> getUserCommunityNames(PSRequest request)
       throws PSInternalRequestCallException {
     if (request == null) throw new IllegalArgumentException("request  may not be null");
 
+    @SuppressWarnings("unchecked")
     List<String> names = (List<String>) getPrivateObject(USER_COMMUNITY_NAMES);
     if (names == null) {
-      names = new ArrayList<String>();
+      names = new ArrayList<>();
       List<String> ids = getUserCommunities(request);
       if (!ids.isEmpty()) {
         IPSGuid[] guids = new IPSGuid[ids.size()];
@@ -369,7 +367,7 @@ public class PSUserSession {
       setPrivateObject(USER_COMMUNITY_NAMES, names);
     }
 
-    return new ArrayList<String>(names);
+    return new ArrayList<>(names);
   }
 
   /**
@@ -415,8 +413,7 @@ public class PSUserSession {
   public String getRealAuthenticatedUserEntry() {
     String userName = null;
     if (null != m_UserEntries) {
-      for (Iterator iter = m_UserEntries.iterator(); iter.hasNext(); ) {
-        PSUserEntry entry = (PSUserEntry) iter.next();
+      for (PSUserEntry entry : m_UserEntries) {
         userName = entry.getName();
         break;
       }
@@ -496,7 +493,7 @@ public class PSUserSession {
     if (driver == null) driver = "";
     if (server == null) server = "";
 
-    return (String[]) m_Credentials.get(driver + "/" + server);
+    return m_Credentials.get(driver + "/" + server);
   }
 
   /**
@@ -585,7 +582,7 @@ public class PSUserSession {
    *     to the container object itself, and thus prevent GC of the copied container. (It's
    *     <em>very</em> likely, but I saw no guarantee in the spec) (dbreslau 12/12/02)
    */
-  public Iterator authenticationIdIterator() {
+  public Iterator<String> authenticationIdIterator() {
     return m_authentications.keySet().iterator();
   }
 
@@ -670,25 +667,21 @@ public class PSUserSession {
     if (doc == null) throw new IllegalArgumentException("the document cannot be null");
 
     Element authentications = doc.createElement("Authentications");
-    Iterator auths = m_authentications.keySet().iterator();
-    while (auths.hasNext()) {
+    for (String user : m_authentications.keySet()) {
       Element authentication = doc.createElement("Authentication");
 
-      String user = (String) auths.next();
       authentication.setAttribute("user", user);
-      authentication.setAttribute("password", (String) m_authentications.get(user));
+      authentication.setAttribute("password", m_authentications.get(user));
 
       authentications.appendChild(authentication);
     }
 
     Element credentials = doc.createElement("Credentials");
-    Iterator creds = m_Credentials.keySet().iterator();
-    while (creds.hasNext()) {
+    for (String driverServer : m_Credentials.keySet()) {
       Element credential = doc.createElement("Credential");
 
-      String driverServer = (String) creds.next();
       credential.setAttribute("driverServer", driverServer);
-      String[] login = (String[]) m_Credentials.get(driverServer);
+      String[] login = m_Credentials.get(driverServer);
       credential.setAttribute("user", login[0]);
       credential.setAttribute("password", login[1]);
 
@@ -696,19 +689,15 @@ public class PSUserSession {
     }
 
     Element userEntries = doc.createElement("AuthenticatedUsers");
-    Iterator entries = m_UserEntries.iterator();
-    while (entries.hasNext()) {
-      PSUserEntry entry = (PSUserEntry) entries.next();
+    for (PSUserEntry entry : m_UserEntries) {
       userEntries.appendChild(entry.getUserEntryStatus(doc));
     }
 
     Element usedDbCredentials = doc.createElement("UsedDatabaseCredentials");
-    Iterator usedCreds = m_dbIds.keySet().iterator();
-    while (usedCreds.hasNext()) {
-      String driverServer = (String) usedCreds.next();
+    for (String driverServer : m_dbIds.keySet()) {
       Element usedDbCredential = doc.createElement("Credential");
       usedDbCredential.setAttribute("driverServer", driverServer);
-      usedDbCredential.setAttribute("user", (String) m_dbIds.get(driverServer));
+      usedDbCredential.setAttribute("user", m_dbIds.get(driverServer));
 
       usedDbCredentials.appendChild(usedDbCredential);
     }
@@ -767,11 +756,9 @@ public class PSUserSession {
    * @param context - system or designer
    * @param map - system or private map, assumed not <code>null</code>
    */
-  private void updateProperties(String context, Map map) {
+  private void updateProperties(String context, Map<?, ?> map) {
     if (!m_isLoaded || map.isEmpty()) return;
-    for (Iterator itr = m_usrMeta.iterator(); itr.hasNext(); ) {
-      PSPersistentPropertyMeta meta = (PSPersistentPropertyMeta) itr.next();
-
+    for (PSPersistentPropertyMeta meta : m_usrMeta) {
       String propName = meta.getPropertyName();
       // if key is not there at all then the property does not exist.
       // this applies to situation where meta exist but property does not
@@ -779,7 +766,8 @@ public class PSUserSession {
       if (!map.containsKey(propName)) {
         continue;
       }
-      String newValue = (String) map.get(propName);
+      Object raw = map.get(propName);
+      String newValue = raw == null ? null : String.valueOf(raw);
       boolean isNew = isNewProperty(propName);
 
       // check to see if the property is new and exists in the map
@@ -837,8 +825,7 @@ public class PSUserSession {
    * @return <code>null</code> if not found
    */
   private PSPersistentProperty getProperty(String propName) {
-    for (Iterator itr = m_usrProp.iterator(); itr.hasNext(); ) {
-      PSPersistentProperty propObj = (PSPersistentProperty) itr.next();
+    for (PSPersistentProperty propObj : m_usrProp) {
       String name = propObj.getName();
       if (name != null) if (name.equals(propName)) return propObj;
     }
@@ -857,8 +844,7 @@ public class PSUserSession {
       if (ms_log.isDebugEnabled()) {
         ms_log.debug("Persistent property [" + propName + "] does not exist");
         ms_log.debug("Current persistent properties:");
-        for (Iterator iter = m_usrProp.iterator(); iter.hasNext(); ) {
-          PSPersistentProperty propObj = (PSPersistentProperty) iter.next();
+        for (PSPersistentProperty propObj : m_usrProp) {
           ms_log.debug(propObj.getName());
         }
       }
@@ -932,7 +918,7 @@ public class PSUserSession {
     m_UserEntries.clear();
   }
 
-  public synchronized Collection getUserPropertyMetadata() {
+  public synchronized Collection<PSPersistentPropertyMeta> getUserPropertyMetadata() {
 
     if (m_usrMeta == null) {
       loadPersistentProperties();
@@ -940,18 +926,19 @@ public class PSUserSession {
     return m_usrMeta;
   }
 
-  public synchronized void setUserPropertyMetadata(Collection m_usrMeta) {
+  public synchronized void setUserPropertyMetadata(
+      Collection<PSPersistentPropertyMeta> m_usrMeta) {
     this.m_usrMeta = m_usrMeta;
   }
 
-  public synchronized Collection getUserProperties() {
+  public synchronized Collection<PSPersistentProperty> getUserProperties() {
     if (m_usrProp == null) {
       loadPersistentProperties();
     }
     return m_usrProp;
   }
 
-  public synchronized void setUserProperties(Collection m_usrProp) {
+  public synchronized void setUserProperties(Collection<PSPersistentProperty> m_usrProp) {
     this.m_usrProp = m_usrProp;
   }
 
@@ -969,10 +956,7 @@ public class PSUserSession {
     m_usrMeta = mgr.getPersistedPropertyMeta(CATEGORY, this, ALL);
     m_usrProp = mgr.getPersistedProperty(CATEGORY, this, ALL);
 
-    Iterator properties = m_usrProp.iterator();
-    while (properties.hasNext()) {
-      PSPersistentProperty prop = (PSPersistentProperty) properties.next();
-
+    for (PSPersistentProperty prop : m_usrProp) {
       String context = prop.getContext();
       if (context == null) continue;
 
@@ -1109,17 +1093,17 @@ public class PSUserSession {
    * <code>null</code> until <code>m_isLoaded
    * </code> is <code>true</code>, then never <code>null</code> after that.
    */
-  private volatile Collection m_usrMeta = null;
+  private volatile Collection<PSPersistentPropertyMeta> m_usrMeta = null;
 
   /**
    * Stores <code>PSPersistentProperty</code> objects returned by PSPersistentPropertyManager and
    * those set on the session object. <code>null</code> until <code>m_isLoaded</code> is <code>true
    * </code>, then never <code>null</code> after that.
    */
-  private volatile Collection m_usrProp = null;
+  private volatile Collection<PSPersistentProperty> m_usrProp = null;
 
   /** Maintains system session properties */
-  private ConcurrentHashMap m_systemObjects = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, Object> m_systemObjects = new ConcurrentHashMap<>();
 
   /** The designer session cookie */
   public static final String DESIGNER_SESSION_COOKIE = "psdsessid";
@@ -1145,7 +1129,7 @@ public class PSUserSession {
    * <p>Accessing methods must <code>synchronize</code> on <code>this</code> to ensure thread
    * safety. Since the field is private, it should be easy to verify this.
    */
-  private CopyOnWriteArrayList m_UserEntries = new CopyOnWriteArrayList();
+  private CopyOnWriteArrayList<PSUserEntry> m_UserEntries = new CopyOnWriteArrayList<>();
 
   /**
    * Store the back-end credentials for this user with key = driver/server and value = String[] {
@@ -1154,7 +1138,7 @@ public class PSUserSession {
    * <p>Accessing methods must <code>synchronize</code> on <code>this</code> to ensure thread
    * safety. Since the field is private, it should be easy to verify this.
    */
-  private ConcurrentHashMap m_Credentials = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, String[]> m_Credentials = new ConcurrentHashMap<>();
 
   /**
    * Table of database ids.
@@ -1162,7 +1146,7 @@ public class PSUserSession {
    * <p>Accessing methods must <code>synchronize</code> on <code>this</code> to ensure thread
    * safety. Since the field is private, it should be easy to verify this.
    */
-  private ConcurrentHashMap m_dbIds = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, String> m_dbIds = new ConcurrentHashMap<>();
 
   /**
    * Table of database authentications.
@@ -1170,7 +1154,7 @@ public class PSUserSession {
    * <p>Accessing methods must <code>synchronize</code> on <code>this</code> to ensure thread
    * safety. Since the field is private, it should be easy to verify this.
    */
-  private Map m_authentications = new ConcurrentHashMap();
+  private Map<String, String> m_authentications = new ConcurrentHashMap<>();
 
   /**
    * Allows extensions to store user session information in a map.
@@ -1178,7 +1162,7 @@ public class PSUserSession {
    * <p>Accessing methods must <code>synchronize</code> on <code>this</code> to ensure thread
    * safety. Since the field is private, it should be easy to verify this.
    */
-  private ConcurrentHashMap m_privateObjects = new ConcurrentHashMap();
+  private ConcurrentHashMap<Object, Object> m_privateObjects = new ConcurrentHashMap<>();
 
   /**
    * Flag to mark this session as designer session (<code>true</code>). The default is set to <code>

--- a/system/src/main/java/com/percussion/server/compare/PSCompareRequestHandler.java
+++ b/system/src/main/java/com/percussion/server/compare/PSCompareRequestHandler.java
@@ -53,14 +53,13 @@ import org.xml.sax.SAXException;
  */
 public class PSCompareRequestHandler implements IPSLoadableRequestHandler {
   // see the IPSLoadableRequestHandler interface for method javadocs
-  @SuppressWarnings("rawtypes")
-  public void init(Collection requestRoots, InputStream cfgFileIn) {
+  public void init(Collection<String> requestRoots, InputStream cfgFileIn) {
     if (requestRoots == null || requestRoots.isEmpty())
       throw new IllegalArgumentException("must provide at least one request root");
 
     // validate that requestRoots contains only Strings
-    for (Iterator<String> iter = requestRoots.iterator(); iter.hasNext(); ) {
-      if (!(iter.next() instanceof String))
+    for (String root : requestRoots) {
+      if (root == null)
         throw new IllegalArgumentException(
             "request roots collection may only contain String objects");
     }
@@ -86,8 +85,7 @@ public class PSCompareRequestHandler implements IPSLoadableRequestHandler {
   }
 
   // see IPSRootedHandler for documentation
-  @SuppressWarnings("rawtypes")
-  public Iterator getRequestRoots() {
+  public Iterator<String> getRequestRoots() {
     return m_requestRoots.iterator();
   }
 
@@ -112,11 +110,9 @@ public class PSCompareRequestHandler implements IPSLoadableRequestHandler {
       PSUserSession session = request.getUserSession();
       String lang = "en-US";
       if (session != null) {
-        Collection userProps = session.getUserProperties();
+        Collection<PSPersistentProperty> userProps = session.getUserProperties();
         if (userProps != null) {
-          Iterator<PSPersistentProperty> userPropsItr = userProps.iterator();
-          while (userPropsItr.hasNext()) {
-            PSPersistentProperty prop = userPropsItr.next();
+          for (PSPersistentProperty prop : userProps) {
             if (PSI18nUtils.USER_SESSION_OBJECT_SYS_LANG.equals(prop.getName())) {
               String lg = prop.getValue();
               if (lg != null && !lg.isEmpty()) {

--- a/system/src/main/java/com/percussion/server/job/PSJobHandler.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandler.java
@@ -59,7 +59,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
    * @throws PSServerException if <code>InputStream</code> is <code>null</code> or contains invalid
    *     content.
    */
-  public void init(Collection requestRoots, InputStream cfgFileIn) throws PSServerException {
+  public void init(Collection<String> requestRoots, InputStream cfgFileIn) throws PSServerException {
     if (requestRoots == null || requestRoots.size() == 0)
       throw new IllegalArgumentException("must provide at least one request root");
 
@@ -272,7 +272,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
       throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);
     }
 
-    PSJobRunner job = (PSJobRunner) m_jobRunners.get(jobId);
+    PSJobRunner job = m_jobRunners.get(jobId);
     if (job == null) throw new PSJobException(IPSJobErrors.INVALID_JOB_ID, jobId.toString());
 
     // prepare response
@@ -328,7 +328,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
       throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);
     }
 
-    PSJobRunner job = (PSJobRunner) m_jobRunners.get(jobId);
+    PSJobRunner job = m_jobRunners.get(jobId);
     if (job == null) throw new PSJobException(IPSJobErrors.INVALID_JOB_ID, jobId.toString());
 
     int resultCode = doCancelJob(job);
@@ -355,7 +355,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
    */
   public void jobCompleted(long jobId) {
     // remove listener
-    PSJobRunner job = (PSJobRunner) m_jobRunners.get(Integer.valueOf((int) jobId));
+    PSJobRunner job = m_jobRunners.get(Integer.valueOf((int) jobId));
     if (job != null) job.removeJobListener(this);
 
     // unlock handler
@@ -363,7 +363,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
   }
 
   // see IPSRootedHandler for documentation
-  public Iterator getRequestRoots() {
+  public Iterator<String> getRequestRoots() {
     return m_requestRoots.iterator();
   }
 
@@ -475,7 +475,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
    * Storage for the request roots, initialized in <code>init()</code>, never <code>null</code>,
    * empty or modified after that. A list of <code>String</code> objects.
    */
-  private Collection m_requestRoots = null;
+  private Collection<String> m_requestRoots = null;
 
   /**
    * Job handler config used by this handler, intialized by file provided by <code>init()</code>
@@ -498,7 +498,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
    * the job id as an <code>Integer</code>, value is an instance of a <code>PSJobRunner</code>.
    * Never <code>null</code>.
    */
-  private Map m_jobRunners = new HashMap();
+  private Map<Integer, PSJobRunner> m_jobRunners = new HashMap<>();
 
   /**
    * The next job id to use, incremented each time a job is started by a call to <code>runJob()

--- a/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
@@ -198,7 +198,7 @@ public class PSJobHandlerConfiguration {
     if (jobType == null || jobType.trim().length() == 0)
       throw new IllegalArgumentException("jobType may not be null or empty");
 
-    String className = (String) m_jobs.get(getContext(category, jobType));
+    String className = m_jobs.get(getContext(category, jobType));
 
     if (className == null) {
       Object[] args = {category, jobType};
@@ -215,7 +215,7 @@ public class PSJobHandlerConfiguration {
    * @return The params, never <code>null</code>.
    */
   public Properties getHandlerInitParams() {
-    Properties props = (Properties) m_initParams.get(getContext(null, null));
+    Properties props = m_initParams.get(getContext(null, null));
 
     return props;
   }
@@ -238,7 +238,7 @@ public class PSJobHandlerConfiguration {
     if (jobType == null || jobType.trim().length() == 0)
       throw new IllegalArgumentException("jobType may not be null or empty");
 
-    Properties props = (Properties) m_initParams.get(getContext(category, jobType));
+    Properties props = m_initParams.get(getContext(category, jobType));
 
     if (props == null) {
       Object[] args = {category, jobType};
@@ -328,7 +328,7 @@ public class PSJobHandlerConfiguration {
    * are specified by a context of "handler/<category>/<jobType>". Never <code>null</code>,
    * intialized during ctor, never modified after that.
    */
-  private HashMap m_jobs = new HashMap();
+  private HashMap<String, String> m_jobs = new HashMap<>();
 
   /**
    * Map of initParams. Each key is a context as a <code>String</code> and the value is a <code>
@@ -337,5 +337,5 @@ public class PSJobHandlerConfiguration {
    * used as a key to store initParams for the handler as well as the category and the jobs in that
    * category. Never <code>null</code>, initialized during ctor, never modified after that.
    */
-  private HashMap m_initParams = new HashMap();
+  private HashMap<String, Properties> m_initParams = new HashMap<>();
 }

--- a/system/src/main/java/com/percussion/server/job/PSJobRunner.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobRunner.java
@@ -107,10 +107,8 @@ public abstract class PSJobRunner extends Thread {
     // need to copy the listener list because as we call jobCompleted, each
     // listener will remove themselves, and it will cause a concurrent
     // modification exception if we iterate on m_listeners
-    List listeners = new ArrayList(m_listeners);
-    Iterator i = listeners.iterator();
-    while (i.hasNext()) {
-      IPSJobListener listener = (IPSJobListener) i.next();
+    List<IPSJobListener> listeners = new ArrayList<>(m_listeners);
+    for (IPSJobListener listener : listeners) {
       listener.jobCompleted(getId());
     }
   }
@@ -254,7 +252,7 @@ public abstract class PSJobRunner extends Thread {
   protected int m_id = -1;
 
   /** List of job listeners, never <code>null</code>, may be empty. */
-  private List m_listeners = new ArrayList();
+  private List<IPSJobListener> m_listeners = new ArrayList<>();
 
   /**
    * the actual request that will result in spawning a thread. The consumer i.e the subclass may set

--- a/system/src/test/java/com/percussion/server/PSServerResidualTypedTest.java
+++ b/system/src/test/java/com/percussion/server/PSServerResidualTypedTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.server.compare.PSCompareRequestHandler;
+import com.percussion.server.job.PSJobHandlerConfiguration;
+import com.percussion.server.job.PSJobRunner;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Behavioral unit tests for typed residual collections under {@code com.percussion.server}
+ * (non-cache, non-webservices) for issue #3170.
+ */
+class PSServerResidualTypedTest {
+
+  @Test
+  @DisplayName("getPersistedPropertyMeta rejects both category and name empty")
+  void getPersistedPropertyMetaRejectsEmptyKeys() {
+    PSPersistentPropertyManager mgr = PSPersistentPropertyManager.getInstance();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> mgr.getPersistedPropertyMeta("", null, ""));
+  }
+
+  @Test
+  @DisplayName("getPersistedProperty rejects both category and name empty")
+  void getPersistedPropertyRejectsEmptyKeys() {
+    PSPersistentPropertyManager mgr = PSPersistentPropertyManager.getInstance();
+    assertThrows(
+        IllegalArgumentException.class, () -> mgr.getPersistedProperty("", null, ""));
+  }
+
+  @Test
+  @DisplayName("save rejects null collection")
+  void saveRejectsNullCollection() {
+    PSPersistentPropertyManager mgr = PSPersistentPropertyManager.getInstance();
+    assertThrows(IllegalArgumentException.class, () -> mgr.save(null, null));
+  }
+
+  @Test
+  @DisplayName("getUserName rejects null session")
+  void getUserNameRejectsNull() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSPersistentPropertyManager.getUserName(null));
+  }
+
+  @Test
+  @DisplayName("compare handler init accepts typed request roots")
+  void compareHandlerInitTypedRoots() {
+    PSCompareRequestHandler handler = new PSCompareRequestHandler();
+    List<String> roots = new ArrayList<>();
+    roots.add("compare");
+    handler.init(roots, null);
+    Iterator<String> it = handler.getRequestRoots();
+    assertTrue(it.hasNext());
+    assertEquals("compare", it.next());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  @DisplayName("compare handler init rejects empty roots")
+  void compareHandlerInitRejectsEmpty() {
+    PSCompareRequestHandler handler = new PSCompareRequestHandler();
+    assertThrows(
+        IllegalArgumentException.class, () -> handler.init(new ArrayList<>(), null));
+  }
+
+  @Test
+  @DisplayName("PSJobHandlerConfiguration loads typed job class and init params")
+  void jobHandlerConfigTypedMaps() throws Exception {
+    String xml =
+        """
+        <PSXJobHandlerConfiguration>
+          <InitParams>
+            <InitParam name="h1" value="v1"/>
+          </InitParams>
+          <Categories>
+            <Category name="cat1">
+              <InitParams>
+                <InitParam name="c1" value="cv1"/>
+              </InitParams>
+              <Jobs>
+                <Job jobType="jt1" className="com.example.JobRunner">
+                  <InitParams>
+                    <InitParam name="j1" value="jv1"/>
+                  </InitParams>
+                </Job>
+              </Jobs>
+            </Category>
+          </Categories>
+        </PSXJobHandlerConfiguration>
+        """;
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), false);
+    PSJobHandlerConfiguration cfg = new PSJobHandlerConfiguration(doc);
+    assertEquals("com.example.JobRunner", cfg.getJobClassName("cat1", "jt1"));
+    Properties props = cfg.getJobInitParams("cat1", "jt1");
+    assertNotNull(props);
+    assertEquals("jv1", props.getProperty("j1"));
+    assertEquals("cv1", props.getProperty("c1"));
+    assertEquals("v1", props.getProperty("h1"));
+  }
+
+  @Test
+  @DisplayName("PSJobRunner typed listeners fire on setCompleted")
+  void jobRunnerTypedListeners() throws Exception {
+    TestJobRunner runner = new TestJobRunner();
+    runner.init(42, null, null, null);
+    final long[] completedId = {-1L};
+    runner.addJobListener(id -> completedId[0] = id);
+    Method setCompleted = PSJobRunner.class.getDeclaredMethod("setCompleted");
+    setCompleted.setAccessible(true);
+    setCompleted.invoke(runner);
+    assertEquals(42L, completedId[0]);
+    assertTrue(runner.isCompleted());
+  }
+
+  @Test
+  @DisplayName("singleton PSPersistentPropertyManager is stable")
+  void managerSingleton() {
+    assertSame(
+        PSPersistentPropertyManager.getInstance(), PSPersistentPropertyManager.getInstance());
+  }
+
+  @Test
+  @DisplayName("public collection return types are generic (compile-time contract)")
+  void publicApiCollectionTypes() throws Exception {
+    Method meta =
+        PSPersistentPropertyManager.class.getMethod(
+            "getPersistedPropertyMeta", String.class, PSUserSession.class, String.class);
+    assertEquals(Collection.class, meta.getReturnType());
+    // generic signature retains type arguments
+    assertTrue(meta.getGenericReturnType().getTypeName().contains("PSPersistentPropertyMeta"));
+
+    Method props =
+        PSPersistentPropertyManager.class.getMethod(
+            "getPersistedProperty", String.class, PSUserSession.class, String.class);
+    assertTrue(props.getGenericReturnType().getTypeName().contains("PSPersistentProperty"));
+
+    Method sessionProps = PSUserSession.class.getMethod("getUserProperties");
+    assertTrue(sessionProps.getGenericReturnType().getTypeName().contains("PSPersistentProperty"));
+  }
+
+  /** Minimal concrete job runner for listener tests. */
+  private static final class TestJobRunner extends PSJobRunner {
+    @Override
+    public void init(
+        int id, Document descriptor, PSRequest req, Properties initParams) {
+      m_id = id;
+    }
+
+    @Override
+    public void doRun() {
+      // no-op
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Partial residual fix for **#3170** (parent epic **#2022**, grandparent **#2200**, residual of **#3160** / open PR **#3171**).

PR-sized **`com.percussion.server` residual** `-Xlint` rawtypes/unchecked batch (non-cache, non-webservices) with real generics.

### Changed
- `PSPersistentPropertyManager` — nested typed category/leaf caches (`CategoryMap`/`LeafMap`), `Collection<PSPersistentPropertyMeta|PSPersistentProperty>` public APIs, typed `save`; fixed `resetMetaCache` remove-if
- `PSUserSession` — typed user entries, credentials/db ids/auth maps, system/private maps, property collections; narrowed community-list unchecked casts
- `PSCompareRequestHandler` — `Collection<String>` / `Iterator<String>` request roots; typed user properties
- `PSJobHandler` / `PSJobRunner` / `PSJobHandlerConfiguration` — typed request roots, job runner map, listener list, job/init-param maps
- Test: `PSServerResidualTypedTest` (10 tests)

### Out of scope
- `server.cache` (#2877 / PR #3161)
- `server.webservices` (#3160 / PR #3171)
- Remaining server (PSRequest/PSServer/content/clone…): **#3186**
- `services.*` **#3181**; security residual **#3182**

## Test plan
- [x] system module `mvnw clean install` (no skipTests)
- [x] New typed-collection unit tests green
- [x] Erlang review written

## Gates evidence
- **modules_built:** `system`
- **build_evidence:** `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1965**, Failures: 0, Errors: 0, Skipped: 241; `PSServerResidualTypedTest` Tests run: 10, Failures: 0
- **downstream_checked:** C2 — public Collection return/param types refined (erasure-compatible); monorepo callers of `getUserProperties` / getPersistedProperty* reviewed (PSCompareRequestHandler, PreferencesAdaptor `.contains`); no `final`/`sealed`; no reverse-dep module install required beyond system
- **C5 UI proof:** N/A (pure tech-debt / no UI surface)

## Product documentation
- [x] N/A — pure Xlint/generics tech-debt; no operator/user-facing behavior change

## Residual
- **#3186** remaining server (PSRequest/PSServer/content/clone/actions/command)
- **#3181** services.*; **#3182** security residual

## Links
- Fixes #3170
- Parent epic #2022
- Grandparent #2200
- Related #3160 / PR #3171; #2877 / PR #3161

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
