### PR TITLE
fix(perc-system): type services.security raw collections (#3181)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3181-services-security-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3181-services-security-xlint-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review: issue #3181 services.security Xlint batch
+
+**Change class:** Generics/rawtypes cleanup (tech-debt) under `com.percussion.services.security` (+ small utils/legacy helpers).
+
+## Scope reviewed
+- `system/services/src/com/percussion/services/security/**` typed collections
+- `PSAssemblyServiceUtils`, `PSCriteriaQueryRepeater`
+- `PSHibernateEvictionTableUpdateHandler` / `PSCmsObjectMgr.handleDataEviction` Class<?> align
+- Unit tests: `PSJaasUtilsTest`, `PSServicesSecurityTypedTest`
+
+## Hard gates
+| Gate | Result |
+|------|--------|
+| Bugs | None found — behavior preserved; loops replace FilterIterator without changing match rules |
+| Behavioral tests | Yes — null guards + create/find + permissions enum |
+| Portable paths | N/A (no I/O) |
+| API blast radius | `findOrCreateGroup(Collection<? super Principal>)`, `findFirstPSPrincipal(Collection<?>)`, `Map<String,?>` assembly params, `Class<?>[]` eviction ctor — callers pass compatible collections |
+
+## Notes
+- Prefer real generics over suppressions; removed obsolete `@SuppressWarnings("unchecked")` where typed.
+- Out of scope residual: publisher/assembly/contentmgr/legacy bulk Xlint (~200+ diags).
+
+## Verdict
+**PASS** — ready for commit/PR after system clean install.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
+++ b/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
@@ -191,7 +191,7 @@ public class PSCmsObjectMgr
       {"CONTENTSTATUS", "RXLOCALE", "RXLOCALEFORMAT"};
       String[] pks =
       {"CONTENTID", "LOCALEID", "LANGUAGESTRING"};
-      Class clazz[] =
+      Class<?> clazz[] =
       {PSComponentSummary.class, PSLocale.class, PSLocaleFormat.class};
 
       PSServer.addInitListener(new PSHibernateEvictionTableUpdateHandler(tables, pks, clazz));
@@ -1008,7 +1008,7 @@ public class PSCmsObjectMgr
       return rval.stream();
    }
 
-   public void handleDataEviction(Class clazz, Serializable id) throws PSORMException
+   public void handleDataEviction(Class<?> clazz, Serializable id) throws PSORMException
    {
       Session s = getSession();
 

--- a/system/services/src/com/percussion/services/security/PSAclUtils.java
+++ b/system/services/src/com/percussion/services/security/PSAclUtils.java
@@ -19,6 +19,7 @@ package com.percussion.services.security;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
 
+import com.percussion.security.shim.acl.AclEntry;
 import com.percussion.security.shim.acl.NotOwnerException;
 import com.percussion.security.shim.acl.Permission;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PSAclUtils
          throw new IllegalArgumentException("source cannot be null.");
       if (target == null)
          throw new IllegalArgumentException("target cannot be null.");
-      Enumeration enumEntries = source.entries();
+      Enumeration<? extends AclEntry> enumEntries = source.entries();
       while (enumEntries.hasMoreElements())
       {
          IPSAclEntry entry = (IPSAclEntry) enumEntries.nextElement();
@@ -66,10 +67,10 @@ public class PSAclUtils
             // Already has the entry so just modify the
             // permissions
             tEntry.clearPermissions();
-            Enumeration enumPerms = entry.permissions();
+            Enumeration<Permission> enumPerms = entry.permissions();
             while (enumPerms.hasMoreElements())
             {
-               Permission perm = (Permission) enumPerms.nextElement();
+               Permission perm = enumPerms.nextElement();
                tEntry.addPermission(perm);
             }
          }
@@ -78,10 +79,10 @@ public class PSAclUtils
             // Need to add the entry
             IPSAclEntry newEntry = target
                .createEntry(entry.getTypedPrincipal());
-            Enumeration enumPerms = entry.permissions();
+            Enumeration<Permission> enumPerms = entry.permissions();
             while (enumPerms.hasMoreElements())
             {
-               Permission perm = (Permission) enumPerms.nextElement();
+               Permission perm = enumPerms.nextElement();
                newEntry.addPermission(perm);
             }
             try
@@ -107,7 +108,7 @@ public class PSAclUtils
       if (acl == null)
          throw new IllegalArgumentException("acl cannot be null.");
       List<IPSAclEntry> removeList = new ArrayList<>();
-      Enumeration enumEntries = acl.entries();
+      Enumeration<? extends AclEntry> enumEntries = acl.entries();
       while (enumEntries.hasMoreElements())
       {
          IPSAclEntry entry = (IPSAclEntry) enumEntries.nextElement();
@@ -158,7 +159,7 @@ public class PSAclUtils
    {
       removeAllEntries(acl, PrincipalTypes.COMMUNITY);
       // Find the system community entry and set permission
-      Enumeration enumEntries = acl.entries();
+      Enumeration<? extends AclEntry> enumEntries = acl.entries();
       while (enumEntries.hasMoreElements())
       {
          IPSAclEntry entry = (IPSAclEntry) enumEntries.nextElement();
@@ -180,7 +181,7 @@ public class PSAclUtils
    public static void removeVisibilityOnSystemCommunityEntry(IPSAcl acl)
    {
       // Find the system community entry and remove permission
-      Enumeration enumEntries = acl.entries();
+      Enumeration<? extends AclEntry> enumEntries = acl.entries();
       while (enumEntries.hasMoreElements())
       {
          IPSAclEntry entry = (IPSAclEntry) enumEntries.nextElement();

--- a/system/services/src/com/percussion/services/security/PSJaasUtils.java
+++ b/system/services/src/com/percussion/services/security/PSJaasUtils.java
@@ -48,8 +48,6 @@ import java.util.TreeSet;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.iterators.FilterIterator;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -67,39 +65,6 @@ public class PSJaasUtils
    public static final String ROLE_DEFAULT = "Default";
 
    /**
-    * Predicate for filtering an iterater to return only group entries.
-    */
-   private static class PSGroupNamePredicate implements Predicate
-   {
-      /**
-       * The name of the principal that contains groups, never
-       * <code>null</code>.
-       */
-      String mi_name = null;
-
-      /**
-       * Ctor
-       * @param n name, assumed not <code>null</code>
-       */
-      PSGroupNamePredicate(String n)
-      {
-         mi_name = n;
-      }
-
-      public boolean evaluate(Object principal)
-      {
-         if (principal instanceof Principal)
-         {
-            return principal instanceof Group &&
-               ((Principal) principal).getName().equals(mi_name);
-         }
-         else
-            return false;
-      }
-
-   }
-
-   /**
     * Find the group that represents the roles for the subject, or create a new
     * group with the appropriate name. If a group is created, it will be
     * appended to the collection of principals.
@@ -111,25 +76,28 @@ public class PSJaasUtils
     *          the name of the group to find, never <code>null</code>
     * @return the group, either found or created, never <code>null</code>
     */
-   @SuppressWarnings(value={"unchecked"})
-   public static Group findOrCreateGroup(Collection coll, String name)
+   public static Group findOrCreateGroup(Collection<? super Principal> coll, String name)
    {
       if (StringUtils.isEmpty(name))
       {
          throw new IllegalArgumentException("name may not be null or empty");
       }
-      Iterator roleGroups =
-         new FilterIterator(coll.iterator(), new PSGroupNamePredicate(name));
-      if (! roleGroups.hasNext())
+      if (coll == null)
       {
-         Group roleGroup = new PSGroup(name);
-         coll.add(roleGroup);
-         return roleGroup;
+         throw new IllegalArgumentException("coll may not be null");
       }
-      else
+      for (Object principal : coll)
       {
-         return (Group) roleGroups.next();
+         if (principal instanceof Group
+            && principal instanceof Principal
+            && name.equals(((Principal) principal).getName()))
+         {
+            return (Group) principal;
+         }
       }
+      Group roleGroup = new PSGroup(name);
+      coll.add(roleGroup);
+      return roleGroup;
    }
 
    /**
@@ -141,21 +109,20 @@ public class PSJaasUtils
     * @return the first principal that matches or <code>null</code> if none
     *         match
     */
-   @SuppressWarnings(value={"unchecked"})
-   public static Principal findFirstPSPrincipal(Collection coll)
+   public static Principal findFirstPSPrincipal(Collection<?> coll)
    {
-      Iterator iter = new FilterIterator(coll.iterator(), new Predicate()
+      if (coll == null)
       {
-         public boolean evaluate(Object principal)
+         throw new IllegalArgumentException("coll may not be null");
+      }
+      for (Object principal : coll)
+      {
+         if (principal instanceof PSPrincipal)
          {
-            return principal instanceof PSPrincipal;
+            return (PSPrincipal) principal;
          }
-      });
-
-      if (iter.hasNext())
-         return (Principal) iter.next();
-      else
-         return null;
+      }
+      return null;
    }
 
    /**
@@ -254,7 +221,6 @@ public class PSJaasUtils
     *
     * @return The subject, never <code>null</code>.
     */
-   @SuppressWarnings(value={"unchecked"})
    public static Subject userEntryToSubject(PSUserEntry userEntry, String pwd)
    {
       if (userEntry == null)
@@ -302,14 +268,12 @@ public class PSJaasUtils
       PSUserAttributes attrs = userEntry.getAttributes();
       if (attrs != null)
       {
-         Iterator entries = attrs.entrySet().iterator();
-         while (entries.hasNext())
+         for (Map.Entry<String, String> entry : attrs.entrySet())
          {
-            Map.Entry entry = (Map.Entry)entries.next();
             List<String> values = new ArrayList<>();
-            values.add((String) entry.getValue());
+            values.add(entry.getValue());
             IPSPrincipalAttribute attr = new PSPrincipalAttribute(
-               (String) entry.getKey(), PrincipalAttributes.ANY, values);
+               entry.getKey(), PrincipalAttributes.ANY, values);
             principals.add(attr);
          }
       }
@@ -354,7 +318,7 @@ public class PSJaasUtils
       Set<Principal> principals = sub.getPrincipals();
       principals.add(subjectToPrincipal(psSub));
 
-      Iterator attrs = psSub.getAttributes().iterator();
+      Iterator<?> attrs = psSub.getAttributes().iterator();
       while (attrs.hasNext())
          principals.add(PSJaasUtils.convertAttribute(
             (PSAttribute) attrs.next(), emailAttrName));
@@ -391,12 +355,10 @@ public class PSJaasUtils
          throw new IllegalArgumentException("attr may not be null");
 
       List<String> values = new ArrayList<>();
-      Iterator valItr = attr.getValues().iterator();
-      while (valItr.hasNext())
+      for (String val : attr.getValues())
       {
-         Object val = valItr.next();
          if (val != null)
-            values.add(val.toString());
+            values.add(val);
       }
 
       PrincipalAttributes attrType = attr.getName().equals(emailAttrName) ?
@@ -501,16 +463,23 @@ public class PSJaasUtils
       Set<Principal> principals)
    {
       String username = null;
-      Iterator principalGroups = new FilterIterator(principals.iterator(),
-         new PSGroupNamePredicate("CallerPrincipal"));
-      if (principalGroups.hasNext())
+      for (Principal principal : principals)
       {
-         Group group = (Group) principalGroups.next();
+         if (!(principal instanceof Group))
+         {
+            continue;
+         }
+         if (!"CallerPrincipal".equals(principal.getName()))
+         {
+            continue;
+         }
+         Group group = (Group) principal;
          if (group.members().hasMoreElements())
          {
             Principal userPrincipal = group.members().nextElement();
             username = userPrincipal.getName();
          }
+         break;
       }
 
       return username;

--- a/system/services/src/com/percussion/services/security/PSServletRequestWrapper.java
+++ b/system/services/src/com/percussion/services/security/PSServletRequestWrapper.java
@@ -25,7 +25,7 @@ import com.percussion.security.shim.acl.Group;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Iterator;
+
 
 import javax.security.auth.Subject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -104,10 +104,8 @@ public class PSServletRequestWrapper extends HttpServletRequestWrapper
       String remoteUser = null;
       if (m_subject != null)
       {
-         Iterator<Principal> principals = m_subject.getPrincipals().iterator();
-         while (principals.hasNext())
+         for (Principal p : m_subject.getPrincipals())
          {
-            Principal p = principals.next();
             if (p instanceof Group)
                continue;
             if (p instanceof IPSTypedPrincipal)
@@ -140,17 +138,14 @@ public class PSServletRequestWrapper extends HttpServletRequestWrapper
       else
       {
          getRoles(); // Ensure that roles are populated
-         Iterator it = m_roles.iterator();
-         boolean exists = false;
-         while(it.hasNext())
+         for (String existingRole : m_roles)
          {
-            if ( StringUtils.equalsIgnoreCase(role, (String)it.next()) )
+            if (StringUtils.equalsIgnoreCase(role, existingRole))
             {
-               exists = true;
-               break;
+               return true;
             }
          }
-         return exists;
+         return false;
       }
    }
 

--- a/system/services/src/com/percussion/services/security/data/PSAclEntryImpl.java
+++ b/system/services/src/com/percussion/services/security/data/PSAclEntryImpl.java
@@ -445,15 +445,11 @@ public class PSAclEntryImpl implements IPSAclEntry
     * 
     * @see java.security.acl.AclEntry#permissions()
     */
-   @SuppressWarnings(value =
-   {
-      "unchecked"
-   })
    public Enumeration<Permission> permissions()
    {
       return new Enumeration<Permission>()
       {
-         private Iterator it = psPermissions.iterator();
+         private final Iterator<PSAccessLevelImpl> it = psPermissions.iterator();
 
          public boolean hasMoreElements()
          {
@@ -462,7 +458,7 @@ public class PSAclEntryImpl implements IPSAclEntry
 
          public Permission nextElement()
          {
-            return ((PSAccessLevelImpl) it.next()).getPermission();
+            return it.next().getPermission();
          }
       };
    }

--- a/system/services/src/com/percussion/services/security/data/PSCommunity.java
+++ b/system/services/src/com/percussion/services/security/data/PSCommunity.java
@@ -44,7 +44,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
+
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -524,11 +524,8 @@ public class PSCommunity implements Serializable, IPSCatalogSummary,
    public Object tuneClone(long newId)
    {
       id = newId;
-      Iterator roleAssocs = roleAssociations.iterator();
-      while (roleAssocs.hasNext())
+      for (PSCommunityRoleAssociation assoc : roleAssociations)
       {
-         PSCommunityRoleAssociation assoc = (PSCommunityRoleAssociation) roleAssocs
-            .next();
          assoc.setCommunityId(id);
       }
       return this;

--- a/system/services/src/com/percussion/services/security/impl/PSAclService.java
+++ b/system/services/src/com/percussion/services/security/impl/PSAclService.java
@@ -182,7 +182,9 @@ public class PSAclService implements IPSAclService
    {
       Session session = entityManager.unwrap(Session.class);
 
-      List<Object[]> rows = session.createQuery("select distinct a.objectId, a.objectType from PSAclImpl a").list();
+      List<Object[]> rows = session
+         .createQuery("select distinct a.objectId, a.objectType from PSAclImpl a", Object[].class)
+         .list();
       return rows.stream().map(r -> new PSGuid(PSTypeEnum.valueOf(((Number) r[1]).intValue()), ((Number) r[0]).longValue()));
    }
 
@@ -389,10 +391,12 @@ public class PSAclService implements IPSAclService
       synchronized (this) {
          getSession().flush();
          CriteriaBuilder builder = getSession().getCriteriaBuilder();
-         CriteriaQuery criteria = builder.createQuery(PSAclImpl.class);
-         Root critRoot = criteria.from(PSAclImpl.class);
+         CriteriaQuery<PSAclImpl> criteria = builder.createQuery(PSAclImpl.class);
+         Root<PSAclImpl> critRoot = criteria.from(PSAclImpl.class);
+         criteria.select(critRoot);
 
-         List<IPSAcl> acls = entityManager.createQuery(criteria).getResultList();
+         List<PSAclImpl> loaded = entityManager.createQuery(criteria).getResultList();
+         List<IPSAcl> acls = new ArrayList<>(loaded);
          for (IPSAcl acl : acls) {
             if (acl.getObjectId() >> 32 != 0) {
                ms_logger.error("Fixing acl entry with bad id " + acl.getObjectId());

--- a/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
+++ b/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
@@ -109,7 +109,7 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
                 "PSX_ROLES", "PSX_SUBJECTS", "RXCOMMUNITY", "RXCOMMUNITYROLE"
             };
         String[] pks = { "ID", "ID", "COMMUNITYID", null };
-        Class[] clazz = {
+        Class<?>[] clazz = {
                 PSBackEndRole.class, PSBackEndSubject.class, PSCommunity.class,
                 PSCommunityRoleAssociation.class
             };
@@ -308,7 +308,7 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
                 subjectType, null);
         PSSubject sub = roleCfg.getGlobalSubject(relativeSub, true);
 
-        Iterator roles = roleCfg.getRoles().iterator();
+        Iterator<?> roles = roleCfg.getRoles().iterator();
 
         while (roles.hasNext()) {
             PSRole role = (PSRole) roles.next();
@@ -336,7 +336,7 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
     private void removeSubjectFromRole(PSRole role,
         PSRelativeSubject relativeSub) {
         PSRelativeSubject tgtSub = null;
-        Iterator subs = role.getSubjects().iterator();
+        Iterator<?> subs = role.getSubjects().iterator();
 
         while (subs.hasNext()) {
             PSRelativeSubject sub = (PSRelativeSubject) subs.next();
@@ -421,11 +421,7 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
 
         Set<IPSPrincipalAttribute> attrSet = new HashSet<>();
 
-        Iterator attrs = PSBackendCataloger.getRoleAttributes(roleName)
-                                           .iterator();
-
-        while (attrs.hasNext()) {
-            PSAttribute attr = (PSAttribute) attrs.next();
+        for (PSAttribute attr : PSBackendCataloger.getRoleAttributes(roleName)) {
             attrSet.add(PSJaasUtils.convertAttribute(attr));
         }
 
@@ -442,11 +438,8 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
 
         Set<Subject> subSet = new HashSet<>();
 
-        Iterator subs = PSBackendCataloger.getSubjectRoleAttributes(subjectNameFilter,
-                0, roleName, null).iterator();
-
-        while (subs.hasNext()) {
-            PSSubject psSub = (PSSubject) subs.next();
+        for (PSSubject psSub : PSBackendCataloger.getSubjectRoleAttributes(
+                subjectNameFilter, 0, roleName, null)) {
             subSet.add(PSJaasUtils.convertSubject(psSub));
         }
 
@@ -458,11 +451,9 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
         String attributeNameFilter, boolean includeEmptySubjects) {
         Set<Subject> subSet = new HashSet<>();
 
-        Iterator subs = PSBackendCataloger.getSubjectGlobalAttributes(subjectNameFilter,
-                0, null, attributeNameFilter, includeEmptySubjects).iterator();
-
-        while (subs.hasNext()) {
-            PSSubject psSub = (PSSubject) subs.next();
+        for (PSSubject psSub : PSBackendCataloger.getSubjectGlobalAttributes(
+                subjectNameFilter, 0, null, attributeNameFilter,
+                includeEmptySubjects)) {
             subSet.add(PSJaasUtils.convertSubject(psSub));
         }
 
@@ -892,8 +883,9 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
         Session session = getSession();
 
         IPSGuid[] ids = roleIds.toArray(new IPSGuid[roleIds.size()]);
-        Query query = session.createQuery(
-                "from PSCommunityRoleAssociation cr where cr.id.roleId in (:ids)");
+        Query<PSCommunityRoleAssociation> query = session.createQuery(
+                "from PSCommunityRoleAssociation cr where cr.id.roleId in (:ids)",
+                PSCommunityRoleAssociation.class);
         query.setParameterList("ids", PSGuidUtils.toLongArray(ids));
 
         return query.list();

--- a/system/services/src/com/percussion/services/security/loginmods/PSRxLoginModule.java
+++ b/system/services/src/com/percussion/services/security/loginmods/PSRxLoginModule.java
@@ -50,7 +50,7 @@ public class PSRxLoginModule implements LoginModule
 
    // see base class
    public void initialize(Subject subject, CallbackHandler handler,
-      Map sharedState, Map options)
+      Map<String, ?> sharedState, Map<String, ?> options)
    {
       m_subject = subject;
       m_callbackHandler = handler;

--- a/system/services/src/com/percussion/services/utils/general/PSAssemblyServiceUtils.java
+++ b/system/services/src/com/percussion/services/utils/general/PSAssemblyServiceUtils.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +77,7 @@ public class PSAssemblyServiceUtils
     */
 
    public static IPSAssemblyResult getAssembledDocumentResult(
-      String url, Map extraParams) throws PSRequestParsingException,
+      String url, Map<String, ?> extraParams) throws PSRequestParsingException,
       PSAssemblyException, PSCmsException,
       ItemNotFoundException, PSFilterException,
       RepositoryException, PSTemplateNotImplementedException
@@ -87,25 +86,22 @@ public class PSAssemblyServiceUtils
       .getAssemblyService();
       IPSAssemblyItem item = service.createAssemblyItem();
 
-      Map params;
-
       /* The HashMap returned by the parseParameters method has an overridden
        * put method which creates ArrayLists for key values if the key already
        * exists in the map, so create a new HashMap with the mappings in order
        * to use putAll with expected behavior.
        */
-      params = new HashMap(PSParseUrlQueryString.parseParameters(url));
+      Map<String, Object> params =
+         new HashMap<>(PSParseUrlQueryString.parseParameters(url));
       if(extraParams != null && !extraParams.isEmpty())
         params.putAll(extraParams);
 
-      Iterator iter = params.keySet().iterator();
-      while (iter.hasNext())
+      for (Map.Entry<String, Object> entry : params.entrySet())
       {
-        Object param = iter.next();
-        Object obj = params.get(param);
+        Object obj = entry.getValue();
         String value = (obj == null) ? "" : obj.toString();
         if (!StringUtils.isBlank(value))
-           item.setParameterValue(param.toString(), value);
+           item.setParameterValue(entry.getKey(), value);
       }
 
       item.normalize();
@@ -137,7 +133,7 @@ public class PSAssemblyServiceUtils
     * @throws UnsupportedEncodingException if the charset is not supported
     */
    public static String getAssembledDocument(
-      String url, Map extraParams) throws PSRequestParsingException,
+      String url, Map<String, ?> extraParams) throws PSRequestParsingException,
    PSAssemblyException, PSCmsException,
    ItemNotFoundException, PSFilterException,
    RepositoryException, PSTemplateNotImplementedException,

--- a/system/services/src/com/percussion/services/utils/orm/PSCriteriaQueryRepeater.java
+++ b/system/services/src/com/percussion/services/utils/orm/PSCriteriaQueryRepeater.java
@@ -129,7 +129,7 @@ public abstract class PSCriteriaQueryRepeater<E>
             throw new IllegalStateException("createQuery must not return null");
          }
 
-         List dbResults = query.list();
+         List<E> dbResults = query.list();
          if (dbResults != null)
             results.addAll(dbResults);
       }

--- a/system/src/main/java/com/percussion/data/utils/PSHibernateEvictionTableUpdateHandler.java
+++ b/system/src/main/java/com/percussion/data/utils/PSHibernateEvictionTableUpdateHandler.java
@@ -43,7 +43,7 @@ public class PSHibernateEvictionTableUpdateHandler extends PSTableUpdateHandlerB
   private String[] m_keys;
 
   /** The classes that correspond to the tables */
-  private Class[] m_classes;
+  private Class<?>[] m_classes;
 
   /**
    * Ctor
@@ -57,7 +57,7 @@ public class PSHibernateEvictionTableUpdateHandler extends PSTableUpdateHandlerB
    *     class from the cache, useful when objects specify a compound key.
    */
   public PSHibernateEvictionTableUpdateHandler(
-      String tables[], String pkcolumns[], Class persistenceClasses[]) {
+      String tables[], String pkcolumns[], Class<?> persistenceClasses[]) {
     super(tables);
     if (pkcolumns == null) {
       throw new IllegalArgumentException("pkcolumns may not be null");
@@ -89,7 +89,7 @@ public class PSHibernateEvictionTableUpdateHandler extends PSTableUpdateHandlerB
 
     if (i < 0) return;
 
-    Class clazz = m_classes[i];
+    Class<?> clazz = m_classes[i];
     String keycol = m_keys[i];
     Serializable data = null;
     if (keycol != null) {

--- a/system/src/test/java/com/percussion/services/security/PSJaasUtilsTest.java
+++ b/system/src/test/java/com/percussion/services/security/PSJaasUtilsTest.java
@@ -28,10 +28,7 @@ import com.percussion.services.security.loginmods.data.PSPrincipal;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import javax.security.auth.Subject;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.iterators.FilterIterator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -77,34 +74,15 @@ public class PSJaasUtilsTest {
    *
    * @throws Exception if the test fails.
    */
-  @SuppressWarnings(value = {"unchecked"})
   @Test
   public void testCollectionResults() throws Exception {
     ms_testData.add(new PSPrincipal("user"));
     ms_testData.add(new PSPrincipal("grape"));
     ms_testData.add(new PSPrincipal("orange"));
 
-    Iterator<Principal> rval;
-
     Principal u = PSJaasUtils.findFirstPSPrincipal(ms_testData);
     assertTrue(u == ms_testData.iterator().next());
-
-    rval =
-        new FilterIterator(
-            ms_testData.iterator(),
-            new Predicate() {
-              public boolean evaluate(Object principal) {
-                return true;
-              }
-            });
-
-    Iterator<Principal> td = ms_testData.iterator();
-
-    assertEquals(rval.next(), td.next());
-    assertEquals(rval.next(), td.next());
-    assertEquals(rval.next(), td.next());
-    assertTrue(rval.hasNext() == false);
-    assertTrue(td.hasNext() == false);
+    assertEquals("user", u.getName());
   }
 
   /**
@@ -112,7 +90,6 @@ public class PSJaasUtilsTest {
    *
    * @throws Exception if the test fails.
    */
-  @SuppressWarnings(value = {"unchecked"})
   @Test
   public void testSubjectToEntry() throws Exception {
     PSGroupEntry group1 = new PSGroupEntry("group1", 0);

--- a/system/src/test/java/com/percussion/services/security/PSServicesSecurityTypedTest.java
+++ b/system/src/test/java/com/percussion/services/security/PSServicesSecurityTypedTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.security.shim.acl.Group;
+import com.percussion.security.shim.acl.Permission;
+import com.percussion.services.security.data.PSAclEntryImpl;
+import com.percussion.services.security.loginmods.data.PSGroup;
+import com.percussion.services.security.loginmods.data.PSPrincipal;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral unit tests for typed {@code com.percussion.services.security} collections (issue
+ * #3181).
+ */
+class PSServicesSecurityTypedTest {
+
+  @Test
+  @DisplayName("findOrCreateGroup finds existing role group and rejects null collection")
+  void findOrCreateGroupTyped() {
+    Set<Principal> principals = new HashSet<>();
+    Group existing = new PSGroup(PSJaasUtils.ROLE_GROUP_NAME);
+    principals.add(existing);
+
+    Group found = PSJaasUtils.findOrCreateGroup(principals, PSJaasUtils.ROLE_GROUP_NAME);
+    assertSame(existing, found);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSJaasUtils.findOrCreateGroup(null, PSJaasUtils.ROLE_GROUP_NAME));
+  }
+
+  @Test
+  @DisplayName("findOrCreateGroup creates and appends missing group")
+  void findOrCreateGroupCreates() {
+    List<Principal> principals = new ArrayList<>();
+    Group created = PSJaasUtils.findOrCreateGroup(principals, "CallerPrincipal");
+    assertNotNull(created);
+    assertEquals("CallerPrincipal", created.getName());
+    assertEquals(1, principals.size());
+    assertTrue(principals.contains(created));
+  }
+
+  @Test
+  @DisplayName("findFirstPSPrincipal returns first PSPrincipal or null")
+  void findFirstPSPrincipalTyped() {
+    List<Principal> principals = new ArrayList<>();
+    principals.add(new PSGroup("Roles"));
+    PSPrincipal user = new PSPrincipal("admin1");
+    principals.add(user);
+    principals.add(new PSPrincipal("other"));
+
+    assertSame(user, PSJaasUtils.findFirstPSPrincipal(principals));
+    assertNull(PSJaasUtils.findFirstPSPrincipal(List.of(new PSGroup("Roles"))));
+    assertThrows(IllegalArgumentException.class, () -> PSJaasUtils.findFirstPSPrincipal(null));
+  }
+
+  @Test
+  @DisplayName("PSAclEntryImpl.permissions enumerates typed Permission values")
+  void aclEntryPermissionsTyped() {
+    PSAclEntryImpl entry = new PSAclEntryImpl();
+    entry.setName("tester");
+    entry.setType(com.percussion.security.IPSTypedPrincipal.PrincipalTypes.USER);
+    entry.addPermission(PSPermissions.READ);
+    entry.addPermission(PSPermissions.UPDATE);
+
+    Enumeration<Permission> perms = entry.permissions();
+    Set<Permission> found = new HashSet<>();
+    while (perms.hasMoreElements()) {
+      found.add(perms.nextElement());
+    }
+    assertTrue(found.contains(PSPermissions.READ));
+    assertTrue(found.contains(PSPermissions.UPDATE));
+    assertFalse(found.isEmpty());
+  }
+
+  @Test
+  @DisplayName("PSAclEntryImpl permissions empty when no access levels")
+  void aclEntryPermissionsEmpty() {
+    PSAclEntryImpl entry = new PSAclEntryImpl();
+    entry.setName("empty");
+    Enumeration<Permission> perms = entry.permissions();
+    assertFalse(perms.hasMoreElements());
+  }
+}


### PR DESCRIPTION
## Summary
Partial residual fix for **#3181** (parent epic **#2022**, related **#3170** / **#2299**).

PR-sized **com.percussion.services.security** -Xlint rawtypes/unchecked batch with real generics. Does **not** thrash server.cache / server.webservices files from open PRs #3161/#3171.

### Changed
- `PSJaasUtils` — typed `Collection<? super Principal>` / `Collection<?>`; replace FilterIterator with typed loops; typed `Map.Entry` / attribute iteration
- `PSAclUtils` — `Enumeration<? extends AclEntry>` / `Enumeration<Permission>`
- `PSServletRequestWrapper` — foreach over typed roles/principals
- `PSAclEntryImpl.permissions()` — `Iterator<PSAccessLevelImpl>`
- `PSCommunity.tuneClone` — enhanced for-each on role associations
- `PSAclService` — typed `CriteriaQuery`/`Root`; typed HQL `Object[]` query
- `PSBackEndRoleMgr` — typed iterators/for-each; `Query<PSCommunityRoleAssociation>`; `Class<?>[]`
- `PSRxLoginModule` — `Map<String, ?>` per LoginModule
- `PSAssemblyServiceUtils` — `Map<String, ?>` / `Map<String, Object>`
- `PSCriteriaQueryRepeater` — `List<E>`
- `PSHibernateEvictionTableUpdateHandler` / `PSCmsObjectMgr.handleDataEviction` — `Class<?>`

### Tests
- `PSServicesSecurityTypedTest` (5 tests)
- `PSJaasUtilsTest` updated (3 tests)

## Test plan
- [x] system module `mvnw clean install` (no skipTests)
- [x] New/updated typed unit tests green
- [x] Erlang review written

## Gates evidence
- **modules_built:** `system`
- **build_evidence:** `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1960**, Failures: 0, Errors: 0, Skipped: 241; focused `PSJaasUtilsTest,PSServicesSecurityTypedTest` Tests run: 8, Failures: 0
- **downstream_checked:** C2 partial — refined collection/Map/Class generics only (callers already pass `Set<Principal>`, `Map<String,Object>`, Class arrays). Grepped monorepo callers for `findOrCreateGroup` / `getAssembledDocument*` / eviction handler; no reverse-dep module install required beyond system.
- **C5 UI proof:** N/A (pure tech-debt / no UI surface)

## Product documentation
- [x] N/A — pure Xlint/generics tech-debt; no operator/user-facing behavior change

## Residual
- Follow-up: https://github.com/intersoftdatalabs-in/percussioncms/issues/3188 (remaining services.* packages: publisher/assembly/contentmgr/legacy)

## Links
- Fixes #3181
- Parent epic #2022
- Related #3170 / #2299
- Out of scope: #3161 / #3171 server.cache/webservices

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
