### PR TITLE
fix(deployer): SharedGroup + WorkflowDef Xlint generics batch (#3179)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSharedGroupDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSharedGroupDependencyHandler.java
@@ -85,7 +85,8 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -94,7 +95,8 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   public Iterator<PSDependency> getDependencies(PSSecurityToken tok) throws PSDeployException {
     var sharedDef = PSDependencyUtils.getSharedDef();
     List<PSDependency> deps = new ArrayList<>();
-    Iterator groups = sharedDef.getFieldGroups();
+    // PSContentEditorSharedDef.getFieldGroups() is a raw Iterator (system module).
+    Iterator<?> groups = sharedDef.getFieldGroups();
     while (groups != null && groups.hasNext()) {
       Object grp = groups.next();
       // field groups are PSSharedFieldGroup according to PSContentEditorSharedDef
@@ -105,11 +107,13 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see base class
+  @Override
   public String getType() {
     return DEPENDENCY_TYPE;
   }
 
   // see base class
+  @Override
   public boolean doesDependencyExist(PSSecurityToken tok, String id) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -120,6 +124,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see base class
+  @Override
   public PSDependency getDependency(PSSecurityToken tok, String id) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -134,7 +139,8 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see base class
-  public Iterator getChildDependencies(PSSecurityToken tok, PSDependency dep)
+  @Override
+  public Iterator<PSDependency> getChildDependencies(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -208,6 +214,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see base class
+  @Override
   public void installDependencyFiles(
       PSSecurityToken tok, PSArchiveHandler archive, PSDependency dep, PSImportCtx ctx)
       throws PSDeployException {
@@ -224,10 +231,10 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
 
     String groupName = dep.getDependencyId();
     Document doc = null;
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
     File origFile = null;
     while (files.hasNext() && doc == null) {
-      PSDependencyFile file = (PSDependencyFile) files.next();
+      PSDependencyFile file = files.next();
       if (file.getType() == PSDependencyFile.TYPE_SHARED_GROUP_XML) {
         doc = createXmlDocument(archive.getFileData(file));
         origFile = file.getOriginalFile();
@@ -347,6 +354,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see IPSIdTypeHandler interface
+  @Override
   public PSApplicationIDTypes getIdTypes(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
@@ -361,10 +369,11 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
       PSServerXmlObjectStore os = PSServerXmlObjectStore.getInstance();
       PSContentEditorSharedDef sharedDef = os.getContentEditorSharedDef();
 
-      List mappings = new ArrayList();
+      List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
       String groupName = dep.getDependencyId();
       PSSharedFieldGroup sharedGroup = null;
-      Iterator groups = sharedDef.getFieldGroups();
+      // PSContentEditorSharedDef.getFieldGroups() is a raw Iterator (system module).
+      Iterator<?> groups = sharedDef.getFieldGroups();
       while (groups.hasNext() && sharedGroup == null) {
         PSSharedFieldGroup test = (PSSharedFieldGroup) groups.next();
         if (test.getName().equals(groupName)) sharedGroup = test;
@@ -411,6 +420,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see IPSIdTypeHandler interface
+  @Override
   public void transformIds(Object object, PSApplicationIDTypes idTypes, PSIdMap idMap)
       throws PSDeployException {
     if (object == null) throw new IllegalArgumentException("object may not be null");
@@ -425,18 +435,19 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
     PSSharedFieldGroup group = (PSSharedFieldGroup) object;
 
     String groupName = group.getName();
-    Iterator resources = idTypes.getResourceList(false);
+    Iterator<String> resources = idTypes.getResourceList(false);
     while (resources.hasNext()) {
-      String resource = (String) resources.next();
+      String resource = resources.next();
       if (!groupName.equals(resource)) continue;
 
-      Iterator elements = idTypes.getElementList(resource, false);
+      Iterator<String> elements = idTypes.getElementList(resource, false);
       while (elements.hasNext()) {
-        String element = (String) elements.next();
-        Iterator mappings = idTypes.getIdTypeMappings(resource, element, false);
+        String element = elements.next();
+        Iterator<PSApplicationIDTypeMapping> mappings =
+            idTypes.getIdTypeMappings(resource, element, false);
         while (mappings.hasNext()) {
 
-          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+          PSApplicationIDTypeMapping mapping = mappings.next();
 
           if (mapping.getType().equals(PSApplicationIDTypeMapping.TYPE_NONE)) {
             continue;
@@ -494,15 +505,13 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
   public static final String DEPENDENCY_TYPE = "SharedGroup";
 
   /** List of child types supported by this handler, never <code>null</code> or empty. */
-  private static List ms_childTypes = new ArrayList();
-
-  static {
-    ms_childTypes.add(PSApplicationDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSControlDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSExitDefDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSKeywordDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSSchemaDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSStylesheetDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSSupportFileDependencyHandler.DEPENDENCY_TYPE);
-  }
+  private static final List<String> ms_childTypes =
+      List.of(
+          PSApplicationDependencyHandler.DEPENDENCY_TYPE,
+          PSControlDependencyHandler.DEPENDENCY_TYPE,
+          PSExitDefDependencyHandler.DEPENDENCY_TYPE,
+          PSKeywordDependencyHandler.DEPENDENCY_TYPE,
+          PSSchemaDependencyHandler.DEPENDENCY_TYPE,
+          PSStylesheetDependencyHandler.DEPENDENCY_TYPE,
+          PSSupportFileDependencyHandler.DEPENDENCY_TYPE);
 }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
@@ -36,7 +36,6 @@ import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.PSGuidUtils;
 import com.percussion.services.security.IPSBackEndRoleMgr;
 import com.percussion.services.security.PSRoleMgrLocator;
-import com.percussion.services.security.data.PSBackEndRole;
 import com.percussion.services.workflow.IPSWorkflowService;
 import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.services.workflow.data.PSWorkflow;
@@ -98,9 +97,10 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Set<PSDependency> childDeps = new HashSet<>();
 
     // get LOCAL state child dependencies
-    Iterator childIDs = getChildPairIdsFromTable(STATES_TABLE, STATE_ID, WORKFLOW_ID, workflowId);
+    Iterator<String> childIDs =
+        getChildPairIdsFromTable(STATES_TABLE, STATE_ID, WORKFLOW_ID, workflowId);
     while (childIDs.hasNext()) {
-      String childId = (String) childIDs.next();
+      String childId = childIDs.next();
       PSPairDependencyId pairId = new PSPairDependencyId(childId);
       PSDependencyHandler handler =
           getDependencyHandler(PSStateDefDependencyHandler.DEPENDENCY_TYPE);
@@ -122,6 +122,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
   }
 
   // see base class
+  @Override
   public Iterator<PSDependency> getDependencies(PSSecurityToken tok) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -129,6 +130,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
   }
 
   // see base class
+  @Override
   public PSDependency getDependency(PSSecurityToken tok, String id) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -160,11 +162,13 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
           PSStateDefDependencyHandler.DEPENDENCY_TYPE, PSAclDefDependencyHandler.DEPENDENCY_TYPE);
 
   // see base class
+  @Override
   public String getType() {
     return DEPENDENCY_TYPE;
   }
 
   // see base class
+  @Override
   public void reserveNewId(PSDependency dep, PSIdMap idMap) throws PSDeployException {
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
@@ -180,6 +184,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * Override the method from supper class, but this is to get the next id specifically for <code>
    * WORKFLOW_ID</code> in <code>WORKFLOW_TABLE</code>.
    */
+  @Override
   protected String getNextId(String table, PSDependency dep) throws PSDeployException {
     int id = PSDbmsHelper.getInstance().getNextIdInMemory(WORKFLOW_TABLE, WORKFLOW_ID, null, null);
 
@@ -187,7 +192,8 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
   }
 
   // see base class
-  public Iterator getDependencyFiles(PSSecurityToken tok, PSDependency dep)
+  @Override
+  public Iterator<PSDependencyFile> getDependencyFiles(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -196,7 +202,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     if (!dep.getObjectType().equals(DEPENDENCY_TYPE))
       throw new IllegalArgumentException("dep wrong type");
 
-    List<PSDependencyFile> files = new ArrayList<PSDependencyFile>();
+    List<PSDependencyFile> files = new ArrayList<>();
 
     // retrieve data from all tables, add to the list if not empty
     for (int i = 0; i < TABLE_ENUM.length; i++) {
@@ -213,7 +219,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
   }
 
   // see base class
-
+  @Override
   public void installDependencyFiles(
       PSSecurityToken tok, PSArchiveHandler archive, PSDependency dep, PSImportCtx ctx)
       throws PSDeployException {
@@ -224,7 +230,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
       throw new IllegalArgumentException("dep wrong type");
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
-    Map dataMap = getImportDataFromArchive(archive, dep);
+    Map<String, PSDependencyData> dataMap = getImportDataFromArchive(archive, dep);
 
     // get the target workflow id
     PSIdMapping wfMapping = getIdMapping(ctx, dep);
@@ -232,11 +238,10 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
 
     // reserve ids for various tables, since they are managed by this
     // handler only, not managed by the frame work.
-    Map rolesIdMap =
-        reserveIdsForTable(ROLE_ID, workflowId, (PSDependencyData) dataMap.get(ROLES_TABLE));
-    Map notifIdMap =
-        reserveIdsForTable(
-            NOTIFICATION_ID, workflowId, (PSDependencyData) dataMap.get(NOTIFICATIONS_TABLE));
+    Map<String, String> rolesIdMap =
+        reserveIdsForTable(ROLE_ID, workflowId, dataMap.get(ROLES_TABLE));
+    Map<String, String> notifIdMap =
+        reserveIdsForTable(NOTIFICATION_ID, workflowId, dataMap.get(NOTIFICATIONS_TABLE));
 
     // delete the rows which reference to the workflow dependency from
     // all database tables.
@@ -264,7 +269,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     }
 
     // update the version in dependency table data
-    PSDependencyData data = (PSDependencyData) dataMap.get(WORKFLOW_TABLE);
+    PSDependencyData data = dataMap.get(WORKFLOW_TABLE);
     PSJdbcTableData tableData = data.getData();
     tableData.updateColumn("VERSION", String.valueOf(version));
 
@@ -274,25 +279,25 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     // update(increment) the workflow version
     ms_wfService.updateWorkflowVersion(guid);
 
-    data = (PSDependencyData) dataMap.get(STATES_TABLE);
+    data = dataMap.get(STATES_TABLE);
     if (data != null) installDataToStatesTable(data, dep, ctx);
 
-    data = (PSDependencyData) dataMap.get(TRANSITIONS_TABLE);
+    data = dataMap.get(TRANSITIONS_TABLE);
     if (data != null) installDataToTnxTable(data, dep, ctx);
 
-    data = (PSDependencyData) dataMap.get(NOTIFICATIONS_TABLE);
+    data = dataMap.get(NOTIFICATIONS_TABLE);
     if (data != null) installDataToNotifTable(data, dep, ctx, notifIdMap);
 
-    data = (PSDependencyData) dataMap.get(ROLES_TABLE);
+    data = dataMap.get(ROLES_TABLE);
     if (data != null) installDataToRolesTable(data, dep, ctx, rolesIdMap);
 
-    data = (PSDependencyData) dataMap.get(STATEROLES_TABLE);
+    data = dataMap.get(STATEROLES_TABLE);
     if (data != null) installDataToStateRolesTable(data, dep, ctx, rolesIdMap);
 
-    data = (PSDependencyData) dataMap.get(TRANSITIONNOTIFICATIONS_TABLE);
+    data = dataMap.get(TRANSITIONNOTIFICATIONS_TABLE);
     if (data != null) installDataToTnxNotifTable(data, dep, ctx, notifIdMap);
 
-    data = (PSDependencyData) dataMap.get(TRANSITIONROLES_TABLE);
+    data = dataMap.get(TRANSITIONROLES_TABLE);
     if (data != null) installDataToTnxRolesTable(data, dep, ctx, rolesIdMap);
 
     // Ensure the Workflow Roles being installed are included in the
@@ -302,8 +307,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     workflow = ms_wfService.loadWorkflow(guid);
     List<PSWorkflowRole> wfRoles = workflow.getRoles();
     for (PSWorkflowRole wfRole : wfRoles) {
-      String wfRoleName = wfRole.getName();
-      PSBackEndRole ber = beRoleMgr.createRole(wfRoleName);
+      beRoleMgr.createRole(wfRole.getName());
     }
   }
 
@@ -321,7 +325,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -332,15 +336,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for STATE_ID, WORKFLOW_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
@@ -382,7 +386,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -396,15 +400,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSIdMapping> stateMappings = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for STATE_ID, WORKFLOW_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
@@ -426,9 +430,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSDbmsHelper.getInstance().processTable(schema, newData);
 
     // make sure state mappings are reset after update
-    Iterator mappings = stateMappings.iterator();
-    while (mappings.hasNext()) {
-      PSIdMapping mapping = (PSIdMapping) mappings.next();
+    for (PSIdMapping mapping : stateMappings) {
       mapping.setIsNewObject(false);
     }
 
@@ -497,7 +499,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -511,16 +513,16 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSIdMapping> transMappings = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for TRANSITION_ID, WORKFLOW_ID,
       // TRANSITIONFROMSTATE_ID, TRANSITIONTOSTATE_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
@@ -545,9 +547,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSDbmsHelper.getInstance().processTable(schema, newData);
 
     // make sure transition mappings are reset after update
-    Iterator mappings = transMappings.iterator();
-    while (mappings.hasNext()) {
-      PSIdMapping mapping = (PSIdMapping) mappings.next();
+    for (PSIdMapping mapping : transMappings) {
       mapping.setIsNewObject(false);
     }
 
@@ -573,12 +573,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * @throws PSDeployException if any error occurs.
    */
   private void installDataToNotifTable(
-      PSDependencyData depData, PSDependency wfDep, PSImportCtx ctx, Map notifDdMap)
+      PSDependencyData depData,
+      PSDependency wfDep,
+      PSImportCtx ctx,
+      Map<String, String> notifDdMap)
       throws PSDeployException {
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -590,20 +593,20 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for NOTIFICATION_ID and WORKFLOW_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
         } else if (colName.equalsIgnoreCase(NOTIFICATION_ID)) {
-          String newId = (String) notifDdMap.get(col.getValue());
+          String newId = notifDdMap.get(col.getValue());
           col.setValue(newId);
         }
 
@@ -641,12 +644,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * @throws PSDeployException if any error occurs.
    */
   private void installDataToRolesTable(
-      PSDependencyData depData, PSDependency wfDep, PSImportCtx ctx, Map rolesIdMap)
+      PSDependencyData depData,
+      PSDependency wfDep,
+      PSImportCtx ctx,
+      Map<String, String> rolesIdMap)
       throws PSDeployException {
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -658,20 +664,20 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for ROLE_ID and WORKFLOW_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
         } else if (colName.equalsIgnoreCase(ROLE_ID)) {
-          String newId = (String) rolesIdMap.get(col.getValue());
+          String newId = rolesIdMap.get(col.getValue());
           col.setValue(newId);
         }
 
@@ -709,12 +715,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * @throws PSDeployException if any error occurs.
    */
   private void installDataToStateRolesTable(
-      PSDependencyData depData, PSDependency wfDep, PSImportCtx ctx, Map rolesIdMap)
+      PSDependencyData depData,
+      PSDependency wfDep,
+      PSImportCtx ctx,
+      Map<String, String> rolesIdMap)
       throws PSDeployException {
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -726,20 +735,20 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for WORKFLOW_ID, STATE_ID and ROLE_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           if (wfMapping != null) col.setValue(wfMapping.getTargetId());
         } else if (colName.equalsIgnoreCase(ROLE_ID)) {
-          String newId = (String) rolesIdMap.get(col.getValue());
+          String newId = rolesIdMap.get(col.getValue());
           col.setValue(newId);
         } else if (colName.equalsIgnoreCase(STATE_ID)) {
           setStateIdCol(col, wfDep, ctx);
@@ -779,7 +788,10 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * @throws PSDeployException if any error occurs.
    */
   private void installDataToTnxNotifTable(
-      PSDependencyData depData, PSDependency wfDep, PSImportCtx ctx, Map notifIdMap)
+      PSDependencyData depData,
+      PSDependency wfDep,
+      PSImportCtx ctx,
+      Map<String, String> notifIdMap)
       throws PSDeployException {
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
@@ -787,9 +799,10 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
     String workflowId = (wfMapping == null) ? wfDep.getDependencyId() : wfMapping.getTargetId();
 
-    Map tnxNotifIdMap = reserveIdsForTable(TRANSITIONNOTIFICATION_ID, workflowId, depData);
+    Map<String, String> tnxNotifIdMap =
+        reserveIdsForTable(TRANSITIONNOTIFICATION_ID, workflowId, depData);
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -799,26 +812,26 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for WORKFLOW_ID, TRANSITIONNOTIFICATION_ID,
       // TRANSITION_ID and NOTIFICATION_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           col.setValue(workflowId);
         } else if (colName.equalsIgnoreCase(TRANSITIONNOTIFICATION_ID)) {
-          String newId = (String) tnxNotifIdMap.get(col.getValue());
+          String newId = tnxNotifIdMap.get(col.getValue());
           col.setValue(newId);
         } else if (colName.equalsIgnoreCase(TRANSITION_ID)) {
           setTransIdCol(col, wfDep, ctx);
         } else if (colName.equalsIgnoreCase(NOTIFICATION_ID)) {
-          String newId = (String) notifIdMap.get(col.getValue());
+          String newId = notifIdMap.get(col.getValue());
           col.setValue(newId);
         }
 
@@ -858,7 +871,10 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    * @throws PSDeployException if any error occurs.
    */
   private void installDataToTnxRolesTable(
-      PSDependencyData depData, PSDependency wfDep, PSImportCtx ctx, Map rolesIdMap)
+      PSDependencyData depData,
+      PSDependency wfDep,
+      PSImportCtx ctx,
+      Map<String, String> rolesIdMap)
       throws PSDeployException {
     PSJdbcTableSchema schema = depData.getSchema();
     schema.setAllowSchemaChanges(false); // don't want to change the table!
@@ -866,7 +882,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
     String workflowId = (wfMapping == null) ? wfDep.getDependencyId() : wfMapping.getTargetId();
 
-    Iterator rows = depData.getData().getRows();
+    Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -876,23 +892,23 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for WORKFLOW_ID, TRANSITIONROLE_ID,
       // TRANSITION_ID
 
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(WORKFLOW_ID)) {
           col.setValue(workflowId);
         } else if (colName.equalsIgnoreCase(TRANSITION_ID)) {
           setTransIdCol(col, wfDep, ctx);
         } else if (colName.equalsIgnoreCase(TRANSITIONROLE_ID)) {
-          String newId = (String) rolesIdMap.get(col.getValue());
+          String newId = rolesIdMap.get(col.getValue());
           col.setValue(newId);
         }
 
@@ -929,15 +945,15 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
    *     <code>null</code> if <code>data</code> is <code>null</code>.
    * @throws PSDeployException if any error occurs.
    */
-  private Map reserveIdsForTable(String idCol, String workflowId, PSDependencyData depData)
-      throws PSDeployException {
+  private Map<String, String> reserveIdsForTable(
+      String idCol, String workflowId, PSDependencyData depData) throws PSDeployException {
     Map<String, String> idmap = null;
 
     if (depData != null) {
       PSDbmsHelper dbmsHelper = PSDbmsHelper.getInstance();
 
       PSJdbcTableData tblData = depData.getData();
-      List rows = PSDeployComponentUtils.cloneList(tblData.getRows());
+      List<PSJdbcRowData> rows = PSDeployComponentUtils.cloneList(tblData.getRows());
 
       int idBlockSize = rows.size();
       int[] ids =
@@ -947,7 +963,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
       String table = tblData.getName();
       idmap = new HashMap<>(idBlockSize);
       for (int i = 0; i < idBlockSize; i++) {
-        PSJdbcRowData row = (PSJdbcRowData) rows.get(i);
+        PSJdbcRowData row = rows.get(i);
         String oldId = dbmsHelper.getColumnString(table, idCol, row);
         idmap.put(oldId, Integer.toString(ids[i]));
       }
@@ -969,9 +985,9 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
   private Map<String, PSDependencyData> getImportDataFromArchive(
       PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     Map<String, PSDependencyData> dataMap = new HashMap<>();
-    Iterator files = getDependecyDataFiles(archive, dep);
+    Iterator<PSDependencyFile> files = getDependecyDataFiles(archive, dep);
     while (files.hasNext()) {
-      PSDependencyFile file = (PSDependencyFile) files.next();
+      PSDependencyFile file = files.next();
       PSDependencyData depData = getDepDataFromFile(archive, file);
       dataMap.put(depData.getData().getName(), depData);
     }

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSSharedGroupWorkflowDefHandlersTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSSharedGroupWorkflowDefHandlersTypedTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
+import com.percussion.security.PSSecurityToken;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed SharedGroup + WorkflowDef dependency handler surfaces (issue #3179 /
+ * #2028 Xlint residual after SystemDef #3178). Runtime packaging paths require a live CMS; these
+ * tests lock compile-time API shapes that cleared rawtypes diagnostics.
+ */
+public class PSSharedGroupWorkflowDefHandlersTypedTest {
+
+  @Test
+  public void sharedGroupChildDependenciesAndFilesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSSharedGroupDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSSharedGroupDependencyHandler.class.getMethod(
+            "getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSSharedGroupDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSSharedGroupDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("SharedGroup", PSSharedGroupDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void workflowDefChildDependenciesAndFilesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSWorkflowDefDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSWorkflowDefDependencyHandler.class.getMethod(
+            "getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSWorkflowDefDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSWorkflowDefDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("WorkflowDef", PSWorkflowDefDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void sharedGroupAndWorkflowDefChildTypesListsAreStringParameterized() throws Exception {
+    assertStringListField(PSSharedGroupDependencyHandler.class, "ms_childTypes");
+    assertStringListField(PSWorkflowDefDependencyHandler.class, "ms_childTypes");
+  }
+
+  private static void assertStringListField(Class<?> clazz, String fieldName) throws Exception {
+    var field = clazz.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    Type generic = field.getGenericType();
+    assertTrue(generic instanceof ParameterizedType, fieldName + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(String.class, args[0]);
+    assertEquals(List.class, field.getType());
+  }
+
+  private static void assertTypedIterator(Method method, Class<?> typeArg) {
+    assertEquals(Iterator.class, method.getReturnType());
+    Type generic = method.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType, method.getName() + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(typeArg, args[0], method.getName() + " type arg");
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-3179-deployer-xlint-sharedgroup-workflowdef-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3179-deployer-xlint-sharedgroup-workflowdef-erlang.md
@@ -1,0 +1,22 @@
+# Erlang review — issue #3179 SharedGroup + WorkflowDef Xlint
+
+**Scope:** `PSSharedGroupDependencyHandler`, `PSWorkflowDefDependencyHandler`, typed signature test  
+**Change class:** perc-deployer Xlint residual (real generics, no behavior change)
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic regressions | Pass — casts removed only where APIs already return typed iterators/lists; raw system-module APIs (`getFieldGroups`) use `Iterator<?>` + documented casts |
+| Behavioral unit tests | Pass — `PSSharedGroupWorkflowDefHandlersTypedTest` locks typed public API shapes (3 tests) |
+| Portable paths / I/O | N/A — no path/file I/O changes |
+| Companions | Pass — mirrors SystemDef #3178 / ContentType #3047 pattern |
+| Suppressions | None |
+
+## Notes
+
+- Private install helpers in WorkflowDef now use `Iterator<PSJdbcRowData>`, `Iterator<PSJdbcColumnData>`, `Map<String,String>` id maps.
+- Unused `PSBackEndRole` assignment dropped (`createRole` call retained).
+- Module: `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 271.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.


### PR DESCRIPTION
## Summary

Continue perc-deployer Xlint cleanup after SystemDef (#3178 / PR #3191). This slice clears **SharedGroup** + **WorkflowDef** production sources with real generics:

- **PSSharedGroupDependencyHandler** — typed `Iterator<PSDependency>` / `Iterator<PSDependencyFile>` / `Iterator<String>` overrides; `List<PSApplicationIDTypeMapping>`; typed archive files and ID-type resource/element walks; `List<String> ms_childTypes` via `List.of`; `Iterator<?>` for system raw `getFieldGroups()`
- **PSWorkflowDefDependencyHandler** — typed dependency/file iterators; `Map<String, PSDependencyData>` archive import; `Map<String, String>` reserved-id maps; `Iterator<PSJdbcRowData>` / `Iterator<PSJdbcColumnData>` install helpers
- Signature unit test `PSSharedGroupWorkflowDefHandlersTypedTest` (3 tests)
- No product behavior change

**Fixes #3179**  
**Partial #2028** (perc-deployer Xlint epic)  
**Partial #2200** (monorepo Xlint/javadoc tracker)  
Prior: SystemDef PR #3191

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd deployer && ../mvnw.cmd clean install` (JDK 21) — expect BUILD SUCCESS
2. Confirm `PSSharedGroupWorkflowDefHandlersTypedTest` runs (3 tests)
3. Confirm zero compiler warnings on `PSSharedGroup*.java` / `PSWorkflowDef*.java`
4. Remaining #2028 residual already filed: #3180 FilterDef/Custom/Context

## Checklist

- [x] **Product documentation** — N/A (pure generics tech-debt; no operator/behavior change)
- [x] **Unit / module tests** — `PSSharedGroupWorkflowDefHandlersTypedTest`; deployer standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 271, Failures: 0, Errors: 0, Skipped: 19
- [x] **Cross-platform** — N/A (no path/file I/O changes)

### C3 evidence

- **modules_built:** `deployer`
- **build_evidence:** `cd deployer; ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 271, Failures: 0, Errors: 0, Skipped: 19; `PSSharedGroupWorkflowDefHandlersTypedTest` Tests run: 3, Failures: 0; zero Xlint on SharedGroup/WorkflowDef production sources
- **downstream_checked:** none (no public API shape / final / signature change beyond method return generics already present on base overrides; no reverse-dep compile risk)
- **C5 UI proof:** N/A (backend tech-debt only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
