### PR TITLE
fix(deployer): FilterDef/Custom/Context Xlint generics batch (#3180)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDefDependencyHandler.java
@@ -112,7 +112,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
    *     </code>, does not contain <code>null</code> or empty entries.
    */
   @Override
-  public Iterator getChildTypes() {
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -137,7 +137,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
 
   // see base class
   @Override
-  public Iterator getDependencyFiles(
+  public Iterator<PSDependencyFile> getDependencyFiles(
       @SuppressWarnings("unused") PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
@@ -225,6 +225,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
    * See {@link IPSServiceDependencyHandler#doInstallDependencyFiles( PSSecurityToken,
    * PSArchiveHandler, PSDependency, PSImportCtx)} for details.
    */
+  @Override
   public void doInstallDependencyFiles(
       PSSecurityToken tok, PSArchiveHandler archive, PSDependency dep, PSImportCtx ctx)
       throws PSDeployException, PSNotFoundException {
@@ -236,8 +237,8 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
     // retrieve the data from the archive
-    Iterator files = getDependecyDataFiles(archive, dep);
-    PSDependencyFile file = (PSDependencyFile) files.next();
+    Iterator<PSDependencyFile> files = getDependecyDataFiles(archive, dep);
+    PSDependencyFile file = files.next();
 
     IPSPublishingContext context = null;
     PSIdMapping ctxtMapping = getIdMapping(ctx, dep);
@@ -355,9 +356,6 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
   private static IPSSiteManager m_siteMgr = PSSiteManagerLocator.getSiteManager();
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List<String> ms_childTypes = new ArrayList<>();
-
-  static {
-    ms_childTypes.add(PSLocSchemeDefDependencyHandler.DEPENDENCY_TYPE);
-  }
+  private static final List<String> ms_childTypes =
+      List.of(PSLocSchemeDefDependencyHandler.DEPENDENCY_TYPE);
 }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDependencyHandler.java
@@ -18,7 +18,6 @@ package com.percussion.deployer.server.dependencies;
 
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -77,9 +76,6 @@ public class PSContextDependencyHandler extends PSElementDependencyHandler {
   private PSDependencyHandler m_childHandler = null;
 
   /** List of child types supported by this handler, never <code>null</code> or empty. */
-  private static List ms_childTypes = new ArrayList();
-
-  static {
-    ms_childTypes.add(PSContextDefDependencyHandler.DEPENDENCY_TYPE);
-  }
+  private static final List<String> ms_childTypes =
+      List.of(PSContextDefDependencyHandler.DEPENDENCY_TYPE);
 }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCustomDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCustomDependencyHandler.java
@@ -57,6 +57,7 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
+  @Override
   public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
@@ -75,18 +76,19 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
    * and name of the element set to the child depedency's key and display name, and the child
    * dependency set as a local child dependency. See {@link PSDependencyHandler} for more info.
    */
-  public Iterator getDependencies(PSSecurityToken tok)
+  @Override
+  public Iterator<PSDependency> getDependencies(PSSecurityToken tok)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
-    List deps = new ArrayList();
-    Iterator types = getChildTypes();
+    List<PSDependency> deps = new ArrayList<>();
+    Iterator<String> types = getChildTypes();
     while (types.hasNext()) {
-      String type = (String) types.next();
+      String type = types.next();
       PSDependency custDep = createDeployableElement(m_def, type, type);
-      Iterator childDeps = getChildDependencies(tok, custDep);
+      Iterator<PSDependency> childDeps = getChildDependencies(tok, custDep);
       while (childDeps.hasNext()) {
-        PSDependency childDep = (PSDependency) childDeps.next();
+        PSDependency childDep = childDeps.next();
         PSDependency dep = getDependency(tok, childDep.getKey());
         if (dep != null) deps.add(dep);
       }
@@ -96,11 +98,13 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
   }
 
   // see base class
+  @Override
   public String getType() {
     return DEPENDENCY_TYPE;
   }
 
   // see base class
+  @Override
   public boolean doesDependencyExist(PSSecurityToken tok, String id)
       throws PSDeployException, PSNotFoundException {
     return getDependency(tok, id) != null;
@@ -114,6 +118,7 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
    * specified as the id and name, and an element with no children is returned. See {@link
    * PSDependencyHandler} for more info.
    */
+  @Override
   public PSDependency getDependency(PSSecurityToken tok, String id)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
@@ -150,7 +155,8 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
    * of the provided <code>dep</code> must be the type of the children that will be returned. See
    * {@link PSDependencyHandler} for more info.
    */
-  public Iterator getChildDependencies(PSSecurityToken tok, PSDependency dep)
+  @Override
+  public Iterator<PSDependency> getChildDependencies(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -159,12 +165,12 @@ public class PSCustomDependencyHandler extends PSDependencyHandler {
     if (!dep.getObjectType().equals(DEPENDENCY_TYPE))
       throw new IllegalArgumentException("dep wrong type");
 
-    List childList = new ArrayList();
+    List<PSDependency> childList = new ArrayList<>();
     String childType = dep.getDependencyId();
     PSDependencyHandler childHandler = getDependencyHandler(childType);
-    Iterator childDeps = childHandler.getDependencies(tok);
+    Iterator<PSDependency> childDeps = childHandler.getDependencies(tok);
     while (childDeps.hasNext()) {
-      PSDependency childDep = (PSDependency) childDeps.next();
+      PSDependency childDep = childDeps.next();
       // don't return non-deployable children
       if (!childDep.canBeIncludedExcluded()) continue;
       childDep.setDependencyType(PSDependency.TYPE_LOCAL);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDefDependencyHandler.java
@@ -114,7 +114,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
 
   // see base class
   @Override
-  public Iterator getChildDependencies(PSSecurityToken tok, PSDependency dep)
+  public Iterator<PSDependency> getChildDependencies(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -243,8 +243,8 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
   public void installDependencyFiles(
       PSSecurityToken tok, PSArchiveHandler archive, PSDependency dep, PSImportCtx ctx)
       throws PSDeployException {
-    Iterator files = getFilterDependecyFilesFromArchive(archive, dep);
-    PSDependencyFile depFile = (PSDependencyFile) files.next();
+    Iterator<PSDependencyFile> files = getFilterDependecyFilesFromArchive(archive, dep);
+    PSDependencyFile depFile = files.next();
 
     IPSDeployService depSvc = PSDeployServiceLocator.getDeployService();
     try {
@@ -365,12 +365,12 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
    * @throws PSDeployException if there is no dependency file in the archive for the specified
    *     dependency object, or any other error occurs.
    */
-  protected Iterator getFilterDependecyFilesFromArchive(PSArchiveHandler archive, PSDependency dep)
-      throws PSDeployException {
+  protected Iterator<PSDependencyFile> getFilterDependecyFilesFromArchive(
+      PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -385,7 +385,8 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
   }
 
   // see base class
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -419,6 +420,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
   }
 
   // see base class
+  @Override
   public PSApplicationIDTypes getIdTypes(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
@@ -434,16 +436,11 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
         for (IPSItemFilterRuleDef ruleDef : ruleDefSet) {
           Map<String, String> paramMap = ruleDef.getParams();
 
-          List mappings = new ArrayList<>();
+          List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
           // check each param for idtypes
-          Iterator entries = paramMap.entrySet().iterator();
-          while (entries.hasNext()) {
-            Map.Entry entry = (Map.Entry) entries.next();
-
+          for (Map.Entry<String, String> entry : paramMap.entrySet()) {
             // convert to PSParam to leverage existing transformer code
-            Iterator params = PSDeployComponentUtils.convertToParams(entry).iterator();
-            while (params.hasNext()) {
-              PSParam param = (PSParam) params.next();
+            for (PSParam param : PSDeployComponentUtils.convertToParams(entry)) {
               PSAppTransformer.checkParam(mappings, param, null);
             }
           }
@@ -521,6 +518,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
   }
 
   // see base class
+  @Override
   public void transformIds(Object object, PSApplicationIDTypes idTypes, PSIdMap idMap)
       throws PSDeployException {
     if (object == null) throw new IllegalArgumentException("object may not be null");
@@ -532,31 +530,29 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
       throw new IllegalArgumentException("invalid object type");
     }
 
-    Map paramMap = (Map) object;
+    @SuppressWarnings("unchecked")
+    Map<String, Object> paramMap = (Map<String, Object>) object;
     // walk id types and perform any transforms
-    Iterator resources = idTypes.getResourceList(false);
+    Iterator<String> resources = idTypes.getResourceList(false);
     while (resources.hasNext()) {
-      String resource = (String) resources.next();
-      Iterator elements = idTypes.getElementList(resource, false);
+      String resource = resources.next();
+      Iterator<String> elements = idTypes.getElementList(resource, false);
       while (elements.hasNext()) {
-        String element = (String) elements.next();
-        Iterator mappings = idTypes.getIdTypeMappings(resource, element, false);
+        String element = elements.next();
+        Iterator<PSApplicationIDTypeMapping> mappings =
+            idTypes.getIdTypeMappings(resource, element, false);
         while (mappings.hasNext()) {
-          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+          PSApplicationIDTypeMapping mapping = mappings.next();
 
           if (mapping.getType().equals(PSApplicationIDTypeMapping.TYPE_NONE)) continue;
 
           if (element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_RULEDEF_PARAMS)) {
             // transform the params
-            Iterator entries = paramMap.entrySet().iterator();
-            while (entries.hasNext()) {
+            for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
               // convert to PSParam(s) to leverage existing code
               List<String> valList = new ArrayList<>();
-              Map.Entry entry = (Map.Entry) entries.next();
-              List paramList = PSDeployComponentUtils.convertToParams(entry);
-              for (Object o : paramList) {
-                PSParam param = (PSParam) o;
-
+              List<PSParam> paramList = PSDeployComponentUtils.convertToParams(entry);
+              for (PSParam param : paramList) {
                 // transform
                 PSAppTransformer.transformParam(param, mapping, idMap);
                 valList.add(param.getValue().getValueText());
@@ -594,18 +590,15 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
   /** Filter Svc */
   private static IPSFilterService m_filterSvc = PSFilterServiceLocator.getFilterService();
 
-  private HashMap<String, IPSItemFilter> m_namedFiltersMap = new HashMap<>();
+  private final Map<String, IPSItemFilter> m_namedFiltersMap = new HashMap<>();
 
-  private HashMap<IPSGuid, IPSItemFilter> m_guidFiltersMap = new HashMap<>();
+  private final Map<IPSGuid, IPSItemFilter> m_guidFiltersMap = new HashMap<>();
 
   /** the rule def params name */
   public static String RULEDEF_ARGS = "RuleDefParams";
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List<String> ms_childTypes = new ArrayList<>();
-
-  static {
-    ms_childTypes.add(PSExitDefDependencyHandler.DEPENDENCY_TYPE);
-    ms_childTypes.add(PSAclDefDependencyHandler.DEPENDENCY_TYPE);
-  }
+  private static final List<String> ms_childTypes =
+      List.of(
+          PSExitDefDependencyHandler.DEPENDENCY_TYPE, PSAclDefDependencyHandler.DEPENDENCY_TYPE);
 }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDependencyHandler.java
@@ -18,7 +18,6 @@ package com.percussion.deployer.server.dependencies;
 
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -72,9 +71,6 @@ public class PSFilterDependencyHandler extends PSElementDependencyHandler {
   private PSDependencyHandler m_childHandler = null;
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List<String> ms_childTypes = new ArrayList<>();
-
-  static {
-    ms_childTypes.add(PSFilterDefDependencyHandler.DEPENDENCY_TYPE);
-  }
+  private static final List<String> ms_childTypes =
+      List.of(PSFilterDefDependencyHandler.DEPENDENCY_TYPE);
 }

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSFilterDefCustomContextHandlersTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSFilterDefCustomContextHandlersTypedTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
+import com.percussion.deployer.server.PSArchiveHandler;
+import com.percussion.security.PSSecurityToken;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed FilterDef / Custom / Context* dependency handler surfaces (issue
+ * #3180 / #2028 Xlint residual after SharedGroup+WorkflowDef #3179). Runtime packaging paths
+ * require a live CMS; these tests lock compile-time API shapes that cleared rawtypes diagnostics.
+ */
+public class PSFilterDefCustomContextHandlersTypedTest {
+
+  @Test
+  public void filterDefChildDependenciesAndFilesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSFilterDefDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSFilterDefDependencyHandler.class.getMethod("getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSFilterDefDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSFilterDefDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("FilterDef", PSFilterDefDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void filterDefFilesFromArchiveReturnsTypedIterator() throws Exception {
+    Method method =
+        PSFilterDefDependencyHandler.class.getDeclaredMethod(
+            "getFilterDependecyFilesFromArchive", PSArchiveHandler.class, PSDependency.class);
+    method.setAccessible(true);
+    assertTypedIterator(method, PSDependencyFile.class);
+  }
+
+  @Test
+  public void customChildDependenciesAndDependenciesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSCustomDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSCustomDependencyHandler.class.getMethod("getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(PSCustomDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("Custom", PSCustomDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void contextDefAndElementHandlersReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSContextDefDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContextDefDependencyHandler.class.getMethod("getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContextDefDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSContextDefDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertTypedIterator(PSContextDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertTypedIterator(PSFilterDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("ContextDef", PSContextDefDependencyHandler.DEPENDENCY_TYPE);
+    assertEquals("Context", PSContextDependencyHandler.DEPENDENCY_TYPE);
+    assertEquals("Filter", PSFilterDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void filterDefCustomContextChildTypesListsAreStringParameterized() throws Exception {
+    assertStringListField(PSFilterDefDependencyHandler.class, "ms_childTypes");
+    assertStringListField(PSCustomDependencyHandler.class, "ms_childTypes");
+    assertStringListField(PSContextDefDependencyHandler.class, "ms_childTypes");
+    assertStringListField(PSContextDependencyHandler.class, "ms_childTypes");
+    assertStringListField(PSFilterDependencyHandler.class, "ms_childTypes");
+  }
+
+  private static void assertStringListField(Class<?> clazz, String fieldName) throws Exception {
+    var field = clazz.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    Type generic = field.getGenericType();
+    assertTrue(generic instanceof ParameterizedType, fieldName + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(String.class, args[0]);
+    assertEquals(List.class, field.getType());
+  }
+
+  private static void assertTypedIterator(Method method, Class<?> typeArg) {
+    assertEquals(Iterator.class, method.getReturnType());
+    Type generic = method.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType, method.getName() + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(typeArg, args[0], method.getName() + " type arg");
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-3180-deployer-xlint-filterdef-custom-context-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3180-deployer-xlint-filterdef-custom-context-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review: issue #3180 FilterDef/Custom/Context Xlint
+
+**Branch:** `fix/issue-3180-filterdef-custom-context-xlint`  
+**Scope:** uncommitted deployer FilterDef / Custom / Context* handler generics  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A (no path/file I/O changes)
+
+## Summary
+
+PR-sized residual of parent #2028: real generics on FilterDef*, Custom*, Context* dependency handlers. Mirrors SystemDef (#3178) and SharedGroup+WorkflowDef (#3179) patterns.
+
+## Changes reviewed
+
+| File | Notes |
+|------|-------|
+| `PSFilterDefDependencyHandler` | Typed iterators, id-type mappings list, transformIds Map/entry, archive files |
+| `PSFilterDependencyHandler` | `List.of` child types |
+| `PSCustomDependencyHandler` | Typed deps/children iterators + `@Override` |
+| `PSContextDefDependencyHandler` | Typed child types / dependency files / archive files |
+| `PSContextDependencyHandler` | `List.of` child types |
+| `PSFilterDefCustomContextHandlersTypedTest` | Signature smoke (peer pattern) |
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable paths).
+
+## Notes
+
+- `@SuppressWarnings("unchecked")` on `transformIds` map cast matches ContentListDef peer (runtime object is caller-supplied Map).
+- `List.of` for `ms_childTypes` matches sibling batches; immutable is intentional.
+- Pure tech-debt; product-docs N/A; C5 UI proof N/A.
+
+## Build evidence (pre-commit)
+
+```
+cd deployer && ../mvnw clean install
+Tests run: 273, Failures: 0, Errors: 0, Skipped: 19
+PSFilterDefCustomContextHandlersTypedTest: Tests run: 5, Failures: 0
+BUILD SUCCESS
+```


### PR DESCRIPTION
## Summary
PR-sized `-Xlint` residual cleanup for **FilterDef**, **Custom**, and **Context*** deployer dependency handlers (Parent epic #2028; slice #3180).

Applies real generics (typed `Iterator`/`List`/`Map` surfaces, `List.of` child-type lists, typed id-type mappings) following SystemDef (#3178 / PR #3191) and SharedGroup+WorkflowDef (#3179 / PR #3192) patterns.

### Files
- `PSFilterDefDependencyHandler` — child deps, archive files, id types, transformIds
- `PSFilterDependencyHandler` — typed child types
- `PSCustomDependencyHandler` — deps / child deps iterators
- `PSContextDefDependencyHandler` — child types, dependency files, install archive files
- `PSContextDependencyHandler` — typed child types
- `PSFilterDefCustomContextHandlersTypedTest` — signature smoke

## Test plan
- [x] `cd deployer && ../mvnw clean install` (no skipTests)
- [x] New typed signature smoke tests green
- [x] Erlang self-review approve (see `docs/ai-generated/code-reviews/issue-3180-deployer-xlint-filterdef-custom-context-erlang.md`)

## Gates evidence
**modules_built:** `deployer`

**build_evidence:**
```
cd deployer
../mvnw.cmd clean install
# BUILD SUCCESS
# Tests run: 273, Failures: 0, Errors: 0, Skipped: 19
# PSFilterDefCustomContextHandlersTypedTest: Tests run: 5, Failures: 0
```

**downstream_checked:** none (no `final`/`sealed` on public types; no public signature break beyond generic return types matching base class; C2 N/A)

**C5 UI proof:** N/A — pure Java tech-debt, zero UI surface

**Product documentation:** N/A — pure refactor / Xlint cleanup, no operator-visible behavior change

## Fixes
Fixes #3180  
Parent: #2028

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
