### PR TITLE
fix(installer/sitemanage): demo sites page-based + path/folder Sites list (#2989)

### DIFF
--- a/docs/ai-generated/code-reviews/3209-demo-sites-findall-nate-review-erlang.md
+++ b/docs/ai-generated/code-reviews/3209-demo-sites-findall-nate-review-erlang.md
@@ -1,0 +1,54 @@
+# Erlang review: PR #3209 Nate review — list all sites
+
+## Summary
+
+Human review (`natechadwick`, CHANGES_REQUESTED) on PR #3209 was ignored by the
+overnight Kilo follow-up (which only answered four inline Kilo threads).
+
+Requested product behavior:
+
+- Sample / FastForward sites are **Rhythmyx**, not CM1 — `IS_PAGE_BASED` must be
+  false (already true in seed XML).
+- `PSSiteDataService.findAll` must **not** drop sites for page-based, pub
+  server, or nav tree. The list is all sites; Explorer varies later by type.
+
+This change removes `.filter(PSSiteSummary::isPageBased)` from `findAll`, adds
+behavioral unit tests, and documents the list contract in product-docs.
+
+## Scope
+
+- Worktree: `.kilo/worktrees/pr-3209` on `fix/issue-2989-demo-sites-pagebased-folders`
+- Files:
+  - `projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java`
+  - `projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceFindAllTest.java`
+  - `product-docs/8.2/admin/sites.md`
+  - this report
+- Memory patterns hit: missing behavioral tests; product-docs for operator-facing
+  list behavior
+- Cross-platform path review: N/A (no file I/O)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: no — `PSSiteDataServiceFindAllTest` covers mixed
+  page-based/Rhythmyx listing and copy-target omission
+- Change-class closure: site-list service + unit test + product-docs admin page
+- Agent rule files: none
+
+## Issues
+
+None.
+
+## Verification noted
+
+```text
+cd projects/sitemanage
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 1102, Failures: 0, Errors: 0, Skipped: 125
+# PSSiteDataServiceFindAllTest: 2 tests, 0 fail
+```

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -108,6 +108,78 @@
 			<column name="LOCALE">en-us</column>
 			<column name="OBJECTTYPE">2</column>
 		</row>
+		<!-- Site root folders matching RXSITES.FOLDER_ROOT (#2989). Without these,
+		     path/folder Sites can list sites but getIdByPath(folderRoot) fails. -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">350</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">EnterpriseInvestments</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">351</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">CorporateInvestments</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
 	</table>
 	<table name="CONTENTTYPES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4346,6 +4418,16 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="REVISIONID">1</column>
 			<column name="DESCRIPTION"/>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">350</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Enterprise Investments site root</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">351</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Corporate Investments site root</column>
+		</row>
 	</table>
 	<table name="PSX_OBJECTACL" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4396,6 +4478,38 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="NAME">admin1</column>
 			<column name="PERMISSIONS">7</column>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">350</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2001</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">350</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2002</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">351</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2003</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">351</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2004</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
 	</table>
 	<table name="PSX_PROPERTIES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4418,6 +4532,22 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="CONTENTID">303</column>
 			<column name="REVISIONID">1</column>
 			<column name="SYSID">1003</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">350</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2001</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">351</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">2002</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4446,6 +4576,23 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="OWNER_ID">301</column>
 			<column name="OWNER_REVISION">-1</column>
 			<column name="DEPENDENT_ID">303</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<!-- Sites (contentid 2) children for sample site roots (#2989) -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">350</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">2</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">350</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">351</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">2</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">351</column>
 			<column name="DEPENDENT_REVISION">-1</column>
 		</row>
 	</table>
@@ -8685,6 +8832,9 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="DEFAULT_DOCUMENT">index.html</column>
 			<column name="CANONICAL_DIST">pages</column>
 			<column name="IS_CANONICAL_REPLACE">T</column>
+			<!-- Sample / Rhythmyx FastForward sites are NOT page-based (CM1 sites are).
+			     Listing must not require IS_PAGE_BASED=T (#2989). -->
+			<column name="IS_PAGE_BASED">F</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
 			<column name="SITEID">303</column>
@@ -8709,6 +8859,8 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="DEFAULT_DOCUMENT">index.html</column>
 			<column name="CANONICAL_DIST">pages</column>
 			<column name="IS_CANONICAL_REPLACE">T</column>
+			<!-- Sample / Rhythmyx FastForward sites are NOT page-based (CM1 sites are). -->
+			<column name="IS_PAGE_BASED">F</column>
 		</row>
 	</table>
 	<table name="RXSLOTCONTENT" onCreateOnly="no">

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -4433,7 +4433,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">301</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1001</column>
+			<column name="SYSID">91001</column>
 			<column name="TYPE">2</column>
 			<column name="NAME">Everyone</column>
 			<column name="PERMISSIONS">1</column>
@@ -4441,7 +4441,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">301</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1002</column>
+			<column name="SYSID">91002</column>
 			<column name="TYPE">0</column>
 			<column name="NAME">admin1</column>
 			<column name="PERMISSIONS">7</column>
@@ -4449,7 +4449,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">302</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1003</column>
+			<column name="SYSID">91003</column>
 			<column name="TYPE">2</column>
 			<column name="NAME">Everyone</column>
 			<column name="PERMISSIONS">1</column>
@@ -4457,7 +4457,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">302</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1004</column>
+			<column name="SYSID">91004</column>
 			<column name="TYPE">0</column>
 			<column name="NAME">admin1</column>
 			<column name="PERMISSIONS">7</column>
@@ -4465,7 +4465,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">303</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1005</column>
+			<column name="SYSID">91005</column>
 			<column name="TYPE">2</column>
 			<column name="NAME">Everyone</column>
 			<column name="PERMISSIONS">1</column>
@@ -4473,7 +4473,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">303</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1006</column>
+			<column name="SYSID">91006</column>
 			<column name="TYPE">0</column>
 			<column name="NAME">admin1</column>
 			<column name="PERMISSIONS">7</column>
@@ -4481,7 +4481,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">350</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2001</column>
+			<column name="SYSID">92001</column>
 			<column name="TYPE">2</column>
 			<column name="NAME">Everyone</column>
 			<column name="PERMISSIONS">1</column>
@@ -4489,7 +4489,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">350</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2002</column>
+			<column name="SYSID">92002</column>
 			<column name="TYPE">1</column>
 			<column name="NAME">Admin</column>
 			<column name="PERMISSIONS">7</column>
@@ -4497,7 +4497,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">351</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2003</column>
+			<column name="SYSID">92003</column>
 			<column name="TYPE">2</column>
 			<column name="NAME">Everyone</column>
 			<column name="PERMISSIONS">1</column>
@@ -4505,7 +4505,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">351</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2004</column>
+			<column name="SYSID">92004</column>
 			<column name="TYPE">1</column>
 			<column name="NAME">Admin</column>
 			<column name="PERMISSIONS">7</column>
@@ -4515,7 +4515,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">301</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1001</column>
+			<column name="SYSID">91001</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4523,7 +4523,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">302</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1002</column>
+			<column name="SYSID">91002</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4531,7 +4531,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">303</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">1003</column>
+			<column name="SYSID">91003</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4539,7 +4539,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">350</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2001</column>
+			<column name="SYSID">92001</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4547,7 +4547,7 @@ if (! empty($usage) and $usage == 'L') {
 		<row action="r" onTableCreateOnly="no">
 			<column name="CONTENTID">351</column>
 			<column name="REVISIONID">1</column>
-			<column name="SYSID">2002</column>
+			<column name="SYSID">92002</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -732,6 +732,10 @@
 			tableDef="${data.dir}/cmsTableDef.xml,${data.dir}/RxffTableDef.xml"
 			failonerror="true" silenceerrors="false" />
 
+		<!-- Sample sites are Rhythmyx (not CM1 page-based). Seed XML sets IS_PAGE_BASED=F.
+			 Do not force T here; findAll no longer filters by isPageBased / pub server / nav tree
+			 (#2989). CM1 sites remain page-based when created via CM1 paths. -->
+
 		<echo>Sample sites seeded.</echo>
 	</target>
 

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
@@ -147,6 +147,91 @@ class InstallSampleSitesWiringTest {
     assertTrue(
         siteNames.stream().anyMatch(n -> n.toLowerCase(Locale.ROOT).contains("corporate")),
         "expected Corporate Investments sample site name in RXSITES, found " + siteNames);
+
+    // Sample / Rhythmyx sites are NOT page-based; CM1 sites are. Listing must not require T (#2989).
+    for (int i = 0; i < rows.getLength(); i++) {
+      Element row = (Element) rows.item(i);
+      String pageBased = columnValue(row, "IS_PAGE_BASED");
+      assertTrue(
+          pageBased != null
+              && ("F".equalsIgnoreCase(pageBased.trim())
+                  || "false".equalsIgnoreCase(pageBased.trim())
+                  || "0".equals(pageBased.trim())
+                  || "N".equalsIgnoreCase(pageBased.trim())),
+          "RXSITES sample row must set IS_PAGE_BASED false (not CM1 page-based); was: "
+              + pageBased
+              + " site="
+              + columnValue(row, "SITENAME"));
+      String folderRoot = columnValue(row, "FOLDER_ROOT");
+      assertTrue(
+          folderRoot != null && folderRoot.startsWith("//Sites/"),
+          "RXSITES FOLDER_ROOT must be under //Sites/; was: " + folderRoot);
+    }
+  }
+
+  @Test
+  void sampleDataDeclaresSiteRootFoldersUnderSites()
+      throws IOException, ParserConfigurationException, SAXException {
+    assertTrue(Files.isRegularFile(SAMPLE_DATA), "missing " + SAMPLE_DATA);
+    Document doc = parseXml(SAMPLE_DATA);
+    Element contentStatus = findTable(doc, "CONTENTSTATUS");
+    if (contentStatus == null) {
+      fail("RxffTableData.xml must declare CONTENTSTATUS for sample site folders");
+    }
+    Set<String> titles = new LinkedHashSet<>();
+    NodeList rows = contentStatus.getElementsByTagName("row");
+    for (int i = 0; i < rows.getLength(); i++) {
+      String title = columnValue((Element) rows.item(i), "TITLE");
+      if (title != null && !title.isBlank()) {
+        titles.add(title.trim());
+      }
+    }
+    assertTrue(
+        titles.contains("EnterpriseInvestments"),
+        "CONTENTSTATUS must include EnterpriseInvestments folder matching FOLDER_ROOT; found "
+            + titles);
+    assertTrue(
+        titles.contains("CorporateInvestments"),
+        "CONTENTSTATUS must include CorporateInvestments folder matching FOLDER_ROOT; found "
+            + titles);
+
+    Element rels = findTable(doc, "PSX_OBJECTRELATIONSHIP");
+    if (rels == null) {
+      fail("RxffTableData.xml must declare PSX_OBJECTRELATIONSHIP for site folder graph");
+    }
+    boolean hasSiteChild = false;
+    NodeList relRows = rels.getElementsByTagName("row");
+    for (int i = 0; i < relRows.getLength(); i++) {
+      Element row = (Element) relRows.item(i);
+      String owner = columnValue(row, "OWNER_ID");
+      String dep = columnValue(row, "DEPENDENT_ID");
+      // Sites system folder is contentid 2
+      if ("2".equals(owner) && ("350".equals(dep) || "351".equals(dep))) {
+        hasSiteChild = true;
+        break;
+      }
+    }
+    assertTrue(
+        hasSiteChild,
+        "PSX_OBJECTRELATIONSHIP must link Sites (owner 2) to sample site root folders 350/351");
+  }
+
+  @Test
+  void installSampleSitesDoesNotForcePageBasedTrue()
+      throws IOException, ParserConfigurationException, SAXException {
+    assertTrue(Files.isRegularFile(INSTALL_REPOSITORY_XML), "missing " + INSTALL_REPOSITORY_XML);
+    Document installDoc = parseXml(INSTALL_REPOSITORY_XML);
+    Element sampleSitesTarget = findNamedTarget(installDoc, "installSampleSites");
+    if (sampleSitesTarget == null) {
+      fail("installSampleSites target must exist in installRepository.xml");
+    }
+    String targetBody = elementTextSnapshot(sampleSitesTarget);
+    // Must not force sample / Rhythmyx sites to page-based=true (#2989 product correction).
+    assertFalse(
+        targetBody.matches("(?s).*IS_PAGE_BASED\\s*=\\s*'T'.*")
+            || targetBody.matches("(?s).*IS_PAGE_BASED\\s*=\\s*\"T\".*"),
+        "installSampleSites must not UPDATE sample RXSITES IS_PAGE_BASED to T"
+            + " (samples are Rhythmyx, not CM1 page-based)");
   }
 
   @Test

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -28,7 +28,7 @@ Traditional Sites store pages and assets in the Percussion **content repository*
 3. In the tree, expand **Sites**.
 4. Select a site folder to browse its pages and folders in the detail list.
 
-After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
+After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Explorer features differ by site type after the site is listed and navigable. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
 
 ### Create a traditional Site from Explorer
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
@@ -1,6 +1,6 @@
 // REFACTORED: CP-JAVA11
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,31 @@
 
 package com.percussion.pathmanagement.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- * Represents a list of path items. Used for REST API responses. Sunny Sal says: "PathItemList:
- * because one path is never enough!"
+ * JSON body for path/folder children: {@code {"PathItem":[...]}} (same shape as {@code
+ * PSSiteSummaryList} / {@code {"SiteSummary":[...]}}).
+ *
+ * <p>Returned from REST via {@code Response.ok(list).type(APPLICATION_JSON)} so Jackson writes the
+ * list. Returning {@code List&lt;PSPathItem&gt;} as the resource method type previously selected a
+ * JAXB collection writer that failed with IllegalAnnotationExceptions for non-empty Sites (#2989).
+ * No JAXB {@code @XmlRootElement} on this ArrayList subclass.
  */
-@XmlRootElement(name = "PathItemList")
 @ArraySchema(schema = @Schema(implementation = PSPathItem.class))
-@JsonRootName("PathItemList")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.DEFAULT)
+@JsonRootName("PathItem")
 public class PSPathItemList extends ArrayList<PSPathItem> {
   private static final long serialVersionUID = 1L;
+
+  public PSPathItemList() {
+    super();
+  }
 
   public PSPathItemList(Collection<? extends PSPathItem> c) {
     super(c);

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
@@ -1,6 +1,6 @@
 // REFACTORED: CP-JAVA11
 /*
- * Copyright 1999-2026 Percussion Software, Inc.
+ * Copyright 1999-2025 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
@@ -359,20 +359,28 @@ public class PSPathService extends PSDispatchingPathService
     }
   }
 
+  /**
+   * REST path/folder children. Returns a map {@code {"PathItem":[...]}} via Jackson (not a bare
+   * {@code List&lt;PSPathItem&gt;} / JAXB collection write). Non-empty Sites listings previously
+   * failed with IllegalAnnotationExceptions on the List return type while paginatedFolder
+   * (PSPagedItemList wrapper) worked (#2989).
+   */
   @GET
   @Path("/folder/{path:.*}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public List<PSPathItem> findChildren(@PathParam("path") String path)
+  public jakarta.ws.rs.core.Response findFolderPathChildren(@PathParam("path") String path)
       throws PSPathServiceException {
     try {
       if (!SecureStringUtils.isValidCMSPathString(path, PSOperationContext.SEARCH))
         throw new PSPathServiceException("Invalid path.");
 
-      // check child types
       PSPathOptions.setShouldCheckChildTypes(true);
-      return new PSPathItemList(
+      List<PSPathItem> items =
           findChildren(path, null, null, null, null, null, null, null, null, false)
-              .getChildrenInPage());
+              .getChildrenInPage();
+      return jakarta.ws.rs.core.Response.ok(new PSPathItemList(items))
+          .type(MediaType.APPLICATION_JSON)
+          .build();
     } catch (PSPathServiceException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -385,15 +393,21 @@ public class PSPathService extends PSDispatchingPathService
   @GET
   @Path("/childFolders/{path:.*}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public List<PSPathItem> findChildFolders(@PathParam("path") String path)
+  public jakarta.ws.rs.core.Response findChildFolders(@PathParam("path") String path)
       throws PSPathServiceException {
     try {
       if (!SecureStringUtils.isValidCMSPathString(path, PSOperationContext.SEARCH))
         throw new PSPathServiceException("Invalid path.");
 
-      // get folders only
       PSPathOptions.setFolderChildrenOnly(true);
-      return findChildren(path);
+      List<PSPathItem> items = findChildren(path);
+      return jakarta.ws.rs.core.Response.ok(new PSPathItemList(items))
+          .type(MediaType.APPLICATION_JSON)
+          .build();
+    } catch (PSPathServiceException e) {
+      throw e;
+    } catch (PSDataServiceException e) {
+      throw new PSPathServiceException(e);
     } finally {
       PSPathOptions.setFolderChildrenOnly(false);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
@@ -360,34 +360,42 @@ public class PSPathService extends PSDispatchingPathService
   }
 
   /**
-   * REST path/folder children. Returns a map {@code {"PathItem":[...]}} via Jackson (not a bare
-   * {@code List&lt;PSPathItem&gt;} / JAXB collection write). Non-empty Sites listings previously
-   * failed with IllegalAnnotationExceptions on the List return type while paginatedFolder
-   * (PSPagedItemList wrapper) worked (#2989).
+   * Internal + polymorphic {@link IPSPathService#findChildren(String)}: validates path, enables
+   * child-type checks, and returns a {@link PSPathItemList}. REST exposes the same list via {@link
+   * #findFolderPathChildren(String)} as Jackson JSON ({@code {"PathItem":[...]}}) so non-empty Sites
+   * listings avoid JAXB IllegalAnnotationExceptions on bare List returns (#2989).
+   */
+  @Override
+  public List<PSPathItem> findChildren(String path) throws PSPathServiceException {
+    try {
+      if (!SecureStringUtils.isValidCMSPathString(path, PSOperationContext.SEARCH))
+        throw new PSPathServiceException("Invalid path.");
+
+      PSPathOptions.setShouldCheckChildTypes(true);
+      return new PSPathItemList(
+          findChildren(path, null, null, null, null, null, null, null, null, false)
+              .getChildrenInPage());
+    } catch (PSPathServiceException e) {
+      log.error(PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw e;
+    } finally {
+      PSPathOptions.setShouldCheckChildTypes(false);
+    }
+  }
+
+  /**
+   * REST path/folder children. Delegates to {@link #findChildren(String)} then wraps as
+   * {@code Response} with explicit JSON so Jackson writes {@code {"PathItem":[...]}}.
    */
   @GET
   @Path("/folder/{path:.*}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public jakarta.ws.rs.core.Response findFolderPathChildren(@PathParam("path") String path)
       throws PSPathServiceException {
-    try {
-      if (!SecureStringUtils.isValidCMSPathString(path, PSOperationContext.SEARCH))
-        throw new PSPathServiceException("Invalid path.");
-
-      PSPathOptions.setShouldCheckChildTypes(true);
-      List<PSPathItem> items =
-          findChildren(path, null, null, null, null, null, null, null, null, false)
-              .getChildrenInPage();
-      return jakarta.ws.rs.core.Response.ok(new PSPathItemList(items))
-          .type(MediaType.APPLICATION_JSON)
-          .build();
-    } catch (PSPathServiceException e) {
-      log.error(PSExceptionUtils.getMessageForLog(e));
-      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw (e);
-    } finally {
-      PSPathOptions.setShouldCheckChildTypes(false);
-    }
+    return jakarta.ws.rs.core.Response.ok(findChildren(path))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
   }
 
   @GET
@@ -400,14 +408,11 @@ public class PSPathService extends PSDispatchingPathService
         throw new PSPathServiceException("Invalid path.");
 
       PSPathOptions.setFolderChildrenOnly(true);
-      List<PSPathItem> items = findChildren(path);
-      return jakarta.ws.rs.core.Response.ok(new PSPathItemList(items))
+      return jakarta.ws.rs.core.Response.ok(findChildren(path))
           .type(MediaType.APPLICATION_JSON)
           .build();
     } catch (PSPathServiceException e) {
       throw e;
-    } catch (PSDataServiceException e) {
-      throw new PSPathServiceException(e);
     } finally {
       PSPathOptions.setFolderChildrenOnly(false);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/recent/service/rest/impl/PSRecentRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recent/service/rest/impl/PSRecentRestService.java
@@ -23,6 +23,7 @@ import com.percussion.pagemanagement.data.PSTemplateSummaryList;
 import com.percussion.pagemanagement.data.PSWidgetContentType;
 import com.percussion.pagemanagement.data.PSWidgetContentTypeList;
 import com.percussion.pathmanagement.data.PSPathItem;
+import com.percussion.pathmanagement.data.PSPathItemList;
 import com.percussion.recent.service.rest.IPSRecentRestService;
 import com.percussion.recent.service.rest.IPSRecentService;
 import com.percussion.security.error.PSExceptionUtils;
@@ -89,14 +90,14 @@ public class PSRecentRestService implements IPSRecentRestService {
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   @Path("/site-folder/{siteName}")
   public List<PSPathItem> findRecentSiteFolder(@PathParam("siteName") String siteName) {
-    return recentService.findRecentSiteFolder(siteName);
+    return new PSPathItemList(recentService.findRecentSiteFolder(siteName));
   }
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   @Path("/asset-folder")
   public List<PSPathItem> findRecentAssetFolder() {
-    return recentService.findRecentAssetFolder();
+    return new PSPathItemList(recentService.findRecentAssetFolder());
   }
 
   @GET

--- a/projects/sitemanage/src/main/java/com/percussion/recent/service/rest/impl/PSRecentRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recent/service/rest/impl/PSRecentRestService.java
@@ -23,7 +23,6 @@ import com.percussion.pagemanagement.data.PSTemplateSummaryList;
 import com.percussion.pagemanagement.data.PSWidgetContentType;
 import com.percussion.pagemanagement.data.PSWidgetContentTypeList;
 import com.percussion.pathmanagement.data.PSPathItem;
-import com.percussion.pathmanagement.data.PSPathItemList;
 import com.percussion.recent.service.rest.IPSRecentRestService;
 import com.percussion.recent.service.rest.IPSRecentService;
 import com.percussion.security.error.PSExceptionUtils;
@@ -90,14 +89,14 @@ public class PSRecentRestService implements IPSRecentRestService {
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   @Path("/site-folder/{siteName}")
   public List<PSPathItem> findRecentSiteFolder(@PathParam("siteName") String siteName) {
-    return new PSPathItemList(recentService.findRecentSiteFolder(siteName));
+    return recentService.findRecentSiteFolder(siteName);
   }
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   @Path("/asset-folder")
   public List<PSPathItem> findRecentAssetFolder() {
-    return new PSPathItemList(recentService.findRecentAssetFolder());
+    return recentService.findRecentAssetFolder();
   }
 
   @GET

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
@@ -735,13 +735,13 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
 
     var summaries = new ArrayList<PSSiteSummary>();
 
-    // Filter out sites that are currently getting copied
+    // Omit only the in-progress copy target. List every persisted site (Rhythmyx /
+    // not page-based and CM1 / page-based; with or without pub servers or nav tree).
+    // Explorer varies behavior by site type once the site is visible and navigable.
     var entries = getCopySiteInfo().getEntries();
     final String newSiteName = entries.isEmpty() ? null : entries.get("Target");
-    // Java 11 Streams for filtering and mapping
     sums.stream()
         .filter(site -> !StringUtils.equals(site.getName(), newSiteName))
-        .filter(PSSiteSummary::isPageBased)
         .forEach(
             site -> {
               if (includePubInfo) {
@@ -761,9 +761,9 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     return summaries;
 
     // Filter out sites that shouldn't be visible
-    // TODO: Re-enable when site permissions are fixed
+    // TODO: Re-enable when site permissions are fixed (must include all site types)
     /**
-     * ArrayList<IPSGuid> guids = new ArrayList<>(); for(PSSiteSummary s: sums){ if(s.isPageBased())
+     * ArrayList<IPSGuid> guids = new ArrayList<>(); for(PSSiteSummary s: sums){
      * { guids.add(new PSGuid(PSTypeEnum.SITE, s.getSiteId())); } }
      *
      * <p>List<IPSGuid> filtered_guids = securityWs.filterByRuntimeVisibility(guids); Iterator

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSPathItemListJacksonTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSPathItemListJacksonTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for #2989: path/folder Sites non-empty listing must use Jackson-friendly {@link
+ * PSPathItemList} (JsonRootName PathItem, no JAXB XmlRootElement on ArrayList).
+ */
+@Tag("UnitTest")
+class PSPathItemListJacksonTest {
+
+  @Test
+  void pathItemListJacksonAnnotations() {
+    JsonRootName root = PSPathItemList.class.getAnnotation(JsonRootName.class);
+    assertNotNull(root);
+    assertEquals("PathItem", root.value());
+    assertNotNull(PSPathItemList.class.getAnnotation(JsonAutoDetect.class));
+    assertNull(
+        PSPathItemList.class.getAnnotation(XmlRootElement.class),
+        "JAXB XmlRootElement on ArrayList subclass causes IllegalAnnotationExceptions");
+  }
+
+  @Test
+  void pathItemListHoldsSiteChildren() {
+    PSPathItem site = new PSPathItem();
+    site.setName("Corporate_Investments");
+    site.setId("Corporate_Investments");
+    site.setType("site");
+    site.setLeaf(false);
+    PSPathItemList list = new PSPathItemList(List.of(site));
+    assertEquals(1, list.size());
+    assertTrue(new PSPathItemList().isEmpty());
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceFindAllTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceFindAllTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.share.data.PSMapWrapper;
+import com.percussion.sitemanage.dao.IPSiteDao;
+import com.percussion.sitemanage.data.PSSiteSummary;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link PSSiteDataService#findAll()} must return every persisted site. Rhythmyx sample sites are
+ * not page-based; CM1 sites are. Listing must not require page-based, a pub server, or a nav tree
+ * (#2989 / PR #3209 review).
+ */
+public class PSSiteDataServiceFindAllTest {
+
+  @Test
+  void findAllIncludesRhythmyxAndCm1Sites() throws Exception {
+    IPSiteDao dao = mock(IPSiteDao.class);
+    when(dao.findAllSummaries())
+        .thenReturn(List.of(summary("Enterprise_Investments", false), summary("CM1_Site", true)));
+
+    PSSiteDataService service = mock(PSSiteDataService.class);
+    setSiteDao(service, dao);
+    when(service.getCopySiteInfo()).thenReturn(new PSMapWrapper());
+    when(service.findAll(false)).thenCallRealMethod();
+
+    List<PSSiteSummary> listed = service.findAll(false);
+    List<String> names = listed.stream().map(PSSiteSummary::getName).collect(Collectors.toList());
+    assertEquals(2, listed.size());
+    assertTrue(names.contains("Enterprise_Investments"), names.toString());
+    assertTrue(names.contains("CM1_Site"), names.toString());
+    assertEquals(
+        false,
+        listed.stream()
+            .filter(s -> "Enterprise_Investments".equals(s.getName()))
+            .findFirst()
+            .orElseThrow()
+            .isPageBased());
+    assertEquals(
+        true,
+        listed.stream()
+            .filter(s -> "CM1_Site".equals(s.getName()))
+            .findFirst()
+            .orElseThrow()
+            .isPageBased());
+  }
+
+  @Test
+  void findAllOmitsOnlyInProgressCopyTarget() throws Exception {
+    IPSiteDao dao = mock(IPSiteDao.class);
+    when(dao.findAllSummaries())
+        .thenReturn(List.of(summary("Keep_Me", false), summary("Copying_Site", true)));
+
+    PSMapWrapper copy = new PSMapWrapper();
+    copy.getEntries().put("Target", "Copying_Site");
+
+    PSSiteDataService service = mock(PSSiteDataService.class);
+    setSiteDao(service, dao);
+    when(service.getCopySiteInfo()).thenReturn(copy);
+    when(service.findAll(false)).thenCallRealMethod();
+
+    List<PSSiteSummary> listed = service.findAll(false);
+    assertEquals(1, listed.size());
+    assertEquals("Keep_Me", listed.get(0).getName());
+  }
+
+  private static PSSiteSummary summary(String name, boolean pageBased) {
+    PSSiteSummary sum = new PSSiteSummary();
+    sum.setName(name);
+    sum.setPageBased(pageBased);
+    return sum;
+  }
+
+  private static void setSiteDao(PSSiteDataService service, IPSiteDao dao) throws Exception {
+    Field field = PSSiteDataService.class.getDeclaredField("siteDao");
+    field.setAccessible(true);
+    field.set(service, dao);
+  }
+}


### PR DESCRIPTION
## Summary

Parent **#2989** residual after **#3133 / PR #3144**. Fresh H2 `qa-up --demo-sites` inserted **RXSITES** (2 sample sites) but Explorer / `path/folder/Sites` / `sitemanage/site` still looked empty because:

1. **`PSSiteDataService.findAll` filtered `isPageBased`** — Rhythmyx sample sites are **not** page-based (CM1 sites are). The original PR write-up incorrectly treated that as a seed bug (`IS_PAGE_BASED=T`). Human review: **do not filter** by page-based, publishing server, or nav tree — list **all** sites so Explorer can vary features by type.
2. **Missing site root folders** for `FOLDER_ROOT` `//Sites/EnterpriseInvestments` and `//Sites/CorporateInvestments`.
3. **`path/folder` REST** returned non-empty `List<PSPathItem>` via a JAXB/ArrayList path that threw **IllegalAnnotationExceptions**; empty lists and `paginatedFolder` already worked.

### Fix

- Seed sample RXSITES as **Rhythmyx / `IS_PAGE_BASED=F`** (not CM1). Add CONTENTSTATUS/PSX_FOLDER/ACL/relationship rows for site roots.
- **`findAll` lists all persisted sites** (commit `649357df47`, natechadwick review). Only an in-progress copy target is omitted.
- Return `path/folder` (and `childFolders`) as `Response.ok(new PSPathItemList(...)).type(APPLICATION_JSON)` so Jackson emits `{"PathItem":[...]}`.
- Restore recent `PSPathItemList` wrappers + `findChildren(String)` override (Kilo review).
- Wiring + unit tests for seed, `PSPathItemList`, and `findAll` mixed-type listing.

## Test plan

1. `cd projects/sitemanage` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1102, Failures: 0, Skipped: 125 (`PSSiteDataServiceFindAllTest` 2).
2. `cd modules/perc-distribution-tree` then `..\..\..\mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 253, Failures: 0, Skipped: 5 (sample `IS_PAGE_BASED=F`; installSampleSites does not force T).
3. Live H2 (`qa-up --demo-sites`): `GET .../sitemanage/site/` returns both sample SiteSummary with **`pageBased` false**; `GET .../path/folder/Sites` HTTP 200 `{"PathItem":[Corporate_Investments, Enterprise_Investments]}`.
4. Playwright `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js` with `EXPECT_DEMO_SITES=1`: REST list smoke; UI tree expand / Create Site wizard still have residual failures (human QA).

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/sites.md`: Sites list includes all sites; sample FastForward sites are traditional Rhythmyx (not page-based)
- [x] **Unit / module tests** — `PSSiteDataServiceFindAllTest` + existing seed/path-item tests; sitemanage standalone clean install green
- [x] **WebUI + Playwright** — **N/A** for this follow-up (no new screen); existing Explorer surface still has residual human QA
- [x] **Build gates** — sitemanage standalone `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O in this follow-up)

Fixes #2989 (partial until UI Create Site wizard tests green and fresh qa-up re-proof posted)

Partial: UI Create Site wizard surface still fails (strict mode dual testids); tree descendants not expanding in Playwright despite REST children present — leave open human QA #3006/#3008/#3010/#3145.

> Co-Authored by Grok Build 4.6 using grok-4.6 with agent main.
