### PR TITLE
docs: point 8.1.x downloads to percussioncms-java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,21 @@ It was designed from the beginning for multi-channel delivery — websites, stat
 
 **Smart architecture. Smart APIs. Smart UI.**
 
-Intersoft Data Labs assumed full responsibility for support, maintenance, and ongoing development of the Percussion CMS product line in July 2023 after Percussion Software ended commercial support. This repository is the official open-source home of the product under the Apache 2.0 license.
+Intersoft Data Labs assumed full responsibility for support, maintenance, and ongoing development of the Percussion CMS product line in July 2023 after Percussion Software ended commercial support. This repository is the official open-source home of the **Java 21 / 8.2** product line under the Apache 2.0 license.
 
 ---
 
 ## Current Status (August 2026)
 
-| Version     | Status                          | Notes |
-|-------------|----------------------------------|-------|
-| **8.1.7**   | Current stable release           | June 2026 – security hardening, WCAG 2.1 AA accessibility improvements, Google Analytics 4 support, REST API fixes, and dozens of quality-of-life updates |
-| **8.2**     | Active development / modernization | Performance, headless capabilities, UI modernization (including the new login experience shown above), and platform updates |
+| Version / line | Status | Notes |
+|----------------|--------|--------|
+| **8.1.7** | Current **Java 8** stable release | Security hardening, WCAG 2.1 AA accessibility, Google Analytics 4, REST fixes — **downloads in the Java 8 repo** (see below) |
+| **8.1.x** | Fully supported maintenance | Source and binaries: **[percussioncms-java8](https://github.com/intersoftdatalabs-in/percussioncms-java8)** (JDK 1.8) |
+| **8.2** | Active development / modernization | This repository — performance, headless capabilities, UI modernization, Java 21 platform updates |
 
-The 8.1.x line remains fully supported. Work on the 8.2 release is underway on the `development` branch with a focus on platform modernization, improved developer experience, and continued accessibility/security investment.
+The **8.1.x (Java 8)** line remains fully supported. Work on the **8.2** release continues here with a focus on platform modernization, improved developer experience, and continued accessibility/security investment.
 
-**Upgrading to the latest 8.1.x release is strongly recommended** — recent releases contain important security patches.
+**If you run production on Java 8 / 8.1.x, upgrade to the latest 8.1.x release from the Java 8 repository** — recent releases contain important security patches.
 
 ---
 
@@ -52,16 +53,29 @@ The 8.1.x line remains fully supported. Work on the 8.2 release is underway on t
 
 ## How do I get it?
 
-**Binaries and installers** are published on the [Releases page](https://github.com/intersoftdatalabs-in/percussioncms/releases).
+### Java 21 / 8.2 (this repository)
 
-The latest stable release is always featured there.
+**Binaries and installers** for the active product line will be published on this project’s  
+[Releases page](https://github.com/intersoftdatalabs-in/percussioncms/releases) as 8.2 builds become available.
+
+### Java 8 / 8.1.x downloads
+
+**8.1.x installers and full release notes are published on the dedicated Java 8 LTS repository:**
+
+| | |
+|--|--|
+| **Repository** | [intersoftdatalabs-in/percussioncms-java8](https://github.com/intersoftdatalabs-in/percussioncms-java8) |
+| **All 8.1.x releases** | [percussioncms-java8/releases](https://github.com/intersoftdatalabs-in/percussioncms-java8/releases) |
+| **Latest 8.1.x** | [v8.1.7](https://github.com/intersoftdatalabs-in/percussioncms-java8/releases/tag/v8.1.7) |
+
+This repository may still list short **pointer** entries under Releases for discoverability; **use the Java 8 repo for download assets and complete 8.1.x notes**.
 
 ### Commercial Support & Services
 
 **Intersoft Data Labs** is the exclusive commercial support and maintenance provider for Percussion CMS (all versions of CMS and Rhythmyx) since July 2023.
 
 - Production support and SLAs
-- Upgrade and migration assistance
+- Upgrade and migration assistance (including Java 8 → Java 21 paths)
 - Custom development and integrations
 - Hosting / managed services options
 
@@ -85,6 +99,8 @@ mvnw.cmd clean install
 
 Detailed build instructions, environment setup, CodeQL configuration, and development guidelines are in the [Contributor Guide](https://github.com/intersoftdatalabs-in/percussioncms/blob/development/CONTRIBUTING.md).
 
+For **Java 8 / 8.1.x** source builds, use [percussioncms-java8](https://github.com/intersoftdatalabs-in/percussioncms-java8) instead.
+
 ---
 
 ## Contributing
@@ -92,6 +108,18 @@ Detailed build instructions, environment setup, CodeQL configuration, and develo
 We welcome contributions. Please see the [Contributor Guide](https://github.com/intersoftdatalabs-in/percussioncms/blob/development/CONTRIBUTING.md) for coding standards, pull-request process, and development workflow.
 
 This project follows the [Universal Code v1.0.0](docs/policies/UC-v1.0.0.md) (vendored; [upstream](https://github.com/monkeyking-hq/universal-code)).
+
+- **Java 21 / 8.2 work** → open PRs against this repository  
+- **Java 8 / 8.1.x maintenance** → open PRs against [percussioncms-java8](https://github.com/intersoftdatalabs-in/percussioncms-java8)
+
+---
+
+## Related repositories
+
+| Repository | Role |
+|------------|------|
+| **[percussioncms](https://github.com/intersoftdatalabs-in/percussioncms)** (this repo) | Java **21** / **8.2** active development |
+| **[percussioncms-java8](https://github.com/intersoftdatalabs-in/percussioncms-java8)** | Java **8** LTS — **8.1.x** maintenance and downloads |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the main product README so **8.1.x / Java 8** customers are directed to the dedicated LTS repository for downloads and full notes:

- **[percussioncms-java8/releases](https://github.com/intersoftdatalabs-in/percussioncms-java8/releases)** — canonical 8.1.x binaries + release notes  
- This repo remains **Java 21 / 8.2** active development  

Also clarifies the status table and contributing split between the two repos.

### Related ops (already done via GitHub Releases API)

- Cross-posted **v8.1.6** and **v8.1.7** (assets + full notes) to `percussioncms-java8`
- Shortened the **v8.1.6** / **v8.1.7** release bodies on **this** repo to pointer pages (assets left in place so existing download URLs keep working)

## Test plan

- [x] README links resolve to java8 releases  
- [x] Status table distinguishes 8.1.x vs 8.2  
- [ ] Spot-check Releases page on both repos after merge  

---

> Co-Authored by Grok Build 1.0.3 using grok-4.5 with agent main.