### PR TITLE
fix(tablefactory): restore PSJdbcTableSchemaCollection compile

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
@@ -997,9 +997,9 @@ public class PSDbmsHelper {
       try {
         PSJdbcTableSchemaCollection schemaColl =
             new PSJdbcTableSchemaCollection(schemaDoc, getDataTypeMap());
-        Iterator<PSJdbcTableSchema> schemas = schemaColl.iterator();
+        Iterator<?> schemas = schemaColl.iterator();
         while (schemas.hasNext()) {
-          PSJdbcTableSchema schema = schemas.next();
+          PSJdbcTableSchema schema = (PSJdbcTableSchema) schemas.next();
           m_systemTables.add(schema.getName());
         }
       } catch (PSJdbcTableFactoryException e) {

--- a/docs/ai-generated/code-reviews/tablefactory-schema-collection-iterator-erlang.md
+++ b/docs/ai-generated/code-reviews/tablefactory-schema-collection-iterator-erlang.md
@@ -1,0 +1,70 @@
+# Erlang review: tablefactory schema-collection iterator compile fix
+
+## Summary
+
+`PSJdbcTableSchemaCollection` overrode `iterator()` to return
+`Iterator<PSJdbcTableSchema>`. After `PSCollection` became
+`PSConcurrentList<Object>` (`List<Object>`), that override is illegal:
+`Iterator` is invariant, so `Iterator<PSJdbcTableSchema>` cannot implement
+`List.iterator()` (`Iterator<Object>`).
+
+The fix drops the covariant override and updates the three typed call sites
+to `Iterator<?>` plus a `PSJdbcTableSchema` cast. Membership remains enforced
+by `PSCollection.checkType` (`PSJdbcTableSchema.class` in the collection
+ctor). New `PSJdbcTableSchemaCollectionTest` covers iteration, lookup, and
+XML round-trip.
+
+## Scope
+
+- Uncommitted vs `HEAD` on `main` (pre-branch)
+- Files:
+  - `modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java`
+  - `modules/TableFactory/src/main/java/com/percussion/tablefactory/RxJdbcTableFactory.java`
+  - `modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableSchemaCollectionTest.java`
+  - `modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java`
+  - `deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java`
+- Out of scope: `.grok/workflows/*` dirty files on the working tree (not part of this change)
+- Memory patterns hit: missing behavioral tests; incomplete change-class
+  (typed-iterator callers are the companions); no path I/O
+- Cross-platform path review: N/A (no file I/O / path construction)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: no — collection iterator/lookup/XML tests added
+- Change-class closure: yes — the three `Iterator<PSJdbcTableSchema>` callers
+  of `schemaColl.iterator()` were updated
+- Agent rule files: none in this diff
+
+## Issues
+
+None.
+
+### Suggestion (non-blocking)
+
+A named `schemaIterator()` helper would avoid casts at the three call sites.
+Sibling collections (`PSJdbcTableDataCollection`,
+`PSJdbcTableSchemaHandlerCollection`) already iterate as `Object` + cast, so
+matching that pattern is acceptable.
+
+## Verification noted
+
+```text
+cd modules/TableFactory
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 48, Failures: 0, Errors: 0, Skipped: 7
+# PSJdbcTableSchemaCollectionTest: 4 tests, 0 fail
+
+cd modules/perc-ant
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
+
+cd deployer
+..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 279, Failures: 0, Errors: 0, Skipped: 19
+```

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
@@ -248,12 +248,6 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
     }
   }
 
-  @Override
-  @SuppressWarnings("unchecked")
-  public Iterator<PSJdbcTableSchema> iterator() {
-    return (Iterator<PSJdbcTableSchema>) super.iterator();
-  }
-
   /** The name of this objects root Xml element. */
   public static String NODE_NAME = "tables";
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/RxJdbcTableFactory.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/RxJdbcTableFactory.java
@@ -4014,12 +4014,12 @@ public class RxJdbcTableFactory {
       }
 
       int schemaObjectsLen = schemaColl.size();
-      Iterator<PSJdbcTableSchema> it = schemaColl.iterator();
+      Iterator<?> it = schemaColl.iterator();
       int percentCompleted = 0;
       int index = 0;
 
       while (it.hasNext()) {
-        schema = it.next();
+        schema = (PSJdbcTableSchema) it.next();
         String tblName = schema.getName();
         data = dataColl.getTableData(tblName);
         // getTableData may return null if this table has no data associated

--- a/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableSchemaCollectionTest.java
+++ b/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableSchemaCollectionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.tablefactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Unit test for {@link PSJdbcTableSchemaCollection}. Iteration uses the inherited {@code
+ * List<Object>} iterator from {@code PSCollection}; members are {@link PSJdbcTableSchema}.
+ */
+public class PSJdbcTableSchemaCollectionTest {
+
+  @Test
+  public void iteratorYieldsAddedSchemas() throws Exception {
+    PSJdbcTableSchemaCollection collection = new PSJdbcTableSchemaCollection();
+    PSJdbcTableSchema parent = newSchema("PARENT_TABLE");
+    PSJdbcTableSchema child = newSchema("CHILD_TABLE");
+    collection.add(parent);
+    collection.add(child);
+
+    assertEquals(2, collection.size());
+
+    Iterator<?> it = collection.iterator();
+    assertTrue(it.hasNext());
+    assertSame(parent, it.next());
+    assertTrue(it.hasNext());
+    assertSame(child, it.next());
+
+    List<PSJdbcTableSchema> fromForEach = new ArrayList<>();
+    for (Object o : collection) {
+      assertTrue(o instanceof PSJdbcTableSchema);
+      fromForEach.add((PSJdbcTableSchema) o);
+    }
+    assertEquals(List.of(parent, child), fromForEach);
+  }
+
+  @Test
+  public void getTableSchemaIsCaseInsensitive() throws Exception {
+    PSJdbcTableSchemaCollection collection = new PSJdbcTableSchemaCollection();
+    PSJdbcTableSchema schema = newSchema("MyTable");
+    collection.add(schema);
+
+    assertSame(schema, collection.getTableSchema("MyTable"));
+    assertSame(schema, collection.getTableSchema("mytable"));
+    assertNull(collection.getTableSchema("other"));
+  }
+
+  @Test
+  public void getTableSchemaRejectsBlankName() {
+    PSJdbcTableSchemaCollection collection = new PSJdbcTableSchemaCollection();
+    assertThrows(IllegalArgumentException.class, () -> collection.getTableSchema(null));
+    assertThrows(IllegalArgumentException.class, () -> collection.getTableSchema(""));
+    assertThrows(IllegalArgumentException.class, () -> collection.getTableSchema("   "));
+  }
+
+  @Test
+  public void xmlRoundTripPreservesTableNames() throws Exception {
+    PSJdbcDataTypeMap map = new PSJdbcDataTypeMap("MSSQL", "sqlserver", null);
+    PSJdbcTableSchemaCollection collection = new PSJdbcTableSchemaCollection();
+    collection.add(newSchema("TABLE_A"));
+    collection.add(newSchema("TABLE_B"));
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    doc.appendChild(collection.toXml(doc));
+
+    PSJdbcTableSchemaCollection restored = new PSJdbcTableSchemaCollection(doc, map);
+    assertEquals(2, restored.size());
+    assertNotNull(restored.getTableSchema("TABLE_A"));
+    assertNotNull(restored.getTableSchema("TABLE_B"));
+    assertEquals("TABLE_A", restored.getTableSchema("table_a").getName());
+  }
+
+  private static PSJdbcTableSchema newSchema(String name) throws Exception {
+    PSJdbcDataTypeMap map = new PSJdbcDataTypeMap("MSSQL", "sqlserver", null);
+    List<PSJdbcColumnDef> cols = new ArrayList<>();
+    cols.add(
+        new PSJdbcColumnDef(
+            map, "col1", PSJdbcTableComponent.ACTION_CREATE, Types.VARCHAR, "50", false, null));
+    return new PSJdbcTableSchema(name, cols.iterator());
+  }
+}

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
@@ -150,12 +150,12 @@ public final class PSTableAction extends PSAction {
           else dataColl.addAll(new PSJdbcTableDataCollection(doc));
         }
 
-        Iterator<PSJdbcTableSchema> it = schemaColl.iterator();
+        Iterator<?> it = schemaColl.iterator();
 
         int index = 0;
 
         while (it.hasNext()) {
-          schema = it.next();
+          schema = (PSJdbcTableSchema) it.next();
           String tblName = schema.getName();
           data = dataColl.getTableData(tblName);
           // getTableData may return null if this table has no data associated


### PR DESCRIPTION
## Summary

`PSJdbcTableSchemaCollection` failed to compile after `PSCollection` became a `List<Object>` (`PSConcurrentList<Object>`). The class overrode `iterator()` to return `Iterator<PSJdbcTableSchema>`, which cannot implement `List.iterator()` because `Iterator` is invariant.

This PR drops the covariant override (iteration uses the inherited `Iterator<Object>`) and updates the three typed call sites to `Iterator<?>` plus a `PSJdbcTableSchema` cast. Membership is still enforced by `PSCollection.checkType` (`PSJdbcTableSchema.class` in the collection constructor).

New `PSJdbcTableSchemaCollectionTest` covers iteration, case-insensitive lookup, argument checks, and XML round-trip.

## Test plan

1. `cd modules/TableFactory` then `..\..\mvnw.cmd clean install` — expect BUILD SUCCESS (48 tests, 0 fail).
2. Confirm `PSJdbcTableSchemaCollectionTest` runs 4 tests, 0 fail.
3. `cd modules/perc-ant` then `..\..\mvnw.cmd clean install` — expect BUILD SUCCESS (49 tests, 0 fail).
4. `cd deployer` then `..\mvnw.cmd clean install` — expect BUILD SUCCESS (279 tests, 0 fail).
5. No product UI or operator-facing behavior change — skip Playwright / product-docs.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): compile/generics fix only
- [x] **Unit / module tests** — `PSJdbcTableSchemaCollectionTest` (4); tablefactory / perc-ant / deployer standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)

## Verification

```text
cd modules/TableFactory && ..\..\mvnw.cmd clean install
# BUILD SUCCESS — Tests run: 48, Failures: 0, Errors: 0, Skipped: 7

cd modules/perc-ant && ..\..\mvnw.cmd clean install
# BUILD SUCCESS — Tests run: 49, Failures: 0, Errors: 0, Skipped: 0

cd deployer && ..\mvnw.cmd clean install
# BUILD SUCCESS — Tests run: 279, Failures: 0, Errors: 0, Skipped: 19
```

Erlang pre-PR: **approve** — `docs/ai-generated/code-reviews/tablefactory-schema-collection-iterator-erlang.md`

> Co-Authored by Grok Build 4.6 using grok-4.6 with agent main.
