### PR TITLE
fix(#3217): product name Navigation not Architecture

### DIFF
--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -99,7 +99,7 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "architecture":
-              // SPA Architecture shell (#3094 / parent #3092) — not legacy view=arch
+              // SPA Navigation shell at /architecture (#3094 / #3217)
               return (
                 <li key={id}>
                   <NavLink

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -51,8 +51,8 @@ export interface TopNavGates {
 export const ADMIN_NAV_LANDING = "/admin";
 
 /**
- * Client path for Architecture top-nav NavLink and homepage SPA landing (#3094).
- * Primary Architecture entry (SPA). Legacy {@code ?view=arch} /
+ * Client path for Navigation top-nav NavLink and homepage SPA landing (#3094).
+ * Primary Navigation entry (SPA). Legacy {@code ?view=arch} /
  * {@code siteArchitecture.jsp} hard-redirect here (#3099).
  */
 export const ARCHITECTURE_NAV_LANDING = "/architecture";

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -24,10 +24,10 @@ import { message } from "../i18n/message";
  * Small key set only — no multi-locale mass TMX backfill in this slice.
  */
 const KEYS = {
-  TITLE: "perc.ui.architecture.modern@Architecture",
+  TITLE: "perc.ui.architecture.modern@Navigation",
   INTRO:
     "perc.ui.architecture.modern@Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.",
-  SHELL_LOADING: "perc.ui.architecture.modern@Loading Architecture…",
+  SHELL_LOADING: "perc.ui.architecture.modern@Loading Navigation…",
   SITE_LABEL: "perc.ui.architecture.modern@Site",
   SITE_PLACEHOLDER: "perc.ui.architecture.modern@Select a site…",
   SITE_HINT: "perc.ui.architecture.modern@Site context: {0}",

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -206,10 +206,9 @@ export const MSG = {
   NAV_HOME: "perc.ui.navMenu.home@Home",
   NAV_DASHBOARD: "perc.ui.navMenu.dashboard@Dashboard",
   NAV_EDITOR: "perc.ui.navMenu.webmgt@Editor",
-  NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Architecture",
-  /** Architecture SPA top-nav tooltip (#3094). */
-  NAV_ARCHITECTURE_TITLE:
-    "perc.ui.architecture.modern@Site navigation (Architecture)",
+  NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Navigation",
+  /** Navigation SPA top-nav tooltip (#3094 / #3217). */
+  NAV_ARCHITECTURE_TITLE: "perc.ui.architecture.modern@Site navigation",
   /** Design SPA top-nav (#2808) — classic key already en-us "Design". */
   NAV_DESIGN: "perc.ui.navMenu.design@Design",
   NAV_DESIGN_TITLE:

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -53,8 +53,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // SPA path /architecture (#3094); homepage type remains "Architecture"
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // SPA path /architecture (#3094); API homepage type remains "Architecture"
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -55,8 +55,8 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // Product "Navigation" / Architecture SPA (#3094 → /architecture)
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // Product name Navigation; SPA path /architecture (#3094 / #3217)
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -95,7 +95,7 @@ describe("TopNav (#2702)", () => {
     // Must not be a full-page legacy exit
     expect(href).not.toMatch(/view=arch/);
     expect(arch.tagName.toLowerCase()).toBe("a");
-    expect(arch.textContent).toMatch(/^Navigation$/);
+    expect(arch).toHaveTextContent(/Navigation/i);
   });
 
   it("hides Admin for non-admin", () => {

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -95,6 +95,7 @@ describe("TopNav (#2702)", () => {
     // Must not be a full-page legacy exit
     expect(href).not.toMatch(/view=arch/);
     expect(arch.tagName.toLowerCase()).toBe("a");
+    expect(arch.textContent).toMatch(/^Navigation$/);
   });
 
   it("hides Admin for non-admin", () => {

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -78,7 +78,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     expect(screen.getByTestId("architecture-empty-state")).toBeTruthy();
     expect(screen.getByTestId("architecture-shell-title").textContent).toMatch(
-      /Architecture/i,
+      /Navigation/i,
     );
   });
 

--- a/WebUI/src/test/ts/architecture/navigationProductName.test.ts
+++ b/WebUI/src/test/ts/architecture/navigationProductName.test.ts
@@ -34,6 +34,11 @@ describe("Navigation product name (#3217)", () => {
     expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE_TITLE)).toBe(
       "Site navigation",
     );
+    expect(MSG.NAV_ARCHITECTURE).toBe("perc.ui.navMenu.architecture@Navigation");
     expect(MSG.NAV_ARCHITECTURE).not.toMatch(/@Architecture$/);
+    expect(ARCH_MSG_KEYS.TITLE).toBe("perc.ui.architecture.modern@Navigation");
+    expect(MSG.NAV_ARCHITECTURE_TITLE).toBe(
+      "perc.ui.architecture.modern@Site navigation",
+    );
   });
 });

--- a/WebUI/src/test/ts/architecture/navigationProductName.test.ts
+++ b/WebUI/src/test/ts/architecture/navigationProductName.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ARCH_MSG, ARCH_MSG_KEYS } from "../../../main/ts/architecture/messages";
+import { fallbackLabelFromKey, MSG } from "../../../main/ts/i18n/message";
+
+describe("Navigation product name (#3217)", () => {
+  it("uses Navigation for shell title and loading fallbacks", () => {
+    expect(fallbackLabelFromKey(ARCH_MSG_KEYS.TITLE)).toBe("Navigation");
+    expect(ARCH_MSG.TITLE).toBe("Navigation");
+    expect(fallbackLabelFromKey(ARCH_MSG_KEYS.SHELL_LOADING)).toBe(
+      "Loading Navigation…",
+    );
+    expect(ARCH_MSG.SHELL_LOADING).toBe("Loading Navigation…");
+  });
+
+  it("uses Navigation for top-nav label and tooltip fallbacks", () => {
+    expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE)).toBe("Navigation");
+    expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE_TITLE)).toBe(
+      "Site navigation",
+    );
+    expect(MSG.NAV_ARCHITECTURE).not.toMatch(/@Architecture$/);
+  });
+});

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -21,6 +21,7 @@ import {
   profileLandingOptions,
 } from "../../../main/ts/profile/landingOptions";
 import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 
 describe("profileLandingOptions", () => {
   it("allows Home and Editor for any user", () => {
@@ -46,5 +47,13 @@ describe("profileLandingOptions", () => {
   it("keeps current value when no longer allowed", () => {
     const opts = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
     expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
+  });
+
+  it("labels the Architecture homepage type as Navigation (#3217)", () => {
+    const opt = profileLandingOptions({ isDesigner: true }).find(
+      (o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE,
+    );
+    expect(opt).toBeTruthy();
+    expect(fallbackLabelFromKey(opt!.labelKey)).toBe("Navigation");
   });
 });

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 import {
   isLandingAllowedForRoles,
   landingOptionsForRoles,
@@ -39,6 +40,8 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
   });
 
   it("includes Administration (Workflow) for Admin role", () => {

--- a/docs/ai-generated/code-reviews/issue-3217-navigation-product-name-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3217-navigation-product-name-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — issue #3217 Navigation product name
+
+**Date:** 2026-08-12  
+**Scope:** uncommitted branch `fix/issue-3217-navigation-product-name` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure (Playwright companions for WebUI chrome); dual-ship lockstep (JSP not edited)
+
+## Summary
+
+Operator-visible chrome for the Navigation product surface used **Architecture** in SPA fallbacks, shell title TMX, landing-picker keys, tooltip, and product-docs. Routes, testids, homepage type `Architecture`, and package paths stay as-is. Tests now assert visible **Navigation**. Existing Playwright title matchers updated so C5 will not fail on the old name.
+
+## Issues
+
+None (hard-gate).
+
+### Suggestions (non-blocking)
+
+- Legacy JSP still uses `perc.ui.navMenu.architecture@Architecture`. Production TMX en-us for that tuid is already `Navigation`; left unchanged to keep residual hosts working without a dual-ship JSP edit.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or path assertions in this diff.
+
+## Tests
+
+- Vitest: shell title, top-nav fallback, profile + user landing option labels.
+- Playwright: existing architecture-* smokes now expect `/Navigation/i` on `architecture-shell-title`.

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -570,6 +570,7 @@
       <tuv xml:lang="zh-cn"><seg>家</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>家</seg></tuv>
     <tuv xml:lang="ru"><seg>Дом</seg></tuv><tuv xml:lang="he"><seg>בַּיִת</seg></tuv><tuv xml:lang="uk"><seg>додому</seg></tuv><tuv xml:lang="lou"><seg>Lakay</seg></tuv><tuv xml:lang="pl"><seg>Dom</seg></tuv><tuv xml:lang="tr"><seg>Ev</seg></tuv></tu>
+    <!-- #3217: tuid suffix stays @Architecture for residual JSP (mainnav / navigationTemplates / template_layout). en-us text is Navigation. -->
     <tu tuid="perc.ui.navMenu.architecture@Architecture">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
       <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
@@ -586,6 +587,7 @@
       <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
     <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
+    <!-- #3217: canonical SPA key (MSG.NAV_ARCHITECTURE). Must coexist with @Architecture above — JSP still binds the old tuid. -->
     <tu tuid="perc.ui.navMenu.architecture@Navigation">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
       <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
@@ -27109,10 +27111,7 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
       <tuv xml:lang="en-us"><seg>Server</seg></tuv>
     <tuv xml:lang="lou"><seg>Server</seg></tuv><tuv xml:lang="tr"><seg>Sunucu</seg></tuv></tu>
 
-    <!-- Architecture SPA chrome (#3098 Slice F) — feature keys only (en-us). -->
-    <tu tuid="perc.ui.architecture.modern@Architecture">
-      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
-    </tu>
+    <!-- Architecture SPA chrome (#3098 Slice F, #3217). Canonical title tuid is @Navigation (ARCH_MSG_KEYS.TITLE). -->
     <tu tuid="perc.ui.architecture.modern@Navigation">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
     </tu>
@@ -27371,9 +27370,7 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
     <tu tuid="perc.ui.architecture.modern@Enter a valid URL (for example https://example.com or /path)">
       <tuv xml:lang="en-us"><seg>Enter a valid URL (for example https://example.com or /path)</seg></tuv>
     </tu>
-    <tu tuid="perc.ui.architecture.modern@Site navigation (Architecture)">
-      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
-    </tu>
+    <!-- #3217: tooltip tuid is @Site navigation (MSG.NAV_ARCHITECTURE_TITLE). -->
     <tu tuid="perc.ui.architecture.modern@Site navigation">
       <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
     </tu>

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -586,6 +586,22 @@
       <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
     <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
+    <tu tuid="perc.ui.navMenu.architecture@Navigation">
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
+      <tuv xml:lang="bn"><seg>নেভিগেশন</seg></tuv>
+      <tuv xml:lang="de"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="es"><seg>Navegación</seg></tuv>
+      <tuv xml:lang="fr"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="hi"><seg>मार्गदर्शन</seg></tuv>
+      <tuv xml:lang="it"><seg>Navigazione</seg></tuv>
+      <tuv xml:lang="ja-jp"><seg>ナビゲーション</seg></tuv>
+      <tuv xml:lang="nl"><seg>Navigatie</seg></tuv>
+      <tuv xml:lang="pt"><seg>Navegação</seg></tuv>
+      <tuv xml:lang="te"><seg>నావిగేషన్</seg></tuv>
+      <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
+      <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
+    <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
     <tu tuid="perc.ui.navMenu.design@Design">
       <tuv xml:lang="en-us"><seg>Design</seg></tuv>
       <tuv xml:lang="ar"><seg>تصميم</seg></tuv>
@@ -27095,13 +27111,19 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
 
     <!-- Architecture SPA chrome (#3098 Slice F) — feature keys only (en-us). -->
     <tu tuid="perc.ui.architecture.modern@Architecture">
-      <tuv xml:lang="en-us"><seg>Architecture</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Navigation">
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.">
       <tuv xml:lang="en-us"><seg>Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Loading Architecture…">
-      <tuv xml:lang="en-us"><seg>Loading Architecture…</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Loading Navigation…</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Loading Navigation…">
+      <tuv xml:lang="en-us"><seg>Loading Navigation…</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Site">
       <tuv xml:lang="en-us"><seg>Site</seg></tuv>
@@ -27350,7 +27372,10 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
       <tuv xml:lang="en-us"><seg>Enter a valid URL (for example https://example.com or /path)</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Site navigation (Architecture)">
-      <tuv xml:lang="en-us"><seg>Site navigation (Architecture)</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Site navigation">
+      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
     </tu>
 
   </body>

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-links-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-links-smoke.spec.js
@@ -68,7 +68,7 @@ test.describe("Architecture nav landing & links (#3097)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
 
     const sitesEmpty = page.getByTestId("architecture-sites-empty");

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
@@ -68,7 +68,7 @@ test.describe("Architecture nav structure mutations (#3096)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
     await expect(page.getByTestId("architecture-toolbar")).toBeVisible({
       timeout: 15_000,

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
@@ -58,7 +58,7 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
 
     // Toolbar always present once shell mounts

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -43,9 +43,12 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await loginAsAdmin(page);
   });
 
-  test("deep link and TopNav open shell empty state @smoke @ui", async ({
+  test("deep link and TopNav open Navigation shell @smoke @ui", async ({
     page,
   }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
     await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
 
     await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
@@ -54,13 +57,18 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("nav-architecture")).toBeVisible({
       timeout: 20_000,
     });
+    await expect(page.getByTestId("nav-architecture")).toHaveText(/Navigation/i);
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByTestId("architecture-empty-state")).toBeVisible();
+    // Demo-site QA cells auto-select a site (picker); empty H2 cells show empty-state.
+    const emptyState = page.getByTestId("architecture-empty-state");
+    const picker = page.getByTestId("architecture-site-picker");
+    await expect(emptyState.or(picker)).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
+    expect(pageErrors, "uncaught pageerror on Navigation shell").toEqual([]);
 
     // Top-nav Architecture is SPA NavLink (not legacy ?view=arch)
     const href = await page

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -1,33 +1,37 @@
 ---
 id: admin-architecture-navigation
-title: Architecture & site navigation
-description: Modern Architecture SPA for browsing and editing site navigation trees (navons / sections)
+title: Navigation & site structure
+description: Modern Navigation SPA for browsing and editing site navigation trees (navons / sections)
 version: "8.2"
 order: 43
 tags: [admin, architecture, navigation, ui]
 ---
 
-# Architecture & site navigation
+# Navigation & site structure
 
-**Architecture** (site navigation / navon tree editor) runs in the modern SPA product
+**Navigation** (site navigation / navon tree editor) runs in the modern SPA product
 chrome. In Percussion CMS 8.2 the primary entry is the SPA shell. The classic
 `siteArchitecture.jsp` page and `?view=arch` bookmarks hard-redirect into the SPA.
 
-## Open Architecture (SPA)
+The product name is **Navigation**. The SPA route remains `/architecture` (and
+`spa.jsp?entry=architecture`) so existing bookmarks and homepage type
+`Architecture` keep working.
+
+## Open Navigation (SPA)
 
 1. Sign in as an **Admin** or **Designer**.
-2. Choose **Architecture** in the product top navigation, or open the SPA entry:
+2. Choose **Navigation** in the product top navigation, or open the SPA entry:
    - Query contract: `spa.jsp?entry=architecture`
    - Path route: `/cm/app/architecture` (optional site segment or `?site=` for context)
    - Legacy bookmarks: `/cm/app/?view=arch` and `/cm/app/siteArchitecture.jsp` redirect here
 3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
 
-Default landing can also be set to **Architecture** for a user or role (homepage type
-`Architecture`); login then resolves to the SPA Architecture entry.
+Default landing can also be set to **Navigation** for a user or role (homepage type
+`Architecture`); login then resolves to the SPA Navigation entry.
 
 ## Browse a site navigation tree
 
-1. Open **Architecture**.
+1. Open **Navigation**.
 2. Choose a site from the **Site** list (or open a deep link with `?site=YourSiteName`
    or `/architecture/YourSiteName`).
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
@@ -80,7 +84,7 @@ shown in the panel (no silent failure). The tree reloads after a successful muta
 ### Blog sections
 
 Blog-type sections appear in the navigation tree (type badge). Full blog post
-authoring remains outside this Architecture editor; treat blog structure as
+authoring remains outside this Navigation editor; treat blog structure as
 visible but limited in this surface.
 
 ### Still later
@@ -105,10 +109,10 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | Site navigation tree browse (navons / sections) | **Available** (read-only) |
 | Structure editing (create / edit / move / delete) | **Coming soon** |
 | Landing page / section-link parity | **Coming soon** |
-| Legacy `siteArchitecture.jsp` / `?view=arch` | **Redirected** to SPA Architecture (#3099) |
+| Legacy `siteArchitecture.jsp` / `?view=arch` | **Redirected** to SPA Navigation (#3099) |
 
 ## Related
 
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
-- [Users, roles & security](id:admin-users-roles) (default landing options include Architecture)
+- [Users, roles & security](id:admin-users-roles) (default landing options include Navigation)

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -38,7 +38,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
-- [Architecture & site navigation](id:admin-architecture-navigation)
+- [Navigation & site structure](id:admin-architecture-navigation)
 - [Users, roles & security](id:admin-users-roles)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)


### PR DESCRIPTION
## Summary

Restore the operator-visible product name **Navigation** (not Architecture) on SPA chrome, landing/homepage pickers, TMX fallbacks, and product-docs 8.2.

- Top-nav label + tooltip, Navigation shell title, and loading copy say **Navigation**
- Profile and Admin → Users landing pickers use the Navigation label (API homepage type remains `Architecture`)
- SPA route stays `/architecture` (`spa.jsp?entry=architecture`)
- Legacy JSP keys keep `perc.ui.navMenu.architecture@Architecture` (TMX en-us already Navigation)

Fixes #3217  
Parent tracker: #3197 (slice 1 of QA residual #3157 / #3099)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. QA H2 docker: `python docker/scripts/perc-devctl.py qa-up` (use printed `TEST_CMS_URL`).
2. Hot-copy `WebUI/target/generated-webui/cm/modern` into the cell `…/Rhythmyx/cm/modern/` (or rebuild cell).
3. Sign in as Admin. Confirm top-nav item **Navigation** (not Architecture) and path `/architecture`.
4. Open Navigation. Confirm `h1` / `architecture-shell-title` is **Navigation**.
5. Profile preferences + Admin → Users default landing: option label **Navigation** (value still `Architecture`).
6. Playwright: `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` and `npm run test:golden`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` and admin index link text
- [x] **Unit / module tests** — Vitest for shell title, top-nav, landing option fallbacks; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — existing architecture smokes expect `/Navigation/i`; shell smoke asserts top-nav text
- [x] **Build gates** — standalone clean install on `modules/perc-i18n` and `WebUI`
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- `modules_built=modules/perc-i18n,WebUI`
- `build_evidence=`
  - `cd modules/perc-i18n && ../../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 31, Failures: 0
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** Vitest Test Files 291 passed, Tests 2059 passed
- `downstream_checked=none` (no public Java API / `final` / signature change)

### C5 UI proof

- `qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Hot-deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` → **1 passed**
- `npm run test:golden` → **2 passed**
- `console-clean=yes` (pageerror listener empty on Navigation shell)
- `server.log-clean=no` **BUG:#3218** (pre-existing nav-tree HTTP 500 / `SITEID` NULL — out of scope for this slice)

## Out of scope

- Navigation tree HTTP 500 / empty-tree UX → #3218
- Homepage post-login routing + New Site → #3219
