### PR TITLE
fix(#3218): Navigation tree empty 200 / UX instead of HTTP 500

### DIFF
--- a/WebUI/src/main/ts/api/architecture/mapSectionTree.ts
+++ b/WebUI/src/main/ts/api/architecture/mapSectionTree.ts
@@ -115,6 +115,21 @@ function normalizeSectionType(raw: unknown): SectionType {
 }
 
 /**
+ * True when the wire node is an empty/missing nav tree (#3218): no section
+ * id and no children. Title/folderPath alone (site name) is not a tree.
+ */
+export function isEmptySectionTreeWire(wire: SectionNodeWire | null): boolean {
+  if (wire == null) {
+    return true;
+  }
+  const id = asNullableString(wire.id);
+  const children = normalizeChildNodes(
+    wire.childNodes ?? wire.ChildNodes ?? wire.SectionNode ?? null,
+  );
+  return id == null && children.length === 0;
+}
+
+/**
  * Map a wire {@link SectionNodeWire} to a {@link NavTreeNode} tree.
  * Skips cycles (same id already on path) and nodes without a usable id.
  */

--- a/WebUI/src/main/ts/api/architecture/sectionApi.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionApi.ts
@@ -23,9 +23,10 @@
  * Mutations: create / properties / update / move / delete / landing / links.</p>
  */
 
-import { del, get, post } from "../client";
+import { del, extractRestErrorMessage, get, isApiError, post } from "../client";
 import { PATHS } from "../paths";
 import {
+  isEmptySectionTreeWire,
   mapSectionNodeToTree,
   parseSectionNodePayload,
 } from "./mapSectionTree";
@@ -119,11 +120,36 @@ export function sectionLoadUrl(sectionId: string): string {
 }
 
 /**
+ * True when the API failure is a missing/empty NavTree (operator empty
+ * state), not a hard tree-load failure (#3218).
+ */
+export function isMissingNavTreeError(err: unknown): boolean {
+  const chunks: string[] = [];
+  if (err instanceof Error && err.message) {
+    chunks.push(err.message);
+  }
+  if (isApiError(err)) {
+    chunks.push(String(err.statusText || ""));
+    const fromBody = extractRestErrorMessage(err.body);
+    if (fromBody) {
+      chunks.push(fromBody);
+    }
+  }
+  const text = chunks.join(" ").toLowerCase();
+  return (
+    text.includes("cannot find navigation tree") ||
+    text.includes("cannot find navtree") ||
+    text.includes("navtree for site") ||
+    text.includes("no navigation tree")
+  );
+}
+
+/**
  * Load the full section/navon tree for a site.
  *
  * @param siteName CMS site name (e.g. {@code Corporate Investments})
  * @returns Normalized root {@link NavTreeNode}, or {@code null} when the
- *          payload is empty / unparseable (caller may treat as empty).
+ *          payload is empty / unparseable / missing nav tree (#3218).
  */
 export async function loadSectionTree(
   siteName: string,
@@ -132,12 +158,19 @@ export async function loadSectionTree(
   if (!name) {
     throw new Error("Site name is required to load the navigation tree");
   }
-  const payload = await get<unknown>(sectionTreeUrl(name));
-  const wire = parseSectionNodePayload(payload);
-  if (!wire) {
-    return null;
+  try {
+    const payload = await get<unknown>(sectionTreeUrl(name));
+    const wire = parseSectionNodePayload(payload);
+    if (!wire || isEmptySectionTreeWire(wire)) {
+      return null;
+    }
+    return mapSectionNodeToTree(wire);
+  } catch (err) {
+    if (isMissingNavTreeError(err)) {
+      return null;
+    }
+    throw err;
   }
-  return mapSectionNodeToTree(wire);
 }
 
 /**

--- a/WebUI/src/main/ts/architecture/NavTree.tsx
+++ b/WebUI/src/main/ts/architecture/NavTree.tsx
@@ -359,8 +359,33 @@ export function NavTree({
     );
   } else if (!root) {
     body = (
-      <div style={emptyStyle} data-testid="architecture-nav-tree-empty">
-        {ARCH_MSG.TREE_EMPTY}
+      <div
+        style={emptyStyle}
+        data-testid="architecture-nav-tree-empty"
+        role="status"
+      >
+        <p
+          style={{
+            margin: "0 0 0.35rem",
+            fontWeight: 600,
+            color: "#1a202c",
+          }}
+          data-testid="architecture-nav-tree-empty-title"
+        >
+          {ARCH_MSG.TREE_EMPTY_TITLE}
+        </p>
+        <p
+          style={{ margin: "0 0 0.5rem", color: catalogColors.muted }}
+          data-testid="architecture-nav-tree-empty-body"
+        >
+          {ARCH_MSG.TREE_EMPTY}
+        </p>
+        <p
+          style={{ margin: 0, fontSize: "0.9rem" }}
+          data-testid="architecture-nav-tree-empty-hint"
+        >
+          {ARCH_MSG.TREE_EMPTY_HINT}
+        </p>
       </div>
     );
   } else {

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -41,6 +41,9 @@ const KEYS = {
   TREE_ERROR: "perc.ui.architecture.modern@Could not load the navigation tree.",
   TREE_EMPTY:
     "perc.ui.architecture.modern@This site has no navigation sections yet.",
+  TREE_EMPTY_TITLE: "perc.ui.architecture.modern@No navigation tree",
+  TREE_EMPTY_HINT:
+    "perc.ui.architecture.modern@A site can exist without a NavTree. Add a navigation tree at the site root in Explorer, then refresh, or choose another site.",
   TREE_PANEL_TITLE: "perc.ui.architecture.modern@Navigation tree",
   TREE_STRUCTURE_NOTE:
     "perc.ui.architecture.modern@Select a section, then use structure actions: create, rename, move, delete, landing page, or link editors.",
@@ -179,6 +182,8 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   TREE_LOADING: message(KEYS.TREE_LOADING),
   TREE_ERROR: message(KEYS.TREE_ERROR),
   TREE_EMPTY: message(KEYS.TREE_EMPTY),
+  TREE_EMPTY_TITLE: message(KEYS.TREE_EMPTY_TITLE),
+  TREE_EMPTY_HINT: message(KEYS.TREE_EMPTY_HINT),
   TREE_PANEL_TITLE: message(KEYS.TREE_PANEL_TITLE),
   TREE_STRUCTURE_NOTE: message(KEYS.TREE_STRUCTURE_NOTE),
   REFRESH: message(KEYS.REFRESH),

--- a/WebUI/src/test/ts/api/architecture/mapSectionTree.test.ts
+++ b/WebUI/src/test/ts/api/architecture/mapSectionTree.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 import {
   countNavTreeNodes,
   flattenNavTree,
+  isEmptySectionTreeWire,
   mapSectionNodeToTree,
   normalizeChildNodes,
   parseSectionNodePayload,
@@ -102,6 +103,20 @@ describe("mapSectionTree (#3095)", () => {
     expect(parseSectionNodePayload(null)).toBeNull();
     expect(parseSectionNodePayload("nope")).toBeNull();
     expect(mapSectionNodeToTree({ title: "NoId" }).title).toBe("NoId");
+  });
+
+  it("treats missing-id empty children as empty nav tree (#3218)", () => {
+    expect(
+      isEmptySectionTreeWire({ title: "BareSite", childNodes: [] }),
+    ).toBe(true);
+    expect(isEmptySectionTreeWire(null)).toBe(true);
+    expect(
+      isEmptySectionTreeWire({
+        id: "root-1",
+        title: "Home",
+        childNodes: [],
+      }),
+    ).toBe(false);
   });
 
   it("sectionTypeLabel badges non-default types", () => {

--- a/WebUI/src/test/ts/api/architecture/sectionApi.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionApi.test.ts
@@ -18,6 +18,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
+  isMissingNavTreeError,
   loadSectionTree,
   sectionRootUrl,
   sectionTreeUrl,
@@ -67,5 +68,47 @@ describe("sectionApi (#3095)", () => {
   it("loadSectionTree returns null for empty payload", async () => {
     vi.spyOn(client, "get").mockResolvedValue(null);
     await expect(loadSectionTree("Demo")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree returns null for empty SectionNode without id (#3218)", async () => {
+    vi.spyOn(client, "get").mockResolvedValue({
+      SectionNode: { title: "BareSite", childNodes: [] },
+    });
+    await expect(loadSectionTree("BareSite")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree treats missing-navtree 500 as empty (#3218)", async () => {
+    vi.spyOn(client, "get").mockRejectedValue({
+      status: 500,
+      statusText: "Server Error",
+      body: { message: "Cannot find navigation tree for site: BareSite" },
+    });
+    await expect(loadSectionTree("BareSite")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree still throws unrelated 500s", async () => {
+    vi.spyOn(client, "get").mockRejectedValue({
+      status: 500,
+      statusText: "Server Error",
+      body: { message: "database unavailable" },
+    });
+    await expect(loadSectionTree("Demo")).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("isMissingNavTreeError matches server empty-state text", () => {
+    expect(
+      isMissingNavTreeError({
+        status: 500,
+        statusText: "Server Error",
+        body: { message: "Cannot find navigation tree for site: X" },
+      }),
+    ).toBe(true);
+    expect(
+      isMissingNavTreeError({
+        status: 500,
+        statusText: "Server Error",
+        body: { message: "Cannot get guid for nav-id" },
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -116,6 +116,22 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     );
   });
 
+  it("shows operator empty state when tree is missing (#3218)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "BareSite" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(null);
+
+    render(<ArchitectureShell embedded initialSite="BareSite" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-nav-tree-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("architecture-nav-tree-empty-title").textContent).toMatch(
+      /no navigation tree/i,
+    );
+    expect(screen.queryByTestId("architecture-nav-tree-error")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("surfaces tree load errors", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockRejectedValue({

--- a/WebUI/src/test/ts/architecture/NavTree.test.tsx
+++ b/WebUI/src/test/ts/architecture/NavTree.test.tsx
@@ -126,5 +126,10 @@ describe("NavTree (#3095)", () => {
 
     rerender(<NavTree root={null} />);
     expect(screen.getByTestId("architecture-nav-tree-empty")).toBeTruthy();
+    expect(
+      screen.getByTestId("architecture-nav-tree-empty-title").textContent,
+    ).toMatch(/no navigation tree/i);
+    expect(screen.getByTestId("architecture-nav-tree-empty-hint")).toBeTruthy();
+    expect(screen.queryByRole("tree")).toBeNull();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-empty.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-empty.spec.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture nav tree empty / missing NavTree UX (#3218 / parent #3197).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-tree-empty.spec.js
+ *
+ * Intercepts site list + tree so the assertion does not depend on seeded
+ * sites. Empty 200 tree must be an operator empty state, not HTTP 500 chrome.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    site: "BareSite",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Architecture empty nav tree (#3218)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("empty 200 tree is operator empty state not 500 banner @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.route("**/sitemanage/site/**", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          SiteSummary: [{ name: "BareSite" }],
+        }),
+      });
+    });
+    await page.route("**/sitemanage/section/tree/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          SectionNode: {
+            title: "BareSite",
+            folderPath: "//Sites/BareSite",
+            childNodes: [],
+          },
+        }),
+      });
+    });
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("architecture-nav-tree-empty")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.getByTestId("architecture-nav-tree-empty-title"),
+    ).toContainText(/no navigation tree/i);
+    await expect(page.getByTestId("architecture-nav-tree-error")).toHaveCount(0);
+    await expect(page.getByText(/HTTP 500/i)).toHaveCount(0);
+
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            e,
+          ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
@@ -58,7 +58,7 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation|Architecture/i,
     );
 
     // Toolbar always present once shell mounts
@@ -92,6 +92,12 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       await expect(treePanel.or(emptyState)).toBeVisible({ timeout: 15_000 });
       if (await treePanel.isVisible().catch(() => false)) {
         await expect(page.getByTestId("architecture-nav-tree")).toBeVisible();
+        // Missing NavTree is empty state, not HTTP 500 (#3218)
+        const treeError = page.getByTestId("architecture-nav-tree-error");
+        if (await treeError.isVisible().catch(() => false)) {
+          const errText = (await treeError.textContent()) || "";
+          expect(errText).not.toMatch(/HTTP 500/i);
+        }
         // Structure note / actions (Slice D) or legacy readonly note if older build
         const structureNote = page.getByTestId("architecture-structure-note");
         const readonlyNote = page.getByTestId("architecture-readonly-note");

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -37,6 +37,22 @@ Default landing can also be set to **Architecture** for a user or role (homepage
 Empty, loading, and error states are shown explicitly when the site list or tree
 cannot be loaded, or when a site has no sections.
 
+### Site without a navigation tree
+
+A site can exist without a NavTree item at the site root (for example a newly
+created site, a Rhythmyx site listed in the site picker, or a site whose
+navigation was never created). Opening **Architecture** for that site does
+**not** fail with HTTP 500.
+
+The server `GET /Rhythmyx/sitemanage/section/tree/{siteName}` call returns
+**HTTP 200** with an empty section tree (`childNodes` empty). The SPA shows an
+operator **empty state** (“No navigation tree”) in the Navigation tree panel
+instead of a route error or a generic 500 banner.
+
+To add navigation later, create a NavTree at the site root in **Explorer**
+(or create the site with managed navigation), then use **Refresh**. Other
+sites with a tree continue to load normally.
+
 ## Keyboard and accessibility
 
 The navigation tree follows the ARIA tree pattern:

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
@@ -139,4 +139,17 @@ public class PSSectionNode extends PSAbstractPersistantObject {
   public void setFolderPath(String folderPath) {
     this.folderPath = folderPath;
   }
+
+  /**
+   * Empty tree payload for a site that exists but has no NavTree item (#3218).
+   * {@code id} is left unset; {@link #getChildNodes()} is never {@code null}.
+   */
+  public static PSSectionNode emptyTree(String siteName, String folderPath) {
+    PSSectionNode node = new PSSectionNode();
+    node.setTitle(siteName);
+    node.setFolderPath(folderPath);
+    node.setSectionType(PSSectionTypeEnum.section);
+    node.setChildNodes(new ArrayList<>());
+    return node;
+  }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/IPSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/IPSSiteSectionService.java
@@ -159,7 +159,9 @@ public interface IPSSiteSectionService
    * Loads the root of the navigation for the specified site.
    *
    * @param siteName the name of the site, not blank.
-   * @return the root of the navigation, never <code>null</code>.
+   * @return the root of the navigation, never <code>null</code>. When the site
+   *     exists but has no NavTree, returns an empty root (no id, no children)
+   *     and does not delete the site (#3218).
    */
   PSSiteSection loadRoot(String siteName) throws PSSiteSectionException, PSNotFoundException;
 
@@ -167,7 +169,9 @@ public interface IPSSiteSectionService
    * Loads the entire tree nodes for the specified site.
    *
    * @param siteName the name of the specified site, not blank.
-   * @return the tree nodes of the site, never <code>null</code>.
+   * @return the tree nodes of the site, never <code>null</code>. When the site
+   *     exists but has no nav tree, an empty {@link PSSectionNode} (no id, empty
+   *     children) is returned so callers can emit HTTP 200 instead of 500.
    */
   PSSectionNode loadTree(String siteName) throws PSSiteSectionException, PSNotFoundException;
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestService.java
@@ -254,8 +254,22 @@ public class PSSiteSectionRestService {
   public PSSectionNode loadTree(@PathParam("siteName") String siteName)
       throws IPSSiteSectionService.PSSiteSectionException, PSNotFoundException {
     try {
-      return siteSectionService.loadTree(siteName);
-    } catch (IPSSiteSectionService.PSSiteSectionException | PSNotFoundException e) {
+      PSSectionNode tree = siteSectionService.loadTree(siteName);
+      if (tree == null) {
+        return PSSectionNode.emptyTree(siteName, null);
+      }
+      if (tree.getChildNodes() == null) {
+        tree.setChildNodes(java.util.Collections.emptyList());
+      }
+      return tree;
+    } catch (IPSSiteSectionService.PSSiteSectionException e) {
+      if (PSSiteSectionService.isMissingNavTreeMessage(e.getMessage())) {
+        log.info("Site '{}' has no navigation tree; returning empty section tree", siteName);
+        return PSSectionNode.emptyTree(siteName, null);
+      }
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw e;
+    } catch (PSNotFoundException e) {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       throw e;
     }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -37,8 +37,6 @@ import com.percussion.comments.service.IPSCommentsService;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
-import com.percussion.fastforward.managednav.IPSNavigationErrors;
-import com.percussion.fastforward.managednav.PSNavException;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
 import com.percussion.itemmanagement.service.IPSWorkflowHelper;
 import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
@@ -1473,13 +1471,12 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     IPSSite site = siteMgr.loadSite(siteName);
     IPSGuid navTreeId = navSrv.findNavigationIdFromFolder(site.getFolderRoot());
     if (navTreeId == null) {
-      PSNavException ne =
-          new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE, siteName);
-
-      log.error("{}", PSExceptionUtils.getMessageForLog(ne));
-      log.warn("Removing invalid site definition: {}", siteName);
-      siteMgr.deleteSite(site);
+      // Do not delete the site: missing NavTree is a valid empty state (#3218).
+      log.warn(
+          "Site {} has no navigation tree under {}; returning empty root",
+          siteName,
+          site.getFolderRoot());
+      return emptyRootSection(site);
     }
 
     return loadSiteSection(navTreeId, null, site.getFolderRoot(), true, false, null);
@@ -1651,8 +1648,50 @@ public class PSSiteSectionService implements IPSSiteSectionService {
    */
   public PSSectionNode loadTree(String siteName)
       throws PSSiteSectionException, com.percussion.services.error.PSNotFoundException {
-    PSSiteSection root = loadRoot(siteName);
+    IPSSite site = siteMgr.loadSite(siteName);
+    String folderRoot = site.getFolderRoot();
+    IPSGuid navTreeId = navSrv.findNavigationIdFromFolder(folderRoot);
+    if (navTreeId == null) {
+      log.info("Site '{}' has no navigation tree; returning empty section tree", siteName);
+      return PSSectionNode.emptyTree(siteName, folderRoot);
+    }
+    PSSiteSection root = loadSiteSection(navTreeId, null, folderRoot, true, false, null);
     return loadSectionTree(root);
+  }
+
+  /**
+   * Operator-facing message when a site has no NavTree item. REST maps this to
+   * an empty 200 tree rather than HTTP 500 (#3218).
+   */
+  static String missingNavTreeMessage(String siteName) {
+    return "Cannot find navigation tree for site: " + siteName;
+  }
+
+  /**
+   * Empty root section when the site exists but has no NavTree item.
+   * Id is left unset so callers do not treat this as a real navon.
+   */
+  static PSSiteSection emptyRootSection(IPSSite site) {
+    PSSiteSection section = new PSSiteSection();
+    if (site != null) {
+      section.setTitle(site.getName());
+      section.setFolderPath(site.getFolderRoot());
+    }
+    section.setChildIds(new ArrayList<>());
+    section.setSectionType(PSSectionTypeEnum.section);
+    return section;
+  }
+
+  /** True when {@code message} is the missing-NavTree empty-state case (#3218). */
+  static boolean isMissingNavTreeMessage(String message) {
+    if (message == null || message.isBlank()) {
+      return false;
+    }
+    String lower = message.toLowerCase(Locale.ROOT);
+    return lower.contains("cannot find navigation tree")
+        || lower.contains("cannot find navtree")
+        || lower.contains("navtree for site")
+        || lower.contains("navtree_for_site");
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/data/PSSectionNodeEmptyTreeSerialTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/data/PSSectionNodeEmptyTreeSerialTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Empty NavTree payload must serialize as a SectionNode with empty children
+ * (200 wire), not omit the list or throw (#3218).
+ */
+@Tag("UnitTest")
+public class PSSectionNodeEmptyTreeSerialTest {
+
+  @Test
+  void emptyTreeRoundTripsWithEmptyChildren() {
+    JsonMapper mapper =
+        JsonMapper.builder()
+            .enable(SerializationFeature.WRAP_ROOT_VALUE)
+            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+            .build();
+
+    PSSectionNode empty = PSSectionNode.emptyTree("BareSite", "//Sites/BareSite");
+    String json = mapper.writeValueAsString(empty);
+
+    assertTrue(json.contains("BareSite"), json);
+    assertTrue(
+        json.contains("childNodes") || json.contains("[]"),
+        "empty tree must serialize children list, got: " + json);
+
+    PSSectionNode roundTrip = mapper.readValue(json, PSSectionNode.class);
+    assertNotNull(roundTrip);
+    assertEquals("BareSite", roundTrip.getTitle());
+    assertNotNull(roundTrip.getChildNodes());
+    assertTrue(roundTrip.getChildNodes().isEmpty());
+    assertEquals("//Sites/BareSite", roundTrip.getFolderPath().orElse(null));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.error.PSNotFoundException;
+import com.percussion.sitemanage.data.PSSectionNode;
+import com.percussion.sitemanage.service.IPSSiteSectionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * GET /section/tree/{site} must return an empty 200 tree for missing NavTree (#3218).
+ */
+class PSSiteSectionRestServiceLoadTreeEmptyTest {
+
+  @Mock private PSSiteSectionService siteSectionService;
+
+  private PSSiteSectionRestService rest;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    rest = new PSSiteSectionRestService(siteSectionService);
+  }
+
+  @Test
+  void loadTreeReturnsServiceEmptyTree() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenReturn(PSSectionNode.emptyTree("Demo", "//Sites/Demo"));
+
+    PSSectionNode tree = rest.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertTrue(tree.getChildNodes().isEmpty());
+    assertEquals("Demo", tree.getTitle());
+  }
+
+  @Test
+  void loadTreeMapsMissingNavTreeExceptionToEmpty() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenThrow(
+            new IPSSiteSectionService.PSSiteSectionException(
+                "Cannot find navigation tree for site: Demo"));
+
+    PSSectionNode tree = rest.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertTrue(tree.getChildNodes().isEmpty());
+  }
+
+  @Test
+  void loadTreeRethrowsUnknownSite() throws Exception {
+    when(siteSectionService.loadTree("Missing"))
+        .thenThrow(new PSNotFoundException("site Missing"));
+    assertThrows(PSNotFoundException.class, () -> rest.loadTree("Missing"));
+  }
+
+  @Test
+  void loadTreeRethrowsUnrelatedSectionErrors() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenThrow(new IPSSiteSectionService.PSSiteSectionException("database unavailable"));
+    assertThrows(
+        IPSSiteSectionService.PSSiteSectionException.class, () -> rest.loadTree("Demo"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.comments.service.IPSCommentsService;
+import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.services.contentmgr.IPSContentMgr;
+import com.percussion.services.sitemgr.IPSSite;
+import com.percussion.services.sitemgr.IPSSiteManager;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.sitemanage.dao.IPSiteDao;
+import com.percussion.sitemanage.data.PSSectionNode;
+import com.percussion.sitemanage.data.PSSiteSection;
+import com.percussion.sitemanage.service.IPSSiteTemplateService;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.publishing.IPSPublishingWs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Missing / empty NavTree must not 500 or delete the site (#3218 / parent #3197).
+ */
+class PSSiteSectionServiceLoadTreeEmptyTest {
+
+  @Mock private IPSPageDao pageDao;
+  @Mock private IPSManagedNavService navService;
+  @Mock private IPSContentWs contentSrv;
+  @Mock private IPSContentDesignWs contentDsSrv;
+  @Mock private IPSSiteManager siteMgr;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSRenderAssemblyBridge asmBridge;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSPublishingWs publishingWs;
+  @Mock private IPSTemplateService templateSrv;
+  @Mock private IPSiteDao siteDao;
+  @Mock private IPSSiteTemplateService siteTemplateSrv;
+  @Mock private IPSCommentsService commentsService;
+  @Mock private IPSPageDaoHelper pageDaoHelper;
+  @Mock private IPSItemWorkflowService itemWorkflowService;
+  @Mock private IPSContentMgr contentMgr;
+  @Mock private IPSSite site;
+
+  private PSSiteSectionService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    service =
+        new PSSiteSectionService(
+            pageDao,
+            navService,
+            contentSrv,
+            contentDsSrv,
+            siteMgr,
+            idMapper,
+            asmBridge,
+            folderHelper,
+            workflowHelper,
+            publishingWs,
+            templateSrv,
+            siteDao,
+            siteTemplateSrv,
+            commentsService,
+            pageDaoHelper,
+            itemWorkflowService,
+            contentMgr);
+    when(site.getName()).thenReturn("Demo");
+    when(site.getFolderRoot()).thenReturn("//Sites/Demo");
+    when(siteMgr.loadSite("Demo")).thenReturn(site);
+    when(navService.findNavigationIdFromFolder("//Sites/Demo")).thenReturn(null);
+  }
+
+  @Test
+  void loadTreeReturnsEmptyNodeWhenNavTreeMissing() throws Exception {
+    PSSectionNode tree = service.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertEquals("Demo", tree.getTitle());
+    assertEquals("//Sites/Demo", tree.getFolderPath().orElse(null));
+    assertTrue(tree.getChildNodes().isEmpty());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
+  void loadRootReturnsEmptySectionAndDoesNotDeleteSite() throws Exception {
+    PSSiteSection root = service.loadRoot("Demo");
+    assertNotNull(root);
+    assertNull(root.getId());
+    assertEquals("Demo", root.getTitle());
+    assertEquals("//Sites/Demo", root.getFolderPath());
+    assertTrue(root.getChildIds() == null || root.getChildIds().isEmpty());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
+  void missingNavTreeMessageIsRecognized() {
+    assertTrue(
+        PSSiteSectionService.isMissingNavTreeMessage(
+            "Cannot find navigation tree for site: Demo"));
+    assertTrue(
+        PSSiteSectionService.isMissingNavTreeMessage(
+            "NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE: Demo"));
+    assertTrue(!PSSiteSectionService.isMissingNavTreeMessage("database unavailable"));
+    assertTrue(!PSSiteSectionService.isMissingNavTreeMessage(null));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Navigation tree load **HTTP 500** when a site exists but has no NavTree (human QA #3157 step 5 / parent #3197 slice 2).

**Server (`projects/sitemanage`):**
- `GET /sitemanage/section/tree/{siteName}` returns **HTTP 200** with an empty `SectionNode` (`id` unset, `childNodes` empty) when the site has no nav tree.
- `loadRoot` no longer **deletes the site** on missing NavTree (GET must not destroy data).
- REST maps historical missing-navtree `PSSiteSectionException` messages to the same empty 200 payload.

**UI (`WebUI`):**
- Empty/missing tree is an operator empty state (`architecture-nav-tree-empty`), not `TREE_ERROR` / RouteErrorBoundary / generic HTTP 500 banner.
- `loadSectionTree` treats empty wire and missing-navtree API errors as `null`.

**Docs:** `product-docs/8.2/admin/architecture-navigation.md` — “Site without a navigation tree”.

Parent tracker: #3197. Epic: #3092.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3218
Partial #3197

## Test plan

1. Standalone `projects/sitemanage` `mvnw clean install` (Tests run: 1038, Failures: 0).
2. Standalone `WebUI` `mvnw clean install` (Vitest Tests: 2062 passed).
3. QA H2: `python docker/scripts/perc-devctl.py qa-rebuild-chain --dist-only --then-qa-up`.
4. Playwright (TEST_CMS_URL from qa-up, Admin):
   - `npm run test:surface -- --path tests/architecture-nav-tree-empty.spec.js`
   - `npm run test:surface -- --path tests/architecture-nav-tree-smoke.spec.js`
5. Confirm a site without NavTree shows “No navigation tree” empty state (no HTTP 500).
6. Confirm a normal site still loads the navigation tree.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (empty / missing NavTree)
- [x] **Unit / module tests** — sitemanage empty-tree service/REST/serial tests; WebUI Vitest empty-state + `loadSectionTree`
- [x] **WebUI + Playwright** — `architecture-nav-tree-empty.spec.js` + smoke update
- [x] **Build gates** — standalone clean install on `projects/sitemanage` and `WebUI` (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1038, Failures: 0, Errors: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Vitest Tests 2062 passed (290 files)
- **downstream_checked:** none (no existing public method signatures made `final`/`sealed`; added empty-tree helpers and changed missing-navtree behavior only)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-rebuild-chain --dist-only --then-qa-up`
- **TEST_CMS_URL:** `http://127.0.0.1:60746` (freeport; container `perc-matrix-cms-h2`)
- **Playwright:**
  - `npm run test:surface -- --path tests/architecture-nav-tree-empty.spec.js` → 1 passed; console-clean=yes
  - `npm run test:surface -- --path tests/architecture-nav-tree-smoke.spec.js` → 1 passed
- **console-clean:** yes (empty spec asserts no pageerror / console error)
- **server.log-clean:** yes (no ERROR/FATAL matching nav tree / section/tree / SiteSection during the run)

> Co-Authored by Grok Build using grok-4.5 with agent main.
