### PR TITLE
fix(utils): parameterize PSCollection so perc-system compiles

### DIFF
--- a/docs/ai-generated/code-reviews/perc-system-pscollection-compile-erlang.md
+++ b/docs/ai-generated/code-reviews/perc-system-pscollection-compile-erlang.md
@@ -1,0 +1,70 @@
+# Erlang review: perc-system PSCollection compile restore
+
+## Summary
+
+PR #3173 parameterized `PSCollection` as `PSConcurrentList<Object>` (`List<Object>`).
+That is not source-compatible with perc-system: `Iterator` is invariant, so
+`PSRelationshipSet.iterator()` returning `Iterator<PSRelationship>` cannot implement
+`List<Object>.iterator()`, and `Iterator<Object>` cannot be assigned to
+`Iterator<PSDisplayMapping>` (and the same pattern across objectstore/cms/security).
+
+This change parameterizes `PSCollection<E> extends PSConcurrentList<E>`. Raw
+subclasses (`PSCollectionComponent`, TableFactory collections) remain raw lists,
+so covariant `iterator()` overrides and `Iterable<Specific>` assignments compile
+again. Typed `PSCollection<String>` is a real `List<String>`. Iterator-from-
+constructor uses a snapshot + private ctor so it does not call overridable `add`
+during construction.
+
+## Scope
+
+- Uncommitted vs `HEAD` on `fix/perc-system-pscollection-compile` (from `main`)
+- Files:
+  - `modules/utils/src/main/java/com/percussion/util/PSCollection.java`
+  - `modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java`
+  - `modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java`
+- Out of scope: perc-system / TableFactory sources (consumers only)
+- Memory patterns hit: missing behavioral tests (addressed); change-class closure
+  (utils type + consumer compile); do not lock historically raw collections to
+  `List<Object>`; no path I/O
+- Cross-platform path review: N/A (no file I/O / path construction)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: no — typed list API, runtime `checkType`, covariant
+  raw-subclass `iterator()` / `Iterable<E>`
+- Change-class closure: yes — producer (`utils`) plus verified perc-system and
+  TableFactory standalone clean installs
+- Agent rule files: none in this diff
+
+## Issues
+
+None.
+
+### Suggestion (non-blocking)
+
+Later batches can parameterize `PSCollectionComponent<E>` and product subclasses
+so raw-type warnings at `extends PSCollection` go to zero. Do **not** “fix” those
+by locking the base type to `List<Object>` again.
+
+## Verification noted
+
+```text
+cd modules/utils
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 382, Failures: 0, Errors: 0, Skipped: 9
+# PSCollectionTypedTest: 6 tests, 0 fail
+
+cd system
+..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 1996, Failures: 0, Errors: 0, Skipped: 241
+
+cd modules/TableFactory
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS (consumer still compiles after #3216 + this change)
+```

--- a/modules/utils/src/main/java/com/percussion/util/PSCollection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSCollection.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -25,15 +26,20 @@ import java.util.Objects;
  * The PSCollection class is used to maintain a collection of objects. Objects can be added, changed
  * or removed from the collection. All objects in the collection must be of the same class.
  *
- * <p>Element type is {@link Object} at the list API surface (historical heterogeneous product use);
- * runtime membership is still enforced via {@link #m_memberClass}. Parameterized as {@code
- * PSConcurrentList<Object>} so callers and subclasses no longer sit on a raw concurrent list.
+ * <p>Parameterized as {@code PSConcurrentList<E>} so a typed collection is {@code List<E>} (and
+ * {@code iterator()} is {@code Iterator<E>}). Raw {@code PSCollection} (historical product
+ * subclasses such as {@code PSCollectionComponent}) stay a raw list, so covariant {@code
+ * iterator()} overrides remain legal. Do not lock the public type to {@code List<Object>} — that
+ * makes {@code Iterator<Specific>} incompatible with {@code List.iterator()}.
  *
+ * <p>Runtime membership is still enforced via {@link #m_memberClass}.
+ *
+ * @param <E> element type
  * @author Tas Giakouminakis
  * @version 1.0
  * @since 1.0
  */
-public class PSCollection extends PSConcurrentList<Object> {
+public class PSCollection<E> extends PSConcurrentList<E> {
 
   /**
    * Serialization id. Parent {@link PSConcurrentList} owns list payload serialization; this class
@@ -47,8 +53,9 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param className the name of the class which this collection's members must be or extend
    * @exception ClassNotFoundException if the specified class cannot be found
    */
+  @SuppressWarnings("unchecked")
   public PSCollection(String className) throws ClassNotFoundException {
-    this(Class.forName(className));
+    this((Class<? extends E>) Class.forName(className));
   }
 
   /**
@@ -56,7 +63,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    *
    * @param cl the class which this collection's members must be or extend
    */
-  public PSCollection(Class<?> cl) {
+  public PSCollection(Class<? extends E> cl) {
     m_memberClass = cl;
   }
 
@@ -67,8 +74,8 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param cl the class which this collection's members must be or extend.
    * @param initialCapacity the initial capacity of the collection.
    */
-  public PSCollection(Class<?> cl, int initialCapacity) {
-    super(Object.class, initialCapacity);
+  public PSCollection(Class<? extends E> cl, int initialCapacity) {
+    super(cl, initialCapacity);
     m_memberClass = cl;
   }
 
@@ -79,15 +86,18 @@ public class PSCollection extends PSConcurrentList<Object> {
    *     type. May not be <code>null</code>.
    * @throws ClassCastException if all of the objects under the iterator are not of the same type.
    */
-  public PSCollection(Iterator<?> i) throws ClassCastException {
-    m_memberClass = null;
+  public PSCollection(Iterator<? extends E> i) throws ClassCastException {
+    this(snapshot(i));
+  }
 
-    while (i.hasNext()) {
-      Object o = i.next();
-      if (m_memberClass == null) m_memberClass = o.getClass();
-
-      super.add(o);
-    }
+  /**
+   * Secondary ctor so the iterator snapshot can be passed to {@link
+   * PSConcurrentList#PSConcurrentList(java.util.List)} without calling overridable {@code add}
+   * during construction (this-escape).
+   */
+  private PSCollection(Snapshot<E> snapshot) {
+    super(snapshot.items);
+    m_memberClass = snapshot.memberClass;
   }
 
   /** Default constructor needed for serialization. */
@@ -105,7 +115,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public void add(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
+  public void add(int index, E o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     super.add(index, o);
@@ -121,7 +131,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean add(Object o) throws ClassCastException {
+  public boolean add(E o) throws ClassCastException {
     checkType(o);
 
     return super.add(o);
@@ -135,7 +145,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param o the object to add to the collection
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public void addElement(Object o) throws ClassCastException {
+  public void addElement(E o) throws ClassCastException {
     add(o);
   }
 
@@ -149,7 +159,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean addAll(Collection<?> c)
+  public boolean addAll(Collection<? extends E> c)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
@@ -167,7 +177,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean addAll(int index, Collection<?> c)
+  public boolean addAll(int index, Collection<? extends E> c)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
@@ -186,7 +196,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public Object set(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
+  public E set(int index, E o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     return super.set(index, o);
@@ -202,14 +212,14 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ArrayIndexOutOfBoundsException if index is out of range
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public void setElementAt(Object o, int index)
+  public void setElementAt(E o, int index)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     set(index, o);
   }
 
-  public void insertElementAt(Object o, int i) {
+  public void insertElementAt(E o, int i) {
     this.add(i, o);
   }
 
@@ -234,7 +244,7 @@ public class PSCollection extends PSConcurrentList<Object> {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PSCollection that)) return false;
+    if (!(o instanceof PSCollection<?> that)) return false;
     return Objects.equals(m_memberClass, that.m_memberClass);
   }
 
@@ -299,7 +309,7 @@ public class PSCollection extends PSConcurrentList<Object> {
     return copy;
   }
 
-  public Object lastElement() {
+  public E lastElement() {
     if (this.size() > 0) {
       return this.get(this.size() - 1);
     } else {
@@ -311,15 +321,38 @@ public class PSCollection extends PSConcurrentList<Object> {
     this.clear();
   }
 
-  public Object elementAt(int index) {
+  public E elementAt(int index) {
     return this.get(index);
   }
 
-  public Object firstElement() {
+  public E firstElement() {
     if (this.size() > 0) return this.get(0);
     else throw new NoSuchElementException();
   }
 
   /** The one and only valid class type for this collection. */
   private Class<?> m_memberClass;
+
+  private static <T> Snapshot<T> snapshot(Iterator<? extends T> i) {
+    ArrayList<T> items = new ArrayList<>();
+    Class<?> member = null;
+    while (i.hasNext()) {
+      T o = i.next();
+      if (member == null) {
+        member = o.getClass();
+      }
+      items.add(o);
+    }
+    return new Snapshot<>(member, items);
+  }
+
+  private static final class Snapshot<T> {
+    private final Class<?> memberClass;
+    private final ArrayList<T> items;
+
+    private Snapshot(Class<?> memberClass, ArrayList<T> items) {
+      this.memberClass = memberClass;
+      this.items = items;
+    }
+  }
 }

--- a/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
@@ -29,15 +29,15 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Behavioral coverage for {@link PSCollection} after parameterizing as {@code
- * PSConcurrentList<Object>} with {@code Class<?>}/{@code Collection<?>}/{@code Iterator<?>}
- * surfaces (#3015 batch 8).
+ * PSConcurrentList<E>}. Residual of #3015 batch 8 / #3173: locking the type to {@code
+ * List<Object>} broke perc-system covariant {@code iterator()} overrides.
  */
 @Tag("UnitTest")
 public class PSCollectionTypedTest {
 
   @Test
-  public void memberClassAndElementsRoundTripThroughObjectListApi() {
-    PSCollection coll = new PSCollection(String.class);
+  public void memberClassAndElementsRoundTripThroughTypedListApi() {
+    PSCollection<String> coll = new PSCollection<>(String.class);
     assertEquals(String.class, coll.getMemberClassType());
     assertTrue(coll.add("a"));
     coll.add(0, "b");
@@ -47,30 +47,79 @@ public class PSCollectionTypedTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void addAllRejectsWrongElementType() {
-    PSCollection coll = new PSCollection(String.class);
+    PSCollection<String> coll = new PSCollection<>(String.class);
     coll.add("ok");
     List<Object> mixed = new ArrayList<>();
     mixed.add("fine");
     mixed.add(Integer.valueOf(1));
-    assertThrows(ClassCastException.class, () -> coll.addAll(mixed));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.addAll(mixed));
     assertEquals(1, coll.size());
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void iteratorCtorInfersMemberClass() {
     Iterator<String> it = Arrays.asList("x", "y").iterator();
-    PSCollection coll = new PSCollection(it);
+    PSCollection<String> coll = new PSCollection<>(it);
     assertEquals(String.class, coll.getMemberClassType());
     assertEquals(2, coll.size());
     assertEquals("x", coll.get(0));
-    assertThrows(ClassCastException.class, () -> coll.add(Integer.valueOf(3)));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.add(Integer.valueOf(3)));
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void initialCapacityCtorStillEnforcesType() {
-    PSCollection coll = new PSCollection(Integer.class, 8);
+    PSCollection<Integer> coll = new PSCollection<>(Integer.class, 8);
     assertTrue(coll.add(Integer.valueOf(1)));
-    assertThrows(ClassCastException.class, () -> coll.add("nope"));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.add("nope"));
+  }
+
+  @Test
+  public void typedCollectionIteratorIsElementType() {
+    PSCollection<String> coll = new PSCollection<>(String.class);
+    coll.add("a");
+    Iterator<String> it = coll.iterator();
+    assertEquals("a", it.next());
+    Iterable<String> iterable = coll;
+    int n = 0;
+    for (String s : iterable) {
+      n++;
+      assertEquals("a", s);
+    }
+    assertEquals(1, n);
+  }
+
+  /**
+   * perc-system pattern: raw {@code PSCollection} / {@code PSCollectionComponent} subclasses
+   * override {@code iterator()} to {@code Iterator<Specific>} and pass the set as {@code
+   * Iterable<Specific>}.
+   */
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void rawSubclassMayOverrideCovariantIterator() {
+    class TypedRaw extends PSCollection {
+      private static final long serialVersionUID = 1L;
+
+      TypedRaw() {
+        super(String.class);
+      }
+
+      @Override
+      public Iterator<String> iterator() {
+        return super.iterator();
+      }
+    }
+    TypedRaw coll = new TypedRaw();
+    coll.add("a");
+    Iterator<String> it = coll.iterator();
+    assertEquals("a", it.next());
+    Iterable<String> iterable = coll;
+    assertEquals("a", iterable.iterator().next());
   }
 }

--- a/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
@@ -88,11 +88,11 @@ public class PSConcurrentListSerializationTest {
 
   @Test
   public void testCollectionRoundTripPreservesMemberClassAndElements() throws Exception {
-    PSCollection original = new PSCollection(String.class);
+    PSCollection<String> original = new PSCollection<>(String.class);
     original.add("one");
     original.add("two");
 
-    PSCollection restored = roundTrip(original);
+    PSCollection<String> restored = roundTrip(original);
 
     assertNotNull(restored);
     assertEquals(String.class, restored.getMemberClassType());


### PR DESCRIPTION
## Summary

After #3173, `PSCollection` was a `List<Object>`. That is not source-compatible with perc-system: `Iterator` is invariant, so covariant overrides such as `PSRelationshipSet.iterator(): Iterator<PSRelationship>` cannot implement `List.iterator()`, and `iterator()` results cannot be assigned to `Iterator<PSDisplayMapping>` (same pattern across objectstore, CMS, security, cache).

This change parameterizes `PSCollection<E> extends PSConcurrentList<E>`. Raw historical subclasses (`PSCollectionComponent`, TableFactory collections) stay raw lists, so those overrides compile again. Typed `PSCollection<String>` is a real `List<String>`.

Residual of #3173. Companion to the TableFactory call-site workaround in #3216. Related: #2022, #2200.

## Test plan

1. `cd modules/utils` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS
2. `cd system` then `..\mvnw.cmd clean install` — BUILD SUCCESS (was COMPILATION ERROR on `PSCollection.iterator()` / `PSRelationshipSet`)
3. `cd modules/TableFactory` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS (consumer)
4. Review `PSCollectionTypedTest`: typed list API, `checkType`, raw-subclass covariant `iterator()`

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): compiler / type-parameter restore; no operator, admin, integrator, or end-user behavior change
- [x] **Unit / module tests** — `PSCollectionTypedTest` (6) + serialization round-trip typed; utils 382 / perc-system 1996 tests green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — standalone clean install: `modules/utils`, `system`, `modules/TableFactory` (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### Gates evidence

- **modules_built:** `modules/utils`, `system` (consumer), `modules/TableFactory` (consumer)
- **build_evidence:**
  - `cd modules/utils && ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 382, Failures: 0, Errors: 0, Skipped: 9
  - `cd system && ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1996, Failures: 0, Errors: 0, Skipped: 241
  - `cd modules/TableFactory && ..\..\mvnw.cmd clean install` → BUILD SUCCESS
- Erlang: approve — `docs/ai-generated/code-reviews/perc-system-pscollection-compile-erlang.md`

> Co-Authored by Grok Build 4.6 using grok-4.6 with agent main.