### PR TITLE
fix(sitemanage): PathItem JAXB relatedObject 500 (#3196)

### DIFF
--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -83,10 +83,44 @@ function firstNonBlankString(
  *
  * <p>Recognizes the {@code RestError} shape from rest {@code ExceptionMapper}s
  * ({@code message} / {@code detailMessage}), optional Jackson root wrap
- * ({@code Error} / {@code RestError}), plain string bodies, and a loose
- * {@code detail} alias. Returns {@code undefined} when no usable text is found
- * so callers can fall back to status chrome.</p>
+ * ({@code Error} / {@code RestError}), sitemanage {@code Errors.globalError}
+ * (including {@code PathItem:[{Errors:...}]} #3196), plain string bodies, and
+ * a loose {@code detail} alias. Returns {@code undefined} when no usable text
+ * is found so callers can fall back to status chrome.</p>
  */
+function extractPsErrorsMessage(errors: Record<string, unknown>): string | undefined {
+  const global = asRecord(errors.globalError);
+  if (!global) {
+    return firstNonBlankString(errors, "message", "defaultMessage", "detail");
+  }
+  const fromGlobal = firstNonBlankString(
+    global,
+    "defaultMessage",
+    "message",
+    "detailMessage",
+    "detail",
+  );
+  if (fromGlobal) {
+    return fromGlobal;
+  }
+  const cause = asRecord(global.cause);
+  if (cause) {
+    const nestedCause = asRecord(cause.errorCause);
+    if (nestedCause) {
+      const fromNested = firstNonBlankString(
+        nestedCause,
+        "message",
+        "localizedMessage",
+      );
+      if (fromNested) {
+        return fromNested;
+      }
+    }
+    return firstNonBlankString(cause, "message", "localizedMessage");
+  }
+  return undefined;
+}
+
 export function extractRestErrorMessage(body: unknown): string | undefined {
   if (typeof body === "string" && body.trim()) {
     return body.trim();
@@ -112,6 +146,24 @@ export function extractRestErrorMessage(body: unknown): string | undefined {
     );
     if (nestedMsg) {
       return nestedMsg;
+    }
+  }
+  const errorsRoot = asRecord(root.Errors) ?? asRecord(root.errors);
+  if (errorsRoot) {
+    const fromErrors = extractPsErrorsMessage(errorsRoot);
+    if (fromErrors) {
+      return fromErrors;
+    }
+  }
+  const pathItem = root.PathItem;
+  if (Array.isArray(pathItem) && pathItem.length > 0) {
+    const first = asRecord(pathItem[0]);
+    const wrapped = first ? asRecord(first.Errors) ?? asRecord(first.errors) : null;
+    if (wrapped) {
+      const fromPathItem = extractPsErrorsMessage(wrapped);
+      if (fromPathItem) {
+        return fromPathItem;
+      }
     }
   }
   return undefined;

--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -45,7 +45,7 @@
  * DTOs in {@code projects/sitemanage/src/main/java/}.</p>
  */
 
-import { get, post } from "../client";
+import { get, post, type ApiError } from "../client";
 import { PATHS } from "../paths";
 import type {
   PSPathItem,
@@ -104,11 +104,43 @@ export function joinPathUrl(base: string, path: string): string {
  * matching the DTO's local element name — Evidence Over Invention: do not
  * invent alternate bare-array wire shapes).</p>
  */
+function isPathItemErrorEnvelope(item: unknown): boolean {
+  if (item == null || typeof item !== "object") {
+    return false;
+  }
+  const rec = item as Record<string, unknown>;
+  const errors = rec.Errors ?? rec.errors;
+  const hasPath = typeof rec.path === "string" && rec.path.length > 0;
+  const hasName = typeof rec.name === "string" && rec.name.length > 0;
+  return !!errors && !hasPath && !hasName;
+}
+
+/**
+ * Treat a {@code PathItem} payload that is actually a PSErrors envelope as a
+ * failure so the Explorer tree shows an error instead of an empty panel (#3196).
+ */
+export function unwrapPathItemList(res: PSPathItemListResponse | null | undefined): PSPathItem[] {
+  const items = res?.PathItem;
+  if (!items) {
+    return [];
+  }
+  const list = Array.isArray(items) ? items : [items];
+  if (list.length > 0 && list.every(isPathItemErrorEnvelope)) {
+    const err: ApiError = {
+      status: 500,
+      statusText: "Internal Server Error",
+      body: res,
+    };
+    throw err;
+  }
+  return list;
+}
+
 export async function findChildren(path: string): Promise<PSPathItem[]> {
   const res = await get<PSPathItemListResponse>(
     joinPathUrl(PATHS.PATH_FOLDER, path),
   );
-  return res?.PathItem ?? [];
+  return unwrapPathItemList(res);
 }
 
 /**

--- a/WebUI/src/test/ts/api/clientErrors.test.ts
+++ b/WebUI/src/test/ts/api/clientErrors.test.ts
@@ -44,6 +44,37 @@ describe("extractRestErrorMessage", () => {
       }),
     ).toBe("adaptor boom");
   });
+
+  it("unwraps sitemanage PSErrors / PathItem error envelope (#3196)", () => {
+    expect(
+      extractRestErrorMessage({
+        Errors: {
+          globalError: {
+            defaultMessage: "1 counts of IllegalAnnotationExceptions",
+            code: "jakarta.ws.rs.InternalServerErrorException",
+          },
+        },
+      }),
+    ).toBe("1 counts of IllegalAnnotationExceptions");
+    expect(
+      extractRestErrorMessage({
+        PathItem: [
+          {
+            Errors: {
+              globalError: {
+                cause: {
+                  message: "HTTP 500 Internal Server Error",
+                  errorCause: {
+                    message: "1 counts of IllegalAnnotationExceptions",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ).toBe("1 counts of IllegalAnnotationExceptions");
+  });
 });
 
 describe("formatApiError RestError alignment", () => {

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -159,6 +159,26 @@ describe("pathmanagement URL shape (no double-slash)", () => {
     expect(cap.lastUrl()).not.toContain("folder//");
   });
 
+  it("findChildren throws when PathItem is a PSErrors envelope (#3196)", async () => {
+    mockJson({
+      PathItem: [
+        {
+          Errors: {
+            globalError: {
+              defaultMessage: "1 counts of IllegalAnnotationExceptions",
+            },
+          },
+        },
+      ],
+    });
+    await expect(findChildren("/")).rejects.toMatchObject({
+      status: 500,
+      body: {
+        PathItem: [{ Errors: { globalError: expect.any(Object) } }],
+      },
+    });
+  });
+
   it("findChildren Sites strips leading slash", async () => {
     const cap = mockJson({ PathItem: [] });
     await findChildren("/Sites/");

--- a/docs/ai-generated/code-reviews/3196-pathitem-illegal-annotation-erlang.md
+++ b/docs/ai-generated/code-reviews/3196-pathitem-illegal-annotation-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: #3196 PathItem IllegalAnnotationExceptions
+
+**Branch:** `fix/issue-3196-pathitem-illegal-annotation`  
+**Scope:** uncommitted vs HEAD (sitemanage PathItem JAXB, WebUI error unwrap, Playwright, product-docs)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** JAXB vs Jackson dual annotations; Explorer tree must not blank-fail; change-class companions (unit + Playwright + product-docs)
+
+## Summary
+
+Explorer left-panel `GET /pathmanagement/path/folder/` returned HTTP 500 with
+`1 counts of IllegalAnnotationExceptions`. Reproduced via
+`JAXBContext.newInstance(PSPathItem.class)`:
+
+> Transient field "relatedObject" cannot have any JAXB annotations.
+
+Glassfish JAXB forbids `@XmlTransient` on a Java `transient` field. The field
+must remain `transient` (runtime `File` / non-serializable association). Removing
+the JAXB annotation and `@JsonIgnore` on accessors is the correct pairing.
+
+No new public method signatures, no `final`/`sealed` on the DTO. Path I/O
+checklist N/A (no filesystem path construction).
+
+## Issues
+
+None (hard gate).
+
+## Notes
+
+- `PSPathItemListJacksonTest` now exercises production `JacksonContextResolver`
+  ObjectMapper and JAXBContext (not annotation reflection only).
+- UI: `extractRestErrorMessage` unwraps `Errors.globalError` and
+  `PathItem:[{Errors}]`; `findChildren` throws on error-shaped PathItem so the
+  tree shows `explorer-tree-error` instead of empty.
+- Playwright: `tests/bugs/bug-3196-pathitem-left-panel.spec.js`.
+- Product docs: left-tree troubleshooting on `admin-content-explorer`.

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3196-pathitem-left-panel.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3196-pathitem-left-panel.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression: Explorer left panel PathItem HTTP 500 IllegalAnnotationExceptions (GH-3196).
+ *
+ * JAXB rejected {@code @XmlTransient} on the transient {@code relatedObject}
+ * field of {@code PSPathItem}. Path list/find then returned 500 and the tree
+ * could not render roots.
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
+const { isHumanReadableErrorText } = require("../helpers/pathmanagement-url");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
+
+test.describe("GH-3196 PathItem left panel (no IllegalAnnotationExceptions)", () => {
+  test("REST: folder/ returns PathItem children, not Errors / 500", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = adminBasicAuthHeaders();
+    const root = await request.get(`${PATH_FOLDER}/`, { headers });
+    const text = await root.text();
+    expect(
+      root.status(),
+      `GET ${PATH_FOLDER}/ must be 200 (not PathItem 500). Body: ${text.slice(0, 500)}`,
+    ).toBe(200);
+    expect(text).not.toContain("IllegalAnnotationExceptions");
+    const body = JSON.parse(text);
+    const items = Array.isArray(body?.PathItem)
+      ? body.PathItem
+      : Array.isArray(body)
+        ? body
+        : [];
+    expect(items.length, "root PathItem list must not be empty").toBeGreaterThan(
+      0,
+    );
+    expect(items[0].Errors, "PathItem items must not be PSErrors envelopes").toBeUndefined();
+    const names = items.map((it) => it?.name).filter(Boolean);
+    expect(names, `roots: ${names.join(", ")}`).toContain("Sites");
+  });
+
+  test("UI: left tree shows roots or a human-readable error (not blank)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      // Ignore unrelated 404/400 resource noise (favicon, optional chrome).
+      if (/Failed to load resource/i.test(text)) {
+        return;
+      }
+      pageErrors.push(text);
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    const tree = page.locator('[data-testid="explorer-tree"]');
+    await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    const treeErr = page.locator('[data-testid="explorer-tree-error"]');
+    if ((await treeErr.count()) > 0 && (await treeErr.first().isVisible())) {
+      const errText = await treeErr.first().innerText();
+      expect(isHumanReadableErrorText(errText), errText).toBe(true);
+      expect(errText).not.toContain("[object Object]");
+      throw new Error(`Explorer tree failed to load: ${errText}`);
+    }
+
+    const nodes = tree.locator('[data-testid^="tree-node-"]');
+    await expect(nodes.first()).toBeVisible({ timeout: 20_000 });
+    expect(pageErrors, `console/page errors: ${pageErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -42,6 +42,16 @@ Explorer. Use it when you need the full repository folder hierarchy rather than 
 Assets or Sites shortcuts. Expanding **Folders** loads children from the server; folder
 visibility still respects folder ACLs.
 
+If the left tree fails to load, Explorer shows an **error** in the tree panel (not a
+blank list). Typical causes are a path-service HTTP error or a session timeout.
+Refresh after login, then confirm
+`/Rhythmyx/services/pathmanagement/path/folder/` returns JSON
+`{"PathItem":[…]}` with Sites / Folders / Assets (and Design / Recycling when
+your role allows them). A `500` whose message mentions
+`IllegalAnnotationExceptions` is a server serialization defect on `PathItem`
+(fixed in 8.2 for the `relatedObject` field) — collect that response body for
+support.
+
 ## Folder mutations dual-run (optional)
 
 By default, Explorer **create / rename / move / delete** folder actions use the same

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItem.java
@@ -17,6 +17,7 @@
  */
 package com.percussion.pathmanagement.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.pathmanagement.data.xmladapters.PSMapAdapter;
 import com.percussion.share.data.IPSFolderPath;
@@ -48,8 +49,16 @@ public class PSPathItem extends PSDataItemSummary implements IPSItemSummary, IPS
   @XmlElement private String path;
   private PSFolderPermission.Access accessLevel;
 
-  /** Runtime association only — not part of Java serialization. */
-  @XmlTransient private transient Object relatedObject;
+  /**
+   * Runtime association only (e.g. a {@code File} for design FS items). Must stay out of Java
+   * serialization ({@code transient}) and JSON ({@code @JsonIgnore} on accessors).
+   *
+   * <p>Do not put JAXB annotations on this field: Glassfish JAXB rejects {@code @XmlTransient} (or
+   * any JAXB annotation) on a {@code transient} field with {@code IllegalAnnotationExceptions}
+   * ("Transient field relatedObject cannot have any JAXB annotations"), which surfaced as HTTP 500
+   * on Explorer path list/find (#3196).
+   */
+  private transient Object relatedObject;
 
   @XmlElement(name = "columnData")
   @XmlJavaTypeAdapter(PSMapAdapter.class)
@@ -181,10 +190,12 @@ public class PSPathItem extends PSDataItemSummary implements IPSItemSummary, IPS
     this.accessLevel = accessLevel;
   }
 
+  @JsonIgnore
   public Object getRelatedObject() {
     return relatedObject;
   }
 
+  @JsonIgnore
   public void setRelatedObject(Object relatedObject) {
     this.relatedObject = relatedObject;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSPathItemListJacksonTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSPathItemListJacksonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2026 Percussion Software, Inc.
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,26 @@
 package com.percussion.pathmanagement.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.sitemanage.json.JacksonContextResolver;
+import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 /**
- * Regression for #2989: path/folder Sites non-empty listing must use Jackson-friendly {@link
- * PSPathItemList} (JsonRootName PathItem, no JAXB XmlRootElement on ArrayList).
+ * Regression for path/folder JSON (#2989, #3196): {@link PSPathItemList} uses Jackson {@code
+ * JsonRootName PathItem} (no JAXB {@code XmlRootElement} on the ArrayList subclass), and {@link
+ * PSPathItem} must be a legal JAXB type so CXF/Jackson JAXB introspector does not return HTTP 500
+ * {@code IllegalAnnotationExceptions}.
  */
 @Tag("UnitTest")
 class PSPathItemListJacksonTest {
@@ -56,5 +62,47 @@ class PSPathItemListJacksonTest {
     PSPathItemList list = new PSPathItemList(List.of(site));
     assertEquals(1, list.size());
     assertTrue(new PSPathItemList().isEmpty());
+  }
+
+  @Test
+  void jaxbContextAcceptsPathItemAndPathItemList() throws Exception {
+    assertNotNull(JAXBContext.newInstance(PSPathItem.class, PSPathItemList.class));
+  }
+
+  @Test
+  void serializesRepresentativeTreeWithSiteManageObjectMapper() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(PSPathItemList.class);
+    PSPathItem sites = new PSPathItem();
+    sites.setName("Sites");
+    sites.setId("Sites");
+    sites.setType("site");
+    sites.setPath("/Sites/");
+    sites.setFolderPath("//Sites");
+    sites.setLeaf(false);
+    sites.setHasFolderChildren(true);
+    sites.setTypeProperty("siteId", "1");
+    sites.getDisplayProperties().put("sys_title", "Sites");
+    sites.setRelatedObject(new Object());
+
+    String json = mapper.writeValueAsString(new PSPathItemList(List.of(sites)));
+    assertTrue(json.contains("\"PathItem\""), json);
+    assertTrue(json.contains("Sites"), json);
+    assertFalse(json.contains("relatedObject"), json);
+  }
+
+  @Test
+  void serializesSinglePathItemWithSiteManageObjectMapper() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(PSPathItem.class);
+    PSPathItem item = new PSPathItem();
+    item.setName("Corporate_Investments");
+    item.setId("guid-1");
+    item.setType("site");
+    item.setPath("/Sites/Corporate_Investments/");
+    item.setLeaf(false);
+    item.setRelatedObject(new Object());
+    String json = mapper.writeValueAsString(item);
+    assertTrue(json.contains("\"PathItem\""), json);
+    assertTrue(json.contains("Corporate_Investments"), json);
+    assertFalse(json.contains("relatedObject"), json);
   }
 }


### PR DESCRIPTION
## Summary

Content Explorer left panel failed with HTTP 500 `IllegalAnnotationExceptions` on `PathItem` because Glassfish JAXB rejects `@XmlTransient` on the Java `transient` field `relatedObject` (`PSPathItem`). Path list/find then could not serialize, and the folder tree did not render.

This change keeps `relatedObject` `transient` (runtime `File` association, not Java-serialized), removes the illegal JAXB annotation, and `@JsonIgnore`s accessors so it stays off JSON. `PSPathItemListJacksonTest` now builds `JAXBContext` and serializes a representative tree with the sitemanage `JacksonContextResolver` ObjectMapper. The SPA unwraps `PathItem`/`Errors` envelopes so a future failure shows a clear tree error instead of a blank panel.

Fixes #3196

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS, Tests run: 1105, Failures: 0, Skipped: 125.
2. `cd WebUI && ../mvnw clean install` — BUILD SUCCESS, Vitest 2058 passed.
3. `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS.
4. QA H2: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993`; hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar` + `WebUI` modern assets; restart Jetty.
5. Playwright: `npm run test:surface -- --path tests/bugs/bug-3196-pathitem-left-panel.spec.js` — 2 passed (REST folder/ 200 with Sites; UI tree roots).
6. Playwright golden: `npm run test:golden` — 2 passed.
7. Confirm `GET /Rhythmyx/services/pathmanagement/path/folder/` JSON is `{"PathItem":[...]}` with Sites/Folders/Assets (no `IllegalAnnotationExceptions`).

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` left-tree troubleshooting
- [x] **Unit / module tests** — `PSPathItemListJacksonTest` JAXB + ObjectMapper; WebUI `extractRestErrorMessage` / `findChildren` envelope tests
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3196-pathitem-left-panel.spec.js`
- [x] **Build gates** — standalone clean install sitemanage, WebUI, perc-qa-automation
- [x] **Cross-platform** — N/A (no filesystem path I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1105 Failures: 0 Skipped: 125; `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS Vitest 2058 passed; `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS
- **downstream_checked:** C2 N/A (no `final`/`sealed`/public signature change). Grep `extends PSPathItem` / `new PSPathItem() {` — no DTO anonymous subclasses.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up`; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`
- deploy: docker cp new `sitemanage-8.2.0-SNAPSHOT.jar` + `WebUI/target/generated-webui/cm/modern/assets`; Jetty restart
- Playwright surface: `npm run test:surface -- --path tests/bugs/bug-3196-pathitem-left-panel.spec.js` — 2 passed
- golden: `npm run test:golden` — 2 passed
- console-clean=yes (no uncaught pageerror; ignored unrelated 404 resource noise)
- server.log-clean=yes for PathItem/Jackson (`IllegalAnnotationExceptions` absent). Unrelated pre-existing `PSSiteSectionService` SITEID batch errors not this feature.

> Co-Authored by Grok Build using grok-4.5 with agent main.
