### PR TITLE
fix(webui): Navigation homepage landing + New Site (#3219)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -210,7 +210,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     if ("widgetbuilder".equals(entry)) {
       entry = "widget-builder";
     }
-    if ("arch".equals(entry)) {
+    if ("arch".equals(entry) || "navigation".equals(entry)) {
       entry = "architecture";
     }
     if (!SPA_ENTRIES.contains(entry)) {

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -61,7 +61,7 @@ export function parseEntryQuery(
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
   }
-  if (entryRaw === "arch") {
+  if (entryRaw === "arch" || entryRaw === "navigation") {
     entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
@@ -201,7 +201,7 @@ export function parseClientPath(
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
   }
-  if (entryRaw === "arch") {
+  if (entryRaw === "arch" || entryRaw === "navigation") {
     entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -55,6 +55,7 @@ import {
 } from "../api/architecture/sectionMutations";
 import type { NavTreeNode } from "../api/architecture/types";
 import { fetchSites } from "../api/home/homeApi";
+import { SiteCreateWizard } from "../contentExplorer/wizards/SiteCreateWizard";
 import { catalogColors } from "../developer/catalogStyles";
 import { CreateSectionDialog } from "./CreateSectionDialog";
 import { ExternalLinkDialog } from "./ExternalLinkDialog";
@@ -85,6 +86,11 @@ export interface ArchitectureShellProps {
    * (unit tests). Default true.
    */
   useLandingContentBrowser?: boolean;
+  /**
+   * Show New Site (Explorer SiteCreateWizard) for entitled roles.
+   * Default true — Architecture is already Admin/Designer gated (#3219).
+   */
+  allowNewSite?: boolean;
 }
 
 type SitesLoadState =
@@ -107,6 +113,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   embedded = false,
   confirmFn,
   useLandingContentBrowser = true,
+  allowNewSite = true,
 }) => {
   const confirmAction = useCallback(
     (msg: string) => (confirmFn ? confirmFn(msg) : window.confirm(msg)),
@@ -141,6 +148,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     externalUrl: string;
     target: string;
   } | null>(null);
+  const [showNewSite, setShowNewSite] = useState(false);
 
   // Honor route/deep-link site when prop changes
   useEffect(() => {
@@ -218,6 +226,30 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
 
   const onRefresh = useCallback(() => {
     setRefreshToken((n) => n + 1);
+  }, []);
+
+  const reloadSites = useCallback(async (preferSite?: string | null) => {
+    try {
+      const list = await fetchSites();
+      const names = list
+        .map((s) => (s.name != null ? String(s.name).trim() : ""))
+        .filter((n) => n.length > 0)
+        .sort((a, b) => a.localeCompare(b));
+      setSitesState({ status: "ready", names });
+      const preferred = preferSite != null ? String(preferSite).trim() : "";
+      setSelectedSite((prev) => {
+        if (preferred && names.includes(preferred)) return preferred;
+        if (prev && names.includes(prev)) return prev;
+        if (!prev && names.length > 0) return names[0];
+        return prev;
+      });
+    } catch (err) {
+      if (isSessionRedirectError(err)) return;
+      setSitesState({
+        status: "error",
+        message: formatApiError(err, ARCH_MSG.SITES_ERROR),
+      });
+    }
   }, []);
 
   const treeRoot =
@@ -622,7 +654,80 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         >
           {ARCH_MSG.REFRESH}
         </button>
+        {allowNewSite ? (
+          <button
+            type="button"
+            data-testid="architecture-action-new-site"
+            aria-expanded={showNewSite}
+            aria-controls="architecture-new-site-panel"
+            onClick={() => setShowNewSite((open) => !open)}
+            style={{
+              padding: "0.4rem 0.85rem",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: 4,
+              background: showNewSite ? "#e8eef8" : "#fff",
+              color: "#222",
+              cursor: "pointer",
+              fontSize: "0.9rem",
+            }}
+          >
+            {ARCH_MSG.ACTION_NEW_SITE}
+          </button>
+        ) : null}
       </section>
+
+      {allowNewSite && showNewSite ? (
+        <section
+          id="architecture-new-site-panel"
+          role="region"
+          aria-label={ARCH_MSG.NEW_SITE_REGION}
+          data-testid="architecture-new-site-panel"
+          style={{
+            border: `1px solid ${catalogColors.headerBorder}`,
+            borderRadius: 8,
+            padding: "1rem 1.25rem",
+            marginBottom: "12px",
+            background: "#fff",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "0.75rem",
+              marginBottom: "0.75rem",
+            }}
+          >
+            <h2
+              style={{ margin: 0, fontSize: "1.05rem", color: "#1a202c" }}
+              data-testid="architecture-new-site-title"
+            >
+              {ARCH_MSG.ACTION_NEW_SITE}
+            </h2>
+            <button
+              type="button"
+              data-testid="architecture-new-site-close"
+              onClick={() => setShowNewSite(false)}
+              style={{
+                padding: "0.3rem 0.7rem",
+                border: `1px solid ${catalogColors.softBorder}`,
+                borderRadius: 4,
+                background: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              {ARCH_MSG.NEW_SITE_CLOSE}
+            </button>
+          </div>
+          <SiteCreateWizard
+            onCreated={({ siteName }) => {
+              setShowNewSite(false);
+              void reloadSites(siteName);
+            }}
+          />
+        </section>
+      ) : null}
 
       {!selectedSite ? (
         <section

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -66,6 +66,7 @@ import { SectionLinkDialog } from "./SectionLinkDialog";
 import { SitePicker } from "./SitePicker";
 import { StructureActionBar } from "./StructureActionBar";
 import { ARCH_MSG } from "./messages";
+import { useDialogEscape } from "./useDialogEscape";
 
 export interface ArchitectureShellProps {
   /**
@@ -149,6 +150,50 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     target: string;
   } | null>(null);
   const [showNewSite, setShowNewSite] = useState(false);
+  const newSiteToggleRef = useRef<HTMLButtonElement>(null);
+  const newSitePanelRef = useRef<HTMLElement>(null);
+
+  useDialogEscape(showNewSite, mutationBusy, () => setShowNewSite(false));
+
+  useEffect(() => {
+    if (!showNewSite) {
+      return;
+    }
+    const root = newSitePanelRef.current;
+    if (!root) {
+      return;
+    }
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+    focusables()[0]?.focus();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key !== "Tab") {
+        return;
+      }
+      const list = focusables();
+      if (list.length === 0) {
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => {
+      root.removeEventListener("keydown", onKey);
+      newSiteToggleRef.current?.focus();
+    };
+  }, [showNewSite]);
 
   // Honor route/deep-link site when prop changes
   useEffect(() => {
@@ -158,28 +203,41 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     }
   }, [initialSite]);
 
+  const applySiteNames = useCallback(
+    (names: string[], preferSite?: string | null) => {
+      setSitesState({ status: "ready", names });
+      const preferred = preferSite != null ? String(preferSite).trim() : "";
+      setSelectedSite((prev) => {
+        if (preferred && names.includes(preferred)) return preferred;
+        if (prev && names.includes(prev)) return prev;
+        if (prev && names.length === 0) return prev;
+        if (prev && !names.includes(prev) && names.length > 0) {
+          return prev;
+        }
+        if (!prev && names.length > 0) return names[0];
+        return prev;
+      });
+    },
+    [],
+  );
+
+  const loadSiteNames = useCallback(async (): Promise<string[]> => {
+    const list = await fetchSites();
+    return list
+      .map((s) => (s.name != null ? String(s.name).trim() : ""))
+      .filter((n) => n.length > 0)
+      .sort((a, b) => a.localeCompare(b));
+  }, []);
+
   // Load site list once
   useEffect(() => {
     let cancelled = false;
     setSitesState({ status: "loading" });
     void (async () => {
       try {
-        const list = await fetchSites();
+        const names = await loadSiteNames();
         if (cancelled) return;
-        const names = list
-          .map((s) => (s.name != null ? String(s.name).trim() : ""))
-          .filter((n) => n.length > 0)
-          .sort((a, b) => a.localeCompare(b));
-        setSitesState({ status: "ready", names });
-        setSelectedSite((prev) => {
-          if (prev && names.includes(prev)) return prev;
-          if (prev && names.length === 0) return prev;
-          if (prev && !names.includes(prev) && names.length > 0) {
-            return prev;
-          }
-          if (!prev && names.length > 0) return names[0];
-          return prev;
-        });
+        applySiteNames(names);
       } catch (err) {
         if (cancelled) return;
         if (isSessionRedirectError(err)) return;
@@ -192,7 +250,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applySiteNames, loadSiteNames]);
 
   // Load tree when site or refresh changes
   useEffect(() => {
@@ -228,29 +286,30 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     setRefreshToken((n) => n + 1);
   }, []);
 
-  const reloadSites = useCallback(async (preferSite?: string | null) => {
-    try {
-      const list = await fetchSites();
-      const names = list
-        .map((s) => (s.name != null ? String(s.name).trim() : ""))
-        .filter((n) => n.length > 0)
-        .sort((a, b) => a.localeCompare(b));
-      setSitesState({ status: "ready", names });
+  const reloadSites = useCallback(
+    async (preferSite?: string | null) => {
       const preferred = preferSite != null ? String(preferSite).trim() : "";
-      setSelectedSite((prev) => {
-        if (preferred && names.includes(preferred)) return preferred;
-        if (prev && names.includes(prev)) return prev;
-        if (!prev && names.length > 0) return names[0];
-        return prev;
-      });
-    } catch (err) {
-      if (isSessionRedirectError(err)) return;
-      setSitesState({
-        status: "error",
-        message: formatApiError(err, ARCH_MSG.SITES_ERROR),
-      });
-    }
-  }, []);
+      try {
+        const names = await loadSiteNames();
+        applySiteNames(names, preferred);
+        if (preferred) {
+          setMutationError(null);
+        }
+      } catch (err) {
+        if (isSessionRedirectError(err)) return;
+        setSitesState({
+          status: "error",
+          message: formatApiError(err, ARCH_MSG.SITES_ERROR),
+        });
+        if (preferred) {
+          setMutationError(
+            ARCH_MSG.NEW_SITE_RELOAD_ERROR.split("{0}").join(preferred),
+          );
+        }
+      }
+    },
+    [applySiteNames, loadSiteNames],
+  );
 
   const treeRoot =
     treeState.status === "ready" ? treeState.root : null;
@@ -657,9 +716,13 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         {allowNewSite ? (
           <button
             type="button"
+            ref={newSiteToggleRef}
             data-testid="architecture-action-new-site"
             aria-expanded={showNewSite}
-            aria-controls="architecture-new-site-panel"
+            aria-haspopup="dialog"
+            aria-controls={
+              showNewSite ? "architecture-new-site-panel" : undefined
+            }
             onClick={() => setShowNewSite((open) => !open)}
             style={{
               padding: "0.4rem 0.85rem",
@@ -676,10 +739,27 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         ) : null}
       </section>
 
+      {mutationError ? (
+        <p
+          role="alert"
+          data-testid="architecture-mutation-error"
+          style={{
+            margin: "0 0 12px",
+            color: catalogColors.error,
+            fontSize: "0.9rem",
+          }}
+        >
+          {mutationError}
+        </p>
+      ) : null}
+
       {allowNewSite && showNewSite ? (
         <section
           id="architecture-new-site-panel"
-          role="region"
+          ref={newSitePanelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="architecture-new-site-title"
           aria-label={ARCH_MSG.NEW_SITE_REGION}
           data-testid="architecture-new-site-panel"
           style={{
@@ -700,6 +780,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             }}
           >
             <h2
+              id="architecture-new-site-title"
               style={{ margin: 0, fontSize: "1.05rem", color: "#1a202c" }}
               data-testid="architecture-new-site-title"
             >
@@ -877,20 +958,6 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
               data-testid="architecture-select-hint"
             >
               {ARCH_MSG.SELECT_HINT}
-            </p>
-          ) : null}
-
-          {mutationError ? (
-            <p
-              role="alert"
-              data-testid="architecture-mutation-error"
-              style={{
-                margin: "0 0 8px",
-                color: catalogColors.error,
-                fontSize: "0.9rem",
-              }}
-            >
-              {mutationError}
             </p>
           ) : null}
 

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -48,6 +48,8 @@ const KEYS = {
   ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
   NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
   NEW_SITE_REGION: "perc.ui.architecture.modern@New Site panel",
+  NEW_SITE_RELOAD_ERROR:
+    "perc.ui.architecture.modern@Site {0} was created, but the site list could not be refreshed.",
   // Kept for older tests / deep links that still assert empty-shell keys
   EMPTY_TITLE: "perc.ui.architecture.modern@No site selected",
   EMPTY_BODY:
@@ -188,6 +190,7 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   ACTION_NEW_SITE: message(KEYS.ACTION_NEW_SITE),
   NEW_SITE_CLOSE: message(KEYS.NEW_SITE_CLOSE),
   NEW_SITE_REGION: message(KEYS.NEW_SITE_REGION),
+  NEW_SITE_RELOAD_ERROR: message(KEYS.NEW_SITE_RELOAD_ERROR),
   EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
   EMPTY_BODY: message(KEYS.EMPTY_BODY),
   ACTIONS_LABEL: message(KEYS.ACTIONS_LABEL),

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -45,6 +45,9 @@ const KEYS = {
   TREE_STRUCTURE_NOTE:
     "perc.ui.architecture.modern@Select a section, then use structure actions: create, rename, move, delete, landing page, or link editors.",
   REFRESH: "perc.ui.architecture.modern@Refresh",
+  ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
+  NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
+  NEW_SITE_REGION: "perc.ui.architecture.modern@New Site panel",
   // Kept for older tests / deep links that still assert empty-shell keys
   EMPTY_TITLE: "perc.ui.architecture.modern@No site selected",
   EMPTY_BODY:
@@ -182,6 +185,9 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   TREE_PANEL_TITLE: message(KEYS.TREE_PANEL_TITLE),
   TREE_STRUCTURE_NOTE: message(KEYS.TREE_STRUCTURE_NOTE),
   REFRESH: message(KEYS.REFRESH),
+  ACTION_NEW_SITE: message(KEYS.ACTION_NEW_SITE),
+  NEW_SITE_CLOSE: message(KEYS.NEW_SITE_CLOSE),
+  NEW_SITE_REGION: message(KEYS.NEW_SITE_REGION),
   EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
   EMPTY_BODY: message(KEYS.EMPTY_BODY),
   ACTIONS_LABEL: message(KEYS.ACTIONS_LABEL),

--- a/WebUI/src/main/ts/login/bootstrap.ts
+++ b/WebUI/src/main/ts/login/bootstrap.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
   sanitizeLoginRedirect,
 } from "./redirect";
 import type { LoginBootstrap, SpaLandingBootstrap } from "./types";
@@ -86,7 +86,7 @@ export function readLoginBootstrap(): LoginBootstrap {
     autocomplete: raw?.autocomplete === "off" ? "off" : "on",
     defaultRedirect: sanitizeLoginRedirect(
       raw?.defaultRedirect,
-      DEFAULT_SPA_ENTRY_REDIRECT,
+      DEFAULT_POST_LOGIN_REDIRECT,
     ),
     csrfTokenName: csrf.name,
     csrfTokenValue: csrf.value,

--- a/WebUI/src/main/ts/login/index.ts
+++ b/WebUI/src/main/ts/login/index.ts
@@ -22,6 +22,7 @@ export {
   buildSpaEntryRedirect,
   sanitizeLoginRedirect,
   DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
 } from "./redirect";
 export type {
   LoginBootstrap,

--- a/WebUI/src/main/ts/login/redirect.ts
+++ b/WebUI/src/main/ts/login/redirect.ts
@@ -22,6 +22,14 @@
  */
 export const DEFAULT_SPA_ENTRY_REDIRECT = "/cm/app/spa.jsp?entry=home";
 
+/**
+ * Unauthenticated login default ({@code sys_redirect}) when the user has no
+ * explicit return URL. {@code /cm/app/} is the index.jsp dispatcher — it
+ * applies {@code getUserHomepage()} so Architecture / Navigation land on
+ * the Navigation SPA instead of Home (#3219 / parent #3197).
+ */
+export const DEFAULT_POST_LOGIN_REDIRECT = "/cm/app/";
+
 const ALLOWED_ENTRIES = new Set([
   "home",
   "publish",
@@ -76,9 +84,19 @@ export function buildSpaEntryRedirect(
  * @param candidate - raw redirect from bootstrap or query
  * @param fallback - used when candidate is invalid
  */
+function isAllowedAppRedirect(raw: string): boolean {
+  if (raw.startsWith("/cm/app/spa.jsp")) {
+    return true;
+  }
+  if (raw === "/cm/app" || raw === "/cm/app/") {
+    return true;
+  }
+  return raw.startsWith("/cm/app?") || raw.startsWith("/cm/app/?");
+}
+
 export function sanitizeLoginRedirect(
   candidate: string | null | undefined,
-  fallback: string = DEFAULT_SPA_ENTRY_REDIRECT,
+  fallback: string = DEFAULT_POST_LOGIN_REDIRECT,
 ): string {
   if (candidate == null || !String(candidate).trim()) {
     return fallback;
@@ -91,8 +109,8 @@ export function sanitizeLoginRedirect(
   if (!raw.startsWith("/") || raw.includes("..")) {
     return fallback;
   }
-  // Prefer SPA entry; also allow /cm/app for transitional landings
-  if (raw.startsWith("/cm/app/spa.jsp") || raw === "/cm/app" || raw.startsWith("/cm/app?")) {
+  // Prefer SPA entry; also allow /cm/app dispatcher (homepage resolve)
+  if (isAllowedAppRedirect(raw)) {
     return raw.length > 2048 ? fallback : raw;
   }
   return fallback;

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -53,8 +53,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // SPA path /architecture (#3094); homepage type remains "Architecture"
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // Stored type stays Architecture; product label is Navigation (#3219)
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/ts/profile/resolveLandingEntry.ts
+++ b/WebUI/src/main/ts/profile/resolveLandingEntry.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map stored homepage / landing tokens to SPA entry + client path (#3219).
+ *
+ * <p>Canonical stored type remains {@code Architecture}. Product name
+ * Navigation and view-key aliases ({@code arch}, {@code navigation}) must
+ * resolve to the Architecture SPA, not Home.</p>
+ */
+
+import { HOMEPAGE_TYPES } from "../api/user/userHomepageApi";
+import type { SpaEntry } from "../app/deepLinks/allowlists";
+
+/** Unauthenticated login posts here so index.jsp can apply getUserHomepage(). */
+export const POST_LOGIN_DISPATCHER = "/cm/app/";
+
+/**
+ * Normalize a homepage type, view key, or product label to an SPA entry.
+ * Blank / unknown → {@code home} (same fail-closed as server mapping).
+ */
+export function resolveHomepageToSpaEntry(
+  raw: string | null | undefined,
+): SpaEntry {
+  const trimmed = raw == null ? "" : String(raw).trim();
+  if (!trimmed) {
+    return "home";
+  }
+  switch (trimmed) {
+    case HOMEPAGE_TYPES.HOME:
+      return "home";
+    case HOMEPAGE_TYPES.DASHBOARD:
+      return "home";
+    case HOMEPAGE_TYPES.EDITOR:
+      return "home";
+    case HOMEPAGE_TYPES.DESIGNER:
+      return "design";
+    case HOMEPAGE_TYPES.ARCHITECTURE:
+      return "architecture";
+    case HOMEPAGE_TYPES.PUBLISH:
+      return "publish";
+    case HOMEPAGE_TYPES.WORKFLOW:
+      return "admin";
+    case HOMEPAGE_TYPES.WIDGET_BUILDER:
+      return "widget-builder";
+    default:
+      break;
+  }
+  const lower = trimmed.toLowerCase();
+  switch (lower) {
+    case "home":
+      return "home";
+    case "dash":
+    case "dashboard":
+      return "home";
+    case "editor":
+    case "pageeditor":
+    case "webmgt":
+      return "home";
+    case "design":
+    case "designer":
+    case "siteadmin":
+      return "design";
+    case "arch":
+    case "architecture":
+    case "navigation":
+    case "site_arch":
+    case "sitearch":
+      return "architecture";
+    case "publish":
+      return "publish";
+    case "workflow":
+    case "admin":
+      return "admin";
+    case "widgetbuilder":
+    case "widget-builder":
+    case "widget_builder":
+      return "widget-builder";
+    case "explorer":
+      return "explorer";
+    case "profile":
+      return "profile";
+    case "developer":
+      return "developer";
+    default:
+      return "home";
+  }
+}
+
+/** Client route under the SPA basename for a stored homepage token. */
+export function resolveHomepageToClientPath(
+  raw: string | null | undefined,
+): string {
+  const entry = resolveHomepageToSpaEntry(raw);
+  switch (entry) {
+    case "home":
+      return "/home";
+    case "widget-builder":
+      return "/widget-builder";
+    default:
+      return `/${entry}`;
+  }
+}
+
+/** True when a stored or typed landing token means Navigation / Architecture. */
+export function isNavigationHomepageToken(
+  raw: string | null | undefined,
+): boolean {
+  return resolveHomepageToSpaEntry(raw) === "architecture";
+}

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -56,7 +56,7 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
     // Product "Navigation" / Architecture SPA (#3094 → /architecture)
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -80,6 +80,7 @@
             "developer",
             "arch",
             "architecture",
+            "navigation",
             "dash"
     };
 
@@ -87,6 +88,8 @@
     String[] adminViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "workflow",
             "widgetbuilder",
@@ -98,6 +101,8 @@
     String[] designerViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "widgetbuilder",
             "developer"
@@ -233,8 +238,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
-        else if ("arch".equals(view) || "architecture".equals(view))
-            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
+            // #3094 / #3219: Architecture homepage / Navigation → SPA shell
             entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
@@ -308,9 +314,10 @@
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
         }
-        else if ("arch".equals(view) || "architecture".equals(view))
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
         {
-            // Optional site context for Architecture SPA (#3094)
+            // Optional site context for Architecture SPA (#3094 / #3219)
             String site = request.getParameter("site");
             if (site != null && !site.isBlank() && site.length() <= 128
                     && !site.contains("://") && !site.contains("..") && !site.contains("/"))

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -52,7 +52,7 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
-        if ("arch".equals(n)) {
+        if ("arch".equals(n) || "navigation".equals(n)) {
             return "architecture";
         }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -80,6 +80,7 @@
             "developer",
             "arch",
             "architecture",
+            "navigation",
             "dash"
     };
 
@@ -87,6 +88,8 @@
     String[] adminViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "workflow",
             "widgetbuilder",
@@ -98,6 +101,8 @@
     String[] designerViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "widgetbuilder",
             "developer"
@@ -233,8 +238,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
-        else if ("arch".equals(view) || "architecture".equals(view))
-            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
+            // #3094 / #3219: Architecture homepage / Navigation → SPA shell
             entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
@@ -308,9 +314,10 @@
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
         }
-        else if ("arch".equals(view) || "architecture".equals(view))
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
         {
-            // Optional site context for Architecture SPA (#3094)
+            // Optional site context for Architecture SPA (#3094 / #3219)
             String site = request.getParameter("site");
             if (site != null && !site.isBlank() && site.length() <= 128
                     && !site.contains("://") && !site.contains("..") && !site.contains("/"))

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -52,7 +52,7 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
-        if ("arch".equals(n)) {
+        if ("arch".equals(n) || "navigation".equals(n)) {
             return "architecture";
         }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)

--- a/WebUI/src/main/webapp/rxlogin.jsp
+++ b/WebUI/src/main/webapp/rxlogin.jsp
@@ -62,15 +62,22 @@
         autocomplete = "off";
     }
 
-    // Default post-login SPA entry (query contract — never use # fragments).
-    String defaultRedirect = "/cm/app/spa.jsp?entry=home";
+    // Default post-login: index.jsp dispatcher resolves homepage preference
+    // (Architecture / Navigation → SPA architecture). Explicit return URLs
+    // still win. Query contract only — never # fragments. (#3219)
+    String defaultRedirect = "/cm/app/";
     String returnParam = request.getParameter("return");
-    if (returnParam != null
-            && returnParam.startsWith("/cm/app/spa.jsp")
+    boolean allowedReturn = returnParam != null
+            && (returnParam.startsWith("/cm/app/spa.jsp")
+                || "/cm/app".equals(returnParam)
+                || "/cm/app/".equals(returnParam)
+                || returnParam.startsWith("/cm/app?")
+                || returnParam.startsWith("/cm/app/?"))
             && !returnParam.contains("..")
             && !returnParam.contains("://")
             && !returnParam.contains("#")
-            && returnParam.length() < 2048) {
+            && returnParam.length() < 2048;
+    if (allowedReturn) {
         defaultRedirect = returnParam;
     }
 

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -106,6 +106,9 @@ public class PSWebUiSpaFallbackFilterTest {
     assertEquals(
         "/cm/app/spa.jsp?entry=architecture",
         PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/arch", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=architecture",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/navigation", null));
   }
 
   @Test

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -85,6 +85,11 @@ describe("parseEntryQuery", () => {
       "/architecture",
     );
     expect(parseEntryQuery("?entry=arch").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=navigation").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=navigation").clientPath).toBe(
+      "/architecture",
+    );
+    expect(parseClientPath("/navigation").entry).toBe("architecture");
     expect(parseEntryQuery("?entry=architecture&site=Demo").site).toBe("Demo");
     expect(parseEntryQuery("?entry=architecture&site=Demo").clientPath).toBe(
       "/architecture/Demo",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -79,7 +79,7 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/design/templates").section).toBe("templates");
   });
 
-  it("maps architecture entry, arch alias, and site (#3094)", () => {
+  it("maps architecture, arch, and navigation aliases plus site (#3094/#3219)", () => {
     expect(parseEntryQuery("?entry=architecture").entry).toBe("architecture");
     expect(parseEntryQuery("?entry=architecture").clientPath).toBe(
       "/architecture",
@@ -97,6 +97,11 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/architecture").entry).toBe("architecture");
     expect(parseClientPath("/architecture/Demo").site).toBe("Demo");
     expect(parseClientPath("/architecture/Demo").clientPath).toBe(
+      "/architecture/Demo",
+    );
+    expect(parseClientPath("/navigation/Demo").entry).toBe("architecture");
+    expect(parseClientPath("/navigation/Demo").site).toBe("Demo");
+    expect(parseClientPath("/navigation/Demo").clientPath).toBe(
       "/architecture/Demo",
     );
   });

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -191,6 +191,11 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     expect(text).toContain("perc-login-root");
     // Classic host file is gone; comment may still mention the name historically
     expect(existsSync(resolve(webappRoot, "rxlogin-classic.jsp"))).toBe(false);
+    // #3219: default sys_redirect is the dispatcher (homepage resolve), not Home
+    expect(text).toContain('String defaultRedirect = "/cm/app/";');
+    expect(text).not.toContain(
+      'String defaultRedirect = "/cm/app/spa.jsp?entry=home"',
+    );
   });
 
   it("security conf no longer grants anonymous to deleted classic login", () => {

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -192,9 +192,11 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     // Classic host file is gone; comment may still mention the name historically
     expect(existsSync(resolve(webappRoot, "rxlogin-classic.jsp"))).toBe(false);
     // #3219: default sys_redirect is the dispatcher (homepage resolve), not Home
-    expect(text).toContain('String defaultRedirect = "/cm/app/";');
-    expect(text).not.toContain(
-      'String defaultRedirect = "/cm/app/spa.jsp?entry=home"',
+    expect(text.replace(/\s+/g, " ")).toMatch(
+      /String defaultRedirect\s*=\s*"\/cm\/app\/"\s*;/,
+    );
+    expect(text).not.toMatch(
+      /String defaultRedirect\s*=\s*"\/cm\/app\/spa\.jsp\?entry=home"/,
     );
   });
 

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -572,4 +572,41 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     expect(delSecSpy).not.toHaveBeenCalled();
   });
+
+  it("shows New Site for entitled users and opens the create wizard (#3219)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    const siteCreate = await import(
+      "../../../main/ts/api/contentExplorer/siteCreateApi"
+    );
+    vi.spyOn(siteCreate, "listBaseTemplates").mockResolvedValue([
+      { name: "perc.base.plain", label: "Plain" },
+    ]);
+
+    render(<ArchitectureShell embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-new-site")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-new-site-panel")).toBeTruthy();
+    });
+    expect(screen.getByTestId("architecture-new-site-title").textContent).toMatch(
+      /New Site/i,
+    );
+    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("architecture-new-site-close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    });
+  });
+
+  it("hides New Site when allowNewSite is false", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    render(<ArchitectureShell embedded allowNewSite={false} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-sites-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("architecture-action-new-site")).toBeNull();
+  });
 });

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -595,10 +595,63 @@ describe("ArchitectureShell (#3095/#3096)", () => {
       /New Site/i,
     );
     expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("architecture-new-site-panel").getAttribute("role")).toBe(
+      "dialog",
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-new-site-panel")).toBeTruthy();
+    });
     fireEvent.click(screen.getByTestId("architecture-new-site-close"));
     await waitFor(() => {
       expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
     });
+  });
+
+  it("keeps a create-success mutation error when site reload fails (#3219)", async () => {
+    const fetchSites = vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    const siteCreate = await import(
+      "../../../main/ts/api/contentExplorer/siteCreateApi"
+    );
+    vi.spyOn(siteCreate, "listBaseTemplates").mockResolvedValue([
+      { name: "perc.base.plain", label: "Plain" },
+    ]);
+    vi.spyOn(siteCreate, "createTraditionalSite").mockResolvedValue({
+      name: "Acme",
+    });
+
+    render(<ArchitectureShell embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-new-site")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-name")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fetchSites.mockRejectedValue(new Error("catalog down"));
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-mutation-error").textContent).toMatch(
+        /Acme.*could not be refreshed/i,
+      );
+    });
+    expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    expect(screen.getByTestId("architecture-sites-error").textContent).toMatch(
+      /catalog down/i,
+    );
   });
 
   it("hides New Site when allowNewSite is false", async () => {

--- a/WebUI/src/test/ts/login/redirect.test.ts
+++ b/WebUI/src/test/ts/login/redirect.test.ts
@@ -20,12 +20,20 @@ import {
   buildSpaEntryRedirect,
   sanitizeLoginRedirect,
   DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
 } from "@/login/redirect";
 
 describe("login redirect helpers", () => {
   it("builds default home SPA entry", () => {
     expect(buildSpaEntryRedirect()).toBe("/cm/app/spa.jsp?entry=home");
     expect(DEFAULT_SPA_ENTRY_REDIRECT).toBe("/cm/app/spa.jsp?entry=home");
+  });
+
+  it("uses the app dispatcher as unauthenticated post-login default (#3219)", () => {
+    expect(DEFAULT_POST_LOGIN_REDIRECT).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect(null)).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect("")).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect("/cm/app/")).toBe("/cm/app/");
   });
 
   it("allowlists entries and rejects unknown", () => {
@@ -47,12 +55,18 @@ describe("login redirect helpers", () => {
   });
 
   it("rejects open redirects and fragments", () => {
-    expect(sanitizeLoginRedirect("http://evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
-    expect(sanitizeLoginRedirect("//evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
-    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=home#/hack")).toBe(
-      DEFAULT_SPA_ENTRY_REDIRECT,
+    expect(sanitizeLoginRedirect("http://evil.example/x")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
     );
-    expect(sanitizeLoginRedirect("../etc/passwd")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
+    expect(sanitizeLoginRedirect("//evil.example/x")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
+    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=home#/hack")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
+    expect(sanitizeLoginRedirect("../etc/passwd")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
   });
 
   it("accepts SPA and transitional /cm/app paths", () => {
@@ -60,5 +74,6 @@ describe("login redirect helpers", () => {
       "/cm/app/spa.jsp?entry=workflow",
     );
     expect(sanitizeLoginRedirect("/cm/app")).toBe("/cm/app");
+    expect(sanitizeLoginRedirect("/cm/app/?view=arch")).toBe("/cm/app/?view=arch");
   });
 });

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -43,6 +43,16 @@ describe("profileLandingOptions", () => {
     expect(arch?.labelKey).toMatch(/Navigation/i);
   });
 
+  it("hides Architecture (Navigation) landing for non-designers", () => {
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, {})).toBe(
+      false,
+    );
+    const opts = profileLandingOptions({});
+    expect(
+      opts.some((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE),
+    ).toBe(false);
+  });
+
   it("opens Design for designers and Administration for admins", () => {
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -31,6 +31,18 @@ describe("profileLandingOptions", () => {
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, {})).toBe(false);
   });
 
+  it("includes Architecture (Navigation) landing for designers", () => {
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, {
+        isDesigner: true,
+      }),
+    ).toBe(true);
+    const opts = profileLandingOptions({ isDesigner: true });
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(arch).toBeTruthy();
+    expect(arch?.labelKey).toMatch(/Navigation/i);
+  });
+
   it("opens Design for designers and Administration for admins", () => {
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -57,8 +57,17 @@ describe("resolveHomepageToSpaEntry (#3219)", () => {
     expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
       "widget-builder",
     );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.HOME)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DASHBOARD)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.EDITOR)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DESIGNER)).toBe("/design");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.PUBLISH)).toBe("/publish");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WORKFLOW)).toBe("/admin");
     expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
       "/widget-builder",
     );
+    expect(resolveHomepageToClientPath("explorer")).toBe("/explorer");
+    expect(resolveHomepageToClientPath("profile")).toBe("/profile");
+    expect(resolveHomepageToClientPath("developer")).toBe("/developer");
   });
 });

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import {
+  isNavigationHomepageToken,
+  resolveHomepageToClientPath,
+  resolveHomepageToSpaEntry,
+} from "../../../main/ts/profile/resolveLandingEntry";
+
+describe("resolveHomepageToSpaEntry (#3219)", () => {
+  it("maps Architecture and Navigation aliases to the architecture SPA", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(
+      "architecture",
+    );
+    expect(resolveHomepageToSpaEntry("Navigation")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("navigation")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("arch")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("Architecture")).toBe("architecture");
+    expect(resolveHomepageToClientPath("Navigation")).toBe("/architecture");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(
+      "/architecture",
+    );
+    expect(isNavigationHomepageToken("Navigation")).toBe(true);
+    expect(isNavigationHomepageToken(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(true);
+  });
+
+  it("does not send Home / Editor / unknown tokens to architecture", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.HOME)).toBe("home");
+    expect(resolveHomepageToSpaEntry("")).toBe("home");
+    expect(resolveHomepageToSpaEntry(null)).toBe("home");
+    expect(resolveHomepageToSpaEntry("Editor")).toBe("home");
+    expect(resolveHomepageToSpaEntry("NotAModule")).toBe("home");
+    expect(resolveHomepageToClientPath("Home")).toBe("/home");
+    expect(isNavigationHomepageToken("Home")).toBe(false);
+  });
+
+  it("maps other product homepage types to their SPA entries", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.DESIGNER)).toBe("design");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.PUBLISH)).toBe("publish");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WORKFLOW)).toBe("admin");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
+      "widget-builder",
+    );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
+      "/widget-builder",
+    );
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -39,6 +39,8 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(arch?.labelKey).toMatch(/Navigation/i);
   });
 
   it("includes Administration (Workflow) for Admin role", () => {

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -27121,6 +27121,9 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
     <tu tuid="perc.ui.architecture.modern@Could not load the site list.">
       <tuv xml:lang="en-us"><seg>Could not load the site list.</seg></tuv>
     </tu>
+    <tu tuid="perc.ui.architecture.modern@Site {0} was created, but the site list could not be refreshed.">
+      <tuv xml:lang="en-us"><seg>Site {0} was created, but the site list could not be refreshed.</seg></tuv>
+    </tu>
     <tu tuid="perc.ui.architecture.modern@No sites are available. Create a site to browse its navigation tree.">
       <tuv xml:lang="en-us"><seg>No sites are available. Create a site to browse its navigation tree.</seg></tuv>
     </tu>

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -94,6 +94,7 @@ test.describe("Architecture SPA shell (#3094)", () => {
     });
     const newSite = page.getByTestId("architecture-action-new-site");
     await expect(newSite).toBeVisible();
+    await expect(newSite).toBeEnabled();
     await expect(newSite).toContainText(/New Site/i);
     await newSite.click();
     await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -57,9 +57,11 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByTestId("architecture-empty-state")).toBeVisible();
+    const empty = page.getByTestId("architecture-empty-state");
+    const tree = page.getByTestId("architecture-tree-panel");
+    await expect(empty.or(tree)).toBeVisible();
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Architecture|Navigation/i,
     );
 
     // Top-nav Architecture is SPA NavLink (not legacy ?view=arch)
@@ -78,5 +80,26 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
+  });
+
+  test("New Site affordance opens the create-site wizard @smoke @ui", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    const newSite = page.getByTestId("architecture-action-new-site");
+    await expect(newSite).toBeVisible();
+    await expect(newSite).toContainText(/New Site/i);
+    await newSite.click();
+    await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();
+    await expect(page.getByTestId("site-create-step-details")).toBeVisible();
+    await page.getByTestId("architecture-new-site-close").click();
+    await expect(page.getByTestId("architecture-new-site-panel")).toHaveCount(0);
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
@@ -36,7 +36,10 @@ async function openPreferences(page) {
   await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
     timeout: 30_000,
   });
-  await page.getByTestId("perc-profile-nav-preferences").click();
+  const prefsNav = page.getByTestId("perc-profile-nav-preferences");
+  await expect(prefsNav).toBeVisible({ timeout: 20_000 });
+  await expect(prefsNav).toBeEnabled();
+  await prefsNav.click();
   const landing = page.getByTestId("perc-profile-preferences-landing");
   await expect(landing).toBeVisible({ timeout: 20_000 });
   return landing;
@@ -44,7 +47,18 @@ async function openPreferences(page) {
 
 async function saveLanding(page, value) {
   const landing = await openPreferences(page);
-  await landing.selectOption(value);
+  const optionValues = await landing.locator("option").evaluateAll((els) =>
+    els.map((o) => o.value),
+  );
+  const target = optionValues.includes(value)
+    ? value
+    : optionValues.includes("Home")
+      ? "Home"
+      : optionValues[0];
+  if (target == null) {
+    throw new Error("Landing select has no options to restore");
+  }
+  await landing.selectOption(target);
   const save = page.getByTestId("perc-profile-preferences-save");
   if (await save.isEnabled()) {
     await save.click();
@@ -52,7 +66,7 @@ async function saveLanding(page, value) {
       page.getByTestId("perc-profile-preferences-success"),
     ).toBeVisible({ timeout: 15_000 });
   } else {
-    await expect(landing).toHaveValue(value);
+    await expect(landing).toHaveValue(target);
   }
 }
 
@@ -66,36 +80,48 @@ test.describe("Homepage Navigation landing (#3219)", () => {
 
     await loginAsAdmin(page);
 
-    const landing = await openPreferences(page);
-    const optionValues = await landing.locator("option").evaluateAll((els) =>
-      els.map((o) => o.value),
-    );
-    expect(optionValues).toContain("Architecture");
+    let restoreTo = "";
+    try {
+      const landing = await openPreferences(page);
+      restoreTo = await landing.inputValue();
+      const optionValues = await landing.locator("option").evaluateAll((els) =>
+        els.map((o) => o.value),
+      );
+      expect(optionValues).toContain("Architecture");
 
-    await saveLanding(page, "Architecture");
+      await saveLanding(page, "Architecture");
 
-    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
-      waitUntil: "domcontentloaded",
-    });
+      await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page.getByTestId("perc-logout-page")).toBeVisible({
+        timeout: 20_000,
+      });
 
-    await page.goto(`${BASE_URL}/Rhythmyx/login`, {
-      waitUntil: "domcontentloaded",
-    });
-    const redirect = page.getByTestId("perc-login-redirect");
-    await expect(redirect).toBeAttached({ timeout: 20_000 });
-    await expect(redirect).toHaveValue("/cm/app/");
+      await page.goto(`${BASE_URL}/Rhythmyx/login`, {
+        waitUntil: "domcontentloaded",
+      });
+      const redirect = page.getByTestId("perc-login-redirect");
+      await expect(redirect).toBeAttached({ timeout: 20_000 });
+      await expect(redirect).toHaveValue("/cm/app/");
 
-    await loginAsAdmin(page);
+      await loginAsAdmin(page);
 
-    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
-      timeout: 40_000,
-    });
-    await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
-    const url = page.url();
-    expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
-    expect(url).not.toMatch(/\/home(\/|$|\?)/);
-
-    await saveLanding(page, "");
+      await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+        timeout: 40_000,
+      });
+      await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
+      const url = page.url();
+      expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
+      expect(url).not.toMatch(/\/home(\/|$|\?)/);
+    } finally {
+      try {
+        await loginAsAdmin(page);
+        await saveLanding(page, restoreTo);
+      } catch {
+        // Best-effort restore; do not mask the original assertion.
+      }
+    }
 
     expect(pageErrors, pageErrors.join("\n")).toEqual([]);
   });

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Issue #3219 / parent #3197 slice 3 — homepage Navigation landing.
+ *
+ * Profile preference Architecture (product: Navigation) must open the
+ * Navigation SPA after a fresh login, not Home.
+ *
+ * Surface-filtered:
+ *   npm run test:surface -- --path tests/bugs/bug-3219-nav-homepage-landing.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+async function openPreferences(page) {
+  await page.goto(
+    `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await page.getByTestId("perc-profile-nav-preferences").click();
+  const landing = page.getByTestId("perc-profile-preferences-landing");
+  await expect(landing).toBeVisible({ timeout: 20_000 });
+  return landing;
+}
+
+async function saveLanding(page, value) {
+  const landing = await openPreferences(page);
+  await landing.selectOption(value);
+  const save = page.getByTestId("perc-profile-preferences-save");
+  if (await save.isEnabled()) {
+    await save.click();
+    await expect(
+      page.getByTestId("perc-profile-preferences-success"),
+    ).toBeVisible({ timeout: 15_000 });
+  } else {
+    await expect(landing).toHaveValue(value);
+  }
+}
+
+test.describe("Homepage Navigation landing (#3219)", () => {
+  test("login default is dispatcher; Architecture pref opens Navigation @smoke @ui", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await loginAsAdmin(page);
+
+    const landing = await openPreferences(page);
+    const optionValues = await landing.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(optionValues).toContain("Architecture");
+
+    await saveLanding(page, "Architecture");
+
+    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.goto(`${BASE_URL}/Rhythmyx/login`, {
+      waitUntil: "domcontentloaded",
+    });
+    const redirect = page.getByTestId("perc-login-redirect");
+    await expect(redirect).toBeAttached({ timeout: 20_000 });
+    await expect(redirect).toHaveValue("/cm/app/");
+
+    await loginAsAdmin(page);
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 40_000,
+    });
+    await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
+    const url = page.url();
+    expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
+    expect(url).not.toMatch(/\/home(\/|$|\?)/);
+
+    await saveLanding(page, "");
+
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -22,8 +22,10 @@ chrome. In Percussion CMS 8.2 the primary entry is the SPA shell. The classic
    - Legacy bookmarks: `/cm/app/?view=arch` and `/cm/app/siteArchitecture.jsp` redirect here
 3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
 
-Default landing can also be set to **Architecture** for a user or role (homepage type
-`Architecture`); login then resolves to the SPA Architecture entry.
+Default landing can also be set to **Navigation** (stored homepage type
+`Architecture`, also accepted as `Navigation`) for a user or role. After sign-in
+with no deep-link return URL, the login form posts to `/cm/app/` so the
+dispatcher applies that preference and opens the Navigation SPA — not Home.
 
 ## Browse a site navigation tree
 
@@ -33,9 +35,14 @@ Default landing can also be set to **Architecture** for a user or role (homepage
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
 4. Expand and collapse nodes with the mouse or keyboard (Enter/Space, Arrow Left/Right).
 5. Use **Refresh** to reload the tree after external changes.
+6. Use **New Site** (Admin or Designer) to open the same traditional-site wizard
+   used in Content Explorer. After a successful create, the new site is selected
+   in this shell.
 
 Empty, loading, and error states are shown explicitly when the site list or tree
-cannot be loaded, or when a site has no sections.
+cannot be loaded, or when a site has no sections. **New Site** remains available
+when the site list is empty so operators can create the first site from this
+screen.
 
 ## Keyboard and accessibility
 
@@ -95,6 +102,7 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | SPA route + top-nav entry under product chrome | **Available** |
 | Role gate (Admin / Designer) | **Available** |
 | Site picker | **Available** |
+| New Site (Explorer create-site wizard) | **Available** |
 | Site navigation tree browse (navons / sections) | **Available** |
 | Structure editing (create / rename / reorder / delete) | **Available** |
 | Landing page / section-link / external-link parity | **Available** |

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -57,9 +57,10 @@ The navigation tree follows the ARIA tree pattern:
 | **Home / End** | Jump to the first or last visible node. |
 | **Enter / Space** | Select the focused section (and toggle expand on branches). |
 
-Structure dialogs (create, rename, landing page, section link, external link, and the
-section picker) are modal (`role="dialog"`, `aria-modal`). **Escape** closes the open
-dialog when a mutation is not in progress. Primary structure actions live in a toolbar
+Structure dialogs (create, rename, landing page, section link, external link, the
+section picker, and **New Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
+closes the open dialog when a mutation is not in progress. Closing **New Site**
+returns keyboard focus to the **New Site** button. Primary structure actions live in a toolbar
 with an accessible name (**Structure actions**).
 
 Chrome strings (shell, tree states, actions, dialogs, validation) use the

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -62,6 +62,16 @@ still apply. Client-side checks require a non-empty password of at least six cha
 and a matching confirmation before submit. Success and failure messages are announced
 to assistive technology via a live region.
 
+## Default landing (homepage)
+
+In **My profile → Preferences**, or **Admin → Users** when editing a user, set
+**Default landing page**. Choose **Navigation** (stored as homepage type
+`Architecture`) to open the site Navigation SPA after sign-in. Leave **Use role
+default** to keep the role homepage. Login without a deep-link return URL posts
+to `/cm/app/` so the dispatcher applies this preference.
+
+See [Architecture & site navigation](id:admin-architecture-navigation).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
+++ b/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
@@ -299,6 +299,7 @@ public class PSLoginServlet extends HttpServlet {
       return;
     }
 
+    String formRedirect = null;
     if (request.getMethod().equalsIgnoreCase("POST")) {
       PSRequest psreq = (PSRequest) getRequestInfo(KEY_PSREQUEST);
 
@@ -312,6 +313,9 @@ public class PSLoginServlet extends HttpServlet {
         uid = psreq.getParameter("j_username");
         pwd = psreq.getParameter("j_password");
         locale = psreq.getParameter("j_locale");
+        // Multipart login form: servlet getParameter() does not see body
+        // fields — take sys_redirect from the parsed PSRequest (#3219).
+        formRedirect = psreq.getParameter(IPSHtmlParameters.SYS_REDIRECT);
 
         if (locale != null) {
           request.getSession().setAttribute(PSI18nUtils.USER_SESSION_OBJECT_SYS_LANG, locale);
@@ -326,7 +330,9 @@ public class PSLoginServlet extends HttpServlet {
 
     String redirect =
         PSRedirectValidation.decodeOverEncodedRedirect(
-            request.getParameter(IPSHtmlParameters.SYS_REDIRECT));
+            !StringUtils.isBlank(formRedirect)
+                ? formRedirect
+                : request.getParameter(IPSHtmlParameters.SYS_REDIRECT));
     if (isValidRedirectUri(request, redirect)) {
       request.getSession().setAttribute(REDIRECT_URL, redirect);
     }
@@ -627,7 +633,8 @@ public class PSLoginServlet extends HttpServlet {
    * <p>Path-absolute SPA entry (query contract). See pure-react-spa design: never use hash
    * fragments on server redirects. Form posts may also supply {@code sys_redirect}.
    */
-  private static final String CMS_INDEX_PAGE = "/cm/app/spa.jsp?entry=home";
+  /** Dispatcher so {@code getUserHomepage()} can land Navigation / Architecture (#3219). */
+  private static final String CMS_INDEX_PAGE = "/cm/app/";
 
   private static final String USER_DIR = "user";
 

--- a/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
+++ b/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
@@ -63,11 +63,9 @@ public class PSLoginServletTest {
     assertEquals(
         "/cm/app/spa.jsp?entry=home",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "/cm/app/spa.jsp?entry=home"));
-    // Default CMS index when blank / null — modern SPA landing
-    assertEquals(
-        "/cm/app/spa.jsp?entry=home", PSLoginServlet.resolveSafePostLoginRedirect(request, null));
-    assertEquals(
-        "/cm/app/spa.jsp?entry=home", PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
+    // Default CMS index when blank / null — dispatcher (homepage resolve, #3219)
+    assertEquals("/cm/app/", PSLoginServlet.resolveSafePostLoginRedirect(request, null));
+    assertEquals("/cm/app/", PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
     // App-relative entry points still allowed
     assertEquals("index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "index.jsp"));
     assertEquals(
@@ -83,15 +81,15 @@ public class PSLoginServletTest {
 
     // External host → fall back to CMS SPA index
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "http://evil.example/phish"));
     // Path traversal
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "/../../etc/passwd"));
     // javascript: scheme (relative form rejected by colon rule)
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "javascript:alert(1)"));
     // Same-host absolute is allowed
     assertEquals(


### PR DESCRIPTION
## Summary

Login always posted `sys_redirect=/cm/app/spa.jsp?entry=home`, and the login servlet ignored multipart form `sys_redirect` (session stayed on Home). A profile/admin homepage of **Navigation** (stored type `Architecture`) therefore opened Home after sign-in.

This slice:

- Defaults unauthenticated login to `/cm/app/` so `index.jsp` applies `getUserHomepage()`
- Reads multipart `sys_redirect` from `PSRequest` after `parseBody()`
- Maps `navigation` / `Architecture` aliases to the Architecture SPA
- Adds **New Site** on `ArchitectureShell` (Explorer `SiteCreateWizard`) for entitled Admin/Designer users
- Updates product-docs for landing + New Site

Parent tracker: #3197 (slice 3 of Navigation QA residual). Epic: #3092.

Fixes #3219

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. QA H2 docker (`perc-devctl qa-up`, `TEST_CMS_URL` from freeport).
2. Sign in as Admin/Designer. Profile → Preferences → Default landing **Navigation** (`Architecture`). Sign out.
3. Sign in with no deep-link return. Confirm Navigation SPA (not Home). Login hidden `sys_redirect` is `/cm/app/`.
4. On Navigation, **New Site** opens the traditional-site wizard; Close hides it.
5. Repeat after logout; restore landing to role default when done.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/architecture-navigation.md`, `product-docs/8.2/admin/users-roles.md`
- [x] **Unit / module tests** — Vitest landing resolve + New Site; Java login/filter tests
- [x] **WebUI + Playwright** — `architecture-shell-smoke.spec.js`, `bugs/bug-3219-nav-homepage-landing.spec.js`, golden smoke
- [x] **Build gates** — standalone `clean install` on `WebUI` and `system`
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- `modules_built=WebUI,system`
- `build_evidence=cd WebUI && ../mvnw clean install` → BUILD SUCCESS (Vitest Tests 2063 passed; Surefire Tests run: 51, Failures: 0). `cd system && ../mvnw clean install` → BUILD SUCCESS (Tests run: 1996, Failures: 0, Errors: 0, Skipped: 241).
- `downstream_checked=none` (no public type made final; login servlet private fallback + parseBody redirect; filter alias only)

### C5 UI proof

- `qa-up` via matrix cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993` (freeport)
- Deploy: copy WebUI `cm/modern/assets` + JSPs; `PSLoginServlet.class` to `WEB-INF/classes`; in-container `StopJetty.sh` / `StartJetty.sh` (not docker restart)
- Playwright: `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` → 2 passed; `npm run test:surface -- --path tests/bugs/bug-3219-nav-homepage-landing.spec.js` → 1 passed; `npm run test:golden` → 2 passed
- `console-clean=yes` (no pageerror on exercised paths)
- `server.log-clean=yes` for the test window. Pre-existing install `PSServerFolderProcessor` PK violation at cell start (not this feature).
