### PR TITLE
fix(WebUI): Admin Administration load without map TypeError (#3202)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -75,6 +75,60 @@ export interface AdminShellProps {
   embedded?: boolean;
 }
 
+interface AdminSectionBoundaryProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+interface AdminSectionBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Isolates a single Admin tab. A TypeError in Workflow/Tasks must not replace
+ * the whole Admin route with RouteErrorBoundary (#3202 / #3195 shared shell).
+ */
+export class AdminSectionErrorBoundary extends React.Component<
+  AdminSectionBoundaryProps,
+  AdminSectionBoundaryState
+> {
+  state: AdminSectionBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): AdminSectionBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error(
+      `[PercModernUI] Admin section failed (${this.props.label})`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      return (
+        <div data-testid="admin-section-error" role="alert">
+          <p>
+            {message(ADMIN_MSG.SECTION_LOAD_FAILED).replace(
+              "{0}",
+              this.props.label,
+            )}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function tabPanel(tab: AdminTab, node: React.ReactNode): React.ReactElement {
+  return (
+    <AdminSectionErrorBoundary label={tab}>{node}</AdminSectionErrorBoundary>
+  );
+}
+
 export const AdminShell: React.FC<AdminShellProps> = ({
   initialTab = "tasks",
   embedded: _embedded = false,
@@ -215,14 +269,16 @@ export const AdminShell: React.FC<AdminShellProps> = ({
         id={`panel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}
       >
-        {activeTab === "tasks" && <TasksSection />}
-        {activeTab === "logs" && <TaskLogsSection />}
-        {activeTab === "notifications" && <TaskNotifications />}
-        {activeTab === "tools" && <ToolsSection />}
-        {activeTab === "workflow" && <WorkflowSection />}
-        {activeTab === "roles" && <RolesSection />}
-        {activeTab === "users" && <UsersSection />}
-        {activeTab === "categories" && <CategoriesSection />}
+        {activeTab === "tasks" && tabPanel("tasks", <TasksSection />)}
+        {activeTab === "logs" && tabPanel("logs", <TaskLogsSection />)}
+        {activeTab === "notifications" &&
+          tabPanel("notifications", <TaskNotifications />)}
+        {activeTab === "tools" && tabPanel("tools", <ToolsSection />)}
+        {activeTab === "workflow" && tabPanel("workflow", <WorkflowSection />)}
+        {activeTab === "roles" && tabPanel("roles", <RolesSection />)}
+        {activeTab === "users" && tabPanel("users", <UsersSection />)}
+        {activeTab === "categories" &&
+          tabPanel("categories", <CategoriesSection />)}
       </main>
     </div>
   );

--- a/WebUI/src/main/ts/admin/TasksSection.tsx
+++ b/WebUI/src/main/ts/admin/TasksSection.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState, useRef } from "react";
 import { get, post, put, del } from "../api/client";
+import { asObjectArray } from "../api/jsonList";
 import { PATHS } from "../api/paths";
 import { message } from "../i18n/message";
 import { ADMIN_MSG } from "./messages";
@@ -50,11 +51,11 @@ export const TasksSection: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const resTasks = await get<ScheduledTask[]>(PATHS.SCHEDULED_TASKS);
-      const resTemplates = await get<NotificationTemplate[]>(`${PATHS.SCHEDULED_TASKS}/templates`);
+      const resTasks = await get<unknown>(PATHS.SCHEDULED_TASKS);
+      const resTemplates = await get<unknown>(`${PATHS.SCHEDULED_TASKS}/templates`);
       if (isMountedRef.current) {
-        setTasks(resTasks || []);
-        setTemplates(resTemplates || []);
+        setTasks(asObjectArray(resTasks) as ScheduledTask[]);
+        setTemplates(asObjectArray(resTemplates) as NotificationTemplate[]);
       }
     } catch (err: any) {
       if (isMountedRef.current) {

--- a/WebUI/src/main/ts/admin/messages.ts
+++ b/WebUI/src/main/ts/admin/messages.ts
@@ -21,6 +21,8 @@ export const ADMIN_MSG = {
    * (not "Administration") when top-nav Admin lands on {@code /admin}.
    */
   ADMIN_TITLE: "perc.ui.dashboard.modern@Admin tools",
+  SECTION_LOAD_FAILED:
+    "perc.ui.admin@Unable to load {0}. Try another Admin tab or reload.",
   TAB_TASKS: "perc.ui.admin@Scheduled Tasks",
   TAB_LOGS: "perc.ui.admin@Execution Logs",
   TAB_NOTIFICATIONS: "perc.ui.admin@Notification Settings",

--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -3,6 +3,7 @@
  */
 
 import { get } from "../client";
+import { asJsonRecord } from "../jsonList";
 import { PATHS } from "../paths";
 import type { WorkflowDef } from "./types";
 
@@ -22,14 +23,57 @@ const LIST_WRAPPER_KEYS = [
   "entries",
 ] as const;
 
+function looksLikeWorkflowItem(obj: Record<string, unknown>): boolean {
+  return (
+    typeof obj.workflowName === "string" ||
+    typeof obj.name === "string" ||
+    Array.isArray(obj.workflowSteps) ||
+    Array.isArray(obj.steps) ||
+    typeof obj.defaultWorkflow === "boolean" ||
+    typeof obj.isDefault === "boolean"
+  );
+}
+
+function unwrapWorkflowWrapper(
+  obj: Record<string, unknown>,
+  depth: number,
+): WorkflowDef[] | null {
+  if (depth > 5) {
+    return null;
+  }
+  for (const key of LIST_WRAPPER_KEYS) {
+    const raw = obj[key];
+    if (raw == null) {
+      continue;
+    }
+    if (Array.isArray(raw)) {
+      return raw as WorkflowDef[];
+    }
+    const nested = asJsonRecord(raw);
+    if (!nested) {
+      continue;
+    }
+    const deeper = unwrapWorkflowWrapper(nested, depth + 1);
+    if (deeper) {
+      return deeper;
+    }
+    if (looksLikeWorkflowItem(nested)) {
+      return [nested as WorkflowDef];
+    }
+  }
+  return null;
+}
+
 /**
  * Parse workflowmanagement metadata list.
  * Accepts a bare JSON array or a known list wrapper object. Unknown object shapes throw
  * so the UI surfaces an error instead of a silent empty catalog.
  *
  * <p>Shared by Developer catalog and Admin WorkflowSection — Jackson WRAP_ROOT often
- * returns {@code { "Workflow": [ ... ] }} (PSUiWorkflowList @JsonRootName), and treating
- * that object as an array causes {@code TypeError: e.map is not a function} (#2959).
+ * returns {@code { "Workflow": [ ... ] }} (PSUiWorkflowList @JsonRootName). Nested
+ * envelopes ({@code { Workflow: { Workflow: [...] } }}) must unwrap fully; treating
+ * a wrapper object as the list causes {@code TypeError: e.map is not a function}
+ * (#2959 / #3202).
  */
 export function parseWorkflowList(payload: unknown): WorkflowDef[] {
   if (payload == null) {
@@ -38,17 +82,11 @@ export function parseWorkflowList(payload: unknown): WorkflowDef[] {
   if (Array.isArray(payload)) {
     return payload as WorkflowDef[];
   }
-  if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    for (const key of LIST_WRAPPER_KEYS) {
-      const raw = obj[key];
-      if (raw == null) continue;
-      if (Array.isArray(raw)) {
-        return raw as WorkflowDef[];
-      }
-      if (typeof raw === "object") {
-        return [raw as WorkflowDef];
-      }
+  const obj = asJsonRecord(payload);
+  if (obj) {
+    const unwrapped = unwrapWorkflowWrapper(obj, 0);
+    if (unwrapped) {
+      return unwrapped;
     }
     throw new Error(
       "Unexpected workflow list payload (expected array or known Workflow wrapper)",

--- a/WebUI/src/main/ts/api/jsonList.ts
+++ b/WebUI/src/main/ts/api/jsonList.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson WRAP_ROOT / JAXB list envelopes used by Admin Administration tabs.
+ * A non-array object stored and then {@code .map}'d is {@code TypeError}
+ * ({@code e.map is not a function}) — #2959 / #3202.
+ */
+
+const MAX_UNWRAP_DEPTH = 5;
+
+export function asJsonRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Coerce a REST list field to {@code string[]}.
+ * Accepts a bare array, a single string (Jackson one-item list), or null.
+ */
+export function asStringArray(value: unknown): string[] {
+  if (value == null) {
+    return [];
+  }
+  if (typeof value === "string") {
+    const t = value.trim();
+    return t ? [t] : [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+/**
+ * Unwrap a named string-list envelope.
+ *
+ * Examples that must not throw or yield a non-array:
+ * - {@code { RoleList: { roles: ["Admin"] } }}
+ * - {@code { RoleList: { roles: "Admin" } }} (single-item)
+ * - {@code { roles: ["Admin"] }} (already unwrapped)
+ * - {@code { RoleList: { roles: { role: ["Admin"] } } }} (JAXB item wrap)
+ */
+export function parseWrappedStringList(
+  payload: unknown,
+  wrapperKeys: readonly string[],
+  itemKeys: readonly string[],
+): string[] {
+  return unwrapStringList(payload, wrapperKeys, itemKeys, 0);
+}
+
+function unwrapStringList(
+  payload: unknown,
+  wrapperKeys: readonly string[],
+  itemKeys: readonly string[],
+  depth: number,
+): string[] {
+  if (depth > MAX_UNWRAP_DEPTH) {
+    return [];
+  }
+  if (payload == null) {
+    return [];
+  }
+  if (typeof payload === "string" || Array.isArray(payload)) {
+    return asStringArray(payload);
+  }
+  const obj = asJsonRecord(payload);
+  if (!obj) {
+    return [];
+  }
+  for (const key of wrapperKeys) {
+    if (key in obj) {
+      const nested = unwrapStringList(
+        obj[key],
+        wrapperKeys,
+        itemKeys,
+        depth + 1,
+      );
+      if (nested.length > 0 || obj[key] == null || Array.isArray(obj[key])) {
+        return nested;
+      }
+    }
+  }
+  for (const key of itemKeys) {
+    if (key in obj) {
+      return unwrapStringList(obj[key], wrapperKeys, itemKeys, depth + 1);
+    }
+  }
+  return [];
+}
+
+/** User/role name lists from {@code GET user/user/roles} and {@code .../users}. */
+export function parseRoleNameList(payload: unknown): string[] {
+  return parseWrappedStringList(
+    payload,
+    ["RoleList", "roleList"],
+    ["roles", "role"],
+  );
+}
+
+export function parseUserNameList(payload: unknown): string[] {
+  return parseWrappedStringList(
+    payload,
+    ["UserList", "userList"],
+    ["users", "user"],
+  );
+}
+
+/**
+ * Coerce a list payload to an array of objects.
+ * Unwraps a single known/first array property; never returns a non-array.
+ */
+export function asObjectArray(payload: unknown): unknown[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  const obj = asJsonRecord(payload);
+  if (!obj) {
+    return [];
+  }
+  for (const value of Object.values(obj)) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return [];
+}

--- a/WebUI/src/main/ts/workflowAdmin/category/CategoriesSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/category/CategoriesSection.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState, useRef } from "react";
 import { get, post } from "../../api/client";
+import { asJsonRecord } from "../../api/jsonList";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
@@ -41,6 +42,30 @@ export interface LockInfo {
   sitename: string;
 }
 
+export function normalizeCategoryNode(raw: unknown): CategoryNode {
+  const o = asJsonRecord(raw) ?? {};
+  const children = Array.isArray(o.childNodes) ? o.childNodes : [];
+  return {
+    id: o.id != null ? String(o.id) : "",
+    title: o.title != null ? String(o.title) : "",
+    selectable: Boolean(o.selectable),
+    childNodes: children.map((child) => normalizeCategoryNode(child)),
+    deleted: typeof o.deleted === "boolean" ? o.deleted : undefined,
+    createdBy: typeof o.createdBy === "string" ? o.createdBy : undefined,
+  };
+}
+
+export function normalizeCategoryTree(raw: unknown): CategoryTree {
+  const o = asJsonRecord(raw) ?? {};
+  const nodes = Array.isArray(o.topLevelNodes) ? o.topLevelNodes : [];
+  return {
+    title: o.title != null ? String(o.title) : "Categories",
+    allowedSites:
+      typeof o.allowedSites === "string" ? o.allowedSites : undefined,
+    topLevelNodes: nodes.map((n) => normalizeCategoryNode(n)),
+  };
+}
+
 export const CategoriesSection: React.FC = () => {
   const [tree, setTree] = useState<CategoryTree | null>(null);
   const [lockInfo, setLockInfo] = useState<LockInfo | null>(null);
@@ -64,7 +89,7 @@ export const CategoriesSection: React.FC = () => {
       const lock = await get<LockInfo>(PATHS.CATEGORY_LOCK_INFO);
       
       if (isMountedRef.current) {
-        setTree(res || { title: "Categories", topLevelNodes: [] });
+        setTree(normalizeCategoryTree(res));
         setLockInfo(lock);
         // Try to identify current user if lock has it, or default to current user session check
         if (lock && lock.userName) {
@@ -318,7 +343,9 @@ export const CategoriesSection: React.FC = () => {
         {/* Children rendering */}
         {isExpanded && hasChildren && (
           <div style={{ marginTop: "4px" }}>
-            {node.childNodes.map((child) => renderNode(child, depth + 1))}
+            {(Array.isArray(node.childNodes) ? node.childNodes : []).map(
+              (child) => renderNode(child, depth + 1),
+            )}
           </div>
         )}
       </div>
@@ -381,7 +408,7 @@ export const CategoriesSection: React.FC = () => {
         {tree && tree.topLevelNodes.length === 0 ? (
           <div style={{ padding: "20px", textAlign: "center", color: "#94a3b8" }}>No categories available.</div>
         ) : (
-          tree?.topLevelNodes.map((node) => renderNode(node))
+          (tree?.topLevelNodes ?? []).map((node) => renderNode(node))
         )}
       </div>
 

--- a/WebUI/src/main/ts/workflowAdmin/role/RolesSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/role/RolesSection.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState } from "react";
 import { get, post } from "../../api/client";
+import { asStringArray, parseRoleNameList } from "../../api/jsonList";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
@@ -38,18 +39,21 @@ export const RolesSection: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      // 1. Get all role names from user service
-      const res = await get<{ RoleList: { roles: string[] } }>(PATHS.USER_ROLES);
-      const roleNames = res?.RoleList?.roles || [];
+      const res = await get<unknown>(PATHS.USER_ROLES);
+      const roleNames = parseRoleNameList(res);
 
-      // 2. Fetch full details for each role using ROLES_FIND
       const details = await Promise.all(
         roleNames.map(async (name) => {
           try {
-            const r = await post<{ Role: Role }>(PATHS.ROLES_FIND, {
+            const r = await post<{ Role?: Role }>(PATHS.ROLES_FIND, {
               psstring: { value: name },
             });
-            return r?.Role || { name, description: "", users: [] };
+            const role = r?.Role || { name, description: "", users: [] };
+            return {
+              name: role.name || name,
+              description: role.description || "",
+              users: asStringArray(role.users),
+            };
           } catch {
             return { name, description: "", users: [] };
           }

--- a/WebUI/src/main/ts/workflowAdmin/user/UsersSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/user/UsersSection.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState } from "react";
 import { get, del } from "../../api/client";
+import { asStringArray, parseUserNameList } from "../../api/jsonList";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
@@ -41,14 +42,21 @@ export const UsersSection: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await get<{ UserList: { users: string[] } }>(PATHS.USERS);
-      const userNames = res?.UserList?.users || [];
+      const res = await get<unknown>(PATHS.USERS);
+      const userNames = parseUserNameList(res);
 
       const details = await Promise.all(
         userNames.map(async (name) => {
           try {
             const u = await get<User>(`${PATHS.USER_FIND}/${encodeURIComponent(name)}`);
-            return u;
+            const providerType: User["providerType"] =
+              u?.providerType === "DIRECTORY" ? "DIRECTORY" : "INTERNAL";
+            return {
+              name: u?.name || name,
+              email: u?.email,
+              providerType,
+              roles: asStringArray(u?.roles),
+            };
           } catch {
             return { name, providerType: "INTERNAL" as const, roles: [] };
           }

--- a/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowEditor.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowEditor.tsx
@@ -133,7 +133,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             data-testid="workflow-staging-role-select"
           >
             <option value="">-- {message(WF_ADMIN_MSG.NONE)} --</option>
-            {availableRoles.map((role) => (
+            {(Array.isArray(availableRoles) ? availableRoles : []).map((role) => (
               <option key={role} value={role}>
                 {role}
               </option>

--- a/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, useState } from "react";
 import { get, post, put, del } from "../../api/client";
 import { parseWorkflowList } from "../../api/developer/workflowsApi";
+import { parseRoleNameList } from "../../api/jsonList";
 import type { WorkflowDef } from "../../api/developer/types";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
@@ -87,14 +88,14 @@ export const WorkflowSection: React.FC = () => {
       // not a bare array — parseWorkflowList unwraps before map (#2959).
       const [wfPayload, rolesRes] = await Promise.all([
         get<unknown>(PATHS.WORKFLOW_METADATA),
-        get<{ RoleList: { roles: string[] } }>(PATHS.USER_ROLES).catch(() => null),
+        get<unknown>(PATHS.USER_ROLES).catch(() => null),
       ]);
       const parsed = parseWorkflowList(wfPayload);
       const list = Array.isArray(parsed)
         ? parsed.map((row) => toWorkflowDefinition(row))
         : [];
       setWorkflows(list);
-      setAvailableRoles(rolesRes?.RoleList?.roles || []);
+      setAvailableRoles(parseRoleNameList(rolesRes));
     } catch (err) {
       setWorkflows([]);
       setError(message(WF_ADMIN_MSG.ERROR_GENERIC));

--- a/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowStepList.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowStepList.tsx
@@ -209,8 +209,10 @@ export const WorkflowStepList: React.FC<WorkflowStepListProps> = ({
                 {message(WF_ADMIN_MSG.STEP_ROLES)}
               </label>
               <div style={{ maxHeight: "150px", overflowY: "auto", border: "1px solid #ccc", padding: "8px" }}>
-                {availableRoles.length === 0 ? (
-                  <span style={{ color: "#666" }}>{message(WF_ADMIN_MSG.NO_ROLES_AVAILABLE)}</span>
+                {(Array.isArray(availableRoles) ? availableRoles : []).length === 0 ? (
+                  <span style={{ color: "#666" }}>
+                    {message(WF_ADMIN_MSG.NO_ROLES_AVAILABLE)}
+                  </span>
                 ) : (
                   availableRoles.map((role) => (
                     <label key={role} style={{ display: "block", marginBottom: "4px" }}>

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -18,7 +18,10 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
-import { AdminShell } from "../../../main/ts/admin/AdminShell";
+import {
+  AdminSectionErrorBoundary,
+  AdminShell,
+} from "../../../main/ts/admin/AdminShell";
 
 // Mock child components
 vi.mock("../../../main/ts/admin/TasksSection", () => ({
@@ -114,6 +117,22 @@ describe("AdminShell", () => {
     const toolsTab = screen.getByTestId("tab-tools");
     fireEvent.click(toolsTab);
     expect(screen.getByTestId("mock-tools-section")).toBeDefined();
+  });
+
+  it("isolates a throwing Admin tab without RouteErrorBoundary (#3202 / #3195)", () => {
+    const Boom: React.FC = () => {
+      throw new Error("section boom");
+    };
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(
+      <AdminSectionErrorBoundary label="workflow">
+        <Boom />
+      </AdminSectionErrorBoundary>,
+    );
+    expect(screen.getByTestId("admin-section-error")).toBeDefined();
+    expect(screen.getByText(/Unable to load workflow/i)).toBeDefined();
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    spy.mockRestore();
   });
 
   it("hosts former Workflow admin sections as Admin tabs (#3088)", () => {

--- a/WebUI/src/test/ts/admin/TasksSection.test.tsx
+++ b/WebUI/src/test/ts/admin/TasksSection.test.tsx
@@ -60,6 +60,31 @@ describe("TasksSection", () => {
     expect(screen.getByText("0 0 12 * * ?")).toBeTruthy();
   });
 
+  it("unwraps WRAP_ROOT task list without crashing (#3202)", async () => {
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (url.includes("templates")) {
+        return { NotificationTemplate: [] };
+      }
+      return {
+        ScheduledTask: [
+          {
+            id: "task-wrap",
+            name: "Wrapped Task",
+            cronSpecification: "0 0 * * * ?",
+            extensionName: "com.percussion.services.schedule.impl.PSPurgeScheduledTaskLog",
+          },
+        ],
+      };
+    });
+
+    render(<TasksSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-tasks-section")).toBeDefined();
+    });
+    expect(screen.getByText("Wrapped Task")).toBeTruthy();
+  });
+
   it("opens create dialog when create button is clicked", async () => {
     vi.mocked(client.get).mockImplementation(async (url: string) => {
       if (url.includes("templates")) {

--- a/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
@@ -50,6 +50,28 @@ describe("parseWorkflowList", () => {
     ).toEqual([{ workflowName: "Only One", defaultWorkflow: true }]);
   });
 
+  it("unwraps nested Workflow WRAP_ROOT (#3202)", () => {
+    expect(
+      parseWorkflowList({
+        Workflow: {
+          Workflow: [
+            { workflowName: "Default Workflow", defaultWorkflow: true },
+          ],
+        },
+      }),
+    ).toEqual([{ workflowName: "Default Workflow", defaultWorkflow: true }]);
+  });
+
+  it("unwraps PSUiWorkflowList envelope with inner Workflow array", () => {
+    expect(
+      parseWorkflowList({
+        PSUiWorkflowList: {
+          Workflow: [{ workflowName: "Simple Workflow" }],
+        },
+      }),
+    ).toEqual([{ workflowName: "Simple Workflow" }]);
+  });
+
   it("unwraps WorkflowList / entries aliases", () => {
     expect(
       parseWorkflowList({ WorkflowList: [{ workflowName: "A" }] }),

--- a/WebUI/src/test/ts/api/jsonList.test.ts
+++ b/WebUI/src/test/ts/api/jsonList.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  asObjectArray,
+  asStringArray,
+  parseRoleNameList,
+  parseUserNameList,
+} from "../../../main/ts/api/jsonList";
+
+describe("asStringArray", () => {
+  it("returns empty for null / non-list", () => {
+    expect(asStringArray(null)).toEqual([]);
+    expect(asStringArray(undefined)).toEqual([]);
+    expect(asStringArray(1)).toEqual([]);
+  });
+
+  it("wraps a single Jackson string item", () => {
+    expect(asStringArray("Admin")).toEqual(["Admin"]);
+  });
+
+  it("filters blank array entries", () => {
+    expect(asStringArray(["Admin", "  ", "Editor"])).toEqual([
+      "Admin",
+      "Editor",
+    ]);
+  });
+});
+
+describe("parseRoleNameList", () => {
+  it("unwraps RoleList.roles array", () => {
+    expect(
+      parseRoleNameList({ RoleList: { roles: ["Admin", "Editor"] } }),
+    ).toEqual(["Admin", "Editor"]);
+  });
+
+  it("unwraps single-string roles (failing #3202 payload shape)", () => {
+    expect(parseRoleNameList({ RoleList: { roles: "Admin" } })).toEqual([
+      "Admin",
+    ]);
+  });
+
+  it("unwraps JAXB item wrap", () => {
+    expect(
+      parseRoleNameList({ RoleList: { roles: { role: ["Admin", "Author"] } } }),
+    ).toEqual(["Admin", "Author"]);
+  });
+
+  it("accepts already-unwrapped { roles }", () => {
+    expect(parseRoleNameList({ roles: ["Contributor"] })).toEqual([
+      "Contributor",
+    ]);
+  });
+
+  it("returns empty for null / unknown object", () => {
+    expect(parseRoleNameList(null)).toEqual([]);
+    expect(parseRoleNameList({ unexpected: true })).toEqual([]);
+  });
+});
+
+describe("parseUserNameList", () => {
+  it("unwraps UserList.users and single-string users", () => {
+    expect(parseUserNameList({ UserList: { users: ["admin"] } })).toEqual([
+      "admin",
+    ]);
+    expect(parseUserNameList({ UserList: { users: "admin" } })).toEqual([
+      "admin",
+    ]);
+  });
+});
+
+describe("asObjectArray", () => {
+  it("returns bare arrays and unwraps first array property", () => {
+    expect(asObjectArray([{ id: "1" }])).toEqual([{ id: "1" }]);
+    expect(asObjectArray({ ScheduledTask: [{ id: "1" }] })).toEqual([
+      { id: "1" },
+    ]);
+  });
+
+  it("returns empty for null / non-list objects", () => {
+    expect(asObjectArray(null)).toEqual([]);
+    expect(asObjectArray({ empty: false })).toEqual([]);
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/CategoriesSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/CategoriesSection.test.tsx
@@ -74,6 +74,22 @@ describe("CategoriesSection", () => {
     expect(screen.getByTestId("lock-indicator-2")).toBeTruthy();
   });
 
+  it("renders empty tree when topLevelNodes is missing (#3202)", async () => {
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (url.includes("category/all")) {
+        return { title: "Categories" };
+      }
+      return { userName: "", sessionId: "", sitename: "" };
+    });
+
+    render(<CategoriesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-categories-section")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("route-error")).toBeNull();
+  });
+
   it("acquires lock when lock tab button clicked", async () => {
     vi.mocked(client.get).mockImplementation(async (url: string) => {
       if (url.includes("category/all")) {

--- a/WebUI/src/test/ts/workflowAdmin/RolesSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/RolesSection.test.tsx
@@ -58,6 +58,23 @@ describe("RolesSection", () => {
     expect(screen.getByTestId("role-card-Contributor")).toBeTruthy();
   });
 
+  it("does not crash when RoleList.roles is a single string (#3202)", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      RoleList: { roles: "Admin" },
+    });
+    vi.mocked(client.post).mockResolvedValue({
+      Role: { name: "Admin", description: "Administrator", users: "admin" },
+    });
+
+    render(<RolesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("role-card-Admin")).toBeTruthy();
+    });
+    expect(screen.getByTestId("perc-roles-section")).toBeTruthy();
+    expect(screen.queryByTestId("route-error")).toBeNull();
+  });
+
   it("opens editor when create role button clicked", async () => {
     vi.mocked(client.get).mockResolvedValue({ RoleList: { roles: [] } });
 

--- a/WebUI/src/test/ts/workflowAdmin/UsersSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/UsersSection.test.tsx
@@ -64,6 +64,29 @@ describe("UsersSection", () => {
     expect(screen.getByTestId("user-card-editor")).toBeTruthy();
   });
 
+  it("does not crash when UserList.users is a single string (#3202)", async () => {
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (url.includes("user/users")) {
+        return { UserList: { users: "admin" } };
+      }
+      if (url.includes("user/find/admin")) {
+        return {
+          name: "admin",
+          providerType: "INTERNAL",
+          roles: "Admin",
+        };
+      }
+      return {};
+    });
+
+    render(<UsersSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user-card-admin")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("route-error")).toBeNull();
+  });
+
   it("opens create user editor on button click", async () => {
     vi.mocked(client.get).mockResolvedValue({ UserList: { users: [] } });
 

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
@@ -104,6 +104,28 @@ describe("WorkflowSection", () => {
     expect(getUrls.some((u) => u.includes("user/roles") || u.endsWith("/roles"))).toBe(true);
   });
 
+  it("unwraps nested Workflow WRAP_ROOT without throwing (#3202)", async () => {
+    mockGets({
+      Workflow: {
+        Workflow: [
+          {
+            workflowName: "Default Workflow",
+            defaultWorkflow: true,
+            stagingRoleNames: "Editor",
+          },
+        ],
+      },
+    });
+
+    render(<WorkflowSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-workflow-section")).toBeTruthy();
+      expect(screen.getByTestId("workflow-row-Default Workflow")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("route-error")).toBeNull();
+  });
+
   it("unwraps Jackson Workflow root wrapper without throwing (#2959)", async () => {
     mockGets({
       Workflow: [

--- a/docs/ai-generated/code-reviews/perc-system-pscollection-compile-erlang.md
+++ b/docs/ai-generated/code-reviews/perc-system-pscollection-compile-erlang.md
@@ -1,0 +1,70 @@
+# Erlang review: perc-system PSCollection compile restore
+
+## Summary
+
+PR #3173 parameterized `PSCollection` as `PSConcurrentList<Object>` (`List<Object>`).
+That is not source-compatible with perc-system: `Iterator` is invariant, so
+`PSRelationshipSet.iterator()` returning `Iterator<PSRelationship>` cannot implement
+`List<Object>.iterator()`, and `Iterator<Object>` cannot be assigned to
+`Iterator<PSDisplayMapping>` (and the same pattern across objectstore/cms/security).
+
+This change parameterizes `PSCollection<E> extends PSConcurrentList<E>`. Raw
+subclasses (`PSCollectionComponent`, TableFactory collections) remain raw lists,
+so covariant `iterator()` overrides and `Iterable<Specific>` assignments compile
+again. Typed `PSCollection<String>` is a real `List<String>`. Iterator-from-
+constructor uses a snapshot + private ctor so it does not call overridable `add`
+during construction.
+
+## Scope
+
+- Uncommitted vs `HEAD` on `fix/perc-system-pscollection-compile` (from `main`)
+- Files:
+  - `modules/utils/src/main/java/com/percussion/util/PSCollection.java`
+  - `modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java`
+  - `modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java`
+- Out of scope: perc-system / TableFactory sources (consumers only)
+- Memory patterns hit: missing behavioral tests (addressed); change-class closure
+  (utils type + consumer compile); do not lock historically raw collections to
+  `List<Object>`; no path I/O
+- Cross-platform path review: N/A (no file I/O / path construction)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: no — typed list API, runtime `checkType`, covariant
+  raw-subclass `iterator()` / `Iterable<E>`
+- Change-class closure: yes — producer (`utils`) plus verified perc-system and
+  TableFactory standalone clean installs
+- Agent rule files: none in this diff
+
+## Issues
+
+None.
+
+### Suggestion (non-blocking)
+
+Later batches can parameterize `PSCollectionComponent<E>` and product subclasses
+so raw-type warnings at `extends PSCollection` go to zero. Do **not** “fix” those
+by locking the base type to `List<Object>` again.
+
+## Verification noted
+
+```text
+cd modules/utils
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 382, Failures: 0, Errors: 0, Skipped: 9
+# PSCollectionTypedTest: 6 tests, 0 fail
+
+cd system
+..\mvnw.cmd clean install
+# BUILD SUCCESS — Tests run: 1996, Failures: 0, Errors: 0, Skipped: 241
+
+cd modules/TableFactory
+..\..\mvnw.cmd clean install
+# BUILD SUCCESS (consumer still compiles after #3216 + this change)
+```

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
@@ -1,17 +1,19 @@
 /**
- * Regression: Admin → Workflow fails with TypeError e.map is not a function (#2959).
+ * Regression: Admin → Workflow fails with TypeError e.map is not a function
+ * (#2959 / residual #3202).
  *
  * GET workflowmanagement/workflows/metadata often returns a Jackson root wrapper
- * ({ Workflow: [...] }). WorkflowSection must unwrap before workflows.map so the
+ * ({ Workflow: [...] } or nested { Workflow: { Workflow: [...] } }).
+ * Workflow / Roles / Users / Categories must unwrap before .map so the
  * Admin shell loads without RouteErrorBoundary.
  *
  * #3088: Workflow admin lives under unified AdminShell (not sibling Workflow shell).
  *
- * Tags: @workflow-admin @administration @smoke @bug-2959
+ * Tags: @workflow-admin @administration @smoke @bug-2959 @bug-3202
  *
  * Surface filter:
  *   npm run test:surface -- --path tests/bugs/bug-2959-admin-workflow-section.spec.js
- *   npm run test:surface -- --tag bug-2959
+ *   npm run test:surface -- --tag bug-3202
  */
 
 const { test, expect } = require("@playwright/test");
@@ -74,6 +76,51 @@ test.describe("Administration WorkflowSection load (#2959)", () => {
       await expect(
         page.locator("[data-testid='perc-workflow-section']"),
       ).toBeVisible({ timeout: 30_000 });
+    },
+  );
+
+  test(
+    "Administration tabs render without RouteErrorBoundary or console TypeError (#3202)",
+    {
+      tag: ["@workflow-admin", "@administration", "@bug-3202", "@smoke"],
+    },
+    async ({ page }) => {
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await page.goto(`${BASE_URL}/cm/app/index.jsp?view=admin`);
+      await expect(page.locator("[data-testid='perc-admin-shell']")).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
+
+      const tabs = [
+        ["tab-workflow", "perc-workflow-section"],
+        ["tab-roles", "perc-roles-section"],
+        ["tab-users", "perc-users-section"],
+        ["tab-categories", "perc-categories-section"],
+        ["tab-tools", "perc-tools-section"],
+      ];
+      for (const [tabId, sectionId] of tabs) {
+        await page.locator(`[data-testid='${tabId}']`).click();
+        await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
+        await expect(page.getByText(/Unable to load Admin/i)).toHaveCount(0);
+        await expect(page.locator(`[data-testid='${sectionId}']`)).toBeVisible({
+          timeout: 30_000,
+        });
+      }
+
+      const mapErrors = consoleErrors.filter((m) =>
+        /map is not a function|Route load\/render failed/i.test(m),
+      );
+      expect(mapErrors, mapErrors.join("\n")).toEqual([]);
     },
   );
 });

--- a/modules/utils/src/main/java/com/percussion/util/PSCollection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSCollection.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -25,15 +26,20 @@ import java.util.Objects;
  * The PSCollection class is used to maintain a collection of objects. Objects can be added, changed
  * or removed from the collection. All objects in the collection must be of the same class.
  *
- * <p>Element type is {@link Object} at the list API surface (historical heterogeneous product use);
- * runtime membership is still enforced via {@link #m_memberClass}. Parameterized as {@code
- * PSConcurrentList<Object>} so callers and subclasses no longer sit on a raw concurrent list.
+ * <p>Parameterized as {@code PSConcurrentList<E>} so a typed collection is {@code List<E>} (and
+ * {@code iterator()} is {@code Iterator<E>}). Raw {@code PSCollection} (historical product
+ * subclasses such as {@code PSCollectionComponent}) stay a raw list, so covariant {@code
+ * iterator()} overrides remain legal. Do not lock the public type to {@code List<Object>} — that
+ * makes {@code Iterator<Specific>} incompatible with {@code List.iterator()}.
  *
+ * <p>Runtime membership is still enforced via {@link #m_memberClass}.
+ *
+ * @param <E> element type
  * @author Tas Giakouminakis
  * @version 1.0
  * @since 1.0
  */
-public class PSCollection extends PSConcurrentList<Object> {
+public class PSCollection<E> extends PSConcurrentList<E> {
 
   /**
    * Serialization id. Parent {@link PSConcurrentList} owns list payload serialization; this class
@@ -47,8 +53,9 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param className the name of the class which this collection's members must be or extend
    * @exception ClassNotFoundException if the specified class cannot be found
    */
+  @SuppressWarnings("unchecked")
   public PSCollection(String className) throws ClassNotFoundException {
-    this(Class.forName(className));
+    this((Class<? extends E>) Class.forName(className));
   }
 
   /**
@@ -56,7 +63,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    *
    * @param cl the class which this collection's members must be or extend
    */
-  public PSCollection(Class<?> cl) {
+  public PSCollection(Class<? extends E> cl) {
     m_memberClass = cl;
   }
 
@@ -67,8 +74,8 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param cl the class which this collection's members must be or extend.
    * @param initialCapacity the initial capacity of the collection.
    */
-  public PSCollection(Class<?> cl, int initialCapacity) {
-    super(Object.class, initialCapacity);
+  public PSCollection(Class<? extends E> cl, int initialCapacity) {
+    super(cl, initialCapacity);
     m_memberClass = cl;
   }
 
@@ -79,15 +86,18 @@ public class PSCollection extends PSConcurrentList<Object> {
    *     type. May not be <code>null</code>.
    * @throws ClassCastException if all of the objects under the iterator are not of the same type.
    */
-  public PSCollection(Iterator<?> i) throws ClassCastException {
-    m_memberClass = null;
+  public PSCollection(Iterator<? extends E> i) throws ClassCastException {
+    this(snapshot(i));
+  }
 
-    while (i.hasNext()) {
-      Object o = i.next();
-      if (m_memberClass == null) m_memberClass = o.getClass();
-
-      super.add(o);
-    }
+  /**
+   * Secondary ctor so the iterator snapshot can be passed to {@link
+   * PSConcurrentList#PSConcurrentList(java.util.List)} without calling overridable {@code add}
+   * during construction (this-escape).
+   */
+  private PSCollection(Snapshot<E> snapshot) {
+    super(snapshot.items);
+    m_memberClass = snapshot.memberClass;
   }
 
   /** Default constructor needed for serialization. */
@@ -105,7 +115,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public void add(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
+  public void add(int index, E o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     super.add(index, o);
@@ -121,7 +131,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean add(Object o) throws ClassCastException {
+  public boolean add(E o) throws ClassCastException {
     checkType(o);
 
     return super.add(o);
@@ -135,7 +145,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @param o the object to add to the collection
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public void addElement(Object o) throws ClassCastException {
+  public void addElement(E o) throws ClassCastException {
     add(o);
   }
 
@@ -149,7 +159,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean addAll(Collection<?> c)
+  public boolean addAll(Collection<? extends E> c)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
@@ -167,7 +177,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public boolean addAll(int index, Collection<?> c)
+  public boolean addAll(int index, Collection<? extends E> c)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(c);
 
@@ -186,7 +196,7 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ClassCastException if the object is not of the appropriate class
    */
   @Override
-  public Object set(int index, Object o) throws ArrayIndexOutOfBoundsException, ClassCastException {
+  public E set(int index, E o) throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     return super.set(index, o);
@@ -202,14 +212,14 @@ public class PSCollection extends PSConcurrentList<Object> {
    * @throws ArrayIndexOutOfBoundsException if index is out of range
    * @throws ClassCastException if the object is not of the appropriate class
    */
-  public void setElementAt(Object o, int index)
+  public void setElementAt(E o, int index)
       throws ArrayIndexOutOfBoundsException, ClassCastException {
     checkType(o);
 
     set(index, o);
   }
 
-  public void insertElementAt(Object o, int i) {
+  public void insertElementAt(E o, int i) {
     this.add(i, o);
   }
 
@@ -234,7 +244,7 @@ public class PSCollection extends PSConcurrentList<Object> {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PSCollection that)) return false;
+    if (!(o instanceof PSCollection<?> that)) return false;
     return Objects.equals(m_memberClass, that.m_memberClass);
   }
 
@@ -299,7 +309,7 @@ public class PSCollection extends PSConcurrentList<Object> {
     return copy;
   }
 
-  public Object lastElement() {
+  public E lastElement() {
     if (this.size() > 0) {
       return this.get(this.size() - 1);
     } else {
@@ -311,15 +321,38 @@ public class PSCollection extends PSConcurrentList<Object> {
     this.clear();
   }
 
-  public Object elementAt(int index) {
+  public E elementAt(int index) {
     return this.get(index);
   }
 
-  public Object firstElement() {
+  public E firstElement() {
     if (this.size() > 0) return this.get(0);
     else throw new NoSuchElementException();
   }
 
   /** The one and only valid class type for this collection. */
   private Class<?> m_memberClass;
+
+  private static <T> Snapshot<T> snapshot(Iterator<? extends T> i) {
+    ArrayList<T> items = new ArrayList<>();
+    Class<?> member = null;
+    while (i.hasNext()) {
+      T o = i.next();
+      if (member == null) {
+        member = o.getClass();
+      }
+      items.add(o);
+    }
+    return new Snapshot<>(member, items);
+  }
+
+  private static final class Snapshot<T> {
+    private final Class<?> memberClass;
+    private final ArrayList<T> items;
+
+    private Snapshot(Class<?> memberClass, ArrayList<T> items) {
+      this.memberClass = memberClass;
+      this.items = items;
+    }
+  }
 }

--- a/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
@@ -29,15 +29,15 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Behavioral coverage for {@link PSCollection} after parameterizing as {@code
- * PSConcurrentList<Object>} with {@code Class<?>}/{@code Collection<?>}/{@code Iterator<?>}
- * surfaces (#3015 batch 8).
+ * PSConcurrentList<E>}. Residual of #3015 batch 8 / #3173: locking the type to {@code
+ * List<Object>} broke perc-system covariant {@code iterator()} overrides.
  */
 @Tag("UnitTest")
 public class PSCollectionTypedTest {
 
   @Test
-  public void memberClassAndElementsRoundTripThroughObjectListApi() {
-    PSCollection coll = new PSCollection(String.class);
+  public void memberClassAndElementsRoundTripThroughTypedListApi() {
+    PSCollection<String> coll = new PSCollection<>(String.class);
     assertEquals(String.class, coll.getMemberClassType());
     assertTrue(coll.add("a"));
     coll.add(0, "b");
@@ -47,30 +47,79 @@ public class PSCollectionTypedTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void addAllRejectsWrongElementType() {
-    PSCollection coll = new PSCollection(String.class);
+    PSCollection<String> coll = new PSCollection<>(String.class);
     coll.add("ok");
     List<Object> mixed = new ArrayList<>();
     mixed.add("fine");
     mixed.add(Integer.valueOf(1));
-    assertThrows(ClassCastException.class, () -> coll.addAll(mixed));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.addAll(mixed));
     assertEquals(1, coll.size());
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void iteratorCtorInfersMemberClass() {
     Iterator<String> it = Arrays.asList("x", "y").iterator();
-    PSCollection coll = new PSCollection(it);
+    PSCollection<String> coll = new PSCollection<>(it);
     assertEquals(String.class, coll.getMemberClassType());
     assertEquals(2, coll.size());
     assertEquals("x", coll.get(0));
-    assertThrows(ClassCastException.class, () -> coll.add(Integer.valueOf(3)));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.add(Integer.valueOf(3)));
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void initialCapacityCtorStillEnforcesType() {
-    PSCollection coll = new PSCollection(Integer.class, 8);
+    PSCollection<Integer> coll = new PSCollection<>(Integer.class, 8);
     assertTrue(coll.add(Integer.valueOf(1)));
-    assertThrows(ClassCastException.class, () -> coll.add("nope"));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.add("nope"));
+  }
+
+  @Test
+  public void typedCollectionIteratorIsElementType() {
+    PSCollection<String> coll = new PSCollection<>(String.class);
+    coll.add("a");
+    Iterator<String> it = coll.iterator();
+    assertEquals("a", it.next());
+    Iterable<String> iterable = coll;
+    int n = 0;
+    for (String s : iterable) {
+      n++;
+      assertEquals("a", s);
+    }
+    assertEquals(1, n);
+  }
+
+  /**
+   * perc-system pattern: raw {@code PSCollection} / {@code PSCollectionComponent} subclasses
+   * override {@code iterator()} to {@code Iterator<Specific>} and pass the set as {@code
+   * Iterable<Specific>}.
+   */
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void rawSubclassMayOverrideCovariantIterator() {
+    class TypedRaw extends PSCollection {
+      private static final long serialVersionUID = 1L;
+
+      TypedRaw() {
+        super(String.class);
+      }
+
+      @Override
+      public Iterator<String> iterator() {
+        return super.iterator();
+      }
+    }
+    TypedRaw coll = new TypedRaw();
+    coll.add("a");
+    Iterator<String> it = coll.iterator();
+    assertEquals("a", it.next());
+    Iterable<String> iterable = coll;
+    assertEquals("a", iterable.iterator().next());
   }
 }

--- a/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
@@ -88,11 +88,11 @@ public class PSConcurrentListSerializationTest {
 
   @Test
   public void testCollectionRoundTripPreservesMemberClassAndElements() throws Exception {
-    PSCollection original = new PSCollection(String.class);
+    PSCollection<String> original = new PSCollection<>(String.class);
     original.add("one");
     original.add("two");
 
-    PSCollection restored = roundTrip(original);
+    PSCollection<String> restored = roundTrip(original);
 
     assertNotNull(restored);
     assertEquals(String.class, restored.getMemberClassType());

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -32,6 +32,11 @@ Legacy bookmarks and deep links under `/workflow` and `/workflow/:tab` redirect 
 matching Admin tab (for example `/admin/workflow`, `/admin/roles`). There is no separate
 Workflow administration shell or sibling cross-link between Admin tools and Administration.
 
+Each tab should show its list or empty state. If a tab cannot load its data, the rest of
+the Admin shell (title and tab list) stays usable so you can switch tabs or reload —
+you should not see a full-page **Unable to load Admin** / **Unable to load Administration**
+panel for a single tab failure.
+
 Non-administrators never see the Admin top-nav item or these configuration surfaces.
 
 ## Topics


### PR DESCRIPTION
## Summary

Admin → Administration still failed human QA after #2959 because Jackson WRAP_ROOT / nested `{ Workflow: { Workflow: [...] } }` envelopes and single-string `RoleList.roles` / `UserList.users` fields were treated as arrays. Mapping those objects produced `TypeError: e.map is not a function` and `RouteErrorBoundary`.

This PR:

- Recursively unwraps workflow list envelopes in `parseWorkflowList` (nested WRAP_ROOT, `PSUiWorkflowList` inner `Workflow` array)
- Adds `jsonList` helpers so Role/User/Task lists are always arrays (including Jackson one-item strings)
- Guards Categories `topLevelNodes` / `childNodes`
- Isolates each Admin tab in `AdminSectionErrorBoundary` so one section TypeError cannot blank the whole Admin route (shared root with #3195; not a Tools rewrite)

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3202
Related: #2711, #2959, #3195

## Test plan

1. Log in as Admin on QA H2 (`perc-devctl qa-up`, use printed `TEST_CMS_URL`).
2. Open **Admin**. Confirm shell + tablist (no **Unable to load Admin**).
3. Open **Workflow**, **Roles**, **Users**, **Categories**. Each tab shows list or empty state; no RouteErrorBoundary.
4. Browser console: no `map is not a function` / route-load failures.
5. Optional: **System Tools** still reachable (same shell). Full Tools rewrite remains #3195 if a tool-specific crash exists.

Env: QA H2 docker; Admin credentials from qa-up.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/index.md` (Admin tabs stay usable if one tab fails)
- [x] **Unit / module tests** — Vitest for unwrap helpers + Workflow/Roles/Users/Categories/Tasks/AdminShell; WebUI standalone `clean install` green
- [x] **WebUI + Playwright** — `tests/bugs/bug-2959-admin-workflow-section.spec.js` (incl. #3202 tab sweep + console TypeError gate)
- [x] **Build gates** — `cd WebUI && ../mvnw.cmd clean install` **BUILD SUCCESS**; Tests run: 2075, Failures: 0
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- `modules_built=WebUI`
- `build_evidence=cd WebUI && ../mvnw.cmd clean install → BUILD SUCCESS; Tests run: 2075, Failures: 0 (Vitest 291 files)`
- `downstream_checked=none` (C2 did not apply: no Java `final`/signature/package-visible API change)

### C5 UI proof

- QA cell: existing healthy `perc-matrix-cms-h2`; `TEST_CMS_URL=http://127.0.0.1:9993`
- Deploy: hot-copy `WebUI/target/generated-webui/cm/modern` → container `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern`
- Playwright: `npm run test:surface -- --path tests/bugs/bug-2959-admin-workflow-section.spec.js` → **3 passed**
- Golden: `npm run test:golden` → **2 passed**
- `console-clean=yes` (no `map is not a function` / Route load/render failed on Administration tabs)
- `server.log-clean=no` — pre-existing `PSRuntimeExceptionMapper` / JAXB `IllegalAnnotationExceptions` also seen before this feature window; not Administration unwrap. Audit log list still `SUCCESS`.

> Co-Authored by Grok Build using grok-4.5 with agent main.
