### PR TITLE
fix(sites): Developer Sites binds GET /services/sites list (#3198)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -18,14 +18,36 @@ export const SITE_DESIGN_GAPS: string[] = [
   "Workflow association is browsed under the Workflows catalog",
 ];
 
-const LIST_WRAPPER_KEYS = ["Site", "site", "SiteList", "sites", "entries"] as const;
+const LIST_WRAPPER_KEYS = [
+  "SiteList",
+  "siteList",
+  "Site",
+  "site",
+  "sites",
+  "entries",
+] as const;
 
-function parseSiteList(payload: unknown): SiteDef[] {
+/**
+ * Parse GET /services/sites JSON.
+ *
+ * <p>Accepts a bare array or Jackson WRAP_ROOT envelopes ({@code SiteList} / {@code Site}).
+ * Nested wraps ({@code {SiteList:{Site:[...]}}}) and per-item {@code {Site:{name}}} objects
+ * are unwrapped so Developer Sites does not render a silent empty table after HTTP 200
+ * (#3198). Unknown object shapes throw so the panel shows an error instead of empty.
+ */
+export function parseSiteList(payload: unknown): SiteDef[] {
+  return collectSiteRows(payload, 0).map(normalizeSiteRow);
+}
+
+function collectSiteRows(payload: unknown, depth: number): unknown[] {
   if (payload == null) {
     return [];
   }
+  if (depth > 5) {
+    throw new Error("Unexpected site list payload (too deeply nested)");
+  }
   if (Array.isArray(payload)) {
-    return payload as SiteDef[];
+    return payload.flatMap((item) => unwrapArrayItem(item, depth));
   }
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
@@ -33,15 +55,72 @@ function parseSiteList(payload: unknown): SiteDef[] {
       const raw = obj[key];
       if (raw == null) continue;
       if (Array.isArray(raw)) {
-        return raw as SiteDef[];
+        return collectSiteRows(raw, depth + 1);
       }
       if (typeof raw === "object") {
-        return [raw as SiteDef];
+        if (looksLikeSite(raw as Record<string, unknown>)) {
+          return [raw];
+        }
+        return collectSiteRows(raw, depth + 1);
       }
+    }
+    if (looksLikeSite(obj)) {
+      return [obj];
     }
     throw new Error("Unexpected site list payload (expected array or known Site wrapper)");
   }
   throw new Error("Unexpected site list payload type");
+}
+
+function unwrapArrayItem(item: unknown, depth: number): unknown[] {
+  if (item == null || typeof item !== "object" || Array.isArray(item)) {
+    return item == null ? [] : [item];
+  }
+  const obj = item as Record<string, unknown>;
+  if (looksLikeSite(obj)) {
+    return [obj];
+  }
+  const nested = obj.Site ?? obj.site;
+  if (nested != null && typeof nested === "object") {
+    return collectSiteRows(nested, depth + 1);
+  }
+  return [obj];
+}
+
+function looksLikeSite(obj: Record<string, unknown>): boolean {
+  return (
+    "name" in obj ||
+    "baseUrl" in obj ||
+    "pageBasedSite" in obj ||
+    "guid" in obj ||
+    "description" in obj
+  );
+}
+
+function normalizeSiteRow(raw: unknown): SiteDef {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const obj = raw as Record<string, unknown>;
+  const name = coerceDisplayString(obj.name);
+  return {
+    ...(obj as SiteDef),
+    name: name || undefined,
+  };
+}
+
+/** Jackson Optional leftovers may arrive as objects; only strings bind as names. */
+export function coerceDisplayString(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.value === "string") {
+      return obj.value.trim();
+    }
+  }
+  return "";
 }
 
 function withGaps(s: SiteDef): SiteDef {

--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -87,14 +87,42 @@ function unwrapArrayItem(item: unknown, depth: number): unknown[] {
   return [obj];
 }
 
+const SITE_SIGNAL_KEYS = [
+  "baseUrl",
+  "pageBasedSite",
+  "guid",
+  "defaultDocument",
+  "siteProtocol",
+  "canonicalDist",
+  "description",
+  "defaultFileExtention",
+] as const;
+
+const NAME_ONLY_KEYS = new Set(["name", "label", "id"]);
+
+/**
+ * A Site row must have a name. Name-only summaries are accepted; a lone
+ * {@code name} plus unrelated keys (e.g. nested metadata) is not a Site.
+ */
 function looksLikeSite(obj: Record<string, unknown>): boolean {
-  return (
-    "name" in obj ||
-    "baseUrl" in obj ||
-    "pageBasedSite" in obj ||
-    "guid" in obj ||
-    "description" in obj
-  );
+  if (!hasSiteName(obj.name)) {
+    return false;
+  }
+  if (SITE_SIGNAL_KEYS.some((key) => key in obj)) {
+    return true;
+  }
+  return Object.keys(obj).every((key) => NAME_ONLY_KEYS.has(key));
+}
+
+function hasSiteName(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    return typeof obj.value === "string" && obj.value.trim().length > 0;
+  }
+  return false;
 }
 
 function normalizeSiteRow(raw: unknown): SiteDef {

--- a/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from "react";
+import { coerceDisplayString } from "../api/developer/sitesApi";
 import type { SiteDef } from "../api/developer/types";
 import { catalogColors, backButton, metaGrid, monoCell } from "./catalogStyles";
 import { DEV_MSG } from "./messages";
@@ -16,8 +17,8 @@ export function SiteDetailPanel({
   site: SiteDef;
   onBack: () => void;
 }): React.ReactElement {
-  const name = typeof site.name === "string" ? site.name : "—";
-  const siteKey = typeof site.name === "string" ? site.name.trim() : "";
+  const name = coerceDisplayString(site.name) || "—";
+  const siteKey = coerceDisplayString(site.name);
   const gaps =
     site.designGaps && site.designGaps.length
       ? site.designGaps

--- a/WebUI/src/main/ts/developer/SitesPanel.tsx
+++ b/WebUI/src/main/ts/developer/SitesPanel.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
-import { listSites } from "../api/developer/sitesApi";
+import { coerceDisplayString, listSites } from "../api/developer/sitesApi";
 import type { SiteDef } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
 import { mutedCell, openButtonStyle } from "./catalogStyles";
@@ -12,8 +12,12 @@ import { DEV_MSG } from "./messages";
 import { SiteDetailPanel } from "./SiteDetailPanel";
 
 function siteName(s: SiteDef): string {
-  const n = s.name;
-  if (typeof n === "string") return n.trim();
+  const n = coerceDisplayString(s.name);
+  if (n) return n;
+  const guid = s.guid;
+  if (guid && typeof guid.stringValue === "string" && guid.stringValue.trim()) {
+    return guid.stringValue.trim();
+  }
   return "";
 }
 
@@ -64,8 +68,14 @@ export function SitesPanel(): React.ReactElement {
     return (
       <CatalogStatus testId="developer-site-loading">{DEV_MSG.SITE_LOADING}</CatalogStatus>
     );
-  if (items.length === 0 || sorted.length === 0)
+  if (items.length === 0)
     return <CatalogStatus testId="developer-site-empty">{DEV_MSG.SITE_EMPTY}</CatalogStatus>;
+  if (sorted.length === 0)
+    return (
+      <CatalogStatus testId="developer-site-error" error>
+        {DEV_MSG.SITE_BIND_ERROR}
+      </CatalogStatus>
+    );
 
   return (
     <div data-testid="developer-site-panel">

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -712,6 +712,8 @@ export const DEV_MSG_KEYS = {
   SITE_LOADING: "perc.ui.developer@Loading sites...",
   SITE_EMPTY: "perc.ui.developer@No sites returned.",
   SITE_ERROR: "perc.ui.developer@Could not load sites.",
+  SITE_BIND_ERROR:
+    "perc.ui.developer@Sites API returned entries but none had a usable name. Check GET /services/sites JSON bind.",
   SITE_HINT:
     "perc.ui.developer@Site definitions for association browse (SY-04). Open a row for URL, defaults, and Virtual Site source. Full site create/delete remains outside this catalog.",
   SITE_COL_NAME: "perc.ui.developer@Name",

--- a/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as client from "../../../../main/ts/api/client";
+import {
+  coerceDisplayString,
+  listSites,
+  parseSiteList,
+} from "../../../../main/ts/api/developer/sitesApi";
+
+vi.mock("../../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+}));
+
+const get = client.get as ReturnType<typeof vi.fn>;
+
+describe("parseSiteList (#3198 bind)", () => {
+  it("returns bare arrays", () => {
+    const rows = [{ name: "Help" }];
+    expect(parseSiteList(rows)).toEqual(rows);
+  });
+
+  it("returns empty for null", () => {
+    expect(parseSiteList(null)).toEqual([]);
+    expect(parseSiteList(undefined)).toEqual([]);
+  });
+
+  it("unwraps SiteList root wrapper", () => {
+    expect(
+      parseSiteList({
+        SiteList: [
+          { name: "Help", description: "docs" },
+          { name: "Corp" },
+        ],
+      }),
+    ).toEqual([
+      { name: "Help", description: "docs" },
+      { name: "Corp" },
+    ]);
+  });
+
+  it("unwraps nested SiteList / Site envelopes", () => {
+    expect(
+      parseSiteList({
+        SiteList: {
+          Site: [{ name: "Help" }],
+        },
+      }),
+    ).toEqual([{ name: "Help" }]);
+  });
+
+  it("unwraps per-item Site wrap", () => {
+    expect(
+      parseSiteList({
+        SiteList: [{ Site: { name: "Help", baseUrl: "https://h.example" } }],
+      }),
+    ).toEqual([{ name: "Help", baseUrl: "https://h.example" }]);
+  });
+
+  it("unwraps a single Site object", () => {
+    expect(parseSiteList({ Site: { name: "Only" } })).toEqual([{ name: "Only" }]);
+  });
+
+  it("throws on unknown object shape", () => {
+    expect(() => parseSiteList({ unexpected: true })).toThrow(
+      /Unexpected site list payload/,
+    );
+  });
+
+  it("throws on non-object non-array types", () => {
+    expect(() => parseSiteList("not-json-list")).toThrow(
+      /Unexpected site list payload type/,
+    );
+  });
+});
+
+describe("coerceDisplayString", () => {
+  it("trims strings and ignores Optional beans", () => {
+    expect(coerceDisplayString("  Help  ")).toBe("Help");
+    expect(coerceDisplayString({ empty: false })).toBe("");
+    expect(coerceDisplayString({ value: "Corp" })).toBe("Corp");
+    expect(coerceDisplayString(null)).toBe("");
+  });
+});
+
+describe("listSites", () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it("binds Jackson SiteList wrap to named rows", async () => {
+    get.mockResolvedValue({
+      SiteList: [{ name: "Help", description: "docs" }],
+    });
+    const out = await listSites();
+    expect(out[0].name).toBe("Help");
+    expect(out[0].designGaps?.length).toBeGreaterThan(0);
+  });
+});

--- a/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
@@ -76,6 +76,18 @@ describe("parseSiteList (#3198 bind)", () => {
     expect(parseSiteList({ Site: { name: "Only" } })).toEqual([{ name: "Only" }]);
   });
 
+  it("does not treat a nested metadata bag as a Site row", () => {
+    expect(() =>
+      parseSiteList({
+        Site: { metadata: { name: "config", env: "qa" } },
+      }),
+    ).toThrow(/Unexpected site list payload/);
+  });
+
+  it("still binds a name-only Site summary", () => {
+    expect(parseSiteList({ Site: { name: "Only" } })).toEqual([{ name: "Only" }]);
+  });
+
   it("throws on unknown object shape", () => {
     expect(() => parseSiteList({ unexpected: true })).toThrow(
       /Unexpected site list payload/,

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -540,6 +540,8 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
       pageBasedSite: true,
     },
   ]),
+  coerceDisplayString: (value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
   SITE_DESIGN_GAPS: [],
 }));
 

--- a/WebUI/src/test/ts/developer/SitesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SitesPanel.test.tsx
@@ -14,6 +14,8 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   listSites: vi.fn(),
   getVirtualSiteProperties: vi.fn().mockResolvedValue({ virtual: false }),
   updateVirtualSiteProperties: vi.fn(),
+  coerceDisplayString: (value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
   SITE_DESIGN_GAPS: ["gap-write", "gap-publish", "gap-wf"],
 }));
 
@@ -115,5 +117,27 @@ describe("SitesPanel", () => {
       expect(screen.getByTestId("developer-site-error")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-site-error").textContent).toBe(DEV_MSG.SITE_ERROR);
+  });
+
+  it("shows bind error when API rows have no usable name (#3198)", async () => {
+    listSites.mockResolvedValue([{ description: "orphan" }]);
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-error").textContent).toBe(DEV_MSG.SITE_BIND_ERROR);
+    expect(screen.queryByTestId("developer-site-empty")).toBeNull();
+  });
+
+  it("lists a site by guid when name is missing", async () => {
+    listSites.mockResolvedValue([
+      { guid: { stringValue: "0-1-301" }, description: "no name" },
+    ]);
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-table").textContent).toContain("0-1-301");
+    expect(screen.queryByTestId("developer-site-empty")).toBeNull();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3198-developer-sites-list.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3198-developer-sites-list.spec.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer → Sites catalog bind (#3198 / parent #3090).
+ *
+ * GET /services/sites must be HTTP 200. When the payload contains Site entries,
+ * the SPA table must list at least one name (never silent empty). Empty JSON
+ * list may show the empty state.
+ *
+ * Surface-filtered QA mode:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/bugs/bug-3198-developer-sites-list.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
+const { catalogRowsSelector } = require("../helpers/developer-catalog-selectors");
+
+function developerSitesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "sites",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function unwrapSiteList(body) {
+  if (body == null) {
+    return [];
+  }
+  if (Array.isArray(body)) {
+    return body;
+  }
+  const nested = body.SiteList ?? body.siteList ?? body.Site ?? body.site;
+  if (Array.isArray(nested)) {
+    return nested.map((row) =>
+      row && row.Site && typeof row.Site === "object" ? row.Site : row,
+    );
+  }
+  if (nested && typeof nested === "object") {
+    const inner = nested.Site ?? nested.site;
+    if (Array.isArray(inner)) {
+      return inner;
+    }
+    if (inner && typeof inner === "object") {
+      return [inner];
+    }
+    if (nested.name || nested.baseUrl) {
+      return [nested];
+    }
+  }
+  return [];
+}
+
+function siteName(row) {
+  if (!row || typeof row !== "object") {
+    return "";
+  }
+  if (typeof row.name === "string") {
+    return row.name.trim();
+  }
+  if (row.guid && typeof row.guid.stringValue === "string") {
+    return row.guid.stringValue.trim();
+  }
+  return "";
+}
+
+test.describe("Developer Sites list bind (#3198)", () => {
+  test("REST: GET /services/sites is 200 with array or SiteList wrap", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      Accept: "application/json",
+    };
+    const url = `${BASE_URL}/Rhythmyx/services/sites`;
+    const res = await request.get(url, { headers });
+    expect(res.status(), `GET ${url} must be 2xx`).toBeGreaterThanOrEqual(200);
+    expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
+
+    const body = await res.json();
+    const sites = unwrapSiteList(body);
+    expect(Array.isArray(sites), `sites payload must unwrap to an array: ${JSON.stringify(body).slice(0, 400)}`).toBe(
+      true,
+    );
+    if (sites.length > 0) {
+      const firstName = siteName(sites[0]);
+      expect(
+        firstName,
+        `first site must expose string name (not Optional bean): ${JSON.stringify(sites[0]).slice(0, 400)}`,
+      ).toBeTruthy();
+    }
+  });
+
+  test("SPA binds site rows when API has data; empty only when list is empty", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      const loc = msg.location() && msg.location().url ? msg.location().url : "";
+      // Ignore static 404s (favicon / leftover hashed chunks) — not uncaught JS.
+      if (/404|Failed to load resource/i.test(text) && /favicon|fonts|\.map$/i.test(loc + text)) {
+        return;
+      }
+      if (/Failed to load resource: the server responded with a status of 404/i.test(text)) {
+        return;
+      }
+      consoleErrors.push(loc ? `${text} (${loc})` : text);
+    });
+
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      Accept: "application/json",
+    };
+    const apiRes = await page.request.get(`${BASE_URL}/Rhythmyx/services/sites`, {
+      headers,
+    });
+    expect(apiRes.status()).toBeGreaterThanOrEqual(200);
+    expect(apiRes.status()).toBeLessThan(300);
+    const apiSites = unwrapSiteList(await apiRes.json());
+    const apiHasRows = apiSites.some((row) => siteName(row));
+
+    await loginAsAdmin(page);
+    await page.goto(developerSitesUrl(), { waitUntil: "networkidle" });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    if (apiHasRows) {
+      await expect(page.locator('[data-testid="developer-site-panel"]')).toBeVisible();
+      const rows = page.locator(catalogRowsSelector("developer-site-row"));
+      await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+      expect(await rows.count()).toBeGreaterThan(0);
+      await expect(page.locator('[data-testid="developer-site-empty"]')).toHaveCount(0);
+    } else {
+      await expect(page.locator('[data-testid="developer-site-empty"]')).toBeVisible();
+    }
+
+    expect(consoleErrors, `JS console/page errors: ${consoleErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
@@ -83,6 +83,11 @@ const CATALOGS = [
     successTestIds: ["developer-sys-panel", "developer-sys-empty"],
     errorTestId: "developer-sys-error",
   },
+  {
+    section: "sites",
+    successTestIds: ["developer-site-panel", "developer-site-empty"],
+    errorTestId: "developer-site-error",
+  },
 ];
 
 function developerUrl(section) {

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -66,6 +66,21 @@ and Markdown tooling, not the classic page editor.
 Invalid combinations (unknown source kind, missing root, unsafe path, config path traversal) are
 rejected by server validation with clear error messages.
 
+### Browse Sites in Developer
+
+**Developer → Sites** lists **all** CMS Sites from `GET /services/sites` (traditional repository
+Sites, CM1 page-based Sites, and Virtual Sites). Sample / demo Sites appear when they exist on
+the server (for example after **Install sample sites**).
+
+1. Sign in as an administrator (or a role that can open **Developer**).
+2. Open **Developer** → **Sites** (SPA entry `spa.jsp?entry=developer&section=sites`).
+3. Confirm the catalog table shows site **name**, **description**, **base URL**, and flags.
+4. Choose a row to open **Site detail** (URL defaults and Virtual Site source).
+
+Empty state (**No sites returned**) appears only when the list API has **zero** Sites. A
+successful HTTP 200 with Site entries must populate the table (never a silent blank). Load
+failures show **Could not load sites** rather than the empty state.
+
 ### Configure Virtual Site source in the product UI
 
 1. Sign in as an administrator (or a role that can open **Developer**).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -101,6 +101,18 @@ Example create body:
 - The Developer SPA Keyword editor uses these endpoints; integrators can call the same surface
   without the UI.
 
+## Sites (catalog)
+
+| Operation | Path | Notes |
+|-----------|------|--------|
+| List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array. Each entry includes a plain string `name` when the Site has one. |
+| Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
+| Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
+| Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+
+An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
+only empty-catalog case. See [Sites & content structure](id:admin-sites).
+
 ## Content types (design catalog)
 
 | Operation | Path | Notes |

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -114,9 +114,9 @@ class SitesAdaptorTest {
 
     Site out = adaptor.findByName("Help");
     assertNotNull(out);
-    assertEquals("Help", out.getName().orElse(null));
-    assertTrue(out.getVirtual().isPresent());
-    assertTrue(Boolean.TRUE.equals(out.getVirtual().get().getVirtual()));
+    assertEquals("Help", out.getName());
+    assertTrue(out.getVirtual() != null);
+    assertTrue(Boolean.TRUE.equals(out.getVirtual().getVirtual()));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/sites/Site.java
+++ b/rest/src/main/java/com/percussion/rest/sites/Site.java
@@ -17,13 +17,25 @@
 
 package com.percussion.rest.sites;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Site in Percussion CMS. Sunny Sal: "Site ka hero, URL ka zero!" */
+/**
+ * Represents a Site in Percussion CMS. Sunny Sal: "Site ka hero, URL ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON always emits {@code
+ * name}, {@code description}, {@code baseUrl}, and {@code guid} when set. Optional-returning
+ * getters historically dropped those fields (or serialized Optional beans) under WRAP_ROOT_VALUE
+ * when the mapper did not unwrap {@code Optional}, leaving Developer Sites with a 200 list payload
+ * and zero named rows (#3198). Matches {@link com.percussion.rest.contenttypes.ContentType} getter
+ * style (issue #1693).
+ */
 @XmlRootElement(name = "Site")
+@JsonRootName("Site")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "Site")
 public class Site {
 
@@ -66,32 +78,32 @@ public class Site {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getBaseUrl() {
-    return Optional.ofNullable(baseUrl);
+  public String getBaseUrl() {
+    return baseUrl;
   }
 
   public void setBaseUrl(String baseUrl) {
     this.baseUrl = baseUrl;
   }
 
-  public Optional<String> getDefaultFileExtention() {
-    return Optional.ofNullable(defaultFileExtention);
+  public String getDefaultFileExtention() {
+    return defaultFileExtention;
   }
 
   public void setDefaultFileExtention(String defaultFileExtention) {
@@ -130,48 +142,48 @@ public class Site {
     this.overrideSystemJQueryUI = overrideSystemJQueryUI;
   }
 
-  public Optional<String> getSiteAdditionalHeadContent() {
-    return Optional.ofNullable(siteAdditionalHeadContent);
+  public String getSiteAdditionalHeadContent() {
+    return siteAdditionalHeadContent;
   }
 
   public void setSiteAdditionalHeadContent(String siteAdditionalHeadContent) {
     this.siteAdditionalHeadContent = siteAdditionalHeadContent;
   }
 
-  public Optional<String> getSiteBeforeBodyCloseContent() {
-    return Optional.ofNullable(siteBeforeBodyCloseContent);
+  public String getSiteBeforeBodyCloseContent() {
+    return siteBeforeBodyCloseContent;
   }
 
   public void setSiteBeforeBodyCloseContent(String siteBeforeBodyCloseContent) {
     this.siteBeforeBodyCloseContent = siteBeforeBodyCloseContent;
   }
 
-  public Optional<String> getSiteAfterBodyOpenContent() {
-    return Optional.ofNullable(siteAfterBodyOpenContent);
+  public String getSiteAfterBodyOpenContent() {
+    return siteAfterBodyOpenContent;
   }
 
   public void setSiteAfterBodyOpenContent(String siteAfterBodyOpenContent) {
     this.siteAfterBodyOpenContent = siteAfterBodyOpenContent;
   }
 
-  public Optional<String> getSiteProtocol() {
-    return Optional.ofNullable(siteProtocol);
+  public String getSiteProtocol() {
+    return siteProtocol;
   }
 
   public void setSiteProtocol(String siteProtocol) {
     this.siteProtocol = siteProtocol;
   }
 
-  public Optional<String> getDefaultDocument() {
-    return Optional.ofNullable(defaultDocument);
+  public String getDefaultDocument() {
+    return defaultDocument;
   }
 
   public void setDefaultDocument(String defaultDocument) {
     this.defaultDocument = defaultDocument;
   }
 
-  public Optional<String> getCanonicalDist() {
-    return Optional.ofNullable(canonicalDist);
+  public String getCanonicalDist() {
+    return canonicalDist;
   }
 
   public void setCanonicalDist(String canonicalDist) {
@@ -194,16 +206,16 @@ public class Site {
     this.pageBasedSite = pageBasedSite;
   }
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<VirtualSiteProperties> getVirtual() {
-    return Optional.ofNullable(virtual);
+  public VirtualSiteProperties getVirtual() {
+    return virtual;
   }
 
   public void setVirtual(VirtualSiteProperties virtual) {

--- a/rest/src/main/java/com/percussion/rest/sites/SiteList.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteList.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.sites;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -34,6 +35,7 @@ import java.util.Collection;
  * wrappers.
  */
 @XmlRootElement(name = "SiteList")
+@JsonRootName("SiteList")
 @ArraySchema(schema = @Schema(implementation = Site.class))
 @XmlSeeAlso(Site.class)
 public class SiteList extends ArrayList<Site> {

--- a/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.percussion.rest.JacksonContextResolver;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.Marshaller;
 import java.io.StringWriter;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -36,7 +38,10 @@ import tools.jackson.databind.json.JsonMapper;
  * Wire shape for SitesResource list GET must marshal {@link SiteList} elements.
  *
  * <p>List GET {@code /services/sites} requires {@link SiteList} JAXB context registration of {@link
- * Site} via {@code @XmlSeeAlso} (#3090). Mirrors {@code UserPreferenceSerialDeserialTest} (#2746).
+ * Site} via {@code @XmlSeeAlso} (#3090). Production JSON uses {@link JacksonContextResolver}
+ * WRAP_ROOT_VALUE; Site getters must emit plain {@code name} strings so Developer Sites can bind
+ * (#3198). Mirrors {@code UserPreferenceSerialDeserialTest} (#2746) and {@code
+ * JacksonContextResolverOptionalTest} (#1693).
  */
 @Tag("UnitTest")
 public class SiteListSerialDeserialTest {
@@ -74,9 +79,43 @@ public class SiteListSerialDeserialTest {
 
     var roundTrip = mapper.readValue(json, SiteList.class);
     assertEquals(1, roundTrip.size(), "list size after round-trip");
-    assertEquals("Help", roundTrip.get(0).getName().orElse(null));
-    assertEquals("Help site", roundTrip.get(0).getDescription().orElse(null));
-    assertEquals("https://help.example.com", roundTrip.get(0).getBaseUrl().orElse(null));
+    assertEquals("Help", roundTrip.get(0).getName());
+    assertEquals("Help site", roundTrip.get(0).getDescription());
+    assertEquals("https://help.example.com", roundTrip.get(0).getBaseUrl());
+  }
+
+  /**
+   * Production CXF mapper (WRAP_ROOT_VALUE) must emit a SiteList envelope whose elements have
+   * string {@code name} fields — not Optional beans and not a nameless wrapper (#3198).
+   */
+  @Test
+  public void productionMapperSerializesSiteListWithPlainNames() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(SiteList.class);
+    var list = new SiteList();
+    list.add(sampleSite());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"SiteList\""), "expected WRAP_ROOT_VALUE SiteList: " + json);
+    assertTrue(json.contains("\"name\""), "site name property must be present: " + json);
+    assertTrue(json.contains("\"Help\""), "site name value must be present: " + json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"baseUrl\""), json);
+    assertFalse(
+        json.contains("\"empty\"") && !json.contains("\"name\":\"Help\""),
+        "name must be a plain string, not an Optional bean: " + json);
+
+    SiteList roundTrip = mapper.readValue(json, SiteList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("Help", roundTrip.get(0).getName());
+    assertEquals("Help site", roundTrip.get(0).getDescription());
+    assertEquals("https://help.example.com", roundTrip.get(0).getBaseUrl());
+  }
+
+  @Test
+  public void productionMapperSerializesEmptySiteListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(SiteList.class);
+    String json = mapper.writeValueAsString(new SiteList());
+    assertTrue(json.contains("SiteList") || json.contains("["), json);
   }
 
   /**

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -71,7 +71,7 @@ public class SitesResourceTest {
 
     SiteList out = resource.listSites();
     assertEquals(1, out.size());
-    assertEquals("Help", out.get(0).getName().orElse(null));
+    assertEquals("Help", out.get(0).getName());
     verify(adaptor).findAllSites();
   }
 
@@ -93,9 +93,9 @@ public class SitesResourceTest {
     when(adaptor.findByName("Help")).thenReturn(s);
 
     Site out = resource.getSite("Help");
-    assertEquals("Help", out.getName().orElse(null));
-    assertTrue(out.getVirtual().isPresent());
-    assertEquals("git-filesystem", out.getVirtual().get().getSourceKind().orElse(null));
+    assertEquals("Help", out.getName());
+    assertTrue(out.getVirtual() != null);
+    assertEquals("git-filesystem", out.getVirtual().getSourceKind().orElse(null));
     verify(adaptor).findByName("Help");
     verify(adaptor, never()).findByGuid(any());
   }
@@ -108,7 +108,7 @@ public class SitesResourceTest {
     when(adaptor.findByGuid("0-1-301")).thenReturn(s);
 
     Site out = resource.getSite("0-1-301");
-    assertEquals("Help", out.getName().orElse(null));
+    assertEquals("Help", out.getName());
     verify(adaptor).findByGuid("0-1-301");
   }
 


### PR DESCRIPTION
## Summary

Developer → Sites still listed **zero sites with no error** after the #3090 SiteList `@XmlSeeAlso` JAXB fix (failed human QA #3129). `GET /services/sites` returned HTTP 200, but Jackson `WRAP_ROOT_VALUE` plus `Site` **Optional** getters hid or omitted `name` / `description` / `baseUrl`. The SPA then treated nameless wrapped rows as an empty catalog.

This change:

- Emits **plain** `Site` getters (`@JsonInclude(NON_NULL)`, `@JsonRootName`) — same pattern as ContentType (#1693) / TemplateSummary (#2189).
- Unwraps `{SiteList: [...]}`, nested `{SiteList:{Site:[...]}}`, and per-item `{Site:{…}}` in `parseSiteList`.
- Shows **empty state only when the list is truly empty**; bind failure is an error, not silence.
- Extends `SiteListSerialDeserialTest` (production `JacksonContextResolver` mapper) and WebUI bind tests; adds Playwright `bug-3198-developer-sites-list.spec.js`.

Fixes #3198  
Parent tracker: #3090  
Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 329, Failures: 0.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1030, Failures: 0 (C2 reverse-dep after `Site` getter signature change).
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Vitest Tests 2068 passed.
4. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
5. QA H2: existing `perc-matrix-cms-h2` (`TEST_CMS_URL=http://127.0.0.1:9993`); hot-deploy `rest-8.2.0-SNAPSHOT.jar` + WebUI `cm/modern`; restart; health=healthy.
6. `npm run test:surface -- --path tests/bugs/bug-3198-developer-sites-list.spec.js` — 2 passed. This H2 cell has **zero** sites: REST 200 empty list + SPA empty state. Console: no uncaught pageerror. server.log: no new Sites-related ERROR/FATAL in the test window.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/sites.md` (Developer Sites browse / empty vs bind) and `product-docs/8.2/developer/rest.md` (GET /services/sites wire shape)
- [x] **Unit / module tests** — SiteList production mapper tests; `parseSiteList` + SitesPanel bind tests
- [x] **WebUI + Playwright** — `tests/bugs/bug-3198-developer-sites-list.spec.js` + sites added to developer-catalog-smoke
- [x] **Build gates** — standalone clean install rest, sitemanage, WebUI, perc-qa-automation; no skipTests
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- `modules_built=rest,projects/sitemanage,WebUI,modules/perc-qa-automation`
- `build_evidence=cd rest && ../mvnw.cmd clean install → BUILD SUCCESS Tests run: 329 Failures: 0; cd projects/sitemanage && ../../mvnw.cmd clean install → BUILD SUCCESS Tests run: 1030 Failures: 0; cd WebUI && ../mvnw.cmd clean install → BUILD SUCCESS Vitest 2068 passed; cd modules/perc-qa-automation && ../../mvnw.cmd clean install → BUILD SUCCESS`
- `downstream_checked=projects/sitemanage clean install; grep monorepo for extends Site / new Site() { — none besides SiteList ctor`

### C5 UI proof

- QA cell: `perc-matrix-cms-h2` TEST_CMS_URL=http://127.0.0.1:9993 (published mapping; not hardcoded as the only port in specs)
- Deploy: docker cp rest jar + generated-webui/cm/modern; docker restart; health=healthy
- Playwright: `npm run test:surface -- --path tests/bugs/bug-3198-developer-sites-list.spec.js` — 2 passed
- console-clean=yes (no uncaught pageerror; ignored leftover static 404 noise)
- server.log-clean=yes (no new Sites-related ERROR/FATAL after restart; older ACL/JAXB noise predates this deploy)

> Co-Authored by Grok Build using grok-4.5 with agent main.
