### PR TITLE
feat(rest): Views standard execute façade (#3115)

### DIFF
--- a/docs/ai-generated/code-reviews/3115-views-rest-execute-erlang.md
+++ b/docs/ai-generated/code-reviews/3115-views-rest-execute-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review: #3115 Views REST execute façade
+
+**Branch:** `feat/issue-3115-views-rest-execute`  
+**Base:** `origin/main`  
+**Date:** 2026-08-12  
+**Persona:** Erlang (independent of implementer)
+
+## Summary
+
+Adds `POST /rest/views/{idOrName}/execute` (WebUI `/services/views/...`) for **standard** CX design views. Loads designs via `IPSUiDesignWs.findViews` / `loadViews` (not the search catalog). Twin request/result DTOs keep Views vs Searches contracts separate. Custom URL views (`isCustomView`) return explicit 400 pointing at Inbox / #3118.
+
+Companion closure matches rest/sitemanage change class: resource + `IViewAdaptor` method + `ViewAdaptor` impl + Mockito `ViewResourceTest` + Spring `TestViewAdaptor` stub + `ViewAdaptorExecuteTest` + product-docs `rest.md`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Behavioral tests cover 200/400/404/503, custom-URL rejection, unsafe keys, paging, and views-catalog load (not `findSearches`). Path I/O not introduced.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | present (`ViewResource.executeView`) |
+| Adaptor interface + wire DTOs | present (`IViewAdaptor`, `ViewExecuteRequest/Result`, `ViewResultItem`) |
+| sitemanage apibridge | present (`ViewAdaptor.executeView`) |
+| Mockito resource tests | present (`ViewResourceTest` 15 tests) |
+| Spring test stub | present (`TestViewAdaptor.executeView`) |
+| sitemanage unit tests | present (`ViewAdaptorExecuteTest` 20 tests) |
+| product-docs | present (`product-docs/8.2/developer/rest.md`) |
+| Playwright / WebUI | N/A (V2/V3 out of scope) |
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path construction. Key hygiene still rejects `/`, `\`, `..`, NUL (URL path tokens, not OS joins).
+
+## Issues
+
+None (hard-gate).
+
+## Memory patterns hit
+
+- Incomplete change-class closure (rest↔sitemanage adaptor surface) — closed
+- Shared Spring test stubs for new adaptor methods — `TestViewAdaptor` updated
+- Behavioral tests for validation/rejection (custom URL, bad paging) — present
+- Non-portable paths — not applicable
+
+## Build evidence (pre-PR)
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 333, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1050, Failures: 0
+- C2: `IViewAdaptor` gained a method; `ViewAdaptor` ctor added `IPSFolderHelper`/`IPSIdMapper`. Grep: only `TestViewAdaptor` + `ViewAdaptor` implement the interface; `new ViewAdaptor` only in new execute tests. Downstream sitemanage install green.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -126,6 +126,59 @@ These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They 
 writable via `PUT` — rule write/save and full control property editors remain Workbench /
 future design APIs. `designGaps` on detail still calls out write and catalog gaps.
 
+## Views (design catalog)
+
+Content Explorer **view** definitions (Workbench / Developer **Views**, UI-07) are exposed under
+`/services/views` (public servlet path `/rest/views`). This is a **separate catalog** from saved
+**searches** (`/services/searches`). Do not execute a view through the search execute endpoint.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/views` | List view definitions (name, category, standard vs custom URL) |
+| `GET` | `/services/views/{idOrName}` | Load one view by name, numeric id, or GUID string |
+| `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view |
+
+### Execute request / response
+
+Optional JSON body (all fields optional):
+
+| Field | Meaning |
+|-------|---------|
+| `folderPath` | Scope results to a folder path; recurse defaults on when set |
+| `startIndex` | 1-based page start (must be ≥ 1) |
+| `maxResults` | Page size (must be ≥ 1); omitted uses the view design max or a product default |
+| `sortColumn` | `sys_title` / `title` / `name`, `type`, or `folderPath` |
+| `sortOrder` | `asc` or `desc` |
+
+Successful response is a paged envelope: `children[]` (Explorer-ready rows with `id`, `name`,
+`title`, `folderPath`, `type`), `totalCount`, `startIndex`, `viewName`, `displayFormatId`.
+
+### Status codes
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / execute success |
+| `400` | Invalid execute body, or the view is a **custom URL** view |
+| `404` | View not found or unsafe key (blank, path separators, `..`) |
+| `500` | Design or execute engine failure |
+| `503` | Views adaptor not configured (deployment miswire) |
+
+### Custom URL views (Inbox family)
+
+Views flagged as **custom** (`customView` / Inbox, Outbox, Recent, and peers that run a classic
+application URL rather than field criteria) **cannot** be executed on this façade. The server
+returns **`400`** with a message that custom URL views are unsupported here. That family is
+deferred to a dedicated Inbox runner — it is **not** a silent empty result.
+
+Standard field-criteria views (`standardView`) execute with the same design operators, display
+format, max results, and case sensitivity stored on the view design.
+
+### Integrator notes
+
+- Keys may be the view **name**, numeric **id**, or GUID string (including untyped GUID).
+- Create / update / delete of view designs is not supported on this API (`designGaps` on detail).
+- The Developer SPA lists views via `GET`; Explorer run-from-tree is a later product slice.
+
 ## Design capability gaps (`designGaps`)
 
 Some Developer detail payloads include a **`designGaps`** array so clients know what the REST

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -10,67 +10,91 @@ import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.rest.Guid;
 import com.percussion.rest.views.IViewAdaptor;
 import com.percussion.rest.views.ViewDef;
+import com.percussion.rest.views.ViewExecuteRequest;
+import com.percussion.rest.views.ViewExecuteResult;
 import com.percussion.rest.views.ViewFieldSummary;
+import com.percussion.rest.views.ViewResultItem;
+import com.percussion.search.IPSExecutableSearch;
+import com.percussion.search.IPSSearchResultRow;
+import com.percussion.search.PSExecutableSearchFactory;
+import com.percussion.search.PSWSSearchResponse;
 import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.PSGuidUtils;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.data.PSItemProperties;
+import com.percussion.share.data.PSPagedObjectList;
+import com.percussion.share.service.IPSIdMapper;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
-/** Read-only CX view definition catalog (UI-07). */
+/**
+ * CX view definition catalog (UI-07) plus standard-view execute façade for Explorer (#3115 / #3110
+ * V1). Loads designs via {@link IPSUiDesignWs#findViews} / {@link IPSUiDesignWs#loadViews} — not
+ * the search catalog.
+ */
 @PSSiteManageBean
 @Lazy
 public class ViewAdaptor implements IViewAdaptor {
 
   private static final Logger log = LogManager.getLogger(ViewAdaptor.class);
 
+  /** Product default page size when design max is unset/unlimited and client omits maxResults. */
+  static final int DEFAULT_PAGE_SIZE = 25;
+
+  /**
+   * Explicit 400 for Inbox-family custom URL views. Dedicated runner is #3118 — this façade must
+   * not silently no-op.
+   */
+  static final String CUSTOM_VIEW_EXECUTE_UNSUPPORTED =
+      "Custom URL views cannot be executed via this endpoint. Inbox and other custom-URL views"
+          + " require a dedicated runner (issue #3118)";
+
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
           "View create / update / delete not supported via this API",
           "View field criterion editing not supported via this API",
+          "Custom URL views (Inbox family) cannot be executed via this API; see Inbox / #3118",
           "Searches are a separate catalog (Developer Searches / UI-06)");
 
+  private static final List<String> RESULT_COLUMNS =
+      List.of("sys_contentid", "sys_title", "sys_contenttypename");
+
   private final IPSUiDesignWs designWs;
+  private final IPSFolderHelper folderHelper;
+  private final IPSIdMapper idMapper;
 
   @Autowired
-  public ViewAdaptor(IPSUiDesignWs designWs) {
+  public ViewAdaptor(
+      IPSUiDesignWs designWs, IPSFolderHelper folderHelper, IPSIdMapper idMapper) {
     this.designWs = designWs;
+    this.folderHelper = folderHelper;
+    this.idMapper = idMapper;
   }
 
   @Override
   public List<ViewDef> listViews() {
     try {
-      List<IPSCatalogSummary> summaries = designWs.findViews(null, null);
-      if (summaries == null || summaries.isEmpty()) {
-        return List.of();
-      }
-      List<IPSGuid> guids = new ArrayList<>();
-      for (IPSCatalogSummary sum : summaries) {
-        if (sum != null && sum.getGUID() != null) {
-          guids.add(sum.getGUID());
-        }
-      }
-      if (guids.isEmpty()) {
-        return List.of();
-      }
-      String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
-      String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
-      List<PSSearch> loaded = designWs.loadViews(guids, false, false, currentSession, currentUser);
+      List<PSSearch> loaded = loadAllViews();
       List<ViewDef> out = new ArrayList<>();
-      if (loaded != null) {
-        for (PSSearch s : loaded) {
-          if (s != null) {
-            // REST-GAPS-02: list rows omit identical designGaps; detail re-attaches them.
-            out.add(toDef(s, false));
-          }
+      for (PSSearch s : loaded) {
+        if (s != null) {
+          // REST-GAPS-02: list rows omit identical designGaps; detail re-attaches them.
+          out.add(toDef(s, false));
         }
       }
       out.sort(
@@ -88,24 +112,263 @@ public class ViewAdaptor implements IViewAdaptor {
     if (!isSafeViewKey(idOrName)) {
       return null;
     }
-    String key = idOrName.trim();
     try {
-      for (ViewDef s : listViews()) {
-        if (s == null) {
-          continue;
-        }
-        if (key.equalsIgnoreCase(s.getName())
-            || String.valueOf(s.getId()).equals(key)
-            || (s.getGuid() != null
-                && key.equalsIgnoreCase(s.getGuid().getStringValue().orElse(null)))) {
-          // Detail path: re-map with designGaps (list projection omits them).
-          return withDesignGaps(s);
-        }
-      }
-      return null;
+      PSSearch found = findPsViewByKey(idOrName.trim());
+      return found != null ? toDef(found, true) : null;
     } catch (RuntimeException e) {
       // list failures already wrap; propagate for 500
       throw e;
+    }
+  }
+
+  @Override
+  public ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request) {
+    if (!isSafeViewKey(idOrName)) {
+      return null;
+    }
+    ViewExecuteRequest effective = normalizeRequest(request);
+    try {
+      PSSearch design = findPsViewByKey(idOrName.trim());
+      if (design == null) {
+        return null;
+      }
+      if (design.isCustomView()) {
+        throw new IllegalArgumentException(CUSTOM_VIEW_EXECUTE_UNSUPPORTED);
+      }
+
+      // Clone so folder/max overrides do not dirty a shared design instance
+      PSSearch search = (PSSearch) design.clone();
+      applyExecuteOverrides(search, effective);
+
+      List<ViewResultItem> allItems = runDesignView(search);
+      sortItems(allItems, effective.getSortColumn(), effective.getSortOrder());
+
+      int startIndex = effective.getStartIndex() != null ? effective.getStartIndex() : 1;
+      Integer maxResults = effective.getMaxResults();
+      PSPagedObjectList<ViewResultItem> page =
+          PSPagedObjectList.getPage(allItems, startIndex, maxResults);
+
+      ViewExecuteResult result = new ViewExecuteResult();
+      result.setChildren(new ArrayList<>(page.getChildrenInPage()));
+      result.setTotalCount(page.getChildrenCount() != null ? page.getChildrenCount() : allItems.size());
+      result.setStartIndex(page.getStartIndex() != null ? page.getStartIndex() : startIndex);
+      result.setViewName(design.getName());
+      result.setDisplayFormatId(design.getDisplayFormatId());
+      return result;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to execute view {}", idOrName, e);
+      throw new IllegalStateException("Failed to execute view", e);
+    }
+  }
+
+  /**
+   * Normalize and validate optional execute overrides. Returns a non-null request with defaults
+   * applied where needed for validation only (maxResults default applied later from design when
+   * client omits it).
+   */
+  static ViewExecuteRequest normalizeRequest(ViewExecuteRequest request) {
+    ViewExecuteRequest out = request != null ? request : new ViewExecuteRequest();
+    Integer start = out.getStartIndex();
+    if (start != null && start < 1) {
+      throw new IllegalArgumentException("startIndex must be >= 1");
+    }
+    Integer max = out.getMaxResults();
+    if (max != null && max < 1) {
+      throw new IllegalArgumentException("maxResults must be >= 1");
+    }
+    String sortOrder = out.getSortOrder();
+    if (StringUtils.isNotBlank(sortOrder)) {
+      String trimmed = sortOrder.trim().toLowerCase(Locale.ROOT);
+      if (!"asc".equals(trimmed) && !"desc".equals(trimmed)) {
+        throw new IllegalArgumentException("sortOrder must be asc or desc");
+      }
+      out.setSortOrder(trimmed);
+    }
+    if (StringUtils.isNotBlank(out.getSortColumn())) {
+      out.setSortColumn(out.getSortColumn().trim());
+    }
+    if (StringUtils.isNotBlank(out.getFolderPath())) {
+      out.setFolderPath(out.getFolderPath().trim());
+    }
+    return out;
+  }
+
+  static void applyExecuteOverrides(PSSearch search, ViewExecuteRequest req) {
+    if (req == null || search == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(req.getFolderPath())) {
+      search.setProperty(PSSearch.PROP_FOLDER_PATH, req.getFolderPath().trim());
+      // Default recurse when client scopes by folder (Explorer parity)
+      if (StringUtils.isBlank(search.getProperty(PSSearch.PROP_FOLDER_PATH_RECURSE))) {
+        search.setProperty(PSSearch.PROP_FOLDER_PATH_RECURSE, "true");
+      }
+    }
+    if (req.getMaxResults() != null && req.getMaxResults() >= 1) {
+      search.setMaximumNumber(req.getMaxResults());
+    } else if (search.getMaximumResultSize() <= 0) {
+      search.setMaximumNumber(DEFAULT_PAGE_SIZE);
+    }
+  }
+
+  static void sortItems(List<ViewResultItem> items, String sortColumn, String sortOrder) {
+    if (items == null || items.isEmpty() || StringUtils.isBlank(sortColumn)) {
+      return;
+    }
+    String col = sortColumn.trim().toLowerCase(Locale.ROOT);
+    int dir = "desc".equalsIgnoreCase(StringUtils.defaultString(sortOrder)) ? -1 : 1;
+    Comparator<String> nullSafe = Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER);
+    Comparator<ViewResultItem> cmp;
+    if ("sys_title".equals(col) || "title".equals(col) || "name".equals(col)) {
+      cmp =
+          Comparator.comparing(
+              i -> StringUtils.defaultIfBlank(i.getTitle(), i.getName()), nullSafe);
+    } else if ("type".equals(col) || "sys_contenttypename".equals(col)) {
+      cmp = Comparator.comparing(ViewResultItem::getType, nullSafe);
+    } else if ("folderpath".equals(col) || "path".equals(col)) {
+      cmp = Comparator.comparing(ViewResultItem::getFolderPath, nullSafe);
+    } else {
+      return;
+    }
+    if (dir < 0) {
+      cmp = cmp.reversed();
+    }
+    items.sort(cmp);
+  }
+
+  /**
+   * Execute the design view ({@link PSSearch} of type view) via the local executable search path
+   * (operators preserved). Package-visible for unit tests that subclass/spy can override.
+   */
+  List<ViewResultItem> runDesignView(PSSearch search) throws Exception {
+    var request = PSWebserviceUtils.getRequest();
+    if (request == null) {
+      throw new IllegalStateException("No active request context for view execute");
+    }
+    IPSExecutableSearch executable =
+        PSExecutableSearchFactory.createExecutableSearch(request, RESULT_COLUMNS, search);
+    PSWSSearchResponse response = executable.executeSearch();
+    return mapSearchResponse(response);
+  }
+
+  List<ViewResultItem> mapSearchResponse(PSWSSearchResponse response) {
+    List<ViewResultItem> out = new ArrayList<>();
+    if (response == null) {
+      return out;
+    }
+    Iterator<IPSSearchResultRow> rows = response.getRows();
+    while (rows != null && rows.hasNext()) {
+      IPSSearchResultRow row = rows.next();
+      if (row == null) {
+        continue;
+      }
+      ViewResultItem item = mapResultRow(row);
+      if (item != null) {
+        out.add(item);
+      }
+    }
+    return out;
+  }
+
+  ViewResultItem mapResultRow(IPSSearchResultRow row) {
+    String contentId = row.getColumnValue("sys_contentid");
+    if (StringUtils.isBlank(contentId)) {
+      return null;
+    }
+    ViewResultItem item = new ViewResultItem();
+    String title = row.getColumnValue("sys_title");
+    String type = row.getColumnValue("sys_contenttypename");
+    item.setName(title);
+    item.setTitle(title);
+    item.setType(type);
+
+    try {
+      var myGuid = PSGuidUtils.makeGuid(Integer.parseInt(contentId.trim()), PSTypeEnum.LEGACY_CONTENT);
+      String stringId = idMapper.getString(myGuid);
+      item.setId(stringId);
+      if (folderHelper.getParentFolderId(myGuid, false) == null) {
+        log.debug(
+            "Item (id = {}) is not in a folder. It will not be included in the view results.",
+            contentId);
+        return null;
+      }
+      PSItemProperties props = folderHelper.findItemPropertiesById(stringId);
+      if (props != null) {
+        item.setId(props.getId() != null ? props.getId() : stringId);
+        item.setName(StringUtils.defaultIfBlank(props.getName(), title));
+        item.setTitle(
+            StringUtils.defaultIfBlank(
+                props.getSummary(), StringUtils.defaultIfBlank(props.getName(), title)));
+        item.setFolderPath(props.getPath());
+        if (StringUtils.isNotBlank(props.getType())) {
+          item.setType(props.getType());
+        }
+      }
+    } catch (NumberFormatException nfe) {
+      log.debug("Skipping non-numeric content id from view row: {}", contentId);
+      return null;
+    } catch (Exception e) {
+      if (e instanceof RuntimeException) {
+        log.warn("Could not enrich view result for content id {}: {}", contentId, e.toString());
+      } else {
+        log.debug("Could not enrich view result for content id {}: {}", contentId, e.toString());
+      }
+      item.setId(contentId);
+    }
+    return item;
+  }
+
+  private List<PSSearch> loadAllViews() throws Exception {
+    List<IPSCatalogSummary> summaries = designWs.findViews(null, null);
+    if (summaries == null || summaries.isEmpty()) {
+      return List.of();
+    }
+    List<IPSGuid> guids = new ArrayList<>();
+    for (IPSCatalogSummary sum : summaries) {
+      if (sum != null && sum.getGUID() != null) {
+        guids.add(sum.getGUID());
+      }
+    }
+    if (guids.isEmpty()) {
+      return List.of();
+    }
+    String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+    String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+    List<PSSearch> loaded = designWs.loadViews(guids, false, false, currentSession, currentUser);
+    return loaded != null ? loaded : List.of();
+  }
+
+  /** Resolve design view by name, GUID string, or numeric id. */
+  PSSearch findPsViewByKey(String key) {
+    try {
+      List<PSSearch> loaded = loadAllViews();
+      for (PSSearch s : loaded) {
+        if (s == null) {
+          continue;
+        }
+        if (key.equalsIgnoreCase(s.getName())) {
+          return s;
+        }
+        if (s.getGUID() != null) {
+          String gsv = s.getGUID().toString();
+          if (StringUtils.isNotBlank(gsv) && key.equalsIgnoreCase(gsv)) {
+            return s;
+          }
+          String untyped = s.getGUID().toStringUntyped();
+          if (StringUtils.isNotBlank(untyped) && key.equalsIgnoreCase(untyped)) {
+            return s;
+          }
+        }
+        if (String.valueOf(s.getId()).equals(key)) {
+          return s;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to resolve view {}", key, e);
+      throw new IllegalStateException("Failed to resolve view", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.views.ViewExecuteRequest;
+import com.percussion.rest.views.ViewExecuteResult;
+import com.percussion.rest.views.ViewResultItem;
+import com.percussion.search.IPSSearchResultRow;
+import com.percussion.search.PSWSSearchResponse;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class ViewAdaptorExecuteTest {
+
+  private IPSUiDesignWs designWs;
+  private IPSFolderHelper folderHelper;
+  private IPSIdMapper idMapper;
+  private ViewAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    designWs = mock(IPSUiDesignWs.class);
+    folderHelper = mock(IPSFolderHelper.class);
+    idMapper = mock(IPSIdMapper.class);
+    adaptor = spy(new ViewAdaptor(designWs, folderHelper, idMapper));
+  }
+
+  @Test
+  void normalizeRequest_nullBecomesEmpty() {
+    ViewExecuteRequest n = ViewAdaptor.normalizeRequest(null);
+    assertNotNull(n);
+    assertNull(n.getStartIndex());
+    assertNull(n.getMaxResults());
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadStartIndex() {
+    ViewExecuteRequest r = new ViewExecuteRequest();
+    r.setStartIndex(0);
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadMaxResults() {
+    ViewExecuteRequest r = new ViewExecuteRequest();
+    r.setMaxResults(0);
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadSortOrder() {
+    ViewExecuteRequest r = new ViewExecuteRequest();
+    r.setSortOrder("sideways");
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_normalizesSortOrderCase() {
+    ViewExecuteRequest r = new ViewExecuteRequest();
+    r.setSortOrder("DESC");
+    assertEquals("desc", ViewAdaptor.normalizeRequest(r).getSortOrder());
+  }
+
+  @Test
+  void applyExecuteOverrides_folderAndMax() {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getMaximumResultSize()).thenReturn(100);
+    when(s.getProperty(PSSearch.PROP_FOLDER_PATH_RECURSE)).thenReturn(null);
+
+    ViewExecuteRequest r = new ViewExecuteRequest();
+    r.setFolderPath("//Sites/Demo");
+    r.setMaxResults(10);
+    ViewAdaptor.applyExecuteOverrides(s, r);
+
+    verify(s).setProperty(PSSearch.PROP_FOLDER_PATH, "//Sites/Demo");
+    verify(s).setProperty(PSSearch.PROP_FOLDER_PATH_RECURSE, "true");
+    verify(s).setMaximumNumber(10);
+  }
+
+  @Test
+  void applyExecuteOverrides_defaultsUnlimitedMax() {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getMaximumResultSize()).thenReturn(0);
+    ViewAdaptor.applyExecuteOverrides(s, new ViewExecuteRequest());
+    verify(s).setMaximumNumber(ViewAdaptor.DEFAULT_PAGE_SIZE);
+  }
+
+  @Test
+  void sortItems_byTitleDesc() {
+    List<ViewResultItem> items = new ArrayList<>();
+    items.add(item("1", "Alpha"));
+    items.add(item("2", "Charlie"));
+    items.add(item("3", "Bravo"));
+    ViewAdaptor.sortItems(items, "sys_title", "desc");
+    assertEquals("Charlie", items.get(0).getTitle());
+    assertEquals("Bravo", items.get(1).getTitle());
+    assertEquals("Alpha", items.get(2).getTitle());
+  }
+
+  @Test
+  void executeView_unsafeKeyReturnsNull() {
+    assertNull(adaptor.executeView("../x", new ViewExecuteRequest()));
+    assertNull(adaptor.executeView("a/b", null));
+    assertNull(adaptor.executeView(null, null));
+  }
+
+  @Test
+  void executeView_missingReturnsNull() throws Exception {
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    assertNull(adaptor.executeView("Missing", new ViewExecuteRequest()));
+  }
+
+  @Test
+  void executeView_customUrlThrows400Style() throws Exception {
+    PSSearch custom = mockView("Inbox", true, false);
+    stubLoadedViews(List.of(custom));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.executeView("Inbox", new ViewExecuteRequest()));
+    assertTrue(ex.getMessage().toLowerCase().contains("custom"));
+    assertTrue(ex.getMessage().contains("#3118"));
+  }
+
+  @Test
+  void executeView_happyPathPagesAndMaps() throws Exception {
+    PSSearch design = mockView("All Content", false, true);
+    when(design.getDisplayFormatId()).thenReturn("0-1-1");
+    when(design.getMaximumResultSize()).thenReturn(100);
+    when(design.clone()).thenReturn(design);
+    stubLoadedViews(List.of(design));
+
+    ViewResultItem a = item("id-a", "A");
+    ViewResultItem b = item("id-b", "B");
+    ViewResultItem c = item("id-c", "C");
+    doReturn(List.of(a, b, c)).when(adaptor).runDesignView(any(PSSearch.class));
+
+    ViewExecuteRequest req = new ViewExecuteRequest();
+    req.setStartIndex(2);
+    req.setMaxResults(1);
+    ViewExecuteResult result = adaptor.executeView("All Content", req);
+
+    assertNotNull(result);
+    assertEquals("All Content", result.getViewName());
+    assertEquals("0-1-1", result.getDisplayFormatId());
+    assertEquals(3, result.getTotalCount());
+    assertEquals(2, result.getStartIndex());
+    assertEquals(1, result.getChildren().size());
+    assertEquals("B", result.getChildren().get(0).getTitle());
+  }
+
+  @Test
+  void executeView_emptyResults() throws Exception {
+    PSSearch design = mockView("Empty", false, true);
+    when(design.getDisplayFormatId()).thenReturn("0-1-1");
+    when(design.getMaximumResultSize()).thenReturn(25);
+    when(design.clone()).thenReturn(design);
+    stubLoadedViews(List.of(design));
+    doReturn(List.of()).when(adaptor).runDesignView(any(PSSearch.class));
+
+    ViewExecuteResult result = adaptor.executeView("Empty", null);
+    assertNotNull(result);
+    assertEquals(0, result.getTotalCount());
+    assertTrue(result.getChildren().isEmpty());
+    assertEquals(1, result.getStartIndex());
+  }
+
+  @Test
+  void executeView_loadsViaFindViewsNotFindSearches() throws Exception {
+    PSSearch design = mockView("Community Content", false, true);
+    when(design.getDisplayFormatId()).thenReturn("0-1-1");
+    when(design.getMaximumResultSize()).thenReturn(25);
+    when(design.clone()).thenReturn(design);
+    stubLoadedViews(List.of(design));
+    doReturn(List.of()).when(adaptor).runDesignView(any(PSSearch.class));
+
+    assertNotNull(adaptor.executeView("Community Content", new ViewExecuteRequest()));
+    verify(designWs).findViews(isNull(), isNull());
+    verify(designWs).loadViews(anyList(), eq(false), eq(false), isNull(), isNull());
+  }
+
+  @Test
+  void mapSearchResponse_skipsNullMappedRowsAndKeepsItems() {
+    IPSSearchResultRow blank = mock(IPSSearchResultRow.class);
+    IPSSearchResultRow ok = mock(IPSSearchResultRow.class);
+
+    doReturn(null).when(adaptor).mapResultRow(blank);
+    ViewResultItem kept = item("guid-42", "Title");
+    kept.setFolderPath("/Sites/Demo");
+    kept.setType("Page");
+    doReturn(kept).when(adaptor).mapResultRow(ok);
+
+    PSWSSearchResponse response = mock(PSWSSearchResponse.class);
+    when(response.getRows()).thenReturn(List.of(blank, ok).iterator());
+
+    List<ViewResultItem> mapped = adaptor.mapSearchResponse(response);
+    assertEquals(1, mapped.size());
+    assertEquals("guid-42", mapped.get(0).getId());
+    assertEquals("/Sites/Demo", mapped.get(0).getFolderPath());
+    assertEquals("Page", mapped.get(0).getType());
+  }
+
+  @Test
+  void mapResultRow_blankContentIdReturnsNull() {
+    IPSSearchResultRow blank = mock(IPSSearchResultRow.class);
+    when(blank.getColumnValue("sys_contentid")).thenReturn("  ");
+    assertNull(adaptor.mapResultRow(blank));
+  }
+
+  @Test
+  void mapSearchResponse_nullSafe() {
+    assertTrue(adaptor.mapSearchResponse(null).isEmpty());
+  }
+
+  @Test
+  void isSafeViewKey_stillHoldsForExecutePath() {
+    assertTrue(ViewAdaptor.isSafeViewKey("All Content"));
+    assertFalse(ViewAdaptor.isSafeViewKey("a\\b"));
+  }
+
+  @Test
+  void findPsViewByKey_matchesGuidStringAndUntyped() throws Exception {
+    PSSearch s = mockView("ByGuid", false, true);
+    stubLoadedViews(List.of(s));
+    IPSGuid g = s.getGUID();
+    when(g.toStringUntyped()).thenReturn("42");
+
+    assertEquals(s, adaptor.findPsViewByKey("0-301-0"));
+    assertEquals(s, adaptor.findPsViewByKey("42"));
+  }
+
+  @Test
+  void findPsViewByKey_skipsBlankGuidString() throws Exception {
+    PSSearch s = mockView("BlankGuid", false, true);
+    stubLoadedViews(List.of(s));
+    IPSGuid g = s.getGUID();
+    when(g.toString()).thenReturn("   ");
+    when(g.toStringUntyped()).thenReturn("");
+    when(s.getId()).thenReturn(99);
+
+    assertNull(adaptor.findPsViewByKey("   "));
+    assertEquals(s, adaptor.findPsViewByKey("99"));
+  }
+
+  private static ViewResultItem item(String id, String title) {
+    ViewResultItem i = new ViewResultItem();
+    i.setId(id);
+    i.setName(title);
+    i.setTitle(title);
+    return i;
+  }
+
+  private PSSearch mockView(String name, boolean custom, boolean standard) {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.isCustomView()).thenReturn(custom);
+    when(s.isStandardView()).thenReturn(standard);
+    when(s.isView()).thenReturn(true);
+    when(s.getId()).thenReturn(10);
+    when(s.getGUID()).thenReturn(null);
+    return s;
+  }
+
+  private void stubLoadedViews(List<PSSearch> views) throws Exception {
+    List<IPSCatalogSummary> summaries = new ArrayList<>();
+    List<IPSGuid> guids = new ArrayList<>();
+    for (int i = 0; i < views.size(); i++) {
+      IPSGuid g = mock(IPSGuid.class);
+      when(g.toString()).thenReturn("0-301-" + i);
+      IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+      when(sum.getGUID()).thenReturn(g);
+      summaries.add(sum);
+      guids.add(g);
+      PSSearch s = views.get(i);
+      when(s.getGUID()).thenReturn(g);
+    }
+    when(designWs.findViews(isNull(), isNull())).thenReturn(summaries);
+    when(designWs.loadViews(anyList(), eq(false), eq(false), isNull(), isNull())).thenReturn(views);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
@@ -6,11 +6,24 @@ package com.percussion.rest.views;
 
 import java.util.List;
 
-/** Adaptor for CX view design catalog (UI-07 read). */
+/** Adaptor for CX view design catalog (UI-07 read) and standard-view execute façade. */
 public interface IViewAdaptor {
 
   List<ViewDef> listViews();
 
   /** Resolve by name or GUID string. Returns null if missing/unsafe. */
   ViewDef findViewByKey(String idOrName);
+
+  /**
+   * Execute a standard (field-criteria) design view by name, GUID string, or numeric id with
+   * optional scope/paging overrides. Loads the view via the views design catalog ({@code
+   * IPSUiDesignWs} find/load views) — not the search catalog.
+   *
+   * @param idOrName view key (same rules as {@link #findViewByKey})
+   * @param request optional overrides; {@code null} treated as empty defaults by implementations
+   * @return paged results, or {@code null} when the view is missing/unsafe
+   * @throws IllegalArgumentException when the body is invalid or the view type cannot be executed
+   *     (e.g. custom URL / Inbox-family views)
+   */
+  ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request);
 }

--- a/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequest.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Optional overrides for {@code POST /rest/views/{idOrName}/execute}.
+ *
+ * <p>v1 does not accept a full field-criteria rewrite — design operators live on the loaded view
+ * ({@code PSSearch} of type view). Clients may only scope, page, and sort.
+ *
+ * <p>Peer of {@code SearchExecuteRequest} in the searches catalog; this type is separate so Views
+ * and Searches stay distinct public contracts.
+ */
+@XmlRootElement(name = "ViewExecuteRequest")
+@Schema(description = "Optional overrides when executing a CX design view by id or name")
+public class ViewExecuteRequest {
+
+  private String folderPath;
+  private Integer startIndex;
+  private Integer maxResults;
+  private String sortColumn;
+  private String sortOrder;
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public Integer getStartIndex() {
+    return startIndex;
+  }
+
+  public void setStartIndex(Integer startIndex) {
+    this.startIndex = startIndex;
+  }
+
+  public Integer getMaxResults() {
+    return maxResults;
+  }
+
+  public void setMaxResults(Integer maxResults) {
+    this.maxResults = maxResults;
+  }
+
+  public String getSortColumn() {
+    return sortColumn;
+  }
+
+  public void setSortColumn(String sortColumn) {
+    this.sortColumn = sortColumn;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public void setSortOrder(String sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/ViewExecuteResult.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewExecuteResult.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Paged result envelope for {@code POST /rest/views/{idOrName}/execute}.
+ *
+ * <p>Peer of {@code SearchExecuteResult}; uses {@link ViewResultItem} so Views and Searches do
+ * not share a catalog identity on the wire.
+ */
+@XmlRootElement(name = "ViewExecuteResult")
+@Schema(description = "Paged Explorer-ready results from executing a CX design view")
+public class ViewExecuteResult {
+
+  private List<ViewResultItem> children = new ArrayList<>();
+  private int totalCount;
+  private int startIndex = 1;
+  private String viewName;
+  private String displayFormatId;
+
+  public List<ViewResultItem> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<ViewResultItem> children) {
+    this.children = children != null ? children : new ArrayList<>();
+  }
+
+  public int getTotalCount() {
+    return totalCount;
+  }
+
+  public void setTotalCount(int totalCount) {
+    this.totalCount = totalCount;
+  }
+
+  public int getStartIndex() {
+    return startIndex;
+  }
+
+  public void setStartIndex(int startIndex) {
+    this.startIndex = startIndex;
+  }
+
+  public String getViewName() {
+    return viewName;
+  }
+
+  public void setViewName(String viewName) {
+    this.viewName = viewName;
+  }
+
+  public String getDisplayFormatId() {
+    return displayFormatId;
+  }
+
+  public void setDisplayFormatId(String displayFormatId) {
+    this.displayFormatId = displayFormatId;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -23,14 +25,15 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only CX view catalog for the Developer module (UI-07 list/detail).
+ * CX view design catalog (UI-07 list/detail) plus standard-view execute façade for Explorer.
  *
- * <p>Searches (UI-06) remain a separate catalog.
+ * <p>Searches (UI-06) remain a separate catalog. Custom-URL views (Inbox family) are not executed
+ * here — they return 400 (see Inbox / #3118).
  */
 @PSSiteManageBean(value = "restViewResource")
 @Path("/views")
 @XmlRootElement
-@Tag(name = "Views", description = "CX view design catalog (read-only)")
+@Tag(name = "Views", description = "CX view design catalog and standard-view execute")
 public class ViewResource {
 
   private final IViewAdaptor adaptor;
@@ -96,6 +99,50 @@ public class ViewResource {
     } catch (WebApplicationException e) {
       // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Execute a standard field-criteria design view. Path is multi-segment so it does not collide
+   * with {@code GET /{idOrName}} catalog detail. Custom URL views return 400.
+   */
+  @POST
+  @Path("/{idOrName}/execute")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Execute a standard design view",
+      description =
+          "Loads the CX view design by name, GUID, or id from the views catalog (not searches)"
+              + " and executes it server-side with design field operators, display format, max"
+              + " results, and case sensitivity. Optional body may override folder scope, paging,"
+              + " and sort. Custom URL views (Inbox / Outbox / Recent) return 400; use the Inbox"
+              + " runner when that surface ships.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = ViewExecuteResult.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid body or unsupported view type"),
+        @ApiResponse(responseCode = "404", description = "View not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ViewExecuteResult executeView(
+      @PathParam("idOrName") String idOrName, ViewExecuteRequest body) {
+    try {
+      ViewExecuteResult result = requireAdaptor().executeView(idOrName, body);
+      if (result == null) {
+        throw new WebApplicationException("View not found", 404);
+      }
+      return result;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid execute request", 400);
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }

--- a/rest/src/main/java/com/percussion/rest/views/ViewResultItem.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResultItem.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * One result row from design-view execute, shaped for Explorer open/reveal (id, title/name,
+ * folderPath, type).
+ *
+ * <p>Peer of {@code SearchResultItem}; kept in the views package so catalog contracts stay
+ * separate.
+ */
+@XmlRootElement(name = "ViewResultItem")
+@Schema(description = "Explorer-ready item row from a design view execute")
+public class ViewResultItem {
+
+  private String id;
+  private String name;
+  private String title;
+  private String folderPath;
+  private String type;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestViewAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestViewAdaptor.java
@@ -19,6 +19,8 @@ package com.percussion.rest.test.apibridge;
 
 import com.percussion.rest.views.IViewAdaptor;
 import com.percussion.rest.views.ViewDef;
+import com.percussion.rest.views.ViewExecuteRequest;
+import com.percussion.rest.views.ViewExecuteResult;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -34,5 +36,14 @@ public class TestViewAdaptor implements IViewAdaptor {
   @Override
   public ViewDef findViewByKey(String idOrName) {
     return null;
+  }
+
+  @Override
+  public ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request) {
+    ViewExecuteResult empty = new ViewExecuteResult();
+    empty.setChildren(List.of());
+    empty.setTotalCount(0);
+    empty.setStartIndex(1);
+    return empty;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
@@ -8,7 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -113,5 +115,78 @@ public class ViewResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getView("My View"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void executeViewSuccess() {
+    ViewExecuteRequest req = new ViewExecuteRequest();
+    req.setStartIndex(1);
+    req.setMaxResults(10);
+    ViewExecuteResult expected = new ViewExecuteResult();
+    expected.setViewName("All Content");
+    expected.setTotalCount(0);
+    when(adaptor.executeView(eq("All Content"), eq(req))).thenReturn(expected);
+
+    ViewExecuteResult out = resource.executeView("All Content", req);
+    assertSame(expected, out);
+    assertEquals("All Content", out.getViewName());
+    verify(adaptor).executeView("All Content", req);
+  }
+
+  @Test
+  public void executeViewNullBodyDelegates() {
+    ViewExecuteResult expected = new ViewExecuteResult();
+    expected.setViewName("All Content");
+    when(adaptor.executeView(eq("All Content"), isNull())).thenReturn(expected);
+
+    assertEquals("All Content", resource.executeView("All Content", null).getViewName());
+    verify(adaptor).executeView("All Content", null);
+  }
+
+  @Test
+  public void executeViewNotFoundIsGeneric404() {
+    when(adaptor.executeView(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeView("missing", new ViewExecuteRequest()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("View not found", ex.getMessage());
+  }
+
+  @Test
+  public void executeViewMapsIllegalArgumentTo400() {
+    when(adaptor.executeView(eq("Inbox"), any()))
+        .thenThrow(
+            new IllegalArgumentException(
+                "Custom URL views cannot be executed via this endpoint"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeView("Inbox", new ViewExecuteRequest()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Custom URL"));
+  }
+
+  @Test
+  public void executeViewWrapsUnexpectedAs500() {
+    IllegalStateException boom = new IllegalStateException("engine down");
+    when(adaptor.executeView(eq("All Content"), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeView("All Content", new ViewExecuteRequest()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnExecute() {
+    ViewResource bare = new ViewResource();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.executeView("any", new ViewExecuteRequest()));
+    assertEquals(503, ex.getResponse().getStatus());
   }
 }

--- a/specs/2400-dce-explorer-parity/research/views-inbox-ia-api-map.md
+++ b/specs/2400-dce-explorer-parity/research/views-inbox-ia-api-map.md
@@ -98,12 +98,13 @@ Both design catalogs store definitions as `PSSearch` rows with different `TYPE`:
 
 ## 2. Public REST / adaptor inventory (today)
 
-### 2.1 Views catalog (UI-07) — **read-only, no execute**
+### 2.1 Views catalog (UI-07) — list/detail plus standard execute (#3115)
 
 | Method | Servlet path | WebUI client path | Resource / adaptor |
 |--------|--------------|-------------------|--------------------|
 | `GET` | `/rest/views` | `/services/views` | `ViewResource.listViews` → `IViewAdaptor.listViews` |
 | `GET` | `/rest/views/{idOrName}` | `/services/views/{idOrName}` | `ViewResource.getView` → `findViewByKey` |
+| `POST` | `/rest/views/{idOrName}/execute` | `/services/views/{idOrName}/execute` | `ViewResource.executeView` → `IViewAdaptor.executeView` (standard views only; custom URL → 400 / #3118) |
 
 | Layer | Path |
 |-------|------|


### PR DESCRIPTION
## Summary

Implements **Views V1** REST execute façade for **standard** (field-criteria) CX design views.

`POST /rest/views/{idOrName}/execute` (WebUI `/services/views/{idOrName}/execute`) loads the view via `IViewAdaptor` / `IPSUiDesignWs.findViews` + `loadViews` — **not** the search catalog. Optional body supports folder scope, paging, and sort. Results are Explorer-ready rows (`id`, `name`, `title`, `folderPath`, `type`) plus `viewName` / `displayFormatId`.

**Custom URL views** (`isCustomView` / Inbox family): explicit **400** with a message that they cannot be executed here; deferred to dedicated Inbox runner **#3118**. Never a silent empty result.

Wire DTOs (`ViewExecuteRequest` / `ViewExecuteResult` / `ViewResultItem`) are peers of the search execute types so catalog contracts stay separate.

Parent: **#3110** / **#3102**. Parity program: **#2400**.

Fixes #3115

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Review Mockito `ViewResourceTest` (200 / 400 custom / 404 / 503 / 500).
2. Review `ViewAdaptorExecuteTest` (unsafe key, missing view, custom URL 400 + #3118, paging, `findViews`/`loadViews` not searches).
3. Optional live: `POST /Rhythmyx/services/views/{standardViewName}/execute` with `{}` as an authenticated user; expect 200 paged children. `POST` Inbox (or any `customView`) expect 400.

Env: unit tests via standalone Maven; live CMS optional (no WebUI / Playwright in this slice).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Views design catalog + execute + custom-URL 400 policy)
- [x] **Unit / module tests** — `ViewResourceTest`, `TestViewAdaptor`, `ViewAdaptorExecuteTest`; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen; V2/V3 out of scope per #3115)
- [x] **Build gates** — standalone clean install on `rest` then `projects/sitemanage`
- [x] **Cross-platform** — **N/A** (no filesystem path I/O; key hygiene rejects `/` `\` `..` as URL tokens)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: **333**, Failures: 0 (`ViewResourceTest` 15)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: **1050**, Failures: 0 (`ViewAdaptorExecuteTest` 20)
- **downstream_checked:** C2 applied (`IViewAdaptor.executeView` added; `ViewAdaptor` ctor gained `IPSFolderHelper` + `IPSIdMapper`). Grep: only `ViewAdaptor` + `TestViewAdaptor` implement `IViewAdaptor`; `new ViewAdaptor(` only in new execute tests. sitemanage standalone install green.

### C5 UI proof

N/A — REST/backend only; issue forbids V2 UI and Playwright.

## Out of scope (residuals already filed)

- Explorer tree / SPA UI → **#3116** (V2)
- Playwright → **#3117** (V3)
- Custom-URL / Inbox runner → **#3118** (I1)

No matrix **Present** claim for Explorer Views UI.

> Co-Authored by Grok Build using grok-4.5 with agent main.
