### PR TITLE
fix(explorer): include View_All in Explorer saved-search picker (#3199)

### DIFF
--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -87,10 +87,27 @@ export function unwrapSearchExecuteResult(payload: unknown): SearchExecuteResult
   };
 }
 
-/** GET /services/searches */
-export async function listSearches(): Promise<SearchDef[]> {
-  const payload = await get<unknown>(PATHS.SEARCHES);
+/**
+ * GET /services/searches
+ *
+ * <p>Explorer saved-search picker must pass {@code includeViews: true} so the
+ * default All view ({@code View_All}) is in the catalog. Developer Searches
+ * stays searches-only (default).</p>
+ */
+export async function listSearches(options?: {
+  includeViews?: boolean;
+}): Promise<SearchDef[]> {
+  const url =
+    options?.includeViews === true
+      ? `${PATHS.SEARCHES}?includeViews=true`
+      : PATHS.SEARCHES;
+  const payload = await get<unknown>(url);
   return asArray<SearchDef>(payload);
+}
+
+/** Explorer catalog: searches plus CX views (View_All / All). */
+export function listExplorerSavedSearches(): Promise<SearchDef[]> {
+  return listSearches({ includeViews: true });
 }
 
 /** GET /services/searches/{idOrName} */

--- a/WebUI/src/main/ts/contentBrowser/types.ts
+++ b/WebUI/src/main/ts/contentBrowser/types.ts
@@ -67,7 +67,8 @@ export interface ContentBrowserProps {
    */
   search?: (criteria: PSSearchCriteria) => Promise<PSSearchResults>;
   /**
-   * Test / host seam: saved-search catalog (default SearchPanel → listSearches).
+   * Test / host seam: saved-search catalog (default SearchPanel →
+   * listExplorerSavedSearches / includeViews).
    */
   listSavedSearches?: () => Promise<SearchDef[]>;
   /**

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -162,7 +162,7 @@ export interface ContentExplorerShellProps {
   search?: SearchPanelProps["search"];
   /**
    * Test / host seam: saved-search catalog for the product Search panel.
-   * Default {@link SearchPanel} → listSearches.
+   * Default {@link SearchPanel} → listExplorerSavedSearches (includeViews).
    */
   listSavedSearches?: SearchPanelProps["listSavedSearches"];
   /**

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -49,7 +49,7 @@ import {
 } from "../api/contentExplorer/searchApi";
 import {
   executeSearch as executeSearchApi,
-  listSearches as listSearchesApi,
+  listExplorerSavedSearches,
 } from "../api/developer/searchesApi";
 import type {
   SearchDef,
@@ -69,7 +69,7 @@ export interface SearchPanelProps {
   search?: (criteria: PSSearchCriteria) => Promise<PSSearchResults>;
   /**
    * Override for the saved-search catalog load
-   * (default: {@link listSearchesApi}).
+   * (default: {@link listExplorerSavedSearches}, includeViews).
    */
   listSavedSearches?: () => Promise<SearchDef[]>;
   /**
@@ -148,7 +148,7 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
     initialQuery = "",
     initialCriteria = {},
     search = searchExtended,
-    listSavedSearches = listSearchesApi,
+    listSavedSearches = listExplorerSavedSearches,
     executeSavedSearch = executeSearchApi,
     onOpen,
     onReveal,

--- a/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
@@ -42,6 +42,11 @@ const ONE_ROW: PSItemProperties[] = [
 
 const SAVED: SearchDef[] = [
   {
+    name: "View_All",
+    label: "All",
+    type: "View",
+  },
+  {
     name: "All Content",
     label: "All Content",
     standardSearch: true,
@@ -307,6 +312,9 @@ describe("SearchPanel", () => {
       expect(Array.from(select.options).some((o) => o.value === "All Content")).toBe(
         true,
       );
+      expect(Array.from(select.options).some((o) => o.value === "View_All")).toBe(
+        true,
+      );
     });
 
     it("shows empty catalog state", async () => {
@@ -334,6 +342,35 @@ describe("SearchPanel", () => {
         expect(screen.getByTestId("search-panel-saved-picker")).toBeTruthy();
       });
       expect(attempt).toBe(2);
+    });
+
+    it("runs the default All view (View_All) via execute", async () => {
+      const executeSavedSearch = vi.fn().mockResolvedValue({
+        children: ONE_ROW,
+        totalCount: 1,
+        startIndex: 1,
+        searchName: "View_All",
+      });
+      render(
+        <SearchPanel
+          listSavedSearches={readyCatalog()}
+          executeSavedSearch={executeSavedSearch}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-select")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("search-panel-saved-select"), {
+        target: { value: "View_All" },
+      });
+      fireEvent.click(screen.getByTestId("search-panel-saved-run"));
+      await waitFor(() => {
+        expect(executeSavedSearch).toHaveBeenCalledTimes(1);
+      });
+      expect(executeSavedSearch.mock.calls[0]?.[0]).toBe("View_All");
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-results")).toBeTruthy();
+      });
     });
 
     it("runs a selected saved search via execute and shows results", async () => {

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -17,6 +17,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   executeSearch,
+  listExplorerSavedSearches,
+  listSearches,
   unwrapSearchExecuteResult,
 } from "../../../main/ts/api/developer/searchesApi";
 import { PATHS } from "../../../main/ts/api/paths";
@@ -54,6 +56,40 @@ describe("unwrapSearchExecuteResult", () => {
   it("returns empty shape for null / non-object", () => {
     expect(unwrapSearchExecuteResult(null).children).toEqual([]);
     expect(unwrapSearchExecuteResult("x").children).toEqual([]);
+  });
+});
+
+describe("listSearches", () => {
+  it("GETs /searches without includeViews by default", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify([{ name: "My Pages" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const out = await listSearches();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(PATHS.SEARCHES);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("My Pages");
+  });
+
+  it("Explorer helper requests includeViews=true", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          SearchDef: [
+            { name: "View_All", label: "All" },
+            { name: "My Pages" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const out = await listExplorerSavedSearches();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      `${PATHS.SEARCHES}?includeViews=true`,
+    );
+    expect(out.map((s) => s.name)).toEqual(["View_All", "My Pages"]);
   });
 });
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
@@ -129,7 +129,7 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
     // Probe REST catalog so we know a runnable key before UI drive; soft-skip
     // when QA H2 fixture has no design searches (documented acceptance).
     const headers = adminBasicAuthHeaders();
-    const catalogUrl = searchesCatalogUrl(BASE_URL);
+    const catalogUrl = searchesCatalogUrl(BASE_URL, { includeViews: true });
     let restStatus = 0;
     let restBody = null;
     try {
@@ -248,7 +248,7 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
   }) => {
     test.setTimeout(45_000);
     const headers = adminBasicAuthHeaders();
-    const res = await request.get(searchesCatalogUrl(BASE_URL), {
+    const res = await request.get(searchesCatalogUrl(BASE_URL, { includeViews: true }), {
       headers: { ...headers, Accept: "application/json" },
     });
     // 200 = catalog; 401/403 still prove webapp auth surface; 5xx is hard fail.
@@ -265,6 +265,19 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
       // Structural unwrap never throws on common shapes.
       const defs = unwrapSearchDefs(body);
       expect(Array.isArray(defs)).toBe(true);
+      // Default CX All view must appear when views are included (#3205 / #3199).
+      const names = defs
+        .map((d) => (d && d.name != null ? String(d.name) : ""))
+        .filter(Boolean);
+      if (names.length > 0) {
+        const hasViewAll = names.some(
+          (n) => n.toLowerCase() === "view_all" || n.toLowerCase() === "all",
+        );
+        expect(
+          hasViewAll,
+          `includeViews catalog should expose View_All (names=${names.join(",")})`,
+        ).toBe(true);
+      }
     }
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
@@ -60,11 +60,14 @@ function explorerEntryUrl(baseUrl, opts = {}) {
  * @param {string} baseUrl
  * @returns {string}
  */
-function searchesCatalogUrl(baseUrl) {
+function searchesCatalogUrl(baseUrl, opts = {}) {
   const root = String(baseUrl || "")
     .trim()
     .replace(/\/+$/, "");
-  return `${root}${PATH_SEARCHES}`;
+  const includeViews = opts.includeViews === true;
+  return includeViews
+    ? `${root}${PATH_SEARCHES}?includeViews=true`
+    : `${root}${PATH_SEARCHES}`;
 }
 
 /**
@@ -170,8 +173,22 @@ function isCustomUrlSearch(def) {
  * @param {unknown} payload raw REST body or SearchDef[]
  * @returns {{ key: string, label: string, def: Record<string, unknown> } | null}
  */
+function isDefaultAllView(def) {
+  if (def == null || typeof def !== "object") {
+    return false;
+  }
+  const name = def.name != null ? String(def.name).trim() : "";
+  const label = searchDefLabel(def);
+  return (
+    name.toLowerCase() === "view_all" ||
+    (name.toLowerCase() === "all" && String(def.type || "").toLowerCase() === "view") ||
+    (label.toLowerCase() === "all" && String(def.type || "").toLowerCase() === "view")
+  );
+}
+
 function pickRunnableSavedSearch(payload) {
   const defs = unwrapSearchDefs(payload);
+  let first = null;
   for (const def of defs) {
     if (isCustomUrlSearch(def)) {
       continue;
@@ -180,9 +197,15 @@ function pickRunnableSavedSearch(payload) {
     if (!key) {
       continue;
     }
-    return { key, label: searchDefLabel(def) || key, def };
+    const picked = { key, label: searchDefLabel(def) || key, def };
+    if (isDefaultAllView(def)) {
+      return picked;
+    }
+    if (first == null) {
+      first = picked;
+    }
   }
-  return null;
+  return first;
 }
 
 /**
@@ -251,6 +274,7 @@ module.exports = {
   explorerEntryUrl,
   searchesCatalogUrl,
   searchesExecuteUrl,
+  isDefaultAllView,
   unwrapSearchDefs,
   searchDefKey,
   searchDefLabel,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
@@ -15,6 +15,7 @@ const {
   explorerEntryUrl,
   searchesCatalogUrl,
   searchesExecuteUrl,
+  isDefaultAllView,
   unwrapSearchDefs,
   searchDefKey,
   searchDefLabel,
@@ -51,6 +52,10 @@ describe("explorer-saved-search helpers (#2507)", () => {
     assert.equal(
       searchesCatalogUrl("http://127.0.0.1:9993/"),
       "http://127.0.0.1:9993/Rhythmyx/services/searches",
+    );
+    assert.equal(
+      searchesCatalogUrl("http://127.0.0.1:9993/", { includeViews: true }),
+      "http://127.0.0.1:9993/Rhythmyx/services/searches?includeViews=true",
     );
     assert.equal(
       searchesExecuteUrl("http://cms.example", "All Content"),
@@ -91,6 +96,22 @@ describe("explorer-saved-search helpers (#2507)", () => {
     assert.equal(isCustomUrlSearch({ customSearch: "true" }), true);
     assert.equal(isCustomUrlSearch({ customSearch: false }), false);
     assert.equal(isCustomUrlSearch({}), false);
+  });
+
+  it("isDefaultAllView matches View_All / All view", () => {
+    assert.equal(isDefaultAllView({ name: "View_All", label: "All" }), true);
+    assert.equal(isDefaultAllView({ name: "All", type: "View" }), true);
+    assert.equal(isDefaultAllView({ name: "My Pages" }), false);
+  });
+
+  it("pickRunnableSavedSearch prefers View_All over other runnable rows", () => {
+    const picked = pickRunnableSavedSearch([
+      { name: "My Pages" },
+      { name: "View_All", label: "All", type: "View" },
+    ]);
+    assert.ok(picked);
+    assert.equal(picked.key, "View_All");
+    assert.equal(picked.label, "All");
   });
 
   it("pickRunnableSavedSearch skips custom URL entries", () => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -97,6 +97,9 @@ When the panel is open you can:
 1. Enter free-text criteria (scoped to the current folder path when a folder is active).
 2. Submit the search and open a hit or reveal it in its parent folder.
 3. Pick a **saved / design search** from the catalog (when the server exposes one) and run it.
+   The picker includes CX **searches and views**. The default **All** view (`View_All`) is
+   listed when that design object exists on the server. Custom URL searches stay listed
+   but cannot be run from Explorer.
 
 Closing **View → Search** (or **Content → Search**) again hides the panel. Revealing a
 result in its folder also closes the panel so the tree/list can show the destination.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -181,6 +181,29 @@ Content-type detail may still include **extra** per-item gaps (for example contr
 failures); those remain on the detail payload only. Structured `{ code, message }` entries apply
 on the Content Type / Template / Slot detail paths described above.
 
+## Searches catalog and execute
+
+CX design **searches** (and optionally **views**) are exposed under `/services/searches`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/searches` | List search definitions (Developer catalog; views omitted) |
+| `GET` | `/services/searches?includeViews=true` | List searches **and** views (Explorer saved-search picker) |
+| `GET` | `/services/searches/{idOrName}` | Load one search or view by name, label, GUID, or numeric id |
+| `POST` | `/services/searches/{idOrName}/execute` | Execute a standard/user search or view (not a custom URL) |
+
+`includeViews=true` is required for the Explorer Search panel so the default **All** view
+(`View_All`) is in the picker. Developer **Searches** remains searches-only; views stay on
+`/services/views`.
+
+If the search catalog fails independently of views (or the reverse), `includeViews=true`
+still returns whichever side loaded so the picker is not a silent empty list or 500 for
+the default All view.
+
+Execute looks up the same combined catalog (searches first, then views). Keys accepted:
+internal name (`View_All`), display label (`All`), GUID string, or numeric id. Custom URL
+searches and custom views return **400**.
+
 ## Content Explorer folders (Rhythmyx path façade)
 
 Public REST for **Rhythmyx** folder operations used by Content Explorer integrators and (later)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -384,8 +384,11 @@ public class SearchAdaptor implements ISearchAdaptor {
     }
     String trimmed = key.trim();
     Exception first = null;
+    boolean searchCatalogOk = false;
+    boolean viewCatalogOk = false;
     try {
       PSSearch found = matchLoaded(loadAllSearches(), trimmed);
+      searchCatalogOk = true;
       if (found != null) {
         return found;
       }
@@ -395,6 +398,7 @@ public class SearchAdaptor implements ISearchAdaptor {
     }
     try {
       PSSearch found = matchLoaded(loadAllViews(), trimmed);
+      viewCatalogOk = true;
       if (found != null) {
         return found;
       }
@@ -404,7 +408,8 @@ public class SearchAdaptor implements ISearchAdaptor {
         first = e;
       }
     }
-    if (first != null) {
+    // Only 500 when both catalogs failed. One healthy catalog + miss is 404.
+    if (first != null && !searchCatalogOk && !viewCatalogOk) {
       throw new IllegalStateException("Failed to resolve search", first);
     }
     return null;

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -78,23 +78,40 @@ public class SearchAdaptor implements ISearchAdaptor {
 
   @Override
   public List<SearchDef> listSearches() {
+    return listSearches(false);
+  }
+
+  /**
+   * Developer catalog is searches-only. Explorer saved-search picker passes {@code
+   * includeViews=true} so the default All view ({@code View_All}) is listed and executable.
+   */
+  @Override
+  public List<SearchDef> listSearches(boolean includeViews) {
+    List<SearchDef> out = new ArrayList<>();
+    Exception searchFailure = null;
     try {
-      List<PSSearch> loaded = loadAllSearches();
-      List<SearchDef> out = new ArrayList<>();
-      for (PSSearch s : loaded) {
-        if (s != null) {
-          // REST-GAPS-02: list rows omit identical designGaps; detail re-attaches them.
-          out.add(toDef(s, false));
-        }
-      }
-      out.sort(
-          Comparator.comparing(
-              SearchDef::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
-      return out;
+      addSearchDefs(out, loadAllSearches());
     } catch (Exception e) {
+      searchFailure = e;
       log.error("Failed to list searches", e);
-      throw new IllegalStateException("Failed to list searches", e);
     }
+    Exception viewFailure = null;
+    if (includeViews) {
+      try {
+        addSearchDefs(out, loadAllViews());
+      } catch (Exception e) {
+        viewFailure = e;
+        log.error("Failed to list views for the Explorer search catalog", e);
+      }
+    }
+    if (out.isEmpty() && (searchFailure != null || viewFailure != null)) {
+      Exception cause = searchFailure != null ? searchFailure : viewFailure;
+      throw new IllegalStateException("Failed to list searches", cause);
+    }
+    out.sort(
+        Comparator.comparing(
+            SearchDef::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+    return out;
   }
 
   @Override
@@ -122,7 +139,7 @@ public class SearchAdaptor implements ISearchAdaptor {
       if (design == null) {
         return null;
       }
-      if (design.isCustomSearch()) {
+      if (design.isCustomSearch() || design.isCustomView()) {
         throw new IllegalArgumentException(
             "Custom URL searches cannot be executed via this endpoint");
       }
@@ -317,7 +334,16 @@ public class SearchAdaptor implements ISearchAdaptor {
   }
 
   private List<PSSearch> loadAllSearches() throws Exception {
-    List<IPSCatalogSummary> summaries = designWs.findSearches(null, null);
+    return loadCatalog(false);
+  }
+
+  private List<PSSearch> loadAllViews() throws Exception {
+    return loadCatalog(true);
+  }
+
+  private List<PSSearch> loadCatalog(boolean views) throws Exception {
+    List<IPSCatalogSummary> summaries =
+        views ? designWs.findViews(null, null) : designWs.findSearches(null, null);
     if (summaries == null || summaries.isEmpty()) {
       return List.of();
     }
@@ -332,41 +358,89 @@ public class SearchAdaptor implements ISearchAdaptor {
     }
     String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
     String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
-    List<PSSearch> loaded = designWs.loadSearches(guids, false, false, currentSession, currentUser);
+    List<PSSearch> loaded =
+        views
+            ? designWs.loadViews(guids, false, false, currentSession, currentUser)
+            : designWs.loadSearches(guids, false, false, currentSession, currentUser);
     return loaded != null ? loaded : List.of();
   }
 
-  /** Resolve design search by name, GUID string, or numeric id. */
+  private static void addSearchDefs(List<SearchDef> out, List<PSSearch> loaded) {
+    if (loaded == null) {
+      return;
+    }
+    for (PSSearch s : loaded) {
+      if (s != null) {
+        // REST-GAPS-02: list rows omit identical designGaps; detail re-attaches them.
+        out.add(toDef(s, false));
+      }
+    }
+  }
+
+  /** Resolve design search or view by name, label, GUID string, or numeric id. */
   PSSearch findPsSearchByKey(String key) {
+    if (!isSafeSearchKey(key)) {
+      return null;
+    }
+    String trimmed = key.trim();
+    Exception first = null;
     try {
-      List<PSSearch> loaded = loadAllSearches();
-      for (PSSearch s : loaded) {
-        if (s == null) {
-          continue;
-        }
-        if (key.equalsIgnoreCase(s.getName())) {
+      PSSearch found = matchLoaded(loadAllSearches(), trimmed);
+      if (found != null) {
+        return found;
+      }
+    } catch (Exception e) {
+      first = e;
+      log.error("Failed to resolve search {} from search catalog", trimmed, e);
+    }
+    try {
+      PSSearch found = matchLoaded(loadAllViews(), trimmed);
+      if (found != null) {
+        return found;
+      }
+    } catch (Exception e) {
+      log.error("Failed to resolve search {} from view catalog", trimmed, e);
+      if (first == null) {
+        first = e;
+      }
+    }
+    if (first != null) {
+      throw new IllegalStateException("Failed to resolve search", first);
+    }
+    return null;
+  }
+
+  static PSSearch matchLoaded(List<PSSearch> loaded, String key) {
+    if (loaded == null || StringUtils.isBlank(key)) {
+      return null;
+    }
+    PSSearch labelMatch = null;
+    for (PSSearch s : loaded) {
+      if (s == null) {
+        continue;
+      }
+      if (key.equalsIgnoreCase(s.getName())) {
+        return s;
+      }
+      if (s.getGUID() != null) {
+        // IPSGuid has no Optional string; guard blank/sentinel toString before match
+        String gsv = s.getGUID().toString();
+        if (StringUtils.isNotBlank(gsv) && key.equalsIgnoreCase(gsv)) {
           return s;
         }
-        if (s.getGUID() != null) {
-          // IPSGuid has no Optional string; guard blank/sentinel toString before match
-          String gsv = s.getGUID().toString();
-          if (StringUtils.isNotBlank(gsv) && key.equalsIgnoreCase(gsv)) {
-            return s;
-          }
-          String untyped = s.getGUID().toStringUntyped();
-          if (StringUtils.isNotBlank(untyped) && key.equalsIgnoreCase(untyped)) {
-            return s;
-          }
-        }
-        if (String.valueOf(s.getId()).equals(key)) {
+        String untyped = s.getGUID().toStringUntyped();
+        if (StringUtils.isNotBlank(untyped) && key.equalsIgnoreCase(untyped)) {
           return s;
         }
       }
-      return null;
-    } catch (Exception e) {
-      log.error("Failed to resolve search {}", key, e);
-      throw new IllegalStateException("Failed to resolve search", e);
+      if (String.valueOf(s.getId()).equals(key)) {
+        return s;
+      }
+      if (labelMatch == null && key.equalsIgnoreCase(s.getLabel())) {
+        labelMatch = s;
+      }
     }
+    return labelMatch;
   }
 
   /** Maps design search meta; includes designGaps by default (detail / unit-test path). */
@@ -392,7 +466,8 @@ public class SearchAdaptor implements ISearchAdaptor {
     d.setParentCategory(s.getParentCategory());
     d.setMaximumResultSize(s.getMaximumResultSize());
     d.setUserSearch(s.isUserSearch());
-    d.setCustomSearch(s.isCustomSearch());
+    // Custom views are URL-backed like custom searches — picker must not execute them.
+    d.setCustomSearch(s.isCustomSearch() || s.isCustomView());
     d.setStandardSearch(s.isStandardSearch());
     d.setUserCustomizable(s.isUserCustomizable());
     d.setCaseSensitive(s.isCaseSensitive());

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -135,6 +135,7 @@ class SearchAdaptorExecuteTest {
   @Test
   void executeSearch_missingReturnsNull() throws Exception {
     when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
     assertNull(adaptor.executeSearch("Missing", new SearchExecuteRequest()));
   }
 
@@ -148,6 +149,63 @@ class SearchAdaptorExecuteTest {
             IllegalArgumentException.class,
             () -> adaptor.executeSearch("Custom", new SearchExecuteRequest()));
     assertTrue(ex.getMessage().toLowerCase().contains("custom"));
+  }
+
+  @Test
+  void executeSearch_resolvesDefaultViewAllFromViewCatalog() throws Exception {
+    PSSearch viewAll = mockSearch("View_All", false, false);
+    when(viewAll.getLabel()).thenReturn("All");
+    when(viewAll.isView()).thenReturn(true);
+    when(viewAll.isCustomView()).thenReturn(false);
+    when(viewAll.getDisplayFormatId()).thenReturn("0-1-1");
+    when(viewAll.getMaximumResultSize()).thenReturn(25);
+    when(viewAll.clone()).thenReturn(viewAll);
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+    stubLoadedViews(List.of(viewAll));
+    doReturn(List.of(item("id-a", "Welcome"))).when(adaptor).runDesignSearch(any(PSSearch.class));
+
+    SearchExecuteResult byName = adaptor.executeSearch("View_All", new SearchExecuteRequest());
+    assertNotNull(byName);
+    assertEquals("View_All", byName.getSearchName());
+    assertEquals(1, byName.getChildren().size());
+
+    SearchExecuteResult byLabel = adaptor.executeSearch("All", new SearchExecuteRequest());
+    assertNotNull(byLabel);
+    assertEquals("View_All", byLabel.getSearchName());
+  }
+
+  @Test
+  void listSearches_includeViewsMergesViewAll() throws Exception {
+    PSSearch search = mockSearch("My Pages", false, true);
+    PSSearch viewAll = mockSearch("View_All", false, false);
+    when(viewAll.getLabel()).thenReturn("All");
+    when(viewAll.isView()).thenReturn(true);
+    when(viewAll.isCustomView()).thenReturn(false);
+    stubLoadedSearches(List.of(search));
+    stubLoadedViews(List.of(viewAll));
+
+    List<com.percussion.rest.searches.SearchDef> developer = adaptor.listSearches(false);
+    assertEquals(1, developer.size());
+    assertEquals("My Pages", developer.get(0).getName());
+
+    List<com.percussion.rest.searches.SearchDef> explorer = adaptor.listSearches(true);
+    assertEquals(2, explorer.size());
+    assertTrue(explorer.stream().anyMatch(d -> "View_All".equals(d.getName())));
+    assertTrue(explorer.stream().anyMatch(d -> "My Pages".equals(d.getName())));
+  }
+
+  @Test
+  void listSearches_includeViewsStillReturnsViewsWhenSearchCatalogFails() throws Exception {
+    PSSearch viewAll = mockSearch("View_All", false, false);
+    when(viewAll.getLabel()).thenReturn("All");
+    when(viewAll.isCustomView()).thenReturn(false);
+    when(designWs.findSearches(isNull(), isNull()))
+        .thenThrow(new IllegalStateException("PSAction missing"));
+    stubLoadedViews(List.of(viewAll));
+
+    List<com.percussion.rest.searches.SearchDef> explorer = adaptor.listSearches(true);
+    assertEquals(1, explorer.size());
+    assertEquals("View_All", explorer.get(0).getName());
   }
 
   @Test
@@ -270,7 +328,9 @@ class SearchAdaptorExecuteTest {
   private PSSearch mockSearch(String name, boolean custom, boolean standard) {
     PSSearch s = mock(PSSearch.class);
     when(s.getName()).thenReturn(name);
+    when(s.getLabel()).thenReturn(name);
     when(s.isCustomSearch()).thenReturn(custom);
+    when(s.isCustomView()).thenReturn(false);
     when(s.isStandardSearch()).thenReturn(standard);
     when(s.getId()).thenReturn(10);
     when(s.getGUID()).thenReturn(null);
@@ -293,5 +353,20 @@ class SearchAdaptorExecuteTest {
     when(designWs.findSearches(isNull(), isNull())).thenReturn(summaries);
     when(designWs.loadSearches(anyList(), eq(false), eq(false), isNull(), isNull()))
         .thenReturn(searches);
+  }
+
+  private void stubLoadedViews(List<PSSearch> views) throws Exception {
+    List<IPSCatalogSummary> summaries = new ArrayList<>();
+    for (int i = 0; i < views.size(); i++) {
+      IPSGuid g = mock(IPSGuid.class);
+      when(g.toString()).thenReturn("0-302-" + i);
+      IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+      when(sum.getGUID()).thenReturn(g);
+      summaries.add(sum);
+      PSSearch s = views.get(i);
+      when(s.getGUID()).thenReturn(g);
+    }
+    when(designWs.findViews(isNull(), isNull())).thenReturn(summaries);
+    when(designWs.loadViews(anyList(), eq(false), eq(false), isNull(), isNull())).thenReturn(views);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -152,6 +152,44 @@ class SearchAdaptorExecuteTest {
   }
 
   @Test
+  void executeSearch_viewAllWhenSearchCatalogThrows() throws Exception {
+    PSSearch viewAll = mockSearch("View_All", false, false);
+    when(viewAll.getLabel()).thenReturn("All");
+    when(viewAll.isCustomView()).thenReturn(false);
+    when(viewAll.getDisplayFormatId()).thenReturn("0-1-1");
+    when(viewAll.getMaximumResultSize()).thenReturn(25);
+    when(viewAll.clone()).thenReturn(viewAll);
+    when(designWs.findSearches(isNull(), isNull()))
+        .thenThrow(new IllegalStateException("PSAction missing"));
+    stubLoadedViews(List.of(viewAll));
+    doReturn(List.of(item("id-a", "Welcome"))).when(adaptor).runDesignSearch(any(PSSearch.class));
+
+    SearchExecuteResult byName = adaptor.executeSearch("View_All", new SearchExecuteRequest());
+    assertNotNull(byName);
+    assertEquals("View_All", byName.getSearchName());
+  }
+
+  @Test
+  void executeSearch_missingAfterSearchCatalogThrowReturnsNull() throws Exception {
+    when(designWs.findSearches(isNull(), isNull()))
+        .thenThrow(new IllegalStateException("PSAction missing"));
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+
+    assertNull(adaptor.executeSearch("Missing", new SearchExecuteRequest()));
+  }
+
+  @Test
+  void matchLoaded_prefersNameOverLabel() {
+    PSSearch named = mockSearch("View_All", false, false);
+    when(named.getLabel()).thenReturn("All");
+    PSSearch other = mockSearch("My Pages", false, true);
+    when(other.getLabel()).thenReturn("All");
+    assertEquals(named, SearchAdaptor.matchLoaded(List.of(other, named), "View_All"));
+    // First label match wins when no internal name equals the key.
+    assertEquals(other, SearchAdaptor.matchLoaded(List.of(other, named), "All"));
+  }
+
+  @Test
   void executeSearch_resolvesDefaultViewAllFromViewCatalog() throws Exception {
     PSSearch viewAll = mockSearch("View_All", false, false);
     when(viewAll.getLabel()).thenReturn("All");

--- a/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
@@ -11,6 +11,18 @@ public interface ISearchAdaptor {
 
   List<SearchDef> listSearches();
 
+  /**
+   * List CX search definitions, optionally merging CX views (Explorer saved-search picker).
+   *
+   * <p>Default implementation ignores {@code includeViews} and delegates to {@link
+   * #listSearches()} so existing test stubs stay source-compatible.
+   *
+   * @param includeViews when true, include view definitions (for example {@code View_All})
+   */
+  default List<SearchDef> listSearches(boolean includeViews) {
+    return listSearches();
+  }
+
   /** Resolve by name or GUID string. Returns null if missing/unsafe. */
   SearchDef findSearchByKey(String idOrName);
 

--- a/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
@@ -14,9 +14,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -51,8 +53,9 @@ public class SearchResource {
   @Operation(
       summary = "List search definitions",
       description =
-          "Lists Content Explorer search definitions (not views). Create/edit/delete are later"
-              + " slices.",
+          "Lists Content Explorer search definitions. Pass includeViews=true to also return CX"
+              + " views (Explorer saved-search picker, including the default All / View_All"
+              + " view). Create/edit/delete are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -62,9 +65,10 @@ public class SearchResource {
         @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
-  public List<SearchDef> listSearches() {
+  public List<SearchDef> listSearches(
+      @QueryParam("includeViews") @DefaultValue("false") boolean includeViews) {
     try {
-      List<SearchDef> list = requireAdaptor().listSearches();
+      List<SearchDef> list = requireAdaptor().listSearches(includeViews);
       return list != null ? list : List.of();
     } catch (WebApplicationException e) {
       throw e;

--- a/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
@@ -29,7 +29,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * CX search design catalog (UI-06 list/detail) plus design-search execute façade for Explorer.
  *
- * <p>Views (UI-07) remain a separate catalog.
+ * <p>Developer list is searches-only. Explorer saved-search picker uses {@code
+ * includeViews=true} so CX views (including {@code View_All}) appear. Dedicated view
+ * management remains on {@code /services/views}.
  */
 @PSSiteManageBean(value = "restSearchResource")
 @Path("/searches")

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
@@ -37,26 +37,37 @@ public class SearchResourceTest {
   public void listSearchesSuccess() {
     SearchDef s = new SearchDef();
     s.setName("All Content");
-    when(adaptor.listSearches()).thenReturn(List.of(s));
-    List<SearchDef> out = resource.listSearches();
+    when(adaptor.listSearches(false)).thenReturn(List.of(s));
+    List<SearchDef> out = resource.listSearches(false);
     assertEquals(1, out.size());
     assertEquals("All Content", out.get(0).getName());
-    verify(adaptor).listSearches();
+    verify(adaptor).listSearches(false);
+  }
+
+  @Test
+  public void listSearchesIncludeViewsDelegates() {
+    SearchDef view = new SearchDef();
+    view.setName("View_All");
+    when(adaptor.listSearches(true)).thenReturn(List.of(view));
+    List<SearchDef> out = resource.listSearches(true);
+    assertEquals(1, out.size());
+    assertEquals("View_All", out.get(0).getName());
+    verify(adaptor).listSearches(true);
   }
 
   @Test
   public void listSearchesNullSafe() {
-    when(adaptor.listSearches()).thenReturn(null);
-    assertTrue(resource.listSearches().isEmpty());
+    when(adaptor.listSearches(false)).thenReturn(null);
+    assertTrue(resource.listSearches(false).isEmpty());
   }
 
   @Test
   public void listSearchesWrapsUnexpectedFailuresAs500() {
     IllegalStateException boom = new IllegalStateException("boom");
-    when(adaptor.listSearches()).thenThrow(boom);
+    when(adaptor.listSearches(false)).thenThrow(boom);
 
     WebApplicationException ex =
-        assertThrows(WebApplicationException.class, () -> resource.listSearches());
+        assertThrows(WebApplicationException.class, () -> resource.listSearches(false));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
   }
@@ -65,7 +76,7 @@ public class SearchResourceTest {
   public void missingAdaptorReturnsServiceUnavailableOnList() {
     SearchResource bare = new SearchResource();
     WebApplicationException ex =
-        assertThrows(WebApplicationException.class, bare::listSearches);
+        assertThrows(WebApplicationException.class, () -> bare.listSearches(false));
     assertEquals(503, ex.getResponse().getStatus());
   }
 

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
@@ -30,7 +30,19 @@ public class TestSearchAdaptor implements ISearchAdaptor {
 
   @Override
   public List<SearchDef> listSearches() {
-    return List.of();
+    return listSearches(false);
+  }
+
+  @Override
+  public List<SearchDef> listSearches(boolean includeViews) {
+    if (!includeViews) {
+      return List.of();
+    }
+    SearchDef viewAll = new SearchDef();
+    viewAll.setName("View_All");
+    viewAll.setLabel("All");
+    viewAll.setType("View");
+    return List.of(viewAll);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Explorer Search failed human QA (#2729 / sibling #3205) because the default **All** design object is a CX **view** (`View_All`), not a search. `GET /services/searches` listed searches only, so the picker missed All and execute could not resolve `View_All`.

This PR (same commits as #3233 plus a 404-vs-500 execute robustness commit):

- Adds `GET /services/searches?includeViews=true` for the Explorer catalog; Developer Searches stays searches-only.
- Resolves execute/detail by searches then views (name, label `All`, GUID, numeric id).
- If the search catalog fails independently, views (including `View_All`) still list.
- Execute returns **404** when one catalog loads and the key is missing (no false 500).
- Rejects custom URL searches **and** custom views on execute.
- SearchPanel uses `listExplorerSavedSearches()` (`includeViews=true`).
- Playwright prefers `View_All` and probes the includeViews catalog.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3199
Fixes #3205
Related QA: #2729 #2607 #3234

Parent tracker: #3199 (QA residual of #2729; chain #2506 → #2607 → #2712 → #2729)

## Test plan

1. QA H2 docker (`perc-devctl qa-up`) or this PR’s hot-deployed cell.
2. Sign in as Admin; open Explorer (`spa.jsp?entry=explorer`).
3. **View → Search**. Saved-search picker must load (not stuck on loading; not silent empty).
4. Confirm **All** (`View_All`) is in the list; select it and **Run saved search**.
5. Confirm results, empty, or a visible error+Retry (not a silent no-op).
6. Confirm free-text Search still works.
7. Custom URL entries stay non-runnable.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — SearchAdaptor catalog/execute + 404-when-one-catalog-ok; SearchResource includeViews; Vitest picker + `listExplorerSavedSearches`
- [x] **WebUI + Playwright** — `tests/explorer-saved-search.spec.js` (includeViews + View_All preference)
- [x] **Build gates** — standalone `mvnw clean install` on `rest`, `projects/sitemanage`, `WebUI`
- [x] **Cross-platform** — N/A (no new filesystem path I/O; URL query only)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **328**, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1108**, Failures: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **2059** passed (290 files)
- **downstream_checked:** C2 applied (`ISearchAdaptor.listSearches(boolean)` default method). Grep `implements ISearchAdaptor` → `SearchAdaptor` + `TestSearchAdaptor` only. Standalone `sitemanage` clean install (impl) green. No `final`/`sealed` type change.

### C5 UI live proof

- Reused healthy `perc-matrix-cms-h2` (`TEST_CMS_URL=http://127.0.0.1:9993`).
- Hot-deploy: `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`; container restart; HTTP login 200.
- `npm run test:unit` (includes explorer-saved-search helpers) → **228 passed**
- `npm run test:surface -- --path tests/explorer-saved-search.spec.js` → **2 passed**, 1 soft-skipped (REST basic-auth catalog probe empty on this cell; UI chrome + includeViews GET <500 still asserted)
- `npm run test:golden` → **2 passed**
- console-clean=yes (Playwright green; no pageerror failures)
- server.log-clean=yes for this feature (no SearchAdaptor / PSAction / PSSearch ERROR in the test window).
- Did **not** `qa-down` (cell was already running).

> Co-Authored by Grok Build using grok-4.5 with agent main.
