### PR TITLE
cluster: Navigation SPA thrash (#3220 #3222 #3227)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -210,7 +210,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     if ("widgetbuilder".equals(entry)) {
       entry = "widget-builder";
     }
-    if ("arch".equals(entry)) {
+    if ("arch".equals(entry) || "navigation".equals(entry)) {
       entry = "architecture";
     }
     if (!SPA_ENTRIES.contains(entry)) {

--- a/WebUI/src/main/ts/api/architecture/mapSectionTree.ts
+++ b/WebUI/src/main/ts/api/architecture/mapSectionTree.ts
@@ -115,6 +115,21 @@ function normalizeSectionType(raw: unknown): SectionType {
 }
 
 /**
+ * True when the wire node is an empty/missing nav tree (#3218): no section
+ * id and no children. Title/folderPath alone (site name) is not a tree.
+ */
+export function isEmptySectionTreeWire(wire: SectionNodeWire | null): boolean {
+  if (wire == null) {
+    return true;
+  }
+  const id = asNullableString(wire.id);
+  const children = normalizeChildNodes(
+    wire.childNodes ?? wire.ChildNodes ?? wire.SectionNode ?? null,
+  );
+  return id == null && children.length === 0;
+}
+
+/**
  * Map a wire {@link SectionNodeWire} to a {@link NavTreeNode} tree.
  * Skips cycles (same id already on path) and nodes without a usable id.
  */

--- a/WebUI/src/main/ts/api/architecture/sectionApi.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionApi.ts
@@ -23,9 +23,10 @@
  * Mutations: create / properties / update / move / delete / landing / links.</p>
  */
 
-import { del, get, post } from "../client";
+import { del, extractRestErrorMessage, get, isApiError, post } from "../client";
 import { PATHS } from "../paths";
 import {
+  isEmptySectionTreeWire,
   mapSectionNodeToTree,
   parseSectionNodePayload,
 } from "./mapSectionTree";
@@ -119,11 +120,36 @@ export function sectionLoadUrl(sectionId: string): string {
 }
 
 /**
+ * True when the API failure is a missing/empty NavTree (operator empty
+ * state), not a hard tree-load failure (#3218).
+ */
+export function isMissingNavTreeError(err: unknown): boolean {
+  const chunks: string[] = [];
+  if (err instanceof Error && err.message) {
+    chunks.push(err.message);
+  }
+  if (isApiError(err)) {
+    chunks.push(String(err.statusText || ""));
+    const fromBody = extractRestErrorMessage(err.body);
+    if (fromBody) {
+      chunks.push(fromBody);
+    }
+  }
+  const text = chunks.join(" ").toLowerCase();
+  return (
+    text.includes("cannot find navigation tree") ||
+    text.includes("cannot find navtree") ||
+    text.includes("navtree for site") ||
+    text.includes("no navigation tree")
+  );
+}
+
+/**
  * Load the full section/navon tree for a site.
  *
  * @param siteName CMS site name (e.g. {@code Corporate Investments})
  * @returns Normalized root {@link NavTreeNode}, or {@code null} when the
- *          payload is empty / unparseable (caller may treat as empty).
+ *          payload is empty / unparseable / missing nav tree (#3218).
  */
 export async function loadSectionTree(
   siteName: string,
@@ -132,12 +158,19 @@ export async function loadSectionTree(
   if (!name) {
     throw new Error("Site name is required to load the navigation tree");
   }
-  const payload = await get<unknown>(sectionTreeUrl(name));
-  const wire = parseSectionNodePayload(payload);
-  if (!wire) {
-    return null;
+  try {
+    const payload = await get<unknown>(sectionTreeUrl(name));
+    const wire = parseSectionNodePayload(payload);
+    if (!wire || isEmptySectionTreeWire(wire)) {
+      return null;
+    }
+    return mapSectionNodeToTree(wire);
+  } catch (err) {
+    if (isMissingNavTreeError(err)) {
+      return null;
+    }
+    throw err;
   }
-  return mapSectionNodeToTree(wire);
 }
 
 /**

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -61,7 +61,7 @@ export function parseEntryQuery(
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
   }
-  if (entryRaw === "arch") {
+  if (entryRaw === "arch" || entryRaw === "navigation") {
     entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
@@ -201,7 +201,7 @@ export function parseClientPath(
   if (entryRaw === "widgetbuilder") {
     entryRaw = "widget-builder";
   }
-  if (entryRaw === "arch") {
+  if (entryRaw === "arch" || entryRaw === "navigation") {
     entryRaw = "architecture";
   }
   const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -99,7 +99,7 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "architecture":
-              // SPA Architecture shell (#3094 / parent #3092) — not legacy view=arch
+              // SPA Navigation shell at /architecture (#3094 / #3217)
               return (
                 <li key={id}>
                   <NavLink

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -51,8 +51,8 @@ export interface TopNavGates {
 export const ADMIN_NAV_LANDING = "/admin";
 
 /**
- * Client path for Architecture top-nav NavLink and homepage SPA landing (#3094).
- * Primary Architecture entry (SPA). Legacy {@code ?view=arch} /
+ * Client path for Navigation top-nav NavLink and homepage SPA landing (#3094).
+ * Primary Navigation entry (SPA). Legacy {@code ?view=arch} /
  * {@code siteArchitecture.jsp} hard-redirect here (#3099).
  */
 export const ARCHITECTURE_NAV_LANDING = "/architecture";

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -55,6 +55,7 @@ import {
 } from "../api/architecture/sectionMutations";
 import type { NavTreeNode } from "../api/architecture/types";
 import { fetchSites } from "../api/home/homeApi";
+import { SiteCreateWizard } from "../contentExplorer/wizards/SiteCreateWizard";
 import { catalogColors } from "../developer/catalogStyles";
 import { CreateSectionDialog } from "./CreateSectionDialog";
 import { ExternalLinkDialog } from "./ExternalLinkDialog";
@@ -85,6 +86,11 @@ export interface ArchitectureShellProps {
    * (unit tests). Default true.
    */
   useLandingContentBrowser?: boolean;
+  /**
+   * Show New Site (Explorer SiteCreateWizard) for entitled roles.
+   * Default true — Architecture is already Admin/Designer gated (#3219).
+   */
+  allowNewSite?: boolean;
 }
 
 type SitesLoadState =
@@ -107,6 +113,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   embedded = false,
   confirmFn,
   useLandingContentBrowser = true,
+  allowNewSite = true,
 }) => {
   const confirmAction = useCallback(
     (msg: string) => (confirmFn ? confirmFn(msg) : window.confirm(msg)),
@@ -141,6 +148,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     externalUrl: string;
     target: string;
   } | null>(null);
+  const [showNewSite, setShowNewSite] = useState(false);
 
   // Honor route/deep-link site when prop changes
   useEffect(() => {
@@ -218,6 +226,30 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
 
   const onRefresh = useCallback(() => {
     setRefreshToken((n) => n + 1);
+  }, []);
+
+  const reloadSites = useCallback(async (preferSite?: string | null) => {
+    try {
+      const list = await fetchSites();
+      const names = list
+        .map((s) => (s.name != null ? String(s.name).trim() : ""))
+        .filter((n) => n.length > 0)
+        .sort((a, b) => a.localeCompare(b));
+      setSitesState({ status: "ready", names });
+      const preferred = preferSite != null ? String(preferSite).trim() : "";
+      setSelectedSite((prev) => {
+        if (preferred && names.includes(preferred)) return preferred;
+        if (prev && names.includes(prev)) return prev;
+        if (!prev && names.length > 0) return names[0];
+        return prev;
+      });
+    } catch (err) {
+      if (isSessionRedirectError(err)) return;
+      setSitesState({
+        status: "error",
+        message: formatApiError(err, ARCH_MSG.SITES_ERROR),
+      });
+    }
   }, []);
 
   const treeRoot =
@@ -622,7 +654,80 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         >
           {ARCH_MSG.REFRESH}
         </button>
+        {allowNewSite ? (
+          <button
+            type="button"
+            data-testid="architecture-action-new-site"
+            aria-expanded={showNewSite}
+            aria-controls="architecture-new-site-panel"
+            onClick={() => setShowNewSite((open) => !open)}
+            style={{
+              padding: "0.4rem 0.85rem",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: 4,
+              background: showNewSite ? "#e8eef8" : "#fff",
+              color: "#222",
+              cursor: "pointer",
+              fontSize: "0.9rem",
+            }}
+          >
+            {ARCH_MSG.ACTION_NEW_SITE}
+          </button>
+        ) : null}
       </section>
+
+      {allowNewSite && showNewSite ? (
+        <section
+          id="architecture-new-site-panel"
+          role="region"
+          aria-label={ARCH_MSG.NEW_SITE_REGION}
+          data-testid="architecture-new-site-panel"
+          style={{
+            border: `1px solid ${catalogColors.headerBorder}`,
+            borderRadius: 8,
+            padding: "1rem 1.25rem",
+            marginBottom: "12px",
+            background: "#fff",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "0.75rem",
+              marginBottom: "0.75rem",
+            }}
+          >
+            <h2
+              style={{ margin: 0, fontSize: "1.05rem", color: "#1a202c" }}
+              data-testid="architecture-new-site-title"
+            >
+              {ARCH_MSG.ACTION_NEW_SITE}
+            </h2>
+            <button
+              type="button"
+              data-testid="architecture-new-site-close"
+              onClick={() => setShowNewSite(false)}
+              style={{
+                padding: "0.3rem 0.7rem",
+                border: `1px solid ${catalogColors.softBorder}`,
+                borderRadius: 4,
+                background: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              {ARCH_MSG.NEW_SITE_CLOSE}
+            </button>
+          </div>
+          <SiteCreateWizard
+            onCreated={({ siteName }) => {
+              setShowNewSite(false);
+              void reloadSites(siteName);
+            }}
+          />
+        </section>
+      ) : null}
 
       {!selectedSite ? (
         <section

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -66,6 +66,7 @@ import { SectionLinkDialog } from "./SectionLinkDialog";
 import { SitePicker } from "./SitePicker";
 import { StructureActionBar } from "./StructureActionBar";
 import { ARCH_MSG } from "./messages";
+import { useDialogEscape } from "./useDialogEscape";
 
 export interface ArchitectureShellProps {
   /**
@@ -149,6 +150,50 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     target: string;
   } | null>(null);
   const [showNewSite, setShowNewSite] = useState(false);
+  const newSiteToggleRef = useRef<HTMLButtonElement>(null);
+  const newSitePanelRef = useRef<HTMLElement>(null);
+
+  useDialogEscape(showNewSite, mutationBusy, () => setShowNewSite(false));
+
+  useEffect(() => {
+    if (!showNewSite) {
+      return;
+    }
+    const root = newSitePanelRef.current;
+    if (!root) {
+      return;
+    }
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+    focusables()[0]?.focus();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key !== "Tab") {
+        return;
+      }
+      const list = focusables();
+      if (list.length === 0) {
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => {
+      root.removeEventListener("keydown", onKey);
+      newSiteToggleRef.current?.focus();
+    };
+  }, [showNewSite]);
 
   // Honor route/deep-link site when prop changes
   useEffect(() => {
@@ -158,28 +203,41 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     }
   }, [initialSite]);
 
+  const applySiteNames = useCallback(
+    (names: string[], preferSite?: string | null) => {
+      setSitesState({ status: "ready", names });
+      const preferred = preferSite != null ? String(preferSite).trim() : "";
+      setSelectedSite((prev) => {
+        if (preferred && names.includes(preferred)) return preferred;
+        if (prev && names.includes(prev)) return prev;
+        if (prev && names.length === 0) return prev;
+        if (prev && !names.includes(prev) && names.length > 0) {
+          return prev;
+        }
+        if (!prev && names.length > 0) return names[0];
+        return prev;
+      });
+    },
+    [],
+  );
+
+  const loadSiteNames = useCallback(async (): Promise<string[]> => {
+    const list = await fetchSites();
+    return list
+      .map((s) => (s.name != null ? String(s.name).trim() : ""))
+      .filter((n) => n.length > 0)
+      .sort((a, b) => a.localeCompare(b));
+  }, []);
+
   // Load site list once
   useEffect(() => {
     let cancelled = false;
     setSitesState({ status: "loading" });
     void (async () => {
       try {
-        const list = await fetchSites();
+        const names = await loadSiteNames();
         if (cancelled) return;
-        const names = list
-          .map((s) => (s.name != null ? String(s.name).trim() : ""))
-          .filter((n) => n.length > 0)
-          .sort((a, b) => a.localeCompare(b));
-        setSitesState({ status: "ready", names });
-        setSelectedSite((prev) => {
-          if (prev && names.includes(prev)) return prev;
-          if (prev && names.length === 0) return prev;
-          if (prev && !names.includes(prev) && names.length > 0) {
-            return prev;
-          }
-          if (!prev && names.length > 0) return names[0];
-          return prev;
-        });
+        applySiteNames(names);
       } catch (err) {
         if (cancelled) return;
         if (isSessionRedirectError(err)) return;
@@ -192,7 +250,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applySiteNames, loadSiteNames]);
 
   // Load tree when site or refresh changes
   useEffect(() => {
@@ -228,29 +286,30 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     setRefreshToken((n) => n + 1);
   }, []);
 
-  const reloadSites = useCallback(async (preferSite?: string | null) => {
-    try {
-      const list = await fetchSites();
-      const names = list
-        .map((s) => (s.name != null ? String(s.name).trim() : ""))
-        .filter((n) => n.length > 0)
-        .sort((a, b) => a.localeCompare(b));
-      setSitesState({ status: "ready", names });
+  const reloadSites = useCallback(
+    async (preferSite?: string | null) => {
       const preferred = preferSite != null ? String(preferSite).trim() : "";
-      setSelectedSite((prev) => {
-        if (preferred && names.includes(preferred)) return preferred;
-        if (prev && names.includes(prev)) return prev;
-        if (!prev && names.length > 0) return names[0];
-        return prev;
-      });
-    } catch (err) {
-      if (isSessionRedirectError(err)) return;
-      setSitesState({
-        status: "error",
-        message: formatApiError(err, ARCH_MSG.SITES_ERROR),
-      });
-    }
-  }, []);
+      try {
+        const names = await loadSiteNames();
+        applySiteNames(names, preferred);
+        if (preferred) {
+          setMutationError(null);
+        }
+      } catch (err) {
+        if (isSessionRedirectError(err)) return;
+        setSitesState({
+          status: "error",
+          message: formatApiError(err, ARCH_MSG.SITES_ERROR),
+        });
+        if (preferred) {
+          setMutationError(
+            ARCH_MSG.NEW_SITE_RELOAD_ERROR.split("{0}").join(preferred),
+          );
+        }
+      }
+    },
+    [applySiteNames, loadSiteNames],
+  );
 
   const treeRoot =
     treeState.status === "ready" ? treeState.root : null;
@@ -657,9 +716,13 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         {allowNewSite ? (
           <button
             type="button"
+            ref={newSiteToggleRef}
             data-testid="architecture-action-new-site"
             aria-expanded={showNewSite}
-            aria-controls="architecture-new-site-panel"
+            aria-haspopup="dialog"
+            aria-controls={
+              showNewSite ? "architecture-new-site-panel" : undefined
+            }
             onClick={() => setShowNewSite((open) => !open)}
             style={{
               padding: "0.4rem 0.85rem",
@@ -676,10 +739,27 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         ) : null}
       </section>
 
+      {mutationError ? (
+        <p
+          role="alert"
+          data-testid="architecture-mutation-error"
+          style={{
+            margin: "0 0 12px",
+            color: catalogColors.error,
+            fontSize: "0.9rem",
+          }}
+        >
+          {mutationError}
+        </p>
+      ) : null}
+
       {allowNewSite && showNewSite ? (
         <section
           id="architecture-new-site-panel"
-          role="region"
+          ref={newSitePanelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="architecture-new-site-title"
           aria-label={ARCH_MSG.NEW_SITE_REGION}
           data-testid="architecture-new-site-panel"
           style={{
@@ -700,6 +780,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             }}
           >
             <h2
+              id="architecture-new-site-title"
               style={{ margin: 0, fontSize: "1.05rem", color: "#1a202c" }}
               data-testid="architecture-new-site-title"
             >
@@ -877,20 +958,6 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
               data-testid="architecture-select-hint"
             >
               {ARCH_MSG.SELECT_HINT}
-            </p>
-          ) : null}
-
-          {mutationError ? (
-            <p
-              role="alert"
-              data-testid="architecture-mutation-error"
-              style={{
-                margin: "0 0 8px",
-                color: catalogColors.error,
-                fontSize: "0.9rem",
-              }}
-            >
-              {mutationError}
             </p>
           ) : null}
 

--- a/WebUI/src/main/ts/architecture/NavTree.tsx
+++ b/WebUI/src/main/ts/architecture/NavTree.tsx
@@ -359,8 +359,33 @@ export function NavTree({
     );
   } else if (!root) {
     body = (
-      <div style={emptyStyle} data-testid="architecture-nav-tree-empty">
-        {ARCH_MSG.TREE_EMPTY}
+      <div
+        style={emptyStyle}
+        data-testid="architecture-nav-tree-empty"
+        role="status"
+      >
+        <p
+          style={{
+            margin: "0 0 0.35rem",
+            fontWeight: 600,
+            color: "#1a202c",
+          }}
+          data-testid="architecture-nav-tree-empty-title"
+        >
+          {ARCH_MSG.TREE_EMPTY_TITLE}
+        </p>
+        <p
+          style={{ margin: "0 0 0.5rem", color: catalogColors.muted }}
+          data-testid="architecture-nav-tree-empty-body"
+        >
+          {ARCH_MSG.TREE_EMPTY}
+        </p>
+        <p
+          style={{ margin: 0, fontSize: "0.9rem" }}
+          data-testid="architecture-nav-tree-empty-hint"
+        >
+          {ARCH_MSG.TREE_EMPTY_HINT}
+        </p>
       </div>
     );
   } else {

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -48,6 +48,8 @@ const KEYS = {
   ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
   NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
   NEW_SITE_REGION: "perc.ui.architecture.modern@New Site panel",
+  NEW_SITE_RELOAD_ERROR:
+    "perc.ui.architecture.modern@Site {0} was created, but the site list could not be refreshed.",
   // Kept for older tests / deep links that still assert empty-shell keys
   EMPTY_TITLE: "perc.ui.architecture.modern@No site selected",
   EMPTY_BODY:
@@ -188,6 +190,7 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   ACTION_NEW_SITE: message(KEYS.ACTION_NEW_SITE),
   NEW_SITE_CLOSE: message(KEYS.NEW_SITE_CLOSE),
   NEW_SITE_REGION: message(KEYS.NEW_SITE_REGION),
+  NEW_SITE_RELOAD_ERROR: message(KEYS.NEW_SITE_RELOAD_ERROR),
   EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
   EMPTY_BODY: message(KEYS.EMPTY_BODY),
   ACTIONS_LABEL: message(KEYS.ACTIONS_LABEL),

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -24,10 +24,10 @@ import { message } from "../i18n/message";
  * Small key set only — no multi-locale mass TMX backfill in this slice.
  */
 const KEYS = {
-  TITLE: "perc.ui.architecture.modern@Architecture",
+  TITLE: "perc.ui.architecture.modern@Navigation",
   INTRO:
     "perc.ui.architecture.modern@Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.",
-  SHELL_LOADING: "perc.ui.architecture.modern@Loading Architecture…",
+  SHELL_LOADING: "perc.ui.architecture.modern@Loading Navigation…",
   SITE_LABEL: "perc.ui.architecture.modern@Site",
   SITE_PLACEHOLDER: "perc.ui.architecture.modern@Select a site…",
   SITE_HINT: "perc.ui.architecture.modern@Site context: {0}",

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -41,6 +41,9 @@ const KEYS = {
   TREE_ERROR: "perc.ui.architecture.modern@Could not load the navigation tree.",
   TREE_EMPTY:
     "perc.ui.architecture.modern@This site has no navigation sections yet.",
+  TREE_EMPTY_TITLE: "perc.ui.architecture.modern@No navigation tree",
+  TREE_EMPTY_HINT:
+    "perc.ui.architecture.modern@A site can exist without a NavTree. Add a navigation tree at the site root in Explorer, then refresh, or choose another site.",
   TREE_PANEL_TITLE: "perc.ui.architecture.modern@Navigation tree",
   TREE_STRUCTURE_NOTE:
     "perc.ui.architecture.modern@Select a section, then use structure actions: create, rename, move, delete, landing page, or link editors.",
@@ -179,6 +182,8 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   TREE_LOADING: message(KEYS.TREE_LOADING),
   TREE_ERROR: message(KEYS.TREE_ERROR),
   TREE_EMPTY: message(KEYS.TREE_EMPTY),
+  TREE_EMPTY_TITLE: message(KEYS.TREE_EMPTY_TITLE),
+  TREE_EMPTY_HINT: message(KEYS.TREE_EMPTY_HINT),
   TREE_PANEL_TITLE: message(KEYS.TREE_PANEL_TITLE),
   TREE_STRUCTURE_NOTE: message(KEYS.TREE_STRUCTURE_NOTE),
   REFRESH: message(KEYS.REFRESH),

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -45,6 +45,9 @@ const KEYS = {
   TREE_STRUCTURE_NOTE:
     "perc.ui.architecture.modern@Select a section, then use structure actions: create, rename, move, delete, landing page, or link editors.",
   REFRESH: "perc.ui.architecture.modern@Refresh",
+  ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
+  NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
+  NEW_SITE_REGION: "perc.ui.architecture.modern@New Site panel",
   // Kept for older tests / deep links that still assert empty-shell keys
   EMPTY_TITLE: "perc.ui.architecture.modern@No site selected",
   EMPTY_BODY:
@@ -182,6 +185,9 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   TREE_PANEL_TITLE: message(KEYS.TREE_PANEL_TITLE),
   TREE_STRUCTURE_NOTE: message(KEYS.TREE_STRUCTURE_NOTE),
   REFRESH: message(KEYS.REFRESH),
+  ACTION_NEW_SITE: message(KEYS.ACTION_NEW_SITE),
+  NEW_SITE_CLOSE: message(KEYS.NEW_SITE_CLOSE),
+  NEW_SITE_REGION: message(KEYS.NEW_SITE_REGION),
   EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
   EMPTY_BODY: message(KEYS.EMPTY_BODY),
   ACTIONS_LABEL: message(KEYS.ACTIONS_LABEL),

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -206,10 +206,9 @@ export const MSG = {
   NAV_HOME: "perc.ui.navMenu.home@Home",
   NAV_DASHBOARD: "perc.ui.navMenu.dashboard@Dashboard",
   NAV_EDITOR: "perc.ui.navMenu.webmgt@Editor",
-  NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Architecture",
-  /** Architecture SPA top-nav tooltip (#3094). */
-  NAV_ARCHITECTURE_TITLE:
-    "perc.ui.architecture.modern@Site navigation (Architecture)",
+  NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Navigation",
+  /** Navigation SPA top-nav tooltip (#3094 / #3217). */
+  NAV_ARCHITECTURE_TITLE: "perc.ui.architecture.modern@Site navigation",
   /** Design SPA top-nav (#2808) — classic key already en-us "Design". */
   NAV_DESIGN: "perc.ui.navMenu.design@Design",
   NAV_DESIGN_TITLE:

--- a/WebUI/src/main/ts/login/bootstrap.ts
+++ b/WebUI/src/main/ts/login/bootstrap.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
   sanitizeLoginRedirect,
 } from "./redirect";
 import type { LoginBootstrap, SpaLandingBootstrap } from "./types";
@@ -86,7 +86,7 @@ export function readLoginBootstrap(): LoginBootstrap {
     autocomplete: raw?.autocomplete === "off" ? "off" : "on",
     defaultRedirect: sanitizeLoginRedirect(
       raw?.defaultRedirect,
-      DEFAULT_SPA_ENTRY_REDIRECT,
+      DEFAULT_POST_LOGIN_REDIRECT,
     ),
     csrfTokenName: csrf.name,
     csrfTokenValue: csrf.value,

--- a/WebUI/src/main/ts/login/index.ts
+++ b/WebUI/src/main/ts/login/index.ts
@@ -22,6 +22,7 @@ export {
   buildSpaEntryRedirect,
   sanitizeLoginRedirect,
   DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
 } from "./redirect";
 export type {
   LoginBootstrap,

--- a/WebUI/src/main/ts/login/redirect.ts
+++ b/WebUI/src/main/ts/login/redirect.ts
@@ -22,6 +22,14 @@
  */
 export const DEFAULT_SPA_ENTRY_REDIRECT = "/cm/app/spa.jsp?entry=home";
 
+/**
+ * Unauthenticated login default ({@code sys_redirect}) when the user has no
+ * explicit return URL. {@code /cm/app/} is the index.jsp dispatcher — it
+ * applies {@code getUserHomepage()} so Architecture / Navigation land on
+ * the Navigation SPA instead of Home (#3219 / parent #3197).
+ */
+export const DEFAULT_POST_LOGIN_REDIRECT = "/cm/app/";
+
 const ALLOWED_ENTRIES = new Set([
   "home",
   "publish",
@@ -76,9 +84,19 @@ export function buildSpaEntryRedirect(
  * @param candidate - raw redirect from bootstrap or query
  * @param fallback - used when candidate is invalid
  */
+function isAllowedAppRedirect(raw: string): boolean {
+  if (raw.startsWith("/cm/app/spa.jsp")) {
+    return true;
+  }
+  if (raw === "/cm/app" || raw === "/cm/app/") {
+    return true;
+  }
+  return raw.startsWith("/cm/app?") || raw.startsWith("/cm/app/?");
+}
+
 export function sanitizeLoginRedirect(
   candidate: string | null | undefined,
-  fallback: string = DEFAULT_SPA_ENTRY_REDIRECT,
+  fallback: string = DEFAULT_POST_LOGIN_REDIRECT,
 ): string {
   if (candidate == null || !String(candidate).trim()) {
     return fallback;
@@ -91,8 +109,8 @@ export function sanitizeLoginRedirect(
   if (!raw.startsWith("/") || raw.includes("..")) {
     return fallback;
   }
-  // Prefer SPA entry; also allow /cm/app for transitional landings
-  if (raw.startsWith("/cm/app/spa.jsp") || raw === "/cm/app" || raw.startsWith("/cm/app?")) {
+  // Prefer SPA entry; also allow /cm/app dispatcher (homepage resolve)
+  if (isAllowedAppRedirect(raw)) {
     return raw.length > 2048 ? fallback : raw;
   }
   return fallback;

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -53,8 +53,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // SPA path /architecture (#3094); homepage type remains "Architecture"
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // SPA path /architecture (#3094); API homepage type remains "Architecture"
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -53,8 +53,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // SPA path /architecture (#3094); homepage type remains "Architecture"
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // Stored type stays Architecture; product label is Navigation (#3219)
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/ts/profile/resolveLandingEntry.ts
+++ b/WebUI/src/main/ts/profile/resolveLandingEntry.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map stored homepage / landing tokens to SPA entry + client path (#3219).
+ *
+ * <p>Canonical stored type remains {@code Architecture}. Product name
+ * Navigation and view-key aliases ({@code arch}, {@code navigation}) must
+ * resolve to the Architecture SPA, not Home.</p>
+ */
+
+import { HOMEPAGE_TYPES } from "../api/user/userHomepageApi";
+import type { SpaEntry } from "../app/deepLinks/allowlists";
+
+/** Unauthenticated login posts here so index.jsp can apply getUserHomepage(). */
+export const POST_LOGIN_DISPATCHER = "/cm/app/";
+
+/**
+ * Normalize a homepage type, view key, or product label to an SPA entry.
+ * Blank / unknown → {@code home} (same fail-closed as server mapping).
+ */
+export function resolveHomepageToSpaEntry(
+  raw: string | null | undefined,
+): SpaEntry {
+  const trimmed = raw == null ? "" : String(raw).trim();
+  if (!trimmed) {
+    return "home";
+  }
+  switch (trimmed) {
+    case HOMEPAGE_TYPES.HOME:
+      return "home";
+    case HOMEPAGE_TYPES.DASHBOARD:
+      return "home";
+    case HOMEPAGE_TYPES.EDITOR:
+      return "home";
+    case HOMEPAGE_TYPES.DESIGNER:
+      return "design";
+    case HOMEPAGE_TYPES.ARCHITECTURE:
+      return "architecture";
+    case HOMEPAGE_TYPES.PUBLISH:
+      return "publish";
+    case HOMEPAGE_TYPES.WORKFLOW:
+      return "admin";
+    case HOMEPAGE_TYPES.WIDGET_BUILDER:
+      return "widget-builder";
+    default:
+      break;
+  }
+  const lower = trimmed.toLowerCase();
+  switch (lower) {
+    case "home":
+      return "home";
+    case "dash":
+    case "dashboard":
+      return "home";
+    case "editor":
+    case "pageeditor":
+    case "webmgt":
+      return "home";
+    case "design":
+    case "designer":
+    case "siteadmin":
+      return "design";
+    case "arch":
+    case "architecture":
+    case "navigation":
+    case "site_arch":
+    case "sitearch":
+      return "architecture";
+    case "publish":
+      return "publish";
+    case "workflow":
+    case "admin":
+      return "admin";
+    case "widgetbuilder":
+    case "widget-builder":
+    case "widget_builder":
+      return "widget-builder";
+    case "explorer":
+      return "explorer";
+    case "profile":
+      return "profile";
+    case "developer":
+      return "developer";
+    default:
+      return "home";
+  }
+}
+
+/** Client route under the SPA basename for a stored homepage token. */
+export function resolveHomepageToClientPath(
+  raw: string | null | undefined,
+): string {
+  const entry = resolveHomepageToSpaEntry(raw);
+  switch (entry) {
+    case "home":
+      return "/home";
+    case "widget-builder":
+      return "/widget-builder";
+    default:
+      return `/${entry}`;
+  }
+}
+
+/** True when a stored or typed landing token means Navigation / Architecture. */
+export function isNavigationHomepageToken(
+  raw: string | null | undefined,
+): boolean {
+  return resolveHomepageToSpaEntry(raw) === "architecture";
+}

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -56,7 +56,7 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
     // Product "Navigation" / Architecture SPA (#3094 → /architecture)
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -55,8 +55,8 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
-    // Product "Navigation" / Architecture SPA (#3094 → /architecture)
-    labelKey: "perc.ui.navMenu.architecture@Architecture",
+    // Product name Navigation; SPA path /architecture (#3094 / #3217)
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -80,6 +80,7 @@
             "developer",
             "arch",
             "architecture",
+            "navigation",
             "dash"
     };
 
@@ -87,6 +88,8 @@
     String[] adminViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "workflow",
             "widgetbuilder",
@@ -98,6 +101,8 @@
     String[] designerViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "widgetbuilder",
             "developer"
@@ -233,8 +238,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
-        else if ("arch".equals(view) || "architecture".equals(view))
-            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
+            // #3094 / #3219: Architecture homepage / Navigation → SPA shell
             entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
@@ -308,9 +314,10 @@
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
         }
-        else if ("arch".equals(view) || "architecture".equals(view))
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
         {
-            // Optional site context for Architecture SPA (#3094)
+            // Optional site context for Architecture SPA (#3094 / #3219)
             String site = request.getParameter("site");
             if (site != null && !site.isBlank() && site.length() <= 128
                     && !site.contains("://") && !site.contains("..") && !site.contains("/"))

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -52,7 +52,7 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
-        if ("arch".equals(n)) {
+        if ("arch".equals(n) || "navigation".equals(n)) {
             return "architecture";
         }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -80,6 +80,7 @@
             "developer",
             "arch",
             "architecture",
+            "navigation",
             "dash"
     };
 
@@ -87,6 +88,8 @@
     String[] adminViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "workflow",
             "widgetbuilder",
@@ -98,6 +101,8 @@
     String[] designerViews = new String[]{
             "design",
             "arch",
+            "architecture",
+            "navigation",
             "publish",
             "widgetbuilder",
             "developer"
@@ -233,8 +238,9 @@
         else if ("workflow".equals(view))
             // #3088: fold legacy Workflow admin view into unified Admin shell
             entry = "admin";
-        else if ("arch".equals(view) || "architecture".equals(view))
-            // #3094: Architecture homepage / view=arch → SPA Architecture shell
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
+            // #3094 / #3219: Architecture homepage / Navigation → SPA shell
             entry = "architecture";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
@@ -308,9 +314,10 @@
             if (section != null)
                 qs.append("&section=").append(URLEncoder.encode(section, "UTF-8"));
         }
-        else if ("arch".equals(view) || "architecture".equals(view))
+        else if ("arch".equals(view) || "architecture".equals(view)
+                || "navigation".equals(view))
         {
-            // Optional site context for Architecture SPA (#3094)
+            // Optional site context for Architecture SPA (#3094 / #3219)
             String site = request.getParameter("site");
             if (site != null && !site.isBlank() && site.length() <= 128
                     && !site.contains("://") && !site.contains("..") && !site.contains("/"))

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -52,7 +52,7 @@
         if ("widgetbuilder".equals(n)) {
             return "widget-builder";
         }
-        if ("arch".equals(n)) {
+        if ("arch".equals(n) || "navigation".equals(n)) {
             return "architecture";
         }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)

--- a/WebUI/src/main/webapp/rxlogin.jsp
+++ b/WebUI/src/main/webapp/rxlogin.jsp
@@ -62,15 +62,22 @@
         autocomplete = "off";
     }
 
-    // Default post-login SPA entry (query contract — never use # fragments).
-    String defaultRedirect = "/cm/app/spa.jsp?entry=home";
+    // Default post-login: index.jsp dispatcher resolves homepage preference
+    // (Architecture / Navigation → SPA architecture). Explicit return URLs
+    // still win. Query contract only — never # fragments. (#3219)
+    String defaultRedirect = "/cm/app/";
     String returnParam = request.getParameter("return");
-    if (returnParam != null
-            && returnParam.startsWith("/cm/app/spa.jsp")
+    boolean allowedReturn = returnParam != null
+            && (returnParam.startsWith("/cm/app/spa.jsp")
+                || "/cm/app".equals(returnParam)
+                || "/cm/app/".equals(returnParam)
+                || returnParam.startsWith("/cm/app?")
+                || returnParam.startsWith("/cm/app/?"))
             && !returnParam.contains("..")
             && !returnParam.contains("://")
             && !returnParam.contains("#")
-            && returnParam.length() < 2048) {
+            && returnParam.length() < 2048;
+    if (allowedReturn) {
         defaultRedirect = returnParam;
     }
 

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -106,6 +106,9 @@ public class PSWebUiSpaFallbackFilterTest {
     assertEquals(
         "/cm/app/spa.jsp?entry=architecture",
         PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/arch", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=architecture",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/navigation", null));
   }
 
   @Test

--- a/WebUI/src/test/ts/api/architecture/mapSectionTree.test.ts
+++ b/WebUI/src/test/ts/api/architecture/mapSectionTree.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 import {
   countNavTreeNodes,
   flattenNavTree,
+  isEmptySectionTreeWire,
   mapSectionNodeToTree,
   normalizeChildNodes,
   parseSectionNodePayload,
@@ -102,6 +103,20 @@ describe("mapSectionTree (#3095)", () => {
     expect(parseSectionNodePayload(null)).toBeNull();
     expect(parseSectionNodePayload("nope")).toBeNull();
     expect(mapSectionNodeToTree({ title: "NoId" }).title).toBe("NoId");
+  });
+
+  it("treats missing-id empty children as empty nav tree (#3218)", () => {
+    expect(
+      isEmptySectionTreeWire({ title: "BareSite", childNodes: [] }),
+    ).toBe(true);
+    expect(isEmptySectionTreeWire(null)).toBe(true);
+    expect(
+      isEmptySectionTreeWire({
+        id: "root-1",
+        title: "Home",
+        childNodes: [],
+      }),
+    ).toBe(false);
   });
 
   it("sectionTypeLabel badges non-default types", () => {

--- a/WebUI/src/test/ts/api/architecture/sectionApi.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionApi.test.ts
@@ -18,6 +18,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
+  isMissingNavTreeError,
   loadSectionTree,
   sectionRootUrl,
   sectionTreeUrl,
@@ -67,5 +68,47 @@ describe("sectionApi (#3095)", () => {
   it("loadSectionTree returns null for empty payload", async () => {
     vi.spyOn(client, "get").mockResolvedValue(null);
     await expect(loadSectionTree("Demo")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree returns null for empty SectionNode without id (#3218)", async () => {
+    vi.spyOn(client, "get").mockResolvedValue({
+      SectionNode: { title: "BareSite", childNodes: [] },
+    });
+    await expect(loadSectionTree("BareSite")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree treats missing-navtree 500 as empty (#3218)", async () => {
+    vi.spyOn(client, "get").mockRejectedValue({
+      status: 500,
+      statusText: "Server Error",
+      body: { message: "Cannot find navigation tree for site: BareSite" },
+    });
+    await expect(loadSectionTree("BareSite")).resolves.toBeNull();
+  });
+
+  it("loadSectionTree still throws unrelated 500s", async () => {
+    vi.spyOn(client, "get").mockRejectedValue({
+      status: 500,
+      statusText: "Server Error",
+      body: { message: "database unavailable" },
+    });
+    await expect(loadSectionTree("Demo")).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("isMissingNavTreeError matches server empty-state text", () => {
+    expect(
+      isMissingNavTreeError({
+        status: 500,
+        statusText: "Server Error",
+        body: { message: "Cannot find navigation tree for site: X" },
+      }),
+    ).toBe(true);
+    expect(
+      isMissingNavTreeError({
+        status: 500,
+        statusText: "Server Error",
+        body: { message: "Cannot get guid for nav-id" },
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -85,6 +85,11 @@ describe("parseEntryQuery", () => {
       "/architecture",
     );
     expect(parseEntryQuery("?entry=arch").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=navigation").entry).toBe("architecture");
+    expect(parseEntryQuery("?entry=navigation").clientPath).toBe(
+      "/architecture",
+    );
+    expect(parseClientPath("/navigation").entry).toBe("architecture");
     expect(parseEntryQuery("?entry=architecture&site=Demo").site).toBe("Demo");
     expect(parseEntryQuery("?entry=architecture&site=Demo").clientPath).toBe(
       "/architecture/Demo",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -79,7 +79,7 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/design/templates").section).toBe("templates");
   });
 
-  it("maps architecture entry, arch alias, and site (#3094)", () => {
+  it("maps architecture, arch, and navigation aliases plus site (#3094/#3219)", () => {
     expect(parseEntryQuery("?entry=architecture").entry).toBe("architecture");
     expect(parseEntryQuery("?entry=architecture").clientPath).toBe(
       "/architecture",
@@ -97,6 +97,11 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/architecture").entry).toBe("architecture");
     expect(parseClientPath("/architecture/Demo").site).toBe("Demo");
     expect(parseClientPath("/architecture/Demo").clientPath).toBe(
+      "/architecture/Demo",
+    );
+    expect(parseClientPath("/navigation/Demo").entry).toBe("architecture");
+    expect(parseClientPath("/navigation/Demo").site).toBe("Demo");
+    expect(parseClientPath("/navigation/Demo").clientPath).toBe(
       "/architecture/Demo",
     );
   });

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -95,7 +95,7 @@ describe("TopNav (#2702)", () => {
     // Must not be a full-page legacy exit
     expect(href).not.toMatch(/view=arch/);
     expect(arch.tagName.toLowerCase()).toBe("a");
-    expect(arch.textContent).toMatch(/^Navigation$/);
+    expect(arch).toHaveTextContent(/Navigation/i);
   });
 
   it("hides Admin for non-admin", () => {

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -95,6 +95,7 @@ describe("TopNav (#2702)", () => {
     // Must not be a full-page legacy exit
     expect(href).not.toMatch(/view=arch/);
     expect(arch.tagName.toLowerCase()).toBe("a");
+    expect(arch.textContent).toMatch(/^Navigation$/);
   });
 
   it("hides Admin for non-admin", () => {

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -191,6 +191,11 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     expect(text).toContain("perc-login-root");
     // Classic host file is gone; comment may still mention the name historically
     expect(existsSync(resolve(webappRoot, "rxlogin-classic.jsp"))).toBe(false);
+    // #3219: default sys_redirect is the dispatcher (homepage resolve), not Home
+    expect(text).toContain('String defaultRedirect = "/cm/app/";');
+    expect(text).not.toContain(
+      'String defaultRedirect = "/cm/app/spa.jsp?entry=home"',
+    );
   });
 
   it("security conf no longer grants anonymous to deleted classic login", () => {

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -192,9 +192,11 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     // Classic host file is gone; comment may still mention the name historically
     expect(existsSync(resolve(webappRoot, "rxlogin-classic.jsp"))).toBe(false);
     // #3219: default sys_redirect is the dispatcher (homepage resolve), not Home
-    expect(text).toContain('String defaultRedirect = "/cm/app/";');
-    expect(text).not.toContain(
-      'String defaultRedirect = "/cm/app/spa.jsp?entry=home"',
+    expect(text.replace(/\s+/g, " ")).toMatch(
+      /String defaultRedirect\s*=\s*"\/cm\/app\/"\s*;/,
+    );
+    expect(text).not.toMatch(
+      /String defaultRedirect\s*=\s*"\/cm\/app\/spa\.jsp\?entry=home"/,
     );
   });
 

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -116,6 +116,22 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     );
   });
 
+  it("shows operator empty state when tree is missing (#3218)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "BareSite" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(null);
+
+    render(<ArchitectureShell embedded initialSite="BareSite" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-nav-tree-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("architecture-nav-tree-empty-title").textContent).toMatch(
+      /no navigation tree/i,
+    );
+    expect(screen.queryByTestId("architecture-nav-tree-error")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("surfaces tree load errors", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockRejectedValue({

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -572,4 +572,41 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     expect(delSecSpy).not.toHaveBeenCalled();
   });
+
+  it("shows New Site for entitled users and opens the create wizard (#3219)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    const siteCreate = await import(
+      "../../../main/ts/api/contentExplorer/siteCreateApi"
+    );
+    vi.spyOn(siteCreate, "listBaseTemplates").mockResolvedValue([
+      { name: "perc.base.plain", label: "Plain" },
+    ]);
+
+    render(<ArchitectureShell embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-new-site")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-new-site-panel")).toBeTruthy();
+    });
+    expect(screen.getByTestId("architecture-new-site-title").textContent).toMatch(
+      /New Site/i,
+    );
+    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("architecture-new-site-close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    });
+  });
+
+  it("hides New Site when allowNewSite is false", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    render(<ArchitectureShell embedded allowNewSite={false} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-sites-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("architecture-action-new-site")).toBeNull();
+  });
 });

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -78,7 +78,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     expect(screen.getByTestId("architecture-empty-state")).toBeTruthy();
     expect(screen.getByTestId("architecture-shell-title").textContent).toMatch(
-      /Architecture/i,
+      /Navigation/i,
     );
   });
 

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -595,10 +595,63 @@ describe("ArchitectureShell (#3095/#3096)", () => {
       /New Site/i,
     );
     expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("architecture-new-site-panel").getAttribute("role")).toBe(
+      "dialog",
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-new-site-panel")).toBeTruthy();
+    });
     fireEvent.click(screen.getByTestId("architecture-new-site-close"));
     await waitFor(() => {
       expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
     });
+  });
+
+  it("keeps a create-success mutation error when site reload fails (#3219)", async () => {
+    const fetchSites = vi.spyOn(homeApi, "fetchSites").mockResolvedValue([]);
+    const siteCreate = await import(
+      "../../../main/ts/api/contentExplorer/siteCreateApi"
+    );
+    vi.spyOn(siteCreate, "listBaseTemplates").mockResolvedValue([
+      { name: "perc.base.plain", label: "Plain" },
+    ]);
+    vi.spyOn(siteCreate, "createTraditionalSite").mockResolvedValue({
+      name: "Acme",
+    });
+
+    render(<ArchitectureShell embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-new-site")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-new-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-name")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fetchSites.mockRejectedValue(new Error("catalog down"));
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-mutation-error").textContent).toMatch(
+        /Acme.*could not be refreshed/i,
+      );
+    });
+    expect(screen.queryByTestId("architecture-new-site-panel")).toBeNull();
+    expect(screen.getByTestId("architecture-sites-error").textContent).toMatch(
+      /catalog down/i,
+    );
   });
 
   it("hides New Site when allowNewSite is false", async () => {

--- a/WebUI/src/test/ts/architecture/NavTree.test.tsx
+++ b/WebUI/src/test/ts/architecture/NavTree.test.tsx
@@ -126,5 +126,10 @@ describe("NavTree (#3095)", () => {
 
     rerender(<NavTree root={null} />);
     expect(screen.getByTestId("architecture-nav-tree-empty")).toBeTruthy();
+    expect(
+      screen.getByTestId("architecture-nav-tree-empty-title").textContent,
+    ).toMatch(/no navigation tree/i);
+    expect(screen.getByTestId("architecture-nav-tree-empty-hint")).toBeTruthy();
+    expect(screen.queryByRole("tree")).toBeNull();
   });
 });

--- a/WebUI/src/test/ts/architecture/navigationProductName.test.ts
+++ b/WebUI/src/test/ts/architecture/navigationProductName.test.ts
@@ -34,6 +34,11 @@ describe("Navigation product name (#3217)", () => {
     expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE_TITLE)).toBe(
       "Site navigation",
     );
+    expect(MSG.NAV_ARCHITECTURE).toBe("perc.ui.navMenu.architecture@Navigation");
     expect(MSG.NAV_ARCHITECTURE).not.toMatch(/@Architecture$/);
+    expect(ARCH_MSG_KEYS.TITLE).toBe("perc.ui.architecture.modern@Navigation");
+    expect(MSG.NAV_ARCHITECTURE_TITLE).toBe(
+      "perc.ui.architecture.modern@Site navigation",
+    );
   });
 });

--- a/WebUI/src/test/ts/architecture/navigationProductName.test.ts
+++ b/WebUI/src/test/ts/architecture/navigationProductName.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ARCH_MSG, ARCH_MSG_KEYS } from "../../../main/ts/architecture/messages";
+import { fallbackLabelFromKey, MSG } from "../../../main/ts/i18n/message";
+
+describe("Navigation product name (#3217)", () => {
+  it("uses Navigation for shell title and loading fallbacks", () => {
+    expect(fallbackLabelFromKey(ARCH_MSG_KEYS.TITLE)).toBe("Navigation");
+    expect(ARCH_MSG.TITLE).toBe("Navigation");
+    expect(fallbackLabelFromKey(ARCH_MSG_KEYS.SHELL_LOADING)).toBe(
+      "Loading Navigation…",
+    );
+    expect(ARCH_MSG.SHELL_LOADING).toBe("Loading Navigation…");
+  });
+
+  it("uses Navigation for top-nav label and tooltip fallbacks", () => {
+    expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE)).toBe("Navigation");
+    expect(fallbackLabelFromKey(MSG.NAV_ARCHITECTURE_TITLE)).toBe(
+      "Site navigation",
+    );
+    expect(MSG.NAV_ARCHITECTURE).not.toMatch(/@Architecture$/);
+  });
+});

--- a/WebUI/src/test/ts/login/redirect.test.ts
+++ b/WebUI/src/test/ts/login/redirect.test.ts
@@ -20,12 +20,20 @@ import {
   buildSpaEntryRedirect,
   sanitizeLoginRedirect,
   DEFAULT_SPA_ENTRY_REDIRECT,
+  DEFAULT_POST_LOGIN_REDIRECT,
 } from "@/login/redirect";
 
 describe("login redirect helpers", () => {
   it("builds default home SPA entry", () => {
     expect(buildSpaEntryRedirect()).toBe("/cm/app/spa.jsp?entry=home");
     expect(DEFAULT_SPA_ENTRY_REDIRECT).toBe("/cm/app/spa.jsp?entry=home");
+  });
+
+  it("uses the app dispatcher as unauthenticated post-login default (#3219)", () => {
+    expect(DEFAULT_POST_LOGIN_REDIRECT).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect(null)).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect("")).toBe("/cm/app/");
+    expect(sanitizeLoginRedirect("/cm/app/")).toBe("/cm/app/");
   });
 
   it("allowlists entries and rejects unknown", () => {
@@ -47,12 +55,18 @@ describe("login redirect helpers", () => {
   });
 
   it("rejects open redirects and fragments", () => {
-    expect(sanitizeLoginRedirect("http://evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
-    expect(sanitizeLoginRedirect("//evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
-    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=home#/hack")).toBe(
-      DEFAULT_SPA_ENTRY_REDIRECT,
+    expect(sanitizeLoginRedirect("http://evil.example/x")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
     );
-    expect(sanitizeLoginRedirect("../etc/passwd")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
+    expect(sanitizeLoginRedirect("//evil.example/x")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
+    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=home#/hack")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
+    expect(sanitizeLoginRedirect("../etc/passwd")).toBe(
+      DEFAULT_POST_LOGIN_REDIRECT,
+    );
   });
 
   it("accepts SPA and transitional /cm/app paths", () => {
@@ -60,5 +74,6 @@ describe("login redirect helpers", () => {
       "/cm/app/spa.jsp?entry=workflow",
     );
     expect(sanitizeLoginRedirect("/cm/app")).toBe("/cm/app");
+    expect(sanitizeLoginRedirect("/cm/app/?view=arch")).toBe("/cm/app/?view=arch");
   });
 });

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -21,6 +21,7 @@ import {
   profileLandingOptions,
 } from "../../../main/ts/profile/landingOptions";
 import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 
 describe("profileLandingOptions", () => {
   it("allows Home and Editor for any user", () => {
@@ -46,5 +47,13 @@ describe("profileLandingOptions", () => {
   it("keeps current value when no longer allowed", () => {
     const opts = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
     expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
+  });
+
+  it("labels the Architecture homepage type as Navigation (#3217)", () => {
+    const opt = profileLandingOptions({ isDesigner: true }).find(
+      (o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE,
+    );
+    expect(opt).toBeTruthy();
+    expect(fallbackLabelFromKey(opt!.labelKey)).toBe("Navigation");
   });
 });

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -43,6 +43,16 @@ describe("profileLandingOptions", () => {
     expect(arch?.labelKey).toMatch(/Navigation/i);
   });
 
+  it("hides Architecture (Navigation) landing for non-designers", () => {
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, {})).toBe(
+      false,
+    );
+    const opts = profileLandingOptions({});
+    expect(
+      opts.some((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE),
+    ).toBe(false);
+  });
+
   it("opens Design for designers and Administration for admins", () => {
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -31,6 +31,18 @@ describe("profileLandingOptions", () => {
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, {})).toBe(false);
   });
 
+  it("includes Architecture (Navigation) landing for designers", () => {
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, {
+        isDesigner: true,
+      }),
+    ).toBe(true);
+    const opts = profileLandingOptions({ isDesigner: true });
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(arch).toBeTruthy();
+    expect(arch?.labelKey).toMatch(/Navigation/i);
+  });
+
   it("opens Design for designers and Administration for admins", () => {
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -57,8 +57,17 @@ describe("resolveHomepageToSpaEntry (#3219)", () => {
     expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
       "widget-builder",
     );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.HOME)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DASHBOARD)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.EDITOR)).toBe("/home");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DESIGNER)).toBe("/design");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.PUBLISH)).toBe("/publish");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WORKFLOW)).toBe("/admin");
     expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
       "/widget-builder",
     );
+    expect(resolveHomepageToClientPath("explorer")).toBe("/explorer");
+    expect(resolveHomepageToClientPath("profile")).toBe("/profile");
+    expect(resolveHomepageToClientPath("developer")).toBe("/developer");
   });
 });

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import {
+  isNavigationHomepageToken,
+  resolveHomepageToClientPath,
+  resolveHomepageToSpaEntry,
+} from "../../../main/ts/profile/resolveLandingEntry";
+
+describe("resolveHomepageToSpaEntry (#3219)", () => {
+  it("maps Architecture and Navigation aliases to the architecture SPA", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(
+      "architecture",
+    );
+    expect(resolveHomepageToSpaEntry("Navigation")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("navigation")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("arch")).toBe("architecture");
+    expect(resolveHomepageToSpaEntry("Architecture")).toBe("architecture");
+    expect(resolveHomepageToClientPath("Navigation")).toBe("/architecture");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(
+      "/architecture",
+    );
+    expect(isNavigationHomepageToken("Navigation")).toBe(true);
+    expect(isNavigationHomepageToken(HOMEPAGE_TYPES.ARCHITECTURE)).toBe(true);
+  });
+
+  it("does not send Home / Editor / unknown tokens to architecture", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.HOME)).toBe("home");
+    expect(resolveHomepageToSpaEntry("")).toBe("home");
+    expect(resolveHomepageToSpaEntry(null)).toBe("home");
+    expect(resolveHomepageToSpaEntry("Editor")).toBe("home");
+    expect(resolveHomepageToSpaEntry("NotAModule")).toBe("home");
+    expect(resolveHomepageToClientPath("Home")).toBe("/home");
+    expect(isNavigationHomepageToken("Home")).toBe(false);
+  });
+
+  it("maps other product homepage types to their SPA entries", () => {
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.DESIGNER)).toBe("design");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.PUBLISH)).toBe("publish");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WORKFLOW)).toBe("admin");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
+      "widget-builder",
+    );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
+      "/widget-builder",
+    );
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 import {
   isLandingAllowedForRoles,
   landingOptionsForRoles,
@@ -39,6 +40,8 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
   });
 
   it("includes Administration (Workflow) for Admin role", () => {

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -39,6 +39,8 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(arch?.labelKey).toMatch(/Navigation/i);
   });
 
   it("includes Administration (Workflow) for Admin role", () => {

--- a/docs/ai-generated/code-reviews/issue-3217-navigation-product-name-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3217-navigation-product-name-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — issue #3217 Navigation product name
+
+**Date:** 2026-08-12  
+**Scope:** uncommitted branch `fix/issue-3217-navigation-product-name` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure (Playwright companions for WebUI chrome); dual-ship lockstep (JSP not edited)
+
+## Summary
+
+Operator-visible chrome for the Navigation product surface used **Architecture** in SPA fallbacks, shell title TMX, landing-picker keys, tooltip, and product-docs. Routes, testids, homepage type `Architecture`, and package paths stay as-is. Tests now assert visible **Navigation**. Existing Playwright title matchers updated so C5 will not fail on the old name.
+
+## Issues
+
+None (hard-gate).
+
+### Suggestions (non-blocking)
+
+- Legacy JSP still uses `perc.ui.navMenu.architecture@Architecture`. Production TMX en-us for that tuid is already `Navigation`; left unchanged to keep residual hosts working without a dual-ship JSP edit.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or path assertions in this diff.
+
+## Tests
+
+- Vitest: shell title, top-nav fallback, profile + user landing option labels.
+- Playwright: existing architecture-* smokes now expect `/Navigation/i` on `architecture-shell-title`.

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -570,6 +570,7 @@
       <tuv xml:lang="zh-cn"><seg>家</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>家</seg></tuv>
     <tuv xml:lang="ru"><seg>Дом</seg></tuv><tuv xml:lang="he"><seg>בַּיִת</seg></tuv><tuv xml:lang="uk"><seg>додому</seg></tuv><tuv xml:lang="lou"><seg>Lakay</seg></tuv><tuv xml:lang="pl"><seg>Dom</seg></tuv><tuv xml:lang="tr"><seg>Ev</seg></tuv></tu>
+    <!-- #3217: tuid suffix stays @Architecture for residual JSP (mainnav / navigationTemplates / template_layout). en-us text is Navigation. -->
     <tu tuid="perc.ui.navMenu.architecture@Architecture">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
       <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
@@ -586,6 +587,7 @@
       <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
     <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
+    <!-- #3217: canonical SPA key (MSG.NAV_ARCHITECTURE). Must coexist with @Architecture above — JSP still binds the old tuid. -->
     <tu tuid="perc.ui.navMenu.architecture@Navigation">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
       <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
@@ -27109,10 +27111,7 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
       <tuv xml:lang="en-us"><seg>Server</seg></tuv>
     <tuv xml:lang="lou"><seg>Server</seg></tuv><tuv xml:lang="tr"><seg>Sunucu</seg></tuv></tu>
 
-    <!-- Architecture SPA chrome (#3098 Slice F) — feature keys only (en-us). -->
-    <tu tuid="perc.ui.architecture.modern@Architecture">
-      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
-    </tu>
+    <!-- Architecture SPA chrome (#3098 Slice F, #3217). Canonical title tuid is @Navigation (ARCH_MSG_KEYS.TITLE). -->
     <tu tuid="perc.ui.architecture.modern@Navigation">
       <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
     </tu>
@@ -27371,9 +27370,7 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
     <tu tuid="perc.ui.architecture.modern@Enter a valid URL (for example https://example.com or /path)">
       <tuv xml:lang="en-us"><seg>Enter a valid URL (for example https://example.com or /path)</seg></tuv>
     </tu>
-    <tu tuid="perc.ui.architecture.modern@Site navigation (Architecture)">
-      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
-    </tu>
+    <!-- #3217: tooltip tuid is @Site navigation (MSG.NAV_ARCHITECTURE_TITLE). -->
     <tu tuid="perc.ui.architecture.modern@Site navigation">
       <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
     </tu>

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -27121,6 +27121,9 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
     <tu tuid="perc.ui.architecture.modern@Could not load the site list.">
       <tuv xml:lang="en-us"><seg>Could not load the site list.</seg></tuv>
     </tu>
+    <tu tuid="perc.ui.architecture.modern@Site {0} was created, but the site list could not be refreshed.">
+      <tuv xml:lang="en-us"><seg>Site {0} was created, but the site list could not be refreshed.</seg></tuv>
+    </tu>
     <tu tuid="perc.ui.architecture.modern@No sites are available. Create a site to browse its navigation tree.">
       <tuv xml:lang="en-us"><seg>No sites are available. Create a site to browse its navigation tree.</seg></tuv>
     </tu>

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -586,6 +586,22 @@
       <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
     <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
+    <tu tuid="perc.ui.navMenu.architecture@Navigation">
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="ar"><seg>ملاحة</seg></tuv>
+      <tuv xml:lang="bn"><seg>নেভিগেশন</seg></tuv>
+      <tuv xml:lang="de"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="es"><seg>Navegación</seg></tuv>
+      <tuv xml:lang="fr"><seg>Navigation</seg></tuv>
+      <tuv xml:lang="hi"><seg>मार्गदर्शन</seg></tuv>
+      <tuv xml:lang="it"><seg>Navigazione</seg></tuv>
+      <tuv xml:lang="ja-jp"><seg>ナビゲーション</seg></tuv>
+      <tuv xml:lang="nl"><seg>Navigatie</seg></tuv>
+      <tuv xml:lang="pt"><seg>Navegação</seg></tuv>
+      <tuv xml:lang="te"><seg>నావిగేషన్</seg></tuv>
+      <tuv xml:lang="zh-cn"><seg>导航</seg></tuv>
+      <tuv xml:lang="zh-tw"><seg>导航</seg></tuv>
+    <tuv xml:lang="ru"><seg>Навигация</seg></tuv><tuv xml:lang="he"><seg>ניווט</seg></tuv><tuv xml:lang="uk"><seg>Навігація</seg></tuv><tuv xml:lang="lou"><seg>Navigasyon</seg></tuv><tuv xml:lang="pl"><seg>Nawigacja</seg></tuv><tuv xml:lang="tr"><seg>Navigasyon</seg></tuv></tu>
     <tu tuid="perc.ui.navMenu.design@Design">
       <tuv xml:lang="en-us"><seg>Design</seg></tuv>
       <tuv xml:lang="ar"><seg>تصميم</seg></tuv>
@@ -27095,13 +27111,19 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
 
     <!-- Architecture SPA chrome (#3098 Slice F) — feature keys only (en-us). -->
     <tu tuid="perc.ui.architecture.modern@Architecture">
-      <tuv xml:lang="en-us"><seg>Architecture</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Navigation">
+      <tuv xml:lang="en-us"><seg>Navigation</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.">
       <tuv xml:lang="en-us"><seg>Browse and edit site navigation trees (navons / sections), including landing pages, section links, and external links.</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Loading Architecture…">
-      <tuv xml:lang="en-us"><seg>Loading Architecture…</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Loading Navigation…</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Loading Navigation…">
+      <tuv xml:lang="en-us"><seg>Loading Navigation…</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Site">
       <tuv xml:lang="en-us"><seg>Site</seg></tuv>
@@ -27350,7 +27372,10 @@ Bu {0}'ı yine de düzenlemek için 'Geçersiz kıl'ı seçin.
       <tuv xml:lang="en-us"><seg>Enter a valid URL (for example https://example.com or /path)</seg></tuv>
     </tu>
     <tu tuid="perc.ui.architecture.modern@Site navigation (Architecture)">
-      <tuv xml:lang="en-us"><seg>Site navigation (Architecture)</seg></tuv>
+      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.architecture.modern@Site navigation">
+      <tuv xml:lang="en-us"><seg>Site navigation</seg></tuv>
     </tu>
 
   </body>

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-links-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-links-smoke.spec.js
@@ -68,7 +68,7 @@ test.describe("Architecture nav landing & links (#3097)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
 
     const sitesEmpty = page.getByTestId("architecture-sites-empty");

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
@@ -68,7 +68,7 @@ test.describe("Architecture nav structure mutations (#3096)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
     await expect(page.getByTestId("architecture-toolbar")).toBeVisible({
       timeout: 15_000,

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-empty.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-empty.spec.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture nav tree empty / missing NavTree UX (#3218 / parent #3197).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-tree-empty.spec.js
+ *
+ * Intercepts site list + tree so the assertion does not depend on seeded
+ * sites. Empty 200 tree must be an operator empty state, not HTTP 500 chrome.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    site: "BareSite",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Architecture empty nav tree (#3218)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("empty 200 tree is operator empty state not 500 banner @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.route("**/sitemanage/site/**", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          SiteSummary: [{ name: "BareSite" }],
+        }),
+      });
+    });
+    await page.route("**/sitemanage/section/tree/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          SectionNode: {
+            title: "BareSite",
+            folderPath: "//Sites/BareSite",
+            childNodes: [],
+          },
+        }),
+      });
+    });
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("architecture-nav-tree-empty")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.getByTestId("architecture-nav-tree-empty-title"),
+    ).toContainText(/no navigation tree/i);
+    await expect(page.getByTestId("architecture-nav-tree-error")).toHaveCount(0);
+    await expect(page.getByText(/HTTP 500/i)).toHaveCount(0);
+
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            e,
+          ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
@@ -58,7 +58,7 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation|Architecture/i,
     );
 
     // Toolbar always present once shell mounts
@@ -92,6 +92,12 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       await expect(treePanel.or(emptyState)).toBeVisible({ timeout: 15_000 });
       if (await treePanel.isVisible().catch(() => false)) {
         await expect(page.getByTestId("architecture-nav-tree")).toBeVisible();
+        // Missing NavTree is empty state, not HTTP 500 (#3218)
+        const treeError = page.getByTestId("architecture-nav-tree-error");
+        if (await treeError.isVisible().catch(() => false)) {
+          const errText = (await treeError.textContent()) || "";
+          expect(errText).not.toMatch(/HTTP 500/i);
+        }
         // Structure note / actions (Slice D) or legacy readonly note if older build
         const structureNote = page.getByTestId("architecture-structure-note");
         const readonlyNote = page.getByTestId("architecture-readonly-note");

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js
@@ -58,7 +58,7 @@ test.describe("Architecture read-only nav tree (#3095)", () => {
       timeout: 20_000,
     });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
 
     // Toolbar always present once shell mounts

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -43,9 +43,12 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await loginAsAdmin(page);
   });
 
-  test("deep link and TopNav open shell empty state @smoke @ui", async ({
+  test("deep link and TopNav open Navigation shell @smoke @ui", async ({
     page,
   }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
     await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
 
     await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
@@ -54,13 +57,18 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("nav-architecture")).toBeVisible({
       timeout: 20_000,
     });
+    await expect(page.getByTestId("nav-architecture")).toHaveText(/Navigation/i);
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByTestId("architecture-empty-state")).toBeVisible();
+    // Demo-site QA cells auto-select a site (picker); empty H2 cells show empty-state.
+    const emptyState = page.getByTestId("architecture-empty-state");
+    const picker = page.getByTestId("architecture-site-picker");
+    await expect(emptyState.or(picker)).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Navigation/i,
     );
+    expect(pageErrors, "uncaught pageerror on Navigation shell").toEqual([]);
 
     // Top-nav Architecture is SPA NavLink (not legacy ?view=arch)
     const href = await page

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -94,6 +94,7 @@ test.describe("Architecture SPA shell (#3094)", () => {
     });
     const newSite = page.getByTestId("architecture-action-new-site");
     await expect(newSite).toBeVisible();
+    await expect(newSite).toBeEnabled();
     await expect(newSite).toContainText(/New Site/i);
     await newSite.click();
     await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -57,9 +57,11 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByTestId("architecture-empty-state")).toBeVisible();
+    const empty = page.getByTestId("architecture-empty-state");
+    const tree = page.getByTestId("architecture-tree-panel");
+    await expect(empty.or(tree)).toBeVisible();
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
-      /Architecture/i,
+      /Architecture|Navigation/i,
     );
 
     // Top-nav Architecture is SPA NavLink (not legacy ?view=arch)
@@ -78,5 +80,26 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
       timeout: 20_000,
     });
+  });
+
+  test("New Site affordance opens the create-site wizard @smoke @ui", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    const newSite = page.getByTestId("architecture-action-new-site");
+    await expect(newSite).toBeVisible();
+    await expect(newSite).toContainText(/New Site/i);
+    await newSite.click();
+    await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();
+    await expect(page.getByTestId("site-create-step-details")).toBeVisible();
+    await page.getByTestId("architecture-new-site-close").click();
+    await expect(page.getByTestId("architecture-new-site-panel")).toHaveCount(0);
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
@@ -36,7 +36,10 @@ async function openPreferences(page) {
   await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
     timeout: 30_000,
   });
-  await page.getByTestId("perc-profile-nav-preferences").click();
+  const prefsNav = page.getByTestId("perc-profile-nav-preferences");
+  await expect(prefsNav).toBeVisible({ timeout: 20_000 });
+  await expect(prefsNav).toBeEnabled();
+  await prefsNav.click();
   const landing = page.getByTestId("perc-profile-preferences-landing");
   await expect(landing).toBeVisible({ timeout: 20_000 });
   return landing;
@@ -44,7 +47,18 @@ async function openPreferences(page) {
 
 async function saveLanding(page, value) {
   const landing = await openPreferences(page);
-  await landing.selectOption(value);
+  const optionValues = await landing.locator("option").evaluateAll((els) =>
+    els.map((o) => o.value),
+  );
+  const target = optionValues.includes(value)
+    ? value
+    : optionValues.includes("Home")
+      ? "Home"
+      : optionValues[0];
+  if (target == null) {
+    throw new Error("Landing select has no options to restore");
+  }
+  await landing.selectOption(target);
   const save = page.getByTestId("perc-profile-preferences-save");
   if (await save.isEnabled()) {
     await save.click();
@@ -52,7 +66,7 @@ async function saveLanding(page, value) {
       page.getByTestId("perc-profile-preferences-success"),
     ).toBeVisible({ timeout: 15_000 });
   } else {
-    await expect(landing).toHaveValue(value);
+    await expect(landing).toHaveValue(target);
   }
 }
 
@@ -66,36 +80,48 @@ test.describe("Homepage Navigation landing (#3219)", () => {
 
     await loginAsAdmin(page);
 
-    const landing = await openPreferences(page);
-    const optionValues = await landing.locator("option").evaluateAll((els) =>
-      els.map((o) => o.value),
-    );
-    expect(optionValues).toContain("Architecture");
+    let restoreTo = "";
+    try {
+      const landing = await openPreferences(page);
+      restoreTo = await landing.inputValue();
+      const optionValues = await landing.locator("option").evaluateAll((els) =>
+        els.map((o) => o.value),
+      );
+      expect(optionValues).toContain("Architecture");
 
-    await saveLanding(page, "Architecture");
+      await saveLanding(page, "Architecture");
 
-    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
-      waitUntil: "domcontentloaded",
-    });
+      await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page.getByTestId("perc-logout-page")).toBeVisible({
+        timeout: 20_000,
+      });
 
-    await page.goto(`${BASE_URL}/Rhythmyx/login`, {
-      waitUntil: "domcontentloaded",
-    });
-    const redirect = page.getByTestId("perc-login-redirect");
-    await expect(redirect).toBeAttached({ timeout: 20_000 });
-    await expect(redirect).toHaveValue("/cm/app/");
+      await page.goto(`${BASE_URL}/Rhythmyx/login`, {
+        waitUntil: "domcontentloaded",
+      });
+      const redirect = page.getByTestId("perc-login-redirect");
+      await expect(redirect).toBeAttached({ timeout: 20_000 });
+      await expect(redirect).toHaveValue("/cm/app/");
 
-    await loginAsAdmin(page);
+      await loginAsAdmin(page);
 
-    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
-      timeout: 40_000,
-    });
-    await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
-    const url = page.url();
-    expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
-    expect(url).not.toMatch(/\/home(\/|$|\?)/);
-
-    await saveLanding(page, "");
+      await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+        timeout: 40_000,
+      });
+      await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
+      const url = page.url();
+      expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
+      expect(url).not.toMatch(/\/home(\/|$|\?)/);
+    } finally {
+      try {
+        await loginAsAdmin(page);
+        await saveLanding(page, restoreTo);
+      } catch {
+        // Best-effort restore; do not mask the original assertion.
+      }
+    }
 
     expect(pageErrors, pageErrors.join("\n")).toEqual([]);
   });

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3219-nav-homepage-landing.spec.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Issue #3219 / parent #3197 slice 3 — homepage Navigation landing.
+ *
+ * Profile preference Architecture (product: Navigation) must open the
+ * Navigation SPA after a fresh login, not Home.
+ *
+ * Surface-filtered:
+ *   npm run test:surface -- --path tests/bugs/bug-3219-nav-homepage-landing.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+async function openPreferences(page) {
+  await page.goto(
+    `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await page.getByTestId("perc-profile-nav-preferences").click();
+  const landing = page.getByTestId("perc-profile-preferences-landing");
+  await expect(landing).toBeVisible({ timeout: 20_000 });
+  return landing;
+}
+
+async function saveLanding(page, value) {
+  const landing = await openPreferences(page);
+  await landing.selectOption(value);
+  const save = page.getByTestId("perc-profile-preferences-save");
+  if (await save.isEnabled()) {
+    await save.click();
+    await expect(
+      page.getByTestId("perc-profile-preferences-success"),
+    ).toBeVisible({ timeout: 15_000 });
+  } else {
+    await expect(landing).toHaveValue(value);
+  }
+}
+
+test.describe("Homepage Navigation landing (#3219)", () => {
+  test("login default is dispatcher; Architecture pref opens Navigation @smoke @ui", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await loginAsAdmin(page);
+
+    const landing = await openPreferences(page);
+    const optionValues = await landing.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(optionValues).toContain("Architecture");
+
+    await saveLanding(page, "Architecture");
+
+    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.goto(`${BASE_URL}/Rhythmyx/login`, {
+      waitUntil: "domcontentloaded",
+    });
+    const redirect = page.getByTestId("perc-login-redirect");
+    await expect(redirect).toBeAttached({ timeout: 20_000 });
+    await expect(redirect).toHaveValue("/cm/app/");
+
+    await loginAsAdmin(page);
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 40_000,
+    });
+    await expect(page.getByTestId("architecture-action-new-site")).toBeVisible();
+    const url = page.url();
+    expect(url).toMatch(/architecture|entry=architecture|view=arch/i);
+    expect(url).not.toMatch(/\/home(\/|$|\?)/);
+
+    await saveLanding(page, "");
+
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -22,8 +22,10 @@ chrome. In Percussion CMS 8.2 the primary entry is the SPA shell. The classic
    - Legacy bookmarks: `/cm/app/?view=arch` and `/cm/app/siteArchitecture.jsp` redirect here
 3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
 
-Default landing can also be set to **Architecture** for a user or role (homepage type
-`Architecture`); login then resolves to the SPA Architecture entry.
+Default landing can also be set to **Navigation** (stored homepage type
+`Architecture`, also accepted as `Navigation`) for a user or role. After sign-in
+with no deep-link return URL, the login form posts to `/cm/app/` so the
+dispatcher applies that preference and opens the Navigation SPA — not Home.
 
 ## Browse a site navigation tree
 
@@ -33,9 +35,14 @@ Default landing can also be set to **Architecture** for a user or role (homepage
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
 4. Expand and collapse nodes with the mouse or keyboard (Enter/Space, Arrow Left/Right).
 5. Use **Refresh** to reload the tree after external changes.
+6. Use **New Site** (Admin or Designer) to open the same traditional-site wizard
+   used in Content Explorer. After a successful create, the new site is selected
+   in this shell.
 
 Empty, loading, and error states are shown explicitly when the site list or tree
-cannot be loaded, or when a site has no sections.
+cannot be loaded, or when a site has no sections. **New Site** remains available
+when the site list is empty so operators can create the first site from this
+screen.
 
 ## Keyboard and accessibility
 
@@ -95,6 +102,7 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | SPA route + top-nav entry under product chrome | **Available** |
 | Role gate (Admin / Designer) | **Available** |
 | Site picker | **Available** |
+| New Site (Explorer create-site wizard) | **Available** |
 | Site navigation tree browse (navons / sections) | **Available** |
 | Structure editing (create / rename / reorder / delete) | **Available** |
 | Landing page / section-link / external-link parity | **Available** |

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -57,9 +57,10 @@ The navigation tree follows the ARIA tree pattern:
 | **Home / End** | Jump to the first or last visible node. |
 | **Enter / Space** | Select the focused section (and toggle expand on branches). |
 
-Structure dialogs (create, rename, landing page, section link, external link, and the
-section picker) are modal (`role="dialog"`, `aria-modal`). **Escape** closes the open
-dialog when a mutation is not in progress. Primary structure actions live in a toolbar
+Structure dialogs (create, rename, landing page, section link, external link, the
+section picker, and **New Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
+closes the open dialog when a mutation is not in progress. Closing **New Site**
+returns keyboard focus to the **New Site** button. Primary structure actions live in a toolbar
 with an accessible name (**Structure actions**).
 
 Chrome strings (shell, tree states, actions, dialogs, validation) use the

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -37,6 +37,22 @@ Default landing can also be set to **Architecture** for a user or role (homepage
 Empty, loading, and error states are shown explicitly when the site list or tree
 cannot be loaded, or when a site has no sections.
 
+### Site without a navigation tree
+
+A site can exist without a NavTree item at the site root (for example a newly
+created site, a Rhythmyx site listed in the site picker, or a site whose
+navigation was never created). Opening **Architecture** for that site does
+**not** fail with HTTP 500.
+
+The server `GET /Rhythmyx/sitemanage/section/tree/{siteName}` call returns
+**HTTP 200** with an empty section tree (`childNodes` empty). The SPA shows an
+operator **empty state** (“No navigation tree”) in the Navigation tree panel
+instead of a route error or a generic 500 banner.
+
+To add navigation later, create a NavTree at the site root in **Explorer**
+(or create the site with managed navigation), then use **Refresh**. Other
+sites with a tree continue to load normally.
+
 ## Keyboard and accessibility
 
 The navigation tree follows the ARIA tree pattern:

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -1,33 +1,37 @@
 ---
 id: admin-architecture-navigation
-title: Architecture & site navigation
-description: Modern Architecture SPA for browsing and editing site navigation trees (navons / sections)
+title: Navigation & site structure
+description: Modern Navigation SPA for browsing and editing site navigation trees (navons / sections)
 version: "8.2"
 order: 43
 tags: [admin, architecture, navigation, ui]
 ---
 
-# Architecture & site navigation
+# Navigation & site structure
 
-**Architecture** (site navigation / navon tree editor) runs in the modern SPA product
+**Navigation** (site navigation / navon tree editor) runs in the modern SPA product
 chrome. In Percussion CMS 8.2 the primary entry is the SPA shell. The classic
 `siteArchitecture.jsp` page and `?view=arch` bookmarks hard-redirect into the SPA.
 
-## Open Architecture (SPA)
+The product name is **Navigation**. The SPA route remains `/architecture` (and
+`spa.jsp?entry=architecture`) so existing bookmarks and homepage type
+`Architecture` keep working.
+
+## Open Navigation (SPA)
 
 1. Sign in as an **Admin** or **Designer**.
-2. Choose **Architecture** in the product top navigation, or open the SPA entry:
+2. Choose **Navigation** in the product top navigation, or open the SPA entry:
    - Query contract: `spa.jsp?entry=architecture`
    - Path route: `/cm/app/architecture` (optional site segment or `?site=` for context)
    - Legacy bookmarks: `/cm/app/?view=arch` and `/cm/app/siteArchitecture.jsp` redirect here
 3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
 
-Default landing can also be set to **Architecture** for a user or role (homepage type
-`Architecture`); login then resolves to the SPA Architecture entry.
+Default landing can also be set to **Navigation** for a user or role (homepage type
+`Architecture`); login then resolves to the SPA Navigation entry.
 
 ## Browse a site navigation tree
 
-1. Open **Architecture**.
+1. Open **Navigation**.
 2. Choose a site from the **Site** list (or open a deep link with `?site=YourSiteName`
    or `/architecture/YourSiteName`).
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
@@ -80,7 +84,7 @@ shown in the panel (no silent failure). The tree reloads after a successful muta
 ### Blog sections
 
 Blog-type sections appear in the navigation tree (type badge). Full blog post
-authoring remains outside this Architecture editor; treat blog structure as
+authoring remains outside this Navigation editor; treat blog structure as
 visible but limited in this surface.
 
 ### Still later
@@ -105,10 +109,10 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | Site navigation tree browse (navons / sections) | **Available** (read-only) |
 | Structure editing (create / edit / move / delete) | **Coming soon** |
 | Landing page / section-link parity | **Coming soon** |
-| Legacy `siteArchitecture.jsp` / `?view=arch` | **Redirected** to SPA Architecture (#3099) |
+| Legacy `siteArchitecture.jsp` / `?view=arch` | **Redirected** to SPA Navigation (#3099) |
 
 ## Related
 
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
-- [Users, roles & security](id:admin-users-roles) (default landing options include Architecture)
+- [Users, roles & security](id:admin-users-roles) (default landing options include Navigation)

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -38,7 +38,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
-- [Architecture & site navigation](id:admin-architecture-navigation)
+- [Navigation & site structure](id:admin-architecture-navigation)
 - [Users, roles & security](id:admin-users-roles)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -62,6 +62,16 @@ still apply. Client-side checks require a non-empty password of at least six cha
 and a matching confirmation before submit. Success and failure messages are announced
 to assistive technology via a live region.
 
+## Default landing (homepage)
+
+In **My profile → Preferences**, or **Admin → Users** when editing a user, set
+**Default landing page**. Choose **Navigation** (stored as homepage type
+`Architecture`) to open the site Navigation SPA after sign-in. Leave **Use role
+default** to keep the role homepage. Login without a deep-link return URL posts
+to `/cm/app/` so the dispatcher applies this preference.
+
+See [Architecture & site navigation](id:admin-architecture-navigation).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
@@ -139,4 +139,17 @@ public class PSSectionNode extends PSAbstractPersistantObject {
   public void setFolderPath(String folderPath) {
     this.folderPath = folderPath;
   }
+
+  /**
+   * Empty tree payload for a site that exists but has no NavTree item (#3218).
+   * {@code id} is left unset; {@link #getChildNodes()} is never {@code null}.
+   */
+  public static PSSectionNode emptyTree(String siteName, String folderPath) {
+    PSSectionNode node = new PSSectionNode();
+    node.setTitle(siteName);
+    node.setFolderPath(folderPath);
+    node.setSectionType(PSSectionTypeEnum.section);
+    node.setChildNodes(new ArrayList<>());
+    return node;
+  }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/IPSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/IPSSiteSectionService.java
@@ -159,7 +159,9 @@ public interface IPSSiteSectionService
    * Loads the root of the navigation for the specified site.
    *
    * @param siteName the name of the site, not blank.
-   * @return the root of the navigation, never <code>null</code>.
+   * @return the root of the navigation, never <code>null</code>. When the site
+   *     exists but has no NavTree, returns an empty root (no id, no children)
+   *     and does not delete the site (#3218).
    */
   PSSiteSection loadRoot(String siteName) throws PSSiteSectionException, PSNotFoundException;
 
@@ -167,7 +169,9 @@ public interface IPSSiteSectionService
    * Loads the entire tree nodes for the specified site.
    *
    * @param siteName the name of the specified site, not blank.
-   * @return the tree nodes of the site, never <code>null</code>.
+   * @return the tree nodes of the site, never <code>null</code>. When the site
+   *     exists but has no nav tree, an empty {@link PSSectionNode} (no id, empty
+   *     children) is returned so callers can emit HTTP 200 instead of 500.
    */
   PSSectionNode loadTree(String siteName) throws PSSiteSectionException, PSNotFoundException;
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestService.java
@@ -254,8 +254,22 @@ public class PSSiteSectionRestService {
   public PSSectionNode loadTree(@PathParam("siteName") String siteName)
       throws IPSSiteSectionService.PSSiteSectionException, PSNotFoundException {
     try {
-      return siteSectionService.loadTree(siteName);
-    } catch (IPSSiteSectionService.PSSiteSectionException | PSNotFoundException e) {
+      PSSectionNode tree = siteSectionService.loadTree(siteName);
+      if (tree == null) {
+        return PSSectionNode.emptyTree(siteName, null);
+      }
+      if (tree.getChildNodes() == null) {
+        tree.setChildNodes(java.util.Collections.emptyList());
+      }
+      return tree;
+    } catch (IPSSiteSectionService.PSSiteSectionException e) {
+      if (PSSiteSectionService.isMissingNavTreeMessage(e.getMessage())) {
+        log.info("Site '{}' has no navigation tree; returning empty section tree", siteName);
+        return PSSectionNode.emptyTree(siteName, null);
+      }
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw e;
+    } catch (PSNotFoundException e) {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       throw e;
     }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -37,8 +37,6 @@ import com.percussion.comments.service.IPSCommentsService;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
-import com.percussion.fastforward.managednav.IPSNavigationErrors;
-import com.percussion.fastforward.managednav.PSNavException;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
 import com.percussion.itemmanagement.service.IPSWorkflowHelper;
 import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
@@ -1473,13 +1471,12 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     IPSSite site = siteMgr.loadSite(siteName);
     IPSGuid navTreeId = navSrv.findNavigationIdFromFolder(site.getFolderRoot());
     if (navTreeId == null) {
-      PSNavException ne =
-          new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE, siteName);
-
-      log.error("{}", PSExceptionUtils.getMessageForLog(ne));
-      log.warn("Removing invalid site definition: {}", siteName);
-      siteMgr.deleteSite(site);
+      // Do not delete the site: missing NavTree is a valid empty state (#3218).
+      log.warn(
+          "Site {} has no navigation tree under {}; returning empty root",
+          siteName,
+          site.getFolderRoot());
+      return emptyRootSection(site);
     }
 
     return loadSiteSection(navTreeId, null, site.getFolderRoot(), true, false, null);
@@ -1651,8 +1648,50 @@ public class PSSiteSectionService implements IPSSiteSectionService {
    */
   public PSSectionNode loadTree(String siteName)
       throws PSSiteSectionException, com.percussion.services.error.PSNotFoundException {
-    PSSiteSection root = loadRoot(siteName);
+    IPSSite site = siteMgr.loadSite(siteName);
+    String folderRoot = site.getFolderRoot();
+    IPSGuid navTreeId = navSrv.findNavigationIdFromFolder(folderRoot);
+    if (navTreeId == null) {
+      log.info("Site '{}' has no navigation tree; returning empty section tree", siteName);
+      return PSSectionNode.emptyTree(siteName, folderRoot);
+    }
+    PSSiteSection root = loadSiteSection(navTreeId, null, folderRoot, true, false, null);
     return loadSectionTree(root);
+  }
+
+  /**
+   * Operator-facing message when a site has no NavTree item. REST maps this to
+   * an empty 200 tree rather than HTTP 500 (#3218).
+   */
+  static String missingNavTreeMessage(String siteName) {
+    return "Cannot find navigation tree for site: " + siteName;
+  }
+
+  /**
+   * Empty root section when the site exists but has no NavTree item.
+   * Id is left unset so callers do not treat this as a real navon.
+   */
+  static PSSiteSection emptyRootSection(IPSSite site) {
+    PSSiteSection section = new PSSiteSection();
+    if (site != null) {
+      section.setTitle(site.getName());
+      section.setFolderPath(site.getFolderRoot());
+    }
+    section.setChildIds(new ArrayList<>());
+    section.setSectionType(PSSectionTypeEnum.section);
+    return section;
+  }
+
+  /** True when {@code message} is the missing-NavTree empty-state case (#3218). */
+  static boolean isMissingNavTreeMessage(String message) {
+    if (message == null || message.isBlank()) {
+      return false;
+    }
+    String lower = message.toLowerCase(Locale.ROOT);
+    return lower.contains("cannot find navigation tree")
+        || lower.contains("cannot find navtree")
+        || lower.contains("navtree for site")
+        || lower.contains("navtree_for_site");
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/data/PSSectionNodeEmptyTreeSerialTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/data/PSSectionNodeEmptyTreeSerialTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Empty NavTree payload must serialize as a SectionNode with empty children
+ * (200 wire), not omit the list or throw (#3218).
+ */
+@Tag("UnitTest")
+public class PSSectionNodeEmptyTreeSerialTest {
+
+  @Test
+  void emptyTreeRoundTripsWithEmptyChildren() {
+    JsonMapper mapper =
+        JsonMapper.builder()
+            .enable(SerializationFeature.WRAP_ROOT_VALUE)
+            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+            .build();
+
+    PSSectionNode empty = PSSectionNode.emptyTree("BareSite", "//Sites/BareSite");
+    String json = mapper.writeValueAsString(empty);
+
+    assertTrue(json.contains("BareSite"), json);
+    assertTrue(
+        json.contains("childNodes") || json.contains("[]"),
+        "empty tree must serialize children list, got: " + json);
+
+    PSSectionNode roundTrip = mapper.readValue(json, PSSectionNode.class);
+    assertNotNull(roundTrip);
+    assertEquals("BareSite", roundTrip.getTitle());
+    assertNotNull(roundTrip.getChildNodes());
+    assertTrue(roundTrip.getChildNodes().isEmpty());
+    assertEquals("//Sites/BareSite", roundTrip.getFolderPath().orElse(null));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.error.PSNotFoundException;
+import com.percussion.sitemanage.data.PSSectionNode;
+import com.percussion.sitemanage.service.IPSSiteSectionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * GET /section/tree/{site} must return an empty 200 tree for missing NavTree (#3218).
+ */
+class PSSiteSectionRestServiceLoadTreeEmptyTest {
+
+  @Mock private PSSiteSectionService siteSectionService;
+
+  private PSSiteSectionRestService rest;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    rest = new PSSiteSectionRestService(siteSectionService);
+  }
+
+  @Test
+  void loadTreeReturnsServiceEmptyTree() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenReturn(PSSectionNode.emptyTree("Demo", "//Sites/Demo"));
+
+    PSSectionNode tree = rest.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertTrue(tree.getChildNodes().isEmpty());
+    assertEquals("Demo", tree.getTitle());
+  }
+
+  @Test
+  void loadTreeMapsMissingNavTreeExceptionToEmpty() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenThrow(
+            new IPSSiteSectionService.PSSiteSectionException(
+                "Cannot find navigation tree for site: Demo"));
+
+    PSSectionNode tree = rest.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertTrue(tree.getChildNodes().isEmpty());
+  }
+
+  @Test
+  void loadTreeRethrowsUnknownSite() throws Exception {
+    when(siteSectionService.loadTree("Missing"))
+        .thenThrow(new PSNotFoundException("site Missing"));
+    assertThrows(PSNotFoundException.class, () -> rest.loadTree("Missing"));
+  }
+
+  @Test
+  void loadTreeRethrowsUnrelatedSectionErrors() throws Exception {
+    when(siteSectionService.loadTree("Demo"))
+        .thenThrow(new IPSSiteSectionService.PSSiteSectionException("database unavailable"));
+    assertThrows(
+        IPSSiteSectionService.PSSiteSectionException.class, () -> rest.loadTree("Demo"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.comments.service.IPSCommentsService;
+import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.services.contentmgr.IPSContentMgr;
+import com.percussion.services.sitemgr.IPSSite;
+import com.percussion.services.sitemgr.IPSSiteManager;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.sitemanage.dao.IPSiteDao;
+import com.percussion.sitemanage.data.PSSectionNode;
+import com.percussion.sitemanage.data.PSSiteSection;
+import com.percussion.sitemanage.service.IPSSiteTemplateService;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.publishing.IPSPublishingWs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Missing / empty NavTree must not 500 or delete the site (#3218 / parent #3197).
+ */
+class PSSiteSectionServiceLoadTreeEmptyTest {
+
+  @Mock private IPSPageDao pageDao;
+  @Mock private IPSManagedNavService navService;
+  @Mock private IPSContentWs contentSrv;
+  @Mock private IPSContentDesignWs contentDsSrv;
+  @Mock private IPSSiteManager siteMgr;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSRenderAssemblyBridge asmBridge;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSPublishingWs publishingWs;
+  @Mock private IPSTemplateService templateSrv;
+  @Mock private IPSiteDao siteDao;
+  @Mock private IPSSiteTemplateService siteTemplateSrv;
+  @Mock private IPSCommentsService commentsService;
+  @Mock private IPSPageDaoHelper pageDaoHelper;
+  @Mock private IPSItemWorkflowService itemWorkflowService;
+  @Mock private IPSContentMgr contentMgr;
+  @Mock private IPSSite site;
+
+  private PSSiteSectionService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    service =
+        new PSSiteSectionService(
+            pageDao,
+            navService,
+            contentSrv,
+            contentDsSrv,
+            siteMgr,
+            idMapper,
+            asmBridge,
+            folderHelper,
+            workflowHelper,
+            publishingWs,
+            templateSrv,
+            siteDao,
+            siteTemplateSrv,
+            commentsService,
+            pageDaoHelper,
+            itemWorkflowService,
+            contentMgr);
+    when(site.getName()).thenReturn("Demo");
+    when(site.getFolderRoot()).thenReturn("//Sites/Demo");
+    when(siteMgr.loadSite("Demo")).thenReturn(site);
+    when(navService.findNavigationIdFromFolder("//Sites/Demo")).thenReturn(null);
+  }
+
+  @Test
+  void loadTreeReturnsEmptyNodeWhenNavTreeMissing() throws Exception {
+    PSSectionNode tree = service.loadTree("Demo");
+    assertNotNull(tree);
+    assertNull(tree.getId());
+    assertEquals("Demo", tree.getTitle());
+    assertEquals("//Sites/Demo", tree.getFolderPath().orElse(null));
+    assertTrue(tree.getChildNodes().isEmpty());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
+  void loadRootReturnsEmptySectionAndDoesNotDeleteSite() throws Exception {
+    PSSiteSection root = service.loadRoot("Demo");
+    assertNotNull(root);
+    assertNull(root.getId());
+    assertEquals("Demo", root.getTitle());
+    assertEquals("//Sites/Demo", root.getFolderPath());
+    assertTrue(root.getChildIds() == null || root.getChildIds().isEmpty());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
+  void missingNavTreeMessageIsRecognized() {
+    assertTrue(
+        PSSiteSectionService.isMissingNavTreeMessage(
+            "Cannot find navigation tree for site: Demo"));
+    assertTrue(
+        PSSiteSectionService.isMissingNavTreeMessage(
+            "NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE: Demo"));
+    assertTrue(!PSSiteSectionService.isMissingNavTreeMessage("database unavailable"));
+    assertTrue(!PSSiteSectionService.isMissingNavTreeMessage(null));
+  }
+}

--- a/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
+++ b/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
@@ -299,6 +299,7 @@ public class PSLoginServlet extends HttpServlet {
       return;
     }
 
+    String formRedirect = null;
     if (request.getMethod().equalsIgnoreCase("POST")) {
       PSRequest psreq = (PSRequest) getRequestInfo(KEY_PSREQUEST);
 
@@ -312,6 +313,9 @@ public class PSLoginServlet extends HttpServlet {
         uid = psreq.getParameter("j_username");
         pwd = psreq.getParameter("j_password");
         locale = psreq.getParameter("j_locale");
+        // Multipart login form: servlet getParameter() does not see body
+        // fields — take sys_redirect from the parsed PSRequest (#3219).
+        formRedirect = psreq.getParameter(IPSHtmlParameters.SYS_REDIRECT);
 
         if (locale != null) {
           request.getSession().setAttribute(PSI18nUtils.USER_SESSION_OBJECT_SYS_LANG, locale);
@@ -326,7 +330,9 @@ public class PSLoginServlet extends HttpServlet {
 
     String redirect =
         PSRedirectValidation.decodeOverEncodedRedirect(
-            request.getParameter(IPSHtmlParameters.SYS_REDIRECT));
+            !StringUtils.isBlank(formRedirect)
+                ? formRedirect
+                : request.getParameter(IPSHtmlParameters.SYS_REDIRECT));
     if (isValidRedirectUri(request, redirect)) {
       request.getSession().setAttribute(REDIRECT_URL, redirect);
     }
@@ -627,7 +633,8 @@ public class PSLoginServlet extends HttpServlet {
    * <p>Path-absolute SPA entry (query contract). See pure-react-spa design: never use hash
    * fragments on server redirects. Form posts may also supply {@code sys_redirect}.
    */
-  private static final String CMS_INDEX_PAGE = "/cm/app/spa.jsp?entry=home";
+  /** Dispatcher so {@code getUserHomepage()} can land Navigation / Architecture (#3219). */
+  private static final String CMS_INDEX_PAGE = "/cm/app/";
 
   private static final String USER_DIR = "user";
 

--- a/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
+++ b/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
@@ -63,11 +63,9 @@ public class PSLoginServletTest {
     assertEquals(
         "/cm/app/spa.jsp?entry=home",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "/cm/app/spa.jsp?entry=home"));
-    // Default CMS index when blank / null — modern SPA landing
-    assertEquals(
-        "/cm/app/spa.jsp?entry=home", PSLoginServlet.resolveSafePostLoginRedirect(request, null));
-    assertEquals(
-        "/cm/app/spa.jsp?entry=home", PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
+    // Default CMS index when blank / null — dispatcher (homepage resolve, #3219)
+    assertEquals("/cm/app/", PSLoginServlet.resolveSafePostLoginRedirect(request, null));
+    assertEquals("/cm/app/", PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
     // App-relative entry points still allowed
     assertEquals("index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "index.jsp"));
     assertEquals(
@@ -83,15 +81,15 @@ public class PSLoginServletTest {
 
     // External host → fall back to CMS SPA index
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "http://evil.example/phish"));
     // Path traversal
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "/../../etc/passwd"));
     // javascript: scheme (relative form rejected by colon rule)
     assertEquals(
-        "/cm/app/spa.jsp?entry=home",
+        "/cm/app/",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "javascript:alert(1)"));
     // Same-host absolute is allowed
     assertEquals(


### PR DESCRIPTION
## Summary

Overnight **same-file thrash absorption** for Navigation / Architecture SPA. Three owned PRs all edited the same chrome, docs, landing-option, TMX, and Playwright smoke files. This PR is a **union** of those heads against `main` so they do not keep colliding.

Does **not** invent extra product scope. Does **not** absorb unrelated open PRs (#3225 PathItem, #3229 Admin, #3231 Sites, #3233/#3236 searches, #3235 views).

**Thrash files (shared by ≥2 absorbed PRs):**

- `WebUI/src/main/ts/architecture/messages.ts`
- `WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx`
- `WebUI/src/main/ts/profile/landingOptions.ts`
- `WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts`
- `WebUI/src/test/ts/profile/landingOptions.test.ts`
- `WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts`
- `modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx`
- `modules/perc-qa-automation/frontend/tests/architecture-nav-tree-smoke.spec.js`
- `modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js`
- `product-docs/8.2/admin/architecture-navigation.md`

Union notes:

- Product chrome title / TMX / landing labels stay **Navigation**; stored homepage type remains `Architecture`; SPA path stays `/architecture` (#3220 + #3227).
- Missing NavTree stays **HTTP 200 empty children** + SPA empty state (#3222); smoke still asserts no HTTP 500.
- Homepage landing dispatcher + **New Site** wizard on the Navigation shell (#3227).
- Docs: landing paragraph from #3227 plus empty-tree 200 from #3222; dropped stale duplicate “Coming soon” status rows that contradicted Available rows.

Partial: #3217 #3218 #3219 (parent Navigation epic #3197).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3220](https://github.com/intersoftdatalabs-in/percussioncms/pull/3220) | `fix/issue-3217-navigation-product-name` @ `62a8fe9296` | yes | Product name Navigation |
| yes | [#3222](https://github.com/intersoftdatalabs-in/percussioncms/pull/3222) | `fix/issue-3218-nav-tree-http-500` @ `c061bcb353` | yes | Empty NavTree 200 + UX |
| yes | [#3227](https://github.com/intersoftdatalabs-in/percussioncms/pull/3227) | `fix/issue-3219-nav-homepage-landing-new-site` @ `11faa2665a` | yes | Landing dispatcher + New Site |

## Test plan

1. Review union of Navigation chrome, empty-tree 200, and homepage/New Site on one branch.
2. `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Vitest **Tests 2074 passed** (292 files).
3. `cd modules/perc-i18n && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 31, Failures: 0.
4. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (Maven has no Surefire tests; Playwright is live/QA).
5. Cluster-specific sitemanage: `cd projects/sitemanage && ../../mvnw.cmd -Dtest=PSSectionNodeEmptyTreeSerialTest,PSSiteSectionRestServiceLoadTreeEmptyTest,PSSiteSectionServiceLoadTreeEmptyTest test` — **BUILD SUCCESS**; Tests run: 8, Failures: 0. (Full sitemanage Surefire hit a local SNAPSHOT/`Ga4MigrationPortTest` class-load failure on this agent; #3222 already reported standalone `clean install` Tests run: 1038.)
6. Cluster-specific system: `cd system && ../mvnw.cmd -Dtest=PSLoginServletTest test` — **BUILD SUCCESS**; Tests run: 10, Failures: 0.
7. Playwright (from absorbed PRs; not re-run live in this cluster step): `architecture-nav-tree-smoke`, `architecture-nav-tree-empty`, `architecture-shell-smoke`, `bugs/bug-3219-nav-homepage-landing`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/architecture-navigation.md` (and #3227 `users-roles.md`)
- [x] **Unit / module tests** — Vitest + empty-tree + login tests as above
- [x] **WebUI + Playwright** — union of architecture smokes + empty-tree + landing specs
- [x] **Build gates** — WebUI / perc-i18n / perc-qa-automation clean install; sitemanage + system focused tests (see test plan)
- [x] **Cross-platform** — N/A (no new path/file I/O in the union)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok 1.0 using grok-4.5 with agent night-issue-prs-cluster.
