### PR TITLE
feat(rest): custom-URL view execute Inbox C1 (#3239)

### DIFF
--- a/docs/ai-generated/code-reviews/3239-custom-url-view-execute-erlang.md
+++ b/docs/ai-generated/code-reviews/3239-custom-url-view-execute-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review: #3239 custom-URL view execute (Inbox C1)
+
+**Branch:** `feat/issue-3239-custom-url-view-execute`  
+**Base:** `origin/main` (includes V1 merge from `feat/issue-3115-views-rest-execute` / PR #3235)  
+**Date:** 2026-08-12  
+**Persona:** Erlang (independent of implementer)
+
+## Summary
+
+Extends `POST /rest/views/{idOrName}/execute` so Inbox-family custom-URL views (`sys_cxViews/inbox` and documented peers) run via the classic app resource and map `Item/@sys_contentid` rows to Explorer items. Unsupported custom URLs stay an explicit 400. Missing request context / missing `sys_cxViews` resource is 503, not 500.
+
+Companion closure matches rest/sitemanage change class: resource + adaptor javadoc + `ViewAdaptor` runner + Mockito `ViewResourceTest` + existing Spring `TestViewAdaptor` stub + `ViewAdaptorExecuteTest` + product-docs `rest.md`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No hard-gate bugs. Behavioral tests cover Inbox success, unsupported/blank URL 400, URL allow-list, document mapping, result cap, and resource 503 rethrow. Custom-URL resolution is application-resource path hygiene (`/`), not OS filesystem joins.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | present (`ViewResource.executeView` docs updated) |
+| Adaptor interface | present (javadoc; no signature change) |
+| sitemanage apibridge | present (`ViewAdaptor.runCustomUrlView`) |
+| Mockito resource tests | present (`ViewResourceTest` 17 tests) |
+| Spring test stub | present (`TestViewAdaptor.executeView` already on V1) |
+| sitemanage unit tests | present (`ViewAdaptorExecuteTest` 27 tests) |
+| product-docs | present (`product-docs/8.2/developer/rest.md`) |
+| Playwright / WebUI | N/A (Explorer leaf is #3240; Playwright #3241) |
+
+## Cross-platform path checklist
+
+- Custom-view URL parse uses `/` as the **application resource** separator (URL/app page), not `File.separator`.
+- Rejects `\`, `..` after strip, NUL, and non-`sys_cxViews` apps.
+- No new filesystem path construction.
+
+## Issues
+
+None (hard-gate).
+
+## Memory patterns hit
+
+- Incomplete change-class closure (rest↔sitemanage adaptor surface) — closed
+- Behavioral tests for validation/rejection (unsupported custom URL) — present
+- Non-portable paths — not applicable (resource URLs)
+
+## Build evidence (pre-PR)
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 335, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1132, Failures: 0, Errors: 0, Skipped: 125
+- C2: no public method/ctor signature change; `IViewAdaptor.executeView` already existed on V1. Downstream sitemanage install green.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -148,7 +148,7 @@ Content Explorer **view** definitions (Workbench / Developer **Views**, UI-07) a
 |--------|------|---------|
 | `GET` | `/services/views` | List view definitions (name, category, standard vs custom URL) |
 | `GET` | `/services/views/{idOrName}` | Load one view by name, numeric id, or GUID string |
-| `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view |
+| `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view or an Inbox-family **custom URL** view |
 
 ### Execute request / response
 
@@ -170,20 +170,34 @@ Successful response is a paged envelope: `children[]` (Explorer-ready rows with 
 | Status | Typical meaning |
 |--------|-----------------|
 | `200` | List / get / execute success |
-| `400` | Invalid execute body, or the view is a **custom URL** view |
+| `400` | Invalid execute body, or an **unsupported** custom URL view |
 | `404` | View not found or unsafe key (blank, path separators, `..`) |
-| `500` | Design or execute engine failure |
-| `503` | Views adaptor not configured (deployment miswire) |
+| `500` | Design or execute engine failure (standard views) |
+| `503` | Views adaptor not configured, or custom-view backend unavailable |
 
 ### Custom URL views (Inbox family)
 
-Views flagged as **custom** (`customView` / Inbox, Outbox, Recent, and peers that run a classic
-application URL rather than field criteria) **cannot** be executed on this façade. The server
-returns **`400`** with a message that custom URL views are unsupported here. That family is
-deferred to a dedicated Inbox runner — it is **not** a silent empty result.
+Views flagged as **custom** (`customView`) store a classic application URL instead of field
+criteria. `POST /services/views/{idOrName}/execute` **runs** the documented Inbox family by
+invoking the classic resource and mapping `Item` rows to Explorer items (`id`, `name`, `title`,
+`folderPath`, `type`):
 
-Standard field-criteria views (`standardView`) execute with the same design operators, display
-format, max results, and case sensitivity stored on the view design.
+| View (typical name) | Classic resource |
+|---------------------|------------------|
+| Inbox | `sys_cxViews/inbox` (`../sys_cxViews/inbox.xml`) |
+| Outbox | `sys_cxViews/outbox` |
+| Recent | `sys_cxViews/recent` |
+| Session | `sys_cxViews/session` |
+| Checked out by me | `sys_cxViews/checkedoutbyme` |
+| Duplicate folder paths | `sys_cxViews/duplicatefolderpaths` |
+
+An empty Inbox is a **`200`** with `children: []` — not an error. Custom URLs **outside** that
+allow-list (blank URL, another application, unknown page, path traversal) return **`400`** with a
+clear message. Missing or unsafe view keys remain **`404`**. A missing request context or
+unavailable `sys_cxViews` resource returns **`503`**, not **`500`**.
+
+Standard field-criteria views (`standardView`) still execute with the same design operators,
+display format, max results, and case sensitivity stored on the view design.
 
 ### Integrator notes
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -28,23 +28,33 @@ import com.percussion.share.service.IPSIdMapper;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.data.PSInternalRequestCallException;
+import com.percussion.server.PSInternalRequest;
+import com.percussion.server.PSServer;
 import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
- * CX view definition catalog (UI-07) plus standard-view execute façade for Explorer (#3115 / #3110
- * V1). Loads designs via {@link IPSUiDesignWs#findViews} / {@link IPSUiDesignWs#loadViews} — not
- * the search catalog.
+ * CX view definition catalog (UI-07) plus view execute façade for Explorer (#3115 / #3239). Loads
+ * designs via {@link IPSUiDesignWs#findViews} / {@link IPSUiDesignWs#loadViews} — not the search
+ * catalog. Standard views use the design search runner; Inbox-family custom URLs invoke {@code
+ * sys_cxViews/*} and map {@code Item} rows to Explorer items.
  */
 @PSSiteManageBean
 @Lazy
@@ -56,19 +66,24 @@ public class ViewAdaptor implements IViewAdaptor {
   static final int DEFAULT_PAGE_SIZE = 25;
 
   /**
-   * Explicit 400 for Inbox-family custom URL views. Dedicated runner is #3118 — this façade must
-   * not silently no-op.
+   * Classic CX custom-view pages that this runner will invoke. Other custom URLs stay an explicit
+   * 400 (never a silent empty list or 500).
    */
-  static final String CUSTOM_VIEW_EXECUTE_UNSUPPORTED =
-      "Custom URL views cannot be executed via this endpoint. Inbox and other custom-URL views"
-          + " require a dedicated runner (issue #3118)";
+  static final Set<String> SUPPORTED_CX_VIEW_PAGES =
+      Set.of("inbox", "outbox", "recent", "session", "checkedoutbyme", "duplicatefolderpaths");
+
+  /** Explicit 400 when a custom-view URL is blank or not a supported {@code sys_cxViews} page. */
+  static final String CUSTOM_VIEW_URL_UNSUPPORTED =
+      "Unsupported custom URL view. Supported classic resources are sys_cxViews/inbox,"
+          + " sys_cxViews/outbox, sys_cxViews/recent, sys_cxViews/session,"
+          + " sys_cxViews/checkedoutbyme, and sys_cxViews/duplicatefolderpaths.";
 
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
           "View create / update / delete not supported via this API",
           "View field criterion editing not supported via this API",
-          "Custom URL views (Inbox family) cannot be executed via this API; see Inbox / #3118",
+          "Custom URL views outside the sys_cxViews Inbox family cannot be executed via this API",
           "Searches are a separate catalog (Developer Searches / UI-06)");
 
   private static final List<String> RESULT_COLUMNS =
@@ -132,29 +147,17 @@ public class ViewAdaptor implements IViewAdaptor {
       if (design == null) {
         return null;
       }
+      List<ViewResultItem> allItems;
       if (design.isCustomView()) {
-        throw new IllegalArgumentException(CUSTOM_VIEW_EXECUTE_UNSUPPORTED);
+        allItems = runCustomUrlView(design, effective);
+      } else {
+        // Clone so folder/max overrides do not dirty a shared design instance
+        PSSearch search = (PSSearch) design.clone();
+        applyExecuteOverrides(search, effective);
+        allItems = runDesignView(search);
       }
-
-      // Clone so folder/max overrides do not dirty a shared design instance
-      PSSearch search = (PSSearch) design.clone();
-      applyExecuteOverrides(search, effective);
-
-      List<ViewResultItem> allItems = runDesignView(search);
       sortItems(allItems, effective.getSortColumn(), effective.getSortOrder());
-
-      int startIndex = effective.getStartIndex() != null ? effective.getStartIndex() : 1;
-      Integer maxResults = effective.getMaxResults();
-      PSPagedObjectList<ViewResultItem> page =
-          PSPagedObjectList.getPage(allItems, startIndex, maxResults);
-
-      ViewExecuteResult result = new ViewExecuteResult();
-      result.setChildren(new ArrayList<>(page.getChildrenInPage()));
-      result.setTotalCount(page.getChildrenCount() != null ? page.getChildrenCount() : allItems.size());
-      result.setStartIndex(page.getStartIndex() != null ? page.getStartIndex() : startIndex);
-      result.setViewName(design.getName());
-      result.setDisplayFormatId(design.getDisplayFormatId());
-      return result;
+      return toExecuteResult(design, effective, allItems);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -238,6 +241,144 @@ public class ViewAdaptor implements IViewAdaptor {
     items.sort(cmp);
   }
 
+  static ViewExecuteResult toExecuteResult(
+      PSSearch design, ViewExecuteRequest effective, List<ViewResultItem> allItems) {
+    int startIndex = effective.getStartIndex() != null ? effective.getStartIndex() : 1;
+    Integer maxResults = effective.getMaxResults();
+    PSPagedObjectList<ViewResultItem> page =
+        PSPagedObjectList.getPage(allItems, startIndex, maxResults);
+
+    ViewExecuteResult result = new ViewExecuteResult();
+    result.setChildren(new ArrayList<>(page.getChildrenInPage()));
+    result.setTotalCount(
+        page.getChildrenCount() != null ? page.getChildrenCount() : allItems.size());
+    result.setStartIndex(page.getStartIndex() != null ? page.getStartIndex() : startIndex);
+    result.setViewName(design.getName());
+    result.setDisplayFormatId(design.getDisplayFormatId());
+    return result;
+  }
+
+  /**
+   * Execute an Inbox-family custom URL view by invoking the classic {@code sys_cxViews} resource
+   * and mapping {@code Item/@sys_contentid} rows to Explorer items. Package-visible for spies.
+   */
+  List<ViewResultItem> runCustomUrlView(PSSearch design, ViewExecuteRequest request)
+      throws Exception {
+    String resource = resolveCustomViewResource(design != null ? design.getUrl() : null);
+    Document doc = fetchCustomViewDocument(resource);
+    List<ViewResultItem> items = mapCustomViewDocument(doc);
+    int cap = resolveCustomViewCap(design, request);
+    if (cap > 0 && items.size() > cap) {
+      return new ArrayList<>(items.subList(0, cap));
+    }
+    return items;
+  }
+
+  static int resolveCustomViewCap(PSSearch design, ViewExecuteRequest request) {
+    if (request != null && request.getMaxResults() != null && request.getMaxResults() >= 1) {
+      return request.getMaxResults();
+    }
+    if (design != null && design.getMaximumResultSize() > 0) {
+      return design.getMaximumResultSize();
+    }
+    return DEFAULT_PAGE_SIZE;
+  }
+
+  /**
+   * Normalize a custom-view URL (typical {@code ../sys_cxViews/inbox.xml}) to an internal request
+   * resource ({@code sys_cxViews/inbox}). Rejects blank, traversal, and non-whitelisted apps/pages.
+   */
+  static String resolveCustomViewResource(String rawUrl) {
+    if (StringUtils.isBlank(rawUrl)) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_UNSUPPORTED);
+    }
+    String url = rawUrl.trim();
+    int query = url.indexOf('?');
+    if (query >= 0) {
+      url = url.substring(0, query);
+    }
+    if (url.indexOf('\\') >= 0 || url.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_UNSUPPORTED);
+    }
+    while (url.startsWith("../")) {
+      url = url.substring(3);
+    }
+    if (url.startsWith("./")) {
+      url = url.substring(2);
+    }
+    while (url.startsWith("/")) {
+      url = url.substring(1);
+    }
+    String lower = url.toLowerCase(Locale.ROOT);
+    if (lower.startsWith("rhythmyx/")) {
+      url = url.substring("rhythmyx/".length());
+      lower = url.toLowerCase(Locale.ROOT);
+    }
+    if (lower.endsWith(".xml")) {
+      url = url.substring(0, url.length() - 4);
+    }
+    if (url.contains("..") || url.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_UNSUPPORTED);
+    }
+    String[] parts = url.split("/");
+    if (parts.length != 2 || !"sys_cxviews".equals(parts[0].toLowerCase(Locale.ROOT))) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_UNSUPPORTED);
+    }
+    String page = parts[1].toLowerCase(Locale.ROOT);
+    if (!SUPPORTED_CX_VIEW_PAGES.contains(page)) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_UNSUPPORTED);
+    }
+    return "sys_cxViews/" + page;
+  }
+
+  /**
+   * Invoke the classic app resource. Package-visible so tests can stub without a live CMS request
+   * context.
+   */
+  Document fetchCustomViewDocument(String resource) {
+    var request = PSWebserviceUtils.getRequest();
+    if (request == null) {
+      throw new WebApplicationException(
+          "View execute backend unavailable (no request context)",
+          Response.Status.SERVICE_UNAVAILABLE);
+    }
+    PSInternalRequest internal = PSServer.getInternalRequest(resource, request, null, true);
+    if (internal == null) {
+      throw new WebApplicationException(
+          "Custom view resource is not available: " + resource,
+          Response.Status.SERVICE_UNAVAILABLE);
+    }
+    try {
+      return internal.getResultDoc();
+    } catch (PSInternalRequestCallException e) {
+      log.error("Failed to execute custom view {}", resource, e);
+      throw new WebApplicationException(
+          "Custom view backend failed: " + resource, Response.Status.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  List<ViewResultItem> mapCustomViewDocument(Document doc) {
+    List<ViewResultItem> out = new ArrayList<>();
+    if (doc == null) {
+      return out;
+    }
+    NodeList rows = doc.getElementsByTagName("Item");
+    for (int i = 0; i < rows.getLength(); i++) {
+      if (!(rows.item(i) instanceof Element itemEl)) {
+        continue;
+      }
+      String contentId = itemEl.getAttribute("sys_contentid");
+      if (StringUtils.isBlank(contentId)) {
+        continue;
+      }
+      ViewResultItem mapped = mapContentIdToItem(contentId.trim());
+      if (mapped != null) {
+        out.add(mapped);
+      }
+    }
+    return out;
+  }
+
   /**
    * Execute the design view ({@link PSSearch} of type view) via the local executable search path
    * (operators preserved). Package-visible for unit tests that subclass/spy can override.
@@ -283,9 +424,28 @@ public class ViewAdaptor implements IViewAdaptor {
     item.setName(title);
     item.setTitle(title);
     item.setType(type);
+    return enrichItemFromContentId(item, contentId.trim());
+  }
 
+  ViewResultItem mapContentIdToItem(String contentId) {
+    if (StringUtils.isBlank(contentId)) {
+      return null;
+    }
+    ViewResultItem item = new ViewResultItem();
+    item.setId(contentId);
+    item.setName(contentId);
+    item.setTitle(contentId);
+    return enrichItemFromContentId(item, contentId);
+  }
+
+  /**
+   * Resolve content id to Explorer id / folder / type. Returns {@code null} when the id is not
+   * numeric or the item is not in a folder.
+   */
+  ViewResultItem enrichItemFromContentId(ViewResultItem item, String contentId) {
     try {
-      var myGuid = PSGuidUtils.makeGuid(Integer.parseInt(contentId.trim()), PSTypeEnum.LEGACY_CONTENT);
+      var myGuid =
+          PSGuidUtils.makeGuid(Integer.parseInt(contentId.trim()), PSTypeEnum.LEGACY_CONTENT);
       String stringId = idMapper.getString(myGuid);
       item.setId(stringId);
       if (folderHelper.getParentFolderId(myGuid, false) == null) {
@@ -297,10 +457,12 @@ public class ViewAdaptor implements IViewAdaptor {
       PSItemProperties props = folderHelper.findItemPropertiesById(stringId);
       if (props != null) {
         item.setId(props.getId() != null ? props.getId() : stringId);
-        item.setName(StringUtils.defaultIfBlank(props.getName(), title));
+        String fallbackName = StringUtils.defaultIfBlank(item.getName(), contentId);
+        item.setName(StringUtils.defaultIfBlank(props.getName(), fallbackName));
         item.setTitle(
             StringUtils.defaultIfBlank(
-                props.getSummary(), StringUtils.defaultIfBlank(props.getName(), title)));
+                props.getSummary(),
+                StringUtils.defaultIfBlank(props.getName(), fallbackName)));
         item.setFolderPath(props.getPath());
         if (StringUtils.isNotBlank(props.getType())) {
           item.setType(props.getType());
@@ -315,7 +477,9 @@ public class ViewAdaptor implements IViewAdaptor {
       } else {
         log.debug("Could not enrich view result for content id {}: {}", contentId, e.toString());
       }
-      item.setId(contentId);
+      if (StringUtils.isBlank(item.getId())) {
+        item.setId(contentId);
+      }
     }
     return item;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,9 +47,12 @@ import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 @Tag("UnitTest")
 class ViewAdaptorExecuteTest {
@@ -152,16 +156,55 @@ class ViewAdaptorExecuteTest {
   }
 
   @Test
-  void executeView_customUrlThrows400Style() throws Exception {
+  void executeView_inboxCustomUrlRunsAndMaps() throws Exception {
     PSSearch custom = mockView("Inbox", true, false);
+    when(custom.getUrl()).thenReturn("../sys_cxViews/inbox.xml");
+    when(custom.getDisplayFormatId()).thenReturn("0-1-1");
+    when(custom.getMaximumResultSize()).thenReturn(25);
+    stubLoadedViews(List.of(custom));
+
+    ViewResultItem row = item("guid-1", "Assignment");
+    row.setFolderPath("//Sites/Demo");
+    row.setType("Page");
+    doReturn(List.of(row)).when(adaptor).runCustomUrlView(any(PSSearch.class), any());
+
+    ViewExecuteResult result = adaptor.executeView("Inbox", new ViewExecuteRequest());
+    assertNotNull(result);
+    assertEquals("Inbox", result.getViewName());
+    assertEquals("0-1-1", result.getDisplayFormatId());
+    assertEquals(1, result.getTotalCount());
+    assertEquals(1, result.getChildren().size());
+    assertEquals("Assignment", result.getChildren().get(0).getTitle());
+    assertEquals("//Sites/Demo", result.getChildren().get(0).getFolderPath());
+    assertEquals("Page", result.getChildren().get(0).getType());
+    verify(adaptor, never()).runDesignView(any());
+  }
+
+  @Test
+  void executeView_customUrlUnsupportedThrows400Style() throws Exception {
+    PSSearch custom = mockView("MyAppView", true, false);
+    when(custom.getUrl()).thenReturn("../my_custom_app/foo.xml");
     stubLoadedViews(List.of(custom));
 
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
-            () -> adaptor.executeView("Inbox", new ViewExecuteRequest()));
-    assertTrue(ex.getMessage().toLowerCase().contains("custom"));
-    assertTrue(ex.getMessage().contains("#3118"));
+            () -> adaptor.executeView("MyAppView", new ViewExecuteRequest()));
+    assertTrue(ex.getMessage().toLowerCase().contains("unsupported"));
+    assertTrue(ex.getMessage().contains("sys_cxViews"));
+  }
+
+  @Test
+  void executeView_customUrlBlankThrows400Style() throws Exception {
+    PSSearch custom = mockView("Broken", true, false);
+    when(custom.getUrl()).thenReturn("  ");
+    stubLoadedViews(List.of(custom));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.executeView("Broken", new ViewExecuteRequest()));
+    assertTrue(ex.getMessage().contains("Unsupported custom URL"));
   }
 
   @Test
@@ -269,6 +312,87 @@ class ViewAdaptorExecuteTest {
 
     assertEquals(s, adaptor.findPsViewByKey("0-301-0"));
     assertEquals(s, adaptor.findPsViewByKey("42"));
+  }
+
+  @Test
+  void resolveCustomViewResource_normalizesInboxFamilyUrls() {
+    assertEquals(
+        "sys_cxViews/inbox", ViewAdaptor.resolveCustomViewResource("../sys_cxViews/inbox.xml"));
+    assertEquals(
+        "sys_cxViews/outbox", ViewAdaptor.resolveCustomViewResource("sys_cxViews/outbox"));
+    assertEquals(
+        "sys_cxViews/recent",
+        ViewAdaptor.resolveCustomViewResource("/Rhythmyx/sys_cxViews/recent.xml?x=1"));
+    assertEquals(
+        "sys_cxViews/session", ViewAdaptor.resolveCustomViewResource("../sys_cxViews/session.xml"));
+    assertEquals(
+        "sys_cxViews/checkedoutbyme",
+        ViewAdaptor.resolveCustomViewResource("../sys_cxViews/checkedoutbyme.xml"));
+    assertEquals(
+        "sys_cxViews/duplicatefolderpaths",
+        ViewAdaptor.resolveCustomViewResource("../sys_cxViews/duplicatefolderpaths.xml"));
+  }
+
+  @Test
+  void resolveCustomViewResource_rejectsUnsafeAndUnknown() {
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveCustomViewResource(null));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveCustomViewResource(""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.resolveCustomViewResource("../other_app/inbox.xml"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.resolveCustomViewResource("sys_cxViews/notapage"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.resolveCustomViewResource("sys_cxViews/inbox/../../../etc/passwd"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.resolveCustomViewResource("sys_cxViews\\inbox"));
+  }
+
+  @Test
+  void mapCustomViewDocument_mapsContentIdsAndSkipsBlank() throws Exception {
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    Element root = doc.createElement("View");
+    doc.appendChild(root);
+    Element blank = doc.createElement("Item");
+    blank.setAttribute("sys_contentid", "  ");
+    root.appendChild(blank);
+    Element ok = doc.createElement("Item");
+    ok.setAttribute("sys_contentid", "42");
+    root.appendChild(ok);
+
+    ViewResultItem mapped = item("guid-42", "Inbox item");
+    mapped.setFolderPath("//Folders/Work");
+    mapped.setType("Page");
+    doReturn(mapped).when(adaptor).mapContentIdToItem("42");
+
+    List<ViewResultItem> out = adaptor.mapCustomViewDocument(doc);
+    assertEquals(1, out.size());
+    assertEquals("guid-42", out.get(0).getId());
+    assertEquals("//Folders/Work", out.get(0).getFolderPath());
+  }
+
+  @Test
+  void mapCustomViewDocument_nullSafe() {
+    assertTrue(adaptor.mapCustomViewDocument(null).isEmpty());
+  }
+
+  @Test
+  void runCustomUrlView_capsResults() throws Exception {
+    PSSearch design = mockView("Inbox", true, false);
+    when(design.getUrl()).thenReturn("../sys_cxViews/inbox.xml");
+    when(design.getMaximumResultSize()).thenReturn(1);
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    doReturn(doc).when(adaptor).fetchCustomViewDocument("sys_cxViews/inbox");
+    doReturn(List.of(item("1", "A"), item("2", "B"), item("3", "C")))
+        .when(adaptor)
+        .mapCustomViewDocument(doc);
+
+    List<ViewResultItem> out = adaptor.runCustomUrlView(design, new ViewExecuteRequest());
+    assertEquals(1, out.size());
+    assertEquals("A", out.get(0).getTitle());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
@@ -6,7 +6,7 @@ package com.percussion.rest.views;
 
 import java.util.List;
 
-/** Adaptor for CX view design catalog (UI-07 read) and standard-view execute façade. */
+/** Adaptor for CX view design catalog (UI-07 read) and view execute façade. */
 public interface IViewAdaptor {
 
   List<ViewDef> listViews();
@@ -15,15 +15,18 @@ public interface IViewAdaptor {
   ViewDef findViewByKey(String idOrName);
 
   /**
-   * Execute a standard (field-criteria) design view by name, GUID string, or numeric id with
-   * optional scope/paging overrides. Loads the view via the views design catalog ({@code
-   * IPSUiDesignWs} find/load views) — not the search catalog.
+   * Execute a design view by name, GUID string, or numeric id with optional scope/paging
+   * overrides. Loads the view via the views design catalog ({@code IPSUiDesignWs} find/load
+   * views) — not the search catalog.
+   *
+   * <p>Standard (field-criteria) views run through the design search engine. Custom-URL views
+   * in the Inbox family ({@code sys_cxViews/inbox}, outbox, recent, session, checkedoutbyme,
+   * duplicatefolderpaths) invoke the classic app resource and map rows to Explorer items.
    *
    * @param idOrName view key (same rules as {@link #findViewByKey})
    * @param request optional overrides; {@code null} treated as empty defaults by implementations
    * @return paged results, or {@code null} when the view is missing/unsafe
-   * @throws IllegalArgumentException when the body is invalid or the view type cannot be executed
-   *     (e.g. custom URL / Inbox-family views)
+   * @throws IllegalArgumentException when the body is invalid or the custom URL is unsupported
    */
   ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request);
 }

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -25,15 +25,16 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * CX view design catalog (UI-07 list/detail) plus standard-view execute façade for Explorer.
+ * CX view design catalog (UI-07 list/detail) plus view execute façade for Explorer.
  *
- * <p>Searches (UI-06) remain a separate catalog. Custom-URL views (Inbox family) are not executed
- * here — they return 400 (see Inbox / #3118).
+ * <p>Searches (UI-06) remain a separate catalog. Inbox-family custom-URL views ({@code
+ * sys_cxViews/inbox} and documented peers) are executed on this same path; other custom URLs
+ * return 400.
  */
 @PSSiteManageBean(value = "restViewResource")
 @Path("/views")
 @XmlRootElement
-@Tag(name = "Views", description = "CX view design catalog and standard-view execute")
+@Tag(name = "Views", description = "CX view design catalog and view execute")
 public class ViewResource {
 
   private final IViewAdaptor adaptor;
@@ -105,21 +106,23 @@ public class ViewResource {
   }
 
   /**
-   * Execute a standard field-criteria design view. Path is multi-segment so it does not collide
-   * with {@code GET /{idOrName}} catalog detail. Custom URL views return 400.
+   * Execute a design view (standard field-criteria or Inbox-family custom URL). Path is
+   * multi-segment so it does not collide with {@code GET /{idOrName}} catalog detail.
    */
   @POST
   @Path("/{idOrName}/execute")
   @Consumes({MediaType.APPLICATION_JSON})
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
-      summary = "Execute a standard design view",
+      summary = "Execute a design view",
       description =
           "Loads the CX view design by name, GUID, or id from the views catalog (not searches)"
-              + " and executes it server-side with design field operators, display format, max"
-              + " results, and case sensitivity. Optional body may override folder scope, paging,"
-              + " and sort. Custom URL views (Inbox / Outbox / Recent) return 400; use the Inbox"
-              + " runner when that surface ships.",
+              + " and executes it server-side. Standard views use design field operators, display"
+              + " format, max results, and case sensitivity. Custom URL views in the Inbox family"
+              + " (sys_cxViews/inbox, outbox, recent, session, checkedoutbyme,"
+              + " duplicatefolderpaths) invoke the classic app resource and return Explorer rows."
+              + " Optional body may override folder scope (standard views), paging, and sort."
+              + " Unsupported custom URLs return 400.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
@@ -155,17 +155,49 @@ public class ViewResourceTest {
   }
 
   @Test
+  public void executeViewInboxCustomUrlSuccess() {
+    ViewExecuteResult expected = new ViewExecuteResult();
+    expected.setViewName("Inbox");
+    ViewResultItem row = new ViewResultItem();
+    row.setId("guid-1");
+    row.setName("Assignment");
+    row.setTitle("Assignment");
+    row.setFolderPath("//Sites/Demo");
+    row.setType("Page");
+    expected.setChildren(List.of(row));
+    expected.setTotalCount(1);
+    when(adaptor.executeView(eq("Inbox"), any())).thenReturn(expected);
+
+    ViewExecuteResult out = resource.executeView("Inbox", new ViewExecuteRequest());
+    assertSame(expected, out);
+    assertEquals(1, out.getChildren().size());
+    assertEquals("Assignment", out.getChildren().get(0).getTitle());
+    verify(adaptor).executeView(eq("Inbox"), any());
+  }
+
+  @Test
   public void executeViewMapsIllegalArgumentTo400() {
-    when(adaptor.executeView(eq("Inbox"), any()))
-        .thenThrow(
-            new IllegalArgumentException(
-                "Custom URL views cannot be executed via this endpoint"));
+    when(adaptor.executeView(eq("Custom"), any()))
+        .thenThrow(new IllegalArgumentException("Unsupported custom URL view"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeView("Custom", new ViewExecuteRequest()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Unsupported custom URL"));
+  }
+
+  @Test
+  public void executeViewRethrowsServiceUnavailable() {
+    WebApplicationException mapped =
+        new WebApplicationException("View execute backend unavailable", 503);
+    when(adaptor.executeView(eq("Inbox"), any())).thenThrow(mapped);
     WebApplicationException ex =
         assertThrows(
             WebApplicationException.class,
             () -> resource.executeView("Inbox", new ViewExecuteRequest()));
-    assertEquals(400, ex.getResponse().getStatus());
-    assertTrue(ex.getMessage().contains("Custom URL"));
+    assertSame(mapped, ex);
+    assertEquals(503, ex.getResponse().getStatus());
   }
 
   @Test

--- a/specs/2400-dce-explorer-parity/research/views-inbox-ia-api-map.md
+++ b/specs/2400-dce-explorer-parity/research/views-inbox-ia-api-map.md
@@ -104,7 +104,7 @@ Both design catalogs store definitions as `PSSearch` rows with different `TYPE`:
 |--------|--------------|-------------------|--------------------|
 | `GET` | `/rest/views` | `/services/views` | `ViewResource.listViews` → `IViewAdaptor.listViews` |
 | `GET` | `/rest/views/{idOrName}` | `/services/views/{idOrName}` | `ViewResource.getView` → `findViewByKey` |
-| `POST` | `/rest/views/{idOrName}/execute` | `/services/views/{idOrName}/execute` | `ViewResource.executeView` → `IViewAdaptor.executeView` (standard views only; custom URL → 400 / #3118) |
+| `POST` | `/rest/views/{idOrName}/execute` | `/services/views/{idOrName}/execute` | `ViewResource.executeView` → `IViewAdaptor.executeView` (standard views + Inbox-family `sys_cxViews/*`; other custom URLs → 400) |
 
 | Layer | Path |
 |-------|------|


### PR DESCRIPTION
## Summary

Public **C1 custom-URL view execute** for Inbox (and documented peers). Extends V1 `POST /rest/views/{idOrName}/execute` (issue #3115 / PR #3235) so `isCustomView` is runnable, not only 400.

This branch **includes the V1 merge** from `feat/issue-3115-views-rest-execute` because that façade is not yet on `main`. C1 then:

- Resolves classic URLs such as `../sys_cxViews/inbox.xml` to `sys_cxViews/inbox`
- Invokes the app resource via `PSServer.getInternalRequest`
- Maps `Item/@sys_contentid` rows to Explorer items (`id`, `name`, `title`, `folderPath`, `type`)
- Allow-list: inbox, outbox, recent, session, checkedoutbyme, duplicatefolderpaths
- Safe keys stay 404; unsupported custom URLs are clear **400**; missing request context / resource is **503** (not 500)

**Fixes #3239**  
**Parent:** #3118 (Inbox I1) · grandparent #3110 / reality-check #3102

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Review unit tests: `ViewAdaptorExecuteTest` (Inbox happy path, unsupported/blank URL, URL normalize, XML map, cap) and `ViewResourceTest` (Inbox 200, 400, 503 rethrow).
2. After merge of V1+C1, `POST /services/views/Inbox/execute` (or `/rest/views/Inbox/execute`) against a live CMS with request context returns `200` and Explorer rows or `children: []`.
3. `POST /services/views/SomeOtherCustom/execute` with a non-allow-listed custom URL returns **400**.
4. Unsafe key (`../x`) returns **404**.

Env: standalone Maven (this PR). Live CMS smoke is Explorer leaf / Playwright (#3240 / #3241).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Inbox-family execute + status codes)
- [x] **Unit / module tests** — behavioral tests; rest + sitemanage standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (REST only; Explorer leaf #3240, Playwright #3241)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A for OS file I/O; custom-view paths are app resource URLs (`/`)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 335, Failures: 0 (`ViewResourceTest` 17)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1132, Failures: 0, Errors: 0, Skipped: 125 (`ViewAdaptorExecuteTest` 27)
- **downstream_checked:** none for C2 signature change (no new public method/ctor; `executeView` already on V1). sitemanage (the adaptor impl) was installed as a changed module. Grep: only `ViewAdaptor` + `TestViewAdaptor` implement `IViewAdaptor`.

## C5 UI proof

N/A — no WebUI / Explorer chrome in this slice.

> Co-Authored by Grok Build using grok-4.5 with agent main.
