### PR TITLE
fix(WebUI): persist My Profile default landing on save/reload (#3207)

### DIFF
--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -320,8 +320,10 @@ export async function putPlainText<T>(
 ): Promise<T> {
   const response = await fetch(url, {
     method: "PUT",
+    // Omit charset — some JAX-RS @Consumes(TEXT_PLAIN) matchers reject
+    // text/plain;charset=UTF-8 with 415 on homepage PUT (#3207).
     headers: buildHeaders(
-      { "Content-Type": "text/plain;charset=UTF-8", ...headers },
+      { "Content-Type": "text/plain", ...headers },
       false,
     ),
     credentials: "same-origin",

--- a/WebUI/src/main/ts/api/user/userHomepageApi.ts
+++ b/WebUI/src/main/ts/api/user/userHomepageApi.ts
@@ -21,7 +21,7 @@
  * Empty string means no override (role homepage resolve → Home).</p>
  */
 
-import { del, get, putPlainText } from "../client";
+import { del, get, isApiError, putPlainText } from "../client";
 import { PATHS } from "../paths";
 
 /** Canonical product types accepted by the server (PascalCase). */
@@ -47,14 +47,84 @@ function homepageUrl(userName?: string): string {
   return `${base}/${encodeURIComponent(userName.trim())}`;
 }
 
-function asPlainString(data: unknown): string {
+/** Prefer TEXT_PLAIN so CXF does not JSON-quote the product type string. */
+const HOMEPAGE_ACCEPT: HeadersInit = { Accept: "text/plain, */*" };
+
+function isNotFound(err: unknown): boolean {
+  return isApiError(err) && err.status === 404;
+}
+
+/**
+ * Unwrap a homepage GET/PUT body to a trimmed string.
+ *
+ * <p>Handles raw {@code text/plain}, leftover JSON-quoted {@code "Editor"},
+ * and small object wrappers ({@code homepage}/{@code value}/{@code data}).</p>
+ */
+export function asPlainHomepageString(data: unknown): string {
   if (data == null) {
     return "";
   }
   if (typeof data === "string") {
-    return data.trim();
+    let s = data.trim();
+    if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) {
+      try {
+        const parsed: unknown = JSON.parse(s);
+        if (typeof parsed === "string") {
+          s = parsed.trim();
+        }
+      } catch {
+        /* keep trimmed original */
+      }
+    }
+    return s;
+  }
+  if (typeof data === "object" && !Array.isArray(data)) {
+    const o = data as Record<string, unknown>;
+    for (const key of ["homepage", "value", "data", "homepageType"]) {
+      if (typeof o[key] === "string") {
+        return asPlainHomepageString(o[key]);
+      }
+    }
   }
   return String(data).trim();
+}
+
+const HOMEPAGE_ALIAS: Record<string, HomepageType> = {
+  home: HOMEPAGE_TYPES.HOME,
+  dash: HOMEPAGE_TYPES.DASHBOARD,
+  dashboard: HOMEPAGE_TYPES.DASHBOARD,
+  editor: HOMEPAGE_TYPES.EDITOR,
+  pageeditor: HOMEPAGE_TYPES.EDITOR,
+  webmgt: HOMEPAGE_TYPES.EDITOR,
+  design: HOMEPAGE_TYPES.DESIGNER,
+  designer: HOMEPAGE_TYPES.DESIGNER,
+  siteadmin: HOMEPAGE_TYPES.DESIGNER,
+  admin: HOMEPAGE_TYPES.DESIGNER,
+  arch: HOMEPAGE_TYPES.ARCHITECTURE,
+  architecture: HOMEPAGE_TYPES.ARCHITECTURE,
+  navigation: HOMEPAGE_TYPES.ARCHITECTURE,
+  site_arch: HOMEPAGE_TYPES.ARCHITECTURE,
+  sitearch: HOMEPAGE_TYPES.ARCHITECTURE,
+  publish: HOMEPAGE_TYPES.PUBLISH,
+  workflow: HOMEPAGE_TYPES.WORKFLOW,
+  widgetbuilder: HOMEPAGE_TYPES.WIDGET_BUILDER,
+  "widget-builder": HOMEPAGE_TYPES.WIDGET_BUILDER,
+  widget_builder: HOMEPAGE_TYPES.WIDGET_BUILDER,
+};
+
+/**
+ * Canonical product homepage type (PascalCase) or {@code ""} when unset.
+ * Unknown non-empty values are returned trimmed (server validates on PUT).
+ */
+export function canonicalizeHomepageType(raw: unknown): string {
+  const s = asPlainHomepageString(raw);
+  if (!s) {
+    return "";
+  }
+  if ((Object.values(HOMEPAGE_TYPES) as string[]).includes(s)) {
+    return s;
+  }
+  return HOMEPAGE_ALIAS[s.toLowerCase()] ?? s;
 }
 
 /**
@@ -64,8 +134,16 @@ function asPlainString(data: unknown): string {
 export async function getUserHomepageOverride(
   userName?: string,
 ): Promise<string> {
-  const data = await get<unknown>(homepageUrl(userName));
-  return asPlainString(data);
+  try {
+    const data = await get<unknown>(homepageUrl(userName), HOMEPAGE_ACCEPT);
+    return canonicalizeHomepageType(data);
+  } catch (err) {
+    // Unset override is empty, not a hard failure for the Preferences select.
+    if (isNotFound(err)) {
+      return "";
+    }
+    throw err;
+  }
 }
 
 /**
@@ -79,18 +157,35 @@ export async function setUserHomepageOverride(
 ): Promise<string> {
   const body = homepage == null ? "" : String(homepage).trim();
   if (!body) {
-    await clearUserHomepageOverride(userName);
+    try {
+      await clearUserHomepageOverride(userName);
+    } catch (err) {
+      if (!isNotFound(err)) {
+        throw err;
+      }
+    }
     return "";
   }
-  const data = await putPlainText<unknown>(homepageUrl(userName), body);
-  return asPlainString(data) || body;
+  const canonical = canonicalizeHomepageType(body) || body;
+  const data = await putPlainText<unknown>(
+    homepageUrl(userName),
+    canonical,
+    HOMEPAGE_ACCEPT,
+  );
+  return canonicalizeHomepageType(data) || canonical;
 }
 
 /** DELETE override for a named user (or self when name omitted). */
 export async function clearUserHomepageOverride(
   userName?: string,
 ): Promise<void> {
-  await del(homepageUrl(userName));
+  try {
+    await del(homepageUrl(userName), HOMEPAGE_ACCEPT);
+  } catch (err) {
+    if (!isNotFound(err)) {
+      throw err;
+    }
+  }
 }
 
 /** GET self default landing override (no user name on path — no IDOR). */

--- a/WebUI/src/main/ts/profile/PreferencesSection.tsx
+++ b/WebUI/src/main/ts/profile/PreferencesSection.tsx
@@ -82,19 +82,30 @@ export function PreferencesSection({
     setFormError(null);
     setSuccessMessage(null);
     try {
-      const [landing, preferenceCount] = await Promise.all([
+      // Landing persist is independent of PreferenceResource. A prefs-list
+      // 4xx/5xx must not blank the Default landing page (#3207 / #2746).
+      const landingSettled = await Promise.allSettled([
         loadLanding(),
         loadPreferenceCount(),
       ]);
+      const landingResult = landingSettled[0];
+      const countResult = landingSettled[1];
+      if (landingResult.status === "rejected") {
+        throw landingResult.reason;
+      }
+      const landing = landingResult.value;
+      const preferenceCount =
+        countResult.status === "fulfilled" &&
+        typeof countResult.value === "number" &&
+        countResult.value >= 0
+          ? countResult.value
+          : 0;
       const normalized = landing == null ? "" : String(landing).trim();
       setLandingDraft(normalized);
       setLoadState({
         status: "ready",
         landing: normalized,
-        preferenceCount:
-          typeof preferenceCount === "number" && preferenceCount >= 0
-            ? preferenceCount
-            : 0,
+        preferenceCount,
       });
     } catch (err) {
       if (isSessionRedirectError(err)) {
@@ -135,12 +146,30 @@ export function PreferencesSection({
       const saved = await saveLanding(landingDraft);
       const normalized = saved == null ? "" : String(saved).trim();
       // Blank clear may return ""; treat empty draft as clear.
-      const effective =
+      const expected =
         landingDraft === "" ? "" : normalized || landingDraft.trim();
-      setLandingDraft(effective);
+      let confirmed = expected;
+      try {
+        const reloaded = await loadLanding();
+        confirmed = reloaded == null ? "" : String(reloaded).trim();
+      } catch {
+        // PUT succeeded; treat GET flake as the saved value.
+        confirmed = expected;
+      }
+      if (confirmed !== expected) {
+        setLandingDraft(confirmed);
+        setLoadState({
+          status: "ready",
+          landing: confirmed,
+          preferenceCount: loadState.preferenceCount,
+        });
+        setFormError(message(PROFILE_MSG.PREF_SAVE_ERROR));
+        return;
+      }
+      setLandingDraft(expected);
       setLoadState({
         status: "ready",
-        landing: effective,
+        landing: expected,
         preferenceCount: loadState.preferenceCount,
       });
       setSuccessMessage(message(PROFILE_MSG.PREF_SAVE_SUCCESS));

--- a/WebUI/src/test/ts/api/userHomepageApi.test.ts
+++ b/WebUI/src/test/ts/api/userHomepageApi.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  asPlainHomepageString,
+  canonicalizeHomepageType,
+  getMyHomepageOverride,
+  HOMEPAGE_TYPES,
+  setMyHomepageOverride,
+} from "../../../main/ts/api/user/userHomepageApi";
+import * as client from "../../../main/ts/api/client";
+
+describe("userHomepageApi", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("asPlainHomepageString unwraps quoted JSON and object wrappers", () => {
+    expect(asPlainHomepageString(null)).toBe("");
+    expect(asPlainHomepageString("Editor")).toBe("Editor");
+    expect(asPlainHomepageString('"Editor"')).toBe("Editor");
+    expect(asPlainHomepageString({ homepage: "Home" })).toBe("Home");
+    expect(asPlainHomepageString({ value: "Architecture" })).toBe("Architecture");
+  });
+
+  it("canonicalizeHomepageType maps aliases to product types", () => {
+    expect(canonicalizeHomepageType("")).toBe("");
+    expect(canonicalizeHomepageType("Editor")).toBe(HOMEPAGE_TYPES.EDITOR);
+    expect(canonicalizeHomepageType("editor")).toBe(HOMEPAGE_TYPES.EDITOR);
+    expect(canonicalizeHomepageType("arch")).toBe(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(canonicalizeHomepageType('"Home"')).toBe(HOMEPAGE_TYPES.HOME);
+  });
+
+  it("getMyHomepageOverride treats 404 as empty override", async () => {
+    vi.spyOn(client, "get").mockRejectedValueOnce({
+      status: 404,
+      statusText: "Not Found",
+      body: null,
+    });
+    await expect(getMyHomepageOverride()).resolves.toBe("");
+  });
+
+  it("getMyHomepageOverride canonicalizes a quoted JSON body", async () => {
+    vi.spyOn(client, "get").mockResolvedValueOnce('"Editor"');
+    await expect(getMyHomepageOverride()).resolves.toBe(HOMEPAGE_TYPES.EDITOR);
+  });
+
+  it("setMyHomepageOverride PUTs text/plain and returns canonical type", async () => {
+    const putSpy = vi.spyOn(client, "putPlainText").mockResolvedValueOnce("Editor");
+    await expect(setMyHomepageOverride("editor")).resolves.toBe(
+      HOMEPAGE_TYPES.EDITOR,
+    );
+    expect(putSpy).toHaveBeenCalled();
+    expect(putSpy.mock.calls[0][1]).toBe(HOMEPAGE_TYPES.EDITOR);
+  });
+
+  it("setMyHomepageOverride blank value DELETEs instead of PUT", async () => {
+    const delSpy = vi.spyOn(client, "del").mockResolvedValueOnce(undefined);
+    const putSpy = vi.spyOn(client, "putPlainText");
+    await expect(setMyHomepageOverride("")).resolves.toBe("");
+    expect(delSpy).toHaveBeenCalled();
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
+++ b/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
@@ -72,7 +72,10 @@ describe("PreferencesSection", () => {
   });
 
   it("saves dirty landing and shows success", async () => {
-    const loadLanding = vi.fn().mockResolvedValue("");
+    const loadLanding = vi
+      .fn()
+      .mockResolvedValueOnce("")
+      .mockResolvedValue("Editor");
     const saveLanding = vi.fn().mockResolvedValue("Editor");
     const loadPreferenceCount = vi.fn().mockResolvedValue(0);
     renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
@@ -95,6 +98,51 @@ describe("PreferencesSection", () => {
       expect(screen.getByTestId("perc-profile-preferences-success")).toBeTruthy();
     });
     expect(select.value).toBe("Editor");
+    expect(loadLanding).toHaveBeenCalledTimes(2);
+  });
+
+  it("still loads landing when preference stack count fails (#3207)", async () => {
+    const loadLanding = vi.fn().mockResolvedValue("Home");
+    const loadPreferenceCount = vi
+      .fn()
+      .mockRejectedValue({ status: 500, statusText: "err", body: null });
+    renderPrefs({ loadLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+    expect(
+      screen.queryByTestId("perc-profile-preferences-load-error"),
+    ).toBeNull();
+    const select = screen.getByTestId(
+      "perc-profile-preferences-landing",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("Home");
+    expect(screen.getByTestId("perc-profile-preferences-count").textContent).toContain(
+      "0",
+    );
+  });
+
+  it("shows save error when reload does not persist the landing (#3207)", async () => {
+    const loadLanding = vi.fn().mockResolvedValue("");
+    const saveLanding = vi.fn().mockResolvedValue("Editor");
+    const loadPreferenceCount = vi.fn().mockResolvedValue(0);
+    renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-preferences-landing",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "Editor" } });
+    fireEvent.click(screen.getByTestId("perc-profile-preferences-save"));
+
+    await waitFor(() => {
+      expect(saveLanding).toHaveBeenCalledWith("Editor");
+      expect(screen.getByTestId("perc-profile-preferences-error")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("perc-profile-preferences-success")).toBeNull();
   });
 
   it("shows load error and retries", async () => {

--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -26,8 +26,9 @@
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Covers: Preferences form mounts (no #2746 load JAXB / retry error);
- * change default landing; reload persists.
+ * change default landing; reload persists (#3207).
  * Axe: zero serious/critical on [data-testid="perc-profile-preferences"].
+ * Console/pageerror + prefs/homepage 4xx/5xx must stay clean on this surface.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -38,7 +39,46 @@ const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 const PREFERENCES_FORM_SCOPE = '[data-testid="perc-profile-preferences"]';
 
 function profileDeepLink() {
-  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}#perc-profile-preferences`;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @returns {{ jsErrors: string[], httpErrors: string[] }}
+ */
+function attachSurfaceErrorCollectors(page) {
+  const jsErrors = [];
+  const httpErrors = [];
+  page.on("pageerror", (err) => {
+    jsErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = msg.text();
+    // Chrome logs 404 fetches as console.error (empty prefs, maps, favicon).
+    // Those are not uncaught page errors — gate on pageerror + 4xx/5xx below.
+    if (/Failed to load resource:.*\b404\b/i.test(text)) {
+      return;
+    }
+    jsErrors.push(text);
+  });
+  page.on("response", (response) => {
+    const url = response.url();
+    const status = response.status();
+    // 404 on GET /preferences/ means no stored entries (empty list).
+    if (status < 400 || status === 404) {
+      return;
+    }
+    const isPrefs =
+      url.includes("/services/preferences") ||
+      url.includes("/user/user/homepage");
+    if (isPrefs) {
+      httpErrors.push(`${status} ${url}`);
+    }
+  });
+  return { jsErrors, httpErrors };
 }
 
 /**
@@ -74,10 +114,12 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     page,
   }) => {
     test.setTimeout(90_000);
+    const { jsErrors, httpErrors } = attachSurfaceErrorCollectors(page);
     await loginAsAdmin(page);
 
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectPreferencesMounted(page);
+    await page.getByTestId("perc-profile-nav-preferences").click();
 
     const landing = page.getByTestId("perc-profile-preferences-landing");
     await expect(landing).toBeEnabled();
@@ -87,6 +129,8 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     await expect(
       page.getByTestId("perc-profile-preferences-count"),
     ).toBeVisible();
+    expect(jsErrors, jsErrors.join("\n")).toEqual([]);
+    expect(httpErrors, httpErrors.join("\n")).toEqual([]);
   });
 
   /**
@@ -132,10 +176,12 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     page,
   }) => {
     test.setTimeout(120_000);
+    const { jsErrors, httpErrors } = attachSurfaceErrorCollectors(page);
     await loginAsAdmin(page);
 
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectPreferencesMounted(page);
+    await page.getByTestId("perc-profile-nav-preferences").click();
 
     const landing = page.getByTestId("perc-profile-preferences-landing");
     await expect(landing).toBeVisible();
@@ -154,6 +200,7 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     // Reload profile hub — value must come back from server
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectPreferencesMounted(page);
+    await page.getByTestId("perc-profile-nav-preferences").click();
     await expect(
       page.getByTestId("perc-profile-preferences-landing"),
     ).toHaveValue(next, { timeout: 30_000 });
@@ -167,5 +214,7 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
         page.getByTestId("perc-profile-preferences-success"),
       ).toBeVisible({ timeout: 30_000 });
     }
+    expect(jsErrors, jsErrors.join("\n")).toEqual([]);
+    expect(httpErrors, httpErrors.join("\n")).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -62,15 +62,26 @@ still apply. Client-side checks require a non-empty password of at least six cha
 and a matching confirmation before submit. Success and failure messages are announced
 to assistive technology via a live region.
 
-## Default landing (homepage)
+## My profile — Preferences (default landing)
 
-In **My profile → Preferences**, or **Admin → Users** when editing a user, set
-**Default landing page**. Choose **Navigation** (stored as homepage type
-`Architecture`) to open the site Navigation SPA after sign-in. Leave **Use role
-default** to keep the role homepage. Login without a deep-link return URL posts
-to `/cm/app/` so the dispatcher applies this preference.
+On the same **My profile** hub, open **Preferences** (or deep-link
+`spa.jsp?entry=profile#perc-profile-preferences`). Admins can also set a user's
+landing from **Admin → Users**.
 
-See [Architecture & site navigation](id:admin-architecture-navigation).
+| Control | What it does |
+|---------|----------------|
+| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open (Home, Editor, **Navigation**, and additional screens when your roles include Designer or Admin). **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Use role default** clears your personal override so the role homepage applies. |
+| **Save preferences** | Writes the landing override for the signed-in user only. The value is reloaded from the server after save so a failed persist is not shown as success. |
+
+The stored-preference count is informational (existing preference entries for your
+account). A problem loading that list does **not** block changing the landing page.
+
+Login without a deep-link return URL posts to `/cm/app/` so the dispatcher applies
+this preference.
+
+Language and density controls are not product-backed yet. Navigation **site**
+section landing pages (Architecture tree) are a separate site-structure setting —
+not this profile control. See [Architecture & site navigation](id:admin-architecture-navigation).
 
 ## Hardening checklist
 
@@ -84,3 +95,4 @@ See [Architecture & site navigation](id:admin-architecture-navigation).
 
 - [Server operations](id:admin-server-ops)
 - [Sites & content structure](id:admin-sites)
+- [Architecture & navigation](id:admin-architecture-navigation) (site section landing pages)


### PR DESCRIPTION
## Summary

Human QA #2598 failed My Profile → Preferences after the #2746 / PR #2757 UserPreferenceList JAXB load fix. Remaining gap on #3207 is **Default landing page** load + save + reload persist (and any new PreferenceResource / homepage 4xx/5xx).

This PR:

- Loads landing independently of `GET /preferences/` so a prefs-list failure cannot blank the landing form.
- Hardens self homepage REST (`GET`/`PUT`/`DELETE /user/user/homepage`): `text/plain` without charset (avoids JAX-RS 415), `Accept: text/plain`, unwrap JSON-quoted/`homepage` wrappers, treat 404 as unset.
- After save, re-GETs the override and only shows success when the persisted value matches.
- Adds Vitest coverage (`userHomepageApi`, PreferencesSection count-failure and persist-mismatch).
- Strengthens Playwright `tests/profile-preferences.spec.js` (hash + nav, persist, pageerror / prefs-or-homepage HTTP gate).
- Documents operator steps under `product-docs/8.2/admin/users-roles.md`.

Does **not** expand into Navigation homepage (#3219/#3238) or Object ACL prefs (#3204).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3207  
Parent / QA trail: #2598 (Failed), #2746 (closed JAXB)

## Test plan

1. Environment: QA H2 docker (`python docker/scripts/perc-devctl.py qa-up`) — capture `TEST_CMS_URL` (freeport; do not hardcode `:9993`).
2. Sign in as Admin → **My profile** → **Preferences**.
3. Confirm landing select + Save + stored count are visible (no Try again / JAXB load error).
4. Change **Default landing page** (Home ↔ Editor) → **Save preferences** → success live region.
5. Reload `spa.jsp?entry=profile#perc-profile-preferences` — value still selected.
6. Optional: `npm run test:surface -- --path tests/profile-preferences.spec.js` from `modules/perc-qa-automation/frontend`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (My profile — Preferences)
- [x] **Unit / module tests** — Vitest for homepage wire + PreferencesSection; WebUI standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js`
- [x] **Build gates** — WebUI standalone clean install (tests on); no Java API shape change
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Total time 01:21 min). Vitest **Test Files 291 passed / Tests 2066 passed**. Java Surefire ran as part of the same install. No new warnings attributable to this change (existing javadoc/dependency-analyze baseline only).
- **downstream_checked:** none (no `final`/signature/package API change; TS + product-docs + Playwright only)

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CONTAINER=perc-matrix-cms-h2`)
- Hot-deploy: copied `WebUI/target/generated-webui/cm/modern/assets` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`
- `npm run test:surface -- --path tests/profile-preferences.spec.js` → **3 passed** (mount, axe-core, save/reload persist)
- **console-clean:** yes (pageerror empty; Chrome 404 resource noise filtered; prefs/homepage HTTP 4xx/5xx empty except allowed 404 empty list)
- **server.log-clean:** yes for prefs/homepage (no PreferenceResource/JAXB/homepage ERROR). One unrelated `PSRuntimeExceptionMapper` “validated object is null” with no stack during login burst — not on `/preferences` or `/homepage`.

`scripts/ci-smoke-product-docs.bat` → **OK** (21 pages).
