### PR TITLE
fix(explorer): #3206 Folder Security identities + persistable properties

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -50,7 +50,9 @@ import { PATHS } from "../paths";
 import type {
   PSPathItem,
   PSPagedResult,
+  PSFolderPermission,
   PSFolderProperties,
+  PSPrincipal,
   PSRenameFolderItem,
   PSMoveFolderItem,
 } from "./types";
@@ -253,14 +255,65 @@ export function unwrapFolderProperties(
   }
   const nested = asRecord(root[FOLDER_PROPERTIES_ROOT]);
   if (nested && (typeof nested.id === "string" || typeof nested.name === "string")) {
-    return nested as unknown as PSFolderProperties;
+    return normalizeFolderProperties(nested);
   }
   // Flat body (unit tests, already-unwrapped). Require an id so a bare
   // envelope mis-shape is not treated as success.
   if (typeof root.id === "string" || typeof root.name === "string") {
-    return root as unknown as PSFolderProperties;
+    return normalizeFolderProperties(root);
   }
   return null;
+}
+
+/**
+ * JAXB+Jackson may wrap principal lists as {@code { Principal: [...] }} or a
+ * single object. Folder Security maps these lists — a non-array crashes the
+ * panel (#3206).
+ */
+export function unwrapPrincipalList(value: unknown): PSPrincipal[] {
+  if (value == null) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter(isPrincipalLike);
+  }
+  const rec = asRecord(value);
+  if (!rec) {
+    return [];
+  }
+  const wrapped = rec.Principal ?? rec.principal;
+  if (wrapped != null) {
+    return unwrapPrincipalList(wrapped);
+  }
+  if (isPrincipalLike(rec)) {
+    return [rec as PSPrincipal];
+  }
+  return [];
+}
+
+function isPrincipalLike(value: unknown): value is PSPrincipal {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const name = (value as PSPrincipal).name;
+  return typeof name === "string" && name.length > 0;
+}
+
+function normalizeFolderProperties(
+  raw: Record<string, unknown>,
+): PSFolderProperties {
+  const props = { ...raw } as unknown as PSFolderProperties;
+  const permRaw = asRecord(raw.permission);
+  if (permRaw) {
+    props.permission = {
+      ...(permRaw as unknown as PSFolderPermission),
+      adminPrincipals: unwrapPrincipalList(permRaw.adminPrincipals),
+      writePrincipals: unwrapPrincipalList(permRaw.writePrincipals),
+      readPrincipals: unwrapPrincipalList(permRaw.readPrincipals),
+      viewPrincipals: unwrapPrincipalList(permRaw.viewPrincipals),
+    };
+  }
+  return props;
 }
 
 /**

--- a/WebUI/src/main/ts/contentExplorer/FolderSecurityPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/FolderSecurityPanel.tsx
@@ -251,7 +251,7 @@ export function FolderSecurityPanel(
     return (Object.keys(PRINCIPAL_LABELS) as PrincipalListKey[]).map((k) => ({
       level: k,
       label: PRINCIPAL_LABELS[k],
-      principals: permission[k] ?? [],
+      principals: Array.isArray(permission[k]) ? permission[k]! : [],
     }));
   }, [status]);
 

--- a/WebUI/src/test/ts/contentExplorer/FolderSecurityPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/FolderSecurityPanel.test.tsx
@@ -428,6 +428,28 @@ describe("FolderSecurityPanel", () => {
     expect(saved.permission?.adminPrincipals?.[0]?.name).toBe("Admin");
   });
 
+  it("renders ROLE identities so lockout can see Admin (#3206)", () => {
+    const props = makeProps({
+      permission: {
+        accessLevel: "ADMIN",
+        adminPrincipals: [{ type: "ROLE", name: "Admin" }],
+      },
+    });
+    render(
+      <FolderSecurityPanel
+        folderId={props.id}
+        currentUserIdentities={["Admin"]}
+        initial={props}
+      />,
+    );
+    expect(
+      screen.getByTestId("folder-security-list-adminPrincipals-remove-Admin"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId("folder-security-list-adminPrincipals-empty"),
+    ).toBeNull();
+  });
+
   it("folder property inputs are disabled in read-only mode (#2410)", () => {
     const props = makeProps({
       permission: permission([], [], [], [], "READ"),

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -28,6 +28,7 @@ import {
   paginatedFolder,
   saveFolderProperties,
   unwrapFolderProperties,
+  unwrapPrincipalList,
   validatePath,
   wrapFolderProperties,
 } from "../../../main/ts/api/contentExplorer/pathApi";
@@ -330,6 +331,41 @@ describe("folderProperties Jackson root wrap (#2749)", () => {
         locale: "en-us",
       },
     });
+  });
+
+  it("unwrapPrincipalList accepts array, JAXB wrap, and single principal (#3206)", () => {
+    expect(
+      unwrapPrincipalList([{ type: "ROLE", name: "Admin" }]),
+    ).toEqual([{ type: "ROLE", name: "Admin" }]);
+    expect(
+      unwrapPrincipalList({
+        Principal: [{ type: "ROLE", name: "Admin" }, { type: "USER", name: "alice" }],
+      }),
+    ).toEqual([
+      { type: "ROLE", name: "Admin" },
+      { type: "USER", name: "alice" },
+    ]);
+    expect(unwrapPrincipalList({ type: "USER", name: "solo" })).toEqual([
+      { type: "USER", name: "solo" },
+    ]);
+    expect(unwrapPrincipalList(null)).toEqual([]);
+  });
+
+  it("unwrapFolderProperties normalizes JAXB-wrapped ROLE identities (#3206)", () => {
+    const props = unwrapFolderProperties({
+      FolderProperties: {
+        id: "16777215-101-703",
+        name: "Design",
+        locale: "en-us",
+        permission: {
+          accessLevel: "ADMIN",
+          adminPrincipals: { Principal: [{ type: "ROLE", name: "Admin" }] },
+        },
+      },
+    });
+    expect(props?.permission?.adminPrincipals).toEqual([
+      { type: "ROLE", name: "Admin" },
+    ]);
   });
 
   it("saveFolderProperties defaults missing permission and rejects missing id", async () => {

--- a/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
@@ -144,8 +144,9 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
     await page.goto(explorerUrl, { waitUntil: "networkidle" });
     const shell = page.locator('[data-testid="content-explorer-shell"]');
     await expect(shell).toBeVisible({ timeout: 15_000 });
+    await page.locator('[data-testid="explorer-menu-view"]').click();
     const toggle = page.locator('[data-testid="explorer-toggle-security"]');
-    await expect(toggle).toBeVisible();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
     await toggle.click();
     // Either the security panel region or the select-folder hint is shown.
     const panelOrHint = page.locator(
@@ -162,6 +163,10 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
     await expect(
       page.locator('[data-testid="content-explorer-shell"]'),
     ).toBeVisible({ timeout: 15_000 });
+    await page.locator('[data-testid="explorer-menu-view"]').click();
+    await expect(page.locator('[data-testid="explorer-toggle-security"]')).toBeVisible({
+      timeout: 10_000,
+    });
     await page.locator('[data-testid="explorer-toggle-security"]').click();
     await expect(page.locator(".perc-mcol")).toHaveCount(0);
   });

--- a/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
@@ -177,7 +177,7 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
    * only outcome. Loading, ready panel, or a structured error (invalid id)
    * are all acceptable; the security panel region must remain mounted.
    */
-  test("REST: Sites folderProperties lists ROLE identities and locale (#3206)", async ({
+  test("REST: Folders child folderProperties lists ROLE identities and locale (#3206)", async ({
     request,
   }) => {
     test.setTimeout(30_000);
@@ -240,15 +240,23 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
     const tree = page.locator('[data-testid="explorer-tree"]');
     await expect(tree).toBeVisible({ timeout: 15_000 });
 
-    const namedSites = tree.locator(
-      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"]',
+    const foldersNode = tree.locator(
+      '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
     );
-    const anyNode = tree.locator('[data-testid^="tree-node-"]');
-    await expect(anyNode.first()).toBeVisible({ timeout: 20_000 });
-    if ((await namedSites.count()) > 0) {
-      await namedSites.first().locator('[role="treeitem"]').click();
+    await expect(foldersNode.first()).toBeVisible({ timeout: 20_000 });
+    await foldersNode.first().locator('[role="treeitem"]').click();
+    const systemNode = tree.locator(
+      '[data-testid="tree-node-/Folders/$/"], [data-testid="tree-node-/Folders/$"]',
+    );
+    const systemRow = page.locator('[data-testid="detail-row-16777215-101-4"]');
+    if ((await systemNode.count()) > 0) {
+      await systemNode.first().locator('[role="treeitem"]').click();
+    } else if ((await systemRow.count()) > 0) {
+      await systemRow.first().click();
     } else {
-      await anyNode.first().locator('[role="treeitem"]').click();
+      const anyRow = page.locator('[data-testid^="detail-row-"]');
+      await expect(anyRow.first()).toBeVisible({ timeout: 15_000 });
+      await anyRow.first().click();
     }
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
@@ -296,7 +304,7 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
   }) => {
     // Use a plausible legacy guid shape; H2 QA may 400/500 for unknown ids —
     // assert mount + absence of miller-column, not a successful ACL payload.
-    await page.goto(aclUrl("16777215-101-703"), { waitUntil: "networkidle" });
+    await page.goto(aclUrl("16777215-101-4"), { waitUntil: "networkidle" });
     const root = page.locator('[data-testid="perc-folder-security-root"]');
     await expect(root).toBeVisible({ timeout: 15_000 });
     await expect(page.locator(".perc-mcol")).toHaveCount(0);

--- a/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
@@ -36,8 +36,25 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+function flattenPrincipals(raw) {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && Array.isArray(raw.Principal)) {
+    return raw.Principal;
+  }
+  if (raw && raw.Principal) {
+    return [raw.Principal];
+  }
+  return [];
+}
 
 /**
  * Build the pilot page URL with a per-test cache-buster so consecutive
@@ -155,6 +172,120 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
    * only outcome. Loading, ready panel, or a structured error (invalid id)
    * are all acceptable; the security panel region must remain mounted.
    */
+  test("REST: Sites folderProperties lists ROLE identities and locale (#3206)", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = adminBasicAuthHeaders();
+    const itemRes = await request.get(
+      `${BASE_URL}/Rhythmyx/services/pathmanagement/path/item/Sites`,
+      { headers },
+    );
+    const itemText = await itemRes.text();
+    expect(
+      itemRes.status(),
+      `findItemByPath Sites: ${itemText.slice(0, 400)}`,
+    ).toBe(200);
+    const itemBody = JSON.parse(itemText);
+    const item = itemBody.PathItem || itemBody;
+    expect(item.id, itemText.slice(0, 400)).toBeTruthy();
+    const propsRes = await request.get(
+      `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folderProperties/${encodeURIComponent(item.id)}`,
+      { headers },
+    );
+    const propsText = await propsRes.text();
+    expect(
+      propsRes.status(),
+      `folderProperties: ${propsText.slice(0, 500)}`,
+    ).toBe(200);
+    expect(propsText).not.toContain("The validated object is null");
+    const propsBody = JSON.parse(propsText);
+    const props = propsBody.FolderProperties || propsBody;
+    expect(props.name || props.id).toBeTruthy();
+    const admins = flattenPrincipals(props.permission && props.permission.adminPrincipals);
+    const names = admins.map((pr) => pr && pr.name).filter(Boolean);
+    expect(
+      names,
+      `admin principals should include Admin role: ${propsText.slice(0, 800)}`,
+    ).toContain("Admin");
+  });
+
+  test("Explorer Folder Security shows properties and Admin identity (#3206)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      if (/Failed to load resource/i.test(text)) {
+        return;
+      }
+      pageErrors.push(text);
+    });
+
+    const explorerUrl = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+    await page.goto(explorerUrl, { waitUntil: "networkidle" });
+    await expect(
+      page.locator('[data-testid="content-explorer-shell"]'),
+    ).toBeVisible({ timeout: 20_000 });
+    const tree = page.locator('[data-testid="explorer-tree"]');
+    await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    const namedSites = tree.locator(
+      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"]',
+    );
+    const anyNode = tree.locator('[data-testid^="tree-node-"]');
+    await expect(anyNode.first()).toBeVisible({ timeout: 20_000 });
+    if ((await namedSites.count()) > 0) {
+      await namedSites.first().locator('[role="treeitem"]').click();
+    } else {
+      await anyNode.first().locator('[role="treeitem"]').click();
+    }
+
+    await page.locator('[data-testid="explorer-menu-view"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-security"]');
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await toggle.click();
+
+    const panel = page.locator('[data-testid="folder-security-panel"]');
+    await expect(panel).toBeVisible({ timeout: 25_000 });
+    await expect(page.locator('[data-testid="folder-properties"]')).toBeVisible();
+    await expect(page.locator('[data-testid="folder-props-locale"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="folder-security-list-adminPrincipals"]'),
+    ).toBeVisible();
+    const adminRemove = page.locator(
+      '[data-testid="folder-security-list-adminPrincipals-remove-Admin"]',
+    );
+    await expect(adminRemove).toBeVisible();
+
+    const locale = page.locator('[data-testid="folder-props-locale"]');
+    const currentLocale = await locale.inputValue();
+    const nextLocale = currentLocale || "en-us";
+    await locale.fill(`${nextLocale}-x`);
+    await expect(page.locator('[data-testid="folder-security-dirty"]')).toHaveText(
+      "●",
+    );
+    await locale.fill(nextLocale);
+    const save = page.locator('[data-testid="folder-security-save"]');
+    await expect(save).toBeEnabled();
+    await save.click();
+    await expect(page.locator('[data-testid="folder-security-error"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('[data-testid="folder-security-dirty"]')).toHaveText(
+      "○",
+      { timeout: 20_000 },
+    );
+    expect(pageErrors, `console/page errors: ${pageErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+
   test("FolderSecurityPanel with folderId stays mounted (no chrome crash) (#2749)", async ({
     page,
   }) => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -151,7 +151,14 @@ list after a client-handled command (for example a workflow transition).
 
 From the **View** menu you can also toggle:
 
-- **Folder security** — ACL / properties for the selected folder
+- **Folder security** — ACL and folder properties for the **selected folder** (tree or
+  list). The panel shows community, community id, locale, display format, and workflow
+  id, plus named **user and role** identities on the Admin / Write / Read / View lists
+  (seed folders typically list the **Admin** and **Designer** roles). Administrators can
+  add or remove principals and edit locale (and other persistable fields), then **Save**.
+  Removing your own user name or a role you hold from a list prompts a self-lockout
+  confirmation before save. Without a selected folder the shell shows a select-folder
+  hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
 - **Clipboard** — multi-select copy/cut staging when items are selected

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
@@ -74,6 +74,7 @@ public class PSFolderPermissionUtils {
     // half-built DTO that later fails setFolderPermission on save (#2749).
     if (acl == null) {
       permission.setAccessLevel(Access.ADMIN);
+      permission.setAdminPrincipals(defaultAdminRolePrincipals());
       return permission;
     }
     setAclEntry(acl, PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE, DESIGNER_ROLE, ADMIN_ACCESS);
@@ -116,6 +117,7 @@ public class PSFolderPermissionUtils {
       }
     }
 
+    ensureDefaultAdminRolePrincipals(adminPrincipals);
     if (!adminPrincipals.isEmpty()) {
       permission.setAdminPrincipals(adminPrincipals);
     }
@@ -302,6 +304,38 @@ public class PSFolderPermissionUtils {
    * @param userName the name of the user in question, it may be <code>null</code> or empty.
    * @param permission the new access level for the user.
    */
+  private static List<Principal> defaultAdminRolePrincipals() {
+    var list = new ArrayList<Principal>();
+    ensureDefaultAdminRolePrincipals(list);
+    return list;
+  }
+
+  /**
+   * Admin and Designer ROLE entries are always persisted on save; include them on GET so
+   * Explorer identities are not empty (#3206 / QA #2600).
+   */
+  private static void ensureDefaultAdminRolePrincipals(List<Principal> adminPrincipals) {
+    addRoleIfAbsent(adminPrincipals, ADMINISTRATOR_ROLE);
+    addRoleIfAbsent(adminPrincipals, DESIGNER_ROLE);
+  }
+
+  private static void addRoleIfAbsent(List<Principal> principals, String roleName) {
+    if (principals == null || roleName == null || roleName.isBlank()) {
+      return;
+    }
+    for (Principal existing : principals) {
+      if (existing != null
+          && roleName.equalsIgnoreCase(existing.getName())
+          && existing.getType() == PrincipalType.ROLE) {
+        return;
+      }
+    }
+    var pr = new Principal();
+    pr.setName(roleName);
+    pr.setType(PrincipalType.ROLE);
+    principals.add(pr);
+  }
+
   /**
    * Persist USER and ROLE principals onto the folder ACL (#3206). ROLE names must not be written
    * as USER entries or Folder Security identities disappear on the next load.

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
@@ -96,12 +96,17 @@ public class PSFolderPermissionUtils {
     var iter = acl.iterator();
     while (iter.hasNext()) {
       var entry = iter.next();
-      if (entry == null || !entry.isUser()) {
+      // Folder Security lists USER and ROLE identities. Virtual Everyone is the
+      // default accessLevel, not a named principal (#3206 / QA #2600).
+      if (entry == null || entry.isVirtual()) {
+        continue;
+      }
+      if (!entry.isUser() && !entry.isRole()) {
         continue;
       }
       var p = new Principal();
       p.setName(entry.getName());
-      p.setType(PrincipalType.USER);
+      p.setType(entry.isRole() ? PrincipalType.ROLE : PrincipalType.USER);
       if (entry.hasAdminAccess()) {
         adminPrincipals.add(p);
       } else if (entry.hasWriteAccess()) {
@@ -213,7 +218,8 @@ public class PSFolderPermissionUtils {
    * of the folder.
    *
    * <p>Note, The folder will always has an entry with ADMIN permission for the "Admin" and
-   * "Designer" roles. However, the role ACL entry is not exposed in {@link PSFolderPermission} yet.
+   * "Designer" roles. Those ROLE entries are listed on {@link PSFolderPermission} principal lists
+   * (#3206).
    *
    * @param folder the folder, never <code>null</code>.
    * @param acl the new access level of the folder, never <code>null</code>
@@ -255,9 +261,9 @@ public class PSFolderPermissionUtils {
       return;
     }
 
-    setUserAcls(acl, perm.getReadPrincipals(), READ_ACCESS);
-    setUserAcls(acl, perm.getWritePrincipals(), WRITE_ACCESS);
-    setUserAcls(acl, perm.getAdminPrincipals(), ADMIN_ACCESS);
+    setPrincipalAcls(acl, perm.getReadPrincipals(), READ_ACCESS);
+    setPrincipalAcls(acl, perm.getWritePrincipals(), WRITE_ACCESS);
+    setPrincipalAcls(acl, perm.getAdminPrincipals(), ADMIN_ACCESS);
   }
 
   /**
@@ -296,22 +302,23 @@ public class PSFolderPermissionUtils {
    * @param userName the name of the user in question, it may be <code>null</code> or empty.
    * @param permission the new access level for the user.
    */
-  private static void setUserAcl(PSObjectAcl acl, String userName, int permission) {
-    setAclEntry(acl, PSObjectAclEntry.ACL_ENTRY_TYPE_USER, userName, permission);
-  }
-
   /**
-   * Sets the access level of ACL entries within the specified ACL, where the type of the entry is
-   * {@link PSObjectAclEntry#ACL_ENTRY_TYPE_USER} and the name of the entry is specified in the
-   * given principals.
-   *
-   * @param acl the ACL in question, assumed not <code>null</code>.
-   * @param users the list of principals in question, it may be <code>null</code> or empty.
-   * @param permission the new access level for the users.
+   * Persist USER and ROLE principals onto the folder ACL (#3206). ROLE names must not be written
+   * as USER entries or Folder Security identities disappear on the next load.
    */
-  private static void setUserAcls(PSObjectAcl acl, List<Principal> users, int permission) {
-    if (users != null) {
-      users.forEach(user -> setUserAcl(acl, user.getName(), permission));
+  private static void setPrincipalAcls(PSObjectAcl acl, List<Principal> principals, int permission) {
+    if (principals == null) {
+      return;
+    }
+    for (Principal principal : principals) {
+      if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+        continue;
+      }
+      int type =
+          principal.getType() == PrincipalType.ROLE
+              ? PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE
+              : PSObjectAclEntry.ACL_ENTRY_TYPE_USER;
+      setAclEntry(acl, type, principal.getName(), permission);
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
@@ -329,6 +329,7 @@ public class PSFolderHelper implements IPSFolderHelper {
 
     PSFolder folder = contentWs.loadFolder(idMapper.getGuid(folderProps.getId()), false);
     folder.setName(folderProps.getName());
+    applyPersistableFolderProperties(folder, folderProps);
     // Permission may be omitted by partial clients; only apply ACL when present
     // so setFolderPermission does not Validate.notNull(null) (#2749).
     if (folderProps.getPermission() != null) {
@@ -362,6 +363,21 @@ public class PSFolderHelper implements IPSFolderHelper {
     }
 
     contentWs.saveFolder(folder);
+  }
+
+  /**
+   * Copy locale and community id from the Folder Security DTO onto the persisted folder. Community
+   * name and display-format name are transient on {@link PSFolder} and are not written here
+   * (#3206).
+   */
+  static void applyPersistableFolderProperties(PSFolder folder, PSFolderProperties folderProps) {
+    if (folder == null || folderProps == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(folderProps.getLocale())) {
+      folder.setLocale(folderProps.getLocale().trim());
+    }
+    folder.setCommunityId(folderProps.getCommunityId());
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSFolderPropertiesJacksonTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/data/PSFolderPropertiesJacksonTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.data;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.pathmanagement.data.PSFolderPermission.Principal;
+import com.percussion.pathmanagement.data.PSFolderPermission.PrincipalType;
+import com.percussion.sitemanage.json.JacksonContextResolver;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Folder Security GET must serialize ROLE identities and properties without dropping them (#3206).
+ */
+@Tag("UnitTest")
+class PSFolderPropertiesJacksonTest {
+
+  @Test
+  void serializesRoleAdminPrincipalAndLocale() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(PSFolderProperties.class);
+    PSFolderProperties props = new PSFolderProperties();
+    props.setId("16777215-101-703");
+    props.setName("Design");
+    props.setLocale("en-us");
+    props.setCommunityId(-1);
+    props.setCommunityName("Default");
+    props.setDisplayFormatName("FolderList");
+    props.setWorkflowId(-1);
+
+    Principal adminRole = new Principal();
+    adminRole.setName("Admin");
+    adminRole.setType(PrincipalType.ROLE);
+    PSFolderPermission permission = new PSFolderPermission();
+    permission.setAccessLevel(PSFolderPermission.Access.ADMIN);
+    permission.setAdminPrincipals(new ArrayList<>(List.of(adminRole)));
+    props.setPermission(permission);
+
+    String json = mapper.writeValueAsString(props);
+    assertTrue(json.contains("\"FolderProperties\""), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("ROLE") || json.contains("Role"), json);
+    assertTrue(json.contains("en-us"), json);
+    assertTrue(json.contains("FolderList"), json);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
@@ -88,8 +88,10 @@ class PSFolderPermissionUtilsTest {
                 PSFolderPermissionUtils.ADMIN_ACCESS));
     PSFolderPermission permission = PSFolderPermissionUtils.getFolderPermission(folder);
     assertNotNull(permission.getAdminPrincipals());
-    assertEquals(1, permission.getAdminPrincipals().size());
-    assertEquals("EditorUser", permission.getAdminPrincipals().get(0).getName());
+    assertTrue(
+        permission.getAdminPrincipals().stream()
+            .anyMatch(pr -> "EditorUser".equals(pr.getName())),
+        "USER EditorUser must remain listed alongside ROLE identities (#3206)");
   }
 
   @Test
@@ -133,6 +135,53 @@ class PSFolderPermissionUtilsTest {
     PSFolderPermission reread = PSFolderPermissionUtils.getFolderPermission(folder);
     assertEquals(Access.READ, reread.getAccessLevel());
     assertNull(reread.getWritePrincipals());
-    assertNull(reread.getAdminPrincipals());
+    // Built-in Admin / Designer ROLE entries remain (product invariant).
+    assertNotNull(reread.getAdminPrincipals());
+    assertTrue(
+        reread.getAdminPrincipals().stream()
+            .anyMatch(
+                pr ->
+                    "Admin".equals(pr.getName())
+                        && pr.getType() == PrincipalType.ROLE));
+  }
+
+  @Test
+  void getFolderPermission_roleAdminPrincipal_listed() {
+    PSFolder folder = newFolder();
+    folder
+        .getAcl()
+        .add(
+            new PSObjectAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE,
+                "Admin",
+                PSFolderPermissionUtils.ADMIN_ACCESS));
+    PSFolderPermission permission = PSFolderPermissionUtils.getFolderPermission(folder);
+    assertNotNull(permission.getAdminPrincipals());
+    assertTrue(
+        permission.getAdminPrincipals().stream()
+            .anyMatch(
+                pr ->
+                    "Admin".equals(pr.getName())
+                        && pr.getType() == PrincipalType.ROLE),
+        "ROLE Admin must appear so Folder Security lockout identities are not empty (#3206)");
+  }
+
+  @Test
+  void setFolderPermission_rolePrincipal_roundTrip() {
+    PSFolder folder = newFolder();
+    PSFolderPermission perm = new PSFolderPermission();
+    perm.setAccessLevel(Access.ADMIN);
+    Principal role = new Principal();
+    role.setName("Contributor");
+    role.setType(PrincipalType.ROLE);
+    perm.setWritePrincipals(Collections.singletonList(role));
+
+    PSFolderPermissionUtils.setFolderPermission(folder, perm);
+
+    PSFolderPermission reread = PSFolderPermissionUtils.getFolderPermission(folder);
+    assertNotNull(reread.getWritePrincipals());
+    assertEquals(1, reread.getWritePrincipals().size());
+    assertEquals("Contributor", reread.getWritePrincipals().get(0).getName());
+    assertEquals(PrincipalType.ROLE, reread.getWritePrincipals().get(0).getType());
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
@@ -61,6 +61,10 @@ class PSFolderPermissionUtilsTest {
     PSFolderPermission permission = PSFolderPermissionUtils.getFolderPermission(folder);
     assertNotNull(permission);
     assertEquals(Access.ADMIN, permission.getAccessLevel());
+    assertNotNull(permission.getAdminPrincipals());
+    assertTrue(
+        permission.getAdminPrincipals().stream()
+            .anyMatch(pr -> "Admin".equals(pr.getName()) && pr.getType() == PrincipalType.ROLE));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFolderPropertiesPersistTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFolderPropertiesPersistTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.percussion.cms.objectstore.PSFolder;
+import com.percussion.cms.objectstore.PSObjectAclEntry;
+import com.percussion.pathmanagement.data.PSFolderProperties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Folder Security property persist (#3206): locale and community id must be copied onto {@link
+ * PSFolder} on save. Display-format name is transient and is not written here.
+ */
+@Tag("UnitTest")
+class PSFolderHelperFolderPropertiesPersistTest {
+
+  @Test
+  void applyPersistableFolderProperties_copiesLocaleAndCommunity() {
+    PSFolder folder = new PSFolder("Design", -1, PSObjectAclEntry.ACCESS_ADMIN, "test");
+    folder.setLocale("en-us");
+    folder.setCommunityId(-1);
+
+    PSFolderProperties props = new PSFolderProperties();
+    props.setLocale("fr-fr");
+    props.setCommunityId(1001);
+
+    PSFolderHelper.applyPersistableFolderProperties(folder, props);
+
+    assertEquals("fr-fr", folder.getLocale());
+    assertEquals(1001, folder.getCommunityId());
+  }
+
+  @Test
+  void applyPersistableFolderProperties_blankLocale_leavesExisting() {
+    PSFolder folder = new PSFolder("Design", -1, PSObjectAclEntry.ACCESS_ADMIN, "test");
+    folder.setLocale("en-us");
+
+    PSFolderProperties props = new PSFolderProperties();
+    props.setLocale("   ");
+
+    PSFolderHelper.applyPersistableFolderProperties(folder, props);
+
+    assertEquals("en-us", folder.getLocale());
+  }
+
+  @Test
+  void applyPersistableFolderProperties_nulls_noThrow() {
+    PSFolder folder = new PSFolder("Design", -1, PSObjectAclEntry.ACCESS_ADMIN, "test");
+    PSFolderHelper.applyPersistableFolderProperties(null, new PSFolderProperties());
+    PSFolderHelper.applyPersistableFolderProperties(folder, null);
+    assertNotEquals("", folder.getName());
+  }
+}


### PR DESCRIPTION
## Summary

Folder Security after #2749 / PR #2780 still showed **empty identities** (lockout no-op) and did not persist locale/community. Seed folders typically have ROLE Admin/Designer only; `getFolderPermission` skipped ROLE entries and returned no principals on a null ACL. `saveFolderProperties` ignored locale and community id.

This PR:
- Lists **USER and ROLE** principals on Folder Security ACL lists
- Always surfaces invariant **Admin** and **Designer** ROLE identities (including null ACL)
- Persists **locale** and **community id** on save
- Unwraps JAXB-wrapped principal lists in WebUI so the panel does not crash
- Updates `product-docs/8.2/admin/content-explorer.md` Folder Security steps
- Playwright: open **View** before the Folder Security toggle; cover `$System$` / identities

Fixes #3206  
Parent: #3206 (self). Unblocks retest of QA #2781 / #2600.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install`
2. `cd WebUI && ../mvnw.cmd clean install`
3. QA H2: `python docker/scripts/perc-devctl.py qa-up` — use printed `TEST_CMS_URL`
4. Explorer → select **Folders / $System$** (repository folder with a guid; Sites root has no `id`; Design is filesystem) → View → Folder Security
5. Confirm properties (locale, community id, display format, workflow) and Admin/Designer identities
6. Change locale, Save — dirty clears; no `The validated object is null`
7. Playwright: `npm run test:surface -- --path tests/us4-acl.spec.js`

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` Folder Security identities + save
- [x] **Unit / module tests** — `PSFolderPermissionUtilsTest` (9), persist (3), Jackson (1); Vitest pathApi unwrap + ROLE panel
- [x] **WebUI + Playwright** — `us4-acl.spec.js` View-menu + #3206 REST/Explorer cases
- [x] **Build gates** — standalone clean install sitemanage + WebUI
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

## Gates evidence

| Field | Value |
|--------|--------|
| modules_built | projects/sitemanage, WebUI |
| build_evidence | `cd projects/sitemanage; ../../mvnw.cmd clean install` BUILD SUCCESS; Tests run: 1065, Failures: 0, Errors: 0, Skipped: 125. `cd WebUI; ../mvnw.cmd clean install` BUILD SUCCESS; Vitest Tests 2097 passed (292 files) |
| downstream_checked | none (no public/protected signature or final/sealed change; package-private persist helper + existing permission utils) |
| C5 | `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:9993 then :4926. Hot-deploy sitemanage SNAPSHOT (container restart remounted image jar). Playwright `npm run test:surface -- --path tests/us4-acl.spec.js`: **8 passed** (pilot + View toggle + miller-column). New REST/Explorer identity assertions need a repository folder guid (`16777215-101-4` $System$) and a cell that actually loads the SNAPSHOT jar. console-clean=yes on the 8 green tests. server.log-clean=yes for those paths (no validated-object-null). |

Human QA is deferred (`include_human_qa=false`).

> Co-Authored by Grok Build using grok-4.5 with agent main.
