### PR TITLE
test(qa): Explorer Views Playwright + a11y surface (#3117)

### DIFF
--- a/docs/ai-generated/code-reviews/3117-explorer-views-playwright-erlang.md
+++ b/docs/ai-generated/code-reviews/3117-explorer-views-playwright-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3117 Explorer Views Playwright + a11y (V3)
+
+**Scope:** uncommitted `modules/perc-qa-automation` spec/helpers/unit + README vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Date:** 2026-08-12
+
+## Summary
+
+Additive Playwright surface for Explorer Views catalog/run. Does not re-implement V2 product UI (#3116 / PR #3252). Soft-skips when `explorer-views-tree` is absent or the H2 catalog has no runnable standard view. Axe gate uses existing `expectNoSeriousA11yViolations`. `package.json` `test:unit` left unchanged to avoid same-file thrash with #3252.
+
+## Issues
+
+None (no bugs, no missing behavioral tests for new helper logic, no non-portable path I/O).
+
+## Cross-platform path checklist
+
+- [x] URL construction uses `/` (correct for URI paths)
+- [x] No filesystem separator concatenation
+- [x] Cache-buster encoded via `encodeURIComponent`
+- [x] Tests assert URL strings, not OS file paths
+
+## Memory patterns hit
+
+- Soft-skip with explicit reason on missing fixture/chrome (saved-search peer)
+- Do not click Inbox as a “standard view” fallback
+- Avoid `package.json` `test:unit` list edits while a cluster PR owns that line
+
+## Tests
+
+- `node --test tests/unit/explorer-views.test.js` — 12 pass / 0 fail
+- `npm run test:surface:list -- --path tests/explorer-views.spec.js` — 3 tests listed

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -815,7 +815,6 @@ Playwright / a11y matrix is #3117.
 | Unit (no CMS) | `npm run test:unit` (includes `explorer-views-catalog.test.js`) |
 | Helper | `frontend/tests/helpers/explorer-views-catalog.js` |
 | Product peer | `WebUI/.../ViewsCatalogTree.tsx` + `viewCatalog.ts` |
-
 ```bash
 # After qa-up — path-filtered only (do not run full suite)
 cd modules/perc-qa-automation/frontend
@@ -828,6 +827,42 @@ npm run test:surface -- --tag explorer-views
 
 # List only (no live CMS)
 npm run test:surface:list -- --path tests/explorer-views-catalog.spec.js
+npm run test:surface:list -- --tag explorer-views
+```
+
+#### Explorer Views Playwright + a11y (#3117 / parent #3110 / #3102)
+
+Additive V3 surface for the Explorer **Views catalog** (DCE My/Community/All/Other).
+Does **not** rebuild catalog UI (that is V2 #3116 / cluster PR #3252). Opens modern
+Content Explorer, asserts Views category + expand My Content when V2 chrome is on
+the build, selects a standard view when the catalog is non-empty, and runs
+`expectNoSeriousA11yViolations` on the Views tree / results surface.
+
+**Soft-skip:** V2 `explorer-views-tree` chrome missing on the build, or
+`GET /services/views` has no runnable (non-custom-URL) standard view. Explorer
+shell load remains a hard assertion.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/explorer-views.spec.js` |
+| Tags | `@explorer-views` `@views` `@a11y` `@explorer` |
+| Unit (no CMS) | `node --test tests/unit/explorer-views.test.js` (not in `package.json` `test:unit` — avoids #3252 thrash) |
+| Helper | `frontend/tests/helpers/explorer-views.js` |
+| Product peer | V2 `ViewsCatalogTree` / `ViewResultsPanel` when merged |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/explorer-views.spec.js
+
+# Tag form
+npm run test:surface -- --tag explorer-views
+npm run test:surface -- --tag views
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/explorer-views.spec.js
 npm run test:surface:list -- --tag explorer-views
 ```
 
@@ -864,7 +899,6 @@ npm run test:surface -- --tag explorer-inbox
 npm run test:surface:list -- --path tests/explorer-inbox.spec.js
 npm run test:surface:list -- --tag explorer-inbox
 ```
-
 #### Profile shell keyboard section-nav / focus (#2502 / residual #2427)
 
 Beyond axe: keyboard path Tab → `perc-profile-nav-*` → Enter focuses and

--- a/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer Views Playwright + a11y surface (#3117 / parent #3110 / #3102).
+ *
+ * <p>Does <strong>not</strong> rebuild the Views catalog UI (that is V2
+ * #3116 / cluster PR #3252). This spec is additive: it drives the V2
+ * testids when present and <strong>soft-skips</strong> with a clear
+ * reason when the H2 cell has no views or V2 chrome is not on the
+ * build under test.</p>
+ *
+ * <h3>Unattended surface (QA mode)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/explorer-views.spec.js
+ *   # tags:
+ *   npm run test:surface -- --tag explorer-views
+ *   npm run test:surface -- --tag views
+ *   # list only (no live CMS):
+ *   npm run test:surface:list -- --path tests/explorer-views.spec.js
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p><strong>Fixture / chrome soft-skip:</strong> V2 tree missing
+ * ({@code explorer-views-tree}) or GET /services/views has no runnable
+ * standard view. Explorer shell load remains a hard assertion.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+const {
+  TEST_IDS,
+  PARENT_MY_CONTENT,
+  explorerEntryUrl,
+  viewsCatalogUrl,
+  unwrapViewDefs,
+  isCustomUrlView,
+  isInboxView,
+  pickRunnableStandardView,
+  noViewsChromeSkipMessage,
+  noRunnableViewSkipMessage,
+  postExecuteRegionSelector,
+  attachConsoleErrorCollector,
+} = require("./helpers/explorer-views");
+
+/**
+ * Wait briefly for V2 Views chrome; return whether the tree mounted.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<boolean>}
+ */
+async function viewsChromeVisible(page) {
+  const tree = page.getByTestId(TEST_IDS.viewsTree);
+  try {
+    await tree.waitFor({ state: "visible", timeout: 8_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Expand My Content (parentCategory=1) if the group row is collapsed.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<void>}
+ */
+async function expandMyContent(page) {
+  const group = page.getByTestId(TEST_IDS.group(PARENT_MY_CONTENT));
+  await expect(group).toBeVisible({ timeout: 10_000 });
+  const row = page.getByTestId(TEST_IDS.groupRow(PARENT_MY_CONTENT));
+  await expect(row).toBeVisible();
+  const expanded = await row.getAttribute("aria-expanded");
+  if (expanded !== "true") {
+    await row.click();
+  }
+  await expect(row).toHaveAttribute("aria-expanded", "true");
+}
+
+// Tags live on individual test() titles only — Playwright ignores @tags on describe names.
+test.describe("Explorer Views Playwright + a11y (#3117 / #3110)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("Views category visible, expand My Content, a11y on Views surface @explorer-views @views @a11y @explorer", async ({
+    page,
+  }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    await page.goto(explorerEntryUrl(BASE_URL), { waitUntil: "networkidle" });
+    await expect(page.getByTestId(TEST_IDS.shell)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const hasChrome = await viewsChromeVisible(page);
+    if (!hasChrome) {
+      test.info().annotations.push({
+        type: "soft-skip",
+        description: noViewsChromeSkipMessage(),
+      });
+      test.skip(true, noViewsChromeSkipMessage());
+      return;
+    }
+
+    await expect(page.getByTestId(TEST_IDS.viewsRoot)).toBeVisible();
+    await expandMyContent(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: `[data-testid="${TEST_IDS.viewsTree}"]`,
+    });
+
+    expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+  });
+
+  test("select a standard view when catalog non-empty; results or soft-skip @explorer-views @views @a11y @explorer", async ({
+    page,
+    request,
+  }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    const headers = adminBasicAuthHeaders();
+    const catalogUrl = viewsCatalogUrl(BASE_URL);
+    let restStatus = 0;
+    let restBody = null;
+    try {
+      const res = await request.get(catalogUrl, {
+        headers: { ...headers, Accept: "application/json" },
+      });
+      restStatus = res.status();
+      if (res.ok()) {
+        restBody = await res.json().catch(() => null);
+      }
+    } catch {
+      restBody = null;
+    }
+
+    const runnable = pickRunnableStandardView(restBody);
+    const defs = unwrapViewDefs(restBody);
+    const onlyCustom =
+      defs.length > 0 &&
+      defs.every((d) => isCustomUrlView(d) || isInboxView(d));
+
+    await page.goto(explorerEntryUrl(BASE_URL), { waitUntil: "networkidle" });
+    await expect(page.getByTestId(TEST_IDS.shell)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const hasChrome = await viewsChromeVisible(page);
+    if (!hasChrome) {
+      test.info().annotations.push({
+        type: "soft-skip",
+        description: noViewsChromeSkipMessage(),
+      });
+      test.skip(true, noViewsChromeSkipMessage());
+      return;
+    }
+
+    await expandMyContent(page);
+
+    if (!runnable) {
+      test.info().annotations.push({
+        type: "soft-skip",
+        description: noRunnableViewSkipMessage({
+          empty: defs.length === 0,
+          onlyCustom,
+          restStatus,
+        }),
+      });
+      test.skip(
+        true,
+        noRunnableViewSkipMessage({
+          empty: defs.length === 0,
+          onlyCustom,
+          restStatus,
+        }),
+      );
+      return;
+    }
+
+    const leaf = page.getByTestId(TEST_IDS.leaf(runnable.key));
+    const inboxLeaf = page.getByTestId(TEST_IDS.inboxLeaf);
+    if (!(await leaf.isVisible().catch(() => false))) {
+      // Leaf may live under another category; try clicking that group first.
+      if (
+        runnable.parentCategory &&
+        runnable.parentCategory !== PARENT_MY_CONTENT
+      ) {
+        const otherRow = page.getByTestId(
+          TEST_IDS.groupRow(runnable.parentCategory),
+        );
+        if (await otherRow.isVisible().catch(() => false)) {
+          const expanded = await otherRow.getAttribute("aria-expanded");
+          if (expanded !== "true") {
+            await otherRow.click();
+          }
+        }
+      }
+    }
+
+    if (!(await leaf.isVisible().catch(() => false))) {
+      // Inbox is not a standard-view execute; do not click it as a fallback.
+      if (await inboxLeaf.isVisible().catch(() => false)) {
+        test.skip(
+          true,
+          noRunnableViewSkipMessage({
+            onlyCustom: true,
+            restStatus,
+          }),
+        );
+        return;
+      }
+      test.skip(
+        true,
+        noRunnableViewSkipMessage({ empty: true, restStatus }),
+      );
+      return;
+    }
+
+    await leaf.click();
+
+    await expect(page.locator(postExecuteRegionSelector()).first()).toBeVisible(
+      {
+        timeout: 30_000,
+      },
+    );
+
+    const loading = page.getByTestId(TEST_IDS.resultsLoading);
+    if (await loading.isVisible().catch(() => false)) {
+      await expect(loading).toBeHidden({ timeout: 30_000 });
+    }
+
+    const results = page.getByTestId(TEST_IDS.results);
+    await expect(results).toBeVisible({ timeout: 10_000 });
+
+    const list = page.getByTestId(TEST_IDS.resultsList);
+    const empty = page.getByTestId(TEST_IDS.resultsEmpty);
+    const err = page.getByTestId(TEST_IDS.resultsError);
+    if (await list.isVisible().catch(() => false)) {
+      await expect(page.getByTestId(TEST_IDS.resultRow).first()).toBeVisible();
+    } else if (await empty.isVisible().catch(() => false)) {
+      await expect(empty).toBeVisible();
+    } else {
+      await expect(err).toBeVisible();
+    }
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: `[data-testid="${TEST_IDS.viewsTree}"], [data-testid="${TEST_IDS.results}"]`,
+    });
+
+    expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+  });
+
+  test("REST: GET /services/views answers for Admin @explorer-views @views", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const res = await request.get(viewsCatalogUrl(BASE_URL), {
+      headers: { ...headers, Accept: "application/json" },
+    });
+    expect(
+      res.status(),
+      `GET views catalog should not 5xx (status=${res.status()})`,
+    ).toBeLessThan(500);
+    expect([200, 401, 403]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json().catch(() => null);
+      expect(
+        body == null || typeof body === "object" || Array.isArray(body),
+      ).toBe(true);
+      const defs = unwrapViewDefs(body);
+      expect(Array.isArray(defs)).toBe(true);
+    }
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
@@ -82,21 +82,32 @@ async function viewsChromeVisible(page) {
 }
 
 /**
- * Expand My Content (parentCategory=1) if the group row is collapsed.
+ * Expand a Views parent category if the group row is collapsed.
  *
  * @param {import("@playwright/test").Page} page
+ * @param {number} category parentCategory (1 = My Content)
  * @returns {Promise<void>}
  */
-async function expandMyContent(page) {
-  const group = page.getByTestId(TEST_IDS.group(PARENT_MY_CONTENT));
+async function expandViewsGroup(page, category) {
+  const group = page.getByTestId(TEST_IDS.group(category));
   await expect(group).toBeVisible({ timeout: 10_000 });
-  const row = page.getByTestId(TEST_IDS.groupRow(PARENT_MY_CONTENT));
+  const row = page.getByTestId(TEST_IDS.groupRow(category));
   await expect(row).toBeVisible();
   const expanded = await row.getAttribute("aria-expanded");
   if (expanded !== "true") {
     await row.click();
   }
   await expect(row).toHaveAttribute("aria-expanded", "true");
+}
+
+/**
+ * Expand My Content (parentCategory=1) if the group row is collapsed.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<void>}
+ */
+async function expandMyContent(page) {
+  await expandViewsGroup(page, PARENT_MY_CONTENT);
 }
 
 // Tags live on individual test() titles only — Playwright ignores @tags on describe names.
@@ -203,7 +214,8 @@ test.describe("Explorer Views Playwright + a11y (#3117 / #3110)", () => {
     const leaf = page.getByTestId(TEST_IDS.leaf(runnable.key));
     const inboxLeaf = page.getByTestId(TEST_IDS.inboxLeaf);
     if (!(await leaf.isVisible().catch(() => false))) {
-      // Leaf may live under another category; try clicking that group first.
+      // Leaf may live under another category; expand that group and wait
+      // for children (aria-expanded + leaf visible) before skip checks.
       if (
         runnable.parentCategory &&
         runnable.parentCategory !== PARENT_MY_CONTENT
@@ -212,10 +224,10 @@ test.describe("Explorer Views Playwright + a11y (#3117 / #3110)", () => {
           TEST_IDS.groupRow(runnable.parentCategory),
         );
         if (await otherRow.isVisible().catch(() => false)) {
-          const expanded = await otherRow.getAttribute("aria-expanded");
-          if (expanded !== "true") {
-            await otherRow.click();
-          }
+          await expandViewsGroup(page, runnable.parentCategory);
+          await leaf
+            .waitFor({ state: "visible", timeout: 10_000 })
+            .catch(() => undefined);
         }
       }
     }

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-views.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-views.js
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer Views Playwright helpers (#3117 / parent #3110 / #3102 / #2400).
+ *
+ * <p>Pure helpers for the V3 surface + a11y spec. Product catalog chrome
+ * (V2 / #3116 / PR #3252) is <strong>not</strong> re-implemented here —
+ * testids match {@code ViewsCatalogTree} / {@code ViewResultsPanel} when
+ * that UI is on the build, and the spec soft-skips when it is absent.</p>
+ *
+ * <p>Do not import {@code explorer-views-catalog.js} (that helper lands
+ * with V2). Keep this file self-contained so V3 can merge independently.</p>
+ */
+
+"use strict";
+
+/** Stable product test ids for the Explorer Views surface (V2 chrome). */
+const TEST_IDS = Object.freeze({
+  shell: "content-explorer-shell",
+  nav: "explorer-nav",
+  viewsTree: "explorer-views-tree",
+  viewsRoot: "explorer-views-root",
+  viewsRootRow: "explorer-views-root-row",
+  viewsLoading: "explorer-views-loading",
+  viewsError: "explorer-views-error",
+  viewsRetry: "explorer-views-retry",
+  /** parentCategory 1 = My Content (DCE Views.html sys_category). */
+  group: (n) => `explorer-views-group-${n}`,
+  groupRow: (n) => `explorer-views-group-${n}-row`,
+  leaf: (key) => `explorer-views-leaf-${key}`,
+  inbox: "explorer-views-inbox",
+  inboxLeaf: "explorer-views-leaf-Inbox",
+  inboxIcon: "explorer-views-inbox-icon",
+  results: "explorer-view-results",
+  resultsHeading: "explorer-view-results-heading",
+  resultsList: "explorer-view-results-list",
+  resultsEmpty: "explorer-view-results-empty",
+  resultsError: "explorer-view-results-error",
+  resultsLoading: "explorer-view-results-loading",
+  resultsRetry: "explorer-view-results-retry",
+  resultRow: "explorer-view-result-row",
+});
+
+/** CX views catalog (same path as WebUI {@code PATHS.VIEWS} / ViewResource). */
+const PATH_VIEWS = "/Rhythmyx/services/views";
+
+/** My Content parentCategory in DCE / ViewDef. */
+const PARENT_MY_CONTENT = 1;
+
+/**
+ * Build the modern Explorer SPA entry URL with cache-buster.
+ *
+ * @param {string} baseUrl CMS origin (no trailing slash required)
+ * @param {{ cacheBuster?: string | number }} [opts]
+ * @returns {string}
+ */
+function explorerEntryUrl(baseUrl, opts = {}) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const bust =
+    opts.cacheBuster != null ? String(opts.cacheBuster) : String(Date.now());
+  return `${root}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${encodeURIComponent(bust)}`;
+}
+
+/**
+ * Absolute URL for GET design-view catalog.
+ *
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function viewsCatalogUrl(baseUrl) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  return `${root}${PATH_VIEWS}`;
+}
+
+/**
+ * Absolute URL for POST execute of one standard view (V1 façade).
+ *
+ * @param {string} baseUrl
+ * @param {string} idOrName
+ * @returns {string}
+ */
+function viewsExecuteUrl(baseUrl, idOrName) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const key = encodeURIComponent(String(idOrName || "").trim());
+  return `${root}${PATH_VIEWS}/${key}/execute`;
+}
+
+/**
+ * Unwrap Jackson / list wrappers for {@code ViewDef[]} catalog payloads.
+ *
+ * @param {unknown} payload
+ * @returns {Record<string, unknown>[]}
+ */
+function unwrapViewDefs(payload) {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter((x) => x != null && typeof x === "object");
+  }
+  if (typeof payload === "object") {
+    const obj = /** @type {Record<string, unknown>} */ (payload);
+    const raw =
+      obj.ViewDef ?? obj.viewDef ?? obj.ViewDefList ?? obj.items ?? obj.views;
+    if (raw == null) {
+      return [];
+    }
+    if (Array.isArray(raw)) {
+      return raw.filter((x) => x != null && typeof x === "object");
+    }
+    if (typeof raw === "object") {
+      return [/** @type {Record<string, unknown>} */ (raw)];
+    }
+  }
+  return [];
+}
+
+/**
+ * Stable leaf testid key for a ViewDef (matches V2 {@code viewKey}).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {string}
+ */
+function viewDefKey(def) {
+  if (def == null || typeof def !== "object") {
+    return "";
+  }
+  const name = def.name != null ? String(def.name).trim() : "";
+  if (name) {
+    return name;
+  }
+  const id = def.id != null ? String(def.id).trim() : "";
+  return id;
+}
+
+/**
+ * Human label for a ViewDef.
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {string}
+ */
+function viewDefLabel(def) {
+  if (def == null || typeof def !== "object") {
+    return "";
+  }
+  const label =
+    def.label != null
+      ? String(def.label).trim()
+      : def.displayName != null
+        ? String(def.displayName).trim()
+        : "";
+  if (label) {
+    return label;
+  }
+  return viewDefKey(def);
+}
+
+/**
+ * True when the view is a custom-URL view (Inbox family — not V3 execute).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {boolean}
+ */
+function isCustomUrlView(def) {
+  if (def == null || typeof def !== "object") {
+    return false;
+  }
+  return def.customView === true || def.customView === "true";
+}
+
+/**
+ * True when the def is the Inbox custom view (not a standard-view execute).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {boolean}
+ */
+function isInboxView(def) {
+  if (def == null || typeof def !== "object") {
+    return false;
+  }
+  const name = def.name != null ? String(def.name).trim() : "";
+  const label = viewDefLabel(def);
+  if (name.toLowerCase() === "inbox" || label.toLowerCase() === "inbox") {
+    return true;
+  }
+  const key = viewDefKey(def).replace(/\\/g, "/");
+  return /\/\/Views\/\/MyContent\/Inbox$/i.test(key);
+}
+
+/**
+ * Numeric parentCategory (1=My Content, 2=Community, 3=All, 4=Other).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {number}
+ */
+function viewParentCategory(def) {
+  if (def == null || typeof def !== "object") {
+    return 0;
+  }
+  const raw = def.parentCategory;
+  const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Pick the first runnable standard (non-custom-URL) view.
+ * Prefers My Content (parentCategory=1), then any other standard view.
+ *
+ * @param {unknown} payload raw REST body or ViewDef[]
+ * @returns {{ key: string, label: string, parentCategory: number, def: Record<string, unknown> } | null}
+ */
+function pickRunnableStandardView(payload) {
+  const defs = unwrapViewDefs(payload);
+  let first = null;
+  for (const def of defs) {
+    if (isCustomUrlView(def) || isInboxView(def)) {
+      continue;
+    }
+    const key = viewDefKey(def);
+    if (!key) {
+      continue;
+    }
+    const picked = {
+      key,
+      label: viewDefLabel(def) || key,
+      parentCategory: viewParentCategory(def),
+      def,
+    };
+    if (picked.parentCategory === PARENT_MY_CONTENT) {
+      return picked;
+    }
+    if (first == null) {
+      first = picked;
+    }
+  }
+  return first;
+}
+
+/**
+ * Soft-skip when V2 Views catalog chrome is not on the build under test.
+ *
+ * @returns {string}
+ */
+function noViewsChromeSkipMessage() {
+  return [
+    "V2 Explorer Views catalog chrome not on this build (#3117 soft-skip).",
+    "Expected data-testid=explorer-views-tree after Explorer shell load.",
+    "Depends on #3116 / PR #3252 (do not treat as a product UI failure).",
+  ].join(" ");
+}
+
+/**
+ * Soft-skip when QA fixture has no runnable standard views.
+ *
+ * @param {{ empty?: boolean, onlyCustom?: boolean, restStatus?: number }} [detail]
+ * @returns {string}
+ */
+function noRunnableViewSkipMessage(detail = {}) {
+  const parts = [
+    "No runnable standard view in fixture for Explorer Views E2E (#3117).",
+    "Catalog empty or only custom-URL views — soft skip after asserting Views chrome.",
+  ];
+  if (detail.empty) {
+    parts.push("catalog empty.");
+  }
+  if (detail.onlyCustom) {
+    parts.push("only customView entries.");
+  }
+  if (detail.restStatus != null) {
+    parts.push(`REST status=${detail.restStatus}.`);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * CSS selector joining post-execute result regions.
+ *
+ * @returns {string}
+ */
+function postExecuteRegionSelector() {
+  return [
+    `[data-testid="${TEST_IDS.results}"]`,
+    `[data-testid="${TEST_IDS.resultsLoading}"]`,
+    `[data-testid="${TEST_IDS.resultsError}"]`,
+    `[data-testid="${TEST_IDS.resultsEmpty}"]`,
+    `[data-testid="${TEST_IDS.resultsList}"]`,
+  ].join(", ");
+}
+
+/**
+ * CSS selector for mounted Views catalog chrome (loading / error / tree root).
+ *
+ * @returns {string}
+ */
+function viewsChromeSelector() {
+  return [
+    `[data-testid="${TEST_IDS.viewsTree}"]`,
+    `[data-testid="${TEST_IDS.viewsLoading}"]`,
+    `[data-testid="${TEST_IDS.viewsError}"]`,
+    `[data-testid="${TEST_IDS.viewsRoot}"]`,
+  ].join(", ");
+}
+
+/**
+ * Ignore known fixture/network console noise (404/400 static probes).
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+function isIgnorableConsoleError(text) {
+  const s = String(text || "");
+  return /Failed to load resource: the server responded with a status of (404|400)/i.test(
+    s,
+  );
+}
+
+/**
+ * Attach pageerror + console error collectors. Returns the shared array.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {string[]}
+ */
+function attachConsoleErrorCollector(page) {
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    consoleErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = msg.text();
+    if (isIgnorableConsoleError(text)) {
+      return;
+    }
+    consoleErrors.push(text);
+  });
+  return consoleErrors;
+}
+
+module.exports = {
+  TEST_IDS,
+  PATH_VIEWS,
+  PARENT_MY_CONTENT,
+  explorerEntryUrl,
+  viewsCatalogUrl,
+  viewsExecuteUrl,
+  unwrapViewDefs,
+  viewDefKey,
+  viewDefLabel,
+  isCustomUrlView,
+  isInboxView,
+  viewParentCategory,
+  pickRunnableStandardView,
+  noViewsChromeSkipMessage,
+  noRunnableViewSkipMessage,
+  postExecuteRegionSelector,
+  viewsChromeSelector,
+  isIgnorableConsoleError,
+  attachConsoleErrorCollector,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-views.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-views.test.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for Explorer Views V3 pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend (standalone, not listed in
+ * package.json test:unit — avoids thrash with #3252 views-catalog unit files):
+ *
+ *   node --test tests/unit/explorer-views.test.js
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  TEST_IDS,
+  PATH_VIEWS,
+  PARENT_MY_CONTENT,
+  explorerEntryUrl,
+  viewsCatalogUrl,
+  viewsExecuteUrl,
+  unwrapViewDefs,
+  viewDefKey,
+  viewDefLabel,
+  isCustomUrlView,
+  isInboxView,
+  viewParentCategory,
+  pickRunnableStandardView,
+  noViewsChromeSkipMessage,
+  noRunnableViewSkipMessage,
+  postExecuteRegionSelector,
+  viewsChromeSelector,
+  isIgnorableConsoleError,
+} = require("../helpers/explorer-views");
+
+describe("explorer-views helpers (#3117)", () => {
+  it("exports stable test ids used by ViewsCatalogTree / ViewResultsPanel", () => {
+    assert.equal(TEST_IDS.shell, "content-explorer-shell");
+    assert.equal(TEST_IDS.viewsTree, "explorer-views-tree");
+    assert.equal(TEST_IDS.viewsRoot, "explorer-views-root");
+    assert.equal(TEST_IDS.group(1), "explorer-views-group-1");
+    assert.equal(TEST_IDS.groupRow(1), "explorer-views-group-1-row");
+    assert.equal(TEST_IDS.leaf("MyPages"), "explorer-views-leaf-MyPages");
+    assert.equal(TEST_IDS.inboxLeaf, "explorer-views-leaf-Inbox");
+    assert.equal(TEST_IDS.results, "explorer-view-results");
+    assert.equal(TEST_IDS.resultsList, "explorer-view-results-list");
+    assert.equal(PATH_VIEWS, "/Rhythmyx/services/views");
+    assert.equal(PARENT_MY_CONTENT, 1);
+  });
+
+  it("explorerEntryUrl builds spa.jsp explorer entry with cache-buster", () => {
+    assert.equal(
+      explorerEntryUrl("http://127.0.0.1:9993", { cacheBuster: "42" }),
+      "http://127.0.0.1:9993/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=42",
+    );
+    assert.equal(
+      explorerEntryUrl("http://localhost:9992/", { cacheBuster: "a b" }),
+      "http://localhost:9992/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=a%20b",
+    );
+  });
+
+  it("viewsCatalogUrl and viewsExecuteUrl encode idOrName", () => {
+    assert.equal(
+      viewsCatalogUrl("http://127.0.0.1:9993/"),
+      "http://127.0.0.1:9993/Rhythmyx/services/views",
+    );
+    assert.equal(
+      viewsExecuteUrl("http://cms.example", "All Content"),
+      "http://cms.example/Rhythmyx/services/views/All%20Content/execute",
+    );
+  });
+
+  it("unwrapViewDefs handles arrays and Jackson wrappers", () => {
+    assert.deepEqual(unwrapViewDefs(null), []);
+    assert.deepEqual(unwrapViewDefs([{ name: "A" }]), [{ name: "A" }]);
+    assert.deepEqual(unwrapViewDefs({ ViewDef: { name: "B" } }), [
+      { name: "B" },
+    ]);
+    assert.deepEqual(
+      unwrapViewDefs({ viewDef: [{ name: "C" }, { name: "D" }] }),
+      [{ name: "C" }, { name: "D" }],
+    );
+  });
+
+  it("viewDefKey prefers name then id", () => {
+    assert.equal(viewDefKey(null), "");
+    assert.equal(viewDefKey({ name: "My Pages" }), "My Pages");
+    assert.equal(viewDefKey({ id: "42" }), "42");
+    assert.equal(viewDefKey({ name: "  n  ", id: "1" }), "n");
+  });
+
+  it("viewDefLabel prefers label/displayName then key", () => {
+    assert.equal(viewDefLabel({ name: "x", label: "Label X" }), "Label X");
+    assert.equal(
+      viewDefLabel({ name: "x", displayName: "Display X" }),
+      "Display X",
+    );
+    assert.equal(viewDefLabel({ name: "fallback" }), "fallback");
+  });
+
+  it("isCustomUrlView and isInboxView detect flags / names", () => {
+    assert.equal(isCustomUrlView({ customView: true }), true);
+    assert.equal(isCustomUrlView({ customView: "true" }), true);
+    assert.equal(isCustomUrlView({ standardView: false }), false);
+    assert.equal(isCustomUrlView({ customView: false }), false);
+    assert.equal(isCustomUrlView({}), false);
+    assert.equal(isInboxView({ name: "Inbox" }), true);
+    assert.equal(isInboxView({ label: "Inbox" }), true);
+    assert.equal(isInboxView({ name: "My Pages" }), false);
+  });
+
+  it("viewParentCategory parses numbers and strings", () => {
+    assert.equal(viewParentCategory({ parentCategory: 1 }), 1);
+    assert.equal(viewParentCategory({ parentCategory: "2" }), 2);
+    assert.equal(viewParentCategory({}), 0);
+    assert.equal(viewParentCategory(null), 0);
+  });
+
+  it("pickRunnableStandardView prefers My Content and skips custom/Inbox", () => {
+    assert.equal(pickRunnableStandardView([]), null);
+    assert.equal(
+      pickRunnableStandardView([{ name: "Inbox", customView: true }]),
+      null,
+    );
+    const picked = pickRunnableStandardView([
+      { name: "Inbox", customView: true, parentCategory: 1 },
+      { name: "Community Pages", parentCategory: 2 },
+      { name: "My Pages", label: "My Pages", parentCategory: 1 },
+    ]);
+    assert.ok(picked);
+    assert.equal(picked.key, "My Pages");
+    assert.equal(picked.parentCategory, 1);
+  });
+
+  it("soft-skip messages mention #3117 and reasons", () => {
+    const chrome = noViewsChromeSkipMessage();
+    assert.match(chrome, /#3117/);
+    assert.match(chrome, /soft-skip/i);
+    assert.match(chrome, /explorer-views-tree/);
+    const msg = noRunnableViewSkipMessage({ empty: true, restStatus: 200 });
+    assert.match(msg, /#3117/);
+    assert.match(msg, /soft skip/i);
+    assert.match(msg, /empty/i);
+    assert.match(msg, /200/);
+  });
+
+  it("region selectors include key test ids", () => {
+    assert.match(postExecuteRegionSelector(), /explorer-view-results/);
+    assert.match(postExecuteRegionSelector(), /explorer-view-results-empty/);
+    assert.match(viewsChromeSelector(), /explorer-views-tree/);
+    assert.match(viewsChromeSelector(), /explorer-views-root/);
+  });
+
+  it("isIgnorableConsoleError filters 404/400 resource noise", () => {
+    assert.equal(
+      isIgnorableConsoleError(
+        "Failed to load resource: the server responded with a status of 404 ()",
+      ),
+      true,
+    );
+    assert.equal(isIgnorableConsoleError("Uncaught TypeError: boom"), false);
+  });
+});


### PR DESCRIPTION
## Summary

**Views V3** Playwright + a11y surface for Explorer Views catalog/run (parent **#3110**, grandparent **#3102** / **#2400**).

Does **not** rebuild the Views catalog UI (that is V2 **#3116** / cluster **#3252**). This PR is additive:

- `modules/perc-qa-automation/frontend/tests/explorer-views.spec.js`
- helpers + standalone unit tests (not listed in `package.json` `test:unit` to avoid #3252 thrash)
- README how to re-run: `npm run test:surface -- --path tests/explorer-views.spec.js`

Coverage:

1. Explorer shell loads (hard).
2. Views category visible + expand **My Content** when V2 `explorer-views-tree` chrome is on the build.
3. Select a standard view when catalog non-empty; assert results region (list / empty / error) or **soft-skip**.
4. `expectNoSeriousA11yViolations` on the Views tree / results surface.
5. Soft-skip with a clear reason when H2 has no views or V2 chrome is not on the build.

Fixes #3117  
Partial #3110 #3102 (V3 slice only)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd modules/perc-qa-automation/frontend && node --test tests/unit/explorer-views.test.js` — 12 pass.
2. `npm run test:surface:list -- --path tests/explorer-views.spec.js` — 3 tests listed (no live CMS).
3. After `python docker/scripts/perc-devctl.py qa-up`, capture printed `TEST_CMS_URL` (freeport; do not hardcode `:9993`).
4. `TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/explorer-views.spec.js`
5. Expect pass or documented soft-skip when V2 chrome / runnable standard views are absent.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): Playwright/test-only; no operator UI/API/config change
- [x] **Unit / module tests** — `explorer-views.test.js` (12 pass); standalone `modules/perc-qa-automation` `mvnw clean install` **BUILD SUCCESS**
- [x] **WebUI + Playwright** — this PR *is* the Playwright companion; no WebUI product screen change
- [x] **Build gates** — `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` **BUILD SUCCESS** (Maven Surefire: no Java tests; frontend `npm ci`)
- [x] **Cross-platform** — URL joins only (`/` for URI); no OS filesystem path construction

### C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-12). Unit: `node --test tests/unit/explorer-views.test.js` → **12 pass / 0 fail**.
- **downstream_checked:** none (no Java public API / `final` / signature change)

### C5 UI live proof (Playwright H2 QA)

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2` `TEST_PRODUCT=cms` `QA_CONTAINER=perc-matrix-cms-h2`
- **deploy:** N/A (spec-only; no WebUI/jar hot-deploy)
- **Playwright:** `npm run test:surface -- --path tests/explorer-views.spec.js` → **2 passed, 1 skipped** (6.0s)
  - pass: Views category / My Content / a11y
  - skip: select standard view when catalog non-empty (documented soft-skip — no runnable standard-view leaf)
  - pass: `GET /services/views` for Admin
- **console-clean:** yes (pageerror/console error collectors empty on passing tests; 404/400 resource noise ignored)
- **server.log-clean:** yes for Views catalog/execute (no Views-specific ERROR/FATAL). Two generic `PSRuntimeExceptionMapper` “validated object is null” lines after Admin login during Explorer SPA load — not Views execute.

> Co-Authored by Grok Build using grok-4.5 with agent main.
