### PR TITLE
fix(webui): Home then Explorer adjacency and Admin chrome (#3201)

### DIFF
--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -24,6 +24,7 @@ import { UserMenu } from "./UserMenu";
 import styles from "./AppLayout.module.css";
 import {
   ADMIN_NAV_LANDING,
+  adminTopNavLabel,
   isAdminNavPath,
   topNavItemIds,
 } from "./topNavConfig";
@@ -32,7 +33,7 @@ import {
  * Product top navigation for the SPA shell.
  * SPA routes use client NavLink; unmigrated surfaces are full-page legacy exits.
  *
- * Order / labels: Home → Explorer → … → single Admin (issue #2702).
+ * Order / labels: Home → Explorer → … → single Admin (issue #2702 / #3201).
  * Dashboard is not a top-nav item (gadgets remain under Home / deep link).
  */
 export function TopNav(): React.ReactElement {
@@ -155,8 +156,8 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "admin":
-              // Consolidated Admin entry (#2702 / #2784 / #3088).
-              // Landing: unified Admin shell; legacy /workflow* redirects into /admin*.
+              // Consolidated Admin entry (#2702 / #2784 / #3088 / #3201).
+              // Landing: Admin tools shell (/admin), not Workflow-only hub.
               return (
                 <li key={id}>
                   <NavLink
@@ -172,7 +173,7 @@ export function TopNav(): React.ReactElement {
                     aria-current={adminActive ? "page" : undefined}
                     {...i18nKeyAttr(MSG.NAV_ADMIN)}
                   >
-                    {message(MSG.NAV_ADMIN)}
+                    {adminTopNavLabel(message(MSG.NAV_ADMIN))}
                   </NavLink>
                 </li>
               );

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -16,15 +16,16 @@
  */
 
 /**
- * Primary product top-nav order and role gates (issue #2702 / #2784 / #3088).
+ * Primary product top-nav order and role gates (issue #2702 / #2784 / #3088 / #3201).
  *
  * Dashboard is intentionally omitted from top chrome (gadgets remain on Home
  * via deep link {@code /home/gadgets}). Administration + Admin tools collapse
- * to a single {@code admin} item.
+ * to a single {@code admin} item labeled <strong>Admin</strong>.
  *
- * <p>Landing is the unified <strong>Admin</strong> shell at {@code /admin}
- * (#2784 / #3088). Workflow / roles / users / categories are Admin tabs;
- * legacy {@code /workflow} paths redirect into {@code /admin/*}.</p>
+ * <p>Landing is the unified <strong>Admin tools</strong> shell at {@code /admin}
+ * (#2784 / #3088 / #3201) — not a Workflow-only hub. Workflow / roles / users /
+ * categories are Admin tabs; legacy {@code /workflow} paths redirect into
+ * {@code /admin/*}.</p>
  */
 
 export type TopNavItemId =
@@ -49,6 +50,23 @@ export interface TopNavGates {
  * Unified Admin shell (tasks, tools, workflow, roles, users, categories).
  */
 export const ADMIN_NAV_LANDING = "/admin";
+
+/**
+ * Visible top-nav label for the consolidated Admin item (#2702 / #3201).
+ *
+ * TMX tuid {@code perc.ui.navMenu.admin@Administration} already ships en-us
+ * {@code Admin}. When TMX is missing, the SPA message helper falls back to
+ * the {@code @Administration} suffix — operators then see the old dual-entry
+ * word. Normalize that English leftover so chrome always reads Admin.
+ * Non-English TMX strings are left unchanged.
+ */
+export function adminTopNavLabel(resolved: string): string {
+  const t = (resolved || "").trim();
+  if (!t || t === "Administration") {
+    return "Admin";
+  }
+  return t;
+}
 
 /**
  * Client path for Navigation top-nav NavLink and homepage SPA landing (#3094).

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -216,8 +216,9 @@ export const MSG = {
   NAV_DEVELOPER: "perc.ui.dashboard.modern@Developer",
   NAV_PUBLISH: "perc.ui.navMenu.publish@Publish",
   /**
-   * Consolidated top-nav Admin label (#2702). Classic key en-us is already "Admin".
-   * Prefer this for top chrome over separate Administration / Admin tools entries.
+   * Consolidated top-nav Admin label (#2702 / #3201). TMX en-us is "Admin".
+   * TopNav also normalizes the English {@code @Administration} fallback so
+   * chrome never shows the old dual-entry word.
    */
   NAV_ADMIN: "perc.ui.navMenu.admin@Administration",
   /** @deprecated Prefer NAV_ADMIN for top chrome; retained for residual page titles. */

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -74,7 +74,8 @@ describe("TopNav (#2702)", () => {
     expect(testIds).not.toContain("nav-dashboard");
     expect(testIds).not.toContain("nav-workflow");
     expect(testIds.filter((id) => id === "nav-admin")).toEqual(["nav-admin"]);
-    expect(screen.getByTestId("nav-admin").textContent).toMatch(/Admin/i);
+    // Exact chrome word (not "Administration") — #3201 / failed QA #2714
+    expect(screen.getByTestId("nav-admin").textContent?.trim()).toBe("Admin");
   });
 
   it("lands consolidated Admin on Admin tools shell path (#2784)", () => {

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 import {
   ADMIN_NAV_LANDING,
   ARCHITECTURE_NAV_LANDING,
+  adminTopNavLabel,
   isAdminNavPath,
   topNavItemIds,
 } from "../../../../main/ts/app/layout/topNavConfig";
@@ -82,10 +83,24 @@ describe("topNavItemIds (#2702)", () => {
   });
 });
 
-describe("ADMIN_NAV_LANDING (#2784)", () => {
+describe("ADMIN_NAV_LANDING (#2784 / #3201)", () => {
   it("points consolidated Admin top-nav at Admin tools shell", () => {
     expect(ADMIN_NAV_LANDING).toBe("/admin");
     expect(isAdminNavPath(ADMIN_NAV_LANDING)).toBe(true);
+  });
+});
+
+describe("adminTopNavLabel (#3201)", () => {
+  it("normalizes English Administration leftover to Admin", () => {
+    expect(adminTopNavLabel("Administration")).toBe("Admin");
+    expect(adminTopNavLabel("  Administration  ")).toBe("Admin");
+    expect(adminTopNavLabel("")).toBe("Admin");
+  });
+
+  it("keeps TMX Admin and non-English labels", () => {
+    expect(adminTopNavLabel("Admin")).toBe("Admin");
+    expect(adminTopNavLabel("Administrateur")).toBe("Administrateur");
+    expect(adminTopNavLabel("Beheerder")).toBe("Beheerder");
   });
 });
 

--- a/docs/ai-generated/code-reviews/2026-08-12-issue-3201-top-nav-erlang.md
+++ b/docs/ai-generated/code-reviews/2026-08-12-issue-3201-top-nav-erlang.md
@@ -1,0 +1,20 @@
+# Erlang review — issue #3201 top-nav Home→Explorer + Admin chrome
+
+Date: 2026-08-12
+Branch: fix/issue-3201-top-nav-home-explorer
+Reviewer: Grok Build (erlang-style self-review)
+
+## Change class
+
+WebUI product chrome (top-nav label + Admin landing) + Playwright companion + product-docs.
+
+## Findings
+
+- **Bugs:** none. `adminTopNavLabel` only rewrites the English leftover "Administration"; TMX translations pass through.
+- **Tests:** Vitest for order, landing `/admin`, and label helper; Playwright `top-nav-restructure.spec.js` asserts exact `Admin`, adjacency, no Dashboard, Admin tools shell, console errors.
+- **Paths:** no filesystem I/O.
+- **Companions:** product-docs `admin/index.md` + `getting-started/index.md`; QA spec updated.
+
+## Gate
+
+Hard gates (bugs / missing behavioral tests / non-portable I/O): **pass**.

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -15,12 +15,12 @@
  */
 
 /**
- * Top navigation restructure (#2702 / #2784 / #2953 / #3088):
+ * Top navigation restructure (#2702 / #2784 / #2953 / #3088 / #3201):
  * - Dashboard removed from SPA top chrome
  * - Explorer immediately after Home
- * - Single consolidated Admin (no separate Administration + Admin tools shells)
- * - Admin lands on unified Admin shell (/admin); workflow/roles/users/categories
- *   are in-shell tabs (sibling chrome removed in #3088)
+ * - Single consolidated Admin labeled "Admin" (not "Administration")
+ * - Admin lands on working Admin tools shell (/admin); workflow/roles/users/
+ *   categories are in-shell tabs (sibling chrome removed in #3088)
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -47,10 +47,20 @@ async function expectSpaTopNav(page) {
   });
 }
 
-test.describe("Top nav restructure (#2702)", () => {
+test.describe("Top nav restructure (#2702 / #3201)", () => {
   test("Home then Explorer; no Dashboard; single Admin @smoke @ui", async ({
     page,
   }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
     await loginAsAdmin(page);
     await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
     await expectSpaTopNav(page);
@@ -63,8 +73,15 @@ test.describe("Top nav restructure (#2702)", () => {
     await expect(home).toBeVisible();
     await expect(explorer).toBeVisible();
     await expect(admin).toBeVisible();
+    await expect(admin).toHaveText(/^Admin$/);
     await expect(nav.getByTestId("nav-dashboard")).toHaveCount(0);
     await expect(nav.getByTestId("nav-workflow")).toHaveCount(0);
+    await expect(nav.getByRole("link", { name: "Dashboard", exact: true })).toHaveCount(
+      0,
+    );
+    await expect(
+      nav.getByRole("link", { name: "Administration", exact: true }),
+    ).toHaveCount(0);
 
     // DOM adjacency: Explorer is the next top-level nav item after Home
     const adjacency = await page.evaluate(() => {
@@ -76,14 +93,17 @@ test.describe("Top nav restructure (#2702)", () => {
     });
     expect(adjacency).toBe(true);
 
-    // Consolidated Admin lands on unified Admin shell (#2784 / #3088)
+    // Consolidated Admin lands on working Admin tools shell (#2784 / #3088 / #3201)
     await admin.click();
     await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
       timeout: 30_000,
     });
+    await expect(page).toHaveURL(/\/admin(?:\/|$|\?)/);
     await expect(page.getByTestId("perc-admin-shell-title")).toContainText(
       /Admin tools/i,
     );
+    await expect(page.getByTestId("tab-tools")).toBeVisible();
+    await expect(page.getByTestId("tab-tasks")).toBeVisible();
     // No sibling cross-links; workflow is an Admin tab (#3088)
     await expect(page.getByTestId("admin-sibling-workflow-link")).toHaveCount(0);
     await expect(page.getByTestId("admin-sibling-tools-link")).toHaveCount(0);
@@ -99,5 +119,14 @@ test.describe("Top nav restructure (#2702)", () => {
     // Still one Admin shell (no WorkflowAdminShell product chrome)
     await expect(page.getByTestId("perc-admin-shell")).toBeVisible();
     await expect(page.getByTestId("perc-workflow-admin-shell")).toHaveCount(0);
+
+    const unexpected = consoleErrors.filter(
+      (t) =>
+        !/favicon|404|net::ERR|Failed to load resource/i.test(t) &&
+        !/Download the React DevTools/i.test(t),
+    );
+    expect(unexpected, `JS console errors: ${unexpected.join(" | ")}`).toEqual(
+      [],
+    );
   });
 });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -12,10 +12,26 @@ tags: [admin]
 Operator and administrator topics for Percussion CMS 8.2 — Sites, security, publishing, and
 day-two server operations.
 
+## Product top navigation (SPA)
+
+For roles that can see the full chrome, the application top navigation is:
+
+1. **Home**
+2. **Explorer** (immediately after Home)
+3. Editor, Navigation, Design, Developer, Publish (role-gated)
+4. **Admin** (administrators only — one item)
+5. Widget Builder (when that feature is active)
+
+**Dashboard** is not a top-nav item. Dashboard gadgets remain on Home
+(`/home/gadgets`) and via homepage preference; they are not a separate
+primary destination.
+
 ## Product Admin navigation (SPA)
 
-The top navigation exposes a **single Admin** item for administrators. Admin opens one
-unified **Admin** product shell with tabs for:
+The top navigation exposes a **single Admin** item for administrators (not
+separate **Administration** and **Admin tools** entries). **Admin** opens the
+working **Admin tools** shell (`/admin`) — not a Workflow-only hub. The shell
+title is **Admin tools**, with tabs for:
 
 | Tab | Purpose |
 |-----|---------|

--- a/product-docs/8.2/getting-started/index.md
+++ b/product-docs/8.2/getting-started/index.md
@@ -28,8 +28,11 @@ This section covers how to obtain, install, upgrade, and take first steps with P
 
 1. Confirm the server process starts and logs under the install `jetty/base/logs` (or platform service logs) are clean.
 2. Sign in with the administrative account created at install time.
-3. Create or open a **Site**, confirm Finder navigation, and open the Web UI editor.
-4. Review [Server operations](id:admin-server-ops) for ports, service control, and logs.
+3. Confirm the SPA top navigation starts with **Home**, then **Explorer** (adjacent).
+   There is no **Dashboard** top-nav item. Administrators see a single **Admin**
+   item that opens **Admin tools** (`/admin`). See [Administration](id:admin).
+4. Create or open a **Site**, confirm Finder navigation, and open the Web UI editor.
+5. Review [Server operations](id:admin-server-ops) for ports, service control, and logs.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Residual after failed human QA [#2714](https://github.com/intersoftdatalabs-in/percussioncms/issues/2714) (parent [#2702](https://github.com/intersoftdatalabs-in/percussioncms/issues/2702)). Top-nav order on `main` already places **Home** then **Explorer** with a single **Admin** landing on `/admin`. QA still saw the English leftover **Administration** when TMX fell back to the `@Administration` key suffix, and prior QA plans still expected a Workflow-only hub plus sibling links (removed in #3088).

This change:

* Normalizes the consolidated top-nav label to **Admin** (`adminTopNavLabel`) without dropping non-English TMX strings.
* Keeps Admin landing on the working **Admin tools** shell (`/admin`) with in-shell tabs (not a dead Workflow-only hub). Dashboard remains a Home/deep-link feature, not top chrome.
* Tightens Vitest + Playwright (`tests/top-nav-restructure.spec.js`) and documents chrome order in product-docs.

Fixes #3201  
Parent: #2714

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. QA H2: `python docker/scripts/perc-devctl.py qa-up` (or existing healthy `perc-matrix-cms-h2`).
2. Log in as Admin. Confirm top nav: **Home**, then **Explorer** (adjacent); no **Dashboard**; single **Admin** (not Administration).
3. Click **Admin** → **Admin tools** shell (`perc-admin-shell`, title Admin tools, URL `/admin`). System Tools + Workflow/Roles/Users/Categories tabs present. No sibling Administration/Admin tools links.
4. Optional: Designer/Contributor — no Admin item; Explorer still after Home.
5. Playwright (after hot-copy of `WebUI/target/generated-webui/cm/modern/assets` into the cell):
   * `npm run test:surface -- --path tests/top-nav-restructure.spec.js`
   * `npm run test:golden`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/index.md` (top-nav order + Admin tools landing) and `product-docs/8.2/getting-started/index.md`
- [x] **Unit / module tests** — `adminTopNavLabel` + TopNav exact label; standalone clean install
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js`
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

* **modules_built:** `WebUI`, `modules/perc-qa-automation`
* **build_evidence:**
  * `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest `Tests 2114 passed (2114)`
  * `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
* **downstream_checked:** none (C2 did not apply — no Java `final`/public API shape change)

### C5 UI live proof

* Reused healthy QA cell `perc-matrix-cms-h2` (`TEST_CMS_URL=http://127.0.0.1:9993`).
* Hot-deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
* `npm run test:surface -- --path tests/top-nav-restructure.spec.js` → **1 passed**
* `npm run test:golden` → **2 passed**
* **console-clean:** yes (spec asserts no unexpected page/console errors)
* **server.log-clean:** yes for Admin chrome path. One `PSRuntimeExceptionMapper` “validated object is null” line occurred during golden Explorer login (no stack; not on Admin click). Not treated as a top-nav defect.

Did **not** `qa-down` — cell was already running (shared `perc-matrix-cms-h2` name).

## Related QA to reconcile

Stale sibling-link plans on #2823 / #2976 / #2714 should follow this PR’s Admin tools + in-shell tabs plan (not Workflow hub + sibling links).
