### PR TITLE
fix(webui): Display Format detail GUID and Object ACL bind (#3200)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -31,7 +31,9 @@ import { get } from "../client";
 import {
   normalizeDisplayFormatGuid,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type { DisplayFormat, DisplayFormatColumn } from "../developer/types";
@@ -40,26 +42,16 @@ export type { DisplayFormat, DisplayFormatColumn };
 
 // Re-export shared GUID helpers so Content Explorer callers (and tests) share
 // one implementation with the Developer API.
-export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
+export {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  resolveDisplayFormatObjectGuid,
+  unwrapDisplayFormat,
+  unwrapDisplayFormatList,
+};
 
 function asArray(payload: unknown): DisplayFormat[] {
-  if (payload == null) return [];
-  let rawList: unknown[] = [];
-  if (Array.isArray(payload)) {
-    rawList = payload;
-  } else if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    const raw =
-      obj.DisplayFormat ??
-      obj.displayFormat ??
-      obj.DisplayFormatList ??
-      obj.displayFormatList;
-    if (raw == null) return [];
-    rawList = Array.isArray(raw) ? raw : [raw];
-  } else {
-    return [];
-  }
-  return rawList.map((item) => unwrapDisplayFormat(item));
+  return unwrapDisplayFormatList(payload);
 }
 
 export function normalizeDisplayFormatColumns(

--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -41,9 +41,26 @@ export type CreateAclOwner = {
  *
  * <p>Returns the design-time ACL for a securable object. 404 when no ACL exists.
  */
+/**
+ * Unwrap Jackson WRAP_ROOT_VALUE {@code {"Acl":{…}}} so ObjectAclSection can
+ * read entries. Flat bodies pass through (#3200 Display Format Object ACL).
+ */
+export function unwrapObjectAcl(payload: unknown): ObjectAcl {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.Acl ?? root.acl;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as ObjectAcl;
+  }
+  return payload as ObjectAcl;
+}
+
 export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
   const key = encodeURIComponent(objectGuid);
-  return get<ObjectAcl>(`${PATHS.ACLS}/object/${key}`);
+  const payload = await get<unknown>(`${PATHS.ACLS}/object/${key}`);
+  return unwrapObjectAcl(payload);
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
@@ -18,33 +18,24 @@ import { get } from "../client";
 import {
   normalizeDisplayFormatGuid,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type { DisplayFormat, DisplayFormatColumn } from "./types";
 
 // Re-export shared GUID helpers so existing developer imports keep working.
-export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
+export {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  resolveDisplayFormatObjectGuid,
+  unwrapDisplayFormat,
+  unwrapDisplayFormatList,
+};
 
 function asArray(payload: unknown): DisplayFormat[] {
-  if (payload == null) return [];
-  let rawList: unknown[] = [];
-  if (Array.isArray(payload)) {
-    rawList = payload;
-  } else if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    const raw =
-      obj.DisplayFormat ??
-      obj.displayFormat ??
-      obj.DisplayFormatList ??
-      obj.displayFormatList;
-    if (raw == null) return [];
-    rawList = Array.isArray(raw) ? raw : [raw];
-  } else {
-    return [];
-  }
-  // Normalize each element (Jackson may wrap list items or omit guid.stringValue).
-  return rawList.map((item) => unwrapDisplayFormat(item));
+  return unwrapDisplayFormatList(payload);
 }
 
 export function normalizeColumns(

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -400,6 +400,8 @@ export interface DisplayFormatColumn {
 /** CX display format (UI-05). */
 export interface DisplayFormat {
   guid?: RestGuid;
+  /** Plain host-type-uuid from adaptor when nested Guid is hard to bind (#3200). */
+  guidString?: string;
   name?: string;
   label?: string;
   displayName?: string;

--- a/WebUI/src/main/ts/api/displayFormatGuid.ts
+++ b/WebUI/src/main/ts/api/displayFormatGuid.ts
@@ -16,7 +16,7 @@
 
 /**
  * Shared Display Format GUID wire helpers used by both Developer and Content
- * Explorer {@code displayFormatsApi} modules (issues #2689 / #2951).
+ * Explorer {@code displayFormatsApi} modules (issues #2689 / #2951 / #3200).
  *
  * <p>Keep a single implementation so synthesis / nested-Guid rules cannot drift
  * between the two REST clients.
@@ -25,11 +25,56 @@
 import type { DisplayFormat, RestGuid } from "./developer/types";
 
 /**
+ * {@code PSTypeEnum.DISPLAY_FORMAT} numeric type. Used only when the wire
+ * omits Guid parts but still has {@code displayId}.
+ */
+export const DISPLAY_FORMAT_TYPE = 31;
+
+function firstNonBlankString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
+function readOptionalLikeString(value: unknown): string | undefined {
+  const direct = firstNonBlankString(value);
+  if (direct) {
+    return direct;
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return readOptionalLikeString(value[0]);
+  }
+  if (value != null && typeof value === "object") {
+    const opt = value as Record<string, unknown>;
+    return (
+      firstNonBlankString(opt.value) ||
+      firstNonBlankString(opt.stringValue) ||
+      firstNonBlankString(opt.present === true ? opt.value : undefined)
+    );
+  }
+  return undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Extract a usable object GUID string from REST Guid wire shapes.
  *
  * <p>Handles plain strings, {@code { stringValue }}, nested {@code { Guid: … }}
- * wraps, and synthesis from {@code hostId-type-uuid} when {@code stringValue} is
- * missing (issue #2951 residual after #2689 root unwrap).
+ * wraps, Optional-like objects, snake_case aliases, and synthesis from
+ * {@code hostId-type-uuid} when {@code stringValue} is missing
+ * (issues #2951 / #3200).
  */
 export function objectGuidString(guid: unknown): string | undefined {
   if (guid == null) {
@@ -44,32 +89,29 @@ export function objectGuidString(guid: unknown): string | undefined {
   }
 
   let g = guid as Record<string, unknown>;
-  // Nested root-style wrap (rare): { Guid: { stringValue / parts } }
   const nestedGuid = g.Guid ?? g.guid;
   if (
     nestedGuid != null &&
     typeof nestedGuid === "object" &&
     !Array.isArray(nestedGuid) &&
     g.stringValue == null &&
+    g.string_value == null &&
     g.hostId == null &&
+    g.host_id == null &&
     g.uuid == null
   ) {
     g = nestedGuid as Record<string, unknown>;
   }
 
-  const sv = g.stringValue;
-  if (typeof sv === "string" && sv.trim()) {
-    return sv.trim();
-  }
-  // Accidental Optional-like object (defensive)
-  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
-    const opt = sv as Record<string, unknown>;
-    if (typeof opt.value === "string" && opt.value.trim()) {
-      return opt.value.trim();
-    }
+  const fromString =
+    readOptionalLikeString(g.stringValue) ||
+    readOptionalLikeString(g.string_value) ||
+    readOptionalLikeString(g.STRING_VALUE);
+  if (fromString) {
+    return fromString;
   }
 
-  const hostId = g.hostId;
+  const hostId = g.hostId ?? g.host_id;
   const type = g.type;
   const uuid = g.uuid;
   const hostOk = typeof hostId === "number" || typeof hostId === "string";
@@ -83,22 +125,68 @@ export function objectGuidString(guid: unknown): string | undefined {
 }
 
 /**
+ * Synthesize {@code 0-31-{displayId}} when the server omitted Guid but still
+ * sent the native display format id ({@link DISPLAY_FORMAT_TYPE}).
+ */
+export function synthesizeDisplayFormatGuidFromDisplayId(
+  displayId: unknown,
+): string | undefined {
+  const n = asFiniteNumber(displayId);
+  if (n == null || n <= 0) {
+    return undefined;
+  }
+  return `0-${DISPLAY_FORMAT_TYPE}-${n}`;
+}
+
+/**
+ * Resolve the GUID the Developer detail header / Object ACL should use.
+ *
+ * <p>Order: nested Guid → plain {@code guidString} → catalog list fallback →
+ * {@code displayId} synthesis. Never returns a blank string.
+ */
+export function resolveDisplayFormatObjectGuid(
+  df: DisplayFormat | null | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  if (df != null) {
+    const fromGuid = objectGuidString(df.guid);
+    if (fromGuid) {
+      return fromGuid;
+    }
+    const fromPlain = firstNonBlankString(df.guidString);
+    if (fromPlain) {
+      return fromPlain;
+    }
+  }
+  const fromCatalog = firstNonBlankString(catalogGuid);
+  if (fromCatalog) {
+    return fromCatalog;
+  }
+  return synthesizeDisplayFormatGuidFromDisplayId(df?.displayId);
+}
+
+/**
  * Ensure {@link DisplayFormat.guid}.stringValue is populated when the wire
- * Guid only carried numeric parts (or was a plain string).
+ * Guid only carried numeric parts (or was a plain string). Also copies
+ * {@code guidString} when that is the only usable form (#3200).
  */
 export function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
-  const gs = objectGuidString(df.guid);
+  const gs =
+    objectGuidString(df.guid) ||
+    firstNonBlankString(df.guidString) ||
+    synthesizeDisplayFormatGuidFromDisplayId(df.displayId);
   if (!gs) {
     return df;
   }
+  const nextGuidString = firstNonBlankString(df.guidString) || gs;
   if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
     const existing = df.guid as RestGuid;
-    if (existing.stringValue === gs) {
+    if (existing.stringValue === gs && df.guidString === nextGuidString) {
       return df;
     }
-    return { ...df, guid: { ...existing, stringValue: gs } };
+    return { ...df, guidString: nextGuidString, guid: { ...existing, stringValue: gs } };
   }
-  return { ...df, guid: { stringValue: gs } };
+  return { ...df, guidString: nextGuidString, guid: { stringValue: gs } };
 }
 
 /**
@@ -129,8 +217,58 @@ export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
       body = root as DisplayFormat;
     }
   } else {
-    // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
     body = root as DisplayFormat;
   }
   return normalizeDisplayFormatGuid(body);
+}
+
+function looksLikeDisplayFormat(obj: Record<string, unknown>): boolean {
+  return (
+    obj.name != null ||
+    obj.internalName != null ||
+    obj.guid != null ||
+    obj.guidString != null ||
+    obj.displayId != null ||
+    obj.label != null
+  );
+}
+
+function flattenDisplayFormatPayload(payload: unknown): unknown[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    const out: unknown[] = [];
+    for (const item of payload) {
+      out.push(...flattenDisplayFormatPayload(item));
+    }
+    return out;
+  }
+  if (typeof payload !== "object") {
+    return [];
+  }
+  const obj = payload as Record<string, unknown>;
+  const listWrap = obj.DisplayFormatList ?? obj.displayFormatList;
+  if (listWrap != null) {
+    return flattenDisplayFormatPayload(listWrap);
+  }
+  const nested = obj.DisplayFormat ?? obj.displayFormat;
+  if (Array.isArray(nested)) {
+    return flattenDisplayFormatPayload(nested);
+  }
+  if (nested != null && typeof nested === "object") {
+    return flattenDisplayFormatPayload(nested);
+  }
+  if (looksLikeDisplayFormat(obj)) {
+    return [obj];
+  }
+  return [];
+}
+
+/**
+ * Unwrap list envelopes: bare array, {@code DisplayFormat:[…]}, nested
+ * {@code DisplayFormatList:{DisplayFormat:[…]}} (#3200).
+ */
+export function unwrapDisplayFormatList(payload: unknown): DisplayFormat[] {
+  return flattenDisplayFormatPayload(payload).map((item) => unwrapDisplayFormat(item));
 }

--- a/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState } from "react";
 import {
   getDisplayFormatDetail,
   normalizeColumns,
-  objectGuidString,
+  resolveDisplayFormatObjectGuid,
 } from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
@@ -58,11 +58,8 @@ export function DisplayFormatDetailPanel({
 
   const columns =
     detail != null ? normalizeColumns(detail.columns) : [];
-  // Prefer detail GUID (after unwrap/normalize); fall back to catalog list GUID.
-  const objectGuid =
-    (detail != null ? objectGuidString(detail.guid) : undefined) ||
-    (catalogGuid && catalogGuid.trim() ? catalogGuid.trim() : undefined) ||
-    undefined;
+  // Prefer detail GUID (unwrap / guidString / displayId); then catalog list GUID.
+  const objectGuid = resolveDisplayFormatObjectGuid(detail, catalogGuid);
 
   return (
     <div data-testid="developer-df-detail">

--- a/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   listDisplayFormats,
   normalizeColumns,
-  objectGuidString,
+  resolveDisplayFormatObjectGuid,
 } from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
@@ -70,11 +70,11 @@ export function DisplayFormatsPanel(): React.ReactElement {
   }, [items]);
 
   const openFormat = (f: DisplayFormat) => {
-    const idOrName = f.name || f.internalName || objectGuidString(f.guid) || "";
+    const idOrName = f.name || f.internalName || resolveDisplayFormatObjectGuid(f) || "";
     if (!idOrName) return;
     setSelected({
       idOrName,
-      catalogGuid: objectGuidString(f.guid),
+      catalogGuid: resolveDisplayFormatObjectGuid(f),
     });
   };
 
@@ -116,7 +116,7 @@ export function DisplayFormatsPanel(): React.ReactElement {
         ]}
         rows={sorted.map((f, index) => {
           const openKey =
-            f.name || f.internalName || objectGuidString(f.guid) || "";
+            f.name || f.internalName || resolveDisplayFormatObjectGuid(f) || "";
           const interactive = openKey.length > 0;
           const colCount = normalizeColumns(f.columns).length;
           const usage: string[] = [];
@@ -124,7 +124,7 @@ export function DisplayFormatsPanel(): React.ReactElement {
           if (f.validForViewsAndSearches) usage.push(DEV_MSG.DF_USAGE_VIEWS);
           if (f.validForRelatedContent) usage.push(DEV_MSG.DF_USAGE_RELATED);
           return {
-            key: objectGuidString(f.guid) || f.name || `df-${index}`,
+            key: resolveDisplayFormatObjectGuid(f) || f.name || `df-${index}`,
             onClick: interactive ? () => openFormat(f) : undefined,
             cells: [
               interactive ? (

--- a/WebUI/src/test/ts/api/developer/aclApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/aclApi.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAclForObject, unwrapObjectAcl } from "../../../../main/ts/api/developer/aclApi";
+
+describe("unwrapObjectAcl", () => {
+  it("unwraps Jackson Acl root so entries are reachable (#3200)", () => {
+    const acl = unwrapObjectAcl({
+      Acl: {
+        id: 7,
+        name: "By_Author ACL",
+        aclEntries: [{ name: "Admin", type: { type: "ROLE" } }],
+      },
+    });
+    expect(acl.id).toBe(7);
+    expect(acl.name).toBe("By_Author ACL");
+    expect(Array.isArray(acl.aclEntries)).toBe(true);
+  });
+
+  it("passes through flat ACL bodies", () => {
+    const flat = { id: 1, name: "x", aclEntries: [] };
+    expect(unwrapObjectAcl(flat)).toEqual(flat);
+  });
+});
+
+describe("getAclForObject", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("unwraps wrapped GET /acls/object/{guid} body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            Acl: { id: 9, name: "df", aclEntries: [{ name: "Default" }] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+    const acl = await getAclForObject("0-31-5");
+    expect(acl.id).toBe(9);
+    expect(acl.name).toBe("df");
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -112,7 +112,10 @@ describe("unwrapDisplayFormat", () => {
       name: "FolderList",
       guid: { stringValue: "0-11-2" },
     };
-    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+    expect(unwrapDisplayFormat(flat)).toEqual({
+      ...flat,
+      guidString: "0-11-2",
+    });
   });
 
   it("takes first element when envelope holds a singleton array", () => {

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -19,7 +19,9 @@ import {
   getDisplayFormatDetail,
   listDisplayFormats,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../../../../main/ts/api/developer/displayFormatsApi";
 
 describe("objectGuidString", () => {
@@ -48,6 +50,23 @@ describe("objectGuidString", () => {
     expect(objectGuidString(undefined)).toBeUndefined();
     expect(objectGuidString({})).toBeUndefined();
     expect(objectGuidString("")).toBeUndefined();
+  });
+
+  it("reads Optional-like and snake_case stringValue (#3200)", () => {
+    expect(objectGuidString({ stringValue: { value: "0-31-8" } })).toBe("0-31-8");
+    expect(objectGuidString({ string_value: "0-31-7" })).toBe("0-31-7");
+  });
+});
+
+describe("resolveDisplayFormatObjectGuid", () => {
+  it("prefers nested guid then guidString then catalog then displayId (#3200)", () => {
+    expect(
+      resolveDisplayFormatObjectGuid({ guid: { stringValue: "0-31-1" }, displayId: 9 }),
+    ).toBe("0-31-1");
+    expect(resolveDisplayFormatObjectGuid({ guidString: "0-31-2", displayId: 9 })).toBe("0-31-2");
+    expect(resolveDisplayFormatObjectGuid({ displayId: 9 }, " 0-31-3 ")).toBe("0-31-3");
+    expect(resolveDisplayFormatObjectGuid({ displayId: 9 })).toBe("0-31-9");
+    expect(resolveDisplayFormatObjectGuid({}, undefined)).toBeUndefined();
   });
 });
 
@@ -109,6 +128,31 @@ describe("unwrapDisplayFormat", () => {
     expect(unwrapDisplayFormat(undefined)).toEqual({});
     expect(unwrapDisplayFormat("x")).toEqual({});
     expect(unwrapDisplayFormat([])).toEqual({});
+  });
+
+  it("copies guidString onto guid.stringValue (#3200)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: { name: "By_Author", guidString: "0-31-4" },
+    });
+    expect(unwrapped.guidString).toBe("0-31-4");
+    expect(unwrapped.guid?.stringValue).toBe("0-31-4");
+  });
+});
+
+describe("unwrapDisplayFormatList", () => {
+  it("flattens nested DisplayFormatList envelope (#3200)", () => {
+    const list = unwrapDisplayFormatList({
+      DisplayFormatList: {
+        DisplayFormat: [
+          { name: "By_Author", guid: { hostId: 0, type: 31, uuid: 5 } },
+          { name: "Default", displayId: 2 },
+        ],
+      },
+    });
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe("By_Author");
+    expect(list[0].guid?.stringValue).toBe("0-31-5");
+    expect(list[1].guid?.stringValue).toBe("0-31-2");
   });
 });
 

--- a/WebUI/src/test/ts/api/displayFormatGuid.test.ts
+++ b/WebUI/src/test/ts/api/displayFormatGuid.test.ts
@@ -62,9 +62,22 @@ describe("normalizeDisplayFormatGuid", () => {
     expect(out.guid?.uuid).toBe(301);
   });
 
-  it("returns same reference when stringValue already matches", () => {
-    const df = { name: "x", guid: { stringValue: "0-11-1", uuid: 1 } };
+  it("returns same reference when stringValue and guidString already match", () => {
+    const df = {
+      name: "x",
+      guid: { stringValue: "0-11-1", uuid: 1 },
+      guidString: "0-11-1",
+    };
     expect(normalizeDisplayFormatGuid(df)).toBe(df);
+  });
+
+  it("fills guidString from guid when companion is missing (#3200)", () => {
+    const out = normalizeDisplayFormatGuid({
+      name: "x",
+      guid: { stringValue: "0-11-1", uuid: 1 },
+    });
+    expect(out.guidString).toBe("0-11-1");
+    expect(out.guid?.stringValue).toBe("0-11-1");
   });
 });
 
@@ -110,7 +123,10 @@ describe("unwrapDisplayFormat", () => {
       name: "FolderList",
       guid: { stringValue: "0-11-2" },
     };
-    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+    expect(unwrapDisplayFormat(flat)).toEqual({
+      ...flat,
+      guidString: "0-11-2",
+    });
   });
 
   it("takes first element when envelope holds a singleton array", () => {

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -397,17 +397,22 @@ vi.mock("../../../main/ts/api/developer/itemFiltersApi", () => ({
   }),
 }));
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn().mockResolvedValue([
-    { name: "Default", label: "Default View", columns: [] },
-  ]),
-  getDisplayFormatDetail: vi.fn().mockResolvedValue({
-    name: "Default",
-    columns: [],
-  }),
-  normalizeColumns: () => [],
-  objectGuidString: () => undefined,
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn().mockResolvedValue([
+      { name: "Default", label: "Default View", columns: [] },
+    ]),
+    getDisplayFormatDetail: vi.fn().mockResolvedValue({
+      name: "Default",
+      columns: [],
+    }),
+    normalizeColumns: () => [],
+  };
+});
 
 vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({
   listActionMenus: vi.fn().mockResolvedValue([

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -10,27 +10,17 @@ import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormat
 import { DisplayFormatDetailPanel } from "../../../main/ts/developer/DisplayFormatDetailPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn(),
-  getDisplayFormatDetail: vi.fn(),
-  normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
-  objectGuidString: (guid: unknown) => {
-    if (guid == null) return undefined;
-    if (typeof guid === "string") {
-      const t = guid.trim();
-      return t || undefined;
-    }
-    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
-    const g = guid as { stringValue?: string; hostId?: number; type?: number; uuid?: number };
-    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
-      return g.stringValue.trim();
-    }
-    if (g.hostId != null && g.type != null && g.uuid != null) {
-      return `${g.hostId}-${g.type}-${g.uuid}`;
-    }
-    return undefined;
-  },
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn(),
+    getDisplayFormatDetail: vi.fn(),
+    normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  };
+});
 
 // ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
 vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
@@ -117,6 +107,39 @@ describe("DisplayFormatDetailPanel", () => {
     expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-11-5");
     expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
       "0-11-5",
+    );
+  });
+
+  it("uses guidString when nested guid is absent (#3200)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: "0-31-9",
+    });
+    render(<DisplayFormatDetailPanel idOrName="By_Author" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-31-9");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-31-9",
+    );
+  });
+
+  it("synthesizes GUID from displayId when guid is omitted (#3200)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: undefined,
+      displayId: 12,
+    });
+    render(<DisplayFormatDetailPanel idOrName="By_Author" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-31-12");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-31-12",
     );
   });
 

--- a/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
@@ -10,24 +10,17 @@ import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormat
 import { DisplayFormatsPanel } from "../../../main/ts/developer/DisplayFormatsPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn(),
-  getDisplayFormatDetail: vi.fn(),
-  normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
-  objectGuidString: (guid: unknown) => {
-    if (guid == null) return undefined;
-    if (typeof guid === "string") {
-      const t = guid.trim();
-      return t || undefined;
-    }
-    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
-    const g = guid as { stringValue?: string };
-    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
-      return g.stringValue.trim();
-    }
-    return undefined;
-  },
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn(),
+    getDisplayFormatDetail: vi.fn(),
+    normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  };
+});
 
 const listDisplayFormats = displayFormatsApi.listDisplayFormats as ReturnType<typeof vi.fn>;
 const getDisplayFormatDetail = displayFormatsApi.getDisplayFormatDetail as ReturnType<

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -361,8 +361,16 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     });
     if (!opened) return;
 
-    // Issue #2951: detail header must render a real GUID (not em-dash) so
-    // ObjectAclSection receives objectGuid — catalog fallback + wire normalize.
+    await assertDisplayFormatDetailGuidAndAcl(page);
+  });
+
+  /**
+   * Issue #3200 / #2951 / #2689: header GUID is real; Object ACL is table,
+   * empty-create, or a real ACL error — never the no-guid shell when the
+   * server has a display format id.
+   * @param {import('@playwright/test').Page} page
+   */
+  async function assertDisplayFormatDetailGuidAndAcl(page) {
     const guidCell = page.locator('[data-testid="developer-df-detail-guid"]');
     await expect(guidCell).toBeVisible({ timeout: 15_000 });
     const guidText = (await guidCell.innerText()).trim();
@@ -370,7 +378,6 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       guidText && guidText !== "—" && guidText !== "-",
       `display-format detail GUID must be synthesized/normalized (got "${guidText}")`,
     ).toBeTruthy();
-    // host-type-uuid wire form or other non-empty string from REST
     expect(guidText.length).toBeGreaterThan(2);
 
     const mode = await assertLayeredObjectAcl(
@@ -378,12 +385,63 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       "developer-df-acl",
       "display-format",
     );
-    // Issue #2689: detail client must unwrap Jackson DisplayFormat root so
-    // objectGuid is present — no-guid shell is a product defect for DF detail.
     expect(
       ["table", "empty"],
       `display-format Object ACL must load with GUID (got mode=${mode})`,
     ).toContain(mode);
+  }
+
+  test("By_Author and one peer Display Format show GUID and Object ACL (#3200)", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("display-formats"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-display-formats"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const panel = page.locator('[data-testid="developer-df-panel"]');
+    const empty = page.locator('[data-testid="developer-df-empty"]');
+    const error = page.locator('[data-testid="developer-df-error"]');
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+    if (await error.isVisible()) {
+      throw new Error(`display formats catalog error: ${(await error.innerText()).trim()}`);
+    }
+    if (await empty.isVisible()) {
+      test.skip(true, "No display formats in CMS");
+      return;
+    }
+
+    const openButtons = page.locator('[data-testid="developer-df-open"]');
+    const count = await openButtons.count();
+    expect(count, "catalog should list at least one display format").toBeGreaterThan(0);
+
+    const names = [];
+    for (let i = 0; i < count; i++) {
+      names.push((await openButtons.nth(i).innerText()).trim());
+    }
+    const byAuthor = names.find((n) => /^By_Author$/i.test(n));
+    const peer = names.find((n) => n && n !== byAuthor);
+    const toOpen = [byAuthor, peer].filter(Boolean);
+    expect(
+      toOpen.length,
+      `need By_Author and/or a peer in catalog (got ${names.join(", ")})`,
+    ).toBeGreaterThan(0);
+
+    for (const name of toOpen) {
+      await page.locator('[data-testid="developer-df-open"]', { hasText: name }).click();
+      await expect(page.locator('[data-testid="developer-df-detail"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await assertDisplayFormatDetailGuidAndAcl(page);
+      await page.locator('[data-testid="developer-df-back"]').click();
+      await expect(page.locator('[data-testid="developer-df-panel"]')).toBeVisible({
+        timeout: 15_000,
+      });
+    }
   });
 
   test("preferences default ACL template shows Design/Runtime column groups", async ({

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -179,7 +179,11 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   }
 
   await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-  await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+  const aclNoEntries = page.locator(`[data-testid="${prefix}-no-entries"]`);
+  await aclSection.scrollIntoViewIfNeeded().catch(() => {});
+  await expect(
+    aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+  ).toBeVisible({
     timeout: 30_000,
   });
 
@@ -190,6 +194,11 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
 
   if (await aclEmpty.isVisible()) {
     // Create-first empty state still proves mount + kind on section
+    await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
+    return "empty";
+  }
+
+  if (await aclNoEntries.isVisible()) {
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
     return "empty";
   }

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -44,7 +44,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
-- [Users, roles & security](id:admin-users-roles)
+- [Users, roles & security](id:admin-users-roles) (includes Developer Display Format Object ACL)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,24 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Design-object ACL (Developer)
+
+System Definition (**Developer**) shows an **Object ACL** section on securable design
+objects, including **Display Formats**.
+
+1. Open **Developer → Display Formats**.
+2. Open a format such as **By_Author** (or any other listed format).
+3. The detail header **GUID** field shows the object GUID when the server has one
+   (never a silent dash when a GUID exists).
+4. **Object ACL** below the column list:
+   - Shows the ACL table when entries exist.
+   - Shows an empty create path when the object has no ACL yet.
+   - Shows an explicit load error if the ACL service fails.
+   - Does **not** say “Object GUID not available” when the header GUID is present.
+
+Use this section to inspect design-time and runtime visibility permissions for that
+display format. Site Object ACL is a separate surface (Sites detail).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -138,6 +138,23 @@ These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They 
 writable via `PUT` — rule write/save and full control property editors remain Workbench /
 future design APIs. `designGaps` on detail still calls out write and catalog gaps.
 
+## Display formats (design catalog)
+
+Content Explorer **display format** definitions (Developer **Display Formats**) are exposed
+under `/services/displayformats`. Responses include a nested `guid` object and a plain
+`guidString` (`host-type-uuid`) so clients can load **Object ACL** via
+`GET /services/acls/object/{guid}`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/displayformats` | List formats (optional `validForFolder` / `validForViewsAndSearches`) |
+| `GET` | `/services/displayformats/{idOrName}` | Load one format by internal name or GUID string |
+
+JSON may wrap the list as `DisplayFormatList` and a single item as `DisplayFormat`. Integrators
+should read `guid.stringValue` or `guidString` (never assume the GUID is missing when
+`displayId` is present). See [Users, roles & security](id:admin-users-roles) for the operator
+Object ACL steps.
+
 ## Views (design catalog)
 
 Content Explorer **view** definitions (Workbench / Developer **Views**, UI-07) are exposed under

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -27,6 +27,8 @@ import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.rest.Guid;
 import com.percussion.rest.displayformat.*;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
@@ -114,10 +116,32 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     ret.setDescription(f.getDescription());
     ret.setDisplayName(f.getDisplayName());
     // Always map GUID so Developer detail / Object ACL can bind objectGuid
-    // (issues #2689 / #2951). PSDisplayFormat#getGUID is expected non-null for
-    // persisted formats; copyGuid still accepts null defensively.
-    ret.setGuid(copyGuid(f.getGUID()));
+    // (issues #2689 / #2951 / #3200). PSDisplayFormat#getGUID is expected
+    // non-null for persisted formats; copyGuid still accepts null defensively.
+    Guid mapped = copyGuid(f.getGUID());
+    ret.setGuid(mapped);
+    ret.setGuidString(plainGuidString(mapped, f.getDisplayId()));
     return ret;
+  }
+
+  /**
+   * Plain {@code host-type-uuid} for SPA binding when nested Guid JSON is hard to read.
+   *
+   * @param mapped REST Guid from {@link #copyGuid}; may be null
+   * @param displayId native display id; used when mapped string is blank
+   * @return wire string, or {@code null} when neither source has a usable id
+   */
+  private static String plainGuidString(Guid mapped, int displayId) {
+    if (mapped != null && mapped.getStringValue().isPresent()) {
+      String sv = mapped.getStringValue().get();
+      if (sv != null && !sv.isBlank()) {
+        return sv.trim();
+      }
+    }
+    if (displayId > 0) {
+      return new PSGuid(PSTypeEnum.DISPLAY_FORMAT, displayId).toString();
+    }
+    return null;
   }
 
   /**
@@ -187,13 +211,15 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
   @Override
   public DisplayFormat findDisplayFormat(IPSGuid id)
       throws PSCmsException, PSUnknownNodeTypeException {
-    return copyDisplayFormat(designWs.findDisplayFormat(id));
+    PSDisplayFormat f = designWs.findDisplayFormat(id);
+    return f == null ? null : copyDisplayFormat(f);
   }
 
   @Override
   public DisplayFormat findDisplayFormat(String name)
       throws PSCmsException, PSUnknownNodeTypeException {
-    return copyDisplayFormat(designWs.findDisplayFormat(name));
+    PSDisplayFormat f = designWs.findDisplayFormat(name);
+    return f == null ? null : copyDisplayFormat(f);
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
@@ -7,6 +7,7 @@ package com.percussion.apibridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -67,5 +68,14 @@ class DisplayFormatAdaptorSafeKeyTest {
     // PSGuid#toString form host-type-uuid; uuid part is display id 301
     assertTrue(sv.endsWith("-301"), "unexpected guid form: " + sv);
     assertEquals(301, out.getGuid().getUuid());
+    assertEquals(sv, out.getGuidString(), "guidString must match guid.stringValue for SPA bind");
+  }
+
+  @Test
+  void findDisplayFormatByKey_returnsNullWhenDesignWsMisses() throws Exception {
+    IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
+    when(designWs.findDisplayFormat(eq("Missing"))).thenReturn(null);
+    DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
+    assertNull(adaptor.findDisplayFormatByKey("Missing"));
   }
 }

--- a/rest/src/main/java/com/percussion/rest/Guid.java
+++ b/rest/src/main/java/com/percussion/rest/Guid.java
@@ -17,7 +17,9 @@
 
 package com.percussion.rest;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.services.guidmgr.data.PSGuid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -29,6 +31,12 @@ import java.util.Optional;
 @Schema(description = "Guid")
 public class Guid {
 
+  /**
+   * Serialized as a plain JSON string via the field (not {@link #getStringValue()}). The Optional
+   * getter is for Java callers; Jackson must not emit Optional as an object or the SPA cannot bind
+   * Object ACL (#3200 / #2951).
+   */
+  @JsonProperty("stringValue")
   @Schema(
       name = "stringValue",
       description =
@@ -120,10 +128,12 @@ public class Guid {
     this.longValue = longValue;
   }
 
+  @JsonIgnore
   public Optional<String> getStringValue() {
     return Optional.ofNullable(stringValue);
   }
 
+  @JsonProperty("stringValue")
   public void setStringValue(String stringValue) {
     this.stringValue = stringValue;
   }

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
@@ -31,6 +31,13 @@ public class DisplayFormat {
   @Schema(description = "The global unique id for this item.")
   private Guid guid;
 
+  /**
+   * Plain {@code host-type-uuid} string for SPA Object ACL binding when nested {@link Guid}
+   * Optional/wrap shapes are hard to read (#3200). Always set by the adaptor when a GUID exists.
+   */
+  @Schema(description = "Plain GUID string (host-type-uuid) for Object ACL and detail header.")
+  private String guidString;
+
   @Schema(description = "The name of this Display Format")
   private String name;
 
@@ -74,6 +81,14 @@ public class DisplayFormat {
 
   public void setGuid(Guid guid) {
     this.guid = guid;
+  }
+
+  public String getGuidString() {
+    return guidString;
+  }
+
+  public void setGuidString(String guidString) {
+    this.guidString = guidString;
   }
 
   public String getName() {
@@ -200,6 +215,7 @@ public class DisplayFormat {
         && validForFolder == that.validForFolder
         && displayId == that.displayId
         && Objects.equals(guid, that.guid)
+        && Objects.equals(guidString, that.guidString)
         && Objects.equals(name, that.name)
         && Objects.equals(label, that.label)
         && Objects.equals(sortedColumnNames, that.sortedColumnNames)
@@ -216,6 +232,7 @@ public class DisplayFormat {
   public int hashCode() {
     return Objects.hash(
         guid,
+        guidString,
         name,
         label,
         validForRelatedContent,
@@ -239,6 +256,9 @@ public class DisplayFormat {
     return "DisplayFormat{"
         + "guid="
         + guid
+        + ", guidString='"
+        + guidString
+        + '\''
         + ", name='"
         + name
         + '\''

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -87,10 +87,10 @@ public class DisplayFormatResource {
     try {
       List<DisplayFormat> list = requireAdaptor().findAllDisplayFormats();
       if (list == null || list.isEmpty()) {
-        return List.of();
+        return new DisplayFormatList();
       }
       if (validForFolder == null && validForViewsAndSearches == null) {
-        return list;
+        return asDisplayFormatList(list);
       }
       List<DisplayFormat> filtered = new ArrayList<>(list.size());
       for (DisplayFormat df : list) {
@@ -111,7 +111,7 @@ public class DisplayFormatResource {
         }
         filtered.add(df);
       }
-      return filtered;
+      return asDisplayFormatList(filtered);
     } catch (WebApplicationException e) {
       throw e;
     } catch (Exception e) {
@@ -147,6 +147,17 @@ public class DisplayFormatResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  /**
+   * Return a {@link DisplayFormatList} so Jackson uses this package's {@code
+   * JacksonContextResolver} (WRAP_ROOT_VALUE) instead of a raw {@code ArrayList} mapper.
+   */
+  private static DisplayFormatList asDisplayFormatList(List<DisplayFormat> list) {
+    if (list instanceof DisplayFormatList displayFormatList) {
+      return displayFormatList;
+    }
+    return new DisplayFormatList(list);
   }
 
   private IDisplayFormatAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/GuidTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidTest.java
@@ -18,10 +18,12 @@
 package com.percussion.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Behavioral tests for {@link Guid} construction after the this-escape real fix (direct field
@@ -45,6 +47,19 @@ class GuidTest {
   @Test
   void stringConstructorRejectsNull() {
     assertThrows(NullPointerException.class, () -> new Guid(null));
+  }
+
+  @Test
+  void jacksonSerializesStringValueAsJsonString() {
+    Guid guid = new Guid("0-31-12");
+    ObjectMapper mapper = new JacksonContextResolver().getContext(Guid.class);
+    String json = mapper.writeValueAsString(guid);
+    assertTrue(
+        json.contains("\"stringValue\":\"0-31-12\"")
+            || json.contains("\"stringValue\" : \"0-31-12\""),
+        json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertFalse(json.contains("Optional["), json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -54,6 +54,7 @@ public class DisplayFormatResourceTest {
     List<DisplayFormat> out = resource.listDisplayFormats(null, null);
     assertEquals(1, out.size());
     assertEquals("Default", out.get(0).getName());
+    assertInstanceOf(DisplayFormatList.class, out);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -70,6 +70,25 @@ public class TestDisplayFormat {
     assertTrue(
         json.contains("\"guid\":{") || json.contains("\"guid\" : {"),
         "guid should be a nested object, not re-wrapped: " + json);
+    // #3200: stringValue must be a JSON string, not an Optional object
+    assertTrue(
+        json.contains("\"stringValue\":\"0-11-5\"") || json.contains("\"stringValue\" : \"0-11-5\""),
+        "stringValue must serialize as a JSON string: " + json);
+  }
+
+  @Test
+  public void jacksonContextResolver_serializesGuidStringCompanion() {
+    DisplayFormat f = new DisplayFormat();
+    f.setName("By_Author");
+    f.setGuid(new Guid("0-31-5"));
+    f.setGuidString("0-31-5");
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(DisplayFormat.class);
+    String json = mapper.writeValueAsString(f);
+
+    assertTrue(
+        json.contains("\"guidString\":\"0-31-5\"") || json.contains("\"guidString\" : \"0-31-5\""),
+        json);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes remaining Developer **Display Format** detail GUID / Object ACL bind after #2951 / PR #2967 (QA #2726 still Failed).

Root causes:
1. `Guid.getStringValue()` is `Optional<String>` — Jackson must emit a **JSON string**, not an Optional bean.
2. List `ArrayList` bypassed `JacksonContextResolver`; now returns `DisplayFormatList`.
3. SPA bind now uses `guid.stringValue` → **`guidString`** (adaptor plain string) → catalog GUID → `displayId` synthesis (`0-31-{id}`).
4. Nested `DisplayFormatList` envelopes flattened.
5. `GET /acls/object/{guid}` unwraps Jackson `{Acl:…}` so Object ACL table / empty / no-entries can render.

Live QA H2 screenshot-class evidence: **By Author** header shows **GUID `0-31-5`** (not em dash). Playwright display-format product path **passed** after hot-deploy.

Does **not** rewrite site Object ACL (#3203) or Design/Runtime prefs (#3204).

Fixes #3200

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest 2112 passed)
4. QA H2: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993`
5. Hot-deploy rest + sitemanage jars + WebUI `cm/modern/assets` into `perc-matrix-cms-h2`; restart once for jars
6. Login Admin → Developer → Display Formats → **By_Author** (and a peer)
7. Header GUID is `host-type-uuid` (e.g. `0-31-5`), not `—`
8. Object ACL is table, empty-create, no-entries, or explicit error — **not** "Object GUID not available"
9. `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js --grep display-format` — 1 passed

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/users-roles.md` Design-object ACL steps; `product-docs/8.2/developer/rest.md` displayformats `guidString`; admin index link
- [x] **Unit / module tests** — Guid JSON string, adaptor guidString, unwrapDisplayFormatList, resolveDisplayFormatObjectGuid, unwrapObjectAcl
- [x] **WebUI + Playwright** — `developer-object-acl-product-path.spec.js` DF GUID + ACL (no-guid rejected; no-entries accepted as loaded)
- [x] **Build gates** — standalone clean install rest, sitemanage, WebUI (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

## Pre-PR Maven evidence (C3)

- **modules_built:** rest, projects/sitemanage, WebUI
- **build_evidence:**
  - `cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS (Tests 2112 passed)
- **downstream_checked:** sitemanage standalone after rest install (adaptor + Guid consumers). No type made final; Guid Java getters unchanged (`@JsonIgnore` on Optional getter + field `@JsonProperty`).

## C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- deploy: docker cp rest + sitemanage jars to `WEB-INF/lib`; docker cp WebUI `cm/modern/assets`; `docker restart perc-matrix-cms-h2`; health `healthy` / login 200
- Playwright: `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js --grep display-format` → **1 passed** (7.8s)
- console-clean=yes (spec passed; no pageerror fail)
- server.log-clean=yes for DF GUID bind (prior mapped null on ACL convert is pre-existing adaptor path; DF header GUID proven `0-31-5`)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #3200 (QA residual of #2726 / #2951)

> Co-Authored by Grok Build using grok-4.5 with agent main.