### PR TITLE
fix(webui): persist Object ACL Design/Runtime prefs + product path (#3204)

### DIFF
--- a/WebUI/src/main/ts/api/developer/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/developer/preferencesApi.ts
@@ -16,8 +16,10 @@
  */
 
 import {
+  getAllUserPreferences,
   loadUserPreference,
   saveUserPreference,
+  unwrapUserPreference,
   type UserPreference,
 } from "../preferences/preferencesApi";
 import {
@@ -41,17 +43,67 @@ export type LoadDefaultAclTemplateResult = {
   fromPreference: boolean;
 };
 
+function isDefaultAclTemplatePref(pref: UserPreference): boolean {
+  return (
+    (pref.name || "").trim().toLowerCase() ===
+    DEFAULT_ACL_TEMPLATE_PREF_NAME.toLowerCase()
+  );
+}
+
+/**
+ * Parse a stored preference into a template. Accepts a JSON string or an
+ * already-parsed object so reload does not drop Runtime visibility (#3204).
+ */
+export function templateFromPreferenceValue(
+  pref: UserPreference | null | undefined,
+): DefaultAclTemplate | null {
+  if (!pref) {
+    return null;
+  }
+  const raw = pref.value as unknown;
+  if (raw == null || raw === "") {
+    return null;
+  }
+  if (typeof raw === "string") {
+    return parseDefaultAclTemplate(raw);
+  }
+  if (typeof raw === "object") {
+    return parseDefaultAclTemplate(raw as Record<string, unknown>);
+  }
+  return parseDefaultAclTemplate(String(raw));
+}
+
 /**
  * Load the Developer default ACL template preference, or system default.
+ *
+ * <p>GET {@code /preferences/{name}} is the primary path. When that returns
+ * 404, an empty value, or a body that production unwrap rejects as flat
+ * ({@code acceptFlat: false}), fall back to GET {@code /preferences/} so a
+ * successful Save still reloads Design/Runtime visibility (#2948 / #3204).
  */
 export async function loadDefaultAclTemplate(): Promise<LoadDefaultAclTemplateResult> {
-  const pref = await loadUserPreference(DEFAULT_ACL_TEMPLATE_PREF_NAME);
-  if (pref?.value) {
-    const parsed = parseDefaultAclTemplate(pref.value);
-    if (parsed) {
-      return { template: parsed, fromPreference: true };
+  const named = await loadUserPreference(DEFAULT_ACL_TEMPLATE_PREF_NAME);
+  const fromNamed = templateFromPreferenceValue(named);
+  if (fromNamed) {
+    return { template: fromNamed, fromPreference: true };
+  }
+
+  const listed = await getAllUserPreferences();
+  const match = listed.find(isDefaultAclTemplatePref);
+  const fromList = templateFromPreferenceValue(match);
+  if (fromList) {
+    return { template: fromList, fromPreference: true };
+  }
+
+  // Last resort: list item present but GET-by-name unwrap was too strict.
+  if (match) {
+    const loosened = unwrapUserPreference(match, { acceptFlat: true });
+    const fromLoose = templateFromPreferenceValue(loosened);
+    if (fromLoose) {
+      return { template: fromLoose, fromPreference: true };
     }
   }
+
   return { template: systemDefaultAclTemplate(), fromPreference: false };
 }
 

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -68,23 +68,57 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
-function asPreferenceArray(data: unknown): UserPreference[] {
-  if (Array.isArray(data)) {
-    return data.filter(isUserPreferenceShape);
+function collectPreferenceShapes(value: unknown): UserPreference[] {
+  if (Array.isArray(value)) {
+    return value.filter(isUserPreferenceShape);
   }
-  if (data != null && typeof data === "object") {
-    const root = data as Record<string, unknown>;
-    for (const key of [
-      "UserPreferenceList",
-      "userPreferenceList",
-      "list",
-      "items",
-    ]) {
-      const nested = root[key];
-      if (Array.isArray(nested)) {
-        return nested.filter(isUserPreferenceShape);
+  return [];
+}
+
+/**
+ * Normalize GET {@code /preferences/} payloads.
+ *
+ * <p>Jackson {@code WRAP_ROOT_VALUE} may emit a bare array, a
+ * {@code UserPreferenceList} array envelope, or a JAXB-style nested
+ * {@code { UserPreferenceList: { UserPreference: [...] } }}. Missing the
+ * nested form made list fallback miss {@code developer.defaultObjectAclTemplate}
+ * after Save (#3204 / #2643).
+ */
+function asPreferenceArray(data: unknown): UserPreference[] {
+  const direct = collectPreferenceShapes(data);
+  if (direct.length > 0) {
+    return direct;
+  }
+  const root = asRecord(data);
+  if (!root) {
+    return [];
+  }
+  for (const key of [
+    "UserPreferenceList",
+    "userPreferenceList",
+    "list",
+    "items",
+  ]) {
+    const nested = root[key];
+    const fromNested = collectPreferenceShapes(nested);
+    if (fromNested.length > 0) {
+      return fromNested;
+    }
+    const nestedObj = asRecord(nested);
+    if (nestedObj) {
+      for (const innerKey of ["UserPreference", "userPreference", "items", "list"]) {
+        const fromInner = collectPreferenceShapes(nestedObj[innerKey]);
+        if (fromInner.length > 0) {
+          return fromInner;
+        }
       }
     }
+  }
+  const fromRootItems = collectPreferenceShapes(
+    root.UserPreference ?? root.userPreference,
+  );
+  if (fromRootItems.length > 0) {
+    return fromRootItems;
   }
   return [];
 }

--- a/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
@@ -419,6 +419,8 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
                     <tr
                       key={r.clientKey}
                       data-testid={`developer-prefs-acl-row-${r.clientKey}`}
+                      data-acl-principal={r.name}
+                      data-acl-principal-type={r.type}
                       style={{
                         borderBottom: `1px solid ${catalogColors.softBorder}`,
                       }}

--- a/WebUI/src/main/ts/developer/defaultAclTemplate.ts
+++ b/WebUI/src/main/ts/developer/defaultAclTemplate.ts
@@ -122,16 +122,25 @@ function normalizeEntry(raw: unknown): DefaultAclTemplateEntry | null {
 /**
  * Parse a preference value into a template. Returns null when empty/invalid
  * (caller should fall back to {@link systemDefaultAclTemplate}).
+ *
+ * <p>Accepts a JSON string or an already-parsed object. Some GET paths leave
+ * {@code UserPreference.value} as a parsed object (or {@code String(obj)} would
+ * become {@code [object Object]} and drop Runtime visibility on reload).
  */
 export function parseDefaultAclTemplate(
-  raw: string | null | undefined,
+  raw: string | Record<string, unknown> | null | undefined,
 ): DefaultAclTemplate | null {
-  if (raw == null || !String(raw).trim()) return null;
+  if (raw == null) return null;
   let data: unknown;
-  try {
-    data = JSON.parse(String(raw));
-  } catch {
-    return null;
+  if (typeof raw === "object") {
+    data = raw;
+  } else {
+    if (!String(raw).trim()) return null;
+    try {
+      data = JSON.parse(String(raw));
+    } catch {
+      return null;
+    }
   }
   const o = asRecord(data);
   if (!o) return null;

--- a/WebUI/src/test/ts/api/developer/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/preferencesApi.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadDefaultAclTemplate,
+  templateFromPreferenceValue,
+} from "../../../../main/ts/api/developer/preferencesApi";
+import * as prefs from "../../../../main/ts/api/preferences/preferencesApi";
+import {
+  serializeDefaultAclTemplate,
+  systemDefaultAclTemplate,
+} from "../../../../main/ts/developer/defaultAclTemplate";
+
+const VISIBLE_TEMPLATE = (() => {
+  const t = systemDefaultAclTemplate();
+  t.entries[0].permissions = [
+    ...t.entries[0].permissions,
+    "RUNTIME_VISIBLE",
+  ];
+  return t;
+})();
+
+const VISIBLE_JSON = serializeDefaultAclTemplate(VISIBLE_TEMPLATE);
+
+describe("developer preferencesApi — default ACL template (#3204)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("templateFromPreferenceValue keeps RUNTIME_VISIBLE from JSON string", () => {
+    const parsed = templateFromPreferenceValue({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_JSON,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("templateFromPreferenceValue keeps RUNTIME_VISIBLE from parsed object value", () => {
+    const parsed = templateFromPreferenceValue({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_TEMPLATE as unknown as string,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("loadDefaultAclTemplate uses GET-by-name when value is present", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_JSON,
+    });
+    const listSpy = vi.spyOn(prefs, "getAllUserPreferences");
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(true);
+    expect(result.template.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to preference list when GET-by-name is empty (#3204)", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce(null);
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([
+      {
+        name: "developer.defaultObjectAclTemplate",
+        value: VISIBLE_JSON,
+      },
+    ]);
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(true);
+    expect(result.template.entries[0].name).toBe("Default");
+    expect(result.template.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("uses system default when neither GET-by-name nor list has a template", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce(null);
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([]);
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(false);
+    expect(result.template.entries[0].permissions).not.toContain(
+      "RUNTIME_VISIBLE",
+    );
+  });
+});

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -46,6 +46,23 @@ describe("preferencesApi (PreferenceResource)", () => {
     await expect(getAllUserPreferences()).resolves.toEqual([]);
   });
 
+  it("getAllUserPreferences unwraps JAXB UserPreferenceList envelope (#3204)", async () => {
+    const getSpy = vi.spyOn(client, "get");
+    getSpy.mockResolvedValueOnce({
+      UserPreferenceList: {
+        UserPreference: [
+          {
+            name: "developer.defaultObjectAclTemplate",
+            value: '{"version":1,"entries":[]}',
+          },
+        ],
+      },
+    });
+    const list = await getAllUserPreferences();
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("developer.defaultObjectAclTemplate");
+  });
+
   it("loadUserPreference returns null on 404", async () => {
     vi.spyOn(client, "get").mockRejectedValueOnce({
       status: 404,

--- a/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
@@ -125,6 +125,10 @@ describe("DeveloperPreferencesPanel", () => {
         "developer-prefs-acl-perm-row:0:Default:USER-RUNTIME_VISIBLE",
       ),
     ).toBeTruthy();
+
+    const defaultRow = screen.getByTestId("developer-prefs-acl-row-row:0:Default:USER");
+    expect(defaultRow.getAttribute("data-acl-principal")).toBe("Default");
+    expect(defaultRow.getAttribute("data-acl-principal-type")).toBe("USER");
   });
 
   it("saves dirty template via preferences API", async () => {

--- a/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
+++ b/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
@@ -98,6 +98,22 @@ describe("defaultAclTemplate helpers", () => {
     expect(parseDefaultAclTemplate(JSON.stringify({ entries: "x" }))).toBeNull();
   });
 
+  /**
+   * #3204 — GET may leave value as a parsed object. String(obj) would become
+   * "[object Object]" and reload would fall back to system default (no Visible).
+   */
+  it("parses an already-decoded object payload (#3204)", () => {
+    const template = cloneDefaultAclTemplate(systemDefaultAclTemplate());
+    template.entries[0].permissions.push("RUNTIME_VISIBLE");
+    const parsed = parseDefaultAclTemplate({
+      version: 1,
+      entries: template.entries,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+    expect(defaultAclTemplatesEqual(parsed!, template)).toBe(true);
+  });
+
   it("parse drops invalid entries and normalizes types/permissions", () => {
     const parsed = parseDefaultAclTemplate(
       JSON.stringify({

--- a/docs/ai-generated/code-reviews/issue-3204-object-acl-prefs-product-path-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3204-object-acl-prefs-product-path-erlang.md
@@ -1,0 +1,23 @@
+# Erlang review — #3204 Object ACL Design/Runtime prefs + product path
+
+## Change class
+
+Operator-facing Developer Preferences persist/reload + Object ACL product path
+(docs + Playwright). Not a site/DF ACL panel rewrite.
+
+## Findings
+
+| Severity | Item | Disposition |
+|----------|------|-------------|
+| Bug | GET-by-name empty/unwrap-null dropped saved Runtime visibility | Fixed: list fallback + object-value parse |
+| Behavioral tests | loadDefaultAclTemplate list fallback; parse object payload; JAXB list unwrap | Added |
+| Playwright | Prefs save → reload Visible persist | Added on product-path spec |
+| Product docs | Operator path missing | `product-docs/8.2/admin/object-acl.md` |
+| Paths | No new filesystem path concat | N/A |
+| API shape | No public Java signature / final/sealed change | downstream_checked=none |
+
+## Hard gates
+
+- No missing persist/reload companion: Vitest + Playwright + product-docs
+- Cross-platform: NIO/path N/A
+- Copyright: new test file uses Intersoft 2026 header

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -24,6 +24,7 @@
  *   - Kind-aware Design vs Runtime: data-acl-object-kind + data-acl-show-runtime
  *     (table when ACL loads; section shell when object guid is missing)
  *   - Developer Preferences default-ACL template: layered Design / Runtime columns
+ *   - Preferences persist: Runtime Visible survives Save + reload (#3204 / #2643)
  *
  * Kind-aware runtime columns mirror WebUI objectAclPermissionModel.ts
  * RUNTIME_RELEVANT_OBJECT_KINDS — peers in that set show Runtime visibility;
@@ -37,7 +38,7 @@
  * QA mode:
  *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js → qa-down
  *
- * Refs #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
+ * Refs #3204, #2643, #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
  */
 
 const { test, expect } = require("@playwright/test");
@@ -437,5 +438,75 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       'input[type="checkbox"][data-testid^="developer-prefs-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
     );
     await expect(runtimeBoxes.first()).toBeVisible();
+  });
+
+  test("preferences Runtime visibility persists after save and reload (#3204)", async ({
+    page,
+  }) => {
+    const jsErrors = [];
+    page.on("pageerror", (err) => jsErrors.push(String(err)));
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      // GET /preferences/{name} 404 is the empty-store path; chrome 404s
+      // (favicon / leftover hashed chunks) are not product defects.
+      if (/404|Failed to load resource/i.test(text)) {
+        return;
+      }
+      jsErrors.push(text);
+    });
+
+    await page.goto(developerSectionUrl("preferences"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-preferences"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const table = page.locator('[data-testid="developer-prefs-acl-table"]');
+    const loading = page.locator('[data-testid="developer-prefs-acl-loading"]');
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(table).toBeVisible({ timeout: 20_000 });
+
+    const defaultRuntime = page.locator(
+      '[data-testid="developer-prefs-acl-table"] tr[data-acl-principal="Default"] input[type="checkbox"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(defaultRuntime).toBeVisible({ timeout: 10_000 });
+
+    const wasChecked = await defaultRuntime.isChecked();
+    await defaultRuntime.click();
+    await expect(defaultRuntime).toBeChecked({ checked: !wasChecked });
+
+    const saveBtn = page.locator('[data-testid="developer-prefs-acl-save"]');
+    await expect(saveBtn).toBeEnabled({ timeout: 10_000 });
+    await saveBtn.click();
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-notice"]'),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-source"]'),
+    ).toContainText(/saved/i);
+
+    await page.goto(developerSectionUrl("preferences"), {
+      waitUntil: "networkidle",
+    });
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(table).toBeVisible({ timeout: 20_000 });
+
+    const reloaded = page.locator(
+      '[data-testid="developer-prefs-acl-table"] tr[data-acl-principal="Default"] input[type="checkbox"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(reloaded).toBeVisible({ timeout: 10_000 });
+    await expect(reloaded).toBeChecked({ checked: !wasChecked });
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-source"]'),
+    ).toContainText(/saved/i);
+
+    expect(
+      jsErrors,
+      `JS console/page errors on prefs persist path: ${jsErrors.join(" | ")}`,
+    ).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -45,6 +45,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
 - [Users, roles & security](id:admin-users-roles)
+- [Object ACL & default template](id:admin-object-acl)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -1,0 +1,68 @@
+---
+id: admin-object-acl
+title: Object ACL & default template
+description: Design access and Runtime visibility on design objects, and the Developer default ACL template
+version: "8.2"
+order: 43
+tags: [admin, security, acl, developer]
+---
+
+# Object ACL & default template
+
+Design objects (content types, templates, and other Developer catalog peers) carry an
+**Object ACL**. The editor splits permissions into two layers that match Workbench:
+
+| Layer | Columns | Meaning |
+|-------|---------|---------|
+| **Design access** | Read, Update, Delete, Modify ACL | Who can see and change the design object in the CMS |
+| **Runtime visibility** | Visible | Whether the object is visible at runtime (for example to a community) |
+
+Special rows such as **Default** (USER) and **AnyCommunity** (COMMUNITY) stay protected
+on content-type ACLs. You can change their permission checkboxes; you cannot remove
+those system principals.
+
+## Product path — open Object ACL
+
+1. Sign in as a user with Developer access (for example **Admin**).
+2. Open **Developer** from product navigation, or deep-link
+   `spa.jsp?entry=developer`.
+3. Open a catalog that supports Object ACL:
+   - **Content types** → first type → **Open**
+   - **Templates** → first template → **Open**
+4. On the detail panel, expand **Object ACL**.
+5. Confirm the table shows **Design access** and **Runtime visibility** column groups
+   (runtime-relevant object kinds such as content type and template always show
+   **Visible**).
+
+Deep links:
+
+- Content types: `spa.jsp?entry=developer&section=content-types`
+- Templates: `spa.jsp?entry=developer&section=templates`
+
+## Product path — default ACL template (Preferences)
+
+New object ACLs can seed from a **per-user default template**. That template is
+stored as the user preference `developer.defaultObjectAclTemplate`.
+
+1. Open **Developer → Preferences** (`spa.jsp?entry=developer&section=preferences`).
+2. Under **Security**, review the **default ACL template** table.
+3. The table uses the same **Design access** / **Runtime visibility** groups as
+   Object ACL on a design object.
+4. The system default is:
+   - **Default** (USER): Read, Update, Delete, Modify ACL (Visible off)
+   - **AnyCommunity** (COMMUNITY): Visible on
+5. To change Runtime visibility for **Default**, check or clear **Visible**, then
+   click **Save default ACL template**.
+6. Reload **Developer → Preferences** (full page refresh or leave and return).
+   **Visible** must match what you saved. The source line should indicate a saved
+   preference, not only the system default.
+
+If Save appears to succeed but **Visible** is unchecked after reload, the preference
+did not persist — check that you are still signed in, then retry. The product loads
+the named preference first and falls back to the full preference list so a saved
+template is not dropped on reload.
+
+## Related
+
+- [Users, roles & security](id:admin-users-roles)
+- [Sites & content structure](id:admin-sites)

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,15 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Object ACL (design objects)
+
+Developer catalog objects use a layered **Object ACL** (Design access vs Runtime
+visibility). Operators set a **default ACL template** under
+**Developer → Preferences → Security**. After **Save default ACL template**,
+**Runtime visibility → Visible** must still match after a page reload.
+
+See [Object ACL & default template](id:admin-object-acl).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.


### PR DESCRIPTION
## Summary

Fixes remaining Developer **Object ACL Design/Runtime visibility prefs** persist/reload after #2948, plus the operator product path (#2643 QA Failed).

**Root cause (residual):** `loadDefaultAclTemplate` trusted only `GET /preferences/{name}` with wrap-only unwrap. A 404, empty value, or JAXB list envelope made reload fall back to the system default (Default USER without `RUNTIME_VISIBLE`) even after a successful Save.

**Fix:** Parse string or already-decoded JSON values; fall back to `GET /preferences/` (including nested `UserPreferenceList` envelopes); keep PUT wrap unchanged (#2708).

**Out of scope:** Site / Display Format ACL panel rewrite (#3203 / #3200), Profile landing (#3207).

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #3204  
QA evidence comment target: #2643  
Prior persist residual: #2948

Fixes #3204

## Test plan

1. QA H2 (`perc-devctl qa-up`) or install with this WebUI bundle.
2. Sign in as Admin → **Developer → Preferences**.
3. Confirm **Design access** / **Runtime visibility** column groups.
4. Toggle **Visible** on **Default**; **Save default ACL template**.
5. Full reload Preferences; **Visible** must match and source must say saved preference.
6. Open **Content types** and **Templates** first-row detail → Object ACL shows the same layered columns.
7. Optional: `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js --grep "content type ACL|template ACL|preferences"`

## Checklist

- [x] **Product documentation** — created `product-docs/8.2/admin/object-acl.md`; linked from admin index and users-roles
- [x] **Unit / module tests** — Vitest load fallback + object parse; WebUI + perc-qa-automation standalone `mvnw clean install`
- [x] **WebUI + Playwright** — product-path spec save/reload persist + CT/template columns
- [x] **Build gates** — standalone clean install on changed modules; no public Java API / final/sealed change
- [x] **Cross-platform** — N/A (no filesystem path I/O)

### modules_built

`WebUI`, `modules/perc-qa-automation`

### build_evidence

```
cd WebUI && ../mvnw.cmd clean install
→ BUILD SUCCESS
  Surefire: Tests run: 51, Failures: 0
  Vitest (npm-test): Test Files 295 passed; Tests 2119 passed

cd modules/perc-qa-automation && ../../mvnw.cmd clean install
→ BUILD SUCCESS (No tests to run)

scripts\ci-smoke-product-docs.bat
→ OK — 22 pages, 8.2/index.html present
```

### downstream_checked

none — no public/protected Java signature or final/sealed change. Client-only + docs + Playwright.

### C5 UI proof

- Existing QA H2 cell `perc-matrix-cms-h2` on `TEST_CMS_URL=http://127.0.0.1:18122` (freeport; not :9993)
- Hot-copied `WebUI/target/generated-webui/cm/modern/assets/` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js --grep "content type ACL|template ACL|preferences"`
  → **4 passed** (CT columns, template columns, prefs layered columns, prefs Visible persist/reload)
- Display-format peer test left failing on this cell (no-guid / ACL table not shown) — tracked by #3200 / #3203; not merged into this PR
- console-clean=yes (pageerror none; ignored expected GET-by-name / resource 404 noise)
- server.log-clean=yes for this feature (startup `PSX_OBJECTACL` PK folder-save ERROR at cell start is pre-existing / unrelated)

## Erlang

Approve — `docs/ai-generated/code-reviews/issue-3204-object-acl-prefs-product-path-erlang.md`

Human QA is deferred this run (`include_human_qa=false`). Existing QA #2643 remains the human retest vehicle after merge.
