### PR TITLE
fix(webui): Site and Display Format Object ACL product path (#3203)

### DIFF
--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -37,13 +37,30 @@ export type CreateAclOwner = {
 };
 
 /**
+ * Unwrap Jackson WRAP_ROOT_VALUE {@code {"Acl":{…}}} so ObjectAclSection can
+ * read entries. Flat bodies pass through (site / display-format Object ACL).
+ */
+export function unwrapObjectAcl(payload: unknown): ObjectAcl {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.Acl ?? root.acl;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as ObjectAcl;
+  }
+  return payload as ObjectAcl;
+}
+
+/**
  * GET /services/acls/object/{objectGuid}
  *
  * <p>Returns the design-time ACL for a securable object. 404 when no ACL exists.
  */
 export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
   const key = encodeURIComponent(objectGuid);
-  return get<ObjectAcl>(`${PATHS.ACLS}/object/${key}`);
+  const payload = await get<unknown>(`${PATHS.ACLS}/object/${key}`);
+  return unwrapObjectAcl(payload);
 }
 
 /**
@@ -58,13 +75,14 @@ export async function createObjectAcl(
 ): Promise<ObjectAcl> {
   const guid: RestGuid =
     typeof objectGuid === "string" ? { stringValue: objectGuid } : objectGuid;
-  return post<ObjectAcl>(PATHS.ACLS, {
+  const payload = await post<unknown>(PATHS.ACLS, {
     objectGuid: guid,
     owner: {
       name: owner.name,
       type: owner.type,
     },
   });
+  return unwrapObjectAcl(payload);
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -3,8 +3,10 @@
  */
 
 import { get, post, put } from "../client";
+import { objectGuidString } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type {
+  RestGuid,
   SiteDef,
   VirtualSiteBuildRequest,
   VirtualSiteBuildResult,
@@ -131,9 +133,17 @@ function normalizeSiteRow(raw: unknown): SiteDef {
   }
   const obj = raw as Record<string, unknown>;
   const name = coerceDisplayString(obj.name);
+  const guidString = objectGuidString(obj.guid);
+  let guid = obj.guid as RestGuid | undefined;
+  if (guidString) {
+    const existing =
+      guid != null && typeof guid === "object" && !Array.isArray(guid) ? guid : {};
+    guid = { ...existing, stringValue: guidString };
+  }
   return {
     ...(obj as SiteDef),
     name: name || undefined,
+    guid,
   };
 }
 

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -191,6 +191,18 @@ function structureEqual(a: DraftEntry[], b: DraftEntry[]): boolean {
   return true;
 }
 
+/** Kind-aware empty copy when the parent panel cannot supply an object GUID. */
+export function noGuidCopy(objectKind?: AclDesignObjectKind | null): string {
+  switch (objectKind) {
+    case "site":
+      return DEV_MSG.ACL_NO_GUID_SITE;
+    case "display-format":
+      return DEV_MSG.ACL_NO_GUID_DISPLAY_FORMAT;
+    default:
+      return DEV_MSG.ACL_NO_GUID;
+  }
+}
+
 /** i18n label for a known REST permission column (Workbench wording). */
 function permissionColumnLabel(perm: AclPermissionName): string {
   switch (perm) {
@@ -600,7 +612,7 @@ export function ObjectAclSection({
       >
         <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.ACL_TITLE}</h3>
         <p style={{ color: catalogColors.empty }} data-testid={`${testIdPrefix}-no-guid`}>
-          {DEV_MSG.ACL_NO_GUID}
+          {noGuidCopy(objectKind)}
         </p>
       </section>
     );

--- a/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from "react";
+import { objectGuidString } from "../api/displayFormatGuid";
 import { coerceDisplayString } from "../api/developer/sitesApi";
 import type { SiteDef } from "../api/developer/types";
 import { catalogColors, backButton, metaGrid, monoCell } from "./catalogStyles";
@@ -19,6 +20,7 @@ export function SiteDetailPanel({
 }): React.ReactElement {
   const name = coerceDisplayString(site.name) || "—";
   const siteKey = coerceDisplayString(site.name);
+  const objectGuid = objectGuidString(site.guid);
   const gaps =
     site.designGaps && site.designGaps.length
       ? site.designGaps
@@ -43,6 +45,13 @@ export function SiteDetailPanel({
         <dl style={metaGrid}>
           <dt>{DEV_MSG.SITE_COL_NAME}</dt>
           <dd style={{ margin: 0, ...monoCell }}>{name}</dd>
+          <dt>{DEV_MSG.SITE_COL_GUID}</dt>
+          <dd
+            style={{ margin: 0, ...monoCell }}
+            data-testid="developer-site-detail-guid"
+          >
+            {objectGuid || "—"}
+          </dd>
           <dt>{DEV_MSG.SITE_COL_DESC}</dt>
           <dd style={{ margin: 0 }}>{site.description || "—"}</dd>
           <dt>{DEV_MSG.SITE_COL_URL}</dt>
@@ -63,7 +72,7 @@ export function SiteDetailPanel({
       {siteKey ? <VirtualSiteSourcePanel siteName={siteKey} /> : null}
 
       <ObjectAclSection
-        objectGuid={site.guid?.stringValue}
+        objectGuid={objectGuid}
         objectKind="site"
         testIdPrefix="developer-site-acl"
       />

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -41,6 +41,10 @@ export const DEV_MSG_KEYS = {
   ACL_OWNER_NAME: "perc.ui.developer@Owner principal",
   ACL_OWNER_NAME_PLACEHOLDER: "perc.ui.developer@User or role that owns the ACL",
   ACL_NO_GUID: "perc.ui.developer@Object GUID not available - cannot load ACL.",
+  ACL_NO_GUID_SITE:
+    "perc.ui.developer@This site has no object GUID — ACL cannot be loaded.",
+  ACL_NO_GUID_DISPLAY_FORMAT:
+    "perc.ui.developer@This display format has no object GUID — ACL cannot be loaded.",
   ACL_NO_ENTRIES: "perc.ui.developer@No ACL entries yet - add a principal below.",
   ACL_COL_ENTRY: "perc.ui.developer@Principal / name",
   ACL_COL_TYPE: "perc.ui.developer@Type",
@@ -717,6 +721,7 @@ export const DEV_MSG_KEYS = {
   SITE_HINT:
     "perc.ui.developer@Site definitions for association browse (SY-04). Open a row for URL, defaults, and Virtual Site source. Full site create/delete remains outside this catalog.",
   SITE_COL_NAME: "perc.ui.developer@Name",
+  SITE_COL_GUID: "perc.ui.developer@GUID",
   SITE_COL_DESC: "perc.ui.developer@Description",
   SITE_COL_URL: "perc.ui.developer@Base URL",
   SITE_COL_FLAGS: "perc.ui.developer@Flags",

--- a/WebUI/src/test/ts/api/developer/aclApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/aclApi.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as client from "../../../../main/ts/api/client";
+import {
+  createObjectAcl,
+  getAclForObject,
+  unwrapObjectAcl,
+} from "../../../../main/ts/api/developer/aclApi";
+
+vi.mock("../../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+const get = client.get as ReturnType<typeof vi.fn>;
+const post = client.post as ReturnType<typeof vi.fn>;
+
+describe("unwrapObjectAcl", () => {
+  it("unwraps Jackson Acl root so entries are reachable (#3203)", () => {
+    const acl = unwrapObjectAcl({
+      Acl: {
+        id: 7,
+        name: "By_Author ACL",
+        aclEntries: [{ name: "Admin", type: { type: "ROLE" } }],
+      },
+    });
+    expect(acl.id).toBe(7);
+    expect(acl.name).toBe("By_Author ACL");
+    expect(Array.isArray(acl.aclEntries)).toBe(true);
+  });
+
+  it("unwraps camelCase acl envelope", () => {
+    const acl = unwrapObjectAcl({
+      acl: { id: 3, name: "site", aclEntries: [] },
+    });
+    expect(acl.id).toBe(3);
+    expect(acl.name).toBe("site");
+  });
+
+  it("passes through flat ACL bodies", () => {
+    const flat = { id: 1, name: "x", aclEntries: [] };
+    expect(unwrapObjectAcl(flat)).toEqual(flat);
+  });
+
+  it("returns empty object for non-objects", () => {
+    expect(unwrapObjectAcl(null)).toEqual({});
+    expect(unwrapObjectAcl("acl")).toEqual({});
+  });
+});
+
+describe("getAclForObject", () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it("unwraps wrapped GET /acls/object/{guid} body", async () => {
+    get.mockResolvedValue({
+      Acl: { id: 9, name: "df", aclEntries: [{ name: "Default" }] },
+    });
+    const acl = await getAclForObject("0-31-5");
+    expect(acl.id).toBe(9);
+    expect(acl.name).toBe("df");
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});
+
+describe("createObjectAcl", () => {
+  beforeEach(() => {
+    post.mockReset();
+  });
+
+  it("unwraps wrapped POST /acls body", async () => {
+    post.mockResolvedValue({
+      Acl: { id: 4, name: "new", aclEntries: [{ name: "Admin" }] },
+    });
+    const acl = await createObjectAcl("0-20-1", { name: "Admin", type: "ROLE" });
+    expect(acl.id).toBe(4);
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});

--- a/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
@@ -88,6 +88,25 @@ describe("parseSiteList (#3198 bind)", () => {
     expect(parseSiteList({ Site: { name: "Only" } })).toEqual([{ name: "Only" }]);
   });
 
+  it("synthesizes guid.stringValue from host/type/uuid parts (#3203)", () => {
+    expect(
+      parseSiteList({
+        Site: { name: "Help", guid: { hostId: 0, type: 20, uuid: 301 } },
+      }),
+    ).toEqual([
+      {
+        name: "Help",
+        guid: { hostId: 0, type: 20, uuid: 301, stringValue: "0-20-301" },
+      },
+    ]);
+  });
+
+  it("keeps existing guid.stringValue", () => {
+    expect(
+      parseSiteList([{ name: "Help", guid: { stringValue: "0-20-1" } }]),
+    ).toEqual([{ name: "Help", guid: { stringValue: "0-20-1" } }]);
+  });
+
   it("throws on unknown object shape", () => {
     expect(() => parseSiteList({ unexpected: true })).toThrow(
       /Unexpected site list payload/,

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -146,7 +146,7 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(siteSection.getAttribute("data-acl-show-runtime")).toBe("true");
     expect(siteSection.getAttribute("data-acl-has-guid")).toBe("false");
     expect(screen.getByTestId("developer-site-acl-no-guid").textContent).toMatch(
-      /GUID not available|cannot load ACL/i,
+      /This site has no object GUID|cannot load ACL/i,
     );
     unmount();
 
@@ -162,6 +162,25 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(kwSection.getAttribute("data-acl-object-kind")).toBe("keyword");
     expect(kwSection.getAttribute("data-acl-show-runtime")).toBe("false");
     expect(kwSection.getAttribute("data-acl-has-guid")).toBe("false");
+    expect(screen.getByTestId("developer-kw-acl-no-guid").textContent).toMatch(
+      /Object GUID not available|cannot load ACL/i,
+    );
+  });
+
+  it("uses display-format kind-aware no-guid copy (#3203)", () => {
+    render(
+      <ObjectAclSection
+        objectGuid={null}
+        objectKind="display-format"
+        testIdPrefix="developer-df-acl"
+      />,
+    );
+    const section = screen.getByTestId("developer-df-acl-section");
+    expect(section.getAttribute("data-acl-object-kind")).toBe("display-format");
+    expect(section.getAttribute("data-acl-show-runtime")).toBe("true");
+    expect(screen.getByTestId("developer-df-acl-no-guid").textContent).toMatch(
+      /This display format has no object GUID|cannot load ACL/i,
+    );
   });
 
   it("groups permission columns under Design access and Runtime visibility (CD-19)", async () => {

--- a/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
@@ -65,6 +65,7 @@ describe("SiteDetailPanel", () => {
     const acl = screen.getByTestId("developer-site-acl-stub");
     expect(acl.getAttribute("data-object-kind")).toBe("site");
     expect(acl.getAttribute("data-object-guid")).toBe("0-10-1");
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("0-10-1");
     const virt = screen.getByTestId("developer-site-virtual-stub");
     expect(virt.getAttribute("data-site-name")).toBe("Corporate");
     const back = screen.getByTestId("developer-site-back");
@@ -97,6 +98,30 @@ describe("SiteDetailPanel", () => {
     expect(detail.textContent).toMatch(/—/);
     expect(screen.getByTestId("developer-site-gaps").textContent).toContain(
       DEV_MSG.SITE_GAP_WRITE,
+    );
+  });
+
+  it("synthesizes object guid from host/type/uuid parts for Object ACL (#3203)", () => {
+    const site: SiteDef = {
+      name: "PartsOnly",
+      guid: { hostId: 0, type: 20, uuid: 99 },
+    };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("0-20-99");
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-20-99",
+    );
+  });
+
+  it("omits object guid when the list payload has none (#3203)", () => {
+    const site: SiteDef = { name: "NoGuid" };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("—");
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-guid")).toBe(
+      "",
+    );
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-kind")).toBe(
+      "site",
     );
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -140,7 +140,7 @@ async function openFirstCatalogDetail(page, ids) {
  * @param {import('@playwright/test').Page} page
  * @param {string} prefix e.g. developer-ct-acl / developer-site-acl
  * @param {string} objectKind expected data-acl-object-kind
- * @returns {Promise<"table"|"no-guid"|"empty">}
+ * @returns {Promise<"table"|"no-guid"|"empty"|"no-entries">}
  */
 async function assertLayeredObjectAcl(page, prefix, objectKind) {
   const expectRuntime = RUNTIME_RELEVANT_OBJECT_KINDS.has(objectKind);
@@ -154,6 +154,7 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   const noGuid = page.locator(`[data-testid="${prefix}-no-guid"]`);
   const aclError = page.locator(`[data-testid="${prefix}-error"]`);
   const aclEmpty = page.locator(`[data-testid="${prefix}-empty"]`);
+  const aclNoEntries = page.locator(`[data-testid="${prefix}-no-entries"]`);
   const aclTable = page.locator(`[data-testid="${prefix}-table"]`);
   const aclLoading = page.locator(`[data-testid="${prefix}-loading"]`);
 
@@ -164,14 +165,16 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
       "data-acl-show-runtime",
       expectRuntime ? "true" : "false",
     );
-    await expect(noGuid).toContainText(/GUID not available|cannot load ACL/i);
+    await expect(noGuid).toContainText(
+      /GUID not available|cannot load ACL|has no object GUID/i,
+    );
     return "no-guid";
   }
 
   // Fallback for older bundles that only put message text in section
   const sectionText = (await aclSection.innerText()).trim();
   if (
-    /GUID not available|cannot load ACL/i.test(sectionText) &&
+    /GUID not available|cannot load ACL|has no object GUID/i.test(sectionText) &&
     !(await aclTable.isVisible().catch(() => false))
   ) {
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
@@ -179,7 +182,9 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   }
 
   await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-  await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+  await expect(
+    aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+  ).toBeVisible({
     timeout: 30_000,
   });
 
@@ -192,6 +197,16 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
     // Create-first empty state still proves mount + kind on section
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
     return "empty";
+  }
+
+  if (await aclNoEntries.isVisible()) {
+    // ACL document exists but has no principals yet — still readable/editable
+    // (add specials / add entry). Live By_Author often serializes without
+    // aclEntries (#3203 / #2672).
+    await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
+    await expect(aclSection).toHaveAttribute("data-acl-has-guid", "true");
+    await expect(aclNoEntries).toContainText(/No ACL entries yet/i);
+    return "no-entries";
   }
 
   await expect(aclTable).toBeVisible();
@@ -334,9 +349,21 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     });
     if (!opened) return;
 
+    const guidCell = page.locator('[data-testid="developer-site-detail-guid"]');
+    await expect(guidCell).toBeVisible({ timeout: 15_000 });
+    const guidText = (await guidCell.innerText()).trim();
     const mode = await assertLayeredObjectAcl(page, "developer-site-acl", "site");
-    // site is RUNTIME_RELEVANT — show-runtime must be true (table or no-guid shell)
-    expect(["table", "no-guid", "empty"]).toContain(mode);
+    // Site list GUID is normalized (stringValue or host-type-uuid). When a GUID
+    // is present, Object ACL must load — no-guid is only valid if the catalog
+    // row truly omitted guid parts (#3203 / #2672).
+    if (guidText && guidText !== "—" && guidText !== "-") {
+      expect(
+        ["table", "empty", "no-entries"],
+        `site Object ACL must load with GUID "${guidText}" (got mode=${mode})`,
+      ).toContain(mode);
+    } else {
+      expect(["table", "no-guid", "empty", "no-entries"]).toContain(mode);
+    }
   });
 
   test("display-format peer ACL mounts objectKind with kind-aware Runtime columns (B4)", async ({
@@ -381,7 +408,7 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     // Issue #2689: detail client must unwrap Jackson DisplayFormat root so
     // objectGuid is present — no-guid shell is a product defect for DF detail.
     expect(
-      ["table", "empty"],
+      ["table", "empty", "no-entries"],
       `display-format Object ACL must load with GUID (got mode=${mode})`,
     ).toContain(mode);
   });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -44,7 +44,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
-- [Users, roles & security](id:admin-users-roles)
+- [Users, roles & security](id:admin-users-roles) (includes Developer Object ACL for Sites and Display Formats)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -75,7 +75,16 @@ the server (for example after **Install sample sites**).
 1. Sign in as an administrator (or a role that can open **Developer**).
 2. Open **Developer** → **Sites** (SPA entry `spa.jsp?entry=developer&section=sites`).
 3. Confirm the catalog table shows site **name**, **description**, **base URL**, and flags.
-4. Choose a row to open **Site detail** (URL defaults and Virtual Site source).
+4. Choose a row to open **Site detail** (URL defaults, object GUID, Virtual Site source,
+   and **Object ACL**).
+
+The **Object ACL** section on Site detail uses the site GUID from the catalog payload
+(`guid.stringValue`, or `hostId-type-uuid` when `stringValue` is omitted). When a GUID
+is present, the ACL table (or empty create path) is readable and editable — Design
+access plus Runtime visibility. When the catalog row has no GUID parts, the section
+still mounts with site-specific empty copy and does not crash the page. See
+[Users, roles & security](id:admin-users-roles) for the same Object ACL behavior on
+Display Formats.
 
 Empty state (**No sites returned**) appears only when the list API has **zero** Sites. A
 successful HTTP 200 with Site entries must populate the table (never a silent blank). Load

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,42 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Design-object ACL (Developer)
+
+System Definition (**Developer**) shows an **Object ACL** section on securable design
+objects, including **Display Formats** and **Sites**.
+
+### Display Formats
+
+1. Open **Developer → Display Formats**.
+2. Open a format such as **By_Author** (or any other listed format).
+3. The detail header **GUID** field shows the object GUID when the server has one
+   (never a silent dash when a GUID exists).
+4. **Object ACL** below the column list:
+   - Shows the ACL table when entries exist (Design access and Runtime visibility).
+   - Shows an empty create path when the object has no ACL yet.
+   - Shows an explicit load error if the ACL service fails.
+   - Does **not** say “Object GUID not available” when the header GUID is present.
+   - If the object truly has no GUID, the section still mounts with kind-aware copy
+     (display format) and does not crash the detail page.
+
+Use this section to inspect and edit design-time and runtime visibility permissions
+for that display format.
+
+### Sites
+
+1. Open **Developer → Sites**.
+2. Open a Site row (catalog from `GET /services/sites`).
+3. The detail header **GUID** field shows the site object GUID when the list payload
+   includes `guid.stringValue` or synthesizable `hostId` / `type` / `uuid` parts.
+4. **Object ACL** on Site detail:
+   - Loads and is readable/editable when a GUID is present (same Design / Runtime
+     columns as other runtime-relevant objects).
+   - If the catalog row has no GUID parts, the section still mounts with site-specific
+     empty copy and does not crash Site detail.
+
+See also [Sites & content structure](id:admin-sites).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.


### PR DESCRIPTION
## Summary

Fixes #3203 (residual of Failed QA #2672 / implement chain #2642 / epic #2274).

Developer **Site** and **Display Format** Object ACL product paths:

- Site catalog rows now normalize `guid.stringValue` (or synthesize `hostId-type-uuid`) so Site detail mounts Object ACL with a real GUID when the list payload has parts.
- Site detail shows the GUID and kind-aware no-GUID copy when parts are missing (section still mounts, no crash).
- `GET`/`POST` `/services/acls` Jackson `{Acl|acl:…}` envelopes are unwrapped so ACL entries are readable after GUID bind.
- Display Format By_Author on H2 often returns an ACL document with **no** `aclEntries`; the editor shows the loaded empty-entry path (add Default / AnyCommunity) instead of “GUID not available”.

Out of scope: #2250 filter polish, FolderSecurityPanel (#3206), creating Sites when the catalog is empty.

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2274 · QA parent: #2672

## Test plan

1. `perc-devctl qa-up` (H2 Docker; use printed `TEST_CMS_URL`, never hardcode `:9993`).
2. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into the cell `…/cm/modern/assets/`.
3. Login as Admin → Developer → **Display Formats** → **By_Author**:
   - Header GUID is present (e.g. `0-31-5`).
   - Object ACL section mounts (`objectKind=display-format`); table, create-empty, or no-entries add path — **not** “GUID not available”.
4. Developer → **Sites** → open a site when the catalog is non-empty:
   - Header GUID present when the list payload has GUID parts.
   - Object ACL loads (table / empty / no-entries) or kind-aware site copy if GUID parts are absent.
5. Smoke Content Types / Templates / Preferences default ACL (regression).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md`, `sites.md`, `index.md` for Developer Object ACL on Sites and Display Formats
- [x] **Unit / module tests** — Vitest unwrap/normalize/no-guid + Site detail wiring; standalone `mvnw clean install` on WebUI and perc-qa-automation
- [x] **WebUI + Playwright** — `developer-object-acl-product-path.spec.js` (GUID required for DF; site GUID when present; `no-entries` accepted as loaded ACL)
- [x] **Build gates** — standalone clean install, tests on; no Java public API shape change
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Java Surefire 51 tests; Vitest ran in Maven test phase; focused Vitest 36 passed)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (No tests to run / npm ci)
- **downstream_checked:** none (no Java `final`/signature change; TS unwrap stays in WebUI)

## C5 UI live proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:18122` (freeport; cell `perc-matrix-cms-h2`)
- **deploy:** docker cp rebuilt `WebUI/target/generated-webui/cm/modern/assets/` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- **Playwright:** `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js`
  - **4 passed / 1 skipped** (Sites catalog empty on this H2 cell — `{"SiteList":[]}`)
  - Display Format By_Author: GUID `0-31-5`, Object ACL loaded (`no-entries` / add path)
- **console-clean:** yes (no pageerror / failed assertion)
- **server.log-clean:** yes for the Playwright window. Install-time `PSX_OBJECTACL` PK violation / folder save ERROR at cell start is pre-existing installer noise (not ACL UI traffic).
- **qa-down:** cell removed after the run

> Co-Authored by Grok Build using grok-4.5 with agent main.
