### PR TITLE
cluster: Object ACL product-path thrash (#3257 #3258 #3259)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -31,7 +31,9 @@ import { get } from "../client";
 import {
   normalizeDisplayFormatGuid,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type { DisplayFormat, DisplayFormatColumn } from "../developer/types";
@@ -40,26 +42,16 @@ export type { DisplayFormat, DisplayFormatColumn };
 
 // Re-export shared GUID helpers so Content Explorer callers (and tests) share
 // one implementation with the Developer API.
-export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
+export {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  resolveDisplayFormatObjectGuid,
+  unwrapDisplayFormat,
+  unwrapDisplayFormatList,
+};
 
 function asArray(payload: unknown): DisplayFormat[] {
-  if (payload == null) return [];
-  let rawList: unknown[] = [];
-  if (Array.isArray(payload)) {
-    rawList = payload;
-  } else if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    const raw =
-      obj.DisplayFormat ??
-      obj.displayFormat ??
-      obj.DisplayFormatList ??
-      obj.displayFormatList;
-    if (raw == null) return [];
-    rawList = Array.isArray(raw) ? raw : [raw];
-  } else {
-    return [];
-  }
-  return rawList.map((item) => unwrapDisplayFormat(item));
+  return unwrapDisplayFormatList(payload);
 }
 
 export function normalizeDisplayFormatColumns(

--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -41,9 +41,26 @@ export type CreateAclOwner = {
  *
  * <p>Returns the design-time ACL for a securable object. 404 when no ACL exists.
  */
+/**
+ * Unwrap Jackson WRAP_ROOT_VALUE {@code {"Acl":{…}}} so ObjectAclSection can
+ * read entries. Flat bodies pass through (#3200 Display Format Object ACL).
+ */
+export function unwrapObjectAcl(payload: unknown): ObjectAcl {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.Acl ?? root.acl;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as ObjectAcl;
+  }
+  return payload as ObjectAcl;
+}
+
 export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
   const key = encodeURIComponent(objectGuid);
-  return get<ObjectAcl>(`${PATHS.ACLS}/object/${key}`);
+  const payload = await get<unknown>(`${PATHS.ACLS}/object/${key}`);
+  return unwrapObjectAcl(payload);
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -37,13 +37,30 @@ export type CreateAclOwner = {
 };
 
 /**
+ * Unwrap Jackson WRAP_ROOT_VALUE {@code {"Acl":{…}}} so ObjectAclSection can
+ * read entries. Flat bodies pass through (site / display-format Object ACL).
+ */
+export function unwrapObjectAcl(payload: unknown): ObjectAcl {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.Acl ?? root.acl;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as ObjectAcl;
+  }
+  return payload as ObjectAcl;
+}
+
+/**
  * GET /services/acls/object/{objectGuid}
  *
  * <p>Returns the design-time ACL for a securable object. 404 when no ACL exists.
  */
 export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
   const key = encodeURIComponent(objectGuid);
-  return get<ObjectAcl>(`${PATHS.ACLS}/object/${key}`);
+  const payload = await get<unknown>(`${PATHS.ACLS}/object/${key}`);
+  return unwrapObjectAcl(payload);
 }
 
 /**
@@ -58,13 +75,14 @@ export async function createObjectAcl(
 ): Promise<ObjectAcl> {
   const guid: RestGuid =
     typeof objectGuid === "string" ? { stringValue: objectGuid } : objectGuid;
-  return post<ObjectAcl>(PATHS.ACLS, {
+  const payload = await post<unknown>(PATHS.ACLS, {
     objectGuid: guid,
     owner: {
       name: owner.name,
       type: owner.type,
     },
   });
+  return unwrapObjectAcl(payload);
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
@@ -18,33 +18,24 @@ import { get } from "../client";
 import {
   normalizeDisplayFormatGuid,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type { DisplayFormat, DisplayFormatColumn } from "./types";
 
 // Re-export shared GUID helpers so existing developer imports keep working.
-export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
+export {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  resolveDisplayFormatObjectGuid,
+  unwrapDisplayFormat,
+  unwrapDisplayFormatList,
+};
 
 function asArray(payload: unknown): DisplayFormat[] {
-  if (payload == null) return [];
-  let rawList: unknown[] = [];
-  if (Array.isArray(payload)) {
-    rawList = payload;
-  } else if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    const raw =
-      obj.DisplayFormat ??
-      obj.displayFormat ??
-      obj.DisplayFormatList ??
-      obj.displayFormatList;
-    if (raw == null) return [];
-    rawList = Array.isArray(raw) ? raw : [raw];
-  } else {
-    return [];
-  }
-  // Normalize each element (Jackson may wrap list items or omit guid.stringValue).
-  return rawList.map((item) => unwrapDisplayFormat(item));
+  return unwrapDisplayFormatList(payload);
 }
 
 export function normalizeColumns(

--- a/WebUI/src/main/ts/api/developer/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/developer/preferencesApi.ts
@@ -16,8 +16,10 @@
  */
 
 import {
+  getAllUserPreferences,
   loadUserPreference,
   saveUserPreference,
+  unwrapUserPreference,
   type UserPreference,
 } from "../preferences/preferencesApi";
 import {
@@ -41,17 +43,67 @@ export type LoadDefaultAclTemplateResult = {
   fromPreference: boolean;
 };
 
+function isDefaultAclTemplatePref(pref: UserPreference): boolean {
+  return (
+    (pref.name || "").trim().toLowerCase() ===
+    DEFAULT_ACL_TEMPLATE_PREF_NAME.toLowerCase()
+  );
+}
+
+/**
+ * Parse a stored preference into a template. Accepts a JSON string or an
+ * already-parsed object so reload does not drop Runtime visibility (#3204).
+ */
+export function templateFromPreferenceValue(
+  pref: UserPreference | null | undefined,
+): DefaultAclTemplate | null {
+  if (!pref) {
+    return null;
+  }
+  const raw = pref.value as unknown;
+  if (raw == null || raw === "") {
+    return null;
+  }
+  if (typeof raw === "string") {
+    return parseDefaultAclTemplate(raw);
+  }
+  if (typeof raw === "object") {
+    return parseDefaultAclTemplate(raw as Record<string, unknown>);
+  }
+  return parseDefaultAclTemplate(String(raw));
+}
+
 /**
  * Load the Developer default ACL template preference, or system default.
+ *
+ * <p>GET {@code /preferences/{name}} is the primary path. When that returns
+ * 404, an empty value, or a body that production unwrap rejects as flat
+ * ({@code acceptFlat: false}), fall back to GET {@code /preferences/} so a
+ * successful Save still reloads Design/Runtime visibility (#2948 / #3204).
  */
 export async function loadDefaultAclTemplate(): Promise<LoadDefaultAclTemplateResult> {
-  const pref = await loadUserPreference(DEFAULT_ACL_TEMPLATE_PREF_NAME);
-  if (pref?.value) {
-    const parsed = parseDefaultAclTemplate(pref.value);
-    if (parsed) {
-      return { template: parsed, fromPreference: true };
+  const named = await loadUserPreference(DEFAULT_ACL_TEMPLATE_PREF_NAME);
+  const fromNamed = templateFromPreferenceValue(named);
+  if (fromNamed) {
+    return { template: fromNamed, fromPreference: true };
+  }
+
+  const listed = await getAllUserPreferences();
+  const match = listed.find(isDefaultAclTemplatePref);
+  const fromList = templateFromPreferenceValue(match);
+  if (fromList) {
+    return { template: fromList, fromPreference: true };
+  }
+
+  // Last resort: list item present but GET-by-name unwrap was too strict.
+  if (match) {
+    const loosened = unwrapUserPreference(match, { acceptFlat: true });
+    const fromLoose = templateFromPreferenceValue(loosened);
+    if (fromLoose) {
+      return { template: fromLoose, fromPreference: true };
     }
   }
+
   return { template: systemDefaultAclTemplate(), fromPreference: false };
 }
 

--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -3,8 +3,10 @@
  */
 
 import { get, post, put } from "../client";
+import { objectGuidString } from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type {
+  RestGuid,
   SiteDef,
   VirtualSiteBuildRequest,
   VirtualSiteBuildResult,
@@ -131,9 +133,17 @@ function normalizeSiteRow(raw: unknown): SiteDef {
   }
   const obj = raw as Record<string, unknown>;
   const name = coerceDisplayString(obj.name);
+  const guidString = objectGuidString(obj.guid);
+  let guid = obj.guid as RestGuid | undefined;
+  if (guidString) {
+    const existing =
+      guid != null && typeof guid === "object" && !Array.isArray(guid) ? guid : {};
+    guid = { ...existing, stringValue: guidString };
+  }
   return {
     ...(obj as SiteDef),
     name: name || undefined,
+    guid,
   };
 }
 

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -400,6 +400,8 @@ export interface DisplayFormatColumn {
 /** CX display format (UI-05). */
 export interface DisplayFormat {
   guid?: RestGuid;
+  /** Plain host-type-uuid from adaptor when nested Guid is hard to bind (#3200). */
+  guidString?: string;
   name?: string;
   label?: string;
   displayName?: string;

--- a/WebUI/src/main/ts/api/displayFormatGuid.ts
+++ b/WebUI/src/main/ts/api/displayFormatGuid.ts
@@ -16,7 +16,7 @@
 
 /**
  * Shared Display Format GUID wire helpers used by both Developer and Content
- * Explorer {@code displayFormatsApi} modules (issues #2689 / #2951).
+ * Explorer {@code displayFormatsApi} modules (issues #2689 / #2951 / #3200).
  *
  * <p>Keep a single implementation so synthesis / nested-Guid rules cannot drift
  * between the two REST clients.
@@ -25,11 +25,56 @@
 import type { DisplayFormat, RestGuid } from "./developer/types";
 
 /**
+ * {@code PSTypeEnum.DISPLAY_FORMAT} numeric type. Used only when the wire
+ * omits Guid parts but still has {@code displayId}.
+ */
+export const DISPLAY_FORMAT_TYPE = 31;
+
+function firstNonBlankString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
+function readOptionalLikeString(value: unknown): string | undefined {
+  const direct = firstNonBlankString(value);
+  if (direct) {
+    return direct;
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return readOptionalLikeString(value[0]);
+  }
+  if (value != null && typeof value === "object") {
+    const opt = value as Record<string, unknown>;
+    return (
+      firstNonBlankString(opt.value) ||
+      firstNonBlankString(opt.stringValue) ||
+      firstNonBlankString(opt.present === true ? opt.value : undefined)
+    );
+  }
+  return undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Extract a usable object GUID string from REST Guid wire shapes.
  *
  * <p>Handles plain strings, {@code { stringValue }}, nested {@code { Guid: … }}
- * wraps, and synthesis from {@code hostId-type-uuid} when {@code stringValue} is
- * missing (issue #2951 residual after #2689 root unwrap).
+ * wraps, Optional-like objects, snake_case aliases, and synthesis from
+ * {@code hostId-type-uuid} when {@code stringValue} is missing
+ * (issues #2951 / #3200).
  */
 export function objectGuidString(guid: unknown): string | undefined {
   if (guid == null) {
@@ -44,32 +89,29 @@ export function objectGuidString(guid: unknown): string | undefined {
   }
 
   let g = guid as Record<string, unknown>;
-  // Nested root-style wrap (rare): { Guid: { stringValue / parts } }
   const nestedGuid = g.Guid ?? g.guid;
   if (
     nestedGuid != null &&
     typeof nestedGuid === "object" &&
     !Array.isArray(nestedGuid) &&
     g.stringValue == null &&
+    g.string_value == null &&
     g.hostId == null &&
+    g.host_id == null &&
     g.uuid == null
   ) {
     g = nestedGuid as Record<string, unknown>;
   }
 
-  const sv = g.stringValue;
-  if (typeof sv === "string" && sv.trim()) {
-    return sv.trim();
-  }
-  // Accidental Optional-like object (defensive)
-  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
-    const opt = sv as Record<string, unknown>;
-    if (typeof opt.value === "string" && opt.value.trim()) {
-      return opt.value.trim();
-    }
+  const fromString =
+    readOptionalLikeString(g.stringValue) ||
+    readOptionalLikeString(g.string_value) ||
+    readOptionalLikeString(g.STRING_VALUE);
+  if (fromString) {
+    return fromString;
   }
 
-  const hostId = g.hostId;
+  const hostId = g.hostId ?? g.host_id;
   const type = g.type;
   const uuid = g.uuid;
   const hostOk = typeof hostId === "number" || typeof hostId === "string";
@@ -83,22 +125,68 @@ export function objectGuidString(guid: unknown): string | undefined {
 }
 
 /**
+ * Synthesize {@code 0-31-{displayId}} when the server omitted Guid but still
+ * sent the native display format id ({@link DISPLAY_FORMAT_TYPE}).
+ */
+export function synthesizeDisplayFormatGuidFromDisplayId(
+  displayId: unknown,
+): string | undefined {
+  const n = asFiniteNumber(displayId);
+  if (n == null || n <= 0) {
+    return undefined;
+  }
+  return `0-${DISPLAY_FORMAT_TYPE}-${n}`;
+}
+
+/**
+ * Resolve the GUID the Developer detail header / Object ACL should use.
+ *
+ * <p>Order: nested Guid → plain {@code guidString} → catalog list fallback →
+ * {@code displayId} synthesis. Never returns a blank string.
+ */
+export function resolveDisplayFormatObjectGuid(
+  df: DisplayFormat | null | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  if (df != null) {
+    const fromGuid = objectGuidString(df.guid);
+    if (fromGuid) {
+      return fromGuid;
+    }
+    const fromPlain = firstNonBlankString(df.guidString);
+    if (fromPlain) {
+      return fromPlain;
+    }
+  }
+  const fromCatalog = firstNonBlankString(catalogGuid);
+  if (fromCatalog) {
+    return fromCatalog;
+  }
+  return synthesizeDisplayFormatGuidFromDisplayId(df?.displayId);
+}
+
+/**
  * Ensure {@link DisplayFormat.guid}.stringValue is populated when the wire
- * Guid only carried numeric parts (or was a plain string).
+ * Guid only carried numeric parts (or was a plain string). Also copies
+ * {@code guidString} when that is the only usable form (#3200).
  */
 export function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
-  const gs = objectGuidString(df.guid);
+  const gs =
+    objectGuidString(df.guid) ||
+    firstNonBlankString(df.guidString) ||
+    synthesizeDisplayFormatGuidFromDisplayId(df.displayId);
   if (!gs) {
     return df;
   }
+  const nextGuidString = firstNonBlankString(df.guidString) || gs;
   if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
     const existing = df.guid as RestGuid;
-    if (existing.stringValue === gs) {
+    if (existing.stringValue === gs && df.guidString === nextGuidString) {
       return df;
     }
-    return { ...df, guid: { ...existing, stringValue: gs } };
+    return { ...df, guidString: nextGuidString, guid: { ...existing, stringValue: gs } };
   }
-  return { ...df, guid: { stringValue: gs } };
+  return { ...df, guidString: nextGuidString, guid: { stringValue: gs } };
 }
 
 /**
@@ -129,8 +217,58 @@ export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
       body = root as DisplayFormat;
     }
   } else {
-    // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
     body = root as DisplayFormat;
   }
   return normalizeDisplayFormatGuid(body);
+}
+
+function looksLikeDisplayFormat(obj: Record<string, unknown>): boolean {
+  return (
+    obj.name != null ||
+    obj.internalName != null ||
+    obj.guid != null ||
+    obj.guidString != null ||
+    obj.displayId != null ||
+    obj.label != null
+  );
+}
+
+function flattenDisplayFormatPayload(payload: unknown): unknown[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    const out: unknown[] = [];
+    for (const item of payload) {
+      out.push(...flattenDisplayFormatPayload(item));
+    }
+    return out;
+  }
+  if (typeof payload !== "object") {
+    return [];
+  }
+  const obj = payload as Record<string, unknown>;
+  const listWrap = obj.DisplayFormatList ?? obj.displayFormatList;
+  if (listWrap != null) {
+    return flattenDisplayFormatPayload(listWrap);
+  }
+  const nested = obj.DisplayFormat ?? obj.displayFormat;
+  if (Array.isArray(nested)) {
+    return flattenDisplayFormatPayload(nested);
+  }
+  if (nested != null && typeof nested === "object") {
+    return flattenDisplayFormatPayload(nested);
+  }
+  if (looksLikeDisplayFormat(obj)) {
+    return [obj];
+  }
+  return [];
+}
+
+/**
+ * Unwrap list envelopes: bare array, {@code DisplayFormat:[…]}, nested
+ * {@code DisplayFormatList:{DisplayFormat:[…]}} (#3200).
+ */
+export function unwrapDisplayFormatList(payload: unknown): DisplayFormat[] {
+  return flattenDisplayFormatPayload(payload).map((item) => unwrapDisplayFormat(item));
 }

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -68,23 +68,57 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
-function asPreferenceArray(data: unknown): UserPreference[] {
-  if (Array.isArray(data)) {
-    return data.filter(isUserPreferenceShape);
+function collectPreferenceShapes(value: unknown): UserPreference[] {
+  if (Array.isArray(value)) {
+    return value.filter(isUserPreferenceShape);
   }
-  if (data != null && typeof data === "object") {
-    const root = data as Record<string, unknown>;
-    for (const key of [
-      "UserPreferenceList",
-      "userPreferenceList",
-      "list",
-      "items",
-    ]) {
-      const nested = root[key];
-      if (Array.isArray(nested)) {
-        return nested.filter(isUserPreferenceShape);
+  return [];
+}
+
+/**
+ * Normalize GET {@code /preferences/} payloads.
+ *
+ * <p>Jackson {@code WRAP_ROOT_VALUE} may emit a bare array, a
+ * {@code UserPreferenceList} array envelope, or a JAXB-style nested
+ * {@code { UserPreferenceList: { UserPreference: [...] } }}. Missing the
+ * nested form made list fallback miss {@code developer.defaultObjectAclTemplate}
+ * after Save (#3204 / #2643).
+ */
+function asPreferenceArray(data: unknown): UserPreference[] {
+  const direct = collectPreferenceShapes(data);
+  if (direct.length > 0) {
+    return direct;
+  }
+  const root = asRecord(data);
+  if (!root) {
+    return [];
+  }
+  for (const key of [
+    "UserPreferenceList",
+    "userPreferenceList",
+    "list",
+    "items",
+  ]) {
+    const nested = root[key];
+    const fromNested = collectPreferenceShapes(nested);
+    if (fromNested.length > 0) {
+      return fromNested;
+    }
+    const nestedObj = asRecord(nested);
+    if (nestedObj) {
+      for (const innerKey of ["UserPreference", "userPreference", "items", "list"]) {
+        const fromInner = collectPreferenceShapes(nestedObj[innerKey]);
+        if (fromInner.length > 0) {
+          return fromInner;
+        }
       }
     }
+  }
+  const fromRootItems = collectPreferenceShapes(
+    root.UserPreference ?? root.userPreference,
+  );
+  if (fromRootItems.length > 0) {
+    return fromRootItems;
   }
   return [];
 }

--- a/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
@@ -419,6 +419,8 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
                     <tr
                       key={r.clientKey}
                       data-testid={`developer-prefs-acl-row-${r.clientKey}`}
+                      data-acl-principal={r.name}
+                      data-acl-principal-type={r.type}
                       style={{
                         borderBottom: `1px solid ${catalogColors.softBorder}`,
                       }}

--- a/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState } from "react";
 import {
   getDisplayFormatDetail,
   normalizeColumns,
-  objectGuidString,
+  resolveDisplayFormatObjectGuid,
 } from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
@@ -58,11 +58,8 @@ export function DisplayFormatDetailPanel({
 
   const columns =
     detail != null ? normalizeColumns(detail.columns) : [];
-  // Prefer detail GUID (after unwrap/normalize); fall back to catalog list GUID.
-  const objectGuid =
-    (detail != null ? objectGuidString(detail.guid) : undefined) ||
-    (catalogGuid && catalogGuid.trim() ? catalogGuid.trim() : undefined) ||
-    undefined;
+  // Prefer detail GUID (unwrap / guidString / displayId); then catalog list GUID.
+  const objectGuid = resolveDisplayFormatObjectGuid(detail, catalogGuid);
 
   return (
     <div data-testid="developer-df-detail">

--- a/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   listDisplayFormats,
   normalizeColumns,
-  objectGuidString,
+  resolveDisplayFormatObjectGuid,
 } from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
@@ -70,11 +70,11 @@ export function DisplayFormatsPanel(): React.ReactElement {
   }, [items]);
 
   const openFormat = (f: DisplayFormat) => {
-    const idOrName = f.name || f.internalName || objectGuidString(f.guid) || "";
+    const idOrName = f.name || f.internalName || resolveDisplayFormatObjectGuid(f) || "";
     if (!idOrName) return;
     setSelected({
       idOrName,
-      catalogGuid: objectGuidString(f.guid),
+      catalogGuid: resolveDisplayFormatObjectGuid(f),
     });
   };
 
@@ -116,7 +116,7 @@ export function DisplayFormatsPanel(): React.ReactElement {
         ]}
         rows={sorted.map((f, index) => {
           const openKey =
-            f.name || f.internalName || objectGuidString(f.guid) || "";
+            f.name || f.internalName || resolveDisplayFormatObjectGuid(f) || "";
           const interactive = openKey.length > 0;
           const colCount = normalizeColumns(f.columns).length;
           const usage: string[] = [];
@@ -124,7 +124,7 @@ export function DisplayFormatsPanel(): React.ReactElement {
           if (f.validForViewsAndSearches) usage.push(DEV_MSG.DF_USAGE_VIEWS);
           if (f.validForRelatedContent) usage.push(DEV_MSG.DF_USAGE_RELATED);
           return {
-            key: objectGuidString(f.guid) || f.name || `df-${index}`,
+            key: resolveDisplayFormatObjectGuid(f) || f.name || `df-${index}`,
             onClick: interactive ? () => openFormat(f) : undefined,
             cells: [
               interactive ? (

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -191,6 +191,18 @@ function structureEqual(a: DraftEntry[], b: DraftEntry[]): boolean {
   return true;
 }
 
+/** Kind-aware empty copy when the parent panel cannot supply an object GUID. */
+export function noGuidCopy(objectKind?: AclDesignObjectKind | null): string {
+  switch (objectKind) {
+    case "site":
+      return DEV_MSG.ACL_NO_GUID_SITE;
+    case "display-format":
+      return DEV_MSG.ACL_NO_GUID_DISPLAY_FORMAT;
+    default:
+      return DEV_MSG.ACL_NO_GUID;
+  }
+}
+
 /** i18n label for a known REST permission column (Workbench wording). */
 function permissionColumnLabel(perm: AclPermissionName): string {
   switch (perm) {
@@ -600,7 +612,7 @@ export function ObjectAclSection({
       >
         <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.ACL_TITLE}</h3>
         <p style={{ color: catalogColors.empty }} data-testid={`${testIdPrefix}-no-guid`}>
-          {DEV_MSG.ACL_NO_GUID}
+          {noGuidCopy(objectKind)}
         </p>
       </section>
     );

--- a/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from "react";
+import { objectGuidString } from "../api/displayFormatGuid";
 import { coerceDisplayString } from "../api/developer/sitesApi";
 import type { SiteDef } from "../api/developer/types";
 import { catalogColors, backButton, metaGrid, monoCell } from "./catalogStyles";
@@ -19,6 +20,7 @@ export function SiteDetailPanel({
 }): React.ReactElement {
   const name = coerceDisplayString(site.name) || "—";
   const siteKey = coerceDisplayString(site.name);
+  const objectGuid = objectGuidString(site.guid);
   const gaps =
     site.designGaps && site.designGaps.length
       ? site.designGaps
@@ -43,6 +45,13 @@ export function SiteDetailPanel({
         <dl style={metaGrid}>
           <dt>{DEV_MSG.SITE_COL_NAME}</dt>
           <dd style={{ margin: 0, ...monoCell }}>{name}</dd>
+          <dt>{DEV_MSG.SITE_COL_GUID}</dt>
+          <dd
+            style={{ margin: 0, ...monoCell }}
+            data-testid="developer-site-detail-guid"
+          >
+            {objectGuid || "—"}
+          </dd>
           <dt>{DEV_MSG.SITE_COL_DESC}</dt>
           <dd style={{ margin: 0 }}>{site.description || "—"}</dd>
           <dt>{DEV_MSG.SITE_COL_URL}</dt>
@@ -63,7 +72,7 @@ export function SiteDetailPanel({
       {siteKey ? <VirtualSiteSourcePanel siteName={siteKey} /> : null}
 
       <ObjectAclSection
-        objectGuid={site.guid?.stringValue}
+        objectGuid={objectGuid}
         objectKind="site"
         testIdPrefix="developer-site-acl"
       />

--- a/WebUI/src/main/ts/developer/defaultAclTemplate.ts
+++ b/WebUI/src/main/ts/developer/defaultAclTemplate.ts
@@ -122,16 +122,25 @@ function normalizeEntry(raw: unknown): DefaultAclTemplateEntry | null {
 /**
  * Parse a preference value into a template. Returns null when empty/invalid
  * (caller should fall back to {@link systemDefaultAclTemplate}).
+ *
+ * <p>Accepts a JSON string or an already-parsed object. Some GET paths leave
+ * {@code UserPreference.value} as a parsed object (or {@code String(obj)} would
+ * become {@code [object Object]} and drop Runtime visibility on reload).
  */
 export function parseDefaultAclTemplate(
-  raw: string | null | undefined,
+  raw: string | Record<string, unknown> | null | undefined,
 ): DefaultAclTemplate | null {
-  if (raw == null || !String(raw).trim()) return null;
+  if (raw == null) return null;
   let data: unknown;
-  try {
-    data = JSON.parse(String(raw));
-  } catch {
-    return null;
+  if (typeof raw === "object") {
+    data = raw;
+  } else {
+    if (!String(raw).trim()) return null;
+    try {
+      data = JSON.parse(String(raw));
+    } catch {
+      return null;
+    }
   }
   const o = asRecord(data);
   if (!o) return null;

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -41,6 +41,10 @@ export const DEV_MSG_KEYS = {
   ACL_OWNER_NAME: "perc.ui.developer@Owner principal",
   ACL_OWNER_NAME_PLACEHOLDER: "perc.ui.developer@User or role that owns the ACL",
   ACL_NO_GUID: "perc.ui.developer@Object GUID not available - cannot load ACL.",
+  ACL_NO_GUID_SITE:
+    "perc.ui.developer@This site has no object GUID — ACL cannot be loaded.",
+  ACL_NO_GUID_DISPLAY_FORMAT:
+    "perc.ui.developer@This display format has no object GUID — ACL cannot be loaded.",
   ACL_NO_ENTRIES: "perc.ui.developer@No ACL entries yet - add a principal below.",
   ACL_COL_ENTRY: "perc.ui.developer@Principal / name",
   ACL_COL_TYPE: "perc.ui.developer@Type",
@@ -717,6 +721,7 @@ export const DEV_MSG_KEYS = {
   SITE_HINT:
     "perc.ui.developer@Site definitions for association browse (SY-04). Open a row for URL, defaults, and Virtual Site source. Full site create/delete remains outside this catalog.",
   SITE_COL_NAME: "perc.ui.developer@Name",
+  SITE_COL_GUID: "perc.ui.developer@GUID",
   SITE_COL_DESC: "perc.ui.developer@Description",
   SITE_COL_URL: "perc.ui.developer@Base URL",
   SITE_COL_FLAGS: "perc.ui.developer@Flags",

--- a/WebUI/src/test/ts/api/developer/aclApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/aclApi.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAclForObject, unwrapObjectAcl } from "../../../../main/ts/api/developer/aclApi";
+
+describe("unwrapObjectAcl", () => {
+  it("unwraps Jackson Acl root so entries are reachable (#3200)", () => {
+    const acl = unwrapObjectAcl({
+      Acl: {
+        id: 7,
+        name: "By_Author ACL",
+        aclEntries: [{ name: "Admin", type: { type: "ROLE" } }],
+      },
+    });
+    expect(acl.id).toBe(7);
+    expect(acl.name).toBe("By_Author ACL");
+    expect(Array.isArray(acl.aclEntries)).toBe(true);
+  });
+
+  it("passes through flat ACL bodies", () => {
+    const flat = { id: 1, name: "x", aclEntries: [] };
+    expect(unwrapObjectAcl(flat)).toEqual(flat);
+  });
+});
+
+describe("getAclForObject", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("unwraps wrapped GET /acls/object/{guid} body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            Acl: { id: 9, name: "df", aclEntries: [{ name: "Default" }] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+    const acl = await getAclForObject("0-31-5");
+    expect(acl.id).toBe(9);
+    expect(acl.name).toBe("df");
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});

--- a/WebUI/src/test/ts/api/developer/aclApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/aclApi.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as client from "../../../../main/ts/api/client";
+import {
+  createObjectAcl,
+  getAclForObject,
+  unwrapObjectAcl,
+} from "../../../../main/ts/api/developer/aclApi";
+
+vi.mock("../../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+const get = client.get as ReturnType<typeof vi.fn>;
+const post = client.post as ReturnType<typeof vi.fn>;
+
+describe("unwrapObjectAcl", () => {
+  it("unwraps Jackson Acl root so entries are reachable (#3203)", () => {
+    const acl = unwrapObjectAcl({
+      Acl: {
+        id: 7,
+        name: "By_Author ACL",
+        aclEntries: [{ name: "Admin", type: { type: "ROLE" } }],
+      },
+    });
+    expect(acl.id).toBe(7);
+    expect(acl.name).toBe("By_Author ACL");
+    expect(Array.isArray(acl.aclEntries)).toBe(true);
+  });
+
+  it("unwraps camelCase acl envelope", () => {
+    const acl = unwrapObjectAcl({
+      acl: { id: 3, name: "site", aclEntries: [] },
+    });
+    expect(acl.id).toBe(3);
+    expect(acl.name).toBe("site");
+  });
+
+  it("passes through flat ACL bodies", () => {
+    const flat = { id: 1, name: "x", aclEntries: [] };
+    expect(unwrapObjectAcl(flat)).toEqual(flat);
+  });
+
+  it("returns empty object for non-objects", () => {
+    expect(unwrapObjectAcl(null)).toEqual({});
+    expect(unwrapObjectAcl("acl")).toEqual({});
+  });
+});
+
+describe("getAclForObject", () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it("unwraps wrapped GET /acls/object/{guid} body", async () => {
+    get.mockResolvedValue({
+      Acl: { id: 9, name: "df", aclEntries: [{ name: "Default" }] },
+    });
+    const acl = await getAclForObject("0-31-5");
+    expect(acl.id).toBe(9);
+    expect(acl.name).toBe("df");
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});
+
+describe("createObjectAcl", () => {
+  beforeEach(() => {
+    post.mockReset();
+  });
+
+  it("unwraps wrapped POST /acls body", async () => {
+    post.mockResolvedValue({
+      Acl: { id: 4, name: "new", aclEntries: [{ name: "Admin" }] },
+    });
+    const acl = await createObjectAcl("0-20-1", { name: "Admin", type: "ROLE" });
+    expect(acl.id).toBe(4);
+    expect(acl.aclEntries).toHaveLength(1);
+  });
+});

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -112,7 +112,10 @@ describe("unwrapDisplayFormat", () => {
       name: "FolderList",
       guid: { stringValue: "0-11-2" },
     };
-    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+    expect(unwrapDisplayFormat(flat)).toEqual({
+      ...flat,
+      guidString: "0-11-2",
+    });
   });
 
   it("takes first element when envelope holds a singleton array", () => {

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -19,7 +19,9 @@ import {
   getDisplayFormatDetail,
   listDisplayFormats,
   objectGuidString,
+  resolveDisplayFormatObjectGuid,
   unwrapDisplayFormat,
+  unwrapDisplayFormatList,
 } from "../../../../main/ts/api/developer/displayFormatsApi";
 
 describe("objectGuidString", () => {
@@ -48,6 +50,23 @@ describe("objectGuidString", () => {
     expect(objectGuidString(undefined)).toBeUndefined();
     expect(objectGuidString({})).toBeUndefined();
     expect(objectGuidString("")).toBeUndefined();
+  });
+
+  it("reads Optional-like and snake_case stringValue (#3200)", () => {
+    expect(objectGuidString({ stringValue: { value: "0-31-8" } })).toBe("0-31-8");
+    expect(objectGuidString({ string_value: "0-31-7" })).toBe("0-31-7");
+  });
+});
+
+describe("resolveDisplayFormatObjectGuid", () => {
+  it("prefers nested guid then guidString then catalog then displayId (#3200)", () => {
+    expect(
+      resolveDisplayFormatObjectGuid({ guid: { stringValue: "0-31-1" }, displayId: 9 }),
+    ).toBe("0-31-1");
+    expect(resolveDisplayFormatObjectGuid({ guidString: "0-31-2", displayId: 9 })).toBe("0-31-2");
+    expect(resolveDisplayFormatObjectGuid({ displayId: 9 }, " 0-31-3 ")).toBe("0-31-3");
+    expect(resolveDisplayFormatObjectGuid({ displayId: 9 })).toBe("0-31-9");
+    expect(resolveDisplayFormatObjectGuid({}, undefined)).toBeUndefined();
   });
 });
 
@@ -109,6 +128,31 @@ describe("unwrapDisplayFormat", () => {
     expect(unwrapDisplayFormat(undefined)).toEqual({});
     expect(unwrapDisplayFormat("x")).toEqual({});
     expect(unwrapDisplayFormat([])).toEqual({});
+  });
+
+  it("copies guidString onto guid.stringValue (#3200)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: { name: "By_Author", guidString: "0-31-4" },
+    });
+    expect(unwrapped.guidString).toBe("0-31-4");
+    expect(unwrapped.guid?.stringValue).toBe("0-31-4");
+  });
+});
+
+describe("unwrapDisplayFormatList", () => {
+  it("flattens nested DisplayFormatList envelope (#3200)", () => {
+    const list = unwrapDisplayFormatList({
+      DisplayFormatList: {
+        DisplayFormat: [
+          { name: "By_Author", guid: { hostId: 0, type: 31, uuid: 5 } },
+          { name: "Default", displayId: 2 },
+        ],
+      },
+    });
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe("By_Author");
+    expect(list[0].guid?.stringValue).toBe("0-31-5");
+    expect(list[1].guid?.stringValue).toBe("0-31-2");
   });
 });
 

--- a/WebUI/src/test/ts/api/developer/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/preferencesApi.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadDefaultAclTemplate,
+  templateFromPreferenceValue,
+} from "../../../../main/ts/api/developer/preferencesApi";
+import * as prefs from "../../../../main/ts/api/preferences/preferencesApi";
+import {
+  serializeDefaultAclTemplate,
+  systemDefaultAclTemplate,
+} from "../../../../main/ts/developer/defaultAclTemplate";
+
+const VISIBLE_TEMPLATE = (() => {
+  const t = systemDefaultAclTemplate();
+  t.entries[0].permissions = [
+    ...t.entries[0].permissions,
+    "RUNTIME_VISIBLE",
+  ];
+  return t;
+})();
+
+const VISIBLE_JSON = serializeDefaultAclTemplate(VISIBLE_TEMPLATE);
+
+describe("developer preferencesApi — default ACL template (#3204)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("templateFromPreferenceValue keeps RUNTIME_VISIBLE from JSON string", () => {
+    const parsed = templateFromPreferenceValue({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_JSON,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("templateFromPreferenceValue keeps RUNTIME_VISIBLE from parsed object value", () => {
+    const parsed = templateFromPreferenceValue({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_TEMPLATE as unknown as string,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("loadDefaultAclTemplate uses GET-by-name when value is present", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce({
+      name: "developer.defaultObjectAclTemplate",
+      value: VISIBLE_JSON,
+    });
+    const listSpy = vi.spyOn(prefs, "getAllUserPreferences");
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(true);
+    expect(result.template.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to preference list when GET-by-name is empty (#3204)", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce(null);
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([
+      {
+        name: "developer.defaultObjectAclTemplate",
+        value: VISIBLE_JSON,
+      },
+    ]);
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(true);
+    expect(result.template.entries[0].name).toBe("Default");
+    expect(result.template.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+  });
+
+  it("uses system default when neither GET-by-name nor list has a template", async () => {
+    vi.spyOn(prefs, "loadUserPreference").mockResolvedValueOnce(null);
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([]);
+    const result = await loadDefaultAclTemplate();
+    expect(result.fromPreference).toBe(false);
+    expect(result.template.entries[0].permissions).not.toContain(
+      "RUNTIME_VISIBLE",
+    );
+  });
+});

--- a/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
@@ -88,6 +88,25 @@ describe("parseSiteList (#3198 bind)", () => {
     expect(parseSiteList({ Site: { name: "Only" } })).toEqual([{ name: "Only" }]);
   });
 
+  it("synthesizes guid.stringValue from host/type/uuid parts (#3203)", () => {
+    expect(
+      parseSiteList({
+        Site: { name: "Help", guid: { hostId: 0, type: 20, uuid: 301 } },
+      }),
+    ).toEqual([
+      {
+        name: "Help",
+        guid: { hostId: 0, type: 20, uuid: 301, stringValue: "0-20-301" },
+      },
+    ]);
+  });
+
+  it("keeps existing guid.stringValue", () => {
+    expect(
+      parseSiteList([{ name: "Help", guid: { stringValue: "0-20-1" } }]),
+    ).toEqual([{ name: "Help", guid: { stringValue: "0-20-1" } }]);
+  });
+
   it("throws on unknown object shape", () => {
     expect(() => parseSiteList({ unexpected: true })).toThrow(
       /Unexpected site list payload/,

--- a/WebUI/src/test/ts/api/displayFormatGuid.test.ts
+++ b/WebUI/src/test/ts/api/displayFormatGuid.test.ts
@@ -62,9 +62,22 @@ describe("normalizeDisplayFormatGuid", () => {
     expect(out.guid?.uuid).toBe(301);
   });
 
-  it("returns same reference when stringValue already matches", () => {
-    const df = { name: "x", guid: { stringValue: "0-11-1", uuid: 1 } };
+  it("returns same reference when stringValue and guidString already match", () => {
+    const df = {
+      name: "x",
+      guid: { stringValue: "0-11-1", uuid: 1 },
+      guidString: "0-11-1",
+    };
     expect(normalizeDisplayFormatGuid(df)).toBe(df);
+  });
+
+  it("fills guidString from guid when companion is missing (#3200)", () => {
+    const out = normalizeDisplayFormatGuid({
+      name: "x",
+      guid: { stringValue: "0-11-1", uuid: 1 },
+    });
+    expect(out.guidString).toBe("0-11-1");
+    expect(out.guid?.stringValue).toBe("0-11-1");
   });
 });
 
@@ -110,7 +123,10 @@ describe("unwrapDisplayFormat", () => {
       name: "FolderList",
       guid: { stringValue: "0-11-2" },
     };
-    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+    expect(unwrapDisplayFormat(flat)).toEqual({
+      ...flat,
+      guidString: "0-11-2",
+    });
   });
 
   it("takes first element when envelope holds a singleton array", () => {

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -46,6 +46,23 @@ describe("preferencesApi (PreferenceResource)", () => {
     await expect(getAllUserPreferences()).resolves.toEqual([]);
   });
 
+  it("getAllUserPreferences unwraps JAXB UserPreferenceList envelope (#3204)", async () => {
+    const getSpy = vi.spyOn(client, "get");
+    getSpy.mockResolvedValueOnce({
+      UserPreferenceList: {
+        UserPreference: [
+          {
+            name: "developer.defaultObjectAclTemplate",
+            value: '{"version":1,"entries":[]}',
+          },
+        ],
+      },
+    });
+    const list = await getAllUserPreferences();
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("developer.defaultObjectAclTemplate");
+  });
+
   it("loadUserPreference returns null on 404", async () => {
     vi.spyOn(client, "get").mockRejectedValueOnce({
       status: 404,

--- a/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
@@ -125,6 +125,10 @@ describe("DeveloperPreferencesPanel", () => {
         "developer-prefs-acl-perm-row:0:Default:USER-RUNTIME_VISIBLE",
       ),
     ).toBeTruthy();
+
+    const defaultRow = screen.getByTestId("developer-prefs-acl-row-row:0:Default:USER");
+    expect(defaultRow.getAttribute("data-acl-principal")).toBe("Default");
+    expect(defaultRow.getAttribute("data-acl-principal-type")).toBe("USER");
   });
 
   it("saves dirty template via preferences API", async () => {

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -397,17 +397,22 @@ vi.mock("../../../main/ts/api/developer/itemFiltersApi", () => ({
   }),
 }));
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn().mockResolvedValue([
-    { name: "Default", label: "Default View", columns: [] },
-  ]),
-  getDisplayFormatDetail: vi.fn().mockResolvedValue({
-    name: "Default",
-    columns: [],
-  }),
-  normalizeColumns: () => [],
-  objectGuidString: () => undefined,
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn().mockResolvedValue([
+      { name: "Default", label: "Default View", columns: [] },
+    ]),
+    getDisplayFormatDetail: vi.fn().mockResolvedValue({
+      name: "Default",
+      columns: [],
+    }),
+    normalizeColumns: () => [],
+  };
+});
 
 vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({
   listActionMenus: vi.fn().mockResolvedValue([

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -10,27 +10,17 @@ import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormat
 import { DisplayFormatDetailPanel } from "../../../main/ts/developer/DisplayFormatDetailPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn(),
-  getDisplayFormatDetail: vi.fn(),
-  normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
-  objectGuidString: (guid: unknown) => {
-    if (guid == null) return undefined;
-    if (typeof guid === "string") {
-      const t = guid.trim();
-      return t || undefined;
-    }
-    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
-    const g = guid as { stringValue?: string; hostId?: number; type?: number; uuid?: number };
-    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
-      return g.stringValue.trim();
-    }
-    if (g.hostId != null && g.type != null && g.uuid != null) {
-      return `${g.hostId}-${g.type}-${g.uuid}`;
-    }
-    return undefined;
-  },
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn(),
+    getDisplayFormatDetail: vi.fn(),
+    normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  };
+});
 
 // ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
 vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
@@ -117,6 +107,39 @@ describe("DisplayFormatDetailPanel", () => {
     expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-11-5");
     expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
       "0-11-5",
+    );
+  });
+
+  it("uses guidString when nested guid is absent (#3200)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: "0-31-9",
+    });
+    render(<DisplayFormatDetailPanel idOrName="By_Author" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-31-9");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-31-9",
+    );
+  });
+
+  it("synthesizes GUID from displayId when guid is omitted (#3200)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: undefined,
+      displayId: 12,
+    });
+    render(<DisplayFormatDetailPanel idOrName="By_Author" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-31-12");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-31-12",
     );
   });
 

--- a/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
@@ -10,24 +10,17 @@ import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormat
 import { DisplayFormatsPanel } from "../../../main/ts/developer/DisplayFormatsPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn(),
-  getDisplayFormatDetail: vi.fn(),
-  normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
-  objectGuidString: (guid: unknown) => {
-    if (guid == null) return undefined;
-    if (typeof guid === "string") {
-      const t = guid.trim();
-      return t || undefined;
-    }
-    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
-    const g = guid as { stringValue?: string };
-    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
-      return g.stringValue.trim();
-    }
-    return undefined;
-  },
-}));
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/displayFormatsApi")
+  >();
+  return {
+    ...actual,
+    listDisplayFormats: vi.fn(),
+    getDisplayFormatDetail: vi.fn(),
+    normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  };
+});
 
 const listDisplayFormats = displayFormatsApi.listDisplayFormats as ReturnType<typeof vi.fn>;
 const getDisplayFormatDetail = displayFormatsApi.getDisplayFormatDetail as ReturnType<

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -146,7 +146,7 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(siteSection.getAttribute("data-acl-show-runtime")).toBe("true");
     expect(siteSection.getAttribute("data-acl-has-guid")).toBe("false");
     expect(screen.getByTestId("developer-site-acl-no-guid").textContent).toMatch(
-      /GUID not available|cannot load ACL/i,
+      /This site has no object GUID|cannot load ACL/i,
     );
     unmount();
 
@@ -162,6 +162,25 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(kwSection.getAttribute("data-acl-object-kind")).toBe("keyword");
     expect(kwSection.getAttribute("data-acl-show-runtime")).toBe("false");
     expect(kwSection.getAttribute("data-acl-has-guid")).toBe("false");
+    expect(screen.getByTestId("developer-kw-acl-no-guid").textContent).toMatch(
+      /Object GUID not available|cannot load ACL/i,
+    );
+  });
+
+  it("uses display-format kind-aware no-guid copy (#3203)", () => {
+    render(
+      <ObjectAclSection
+        objectGuid={null}
+        objectKind="display-format"
+        testIdPrefix="developer-df-acl"
+      />,
+    );
+    const section = screen.getByTestId("developer-df-acl-section");
+    expect(section.getAttribute("data-acl-object-kind")).toBe("display-format");
+    expect(section.getAttribute("data-acl-show-runtime")).toBe("true");
+    expect(screen.getByTestId("developer-df-acl-no-guid").textContent).toMatch(
+      /This display format has no object GUID|cannot load ACL/i,
+    );
   });
 
   it("groups permission columns under Design access and Runtime visibility (CD-19)", async () => {

--- a/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
@@ -65,6 +65,7 @@ describe("SiteDetailPanel", () => {
     const acl = screen.getByTestId("developer-site-acl-stub");
     expect(acl.getAttribute("data-object-kind")).toBe("site");
     expect(acl.getAttribute("data-object-guid")).toBe("0-10-1");
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("0-10-1");
     const virt = screen.getByTestId("developer-site-virtual-stub");
     expect(virt.getAttribute("data-site-name")).toBe("Corporate");
     const back = screen.getByTestId("developer-site-back");
@@ -97,6 +98,30 @@ describe("SiteDetailPanel", () => {
     expect(detail.textContent).toMatch(/—/);
     expect(screen.getByTestId("developer-site-gaps").textContent).toContain(
       DEV_MSG.SITE_GAP_WRITE,
+    );
+  });
+
+  it("synthesizes object guid from host/type/uuid parts for Object ACL (#3203)", () => {
+    const site: SiteDef = {
+      name: "PartsOnly",
+      guid: { hostId: 0, type: 20, uuid: 99 },
+    };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("0-20-99");
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-20-99",
+    );
+  });
+
+  it("omits object guid when the list payload has none (#3203)", () => {
+    const site: SiteDef = { name: "NoGuid" };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-site-detail-guid").textContent).toBe("—");
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-guid")).toBe(
+      "",
+    );
+    expect(screen.getByTestId("developer-site-acl-stub").getAttribute("data-object-kind")).toBe(
+      "site",
     );
   });
 });

--- a/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
+++ b/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
@@ -98,6 +98,22 @@ describe("defaultAclTemplate helpers", () => {
     expect(parseDefaultAclTemplate(JSON.stringify({ entries: "x" }))).toBeNull();
   });
 
+  /**
+   * #3204 — GET may leave value as a parsed object. String(obj) would become
+   * "[object Object]" and reload would fall back to system default (no Visible).
+   */
+  it("parses an already-decoded object payload (#3204)", () => {
+    const template = cloneDefaultAclTemplate(systemDefaultAclTemplate());
+    template.entries[0].permissions.push("RUNTIME_VISIBLE");
+    const parsed = parseDefaultAclTemplate({
+      version: 1,
+      entries: template.entries,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+    expect(defaultAclTemplatesEqual(parsed!, template)).toBe(true);
+  });
+
   it("parse drops invalid entries and normalizes types/permissions", () => {
     const parsed = parseDefaultAclTemplate(
       JSON.stringify({

--- a/docs/ai-generated/code-reviews/issue-3204-object-acl-prefs-product-path-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3204-object-acl-prefs-product-path-erlang.md
@@ -1,0 +1,23 @@
+# Erlang review — #3204 Object ACL Design/Runtime prefs + product path
+
+## Change class
+
+Operator-facing Developer Preferences persist/reload + Object ACL product path
+(docs + Playwright). Not a site/DF ACL panel rewrite.
+
+## Findings
+
+| Severity | Item | Disposition |
+|----------|------|-------------|
+| Bug | GET-by-name empty/unwrap-null dropped saved Runtime visibility | Fixed: list fallback + object-value parse |
+| Behavioral tests | loadDefaultAclTemplate list fallback; parse object payload; JAXB list unwrap | Added |
+| Playwright | Prefs save → reload Visible persist | Added on product-path spec |
+| Product docs | Operator path missing | `product-docs/8.2/admin/object-acl.md` |
+| Paths | No new filesystem path concat | N/A |
+| API shape | No public Java signature / final/sealed change | downstream_checked=none |
+
+## Hard gates
+
+- No missing persist/reload companion: Vitest + Playwright + product-docs
+- Cross-platform: NIO/path N/A
+- Copyright: new test file uses Intersoft 2026 header

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -361,8 +361,16 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     });
     if (!opened) return;
 
-    // Issue #2951: detail header must render a real GUID (not em-dash) so
-    // ObjectAclSection receives objectGuid — catalog fallback + wire normalize.
+    await assertDisplayFormatDetailGuidAndAcl(page);
+  });
+
+  /**
+   * Issue #3200 / #2951 / #2689: header GUID is real; Object ACL is table,
+   * empty-create, or a real ACL error — never the no-guid shell when the
+   * server has a display format id.
+   * @param {import('@playwright/test').Page} page
+   */
+  async function assertDisplayFormatDetailGuidAndAcl(page) {
     const guidCell = page.locator('[data-testid="developer-df-detail-guid"]');
     await expect(guidCell).toBeVisible({ timeout: 15_000 });
     const guidText = (await guidCell.innerText()).trim();
@@ -370,7 +378,6 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       guidText && guidText !== "—" && guidText !== "-",
       `display-format detail GUID must be synthesized/normalized (got "${guidText}")`,
     ).toBeTruthy();
-    // host-type-uuid wire form or other non-empty string from REST
     expect(guidText.length).toBeGreaterThan(2);
 
     const mode = await assertLayeredObjectAcl(
@@ -378,12 +385,63 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       "developer-df-acl",
       "display-format",
     );
-    // Issue #2689: detail client must unwrap Jackson DisplayFormat root so
-    // objectGuid is present — no-guid shell is a product defect for DF detail.
     expect(
       ["table", "empty"],
       `display-format Object ACL must load with GUID (got mode=${mode})`,
     ).toContain(mode);
+  }
+
+  test("By_Author and one peer Display Format show GUID and Object ACL (#3200)", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("display-formats"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-display-formats"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const panel = page.locator('[data-testid="developer-df-panel"]');
+    const empty = page.locator('[data-testid="developer-df-empty"]');
+    const error = page.locator('[data-testid="developer-df-error"]');
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+    if (await error.isVisible()) {
+      throw new Error(`display formats catalog error: ${(await error.innerText()).trim()}`);
+    }
+    if (await empty.isVisible()) {
+      test.skip(true, "No display formats in CMS");
+      return;
+    }
+
+    const openButtons = page.locator('[data-testid="developer-df-open"]');
+    const count = await openButtons.count();
+    expect(count, "catalog should list at least one display format").toBeGreaterThan(0);
+
+    const names = [];
+    for (let i = 0; i < count; i++) {
+      names.push((await openButtons.nth(i).innerText()).trim());
+    }
+    const byAuthor = names.find((n) => /^By_Author$/i.test(n));
+    const peer = names.find((n) => n && n !== byAuthor);
+    const toOpen = [byAuthor, peer].filter(Boolean);
+    expect(
+      toOpen.length,
+      `need By_Author and/or a peer in catalog (got ${names.join(", ")})`,
+    ).toBeGreaterThan(0);
+
+    for (const name of toOpen) {
+      await page.locator('[data-testid="developer-df-open"]', { hasText: name }).click();
+      await expect(page.locator('[data-testid="developer-df-detail"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await assertDisplayFormatDetailGuidAndAcl(page);
+      await page.locator('[data-testid="developer-df-back"]').click();
+      await expect(page.locator('[data-testid="developer-df-panel"]')).toBeVisible({
+        timeout: 15_000,
+      });
+    }
   });
 
   test("preferences default ACL template shows Design/Runtime column groups", async ({

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -24,6 +24,7 @@
  *   - Kind-aware Design vs Runtime: data-acl-object-kind + data-acl-show-runtime
  *     (table when ACL loads; section shell when object guid is missing)
  *   - Developer Preferences default-ACL template: layered Design / Runtime columns
+ *   - Preferences persist: Runtime Visible survives Save + reload (#3204 / #2643)
  *
  * Kind-aware runtime columns mirror WebUI objectAclPermissionModel.ts
  * RUNTIME_RELEVANT_OBJECT_KINDS — peers in that set show Runtime visibility;
@@ -37,7 +38,7 @@
  * QA mode:
  *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js → qa-down
  *
- * Refs #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
+ * Refs #3204, #2643, #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
  */
 
 const { test, expect } = require("@playwright/test");
@@ -437,5 +438,75 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       'input[type="checkbox"][data-testid^="developer-prefs-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
     );
     await expect(runtimeBoxes.first()).toBeVisible();
+  });
+
+  test("preferences Runtime visibility persists after save and reload (#3204)", async ({
+    page,
+  }) => {
+    const jsErrors = [];
+    page.on("pageerror", (err) => jsErrors.push(String(err)));
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      // GET /preferences/{name} 404 is the empty-store path; chrome 404s
+      // (favicon / leftover hashed chunks) are not product defects.
+      if (/404|Failed to load resource/i.test(text)) {
+        return;
+      }
+      jsErrors.push(text);
+    });
+
+    await page.goto(developerSectionUrl("preferences"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-preferences"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const table = page.locator('[data-testid="developer-prefs-acl-table"]');
+    const loading = page.locator('[data-testid="developer-prefs-acl-loading"]');
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(table).toBeVisible({ timeout: 20_000 });
+
+    const defaultRuntime = page.locator(
+      '[data-testid="developer-prefs-acl-table"] tr[data-acl-principal="Default"] input[type="checkbox"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(defaultRuntime).toBeVisible({ timeout: 10_000 });
+
+    const wasChecked = await defaultRuntime.isChecked();
+    await defaultRuntime.click();
+    await expect(defaultRuntime).toBeChecked({ checked: !wasChecked });
+
+    const saveBtn = page.locator('[data-testid="developer-prefs-acl-save"]');
+    await expect(saveBtn).toBeEnabled({ timeout: 10_000 });
+    await saveBtn.click();
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-notice"]'),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-source"]'),
+    ).toContainText(/saved/i);
+
+    await page.goto(developerSectionUrl("preferences"), {
+      waitUntil: "networkidle",
+    });
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(table).toBeVisible({ timeout: 20_000 });
+
+    const reloaded = page.locator(
+      '[data-testid="developer-prefs-acl-table"] tr[data-acl-principal="Default"] input[type="checkbox"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(reloaded).toBeVisible({ timeout: 10_000 });
+    await expect(reloaded).toBeChecked({ checked: !wasChecked });
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-source"]'),
+    ).toContainText(/saved/i);
+
+    expect(
+      jsErrors,
+      `JS console/page errors on prefs persist path: ${jsErrors.join(" | ")}`,
+    ).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -179,7 +179,11 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   }
 
   await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-  await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+  const aclNoEntries = page.locator(`[data-testid="${prefix}-no-entries"]`);
+  await aclSection.scrollIntoViewIfNeeded().catch(() => {});
+  await expect(
+    aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+  ).toBeVisible({
     timeout: 30_000,
   });
 
@@ -190,6 +194,11 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
 
   if (await aclEmpty.isVisible()) {
     // Create-first empty state still proves mount + kind on section
+    await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
+    return "empty";
+  }
+
+  if (await aclNoEntries.isVisible()) {
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
     return "empty";
   }

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -140,7 +140,7 @@ async function openFirstCatalogDetail(page, ids) {
  * @param {import('@playwright/test').Page} page
  * @param {string} prefix e.g. developer-ct-acl / developer-site-acl
  * @param {string} objectKind expected data-acl-object-kind
- * @returns {Promise<"table"|"no-guid"|"empty">}
+ * @returns {Promise<"table"|"no-guid"|"empty"|"no-entries">}
  */
 async function assertLayeredObjectAcl(page, prefix, objectKind) {
   const expectRuntime = RUNTIME_RELEVANT_OBJECT_KINDS.has(objectKind);
@@ -154,6 +154,7 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   const noGuid = page.locator(`[data-testid="${prefix}-no-guid"]`);
   const aclError = page.locator(`[data-testid="${prefix}-error"]`);
   const aclEmpty = page.locator(`[data-testid="${prefix}-empty"]`);
+  const aclNoEntries = page.locator(`[data-testid="${prefix}-no-entries"]`);
   const aclTable = page.locator(`[data-testid="${prefix}-table"]`);
   const aclLoading = page.locator(`[data-testid="${prefix}-loading"]`);
 
@@ -164,14 +165,16 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
       "data-acl-show-runtime",
       expectRuntime ? "true" : "false",
     );
-    await expect(noGuid).toContainText(/GUID not available|cannot load ACL/i);
+    await expect(noGuid).toContainText(
+      /GUID not available|cannot load ACL|has no object GUID/i,
+    );
     return "no-guid";
   }
 
   // Fallback for older bundles that only put message text in section
   const sectionText = (await aclSection.innerText()).trim();
   if (
-    /GUID not available|cannot load ACL/i.test(sectionText) &&
+    /GUID not available|cannot load ACL|has no object GUID/i.test(sectionText) &&
     !(await aclTable.isVisible().catch(() => false))
   ) {
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
@@ -179,7 +182,9 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   }
 
   await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-  await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+  await expect(
+    aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+  ).toBeVisible({
     timeout: 30_000,
   });
 
@@ -192,6 +197,16 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
     // Create-first empty state still proves mount + kind on section
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
     return "empty";
+  }
+
+  if (await aclNoEntries.isVisible()) {
+    // ACL document exists but has no principals yet — still readable/editable
+    // (add specials / add entry). Live By_Author often serializes without
+    // aclEntries (#3203 / #2672).
+    await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
+    await expect(aclSection).toHaveAttribute("data-acl-has-guid", "true");
+    await expect(aclNoEntries).toContainText(/No ACL entries yet/i);
+    return "no-entries";
   }
 
   await expect(aclTable).toBeVisible();
@@ -334,9 +349,21 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     });
     if (!opened) return;
 
+    const guidCell = page.locator('[data-testid="developer-site-detail-guid"]');
+    await expect(guidCell).toBeVisible({ timeout: 15_000 });
+    const guidText = (await guidCell.innerText()).trim();
     const mode = await assertLayeredObjectAcl(page, "developer-site-acl", "site");
-    // site is RUNTIME_RELEVANT — show-runtime must be true (table or no-guid shell)
-    expect(["table", "no-guid", "empty"]).toContain(mode);
+    // Site list GUID is normalized (stringValue or host-type-uuid). When a GUID
+    // is present, Object ACL must load — no-guid is only valid if the catalog
+    // row truly omitted guid parts (#3203 / #2672).
+    if (guidText && guidText !== "—" && guidText !== "-") {
+      expect(
+        ["table", "empty", "no-entries"],
+        `site Object ACL must load with GUID "${guidText}" (got mode=${mode})`,
+      ).toContain(mode);
+    } else {
+      expect(["table", "no-guid", "empty", "no-entries"]).toContain(mode);
+    }
   });
 
   test("display-format peer ACL mounts objectKind with kind-aware Runtime columns (B4)", async ({
@@ -381,7 +408,7 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     // Issue #2689: detail client must unwrap Jackson DisplayFormat root so
     // objectGuid is present — no-guid shell is a product defect for DF detail.
     expect(
-      ["table", "empty"],
+      ["table", "empty", "no-entries"],
       `display-format Object ACL must load with GUID (got mode=${mode})`,
     ).toContain(mode);
   });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -45,6 +45,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
 - [Users, roles & security](id:admin-users-roles)
+- [Object ACL & default template](id:admin-object-acl)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -44,7 +44,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
-- [Users, roles & security](id:admin-users-roles)
+- [Users, roles & security](id:admin-users-roles) (includes Developer Object ACL for Sites and Display Formats)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -44,7 +44,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
-- [Users, roles & security](id:admin-users-roles)
+- [Users, roles & security](id:admin-users-roles) (includes Developer Display Format Object ACL)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)
 

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -1,0 +1,68 @@
+---
+id: admin-object-acl
+title: Object ACL & default template
+description: Design access and Runtime visibility on design objects, and the Developer default ACL template
+version: "8.2"
+order: 43
+tags: [admin, security, acl, developer]
+---
+
+# Object ACL & default template
+
+Design objects (content types, templates, and other Developer catalog peers) carry an
+**Object ACL**. The editor splits permissions into two layers that match Workbench:
+
+| Layer | Columns | Meaning |
+|-------|---------|---------|
+| **Design access** | Read, Update, Delete, Modify ACL | Who can see and change the design object in the CMS |
+| **Runtime visibility** | Visible | Whether the object is visible at runtime (for example to a community) |
+
+Special rows such as **Default** (USER) and **AnyCommunity** (COMMUNITY) stay protected
+on content-type ACLs. You can change their permission checkboxes; you cannot remove
+those system principals.
+
+## Product path — open Object ACL
+
+1. Sign in as a user with Developer access (for example **Admin**).
+2. Open **Developer** from product navigation, or deep-link
+   `spa.jsp?entry=developer`.
+3. Open a catalog that supports Object ACL:
+   - **Content types** → first type → **Open**
+   - **Templates** → first template → **Open**
+4. On the detail panel, expand **Object ACL**.
+5. Confirm the table shows **Design access** and **Runtime visibility** column groups
+   (runtime-relevant object kinds such as content type and template always show
+   **Visible**).
+
+Deep links:
+
+- Content types: `spa.jsp?entry=developer&section=content-types`
+- Templates: `spa.jsp?entry=developer&section=templates`
+
+## Product path — default ACL template (Preferences)
+
+New object ACLs can seed from a **per-user default template**. That template is
+stored as the user preference `developer.defaultObjectAclTemplate`.
+
+1. Open **Developer → Preferences** (`spa.jsp?entry=developer&section=preferences`).
+2. Under **Security**, review the **default ACL template** table.
+3. The table uses the same **Design access** / **Runtime visibility** groups as
+   Object ACL on a design object.
+4. The system default is:
+   - **Default** (USER): Read, Update, Delete, Modify ACL (Visible off)
+   - **AnyCommunity** (COMMUNITY): Visible on
+5. To change Runtime visibility for **Default**, check or clear **Visible**, then
+   click **Save default ACL template**.
+6. Reload **Developer → Preferences** (full page refresh or leave and return).
+   **Visible** must match what you saved. The source line should indicate a saved
+   preference, not only the system default.
+
+If Save appears to succeed but **Visible** is unchecked after reload, the preference
+did not persist — check that you are still signed in, then retry. The product loads
+the named preference first and falls back to the full preference list so a saved
+template is not dropped on reload.
+
+## Related
+
+- [Users, roles & security](id:admin-users-roles)
+- [Sites & content structure](id:admin-sites)

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -75,7 +75,16 @@ the server (for example after **Install sample sites**).
 1. Sign in as an administrator (or a role that can open **Developer**).
 2. Open **Developer** → **Sites** (SPA entry `spa.jsp?entry=developer&section=sites`).
 3. Confirm the catalog table shows site **name**, **description**, **base URL**, and flags.
-4. Choose a row to open **Site detail** (URL defaults and Virtual Site source).
+4. Choose a row to open **Site detail** (URL defaults, object GUID, Virtual Site source,
+   and **Object ACL**).
+
+The **Object ACL** section on Site detail uses the site GUID from the catalog payload
+(`guid.stringValue`, or `hostId-type-uuid` when `stringValue` is omitted). When a GUID
+is present, the ACL table (or empty create path) is readable and editable — Design
+access plus Runtime visibility. When the catalog row has no GUID parts, the section
+still mounts with site-specific empty copy and does not crash the page. See
+[Users, roles & security](id:admin-users-roles) for the same Object ACL behavior on
+Display Formats.
 
 Empty state (**No sites returned**) appears only when the list API has **zero** Sites. A
 successful HTTP 200 with Site entries must populate the table (never a silent blank). Load

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,24 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Design-object ACL (Developer)
+
+System Definition (**Developer**) shows an **Object ACL** section on securable design
+objects, including **Display Formats**.
+
+1. Open **Developer → Display Formats**.
+2. Open a format such as **By_Author** (or any other listed format).
+3. The detail header **GUID** field shows the object GUID when the server has one
+   (never a silent dash when a GUID exists).
+4. **Object ACL** below the column list:
+   - Shows the ACL table when entries exist.
+   - Shows an empty create path when the object has no ACL yet.
+   - Shows an explicit load error if the ACL service fails.
+   - Does **not** say “Object GUID not available” when the header GUID is present.
+
+Use this section to inspect design-time and runtime visibility permissions for that
+display format. Site Object ACL is a separate surface (Sites detail).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,42 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Design-object ACL (Developer)
+
+System Definition (**Developer**) shows an **Object ACL** section on securable design
+objects, including **Display Formats** and **Sites**.
+
+### Display Formats
+
+1. Open **Developer → Display Formats**.
+2. Open a format such as **By_Author** (or any other listed format).
+3. The detail header **GUID** field shows the object GUID when the server has one
+   (never a silent dash when a GUID exists).
+4. **Object ACL** below the column list:
+   - Shows the ACL table when entries exist (Design access and Runtime visibility).
+   - Shows an empty create path when the object has no ACL yet.
+   - Shows an explicit load error if the ACL service fails.
+   - Does **not** say “Object GUID not available” when the header GUID is present.
+   - If the object truly has no GUID, the section still mounts with kind-aware copy
+     (display format) and does not crash the detail page.
+
+Use this section to inspect and edit design-time and runtime visibility permissions
+for that display format.
+
+### Sites
+
+1. Open **Developer → Sites**.
+2. Open a Site row (catalog from `GET /services/sites`).
+3. The detail header **GUID** field shows the site object GUID when the list payload
+   includes `guid.stringValue` or synthesizable `hostId` / `type` / `uuid` parts.
+4. **Object ACL** on Site detail:
+   - Loads and is readable/editable when a GUID is present (same Design / Runtime
+     columns as other runtime-relevant objects).
+   - If the catalog row has no GUID parts, the section still mounts with site-specific
+     empty copy and does not crash Site detail.
+
+See also [Sites & content structure](id:admin-sites).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -72,6 +72,15 @@ to `/cm/app/` so the dispatcher applies this preference.
 
 See [Architecture & site navigation](id:admin-architecture-navigation).
 
+## Object ACL (design objects)
+
+Developer catalog objects use a layered **Object ACL** (Design access vs Runtime
+visibility). Operators set a **default ACL template** under
+**Developer → Preferences → Security**. After **Save default ACL template**,
+**Runtime visibility → Visible** must still match after a page reload.
+
+See [Object ACL & default template](id:admin-object-acl).
+
 ## Hardening checklist
 
 - [ ] Change default/install admin passwords immediately.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -138,6 +138,23 @@ These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They 
 writable via `PUT` — rule write/save and full control property editors remain Workbench /
 future design APIs. `designGaps` on detail still calls out write and catalog gaps.
 
+## Display formats (design catalog)
+
+Content Explorer **display format** definitions (Developer **Display Formats**) are exposed
+under `/services/displayformats`. Responses include a nested `guid` object and a plain
+`guidString` (`host-type-uuid`) so clients can load **Object ACL** via
+`GET /services/acls/object/{guid}`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/displayformats` | List formats (optional `validForFolder` / `validForViewsAndSearches`) |
+| `GET` | `/services/displayformats/{idOrName}` | Load one format by internal name or GUID string |
+
+JSON may wrap the list as `DisplayFormatList` and a single item as `DisplayFormat`. Integrators
+should read `guid.stringValue` or `guidString` (never assume the GUID is missing when
+`displayId` is present). See [Users, roles & security](id:admin-users-roles) for the operator
+Object ACL steps.
+
 ## Views (design catalog)
 
 Content Explorer **view** definitions (Workbench / Developer **Views**, UI-07) are exposed under

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -27,6 +27,8 @@ import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.rest.Guid;
 import com.percussion.rest.displayformat.*;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
@@ -114,10 +116,32 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     ret.setDescription(f.getDescription());
     ret.setDisplayName(f.getDisplayName());
     // Always map GUID so Developer detail / Object ACL can bind objectGuid
-    // (issues #2689 / #2951). PSDisplayFormat#getGUID is expected non-null for
-    // persisted formats; copyGuid still accepts null defensively.
-    ret.setGuid(copyGuid(f.getGUID()));
+    // (issues #2689 / #2951 / #3200). PSDisplayFormat#getGUID is expected
+    // non-null for persisted formats; copyGuid still accepts null defensively.
+    Guid mapped = copyGuid(f.getGUID());
+    ret.setGuid(mapped);
+    ret.setGuidString(plainGuidString(mapped, f.getDisplayId()));
     return ret;
+  }
+
+  /**
+   * Plain {@code host-type-uuid} for SPA binding when nested Guid JSON is hard to read.
+   *
+   * @param mapped REST Guid from {@link #copyGuid}; may be null
+   * @param displayId native display id; used when mapped string is blank
+   * @return wire string, or {@code null} when neither source has a usable id
+   */
+  private static String plainGuidString(Guid mapped, int displayId) {
+    if (mapped != null && mapped.getStringValue().isPresent()) {
+      String sv = mapped.getStringValue().get();
+      if (sv != null && !sv.isBlank()) {
+        return sv.trim();
+      }
+    }
+    if (displayId > 0) {
+      return new PSGuid(PSTypeEnum.DISPLAY_FORMAT, displayId).toString();
+    }
+    return null;
   }
 
   /**
@@ -187,13 +211,15 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
   @Override
   public DisplayFormat findDisplayFormat(IPSGuid id)
       throws PSCmsException, PSUnknownNodeTypeException {
-    return copyDisplayFormat(designWs.findDisplayFormat(id));
+    PSDisplayFormat f = designWs.findDisplayFormat(id);
+    return f == null ? null : copyDisplayFormat(f);
   }
 
   @Override
   public DisplayFormat findDisplayFormat(String name)
       throws PSCmsException, PSUnknownNodeTypeException {
-    return copyDisplayFormat(designWs.findDisplayFormat(name));
+    PSDisplayFormat f = designWs.findDisplayFormat(name);
+    return f == null ? null : copyDisplayFormat(f);
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
@@ -7,6 +7,7 @@ package com.percussion.apibridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -67,5 +68,14 @@ class DisplayFormatAdaptorSafeKeyTest {
     // PSGuid#toString form host-type-uuid; uuid part is display id 301
     assertTrue(sv.endsWith("-301"), "unexpected guid form: " + sv);
     assertEquals(301, out.getGuid().getUuid());
+    assertEquals(sv, out.getGuidString(), "guidString must match guid.stringValue for SPA bind");
+  }
+
+  @Test
+  void findDisplayFormatByKey_returnsNullWhenDesignWsMisses() throws Exception {
+    IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
+    when(designWs.findDisplayFormat(eq("Missing"))).thenReturn(null);
+    DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
+    assertNull(adaptor.findDisplayFormatByKey("Missing"));
   }
 }

--- a/rest/src/main/java/com/percussion/rest/Guid.java
+++ b/rest/src/main/java/com/percussion/rest/Guid.java
@@ -17,7 +17,9 @@
 
 package com.percussion.rest;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.services.guidmgr.data.PSGuid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -29,6 +31,12 @@ import java.util.Optional;
 @Schema(description = "Guid")
 public class Guid {
 
+  /**
+   * Serialized as a plain JSON string via the field (not {@link #getStringValue()}). The Optional
+   * getter is for Java callers; Jackson must not emit Optional as an object or the SPA cannot bind
+   * Object ACL (#3200 / #2951).
+   */
+  @JsonProperty("stringValue")
   @Schema(
       name = "stringValue",
       description =
@@ -120,10 +128,12 @@ public class Guid {
     this.longValue = longValue;
   }
 
+  @JsonIgnore
   public Optional<String> getStringValue() {
     return Optional.ofNullable(stringValue);
   }
 
+  @JsonProperty("stringValue")
   public void setStringValue(String stringValue) {
     this.stringValue = stringValue;
   }

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
@@ -31,6 +31,13 @@ public class DisplayFormat {
   @Schema(description = "The global unique id for this item.")
   private Guid guid;
 
+  /**
+   * Plain {@code host-type-uuid} string for SPA Object ACL binding when nested {@link Guid}
+   * Optional/wrap shapes are hard to read (#3200). Always set by the adaptor when a GUID exists.
+   */
+  @Schema(description = "Plain GUID string (host-type-uuid) for Object ACL and detail header.")
+  private String guidString;
+
   @Schema(description = "The name of this Display Format")
   private String name;
 
@@ -74,6 +81,14 @@ public class DisplayFormat {
 
   public void setGuid(Guid guid) {
     this.guid = guid;
+  }
+
+  public String getGuidString() {
+    return guidString;
+  }
+
+  public void setGuidString(String guidString) {
+    this.guidString = guidString;
   }
 
   public String getName() {
@@ -200,6 +215,7 @@ public class DisplayFormat {
         && validForFolder == that.validForFolder
         && displayId == that.displayId
         && Objects.equals(guid, that.guid)
+        && Objects.equals(guidString, that.guidString)
         && Objects.equals(name, that.name)
         && Objects.equals(label, that.label)
         && Objects.equals(sortedColumnNames, that.sortedColumnNames)
@@ -216,6 +232,7 @@ public class DisplayFormat {
   public int hashCode() {
     return Objects.hash(
         guid,
+        guidString,
         name,
         label,
         validForRelatedContent,
@@ -239,6 +256,9 @@ public class DisplayFormat {
     return "DisplayFormat{"
         + "guid="
         + guid
+        + ", guidString='"
+        + guidString
+        + '\''
         + ", name='"
         + name
         + '\''

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -87,10 +87,10 @@ public class DisplayFormatResource {
     try {
       List<DisplayFormat> list = requireAdaptor().findAllDisplayFormats();
       if (list == null || list.isEmpty()) {
-        return List.of();
+        return new DisplayFormatList();
       }
       if (validForFolder == null && validForViewsAndSearches == null) {
-        return list;
+        return asDisplayFormatList(list);
       }
       List<DisplayFormat> filtered = new ArrayList<>(list.size());
       for (DisplayFormat df : list) {
@@ -111,7 +111,7 @@ public class DisplayFormatResource {
         }
         filtered.add(df);
       }
-      return filtered;
+      return asDisplayFormatList(filtered);
     } catch (WebApplicationException e) {
       throw e;
     } catch (Exception e) {
@@ -147,6 +147,17 @@ public class DisplayFormatResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  /**
+   * Return a {@link DisplayFormatList} so Jackson uses this package's {@code
+   * JacksonContextResolver} (WRAP_ROOT_VALUE) instead of a raw {@code ArrayList} mapper.
+   */
+  private static DisplayFormatList asDisplayFormatList(List<DisplayFormat> list) {
+    if (list instanceof DisplayFormatList displayFormatList) {
+      return displayFormatList;
+    }
+    return new DisplayFormatList(list);
   }
 
   private IDisplayFormatAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/GuidTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidTest.java
@@ -18,10 +18,12 @@
 package com.percussion.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Behavioral tests for {@link Guid} construction after the this-escape real fix (direct field
@@ -45,6 +47,19 @@ class GuidTest {
   @Test
   void stringConstructorRejectsNull() {
     assertThrows(NullPointerException.class, () -> new Guid(null));
+  }
+
+  @Test
+  void jacksonSerializesStringValueAsJsonString() {
+    Guid guid = new Guid("0-31-12");
+    ObjectMapper mapper = new JacksonContextResolver().getContext(Guid.class);
+    String json = mapper.writeValueAsString(guid);
+    assertTrue(
+        json.contains("\"stringValue\":\"0-31-12\"")
+            || json.contains("\"stringValue\" : \"0-31-12\""),
+        json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertFalse(json.contains("Optional["), json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -54,6 +54,7 @@ public class DisplayFormatResourceTest {
     List<DisplayFormat> out = resource.listDisplayFormats(null, null);
     assertEquals(1, out.size());
     assertEquals("Default", out.get(0).getName());
+    assertInstanceOf(DisplayFormatList.class, out);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -70,6 +70,25 @@ public class TestDisplayFormat {
     assertTrue(
         json.contains("\"guid\":{") || json.contains("\"guid\" : {"),
         "guid should be a nested object, not re-wrapped: " + json);
+    // #3200: stringValue must be a JSON string, not an Optional object
+    assertTrue(
+        json.contains("\"stringValue\":\"0-11-5\"") || json.contains("\"stringValue\" : \"0-11-5\""),
+        "stringValue must serialize as a JSON string: " + json);
+  }
+
+  @Test
+  public void jacksonContextResolver_serializesGuidStringCompanion() {
+    DisplayFormat f = new DisplayFormat();
+    f.setName("By_Author");
+    f.setGuid(new Guid("0-31-5"));
+    f.setGuidString("0-31-5");
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(DisplayFormat.class);
+    String json = mapper.writeValueAsString(f);
+
+    assertTrue(
+        json.contains("\"guidString\":\"0-31-5\"") || json.contains("\"guidString\" : \"0-31-5\""),
+        json);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Overnight **same-file thrash absorption** for Developer Object ACL product-path PRs. Three owned PRs all edited `modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js`, `product-docs/8.2/admin/users-roles.md`, and `product-docs/8.2/admin/index.md`. #3257 and #3259 also share `WebUI/src/main/ts/api/developer/aclApi.ts` and its test. This PR is a **union** of those heads against `main` so they do not keep colliding.

Does **not** invent extra product scope. Does **not** absorb unrelated open PRs (#3245 custom-URL execute, #3248 profile prefs, #3249 Admin System Tools, #3252 Explorer Views cluster, #3253 folder security, #3254 Explorer Views Playwright, #3255 top nav).

**Thrash files (shared by ≥2 absorbed PRs):**

- `modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js` (all three)
- `product-docs/8.2/admin/users-roles.md` (all three)
- `product-docs/8.2/admin/index.md` (all three)
- `WebUI/src/main/ts/api/developer/aclApi.ts` (#3257 / #3259)
- `WebUI/src/test/ts/api/developer/aclApi.test.ts` (#3257 / #3259)

Union notes:

- Display Format detail GUID + Object ACL bind (#3257 / #3200).
- Developer Preferences default ACL template persist after Save + reload (#3258 / #3204) and `product-docs/8.2/admin/object-acl.md`.
- Site + Display Format Object ACL product path, `no-entries` Playwright mode (#3259 / #3203).
- Admin docs keep Display Format GUID steps, Sites ACL steps, **and** the default-template persist page.
- `aclApi` keeps a single `unwrapObjectAcl` (Jackson `Acl`/`acl` wrap + flat + null) used by GET and POST.

Partial: #3200 #3204 #3203 (Developer Object ACL product-path chain).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3257](https://github.com/intersoftdatalabs-in/percussioncms/pull/3257) | `fix/issue-3200-df-guid-acl` @ `42615272e1` | yes | Display Format GUID + Object ACL bind |
| yes | [#3258](https://github.com/intersoftdatalabs-in/percussioncms/pull/3258) | `fix/issue-3204-object-acl-prefs-product-path` @ `16eaa65bcf` | yes | Prefs persist + object-acl.md |
| yes | [#3259](https://github.com/intersoftdatalabs-in/percussioncms/pull/3259) | `fix/issue-3203-object-acl-site-display-format` @ `0fc07ffa5e` | yes | Site/DF ACL product path; unioned spec + docs + aclApi tests |

## Test plan

1. Review union of Display Format GUID, prefs persist, and Site/DF Object ACL on one branch.
2. `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS** (after #3257 absorb; rest/sitemanage unchanged by #3258/#3259).
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (after #3257 absorb).
4. `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Surefire **Tests run: 51, Failures: 0**; Vitest **Test Files 296 / Tests 2137 passed**. Focused Object ACL Vitest **8 files / 75 tests passed**.
5. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (Maven has no Surefire tests; Playwright is live/QA).
6. `scripts/ci-smoke-product-docs.bat` — **OK 22 pages**.
7. Playwright (from absorbed PRs; not re-run live in this cluster step): `developer-object-acl-product-path.spec.js` (`display-format`, content type/template/prefs persist, Site GUID + no-entries).

## Checklist

- [x] **Product documentation** — union of `product-docs/8.2/admin/index.md`, `users-roles.md`, `object-acl.md`, `sites.md`, and #3257 `developer/rest.md`
- [x] **Unit / module tests** — WebUI Vitest + rest/sitemanage suites as above
- [x] **WebUI + Playwright** — union of `developer-object-acl-product-path.spec.js` coverage
- [x] **Build gates** — rest / sitemanage / WebUI / perc-qa-automation standalone clean install
- [x] **Cross-platform** — N/A (no new path/file I/O in the union)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent night-issue-prs-cluster.
