### PR TITLE
fix(WebUI): Explorer shell view tools and Search panel placement (#3208)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -22,7 +22,7 @@
  * dropdowns and enablement filtering from {@code rest/actions}), item/folder
  * context menu, search panel, IA relationships panel, dependency viewer, and
  * display-format selector so the SPA route approaches Desktop Content Explorer
- * parity (#2400 / #2407 / #2731 / #2768 / #2769 / #2849).</p>
+ * parity (#2400 / #2407 / #2731 / #2768 / #2769 / #2849 / #3208).</p>
  */
 
 import React, {
@@ -91,6 +91,8 @@ import {
   headerStyle,
   headerTitleStyle,
   shellStyle,
+  shellStyleWithPanels,
+  sidePanelsRegionStyle,
 } from "./styles";
 import { TranslationsPanel } from "./TranslationsPanel";
 import { SiteCopyWizard } from "./wizards/SiteCopyWizard";
@@ -207,12 +209,9 @@ function toClipboardItem(item: PSPathItem): ClipboardItem | null {
 }
 
 const sidePanelStyle: React.CSSProperties = {
-  gridColumn: "1 / -1",
-  borderTop: "1px solid #ddd",
   padding: 8,
   background: "#fcfcfc",
-  maxHeight: "40vh",
-  overflow: "auto",
+  borderBottom: "1px solid #eee",
 };
 
 const toolRowStyle: React.CSSProperties = {
@@ -401,6 +400,10 @@ export function ContentExplorerShell({
   const [showDependencies, setShowDependencies] = useState(false);
   const [displayFormats, setDisplayFormats] = useState<DisplayFormat[]>([]);
   const [selectedFormatKey, setSelectedFormatKey] = useState<string>("");
+  /** Non-fatal display-format catalog failure — selector stays mounted (#3208). */
+  const [displayFormatLoadError, setDisplayFormatLoadError] = useState<
+    string | null
+  >(null);
   const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
   /** Non-fatal catalog load failure — chrome stays mounted (#2972). */
   const [menuLoadError, setMenuLoadError] = useState<string | null>(null);
@@ -457,10 +460,17 @@ export function ContentExplorerShell({
       .then((list) => {
         if (cancelled) return;
         setDisplayFormats(list ?? []);
+        setDisplayFormatLoadError(null);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        // Non-fatal: list still works with default columns.
+        // Non-fatal: list still works with default columns; surface chrome.
+        setDisplayFormats([]);
+        setDisplayFormatLoadError(
+          err instanceof Error && err.message
+            ? err.message
+            : message(EXPLORER_MSG.DISPLAY_FORMAT_LOAD_ERROR),
+        );
         console.warn(
           "[ContentExplorerShell] display formats load failed",
           err instanceof Error ? err.message : String(err),
@@ -720,6 +730,16 @@ export function ContentExplorerShell({
     selection.item.type !== "folder" &&
     selection.item.id != null &&
     String(selection.item.id).trim().length > 0;
+  const hasOpenSidePanel =
+    showSearch ||
+    showSecurity ||
+    showClipboard ||
+    showTranslations ||
+    showRelationships ||
+    showDependencies ||
+    showSiteCreate ||
+    showSiteCopy ||
+    showSubfolderCopy;
 
   const handleMenuBarCommand = useCallback(
     (id: ExplorerMenuCommandId) => {
@@ -837,7 +857,7 @@ export function ContentExplorerShell({
 
   return (
     <div
-      style={shellStyle}
+      style={hasOpenSidePanel ? shellStyleWithPanels : shellStyle}
       role="application"
       aria-label={message(EXPLORER_MSG.TITLE)}
       data-testid="content-explorer-shell"
@@ -862,6 +882,7 @@ export function ContentExplorerShell({
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}
             selectedFormatKey={selectedFormatKey}
+            displayFormatLoadError={displayFormatLoadError}
             onSelectFormat={setSelectedFormatKey}
             onCommand={handleMenuBarCommand}
           />
@@ -917,6 +938,30 @@ export function ContentExplorerShell({
           >
             <button
               type="button"
+              data-testid="explorer-view-tool-search"
+              aria-pressed={showSearch}
+              aria-expanded={showSearch}
+              aria-controls="explorer-search-panel"
+              aria-label={message(EXPLORER_MSG.TOGGLE_SEARCH_ARIA)}
+              title={message(EXPLORER_MSG.TOGGLE_SEARCH_ARIA)}
+              onClick={() => handleMenuBarCommand("view-search")}
+            >
+              {message(EXPLORER_MSG.SEARCH_TITLE)}
+            </button>
+            <button
+              type="button"
+              data-testid="explorer-view-tool-security"
+              aria-pressed={showSecurity}
+              aria-expanded={showSecurity}
+              aria-controls="explorer-security-panel"
+              aria-label={message(EXPLORER_MSG.TOGGLE_SECURITY_ARIA)}
+              title={message(EXPLORER_MSG.TOGGLE_SECURITY_ARIA)}
+              onClick={() => handleMenuBarCommand("view-security")}
+            >
+              {message(EXPLORER_MSG.SECURITY_TITLE)}
+            </button>
+            <button
+              type="button"
               data-testid="explorer-refresh-list"
               aria-label={message(EXPLORER_MSG.ACTION_REFRESH_ARIA)}
               title={message(EXPLORER_MSG.ACTION_REFRESH_ARIA)}
@@ -954,6 +999,11 @@ export function ContentExplorerShell({
         selectedItemIds={multiSelectedIds}
         onToggleSelectItem={handleToggleSelectItem}
       />
+      {hasOpenSidePanel ? (
+      <div
+        data-testid="explorer-side-panels"
+        style={sidePanelsRegionStyle}
+      >
       {showSearch && (
         <section
           id="explorer-search-panel"
@@ -1226,6 +1276,8 @@ export function ContentExplorerShell({
             {message(EXPLORER_MSG.DEPENDENCY_SELECT_ITEM)}
           </div>
         )}
+      </div>
+      ) : null}
       {contextMenu && (
         <div
           style={{

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -66,6 +66,8 @@ export interface ExplorerMenuBarProps {
   hasFolderContext?: boolean;
   displayFormats: ReadonlyArray<DisplayFormat>;
   selectedFormatKey: string;
+  /** Non-fatal catalog load failure; selector remains mounted (#3208). */
+  displayFormatLoadError?: string | null;
   onSelectFormat: (key: string) => void;
   onCommand: (id: ExplorerMenuCommandId) => void;
   className?: string;
@@ -209,6 +211,7 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     hasFolderContext = false,
     displayFormats,
     selectedFormatKey,
+    displayFormatLoadError = null,
     onSelectFormat,
     onCommand,
     className,
@@ -456,6 +459,16 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
             );
           })}
         </select>
+        {displayFormatLoadError ? (
+          <span
+            data-testid="explorer-display-format-error"
+            role="status"
+            aria-live="polite"
+            style={{ color: "#b00020", fontSize: "0.85em" }}
+          >
+            {message(EXPLORER_MSG.DISPLAY_FORMAT_LOAD_ERROR)}
+          </span>
+        ) : null}
       </label>
       {multiSelectedCount > 0 ? (
         <span

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -410,7 +410,7 @@ function SavedSearchPicker(props: {
       <p
         role="status"
         data-testid="search-panel-saved-empty"
-        style={{ marginTop: 10, color: "#888" }}
+        style={{ marginTop: 10, color: "#595959" }}
       >
         {message(EXPLORER_MSG.SEARCH_SAVED_EMPTY)}
       </p>

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -182,6 +182,9 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Custom URL searches cannot be run from Explorer",
   DISPLAY_FORMAT_LABEL: "perc.ui.explorer@Display format",
   DISPLAY_FORMAT_DEFAULT: "perc.ui.explorer@Default columns",
+  /** Non-fatal catalog load failure — selector stays mounted (#3208). */
+  DISPLAY_FORMAT_LOAD_ERROR:
+    "perc.ui.explorer@Could not load display formats",
   /** Product shell: server-driven action toolbar (US3 / #2400 / #2972). */
   SERVER_ACTIONS_ARIA: "perc.ui.explorer@Server actions",
   /** Visible chrome label so QA/operators can identify the toolbar region. */

--- a/WebUI/src/main/ts/contentExplorer/styles.ts
+++ b/WebUI/src/main/ts/contentExplorer/styles.ts
@@ -37,6 +37,28 @@ export const shellStyle: CSSProperties = {
   background: "#fff",
 };
 
+/**
+ * When a Search / Security / other side panel is open, insert a full-width
+ * row under the header so the panel is visible without scrolling past the
+ * tree/list (#3208 / parent #2588).
+ */
+export const shellStyleWithPanels: CSSProperties = {
+  ...shellStyle,
+  gridTemplateRows: "auto auto 1fr",
+  gridTemplateAreas: '"header header" "panels panels" "tree list"',
+};
+
+/** Host for open Explorer side panels (search, security, wizards). */
+export const sidePanelsRegionStyle: CSSProperties = {
+  gridArea: "panels",
+  display: "flex",
+  flexDirection: "column",
+  maxHeight: "40vh",
+  overflow: "auto",
+  borderTop: "1px solid #ddd",
+  background: "#fcfcfc",
+};
+
 export const headerStyle: CSSProperties = {
   gridArea: "header",
   display: "flex",

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -107,6 +107,17 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.getByTestId("explorer-display-format")).toBeInTheDocument();
     // Always-visible refresh residual (#2733) — not only under View menu.
     expect(screen.getByTestId("explorer-refresh-list")).toBeInTheDocument();
+    // #3208: Search / Folder Security are first-class view-tool chrome (QA #2588).
+    expect(screen.getByTestId("explorer-view-tools")).toBeInTheDocument();
+    expect(screen.getByTestId("explorer-view-tool-search")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("explorer-view-tool-security"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("explorer-view-tool-search").getAttribute(
+        "aria-expanded",
+      ),
+    ).toBe("false");
     openViewMenu();
     expect(screen.getByTestId("explorer-toggle-search")).toBeInTheDocument();
     expect(screen.getByTestId("explorer-toggle-security")).toBeInTheDocument();
@@ -149,6 +160,65 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
     fireEvent.change(select, { target: { value: "3" } });
     expect(select.value).toBe("3");
+    expect(
+      screen.getByTestId("explorer-view-tool-search").getAttribute(
+        "aria-expanded",
+      ),
+    ).toBe("true");
+  });
+
+  it("opens Search under the header from the always-visible view-tool toggle (#3208)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        listSavedSearches={async () => []}
+      />,
+    );
+
+    expect(screen.queryByTestId("explorer-side-panels")).toBeNull();
+    fireEvent.click(screen.getByTestId("explorer-view-tool-search"));
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-side-panels")).toBeInTheDocument();
+      expect(screen.getByTestId("explorer-search-panel")).toBeInTheDocument();
+      expect(screen.getByTestId("search-panel-input")).toBeInTheDocument();
+    });
+    const searchTool = screen.getByTestId("explorer-view-tool-search");
+    expect(searchTool.getAttribute("aria-expanded")).toBe("true");
+    expect(searchTool.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      screen
+        .getByTestId("explorer-side-panels")
+        .contains(screen.getByTestId("explorer-search-panel")),
+    ).toBe(true);
+
+    fireEvent.click(screen.getByTestId("explorer-view-tool-search"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-search-panel")).toBeNull();
+      expect(screen.queryByTestId("explorer-side-panels")).toBeNull();
+    });
+  });
+
+  it("surfaces display-format load error without removing the selector (#3208)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => {
+          throw new Error("formats down");
+        }}
+        loadMenuActions={async () => []}
+        loadWorkflowMenuActions={async () => null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-display-format")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("explorer-display-format-error"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("uses injected loaders only (no real network for menus/formats)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -56,6 +56,13 @@ describe("ExplorerMenuBar (#2731)", () => {
     expect(screen.getByTestId("explorer-menu-help")).toBeTruthy();
     // Display format is adjacent shell chrome (always present).
     expect(screen.getByTestId("explorer-display-format")).toBeTruthy();
+    expect(screen.queryByTestId("explorer-display-format-error")).toBeNull();
+  });
+
+  it("keeps the display-format selector when catalog load failed (#3208)", () => {
+    renderBar({ displayFormatLoadError: "formats down" });
+    expect(screen.getByTestId("explorer-display-format")).toBeTruthy();
+    expect(screen.getByTestId("explorer-display-format-error")).toBeTruthy();
   });
 
   it("opens View dropdown with nested toggles (not flat multi-row chrome)", () => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-shell-chrome.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-shell-chrome.spec.js
@@ -89,6 +89,15 @@ test.describe("Explorer shell chrome composition (#2850 / #2407)", () => {
         page.locator(`[data-testid="${TEST_IDS.displayFormat}"]`),
       ).toBeVisible();
       await expect(
+        page.locator(`[data-testid="${TEST_IDS.viewTools}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.viewToolSearch}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.viewToolSecurity}"]`),
+      ).toBeVisible();
+      await expect(
         page.locator(`[data-testid="${TEST_IDS.serverActions}"]`),
       ).toBeVisible();
       await expect(
@@ -110,6 +119,37 @@ test.describe("Explorer shell chrome composition (#2850 / #2407)", () => {
           `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid^="action-toolbar-item-"]`,
         ),
       );
+    },
+  );
+
+  test(
+    "view-tool Search opens the Search panel under header chrome (#3208)",
+    { tag: ["@explorer-shell-chrome", "@explorer", "@search", "@smoke"] },
+    async ({ page }) => {
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const searchTool = page.locator(
+        `[data-testid="${TEST_IDS.viewToolSearch}"]`,
+      );
+      await expect(searchTool).toBeVisible();
+      await expect(searchTool).toHaveAttribute("aria-expanded", "false");
+      await searchTool.click();
+      await expect(searchTool).toHaveAttribute("aria-expanded", "true");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.sidePanels}"]`),
+      ).toBeVisible();
+      const panel = page.locator(
+        `[data-testid="${TEST_IDS.searchPanelHost}"]`,
+      );
+      await expect(panel).toBeVisible({ timeout: 10_000 });
+      await expect(panel).toBeInViewport();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.searchInput}"]`),
+      ).toBeVisible();
+      await searchTool.click();
+      await expect(panel).toHaveCount(0);
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-shell-chrome.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-shell-chrome.js
@@ -19,6 +19,11 @@ const {
 const TEST_IDS = Object.freeze({
   ...MENU_TEST_IDS,
   displayFormat: "explorer-display-format",
+  displayFormatError: "explorer-display-format-error",
+  viewTools: "explorer-view-tools",
+  viewToolSearch: "explorer-view-tool-search",
+  viewToolSecurity: "explorer-view-tool-security",
+  sidePanels: "explorer-side-panels",
   contentSearch: "explorer-menu-content-search",
   searchPanelHost: "explorer-search-panel",
   searchPanel: "search-panel",

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-shell-chrome.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-shell-chrome.test.js
@@ -38,6 +38,11 @@ describe("explorer-shell-chrome helpers (#2850)", () => {
     assert.equal(TEST_IDS.searchPanel, "search-panel");
     assert.equal(TEST_IDS.searchInput, "search-panel-input");
     assert.equal(TEST_IDS.displayFormat, "explorer-display-format");
+    assert.equal(TEST_IDS.displayFormatError, "explorer-display-format-error");
+    assert.equal(TEST_IDS.viewTools, "explorer-view-tools");
+    assert.equal(TEST_IDS.viewToolSearch, "explorer-view-tool-search");
+    assert.equal(TEST_IDS.viewToolSecurity, "explorer-view-tool-security");
+    assert.equal(TEST_IDS.sidePanels, "explorer-side-panels");
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");
   });

--- a/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
@@ -73,13 +73,34 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(page.locator('[data-testid="action-move"]')).toBeVisible();
     await expect(page.locator('[data-testid="action-copy"]')).toBeVisible();
     await expect(page.locator('[data-testid="action-delete"]')).toBeVisible();
-    // #2400 / #2731 product shell: DCE menu bar + server actions; view tools nest under View.
+    // #2400 / #2731 / #3208: DCE menu bar + labeled Server actions +
+    // always-visible Search / Folder Security / Display format chrome.
     await expect(
       page.locator('[data-testid="explorer-menu-bar"]'),
     ).toBeVisible();
     await expect(
       page.locator('[data-testid="explorer-menu-view"]'),
     ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-display-format"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-view-tools"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-view-tool-search"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-view-tool-security"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-server-actions"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-server-actions-label"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
+    // View menu still hosts the same Search / Security commands (#2731).
     await page.locator('[data-testid="explorer-menu-view"]').click();
     await expect(
       page.locator('[data-testid="explorer-toggle-search"]'),
@@ -87,13 +108,6 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(
       page.locator('[data-testid="explorer-toggle-security"]'),
     ).toBeVisible();
-    await expect(
-      page.locator('[data-testid="explorer-display-format"]'),
-    ).toBeVisible();
-    await expect(
-      page.locator('[data-testid="explorer-server-actions"]'),
-    ).toBeVisible();
-    await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
   });
 
   test("server action toolbar mounts; detail list supports context menu (#2849)", async ({
@@ -162,13 +176,15 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
       page.locator(`[data-testid="action-toolbar-item-${DESKTOP_ONLY_NAME}"]`),
     ).toHaveCount(0);
 
-    const row = page.locator('[data-testid^="detail-row-"]').first();
+    const row = page
+      .locator('[data-testid^="detail-row-"]:not([aria-disabled="true"])')
+      .first();
     if ((await row.count()) === 0) {
-      // Empty folder: still assert chrome; context menu needs a row.
+      // Empty folder or only disabled root rows: still assert chrome.
       test.info().annotations.push({
         type: "note",
         description:
-          "No detail rows on this CMS folder; skipped context-menu click path",
+          "No enabled detail rows on this CMS folder; skipped context-menu click path",
       });
       return;
     }
@@ -193,6 +209,29 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(
       page.locator('[data-testid="explorer-search-panel"]'),
     ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-side-panels"]'),
+    ).toBeVisible();
+  });
+
+  test("Explorer view-tool Search opens panel under header chrome (#3208)", async ({
+    page,
+  }) => {
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15_000 });
+    const searchTool = page.locator('[data-testid="explorer-view-tool-search"]');
+    await expect(searchTool).toBeVisible();
+    await searchTool.click();
+    const panel = page.locator('[data-testid="explorer-search-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-side-panels"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="search-panel-input"]')).toBeVisible();
+    await expect(panel).toBeInViewport();
+    await searchTool.click();
+    await expect(panel).toHaveCount(0);
   });
 
   test("no miller-column Finder chrome loads for the modern entry", async ({

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -18,7 +18,8 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | Chrome | Purpose |
 |--------|---------|
 | **Menu bar** (Content / View / Help) | Product commands: search, create site, clipboard, site/subfolder copy, view tools |
-| **Display format** | Column layout for the folder list (`validForFolder` formats) |
+| **Display format** | Column layout for the folder list (`validForFolder` formats). Always shown next to the menu bar; a short error stays next to the selector if the catalog cannot be loaded |
+| **View tools** | Always-visible **Search**, **Folder Security**, and **Refresh** buttons under the reduced actions / Server actions rows (the same commands remain under **View**) |
 | **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
 | **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
 | **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
@@ -95,12 +96,16 @@ Related Content menu commands:
 
 ## Search panel
 
-Use **Search** from either:
+Use **Search** from any of:
 
-- **View → Search**, or
+- the always-visible **Search** button on the Explorer view-tools row
+- **View → Search**
 - **Content → Search**
 
-Both commands toggle the same **Search panel** on the product Explorer route.
+All three commands toggle the same **Search panel**. The panel opens in a
+full-width region **directly under the header chrome** (menu bar, reduced
+actions, Server actions, view tools) so it is visible without scrolling past
+the folder tree and detail list.
 
 When the panel is open you can:
 
@@ -111,8 +116,9 @@ When the panel is open you can:
    listed when that design object exists on the server. Custom URL searches stay listed
    but cannot be run from Explorer.
 
-Closing **View → Search** (or **Content → Search**) again hides the panel. Revealing a
-result in its folder also closes the panel so the tree/list can show the destination.
+Closing **Search** again (view-tools button, **View → Search**, or **Content → Search**)
+hides the panel. Revealing a result in its folder also closes the panel so the
+tree/list can show the destination.
 
 Extended search uses the same sitemanage search services as other product hosts; on
 minimal fixtures without a search index, free-text may show an error state while the


### PR DESCRIPTION
## Summary

Fixes **#3208** (parent QA Failed **#2588**). Explorer shell composition retest after **#2987** (labeled Server actions — still present). Remaining gaps were:

1. **Search** and **Folder Security** lived only under the View menu, so the #2588 test plan "view tools" looked missing.
2. The Search panel opened in an implicit grid cell **below** the 70vh tree/list, so toggling Search appeared to do nothing.
3. Display-format catalog failures were silent (`console.warn` only).

This PR adds always-visible **Search** / **Folder Security** / **Refresh** view-tool buttons, places open side panels in a header-adjacent `explorer-side-panels` row, and surfaces a non-fatal display-format load error next to the selector. Views/Inbox (#3116/#3240/#3252) are out of scope.

Parent tracker: #2588. Related retest QA: #2988.

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up` (H2; capture `TEST_CMS_URL` — freeport).
2. Log in as Admin → `/Rhythmyx/cm/app/spa.jsp?entry=explorer`.
3. Confirm always-visible **Search**, **Folder Security**, **Display format**, labeled **Server actions**, and Content/View/Help menu bar.
4. Click view-tool **Search** — panel opens under the header (in viewport), not below the tree. Collapse again.
5. **View → Search** and **Content → Search** still toggle the same panel.
6. Confirm Server actions region + label remain mounted (empty/error still labeled).
7. Optional: `npm run test:surface -- --path tests/us1-core-explorer.spec.js` and `explorer-shell-chrome.spec.js`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md`
- [x] **Unit / module tests** — Vitest shell/menu-bar + perc-qa unit helpers; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `us1-core-explorer.spec.js` + `explorer-shell-chrome.spec.js` + golden
- [x] **Build gates** — WebUI + perc-qa-automation standalone clean install
- [x] **Cross-platform** — N/A (no path/file I/O)

## Build evidence (C3)

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` (private worktree `issue-3208-build`) → **BUILD SUCCESS**; Surefire Tests run: **51**, Failures: 0; Vitest **2115** passed (294 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; `npm run test:unit` → **228** passed
- **downstream_checked:** none (no public Java API signature / final / sealed change)

## C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2`
- Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` → `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- `npm run test:surface -- --path tests/us1-core-explorer.spec.js` → **8 passed**
- `npm run test:surface -- --path tests/explorer-shell-chrome.spec.js` → **6 passed**
- `npm run test:golden` → **2 passed**
- **console-clean:** yes (Playwright/axe gates green; no page crash)
- **server.log-clean:** yes for this feature (no new Explorer composition ERROR/FATAL). Pre-existing `PSRuntimeExceptionMapper` / "validated object is null" noise also present before this hot-copy.

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3208

> Co-Authored by Grok Build using grok-4.5 with agent main.
