### PR TITLE
fix(perc-system): type services.contentmgr/legacy Hibernate queries (#3210)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3210-services-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3210-services-xlint-erlang.md
@@ -1,0 +1,25 @@
+# Erlang review — issue #3210 services.contentmgr/legacy Xlint batch
+
+**Date:** 2026-08-12  
+**Scope:** `com.percussion.services.legacy` + `com.percussion.services.contentmgr` residual rawtypes/unchecked after #3188  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Change class
+Tech-debt generics: typed Hibernate `Query`/`MutationQuery`/`createNamedQuery`/`createNativeQuery` in `PSCmsObjectMgr`, typed `createQuery(..., Class)` in `PSContentMgr` and `PSContentRepository`, focused unit smoke.
+
+## Findings
+| Severity | Finding | Resolution |
+|----------|---------|------------|
+| none | No behavioral logic bugs found in typing refactor | n/a |
+| none | Paths/I-O not touched | n/a |
+| note | `loadItemEntry` now binds `:id` instead of concatenating Integer into HQL | Safer, same predicate |
+| note | `Query<Map>` uses raw `Map` (Hibernate `new map(...)` projection) | Copy via `asStringObjectMap`; no blanket list suppressions |
+| note | Residual assembly / schedule / workflow / other services remain | File residual child on #2022 |
+
+## Tests
+- `PSServicesLegacyTypedTest` (7): locale HQL builder, update-date mutation HQL, item-entry bind, menu-relation SQL
+- `PSServicesContentmgrTypedTest` (5): map copy + folder-id remap
+- Module: `system` `mvnw clean install` — BUILD SUCCESS, Tests run: 2008, Failures: 0, Skipped: 241
+
+## Verdict
+**Pass** for commit/PR under gates (portable paths N/A; unit smoke present; clean install green).

--- a/system/services/src/com/percussion/services/contentmgr/impl/PSContentMgr.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/PSContentMgr.java
@@ -503,7 +503,7 @@ public class PSContentMgr  implements IPSContentMgr
             + " from PSComponentSummary c where c.m_contentTypeId = :ctid";
 
 
-      List<Object[]> results = getSession().createQuery(query).setParameter(
+      List<Object[]> results = getSession().createQuery(query, Object[].class).setParameter(
             "ctid", psdef.getRawContentType()).list();
 
       for (Object[] result : results)
@@ -645,7 +645,7 @@ public class PSContentMgr  implements IPSContentMgr
             PSLegacyGuid lg = (PSLegacyGuid) i;
             cids.add(lg.getContentId());
          }
-         List<Object[]> results = getSession().createQuery(query).setParameter(
+         List<Object[]> results = getSession().createQuery(query, Object[].class).setParameter(
                "ids", cids).list();
          // Build a map
          Map<Integer,IPSGuid> idToType = new HashMap<>();

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -154,11 +154,6 @@ import static com.percussion.services.utils.orm.PSDataCollectionHelper.clearIdSe
 import static com.percussion.services.utils.orm.PSDataCollectionHelper.executeQuery;
 import static com.percussion.utils.request.PSRequestInfoBase.KEY_PSREQUEST;
 import static com.percussion.utils.request.PSRequestInfoBase.getRequestInfo;
-import static org.hibernate.type.StandardBasicTypes.BOOLEAN;
-import static org.hibernate.type.StandardBasicTypes.DATE;
-import static org.hibernate.type.StandardBasicTypes.INTEGER;
-import static org.hibernate.type.StandardBasicTypes.LONG;
-import static org.hibernate.type.StandardBasicTypes.STRING;
 
 
 /**
@@ -1022,8 +1017,10 @@ public class PSContentRepository
             {
                 query.append(" order by sys_sortrank asc");
             }
+            Class<?> childImpl = child.getImplementingClasses().get(0)
+                    .getImplementingClass();
             List<?> children = getSession().createQuery(
-                    query.toString()).setParameter("cid",content_id).setParameter("rev",revision).list();
+                    query.toString(), childImpl).setParameter("cid",content_id).setParameter("rev",revision).list();
             for (Object rep : children)
             {
                 PSLegacyGuid legacyguid=null;
@@ -2013,7 +2010,7 @@ public class PSContentRepository
      * @throws InvalidQueryException if failed to prepare the query.
      */
 
-    private Query prepareQuery(PSQuery psquery, Long typeid, Session s,
+    private Query<Map> prepareQuery(PSQuery psquery, Long typeid, Session s,
                                IPSQueryNode internalwhere, int maxresults,
                                Map<String, ? extends Object> params) throws InvalidQueryException
     {
@@ -2095,25 +2092,25 @@ public class PSContentRepository
         if (ms_log.isDebugEnabled())
             ms_log.debug("[{}] HQL Query execution: {}" , Thread.currentThread().getId(), querystr);
 
-        Query q = s.createQuery(querystr.toString());
+        Query<Map> q = s.createQuery(querystr.toString(), Map.class);
         Map<String, Object> qparams = wherebuilder.getQueryParams();
         for (Map.Entry<String, Object> pname : qparams.entrySet())
         {
             Object value = pname.getValue();
             logParameter(pname.getKey(), value);
 
-            if(value instanceof Boolean) {
-                q.setParameter(pname.getKey(), value, BOOLEAN);
-            }else if (value instanceof Integer) {
-                q.setParameter(pname.getKey(), value, INTEGER);
-            }else if(value instanceof String){
-                q.setParameter(pname.getKey(), value, STRING);
-            }else if(value instanceof Date) {
-                q.setParameter(pname.getKey(), value, DATE);
-            }else if(value instanceof Long) {
-                q.setParameter(pname.getKey(), value, LONG);
-            }else{
-                q.setParameter(pname.getKey(),value);
+            if (value instanceof Boolean boolVal) {
+                q.setParameter(pname.getKey(), boolVal, Boolean.class);
+            } else if (value instanceof Integer intVal) {
+                q.setParameter(pname.getKey(), intVal, Integer.class);
+            } else if (value instanceof String strVal) {
+                q.setParameter(pname.getKey(), strVal, String.class);
+            } else if (value instanceof Date dateVal) {
+                q.setParameter(pname.getKey(), dateVal, Date.class);
+            } else if (value instanceof Long longVal) {
+                q.setParameter(pname.getKey(), longVal, Long.class);
+            } else {
+                q.setParameter(pname.getKey(), value);
             }
         }
         if (maxresults > 0)
@@ -2132,20 +2129,49 @@ public class PSContentRepository
      * not <code>null</code>.
      */
 
-    private void gatherQueryResults(List<Map<String, Object>> results, PSQueryResult rval)
+    private void gatherQueryResults(List<Map> results, PSQueryResult rval)
     {
         // The results are a map. Create a row for each result
-        for (Map<String, Object> result : results)
+        for (Map result : results)
         {
-            // Handle folder info, replace "sys_folderid" with "rx:sys_folderid"
-            Integer fid = (Integer) result.get(IPSHtmlParameters.SYS_FOLDERID);
-            if (fid != null)
-            {
-                result.remove(IPSHtmlParameters.SYS_FOLDERID);
-                result.put(IPSContentPropertyConstants.RX_SYS_FOLDERID, fid);
-            }
-            rval.addRow(new PSRow(result));
+            rval.addRow(new PSRow(remapFolderId(result)));
         }
+    }
+
+    /**
+     * Copies a Hibernate {@code new map(...)} projection row into a typed map.
+     */
+    static Map<String, Object> asStringObjectMap(Map<?, ?> raw)
+    {
+        Map<String, Object> typed = new HashMap<>();
+        if (raw == null)
+        {
+            return typed;
+        }
+        for (Map.Entry<?, ?> entry : raw.entrySet())
+        {
+            Object key = entry.getKey();
+            if (key != null)
+            {
+                typed.put(String.valueOf(key), entry.getValue());
+            }
+        }
+        return typed;
+    }
+
+    /**
+     * Copies a projection row and remaps {@code sys_folderid} to {@code rx:sys_folderid}.
+     */
+    static Map<String, Object> remapFolderId(Map<?, ?> raw)
+    {
+        Map<String, Object> row = asStringObjectMap(raw);
+        Object fid = row.get(IPSHtmlParameters.SYS_FOLDERID);
+        if (fid != null)
+        {
+            row.remove(IPSHtmlParameters.SYS_FOLDERID);
+            row.put(IPSContentPropertyConstants.RX_SYS_FOLDERID, fid);
+        }
+        return row;
     }
 
     /**
@@ -2274,22 +2300,13 @@ public class PSContentRepository
             for (Long typeid : typeids)
             {
 
-                    Query q = prepareQuery(psquery, typeid, s, internalwhere, maxresults, params);
+                    Query<Map> q = prepareQuery(psquery, typeid, s, internalwhere, maxresults, params);
                     if (q == null)
                         continue;
 
                     PSStopwatch sw = new PSStopwatch();
                     sw.start();
-                    List<Map<String, Object>> results;
-                    if (!collectionIds.isEmpty()) {
-                        @SuppressWarnings("unchecked")
-                        List<Map<String, Object>> tmp = (List<Map<String, Object>>) executeQuery(q);
-                        results = tmp;
-                    } else {
-                      @SuppressWarnings("unchecked")
-                      List<Map<String, Object>> tmp = q.list();
-                      results = tmp;
-                   }
+                    List<Map> results = !collectionIds.isEmpty() ? executeQuery(q) : q.list();
 
                     sw.stop();
 
@@ -2431,7 +2448,7 @@ public class PSContentRepository
                     query.append(" where ab.sys_id.sys_contentid = :cid ").append(
                             "and ab.sys_id.sys_revision = :rev");
 
-                    List<?> datas = s.createQuery(query.toString()).setParameter("cid",id.getSys_contentid())
+                    List<?> datas = s.createQuery(query.toString(), ic).setParameter("cid",id.getSys_contentid())
                             .setParameter("rev", id.getSys_revision()).setResultTransformer(Transformers.aliasToBean(ic)).list();
 
                     if (datas.isEmpty()) continue;
@@ -2451,7 +2468,7 @@ public class PSContentRepository
                         "and sys_revision = :rev and sys_sysid = :child";
 
                 List<?> children = getSession().createQuery(
-                                query).setParameter("cid", pg.getContentId())
+                                query, ic).setParameter("cid", pg.getContentId())
                         .setParameter("rev", pg.getRevision())
                         .setParameter("child", lg.getContentId()).list();
                 if (children.isEmpty()) continue;

--- a/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
+++ b/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
@@ -98,6 +98,7 @@ import org.hibernate.Cache;
 import org.hibernate.CacheMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.MutationQuery;
 import org.hibernate.query.Query;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -225,11 +226,11 @@ public class PSCmsObjectMgr
     public Optional<LocalDateTime> getFirstPublishDate(Integer contentId){
         Date postDate  = null;
         Session session = getSession();
-        Query q = session.getNamedQuery("getPostDate");
+        Query<Date> q = session.createNamedQuery("getPostDate", Date.class);
         q.setParameter("contentId", contentId);
-        List result = q.list();
+        List<Date> result = q.list();
         if(result != null && !result.isEmpty())
-            postDate = (Date) result.get(0);
+            postDate = result.get(0);
         if (postDate == null) return Optional.empty();
         return Optional.of(LocalDateTime.ofInstant(postDate.toInstant(), java.time.ZoneId.systemDefault()));
     }
@@ -308,9 +309,8 @@ public class PSCmsObjectMgr
         List<int[]> pairs = new ArrayList<>();
         Session session = getSession();
         try {
-            @SuppressWarnings("unchecked")
             List<Object[]> rows =
-                    session.createNativeQuery(ACTION_MENU_RELATION_SQL).getResultList();
+                    session.createNativeQuery(ACTION_MENU_RELATION_SQL, Object[].class).getResultList();
             if (rows != null) {
                 for (Object[] row : rows) {
                     if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
@@ -348,6 +348,38 @@ public class PSCmsObjectMgr
                     + ACTION_MENU_RELATION_CHILD_COL
                     + " from "
                     + ACTION_MENU_RELATION_TABLE;
+
+    /**
+     * Builds the HQL for {@link #findLocales(String, String)}. Package-visible for unit tests.
+     */
+    static String buildLocaleFindHql(String lang, String label)
+    {
+       String queryString = "from PSLocale locale ";
+       if (!StringUtils.isBlank(lang))
+       {
+          queryString += "where locale.m_languageString = :lang ";
+       }
+       if (!StringUtils.isBlank(label))
+       {
+          queryString += StringUtils.isBlank(lang) ? "where " : "and ";
+          queryString += "locale.m_displayName like :label ";
+       }
+       queryString += "order by locale.m_displayName asc";
+       return queryString;
+    }
+
+    /**
+     * Builds the mutation HQL for {@link #updateSummaryDateFieldBatch}. Package-visible for tests.
+     */
+    static String formatUpdateDateHql(String fieldName, boolean updateExisting)
+    {
+       String queryToUse = String.format(UPDATE_DATE_HQL, fieldName);
+       if (!updateExisting)
+       {
+          queryToUse += String.format(WHERE_NULL, fieldName);
+       }
+       return queryToUse;
+    }
 
     public List<PSActionMenu> findActionMenusByType(String type) {
         Session session = getSession();
@@ -477,33 +509,25 @@ public class PSCmsObjectMgr
          List<PSLocale> locales = new ArrayList<>();
 
          Map<String, String> paramMap = new LinkedHashMap<>();
-         String queryString = "from PSLocale locale ";
+         String queryString = buildLocaleFindHql(lang, label);
 
          if (!StringUtils.isBlank(lang))
          {
-            queryString += "where locale.m_languageString = :lang ";
             paramMap.put("lang", lang);
          }
 
          if (!StringUtils.isBlank(label))
          {
-            if (paramMap.isEmpty())
-               queryString += "where ";
-            else
-               queryString += "and ";
-
-            queryString += "locale.m_displayName like :label ";
             paramMap.put("label", label);
          }
 
-         queryString += "order by locale.m_displayName asc";
-         Query query = session.createQuery(queryString);
+         Query<PSLocale> query = session.createQuery(queryString, PSLocale.class);
          for (Map.Entry<String, String> entry : paramMap.entrySet())
          {
             query.setParameter(entry.getKey(), entry.getValue());
          }
 
-         locales = (List<PSLocale>) query.list();
+         locales = query.list();
 
          return locales.stream();
 
@@ -516,9 +540,9 @@ public class PSCmsObjectMgr
 
          List<PSLocale> locales = new ArrayList<>();
 
-         Query query = session.createQuery("from PSLocale locale " + "order by locale.m_displayName asc");
+         Query<PSLocale> query = session.createQuery("from PSLocale locale " + "order by locale.m_displayName asc", PSLocale.class);
 
-         locales = (List<PSLocale>) query.list();
+         locales = query.list();
 
          return locales.stream();
 
@@ -621,7 +645,8 @@ public class PSCmsObjectMgr
 
       return getSession()
             .createQuery(
-                  "from PSPersistentPropertyMeta pm where pm.userName like :name").setParameter(
+                  "from PSPersistentPropertyMeta pm where pm.userName like :name",
+                  PSPersistentPropertyMeta.class).setParameter(
                   "name", name).list();
 
    }
@@ -654,7 +679,8 @@ public class PSCmsObjectMgr
 
       return getSession()
             .createQuery(
-                  "from PSPersistentProperty p where p.m_userName like :name").setParameter(
+                  "from PSPersistentProperty p where p.m_userName like :name",
+                  PSPersistentProperty.class).setParameter(
                   "name", userName).list();
    }
 
@@ -843,7 +869,7 @@ public class PSCmsObjectMgr
       Session s = getSession();
 
          List<PSComponentSummary> summaries = s
-               .createQuery("from PSComponentSummary c where c.m_checkoutUserName in (:users)")
+               .createQuery("from PSComponentSummary c where c.m_checkoutUserName in (:users)", PSComponentSummary.class)
                .setParameterList("users", users).list();
          fixupLocators(summaries);
          return summaries.stream();
@@ -855,7 +881,7 @@ public class PSCmsObjectMgr
    {
       List<PSComponentSummary> summaries = getSession()
             .createQuery(
-                  "from PSComponentSummary c where c.m_contentTypeId = :type").setParameter(
+                  "from PSComponentSummary c where c.m_contentTypeId = :type", PSComponentSummary.class).setParameter(
                   "type", contentType).list();
       fixupLocators(summaries);
       return summaries.stream();
@@ -864,21 +890,21 @@ public class PSCmsObjectMgr
 
    public Stream<Integer> findContentIdsByType(long contentType) throws PSORMException
    {
-      return ((List<Integer>) getSession()
+      return getSession()
             .createQuery(
                   "select c.m_contentId "
-                        + "from PSComponentSummary c where c.m_contentTypeId = :type").setParameter(
-                  "type", contentType).list()).stream();
+                        + "from PSComponentSummary c where c.m_contentTypeId = :type", Integer.class).setParameter(
+                  "type", contentType).list().stream();
    }
 
 
    public Stream<Integer> findContentIdsByWorkflow(int workflowid) throws PSORMException
    {
-      return ((List<Integer>) getSession()
+      return getSession()
             .createQuery(
                   "select c.m_contentId "
-                        + "from PSComponentSummary c where c.m_workflowAppId = :workflowid").setParameter(
-                  "workflowid", workflowid).list()).stream();
+                        + "from PSComponentSummary c where c.m_workflowAppId = :workflowid", Integer.class).setParameter(
+                  "workflowid", workflowid).list().stream();
    }
 
 
@@ -886,13 +912,13 @@ public class PSCmsObjectMgr
    {
 
 
-      return ((List<Integer>) getSession()
+      return getSession()
             .createQuery(
                   "select c.m_contentId "
                         + "from PSComponentSummary c where c.m_workflowAppId = :workflowid " +
-                        "and c.m_contentStateId = :stateid")
+                        "and c.m_contentStateId = :stateid", Integer.class)
               .setParameter("workflowid",workflowid).setParameter("stateid",stateid)
-              .list()).stream();
+              .list().stream();
 
    }
 
@@ -961,12 +987,12 @@ public class PSCmsObjectMgr
 
       try
       {
-         Query q;
+         Query<Integer> q;
          if (cids.size() < MAX_IDS)
          {
             q = s.createQuery("SELECT c.m_contentId " + "FROM PSComponentSummary c, PSState s "
                   + "WHERE c.m_contentId in (:ids) AND " + "c.m_workflowAppId = s.workflowId AND "
-                  + "c.m_contentStateId = s.stateId AND " + "s.contentValidValue in (:flags)");
+                  + "c.m_contentStateId = s.stateId AND " + "s.contentValidValue in (:flags)", Integer.class);
             q.setParameterList("ids", cids);
             q.setParameterList("flags", flags);
          }
@@ -976,12 +1002,11 @@ public class PSCmsObjectMgr
             q = s.createQuery("SELECT c.m_contentId " + "FROM PSComponentSummary c, PSState s, PSTempId t "
                   + "WHERE c.m_contentId = t.pk.itemId AND " + "t.pk.id = :idset AND "
                   + "c.m_workflowAppId = s.workflowId AND " + "c.m_contentStateId = s.stateId AND "
-                  + "s.contentValidValue in (:flags)");
+                  + "s.contentValidValue in (:flags)", Integer.class);
             q.setParameter("idset", idset);
             q.setParameterList("flags", flags);
          }
-         //
-         List<Integer> results = (idset != 0) ? (List) executeQuery(q) : q.list();
+         List<Integer> results = (idset != 0) ? executeQuery(q) : q.list();
          Set<Integer> passedcids = new HashSet<>();
          for (Integer cid : results)
          {
@@ -1523,9 +1548,9 @@ public class PSCmsObjectMgr
    {
       Session session = getSession();
 
-         Query query = session.createQuery("from PSCmsObject");
+         Query<PSCmsObject> query = session.createQuery("from PSCmsObject", PSCmsObject.class);
 
-         return ((List<PSCmsObject>) query.list()).stream();
+         return query.list().stream();
 
    }
 
@@ -1799,11 +1824,13 @@ public class PSCmsObjectMgr
       return itemEntry;
    }
 
-   private static final String itemQuery = "select c.m_contentId, c.m_name, c.m_communityId, " +
+   static final String itemQuery = "select c.m_contentId, c.m_name, c.m_communityId, " +
            "c.m_contentTypeId, c.m_objectType, c.m_contentCreatedBy, " +
            "c.m_contentLastModifiedDate, c.m_contentPostDate, c.m_contentCreatedDate, " +
            "c.m_workflowAppId, c.m_contentStateId, c.m_tipRevision, c.m_currRevision, " +
            "c.m_publicRevision, c.m_contentLastModifier, c.m_checkoutUserName, c.m_contentPublishDate from PSComponentSummary c";
+
+   static final String ITEM_ENTRY_BY_ID_HQL = itemQuery + " where c.m_contentId = :id";
 
            private static final int DEFAULT_MAX_SUMMARY_CACHE_SIZE = -1;
            private String CUSTOMIZED_MAX_SUMMARY_CACHE_SIZE;
@@ -1818,7 +1845,7 @@ public class PSCmsObjectMgr
    {
 
          Session session = getSession();
-         Query q = session.createQuery(itemQuery);
+         Query<Object[]> q = session.createQuery(itemQuery, Object[].class);
          q.setCacheable(true);
          q.setCacheMode(CacheMode.NORMAL);
          q.setCacheRegion("PSComponentSummary");
@@ -1863,7 +1890,8 @@ public class PSCmsObjectMgr
     {
         Session session = getSession();
 
-        Query q = session.createQuery(itemQuery + " where c.m_contentId=" + id);
+        Query<Object[]> q = session.createQuery(ITEM_ENTRY_BY_ID_HQL, Object[].class)
+                .setParameter("id", id);
         List<Object[]> listItems = q.list();
 
         Map<Integer, Map<Integer, String>> wfStateIdNameMap = new HashMap<>();
@@ -2340,11 +2368,9 @@ public class PSCmsObjectMgr
     {
         Session s = getSession();
 
-            String queryToUse = String.format(UPDATE_DATE_HQL, fieldName);
-            if (!updateExisting)
-                queryToUse+=String.format(WHERE_NULL, fieldName);
+            String queryToUse = formatUpdateDateHql(fieldName, updateExisting);
 
-            Query query = s.createQuery(queryToUse).setParameter("dateToSet", dateToSet)
+            MutationQuery query = s.createMutationQuery(queryToUse).setParameter("dateToSet", dateToSet)
                     .setParameterList("ids", ids);
             int result = query.executeUpdate();
         PSItemSummaryCache cache = PSItemSummaryCache.getInstance();

--- a/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.contentmgr.impl.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.contentmgr.IPSContentPropertyConstants;
+import com.percussion.system.utils.IPSHtmlParameters;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral unit tests for typed {@code com.percussion.services.contentmgr} query residual
+ * (issue #3210 residual of #2022 after publisher batch #3188).
+ */
+@Tag("UnitTest")
+@DisplayName("services.contentmgr package generics")
+class PSServicesContentmgrTypedTest {
+
+  @Test
+  @DisplayName("asStringObjectMap copies keys as strings and skips null keys")
+  void asStringObjectMapCopiesAndSkipsNullKeys() {
+    Map<Object, Object> raw = new LinkedHashMap<>();
+    raw.put("sys_contentid", 42);
+    raw.put(IPSHtmlParameters.SYS_FOLDERID, 7);
+    raw.put(null, "ignored");
+
+    Map<String, Object> typed = PSContentRepository.asStringObjectMap(raw);
+    assertEquals(42, typed.get("sys_contentid"));
+    assertEquals(7, typed.get(IPSHtmlParameters.SYS_FOLDERID));
+    assertEquals(2, typed.size());
+    assertTrue(typed.containsKey(IPSHtmlParameters.SYS_FOLDERID));
+  }
+
+  @Test
+  @DisplayName("asStringObjectMap returns empty map for null input")
+  void asStringObjectMapNullSafe() {
+    Map<String, Object> typed = PSContentRepository.asStringObjectMap(null);
+    assertTrue(typed.isEmpty());
+    typed.put("x", 1);
+    assertNull(PSContentRepository.asStringObjectMap(null).get("x"));
+  }
+
+  @Test
+  @DisplayName("asStringObjectMap does not alias the source map")
+  void asStringObjectMapDefensiveCopy() {
+    Map<Object, Object> raw = new HashMap<>();
+    raw.put("k", "v");
+    Map<String, Object> typed = PSContentRepository.asStringObjectMap(raw);
+    typed.put("k", "changed");
+    assertEquals("v", raw.get("k"));
+  }
+
+  @Test
+  @DisplayName("remapFolderId moves sys_folderid to rx:sys_folderid")
+  void remapFolderIdMovesLegacyKey() {
+    Map<Object, Object> raw = new LinkedHashMap<>();
+    raw.put(IPSHtmlParameters.SYS_FOLDERID, 99);
+    raw.put("rx:sys_contentid", 5);
+
+    Map<String, Object> remapped = PSContentRepository.remapFolderId(raw);
+    assertNull(remapped.get(IPSHtmlParameters.SYS_FOLDERID));
+    assertEquals(99, remapped.get(IPSContentPropertyConstants.RX_SYS_FOLDERID));
+    assertEquals(5, remapped.get("rx:sys_contentid"));
+  }
+
+  @Test
+  @DisplayName("remapFolderId leaves rows without folder id unchanged")
+  void remapFolderIdNoFolder() {
+    Map<Object, Object> raw = new HashMap<>();
+    raw.put("rx:sys_contentid", 8);
+    Map<String, Object> remapped = PSContentRepository.remapFolderId(raw);
+    assertEquals(8, remapped.get("rx:sys_contentid"));
+    assertNull(remapped.get(IPSContentPropertyConstants.RX_SYS_FOLDERID));
+  }
+}

--- a/system/src/test/java/com/percussion/services/legacy/impl/PSServicesLegacyTypedTest.java
+++ b/system/src/test/java/com/percussion/services/legacy/impl/PSServicesLegacyTypedTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.legacy.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral unit tests for typed {@code com.percussion.services.legacy} Hibernate
+ * query helpers (issue #3210 residual of #2022 after publisher batch #3188).
+ */
+@Tag("UnitTest")
+@DisplayName("services.legacy package generics")
+class PSServicesLegacyTypedTest {
+
+  @Test
+  @DisplayName("findLocales HQL is order-only when lang and label are blank")
+  void localeFindHqlNeitherFilter() {
+    String hql = PSCmsObjectMgr.buildLocaleFindHql(null, "  ");
+    assertEquals("from PSLocale locale order by locale.m_displayName asc", hql);
+    assertFalse(hql.contains(":lang"));
+    assertFalse(hql.contains(":label"));
+  }
+
+  @Test
+  @DisplayName("findLocales HQL binds language only")
+  void localeFindHqlLangOnly() {
+    String hql = PSCmsObjectMgr.buildLocaleFindHql("en-us", null);
+    assertTrue(hql.contains("where locale.m_languageString = :lang"));
+    assertFalse(hql.contains(":label"));
+    assertTrue(hql.endsWith("order by locale.m_displayName asc"));
+  }
+
+  @Test
+  @DisplayName("findLocales HQL binds label only")
+  void localeFindHqlLabelOnly() {
+    String hql = PSCmsObjectMgr.buildLocaleFindHql("", "Test%");
+    assertTrue(hql.contains("where locale.m_displayName like :label"));
+    assertFalse(hql.contains(":lang"));
+  }
+
+  @Test
+  @DisplayName("findLocales HQL binds language and label with AND")
+  void localeFindHqlBothFilters() {
+    String hql = PSCmsObjectMgr.buildLocaleFindHql("fr-ca", "Français%");
+    assertTrue(hql.contains("where locale.m_languageString = :lang"));
+    assertTrue(hql.contains("and locale.m_displayName like :label"));
+    assertFalse(hql.contains("where locale.m_displayName"));
+  }
+
+  @Test
+  @DisplayName("update date mutation HQL appends null guard when not overwriting")
+  void updateDateHqlNullGuard() {
+    String overwrite = PSCmsObjectMgr.formatUpdateDateHql("m_contentPostDate", true);
+    String once = PSCmsObjectMgr.formatUpdateDateHql("m_contentPostDate", false);
+    assertTrue(overwrite.contains("set cs.m_contentPostDate = :dateToSet"));
+    assertTrue(overwrite.contains("cs.m_contentId in (:ids)"));
+    assertFalse(overwrite.contains("is null"));
+    assertTrue(once.startsWith(overwrite));
+    assertTrue(once.endsWith(" and cs.m_contentPostDate is null"));
+  }
+
+  @Test
+  @DisplayName("item-entry HQL selects summary columns and binds content id")
+  void itemEntryHqlColumnsAndBind() {
+    assertTrue(PSCmsObjectMgr.itemQuery.contains("c.m_contentId"));
+    assertTrue(PSCmsObjectMgr.itemQuery.contains("c.m_name"));
+    assertTrue(PSCmsObjectMgr.itemQuery.contains("from PSComponentSummary c"));
+    assertEquals(
+        PSCmsObjectMgr.itemQuery + " where c.m_contentId = :id",
+        PSCmsObjectMgr.ITEM_ENTRY_BY_ID_HQL);
+    assertFalse(PSCmsObjectMgr.ITEM_ENTRY_BY_ID_HQL.contains("where c.m_contentId="));
+  }
+
+  @Test
+  @DisplayName("action menu relation SQL uses RXMENUACTIONRELATION columns")
+  void actionMenuRelationSql() {
+    assertEquals(
+        "select ACTIONID, CHILDACTIONID from RXMENUACTIONRELATION",
+        PSCmsObjectMgr.ACTION_MENU_RELATION_SQL);
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized residual of #3210 / epic #2022 after publisher batch #3188: type `com.percussion.services.legacy` and `com.percussion.services.contentmgr` Hibernate query residual with real generics.

- **PSCmsObjectMgr**: replace raw `Query` / `getNamedQuery` / native query with `createQuery(..., Class)`, `createNamedQuery(..., Class)`, `createNativeQuery(..., Object[].class)`, and `MutationQuery` for date updates; bind `loadItemEntry` with `:id`
- **PSContentMgr**: typed `createQuery(..., Object[].class)` for id/revision and filter projections
- **PSContentRepository**: typed `prepareQuery` as `Query<Map>` for `new map(...)` projections; remove list-level `@SuppressWarnings("unchecked")`; copy/remap folder id via helpers
- **Tests**: `PSServicesLegacyTypedTest` (7) and `PSServicesContentmgrTypedTest` (5)

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent:** #2022  
**Fixes:** #3210  
**Residual:** #3265 (assembly / schedule-workflow / other services)

## Product documentation
- [x] N/A — pure tech-debt generics / no product behavior, UX, API, or operator-step change

## Test plan
1. From `system/`: `../mvnw.cmd clean install` (JDK 21)
2. Focused: `../mvnw.cmd "-Dtest=PSServicesLegacyTypedTest,PSServicesContentmgrTypedTest" test`
3. Confirm BUILD SUCCESS and new tests green

## Checklist
- [x] **Product documentation** — N/A (not product-facing): pure tech-debt generics
- [x] **Unit / module tests** — 12 new unit tests; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## Gates evidence
- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **2008**, Failures: 0, Errors: 0, Skipped: 241
- **focused tests:** `PSServicesLegacyTypedTest` 7 + `PSServicesContentmgrTypedTest` 5 (12 total) green
- **downstream_checked:** none — no public type made `final`/`sealed`; no public/protected method or ctor signature change. Package-visible HQL helpers added for tests only.
- **C5 UI:** N/A (backend tech-debt only)

## Partial / residual
Partial for epic #2022 services.* Xlint: remaining packages tracked as #3265.

> Co-Authored by Grok Build using grok-4.5 with agent main.
