### PR TITLE
fix(#3212): type PSApplicationHandler/PSServer dataHandlers Xlint

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3212-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3212-erlang.md
@@ -11,7 +11,7 @@
 
 ## Gate
 
-No bugs found. Behavioral tests cover request-root maps, handler-state merge, status XML, and log map keys. No filesystem path I/O in this change (cross-platform path checklist N/A).
+No bugs found. Behavioral tests cover request-root maps, handler-state merge, status XML, log map keys, and fail-fast `ClassCastException` on wrong-type handler map entries. No filesystem path I/O in this change (cross-platform path checklist N/A).
 
 ## Issues
 
@@ -19,5 +19,5 @@ None.
 
 ## Notes
 
-- `getInternalRequestHandler(String)` and `PSServer.getApplicationHandler` now return `null` instead of throwing `ClassCastException` when the map value is the wrong interface. Safer; production puts still implement the expected types.
+- `getInternalRequestHandler(String)` and `PSServer.getApplicationHandler` keep the pre-generics explicit cast so wrong-type map entries throw `ClassCastException` immediately instead of a deferred NPE. Missing keys still return `null`.
 - Residual Xlint remains on `PSServer` (`init`, objectstore/macros/log/search, role attributes) and `#3213` content/clone/actions — out of scope.

--- a/docs/ai-generated/code-reviews/issue-3212-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3212-erlang.md
@@ -1,0 +1,23 @@
+# Erlang review — #3212 PSApplicationHandler/PSServer dataHandlers Xlint
+
+**Date:** 2026-08-12  
+**Branch:** `fix/issue-3212-datahandlers-xlint`  
+**Scope:** uncommitted `system` typing of dataHandlers / request-root maps vs `origin/main`  
+**Memory patterns hit:** prefer real generics over blanket `@SuppressWarnings("unchecked")`; restore static test fixtures; do not expand Xlint PRs into sibling packages.
+
+## Recommendation
+
+**approve** — May commit/push: yes
+
+## Gate
+
+No bugs found. Behavioral tests cover request-root maps, handler-state merge, status XML, and log map keys. No filesystem path I/O in this change (cross-platform path checklist N/A).
+
+## Issues
+
+None.
+
+## Notes
+
+- `getInternalRequestHandler(String)` and `PSServer.getApplicationHandler` now return `null` instead of throwing `ClassCastException` when the map value is the wrong interface. Safer; production puts still implement the expected types.
+- Residual Xlint remains on `PSServer` (`init`, objectstore/macros/log/search, role attributes) and `#3213` content/clone/actions — out of scope.

--- a/system/src/main/java/com/percussion/log/PSLogApplicationStatistics.java
+++ b/system/src/main/java/com/percussion/log/PSLogApplicationStatistics.java
@@ -62,34 +62,34 @@ public class PSLogApplicationStatistics extends PSLogInformation {
    * @param id the id of the application these statistics represent
    * @param stats the statistics to be reported
    */
-  public PSLogApplicationStatistics(int id, Map stats) {
+  public PSLogApplicationStatistics(int id, Map<String, String> stats) {
     super(LOG_TYPE, id);
 
-    String elapsedTime = (String) stats.get("elapsedTime");
+    String elapsedTime = stats.get("elapsedTime");
     if (elapsedTime == null) elapsedTime = "";
 
-    String eventsProcessed = (String) stats.get("eventsProcessed");
+    String eventsProcessed = stats.get("eventsProcessed");
     if (eventsProcessed == null) eventsProcessed = "";
 
-    String eventsPending = (String) stats.get("eventsPending");
+    String eventsPending = stats.get("eventsPending");
     if (eventsPending == null) eventsPending = "";
 
-    String eventsFailed = (String) stats.get("eventsFailed");
+    String eventsFailed = stats.get("eventsFailed");
     if (eventsFailed == null) eventsFailed = "";
 
-    String cacheHits = (String) stats.get("cacheHits");
+    String cacheHits = stats.get("cacheHits");
     if (cacheHits == null) cacheHits = "";
 
-    String cacheMisses = (String) stats.get("cacheMisses");
+    String cacheMisses = stats.get("cacheMisses");
     if (cacheMisses == null) cacheMisses = "";
 
-    String minProcTime = (String) stats.get("minProcTime");
+    String minProcTime = stats.get("minProcTime");
     if (minProcTime == null) minProcTime = "";
 
-    String maxProcTime = (String) stats.get("maxProcTime");
+    String maxProcTime = stats.get("maxProcTime");
     if (maxProcTime == null) maxProcTime = "";
 
-    String avgProcTime = (String) stats.get("avgProcTime");
+    String avgProcTime = stats.get("avgProcTime");
     if (avgProcTime == null) avgProcTime = "";
 
     m_subs = new PSLogSubMessage[9];

--- a/system/src/main/java/com/percussion/log/PSLogMultipleHandlers.java
+++ b/system/src/main/java/com/percussion/log/PSLogMultipleHandlers.java
@@ -59,17 +59,17 @@ public class PSLogMultipleHandlers extends PSLogInformation {
    * @param applId the application containing the handlers
    * @param info the information to be reported
    */
-  public PSLogMultipleHandlers(int applId, ConcurrentHashMap info) {
+  public PSLogMultipleHandlers(int applId, ConcurrentHashMap<String, String> info) {
     super(LOG_TYPE, applId);
 
     String sessId = "";
     String dataSetNames = "";
 
     if (info != null) {
-      String sTemp = (String) info.get(PROP_SESS_ID);
+      String sTemp = info.get(PROP_SESS_ID);
       if (sTemp != null) sessId = sTemp;
 
-      sTemp = (String) info.get(PROP_DATASET_NAMES);
+      sTemp = info.get(PROP_DATASET_NAMES);
       if (sTemp != null) dataSetNames = sTemp;
     }
 

--- a/system/src/main/java/com/percussion/server/PSApplicationHandler.java
+++ b/system/src/main/java/com/percussion/server/PSApplicationHandler.java
@@ -184,15 +184,16 @@ public class PSApplicationHandler implements IPSRootedHandler {
    * @return The internal request handler associated with this request name, or <code>null</code> if
    *     a handler could not be located.
    * @throws IllegalArgumentException if the request string is invalid
+   * @throws ClassCastException if a map entry exists but is not an {@link
+   *     IPSInternalRequestHandler} (fail-fast; same as the pre-generics cast)
    */
   public IPSInternalRequestHandler getInternalRequestHandler(String request) {
     if (request == null || request.length() == 0)
       throw new IllegalArgumentException("Invalid request name");
 
-    IPSRequestHandler handler = m_dataHandlers.get(request.toLowerCase());
-    return handler instanceof IPSInternalRequestHandler
-        ? (IPSInternalRequestHandler) handler
-        : null;
+    // Explicit cast: missing keys stay null; wrong types fail immediately
+    // (ClassCastException) instead of a deferred NPE at callers.
+    return (IPSInternalRequestHandler) m_dataHandlers.get(request.toLowerCase());
   }
 
   /**

--- a/system/src/main/java/com/percussion/server/PSApplicationHandler.java
+++ b/system/src/main/java/com/percussion/server/PSApplicationHandler.java
@@ -69,6 +69,7 @@ import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogInformation;
 import com.percussion.log.PSLogMultipleHandlers;
 import com.percussion.security.PSAclHandler;
+import com.percussion.security.PSEntry;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthenticationRequiredException;
 import com.percussion.security.PSAuthorizationException;
@@ -188,7 +189,10 @@ public class PSApplicationHandler implements IPSRootedHandler {
     if (request == null || request.length() == 0)
       throw new IllegalArgumentException("Invalid request name");
 
-    return (IPSInternalRequestHandler) m_dataHandlers.get(request.toLowerCase());
+    IPSRequestHandler handler = m_dataHandlers.get(request.toLowerCase());
+    return handler instanceof IPSInternalRequestHandler
+        ? (IPSInternalRequestHandler) handler
+        : null;
   }
 
   /**
@@ -302,7 +306,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
         foundOne = true;
 
         PSContentEditorPipe pipe = (PSContentEditorPipe) ceh.getContentEditor().getPipe();
-        Collection addedSystemMandatoryFields = pipe.getMapper().getAddedSystemMandatoryFields();
+        Collection<?> addedSystemMandatoryFields = pipe.getMapper().getAddedSystemMandatoryFields();
         if (!addedSystemMandatoryFields.isEmpty()) {
           // warn the user that we added system mandatory fields
           Object[] args = {addedSystemMandatoryFields.toString()};
@@ -338,12 +342,12 @@ public class PSApplicationHandler implements IPSRootedHandler {
    */
   public synchronized void removeDataHandler(PSDataSet ds) {
     // remove the handler defined for this data set
-    IPSRequestHandler rh = (IPSRequestHandler) m_dataHandlers.remove(ds.getName().toLowerCase());
+    IPSRequestHandler rh = m_dataHandlers.remove(ds.getName().toLowerCase());
     if (rh != null) {
       PSRequestor requestor = ds.getRequestor();
       if (requestor != null) {
         String reqPage = requestor.getRequestPage();
-        PSRequestPageMap[] maps = (PSRequestPageMap[]) m_dataHandlerMap.get(reqPage);
+        PSRequestPageMap[] maps = m_dataHandlerMap.get(reqPage);
         if (maps != null) {
           for (int i = 0; i < maps.length; i++) {
             if (maps[i].getRequestHandler() == rh) {
@@ -394,8 +398,8 @@ public class PSApplicationHandler implements IPSRootedHandler {
   }
 
   // see IPSRootedHandler for documentation
-  public Iterator getRequestRoots() {
-    List roots = new ArrayList();
+  public Iterator<String> getRequestRoots() {
+    List<String> roots = new ArrayList<>();
     roots.add(m_requestRoot);
 
     return roots.iterator();
@@ -1030,8 +1034,8 @@ public class PSApplicationHandler implements IPSRootedHandler {
    */
   private void shutdownDataHandlers() {
     // shut down all the data handlers
-    for (Enumeration e = m_dataHandlers.elements(); e.hasMoreElements(); ) {
-      IPSRequestHandler handler = (IPSRequestHandler) e.nextElement();
+    for (Enumeration<IPSRequestHandler> e = m_dataHandlers.elements(); e.hasMoreElements(); ) {
+      IPSRequestHandler handler = e.nextElement();
       PSServer.notifyHandlerShutdownListeners(handler);
       handler.shutdown();
     }
@@ -1042,7 +1046,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
   private void logAppStatistics() {
     if (!m_LogHandler.isAppStatisticsLoggingEnabled()) return;
 
-    Map info = new HashMap();
+    Map<String, String> info = new HashMap<>();
 
     info.put("elapsedTime", String.valueOf(m_stats.getProcessingTime()));
     info.put("eventsProcessed", String.valueOf(m_stats.getSuccessfulEventCount()));
@@ -1110,7 +1114,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
 
     if (dataSetName != null) {
       // get the handler for the data set/request type from the hash
-      rh = (IPSRequestHandler) m_dataHandlers.get(dataSetName.toLowerCase());
+      rh = m_dataHandlers.get(dataSetName.toLowerCase());
     } else {
       pageName = request.getRequestPage(true);
 
@@ -1118,11 +1122,11 @@ public class PSApplicationHandler implements IPSRootedHandler {
        * appropriate data set for this request from the request info
        */
       if ((pageName != null) && (pageName.length() > 0)) {
-        maps = (PSRequestPageMap[]) m_dataHandlerMap.get(pageName.toLowerCase());
+        maps = m_dataHandlerMap.get(pageName.toLowerCase());
         if (maps == null) {
           /* Try the more generic form, for the new flexible engine */
           pageName = pageName.substring(0, pageName.lastIndexOf('.'));
-          maps = (PSRequestPageMap[]) m_dataHandlerMap.get(pageName.toLowerCase());
+          maps = m_dataHandlerMap.get(pageName.toLowerCase());
         }
       }
 
@@ -1134,7 +1138,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
         pageName = request.getRequestPage(false);
 
         if ((pageName != null) && (pageName.length() > 0)) {
-          maps = (PSRequestPageMap[]) m_dataHandlerMap.get(pageName.toLowerCase());
+          maps = m_dataHandlerMap.get(pageName.toLowerCase());
         }
       }
 
@@ -1197,7 +1201,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
         }
 
         if (matchingHandlers > 1) {
-          ConcurrentHashMap info = new ConcurrentHashMap();
+          ConcurrentHashMap<String, String> info = new ConcurrentHashMap<>();
           info.put(PSLogMultipleHandlers.PROP_SESS_ID, request.getUserSessionId());
           info.put(PSLogMultipleHandlers.PROP_DATASET_NAMES, dataSetNames);
           m_LogHandler.write(new PSLogMultipleHandlers(m_id, info));
@@ -1420,10 +1424,10 @@ public class PSApplicationHandler implements IPSRootedHandler {
       throws PSExtensionException, PSNotFoundException {
     IPSExtensionDef def = m_extMgr.getExtensionDef(ref);
     try {
-      Class toTest = Class.forName(interfaceName);
-      for (Iterator i = def.getInterfaces(); i.hasNext(); ) {
-        String iface = (String) (i.next());
-        Class clazz = Class.forName(iface);
+      Class<?> toTest = Class.forName(interfaceName);
+      for (Iterator<String> i = def.getInterfaces(); i.hasNext(); ) {
+        String iface = i.next();
+        Class<?> clazz = Class.forName(iface);
         if (toTest.isAssignableFrom(clazz)) {
           return true;
         }
@@ -1739,8 +1743,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
       PSRequestPageMap pageMap = new PSRequestPageMap(ds, rh);
 
       int len = 1;
-      PSRequestPageMap[] curMaps =
-          (PSRequestPageMap[]) m_dataHandlerMap.get(pageMap.getRequestPage().toLowerCase());
+      PSRequestPageMap[] curMaps = m_dataHandlerMap.get(pageMap.getRequestPage().toLowerCase());
       if (curMaps != null) len += curMaps.length;
 
       PSRequestPageMap[] newMaps = new PSRequestPageMap[len];
@@ -1783,14 +1786,14 @@ public class PSApplicationHandler implements IPSRootedHandler {
    * The data handlers managed by this object. The handlers are stored using dataSetName as the key,
    * and the handler instance as the value.
    */
-  private ConcurrentHashMap m_dataHandlers = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, IPSRequestHandler> m_dataHandlers = new ConcurrentHashMap<>();
 
   /**
    * A mapping from request page names to data handlers objects. The handlers are stored using the
    * request page name as the key and the handler instance as the value. For instance, the handler
    * for the "Stock" data set may have "stock.xml" as its key.
    */
-  private ConcurrentHashMap m_dataHandlerMap = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, PSRequestPageMap[]> m_dataHandlerMap = new ConcurrentHashMap<>();
 
   /** The log handler for this application. this handler also handles tracing. */
   private PSDebugLogHandler m_LogHandler;
@@ -1944,7 +1947,7 @@ public class PSApplicationHandler implements IPSRootedHandler {
    *     of entry will be determined by the type of Acl entry requested. Never <code>null</code>.
    * @throws IllegalArgumentException if <code>type</code> does not represent a valid type.
    */
-  public Iterator getAclEntries(int type) {
+  public Iterator<PSEntry> getAclEntries(int type) {
     // this will validate the type, don't want to duplicate that code here
     return m_aclHandler.getAclEntries(type);
   }

--- a/system/src/main/java/com/percussion/server/PSRequestHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/server/PSRequestHandlerConfiguration.java
@@ -138,7 +138,7 @@ public class PSRequestHandlerConfiguration {
   public PSRequestHandlerConfiguration() throws PSServerException {
     try {
       // load the config file
-      m_handlerDefs = new ArrayList();
+      m_handlerDefs = new ArrayList<>();
       Document cfgDoc = getConfig();
 
       // if no config file, we're done
@@ -194,7 +194,7 @@ public class PSRequestHandlerConfiguration {
           rhConfigFile = new File(rhConfigDir, cfgFileName);
 
         // get the roots
-        HashMap roots = new HashMap();
+        HashMap<String, ArrayList<String>> roots = new HashMap<>();
         String rootsElName = "RequestRoots";
 
         Element rootsEl = tree.getNextElement(rootsElName, firstFlags);
@@ -220,7 +220,7 @@ public class PSRequestHandlerConfiguration {
           if (rootName.startsWith("/")) rootName = rootName.substring(1);
 
           // get its methods
-          ArrayList methods = new ArrayList();
+          ArrayList<String> methods = new ArrayList<>();
           String typeElName = "RequestType";
           Element typeEl = tree.getNextElement(typeElName, firstFlags);
 
@@ -248,10 +248,10 @@ public class PSRequestHandlerConfiguration {
                 handlerName, className, rhConfigFile, roots.keySet().iterator());
 
         // add the methods
-        Iterator i = roots.keySet().iterator();
+        Iterator<String> i = roots.keySet().iterator();
         while (i.hasNext()) {
-          String rootName = (String) i.next();
-          def.addRequestMethods(rootName, ((ArrayList) roots.get(rootName)).iterator());
+          String rootName = i.next();
+          def.addRequestMethods(rootName, roots.get(rootName).iterator());
         }
 
         // add it to the list
@@ -272,7 +272,7 @@ public class PSRequestHandlerConfiguration {
   }
 
   /** Returns an iterator over zero or more PSRequestHandlerDef objects. */
-  public Iterator getHandlerDefs() {
+  public Iterator<PSRequestHandlerDef> getHandlerDefs() {
     return m_handlerDefs.iterator();
   }
 
@@ -307,7 +307,7 @@ public class PSRequestHandlerConfiguration {
    * List of request handler definitions. Initialized in constructor, never <code>null</code> after
    * that.
    */
-  private ArrayList m_handlerDefs = null;
+  private ArrayList<PSRequestHandlerDef> m_handlerDefs = null;
 
   /** Directory off the Rhythmyx root where the config file is located. */
   private static final String CONFIG_DIR = "rxconfig/Server";

--- a/system/src/main/java/com/percussion/server/PSRequestHandlerDef.java
+++ b/system/src/main/java/com/percussion/server/PSRequestHandlerDef.java
@@ -55,7 +55,7 @@ public class PSRequestHandlerDef {
 
     m_requestRoots = new HashMap<>();
     while (requestRoots.hasNext()) {
-      String requestRoot = (String) requestRoots.next();
+      String requestRoot = requestRoots.next();
 
       // add with null request methods for now
       m_requestRoots.put(requestRoot, null);
@@ -131,19 +131,14 @@ public class PSRequestHandlerDef {
    * @throws IllegalArgumentException if requestRoot is <code>null</code>, or if the specified
    *     requestRoot is not found in the list of request roots passed into the constructor.
    */
-  @SuppressWarnings(value = "unchecked")
   public Iterator<String> getRequestMethods(String requestRoot) {
     if (requestRoot == null) throw new IllegalArgumentException("requestRoot may not be null");
 
     if (!m_requestRoots.containsKey(requestRoot))
       throw new IllegalArgumentException("requestRoot not found");
 
-    Iterator result = null;
-
-    ArrayList<String> methodList = (ArrayList) m_requestRoots.get(requestRoot);
-    if (methodList != null) result = methodList.iterator();
-
-    return result;
+    ArrayList<String> methodList = m_requestRoots.get(requestRoot);
+    return methodList != null ? methodList.iterator() : null;
   }
 
   /**

--- a/system/src/main/java/com/percussion/server/PSServer.java
+++ b/system/src/main/java/com/percussion/server/PSServer.java
@@ -1285,13 +1285,17 @@ public class PSServer {
    * Get the application handler for the specified application.
    *
    * @param appName the name of the app to locate
-   * @return the application handler
+   * @return the application handler, or <code>null</code> if no handler is registered for that
+   *     application name
+   * @throws ClassCastException if a handler is registered under the application key but is not a
+   *     {@link PSApplicationHandler} (fail-fast; same as the pre-generics cast)
    */
   public static PSApplicationHandler getApplicationHandler(String appName) {
     if (ms_RequestHandlers == null) return null; // Only for unit testing
 
-    IPSRequestHandler handler = ms_RequestHandlers.get("data-" + appName.toLowerCase());
-    return handler instanceof PSApplicationHandler ? (PSApplicationHandler) handler : null;
+    // Explicit cast: missing keys stay null; wrong types fail immediately
+    // (ClassCastException) instead of a deferred NPE at callers.
+    return (PSApplicationHandler) ms_RequestHandlers.get("data-" + appName.toLowerCase());
   }
 
   public static PSApplicationSummary[] getApplicationSummaries(PSRequest req) {

--- a/system/src/main/java/com/percussion/server/PSServer.java
+++ b/system/src/main/java/com/percussion/server/PSServer.java
@@ -1154,7 +1154,6 @@ public class PSServer {
    * @deprecated This method does not consider page selection criteria or supported mime types when
    *     selecting a page. Use {@link #getInternalRequest(String, PSRequest, Map, boolean)} instead.
    */
-  @SuppressWarnings(value = "unchecked")
   public static IPSInternalRequestHandler getInternalRequestHandler(URL request) {
     IPSInternalRequestHandler irh = null;
     if (request != null) {
@@ -1179,9 +1178,9 @@ public class PSServer {
         if (pos > 0) requestPage = requestPage.substring(0, pos);
         PSApplication app = ah.getApplicationDefinition();
         String resource = null;
-        Iterator<PSDataSet> datasets = app.getDataSets().iterator();
+        Iterator<?> datasets = app.getDataSets().iterator();
         while (datasets.hasNext() && resource == null) {
-          PSDataSet dataset = datasets.next();
+          PSDataSet dataset = (PSDataSet) datasets.next();
           if (dataset.getRequestor().getRequestPage().equalsIgnoreCase(requestPage))
             resource = dataset.getName();
         }
@@ -1272,7 +1271,7 @@ public class PSServer {
     // make sure handler able to process this type of request method
     String reqMethod = req.getServletRequest().getMethod();
     if (rh != null) {
-      ArrayList methodList = (ArrayList) ms_requestHandlerTypes.get(rh);
+      List<String> methodList = ms_requestHandlerTypes.get(rh);
       if (methodList == null || !methodList.contains(reqMethod.toUpperCase())) {
         // don't want to allow this to be used
         rh = null;
@@ -1291,7 +1290,8 @@ public class PSServer {
   public static PSApplicationHandler getApplicationHandler(String appName) {
     if (ms_RequestHandlers == null) return null; // Only for unit testing
 
-    return (PSApplicationHandler) ms_RequestHandlers.get("data-" + appName.toLowerCase());
+    IPSRequestHandler handler = ms_RequestHandlers.get("data-" + appName.toLowerCase());
+    return handler instanceof PSApplicationHandler ? (PSApplicationHandler) handler : null;
   }
 
   public static PSApplicationSummary[] getApplicationSummaries(PSRequest req) {
@@ -1306,9 +1306,7 @@ public class PSServer {
    */
   public static boolean isApplicationActive(String appName) {
 
-    Object ah = ms_RequestHandlers.get("data-" + appName.toLowerCase());
-
-    return (ah != null);
+    return ms_RequestHandlers.get("data-" + appName.toLowerCase()) != null;
   }
 
   /**
@@ -1439,7 +1437,6 @@ public class PSServer {
    *     ignored.
    * @throws IllegalArgumentException if <code>type</code> does not represent a valid type.
    */
-  @SuppressWarnings(value = "unchecked")
   public static Iterator<PSEntry> getAclEntries(int type) {
     Map<String, PSEntry> entryMap = new HashMap<String, PSEntry>();
 
@@ -1800,7 +1797,6 @@ public class PSServer {
    *     .
    * @throws IllegalArgumentException if the provided document is <code>null</code>.
    */
-  @SuppressWarnings(value = "unchecked")
   public static Element getRequestHandlersStatus(Document doc, boolean full) {
     if (doc == null) throw new IllegalArgumentException("the document cannot be null");
 
@@ -1814,7 +1810,7 @@ public class PSServer {
       IPSRequestHandler h = ms_RequestHandlers.get(name);
       handler.setAttribute("class", h.getClass().getName());
 
-      List suppTypes = ms_requestHandlerTypes.get(h);
+      List<String> suppTypes = ms_requestHandlerTypes.get(h);
       Element types = doc.createElement("SupportedTypes");
       if (suppTypes != null) types.appendChild(doc.createTextNode(suppTypes.toString()));
       handler.appendChild(types);
@@ -1834,7 +1830,7 @@ public class PSServer {
 
       if (full && h instanceof PSApplicationHandler) {
         PSApplicationHandler a = (PSApplicationHandler) h;
-        Map cache = a.getStylesheetCache();
+        ConcurrentHashMap<URL, PSCachedStylesheet> cache = a.getStylesheetCache();
         if (cache != null) {
           Iterator<PSCachedStylesheet> stylesheets = cache.values().iterator();
           while (stylesheets.hasNext()) {
@@ -1844,7 +1840,7 @@ public class PSServer {
         }
       }
 
-      List suppTypes = ms_requestHandlerTypes.get(h);
+      List<String> suppTypes = ms_requestHandlerTypes.get(h);
       Element types = doc.createElement("SupportedTypes");
       if (suppTypes != null) types.appendChild(doc.createTextNode(suppTypes.toString()));
       handler.appendChild(types);
@@ -1870,7 +1866,6 @@ public class PSServer {
    * @param apps All applications that need to be started. If an entry in the array is <code>null
    *     </code> it is skipped. If <code>null</code> is supplied, no app handlers will be started.
    */
-  @SuppressWarnings(value = "unchecked")
   private static void initRequestHandlers(PSApplication[] apps)
       throws PSNotFoundException, PSServerException, PSCacheException {
     PSConsole.printInfoMsg("Server", IPSServerErrors.REQ_HANDLER_INIT, (Object[]) null);
@@ -2043,7 +2038,6 @@ public class PSServer {
    *
    * @throws PSServerException for any errors.
    */
-  @SuppressWarnings(value = "unchecked")
   private static void initLoadableRequestHandlers() throws PSServerException {
     PSRequestHandlerConfiguration handlerConfig = new PSRequestHandlerConfiguration();
     Iterator<PSRequestHandlerDef> defs = handlerConfig.getHandlerDefs();
@@ -2055,9 +2049,9 @@ public class PSServer {
         /* Use a constructor with the signature (IPSObjectStoreHandler,
         IPSExtensionManager) if one exists.  Otherwise, use the empty
         contructor */
-        Class handlerClass = Class.forName(def.getClassName());
+        Class<?> handlerClass = Class.forName(def.getClassName());
         try {
-          Constructor handlerCtor =
+          Constructor<?> handlerCtor =
               handlerClass.getConstructor(
                   new Class[] {IPSObjectStoreHandler.class, IPSExtensionManager.class});
           loadableHandler =
@@ -2353,7 +2347,6 @@ public class PSServer {
    * @see IPSHandlerStateListener
    * @see PSHandlerStateEvent
    */
-  @SuppressWarnings(value = "unchecked")
   public static void addHandlerStateListener(
       IPSHandlerStateListener listener, String handlerName, int events) {
     if (listener == null) {
@@ -2363,11 +2356,12 @@ public class PSServer {
       throw new IllegalArgumentException("handlerName must not be null or empty");
     }
 
-    Map listenerEventMap = (Map) ms_handlerStateListenerMap.get(handlerName);
-    if (listenerEventMap == null) listenerEventMap = new HashMap();
+    Map<IPSHandlerStateListener, Integer> listenerEventMap =
+        ms_handlerStateListenerMap.get(handlerName);
+    if (listenerEventMap == null) listenerEventMap = new HashMap<>();
 
     int flags = events;
-    Integer eventsObj = (Integer) listenerEventMap.get(listener);
+    Integer eventsObj = listenerEventMap.get(listener);
     if (eventsObj != null) flags = eventsObj.intValue() | events;
     listenerEventMap.put(listener, Integer.valueOf(flags));
 
@@ -2383,19 +2377,19 @@ public class PSServer {
    * @param stateEvent a valid state event, one of the {@link
    *     PSHandlerStateEvent#HANDLER_EVENT_STARTED HANDLER_EVENT_XXX} flags.
    */
-  @SuppressWarnings(value = "unchecked")
   private static void fireAppHandlerStateChanged(PSApplicationHandler ah, int stateEvent) {
     String handlerName = ah.getName();
     if (!ms_handlerStateListenerMap.containsKey(handlerName)) {
       // No listeners have been registered for the application
       return;
     }
-    Map listenerEvents = (Map) ms_handlerStateListenerMap.get(handlerName);
+    Map<IPSHandlerStateListener, Integer> listenerEvents =
+        ms_handlerStateListenerMap.get(handlerName);
     // Get iterator of all registered listeners for the application handler
-    Iterator listeners = listenerEvents.keySet().iterator();
+    Iterator<IPSHandlerStateListener> listeners = listenerEvents.keySet().iterator();
     while (listeners.hasNext()) {
-      IPSHandlerStateListener listener = (IPSHandlerStateListener) listeners.next();
-      Integer eventsObj = (Integer) listenerEvents.get(listener);
+      IPSHandlerStateListener listener = listeners.next();
+      Integer eventsObj = listenerEvents.get(listener);
       int flags = eventsObj.intValue();
       if (stateEvent != (flags & stateEvent)) continue;
       // Notify the listener
@@ -2439,7 +2433,7 @@ public class PSServer {
   }
 
   /** Get a collection of the rooted app handlers */
-  static Collection getRootedAppHandlers() {
+  static Collection<IPSRequestHandler> getRootedAppHandlers() {
     return ms_rootedRequestHandlers.values();
   }
 
@@ -2449,7 +2443,7 @@ public class PSServer {
    * @return An iterator over zero or more {@link IPSHandlerInitListener} objects, never <code>null
    *     </code>;
    */
-  static Iterator getHandlerInitListeners() {
+  static Iterator<IPSHandlerInitListener> getHandlerInitListeners() {
     return ms_handlerInitListeners.iterator();
   }
 
@@ -2473,7 +2467,6 @@ public class PSServer {
    *
    * @param rh The request handler being initialized, may not be <code>null</code>.
    */
-  @SuppressWarnings(value = "unchecked")
   public static void notifyHandlerInitListeners(IPSRequestHandler rh) {
     if (rh == null) throw new IllegalArgumentException("rh may not be null");
 
@@ -2490,7 +2483,6 @@ public class PSServer {
    *
    * @param rh The request handler being shutdown, may not be <code>null</code>.
    */
-  @SuppressWarnings(value = "unchecked")
   public static void notifyHandlerShutdownListeners(IPSRequestHandler rh) {
     if (rh == null) throw new IllegalArgumentException("rh may not be null");
 
@@ -3743,7 +3735,8 @@ public class PSServer {
    * together. This is to facilitate registering multiple handler state listeners and state events
    * for each handler.
    */
-  private static Map ms_handlerStateListenerMap = new HashMap();
+  private static Map<String, Map<IPSHandlerStateListener, Integer>> ms_handlerStateListenerMap =
+      new HashMap<>();
 
   /**
    * List of listeners to be notified of handler initializations. Listeners are added during server

--- a/system/src/test/java/com/percussion/server/PSApplicationHandlerDataHandlersTypedTest.java
+++ b/system/src/test/java/com/percussion/server/PSApplicationHandlerDataHandlersTypedTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
 
 import com.percussion.log.PSLogApplicationStatistics;
 import com.percussion.log.PSLogMultipleHandlers;
@@ -162,13 +164,30 @@ class PSApplicationHandlerDataHandlersTypedTest {
   }
 
   @Test
-  @DisplayName("getApplicationHandler returns only PSApplicationHandler entries")
-  void getApplicationHandlerIgnoresNonAppEntries() {
+  @DisplayName("getApplicationHandler returns null for missing apps and CCE for wrong types")
+  void getApplicationHandlerFailFastOnWrongType() {
     IPSRequestHandler dummy = new NoopRequestHandler();
     PSServer.ms_RequestHandlers.put("data-foo", dummy);
-    assertNull(PSServer.getApplicationHandler("foo"));
+    assertNull(PSServer.getApplicationHandler("missing"));
+    assertThrows(ClassCastException.class, () -> PSServer.getApplicationHandler("foo"));
     assertFalse(PSServer.isApplicationActive("missing"));
     assertTrue(PSServer.isApplicationActive("foo"));
+  }
+
+  @Test
+  @DisplayName("getInternalRequestHandler returns null when missing and CCE for wrong types")
+  void getInternalRequestHandlerFailFastOnWrongType() throws Exception {
+    PSApplicationHandler ah = mock(PSApplicationHandler.class, CALLS_REAL_METHODS);
+    ConcurrentHashMap<String, IPSRequestHandler> handlers = new ConcurrentHashMap<>();
+    Field dataHandlers = PSApplicationHandler.class.getDeclaredField("m_dataHandlers");
+    dataHandlers.setAccessible(true);
+    dataHandlers.set(ah, handlers);
+
+    assertNull(ah.getInternalRequestHandler("missing"));
+    handlers.put("ds", new NoopRequestHandler());
+    assertThrows(ClassCastException.class, () -> ah.getInternalRequestHandler("ds"));
+    assertThrows(IllegalArgumentException.class, () -> ah.getInternalRequestHandler(""));
+    assertThrows(IllegalArgumentException.class, () -> ah.getInternalRequestHandler((String) null));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/server/PSApplicationHandlerDataHandlersTypedTest.java
+++ b/system/src/test/java/com/percussion/server/PSApplicationHandlerDataHandlersTypedTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.log.PSLogApplicationStatistics;
+import com.percussion.log.PSLogMultipleHandlers;
+import com.percussion.log.PSLogSubMessage;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Behavioral tests for typed dataHandlers / request-root maps (#3212 residual of #3186).
+ */
+class PSApplicationHandlerDataHandlersTypedTest {
+
+  private ConcurrentHashMap<String, IPSRequestHandler> savedRequestHandlers;
+  private ConcurrentHashMap<String, IPSRequestHandler> savedRootedHandlers;
+  private Map<String, Map<IPSHandlerStateListener, Integer>> savedListenerMap;
+
+  @BeforeEach
+  void snapshotServerMaps() throws Exception {
+    savedRequestHandlers = PSServer.ms_RequestHandlers;
+    savedRootedHandlers = getRootedHandlers();
+    savedListenerMap = getHandlerStateListenerMap();
+    PSServer.ms_RequestHandlers = new ConcurrentHashMap<>();
+    setRootedHandlers(new ConcurrentHashMap<>());
+    setHandlerStateListenerMap(new HashMap<>());
+  }
+
+  @AfterEach
+  void restoreServerMaps() throws Exception {
+    PSServer.ms_RequestHandlers = savedRequestHandlers;
+    setRootedHandlers(savedRootedHandlers);
+    setHandlerStateListenerMap(savedListenerMap);
+  }
+
+  @Test
+  @DisplayName("PSRequestHandlerDef stores typed request roots and HTTP methods")
+  void requestHandlerDefTypedRootsAndMethods() {
+    PSRequestHandlerDef def =
+        new PSRequestHandlerDef(
+            "compare",
+            "com.percussion.server.compare.PSCompareRequestHandler",
+            new File("compare.xml"),
+            List.of("compare", "diff").iterator());
+
+    List<String> roots = iteratorToList(def.getRequestRoots());
+    assertEquals(2, roots.size());
+    assertTrue(roots.contains("compare"));
+    assertTrue(roots.contains("diff"));
+
+    def.addRequestMethods("compare", List.of("GET", "POST").iterator());
+    List<String> methods = iteratorToList(def.getRequestMethods("compare"));
+    assertEquals(List.of("GET", "POST"), methods);
+    assertNull(def.getRequestMethods("diff"));
+  }
+
+  @Test
+  @DisplayName("PSRequestHandlerDef rejects missing or unknown request roots")
+  void requestHandlerDefRejectsInvalidRoots() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PSRequestHandlerDef(
+                "h", "c", null, Collections.emptyIterator()));
+
+    PSRequestHandlerDef def =
+        new PSRequestHandlerDef("h", "c", null, List.of("root").iterator());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> def.addRequestMethods("missing", List.of("GET").iterator()));
+    assertThrows(IllegalArgumentException.class, () -> def.getRequestMethods("missing"));
+    assertThrows(IllegalArgumentException.class, () -> def.getRequestMethods(null));
+  }
+
+  @Test
+  @DisplayName("addHandlerStateListener merges ORed event flags per listener")
+  void handlerStateListenerEventsMerge() throws Exception {
+    AtomicInteger started = new AtomicInteger();
+    IPSHandlerStateListener listener = e -> started.incrementAndGet();
+
+    PSServer.addHandlerStateListener(
+        listener, "sys_cx", PSHandlerStateEvent.HANDLER_EVENT_STARTED);
+    PSServer.addHandlerStateListener(
+        listener, "sys_cx", PSHandlerStateEvent.HANDLER_EVENT_STOPPED);
+
+    Map<IPSHandlerStateListener, Integer> events = getHandlerStateListenerMap().get("sys_cx");
+    assertNotNull(events);
+    assertEquals(
+        PSHandlerStateEvent.HANDLER_EVENT_STARTED | PSHandlerStateEvent.HANDLER_EVENT_STOPPED,
+        events.get(listener).intValue());
+  }
+
+  @Test
+  @DisplayName("addHandlerStateListener rejects null listener or empty handler name")
+  void handlerStateListenerRejectsInvalidArgs() {
+    IPSHandlerStateListener listener = e -> {};
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSServer.addHandlerStateListener(
+                null, "sys_cx", PSHandlerStateEvent.HANDLER_EVENT_STARTED));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSServer.addHandlerStateListener(
+                listener, "", PSHandlerStateEvent.HANDLER_EVENT_STARTED));
+  }
+
+  @Test
+  @DisplayName("getRequestHandlersStatus lists typed handler names and classes")
+  void requestHandlersStatusUsesTypedMaps() {
+    IPSRequestHandler dummy = new NoopRequestHandler();
+    PSServer.ms_RequestHandlers.put("extdata-compare", dummy);
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element status = PSServer.getRequestHandlersStatus(doc, false);
+    assertEquals("RequestHandlers", status.getNodeName());
+    NodeList handlers = status.getElementsByTagName("Handler");
+    assertEquals(1, handlers.getLength());
+    Element handler = (Element) handlers.item(0);
+    assertEquals("extdata-compare", handler.getAttribute("name"));
+    assertEquals(NoopRequestHandler.class.getName(), handler.getAttribute("class"));
+  }
+
+  @Test
+  @DisplayName("getApplicationHandler returns only PSApplicationHandler entries")
+  void getApplicationHandlerIgnoresNonAppEntries() {
+    IPSRequestHandler dummy = new NoopRequestHandler();
+    PSServer.ms_RequestHandlers.put("data-foo", dummy);
+    assertNull(PSServer.getApplicationHandler("foo"));
+    assertFalse(PSServer.isApplicationActive("missing"));
+    assertTrue(PSServer.isApplicationActive("foo"));
+  }
+
+  @Test
+  @DisplayName("PSLogApplicationStatistics reads typed string map keys")
+  void logApplicationStatisticsTypedMap() {
+    Map<String, String> stats = new HashMap<>();
+    stats.put("elapsedTime", "10");
+    stats.put("eventsProcessed", "2");
+    stats.put("eventsPending", "0");
+    stats.put("eventsFailed", "1");
+    stats.put("cacheHits", "3");
+    stats.put("cacheMisses", "4");
+    stats.put("minProcTime", "5");
+    stats.put("maxProcTime", "6");
+    stats.put("avgProcTime", "7");
+
+    PSLogApplicationStatistics msg = new PSLogApplicationStatistics(42, stats);
+    PSLogSubMessage[] subs = msg.getSubMessages();
+    assertEquals(9, subs.length);
+    assertEquals("10", subs[0].getText());
+    assertEquals("2", subs[1].getText());
+    assertEquals("7", subs[8].getText());
+  }
+
+  @Test
+  @DisplayName("PSLogMultipleHandlers reads typed session and dataset keys")
+  void logMultipleHandlersTypedMap() {
+    ConcurrentHashMap<String, String> info = new ConcurrentHashMap<>();
+    info.put(PSLogMultipleHandlers.PROP_SESS_ID, "sess-1");
+    info.put(PSLogMultipleHandlers.PROP_DATASET_NAMES, "dsA, dsB");
+
+    PSLogMultipleHandlers msg = new PSLogMultipleHandlers(7, info);
+    PSLogSubMessage[] subs = msg.getSubMessages();
+    assertEquals("sess-1", subs[0].getText());
+    assertEquals("dsA, dsB", subs[1].getText());
+  }
+
+  @Test
+  @DisplayName("dataHandlers and request-root field types are generic")
+  void fieldGenericSignatures() throws Exception {
+    Field dataHandlers = PSApplicationHandler.class.getDeclaredField("m_dataHandlers");
+    assertTrue(dataHandlers.getGenericType().getTypeName().contains("IPSRequestHandler"));
+
+    Field dataHandlerMap = PSApplicationHandler.class.getDeclaredField("m_dataHandlerMap");
+    assertTrue(dataHandlerMap.getGenericType().getTypeName().contains("PSRequestPageMap"));
+
+    Field requestRoots = PSRequestHandlerDef.class.getDeclaredField("m_requestRoots");
+    assertTrue(requestRoots.getGenericType().getTypeName().contains("ArrayList"));
+
+    Method getRoots = PSApplicationHandler.class.getMethod("getRequestRoots");
+    assertTrue(getRoots.getGenericReturnType().getTypeName().contains("String"));
+  }
+
+  @Test
+  @DisplayName("getHandlerDefs returns typed iterator")
+  void handlerDefsIteratorType() throws Exception {
+    Method m = PSRequestHandlerConfiguration.class.getMethod("getHandlerDefs");
+    assertTrue(m.getGenericReturnType().getTypeName().contains("PSRequestHandlerDef"));
+  }
+
+  @Test
+  @DisplayName("rooted handler collection is typed")
+  void rootedHandlersCollectionType() throws Exception {
+    Method m = PSServer.class.getDeclaredMethod("getRootedAppHandlers");
+    assertTrue(m.getGenericReturnType().getTypeName().contains("IPSRequestHandler"));
+  }
+
+  private static List<String> iteratorToList(Iterator<String> it) {
+    List<String> out = new ArrayList<>();
+    if (it == null) {
+      return out;
+    }
+    while (it.hasNext()) {
+      out.add(it.next());
+    }
+    return out;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ConcurrentHashMap<String, IPSRequestHandler> getRootedHandlers()
+      throws Exception {
+    Field f = PSServer.class.getDeclaredField("ms_rootedRequestHandlers");
+    f.setAccessible(true);
+    return (ConcurrentHashMap<String, IPSRequestHandler>) f.get(null);
+  }
+
+  private static void setRootedHandlers(ConcurrentHashMap<String, IPSRequestHandler> map)
+      throws Exception {
+    Field f = PSServer.class.getDeclaredField("ms_rootedRequestHandlers");
+    f.setAccessible(true);
+    f.set(null, map);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Map<IPSHandlerStateListener, Integer>> getHandlerStateListenerMap()
+      throws Exception {
+    Field f = PSServer.class.getDeclaredField("ms_handlerStateListenerMap");
+    f.setAccessible(true);
+    return (Map<String, Map<IPSHandlerStateListener, Integer>>) f.get(null);
+  }
+
+  private static void setHandlerStateListenerMap(
+      Map<String, Map<IPSHandlerStateListener, Integer>> map) throws Exception {
+    Field f = PSServer.class.getDeclaredField("ms_handlerStateListenerMap");
+    f.setAccessible(true);
+    f.set(null, map);
+  }
+
+  private static final class NoopRequestHandler implements IPSRequestHandler {
+    @Override
+    public void processRequest(PSRequest request) {
+      // no-op
+    }
+
+    @Override
+    public void shutdown() {
+      // no-op
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #3212 (parent epic #2022 residual of #3186 / PR #3214): type remaining **PSApplicationHandler / PSServer** `dataHandlers` maps and request-root collections with real generics.

### Changes

- `PSApplicationHandler`: `ConcurrentHashMap<String, IPSRequestHandler>` dataHandlers, `ConcurrentHashMap<String, PSRequestPageMap[]>` request-page map, typed request roots / ACL iterator / log maps.
- `PSServer`: typed handler-state listener map, request-handler status lists, loadable-handler `Class`/`Constructor`, rooted-handler collection; removed leftover `@SuppressWarnings("unchecked")` on those paths.
- `PSRequestHandlerConfiguration` / `PSRequestHandlerDef`: typed request-root → HTTP method maps.
- `PSLogApplicationStatistics` / `PSLogMultipleHandlers`: `Map<String,String>` / `ConcurrentHashMap<String,String>` ctors.

Does **not** absorb #3213 (content/clone/actions command maps).

### Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2022

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2007, Failures: 0, Errors: 0, Skipped: 241)
2. Focused: `-Dtest=PSApplicationHandlerDataHandlersTypedTest` — 11 tests green
3. Product documentation: N/A (pure Xlint/generics tech-debt, no product behavior surface)

## Checklist

- [x] **Product documentation** — N/A (not product-facing): pure generics/Xlint tech-debt
- [x] **Unit / module tests** — `PSApplicationHandlerDataHandlersTypedTest`; system standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install, no skipTests
- [x] **Cross-platform** — N/A (no path/file I/O)

### Gates evidence

- modules_built=`system`
- build_evidence=`cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2007, Failures: 0, Errors: 0, Skipped: 241
- downstream_checked=`getHandlerDefs` already `Iterator<PSRequestHandlerDef>` in `deployer`; `getRootedAppHandlers` in-module only; `getAclEntries` already typed at callers; no `final`/`sealed` or binary signature shape change beyond type parameters

Fixes #3212

> Co-Authored by Grok Build using grok-4.5 with agent main.
