### PR TITLE
fix(system): type content/clone/actions command maps (#3213)

### DIFF
--- a/docs/ai-generated/code-reviews/3213-content-clone-actions-command-maps-erlang.md
+++ b/docs/ai-generated/code-reviews/3213-content-clone-actions-command-maps-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — #3213 content/clone/actions command-map Xlint
+
+- **Branch:** `fix/issue-3213-content-clone-actions-command-maps`
+- **Date:** 2026-08-12
+- **Reviewer:** Erlang (pre-commit, implementer-independent)
+- **Recommendation:** approve
+- **Gate:** May commit/push: yes
+- **Memory patterns hit:** prefer real generics over class-level `@SuppressWarnings`; behavioral tests for typed maps; do not change public API shape without reverse-dep grep
+
+## Summary
+
+PR-sized `-Xlint` cleanup of remaining `com.percussion.server` content / clone / actions / command maps after #3186. Production maps are now parameterized (`Map<String,String>` form content, `Map<String,Object>` clone/internal-request params, `Map<String,ActionResult>` action results, `ConcurrentHashMap<String,Object>` console commands). No new class-level suppressions. No path/file I/O.
+
+## Gate
+
+- **Bugs:** none found
+- **Behavioral tests:** present (`PSFormContentParserTest`, `PSCloneBaseTypedTest`, `PSActionSetResultTest`, `PSActionSetRequestHandlerTypedTest`, `PSConsoleCommandParserTest`)
+- **Cross-platform paths:** N/A (no filesystem path construction)
+- **Change-class companions:** tests + standalone `system` clean install
+
+## Issues
+
+None.
+
+## Notes
+
+- `PSActionSet.toXml()` still cannot adopt a `Document` created in a different owner document; tests use `setSuccess(..., null)` for XML status assertions. Pre-existing, not introduced here.
+- Remaining command-package raw **lists** (`PSConsoleCommandLogDump`) are out of this map slice.

--- a/system/src/main/java/com/percussion/server/actions/PSAction.java
+++ b/system/src/main/java/com/percussion/server/actions/PSAction.java
@@ -80,7 +80,7 @@ public class PSAction {
     }
 
     if (m_extensions != null) {
-      m_extensionInstances = new ArrayList(m_extensions.size());
+      m_extensionInstances = new ArrayList<>(m_extensions.size());
       for (int i = 0; i < m_extensions.size(); i++) {
         PSExtensionCall call = (PSExtensionCall) m_extensions.get(i);
         PSExtensionRef ref = call.getExtensionRef();
@@ -200,7 +200,7 @@ public class PSAction {
    *
    * @return an iterator of PSExtensionRunner objects, never <code>null</code> but may be empty.
    */
-  public Iterator getExtensionRunners() {
+  public Iterator<PSExtensionRunner> getExtensionRunners() {
     if (m_extensionInstances != null) return m_extensionInstances.iterator();
     else return PSIteratorUtils.emptyIterator();
   }
@@ -274,7 +274,7 @@ public class PSAction {
    * m_extensions</code> during the init method. Will be <code>null</code> if <code>m_extensions
    * </code> is <code>null</code>.
    */
-  private List m_extensionInstances = null;
+  private List<PSExtensionRunner> m_extensionInstances = null;
 
   /**
    * Determines whether an action set should stop executing if this action generates an exception.

--- a/system/src/main/java/com/percussion/server/actions/PSActionSet.java
+++ b/system/src/main/java/com/percussion/server/actions/PSActionSet.java
@@ -120,8 +120,7 @@ public class PSActionSet {
     }
 
     // prep each child action
-    for (Iterator iter = m_actions.iterator(); iter.hasNext(); ) {
-      PSAction action = (PSAction) iter.next();
+    for (PSAction action : m_actions) {
       action.init(extMgr);
     }
   }
@@ -169,7 +168,7 @@ public class PSActionSet {
       throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } else {
       // make sure each action name is unique by using a set
-      Set actionNames = new HashSet();
+      Set<String> actionNames = new HashSet<>();
 
       while (elem != null) {
         PSAction action = new PSAction(elem);
@@ -214,7 +213,7 @@ public class PSActionSet {
    *
    * @return iterator of <code>PSAction</code> objects; never <code>null</code> or empty.
    */
-  public Iterator getActions() {
+  public Iterator<PSAction> getActions() {
     return m_actions.iterator();
   }
 
@@ -272,7 +271,7 @@ public class PSActionSet {
     if (originalReq == null) throw new IllegalArgumentException("Request may not be null");
 
     PSActionSetResult actionSetResult = new PSActionSetResult(this, ceUrl);
-    Iterator actions = m_actions.iterator();
+    Iterator<PSAction> actions = m_actions.iterator();
 
     // if there is a content id but no revision id specified in the request,
     // add one
@@ -285,7 +284,7 @@ public class PSActionSet {
     Exception error = null;
     String itemValidationError = null;
     while (actions.hasNext() && error == null && itemValidationError == null) {
-      PSAction action = (PSAction) actions.next();
+      PSAction action = actions.next();
       Document resultDoc = null; // assigned if action is a query
       PSExecutionData execData = null;
       try {
@@ -343,14 +342,14 @@ public class PSActionSet {
       if (error == null && itemValidationError == null) {
         // completed with no errors, process this action's extensions
         // resultDoc will be null if update command, not null if query
-        Iterator iter = action.getExtensionRunners();
+        Iterator<PSExtensionRunner> iter = action.getExtensionRunners();
         try {
           /* Build a new execution data from the context of the just
             completed action resolve any replacement values in the exits.
           */
           execData = new PSExecutionData(null, handler, actionContext);
           while (iter.hasNext()) {
-            PSExtensionRunner runner = (PSExtensionRunner) iter.next();
+            PSExtensionRunner runner = iter.next();
             resultDoc = runner.processResultDoc(execData, resultDoc);
           }
 
@@ -550,7 +549,7 @@ public class PSActionSet {
    * List of <code>PSAction</code> objects, populated by the <code>fromXml
    * </code> method. Never <code>null</code> or empty.
    */
-  private List m_actions = new ArrayList();
+  private List<PSAction> m_actions = new ArrayList<>();
 
   /**
    * The redirect URL, returned to browser after successfully processing all actions. Never <code>

--- a/system/src/main/java/com/percussion/server/actions/PSActionSetRequestHandler.java
+++ b/system/src/main/java/com/percussion/server/actions/PSActionSetRequestHandler.java
@@ -147,7 +147,7 @@ public class PSActionSetRequestHandler implements IPSLoadableRequestHandler {
   }
 
   // see IPSRootedHandler for documentation
-  public Iterator getRequestRoots() {
+  public Iterator<String> getRequestRoots() {
     return requestRoots.iterator();
   }
 
@@ -179,7 +179,7 @@ public class PSActionSetRequestHandler implements IPSLoadableRequestHandler {
           IPSServerErrors.ACTION_SET_MISSING_REQUIRED_PARAMS,
           new Object[] {IPSHtmlParameters.SYS_CONTENTID, IPSHtmlParameters.SYS_CONTENTTYPEID});
 
-    Map params = new HashMap(2);
+    Map<String, Object> params = new HashMap<>(2);
     params.put(IPSHtmlParameters.SYS_CONTENTTYPEID, contenttypeid);
     params.put(IPSHtmlParameters.SYS_CONTENTID, contentid);
 

--- a/system/src/main/java/com/percussion/server/actions/PSActionSetResult.java
+++ b/system/src/main/java/com/percussion/server/actions/PSActionSetResult.java
@@ -54,12 +54,12 @@ public class PSActionSetResult {
 
     m_actionSetName = actionSet.getName();
     m_originalHref = contentEditorUrl;
-    m_actionNames = new ArrayList();
-    m_actionResults = new HashMap();
+    m_actionNames = new ArrayList<>();
+    m_actionResults = new HashMap<>();
 
-    Iterator actions = actionSet.getActions();
+    Iterator<PSAction> actions = actionSet.getActions();
     while (actions.hasNext()) {
-      PSAction action = (PSAction) actions.next();
+      PSAction action = actions.next();
       m_actionNames.add(action.getName());
       setSkipped(action.getName());
     }
@@ -140,9 +140,8 @@ public class PSActionSetResult {
     Element root = PSXmlDocumentBuilder.createRoot(doc, "StoredActionResults");
     root.setAttribute("actionSetName", m_actionSetName);
     root.setAttribute("originalHref", m_originalHref);
-    for (Object m_actionName : m_actionNames) {
-      String actionName = (String) m_actionName;
-      ActionResult result = (ActionResult) m_actionResults.get(actionName);
+    for (String actionName : m_actionNames) {
+      ActionResult result = m_actionResults.get(actionName);
       Element actionEl = doc.createElement("ActionResult");
       actionEl.setAttribute("actionName", actionName);
       actionEl.setAttribute("status", result.getStatusString());
@@ -240,7 +239,7 @@ public class PSActionSetResult {
       throw new IllegalArgumentException(
           "action '" + actionName + "' is not part of this result set.");
 
-    return (ActionResult) m_actionResults.get(actionName);
+    return m_actionResults.get(actionName);
   }
 
   /**
@@ -354,11 +353,11 @@ public class PSActionSetResult {
    * </code>, as both a status flag and a status object need to be maintained. Assigned in the ctor,
    * and never <code>null</code> after.
    */
-  private Map m_actionResults;
+  private Map<String, ActionResult> m_actionResults;
 
   /**
    * Maintains the correct order of the actions (since a <code>Map</code> does not) so the results
    * can be generated in the correct order. Assigned in the ctor, and never <code>null</code> after.
    */
-  private List m_actionNames;
+  private List<String> m_actionNames;
 }

--- a/system/src/main/java/com/percussion/server/clone/PSCloneBase.java
+++ b/system/src/main/java/com/percussion/server/clone/PSCloneBase.java
@@ -85,9 +85,9 @@ public abstract class PSCloneBase extends PSDefaultExtension implements IPSResul
    *     should match with the length of updateResources array.
    * @param updateResources String array of update resources AppName/ResName. The length of this
    *     array should match with the length of updateResources array.
-   * @param queryParams Map of name and value pair of paramesters that will be used while making an
+   * @param queryParams Map of name and value pair of parameters that will be used while making an
    *     internal request to query resources.
-   * @param updateParams Map of name and value pair of paramesters that will be used while making an
+   * @param updateParams Map of name and value pair of parameters that will be used while making an
    *     internal request to update resources.
    * @throws PSExtensionProcessingException when there is an error while making an internal request
    *     to query resources or update resources.
@@ -98,8 +98,8 @@ public abstract class PSCloneBase extends PSDefaultExtension implements IPSResul
       String keyElementValue,
       String[] queryResources,
       String[] updateResources,
-      Map queryParams,
-      Map updateParams)
+      Map<String, Object> queryParams,
+      Map<String, Object> updateParams)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request cannot be null");
     if (queryResources.length != updateResources.length)
@@ -156,13 +156,13 @@ public abstract class PSCloneBase extends PSDefaultExtension implements IPSResul
    *
    * @param request IPSRequestContext object must not be <code>null</code>.
    * @param updateResourceName Name of the update resource must not be <code>null</code> or empty
-   * @param updateParams Map of name and value pair of paramesters that will be used while making an
+   * @param updateParams Map of name and value pair of parameters that will be used while making an
    *     internal request to update resources.
    * @throws PSExtensionProcessingException when there is an error while making an internal request
    *     to query resources or update resources.
    */
   protected void updateContent(
-      IPSRequestContext request, String updateResourceName, Map updateParams)
+      IPSRequestContext request, String updateResourceName, Map<String, Object> updateParams)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request cannot be null");
     if (updateResourceName == null || updateResourceName.trim().length() < 1)

--- a/system/src/main/java/com/percussion/server/clone/PSCloneCommunityExit.java
+++ b/system/src/main/java/com/percussion/server/clone/PSCloneCommunityExit.java
@@ -70,9 +70,9 @@ public class PSCloneCommunityExit extends PSCloneBase {
     if (sourceCommunityId > 0) {
 
       String rolename = request.getParameter("rolename", "").trim();
-      Map qrParams = new HashMap();
+      Map<String, Object> qrParams = new HashMap<>();
       qrParams.put(IPSHtmlParameters.SYS_COMMUNITYID, Integer.toString(sourceCommunityId));
-      Map upParams = new HashMap();
+      Map<String, Object> upParams = new HashMap<>();
       upParams.put("DBActionType", "INSERT");
       // Call the base class cloneChildObjects method to clone the states,
       // roles and others.
@@ -97,7 +97,7 @@ public class PSCloneCommunityExit extends PSCloneBase {
       }
 
       if (roleId.length() > 0) {
-        Map roleParams = new HashMap();
+        Map<String, Object> roleParams = new HashMap<>();
         roleParams.put("DBActionType", "INSERT");
         roleParams.put("roleid", roleId);
         roleParams.put("communityid", targetCommunityId);

--- a/system/src/main/java/com/percussion/server/clone/PSCloneVariantExit.java
+++ b/system/src/main/java/com/percussion/server/clone/PSCloneVariantExit.java
@@ -54,9 +54,9 @@ public class PSCloneVariantExit extends PSCloneBase {
     }
     if (sourceVariantId > 0) {
 
-      Map qrParams = new HashMap();
+      Map<String, Object> qrParams = new HashMap<>();
       qrParams.put(IPSHtmlParameters.SYS_VARIANTID, Integer.toString(sourceVariantId));
-      Map upParams = new HashMap();
+      Map<String, Object> upParams = new HashMap<>();
       upParams.put("DBActionType", "INSERT");
 
       // Call the base class cloneChildObjects method to clone the states and

--- a/system/src/main/java/com/percussion/server/clone/PSCloneWorkflowExit.java
+++ b/system/src/main/java/com/percussion/server/clone/PSCloneWorkflowExit.java
@@ -57,9 +57,9 @@ public class PSCloneWorkflowExit extends PSCloneBase {
 
     if (sourceWorkflowId > 0) {
 
-      Map qrParams = new HashMap();
+      Map<String, Object> qrParams = new HashMap<>();
       qrParams.put(IPSHtmlParameters.SYS_WORKFLOWID, Integer.toString(sourceWorkflowId));
-      Map upParams = new HashMap();
+      Map<String, Object> upParams = new HashMap<>();
       upParams.put("DBActionType", "INSERT");
 
       // Call the base class cloneChildObjects method to clone the states and

--- a/system/src/main/java/com/percussion/server/command/PSConsoleCommandCache.java
+++ b/system/src/main/java/com/percussion/server/command/PSConsoleCommandCache.java
@@ -65,7 +65,7 @@ public abstract class PSConsoleCommandCache extends PSConsoleCommand {
    * @param keys the cache keys to be used for flushing, may be <code>null
    * </code>
    */
-  protected void flushCache(Map keys) {
+  protected void flushCache(Map<String, ?> keys) {
     PSCacheManager cacheManager = PSCacheManager.getInstance();
 
     if (keys == null) cacheManager.flush();

--- a/system/src/main/java/com/percussion/server/command/PSConsoleCommandParser.java
+++ b/system/src/main/java/com/percussion/server/command/PSConsoleCommandParser.java
@@ -181,11 +181,10 @@ public class PSConsoleCommandParser {
       if (cmdBase.length() == 0) cmdBase = cmdName;
       else cmdBase += " " + cmdName;
 
-      if (cmdObject instanceof java.lang.Class) {
+      if (cmdObject instanceof Class) {
         try {
-          Constructor c =
-              ((Class) cmdObject).getConstructor(new Class[] {Class.forName("java.lang.String")});
-          return (IPSConsoleCommand) c.newInstance(new Object[] {cmdArgs});
+          Constructor<?> c = ((Class<?>) cmdObject).getConstructor(String.class);
+          return (IPSConsoleCommand) c.newInstance(cmdArgs);
         } catch (Throwable t) {
           // if the constructor throw an exception, set t to it
           if (t instanceof java.lang.reflect.InvocationTargetException)
@@ -220,11 +219,11 @@ public class PSConsoleCommandParser {
    *
    * <p>Search for the key "" to get the list of valid base commands.
    */
-  private static final ConcurrentHashMap ms_cmdSet;
+  private static final ConcurrentHashMap<String, Object> ms_cmdSet;
 
   static {
     // and this is the ConcurrentHashMap containing the sub commands
-    ms_cmdSet = new ConcurrentHashMap();
+    ms_cmdSet = new ConcurrentHashMap<>();
 
     // in case they use an invalid base command, store the base list
     ms_cmdSet.put(

--- a/system/src/main/java/com/percussion/server/content/PSFormContentParser.java
+++ b/system/src/main/java/com/percussion/server/content/PSFormContentParser.java
@@ -271,9 +271,9 @@ public class PSFormContentParser extends PSContentParser {
       if (contentType.toLowerCase().startsWith("content-type:"))
         contentTypeValue = contentType.substring(contentType.indexOf(':') + 1);
       else contentTypeValue = contentType;
-      Map contentParams = new HashMap();
+      Map<String, String> contentParams = new HashMap<>();
       String type = PSBaseHttpUtils.parseContentType(contentTypeValue, contentParams);
-      boundary = (String) contentParams.get("boundary");
+      boundary = contentParams.get("boundary");
       if (null == boundary)
         // always throws
         contentTypeError(contentType);
@@ -542,7 +542,7 @@ public class PSFormContentParser extends PSContentParser {
     String contentType = ""; // the content-type header value
     line = line.toLowerCase();
     if (line.startsWith("content-type:")) {
-      HashMap contentParams = new HashMap();
+      Map<String, String> contentParams = new HashMap<>();
       try {
         contentType = line.substring(line.indexOf(':') + 1);
         mimeType = PSBaseHttpUtils.parseContentType(contentType, contentParams);
@@ -574,7 +574,7 @@ public class PSFormContentParser extends PSContentParser {
 
       // If it's text and not xml see if it has a charset specification
       if (isText && !isXml) {
-        charsetName = (String) contentParams.get("charset");
+        charsetName = contentParams.get("charset");
         if (charsetName != null && charsetName.length() < 1) {
           charsetName = null; // an empty string is as good as null
         }

--- a/system/src/test/java/com/percussion/server/actions/PSActionSetRequestHandlerTypedTest.java
+++ b/system/src/test/java/com/percussion/server/actions/PSActionSetRequestHandlerTypedTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.extension.PSExtensionManager;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed action-set request-handler maps after #3213 Xlint cleanup.
+ */
+class PSActionSetRequestHandlerTypedTest {
+
+  @Test
+  @DisplayName("init accepts typed request roots and stores them for iteration")
+  void initAcceptsTypedRequestRoots() throws Exception {
+    PSActionSetRequestHandler handler =
+        new PSActionSetRequestHandler(null, new PSExtensionManager());
+    List<String> roots = new ArrayList<>();
+    roots.add("sys_action");
+    handler.init(roots, null);
+
+    Iterator<String> it = handler.getRequestRoots();
+    assertTrue(it.hasNext());
+    assertEquals("sys_action", it.next());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  @DisplayName("init rejects an empty request-root collection")
+  void initRejectsEmptyRoots() {
+    PSActionSetRequestHandler handler =
+        new PSActionSetRequestHandler(null, new PSExtensionManager());
+    assertThrows(IllegalArgumentException.class, () -> handler.init(new ArrayList<>(), null));
+  }
+
+  @Test
+  @DisplayName("init rejects a non-String request root")
+  void initRejectsNonStringRoot() {
+    PSActionSetRequestHandler handler =
+        new PSActionSetRequestHandler(null, new PSExtensionManager());
+    List<Object> roots = new ArrayList<>();
+    roots.add(42);
+    assertThrows(IllegalArgumentException.class, () -> handler.init(roots, null));
+  }
+
+  @Test
+  @DisplayName("constructor rejects a null extension manager")
+  void ctorRejectsNullExtensionManager() {
+    assertThrows(IllegalArgumentException.class, () -> new PSActionSetRequestHandler(null, null));
+  }
+}

--- a/system/src/test/java/com/percussion/server/actions/PSActionSetResultTest.java
+++ b/system/src/test/java/com/percussion/server/actions/PSActionSetResultTest.java
@@ -20,22 +20,21 @@ package com.percussion.server.actions;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /** Tests the basic functionality of the <code>PSActionSetResult</code> class. */
 public class PSActionSetResultTest {
-  /**
-   * Constructs an instance of this class to run the test implemented by the named method.
-   *
-   * @param methodName name of the method that implements a test
-   */
-
-  /** Collects all the tests implemented by this class into a single suite. */
 
   /**
    * Performs basic tests of the results. Make sure ctor rejects invalid parameters. Make sure ctor
    * can properly init state from provided PSActionSet. Make sure the set methods perform correctly.
    */
+  @Test
+  @DisplayName("typed action result map seeds skips and updates one action at a time")
   public void testIt() throws Exception {
     PSActionSetResult resultSet;
 
@@ -107,5 +106,21 @@ public class PSActionSetResultTest {
     result = resultSet.getResult("action0");
     assertEquals(PSActionSetResult.SKIPPED_STATUS, result.getStatus());
     assertEquals(null, result.getResult());
+
+    PSActionSetResult xmlSet =
+        new PSActionSetResult(
+            PSActionSetTest.newActionSet(PSActionSet.XML_NODE_NAME, "test", "a.htm", numActions),
+            "ceurl.htm");
+    xmlSet.setFailed("action1", e);
+    xmlSet.setSuccess("action2", null);
+    Document xml = xmlSet.toXml();
+    Element root = xml.getDocumentElement();
+    assertEquals("StoredActionResults", root.getNodeName());
+    assertEquals("test", root.getAttribute("actionSetName"));
+    NodeList results = root.getElementsByTagName("ActionResult");
+    assertEquals(numActions, results.getLength());
+    assertEquals("skipped", ((Element) results.item(0)).getAttribute("status"));
+    assertEquals("failed", ((Element) results.item(1)).getAttribute("status"));
+    assertEquals("succeeded", ((Element) results.item(2)).getAttribute("status"));
   }
 }

--- a/system/src/test/java/com/percussion/server/clone/PSCloneBaseTypedTest.java
+++ b/system/src/test/java/com/percussion/server/clone/PSCloneBaseTypedTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.clone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.extension.PSParameterMismatchException;
+import com.percussion.server.IPSRequestContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Behavioral coverage for typed clone exit parameter maps after #3213 Xlint cleanup.
+ */
+class PSCloneBaseTypedTest {
+
+  private final TestCloneExit exit = new TestCloneExit();
+
+  @Test
+  @DisplayName("getCloneSourceId rejects a null request")
+  void getCloneSourceIdRejectsNullRequest() {
+    assertThrows(IllegalArgumentException.class, () -> exit.getCloneSourceId(null));
+  }
+
+  @Test
+  @DisplayName("getCloneSourceId returns -1 when the HTML parameter is absent")
+  void getCloneSourceIdMissingParam() throws PSParameterMismatchException {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getParameter(PSCloneBase.CLONESOURCEID)).thenReturn(null);
+    assertEquals(-1, exit.getCloneSourceId(request));
+  }
+
+  @Test
+  @DisplayName("getCloneSourceId parses a typed integer source id")
+  void getCloneSourceIdParsesInt() throws PSParameterMismatchException {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getParameter(PSCloneBase.CLONESOURCEID)).thenReturn("42");
+    assertEquals(42, exit.getCloneSourceId(request));
+  }
+
+  @Test
+  @DisplayName("getCloneSourceId rejects a non-integer source id")
+  void getCloneSourceIdRejectsNonInteger() {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getParameter(PSCloneBase.CLONESOURCEID)).thenReturn("not-an-id");
+    assertThrows(PSParameterMismatchException.class, () -> exit.getCloneSourceId(request));
+  }
+
+  @Test
+  @DisplayName("cloneChildObjects rejects a null request")
+  void cloneChildObjectsRejectsNullRequest() {
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> update = new HashMap<>();
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            exit.cloneChildObjects(
+                null, "Key", "1", new String[] {"q"}, new String[] {"u"}, query, update));
+  }
+
+  @Test
+  @DisplayName("cloneChildObjects rejects mismatched query/update resource arrays")
+  void cloneChildObjectsRejectsMismatchedResources() {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> update = new HashMap<>();
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            exit.cloneChildObjects(
+                request,
+                "Key",
+                "1",
+                new String[] {"q1", "q2"},
+                new String[] {"u1"},
+                query,
+                update));
+  }
+
+  @Test
+  @DisplayName("updateContent rejects a null request")
+  void updateContentRejectsNullRequest() {
+    Map<String, Object> update = new HashMap<>();
+    update.put("DBActionType", "INSERT");
+    assertThrows(
+        IllegalArgumentException.class, () -> exit.updateContent(null, "app/update", update));
+  }
+
+  @Test
+  @DisplayName("updateContent rejects an empty resource name")
+  void updateContentRejectsEmptyResource() {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    Map<String, Object> update = new HashMap<>();
+    assertThrows(IllegalArgumentException.class, () -> exit.updateContent(request, "  ", update));
+  }
+
+  @Test
+  @DisplayName("updateContent reports a missing typed resource")
+  void updateContentMissingResource() {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getInternalRequest("missing/update", Map.of("DBActionType", "INSERT"), false))
+        .thenReturn(null);
+    Map<String, Object> update = new HashMap<>();
+    update.put("DBActionType", "INSERT");
+    assertThrows(
+        PSExtensionProcessingException.class,
+        () -> exit.updateContent(request, "missing/update", update));
+  }
+
+  /** Concrete clone exit so protected map helpers can be exercised. */
+  private static final class TestCloneExit extends PSCloneBase {
+    @Override
+    public Document processResultDocument(
+        Object[] params, IPSRequestContext request, Document resultDoc) {
+      return resultDoc;
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/server/command/PSConsoleCommandParserTest.java
+++ b/system/src/test/java/com/percussion/server/command/PSConsoleCommandParserTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.server.IPSConsoleCommand;
+import com.percussion.server.IPSServerErrors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for the typed console command map after #3213 Xlint cleanup.
+ */
+class PSConsoleCommandParserTest {
+
+  @Test
+  @DisplayName("parse rejects a null command")
+  void parseRejectsNull() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> PSConsoleCommandParser.parse(null));
+    assertEquals(IPSServerErrors.RCONSOLE_CMD_EMPTY, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("parse rejects a blank command")
+  void parseRejectsBlank() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> PSConsoleCommandParser.parse("   "));
+    assertEquals(IPSServerErrors.RCONSOLE_CMD_EMPTY, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("parse looks up a leaf command class from the typed command map")
+  void parseLeafCommand() throws PSIllegalArgumentException {
+    IPSConsoleCommand cmd = PSConsoleCommandParser.parse("show version");
+    assertInstanceOf(PSConsoleCommandShowVersion.class, cmd);
+  }
+
+  @Test
+  @DisplayName("parse requires a sub-command when the map value is a prompt string")
+  void parseRequiresSubCommand() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> PSConsoleCommandParser.parse("start"));
+    assertEquals(IPSServerErrors.RCONSOLE_SUBCMD_REQD, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("parse rejects an unknown base command")
+  void parseRejectsUnknownBase() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> PSConsoleCommandParser.parse("bogus"));
+    assertEquals(IPSServerErrors.RCONSOLE_INVALID_CMD, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("parse rejects an unknown sub-command")
+  void parseRejectsUnknownSubCommand() {
+    PSIllegalArgumentException ex =
+        assertThrows(
+            PSIllegalArgumentException.class, () -> PSConsoleCommandParser.parse("start widgets"));
+    assertEquals(IPSServerErrors.RCONSOLE_INVALID_SUBCMD, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("parse constructs flush cache with typed key arguments")
+  void parseFlushCacheCommand() throws PSIllegalArgumentException {
+    IPSConsoleCommand cmd = PSConsoleCommandParser.parse("flush cache");
+    assertInstanceOf(PSConsoleCommandFlushCache.class, cmd);
+  }
+}

--- a/system/src/test/java/com/percussion/server/content/PSFormContentParserTest.java
+++ b/system/src/test/java/com/percussion/server/content/PSFormContentParserTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.server.PSRequestParsingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed form-content parameter maps after #3213 Xlint cleanup.
+ */
+class PSFormContentParserTest {
+
+  @Test
+  @DisplayName("parseParameterString rejects a null parameter map")
+  void parseParameterStringRejectsNullMap() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSFormContentParser.parseParameterString(null, "a=b"));
+  }
+
+  @Test
+  @DisplayName("parseParameterString rejects a null parameter string")
+  void parseParameterStringRejectsNullString() {
+    Map<String, Object> params = new HashMap<>();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSFormContentParser.parseParameterString(params, null));
+  }
+
+  @Test
+  @DisplayName("parseParameterString stores typed name/value pairs")
+  void parseParameterStringStoresPairs() throws PSRequestParsingException {
+    Map<String, Object> params = new HashMap<>();
+    PSFormContentParser.parseParameterString(params, "alpha=one&beta=two");
+    assertEquals("one", params.get("alpha"));
+    assertEquals("two", params.get("beta"));
+  }
+
+  @Test
+  @DisplayName("duplicate names accumulate into a typed value list")
+  void parseParameterStringDuplicateNamesAccumulate() throws PSRequestParsingException {
+    Map<String, Object> params = new HashMap<>();
+    PSFormContentParser.parseParameterString(params, "tag=a&tag=b");
+    Object value = params.get("tag");
+    assertInstanceOf(ArrayList.class, value);
+    @SuppressWarnings("unchecked")
+    List<Object> values = (List<Object>) value;
+    assertEquals(2, values.size());
+    assertEquals("a", values.get(0));
+    assertEquals("b", values.get(1));
+  }
+
+  @Test
+  @DisplayName("XHTML ampersand entities are converted before splitting params")
+  void parseParameterStringConvertsAmpEntities() throws PSRequestParsingException {
+    Map<String, Object> params = new HashMap<>();
+    PSFormContentParser.parseParameterString(params, "first=1&amp;second=2");
+    assertEquals("1", params.get("first"));
+    assertEquals("2", params.get("second"));
+  }
+
+  @Test
+  @DisplayName("empty parameter string leaves the map empty")
+  void parseParameterStringEmptyIsNoOp() throws PSRequestParsingException {
+    Map<String, Object> params = new HashMap<>();
+    PSFormContentParser.parseParameterString(params, "");
+    assertTrue(params.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Continues perc-system `-Xlint` cleanup for parent epic #2022. Residual of #3186 (PSRequest/PSBaseResponse batch), **not** combined with #3212 dataHandlers.

Types remaining **content / clone / actions / command** maps with real generics (no new class-level suppressions):

- Form content: `Map<String,String>` for `PSBaseHttpUtils.parseContentType` parameter bags
- Clone exits: `Map<String,Object>` query/update/role params; `PSCloneBase.cloneChildObjects` / `updateContent` take the same type as `IPSRequestContext.getInternalRequest`
- Actions: `Map<String,ActionResult>` + `List<String>` result tracking; `PSActionSet` / `PSAction` action and extension-runner lists; catalog extra-params `Map<String,Object>`
- Command: `ConcurrentHashMap<String,Object>` command registry; `flushCache(Map<String,?>)`

Fixes #3213  
Parent tracker: #2022

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (standalone, tests on)
2. Confirm new/updated tests:
   - `PSFormContentParserTest` (parseParameterString typed map)
   - `PSCloneBaseTypedTest` (source id + typed param map contracts)
   - `PSActionSetResultTest` / `PSActionSetRequestHandlerTypedTest`
   - `PSConsoleCommandParserTest` (typed command-map lookup)
3. No UI / install / operator surface — skip Playwright / human QA

## Checklist

- [x] **Product documentation** — N/A (not product-facing): pure compiler/generics tech-debt; no operator-, admin-, integrator-, or end-user-facing behavior change
- [x] **Unit / module tests** — behavioral tests for typed maps; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install (no skipTests); C2 reverse-dep grep for `extends` / anonymous subclasses of changed types
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2023, Failures: 0, Errors: 0, Skipped: 241
- **downstream_checked:** grepped monorepo for `extends PSCloneBase`, `extends PSActionSet`, `extends PSConsoleCommandCache`, and `new <Type>() {`; no anonymous subclasses. Cache/console subclasses do not override `flushCache`. Clone exits do not override `cloneChildObjects`. No reverse-dep module compile against these package-internal map APIs (`perc-ant` `PSAction` is a different type).

### C5 UI proof

N/A — Java backend generics only.

> Co-Authored by Grok Build using grok-4.5 with agent main.
