### PR TITLE
fix(system): type remaining command LogDump/Trace collections (#3272)

### DIFF
--- a/docs/ai-generated/code-reviews/3272-command-remaining-collections-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/3272-command-remaining-collections-xlint-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #3272 command remaining collections Xlint
+
+**Scope:** uncommitted `fix/issue-3272-command-remaining-collections-xlint` vs `origin/main`  
+**Module:** `system` / `perc-system`  
+**Change class:** residual `-Xlint` typing of non-map collections in `com.percussion.server.command`  
+**Memory patterns hit:** behavioral tests for changed helpers; no blanket `@SuppressWarnings`; do not retouch #3213 maps; no public API blast radius
+
+## Summary
+
+Types remaining LogDump `queryTypes` / `applications` / `m_recipients` lists and extracts `toIntArray`. Trace help output iterates `Iterable<PSTraceOption>` via `addTraceOptionElements`. FlushCache cache-type listing uses `Iterator<String>` already returned by `PSCacheManager.getCacheTypes()`. Tests cover helper conversion, ctor parse of type/server/application tokens, invalid tokens, and Trace XML attributes.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction, installers, or path assertions.
+
+## Product documentation
+
+N/A — internal compiler-warning cleanup; no operator/user/API surface change.
+
+## Issues
+
+None.
+
+## Notes
+
+- Public constructors and execute signatures are unchanged. Inner filter ctors are package-private and now take `List<Integer>`. C2 reverse-dep install not required.
+- Remaining raw maps in this package (`PSConsoleCommandParser.ms_cmdSet`, `PSConsoleCommandCache.flushCache(Map)`) belong to #3213 / PR #3271 and were left untouched.

--- a/system/src/main/java/com/percussion/server/command/PSConsoleCommandFlushCache.java
+++ b/system/src/main/java/com/percussion/server/command/PSConsoleCommandFlushCache.java
@@ -106,9 +106,9 @@ public class PSConsoleCommandFlushCache extends PSConsoleCommandCache {
           if (cacheHandler == null) {
             String typeList = "";
             String delim = "";
-            Iterator types = mgr.getCacheTypes();
+            Iterator<String> types = mgr.getCacheTypes();
             while (types.hasNext()) {
-              typeList += (delim + (String) types.next());
+              typeList += (delim + types.next());
               delim = ", ";
             }
 

--- a/system/src/main/java/com/percussion/server/command/PSConsoleCommandLogDump.java
+++ b/system/src/main/java/com/percussion/server/command/PSConsoleCommandLogDump.java
@@ -30,6 +30,9 @@ import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.w3c.dom.Document;
@@ -54,8 +57,8 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
 
     java.util.Date since = null;
     java.util.Date until = null;
-    java.util.List queryTypes = new java.util.ArrayList();
-    java.util.List applications = new java.util.ArrayList();
+    List<Integer> queryTypes = new ArrayList<>();
+    List<Integer> applications = new ArrayList<>();
 
     /* this may contain the following tokens (they're all optional):
      *
@@ -209,8 +212,8 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
   private PSLogDumpFilter createMailFilter(
       java.util.Date since,
       java.util.Date until,
-      java.util.List queryTypes,
-      java.util.List applications)
+      List<Integer> queryTypes,
+      List<Integer> applications)
       throws PSIllegalArgumentException {
     PSServerConfiguration conf = PSServer.getServerConfiguration();
     if (conf == null) {
@@ -240,9 +243,8 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
     msg.setFrom(from);
     msg.setSubject(ms_cmdName);
 
-    int size = m_recipients.size();
-    for (int i = 0; i < size; i++) {
-      msg.addSendTo(m_recipients.get(i).toString());
+    for (String recipient : m_recipients) {
+      msg.addSendTo(recipient);
     }
 
     try {
@@ -267,8 +269,38 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
     return FastDateFormat.getInstance("yyyyMMdd HH:mm:ss").format(date);
   }
 
+  /**
+   * Converts a typed integer list to a primitive array. Empty input becomes {@code null} so log
+   * readers treat "no filter" as unrestricted.
+   *
+   * @param values query types or application ids; {@code null} or empty means unrestricted
+   * @return a new array of the same values, or {@code null} when {@code values} is null or empty
+   */
+  static int[] toIntArray(List<Integer> values) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    int[] result = new int[values.size()];
+    for (int i = 0; i < values.size(); i++) {
+      result[i] = values.get(i).intValue();
+    }
+    return result;
+  }
+
+  int[] getFilterEntryTypes() {
+    return m_filter == null ? null : m_filter.getEntryTypes();
+  }
+
+  int[] getFilterApplicationIds() {
+    return m_filter == null ? null : m_filter.getApplicationIds();
+  }
+
+  List<String> getRecipients() {
+    return Collections.unmodifiableList(m_recipients);
+  }
+
   /** the people we email */
-  private java.util.List m_recipients = new java.util.ArrayList();
+  private List<String> m_recipients = new ArrayList<>();
 
   /** the filter which places the messages into the message/xml doc */
   private PSLogDumpFilter m_filter = null;
@@ -280,24 +312,12 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
     protected PSLogDumpFilter(
         java.util.Date since,
         java.util.Date until,
-        java.util.List queryTypes,
-        java.util.List applications) {
+        List<Integer> queryTypes,
+        List<Integer> applications) {
       m_since = since;
       m_until = until;
-
-      int size = queryTypes.size();
-      if (size == 0) m_queryTypes = null;
-      else {
-        m_queryTypes = new int[size];
-        for (int i = 0; i < size; i++) m_queryTypes[i] = ((Integer) queryTypes.get(i)).intValue();
-      }
-
-      size = applications.size();
-      if (size == 0) m_appIds = null;
-      else {
-        m_appIds = new int[size];
-        for (int i = 0; i < size; i++) m_appIds[i] = ((Integer) applications.get(i)).intValue();
-      }
+      m_queryTypes = toIntArray(queryTypes);
+      m_appIds = toIntArray(applications);
     }
 
     public int[] getApplicationIds() {
@@ -340,8 +360,8 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
     PSMailLogDumpFilter(
         java.util.Date since,
         java.util.Date until,
-        java.util.List queryTypes,
-        java.util.List applications,
+        List<Integer> queryTypes,
+        List<Integer> applications,
         PSMailProvider prov,
         PSMailMessage msg)
         throws java.io.IOException {
@@ -463,8 +483,8 @@ public class PSConsoleCommandLogDump extends PSConsoleCommand {
     PSXmlLogDumpFilter(
         java.util.Date since,
         java.util.Date until,
-        java.util.List queryTypes,
-        java.util.List applications) {
+        List<Integer> queryTypes,
+        List<Integer> applications) {
       super(since, until, queryTypes, applications);
     }
 

--- a/system/src/main/java/com/percussion/server/command/PSConsoleCommandTrace.java
+++ b/system/src/main/java/com/percussion/server/command/PSConsoleCommandTrace.java
@@ -43,7 +43,6 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.xml.PSXmlDocumentBuilder;
-import java.util.Iterator;
 import java.util.StringTokenizer;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -179,13 +178,7 @@ public class PSConsoleCommandTrace extends PSConsoleCommand {
 
       // case help
       if (m_help) {
-        Iterator list = PSTraceMessageFactory.getPossibleOptions().iterator();
-        while (list.hasNext()) {
-          Element el = PSXmlDocumentBuilder.addEmptyElement(respDoc, root, "PSXTraceOption");
-          PSTraceOption option = (PSTraceOption) list.next();
-          el.setAttribute("flag", option.toString());
-          el.setAttribute("name", option.getName());
-        }
+        addTraceOptionElements(respDoc, root, PSTraceMessageFactory.getPossibleOptions());
       }
       // case default
       else if (m_default) {
@@ -236,6 +229,22 @@ public class PSConsoleCommandTrace extends PSConsoleCommand {
     }
 
     return respDoc;
+  }
+
+  /**
+   * Appends typed trace option elements to a console result document.
+   *
+   * @param respDoc result document; never {@code null}
+   * @param root parent element; never {@code null}
+   * @param options factory options; never {@code null}
+   */
+  static void addTraceOptionElements(
+      Document respDoc, Element root, Iterable<PSTraceOption> options) {
+    for (PSTraceOption option : options) {
+      Element el = PSXmlDocumentBuilder.addEmptyElement(respDoc, root, "PSXTraceOption");
+      el.setAttribute("flag", option.toString());
+      el.setAttribute("name", option.getName());
+    }
   }
 
   /** allow package members to see our command name */

--- a/system/src/test/java/com/percussion/server/command/PSConsoleCommandLogDumpTypedTest.java
+++ b/system/src/test/java/com/percussion/server/command/PSConsoleCommandLogDumpTypedTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.command;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.error.PSIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Typed collection helpers and ctor parsing for {@link PSConsoleCommandLogDump} (#3272). */
+@Tag("UnitTest")
+@DisplayName("PSConsoleCommandLogDump typed collections")
+class PSConsoleCommandLogDumpTypedTest {
+
+  @Test
+  @DisplayName("toIntArray returns null for null or empty lists")
+  void toIntArrayEmptyIsUnrestricted() {
+    assertNull(PSConsoleCommandLogDump.toIntArray(null));
+    assertNull(PSConsoleCommandLogDump.toIntArray(List.of()));
+    assertNull(PSConsoleCommandLogDump.toIntArray(new ArrayList<>()));
+  }
+
+  @Test
+  @DisplayName("toIntArray copies typed Integer values in order")
+  void toIntArrayCopiesValues() {
+    List<Integer> values = new ArrayList<>();
+    values.add(1);
+    values.add(4);
+    values.add(0);
+    assertArrayEquals(new int[] {1, 4, 0}, PSConsoleCommandLogDump.toIntArray(values));
+  }
+
+  @Test
+  @DisplayName("empty args leave query types and application ids unrestricted")
+  void emptyArgsLeaveFiltersNull() throws Exception {
+    PSConsoleCommandLogDump cmd = new PSConsoleCommandLogDump("");
+    assertNull(cmd.getFilterEntryTypes());
+    assertNull(cmd.getFilterApplicationIds());
+    assertTrue(cmd.getRecipients().isEmpty());
+  }
+
+  @Test
+  @DisplayName("type tokens populate the typed query-type filter")
+  void parsesTypedQueryTypes() throws Exception {
+    PSConsoleCommandLogDump cmd = new PSConsoleCommandLogDump("type 1 type 4");
+    assertArrayEquals(new int[] {1, 4}, cmd.getFilterEntryTypes());
+    assertNull(cmd.getFilterApplicationIds());
+    assertTrue(cmd.getRecipients().isEmpty());
+  }
+
+  @Test
+  @DisplayName("server token maps to application id 0")
+  void parsesServerAsApplicationZero() throws Exception {
+    PSConsoleCommandLogDump cmd = new PSConsoleCommandLogDump("type 1 server");
+    assertArrayEquals(new int[] {1}, cmd.getFilterEntryTypes());
+    assertArrayEquals(new int[] {0}, cmd.getFilterApplicationIds());
+  }
+
+  @Test
+  @DisplayName("application token populates the typed application-id filter")
+  void parsesTypedApplicationIds() throws Exception {
+    PSConsoleCommandLogDump cmd = new PSConsoleCommandLogDump("type 4 application 7");
+    assertArrayEquals(new int[] {4}, cmd.getFilterEntryTypes());
+    assertArrayEquals(new int[] {7}, cmd.getFilterApplicationIds());
+    assertTrue(cmd.getRecipients().isEmpty());
+  }
+
+  @Test
+  @DisplayName("non-numeric type token is rejected")
+  void rejectsNonNumericType() {
+    assertThrows(PSIllegalArgumentException.class, () -> new PSConsoleCommandLogDump("type abc"));
+  }
+
+  @Test
+  @DisplayName("unknown token is rejected")
+  void rejectsUnknownToken() {
+    assertThrows(PSIllegalArgumentException.class, () -> new PSConsoleCommandLogDump("bogus 1"));
+  }
+}

--- a/system/src/test/java/com/percussion/server/command/PSConsoleCommandTraceTypedTest.java
+++ b/system/src/test/java/com/percussion/server/command/PSConsoleCommandTraceTypedTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.percussion.design.objectstore.PSTraceOption;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/** Typed option iteration helper for {@link PSConsoleCommandTrace} (#3272). */
+@Tag("UnitTest")
+@DisplayName("PSConsoleCommandTrace typed options")
+class PSConsoleCommandTraceTypedTest {
+
+  @Test
+  @DisplayName("addTraceOptionElements writes flag and name attributes in order")
+  void addTraceOptionElementsWritesAttributes() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXConsoleCommandResults");
+
+    List<PSTraceOption> options = new ArrayList<>();
+    options.add(new PSTraceOption(0x10, "Basic Request", "desc", "basicRequest"));
+    options.add(new PSTraceOption(0x20, "App Handler", null, "appHandler"));
+
+    PSConsoleCommandTrace.addTraceOptionElements(doc, root, options);
+
+    NodeList nodes = root.getElementsByTagName("PSXTraceOption");
+    assertEquals(2, nodes.getLength());
+
+    Element first = (Element) nodes.item(0);
+    assertEquals("0x10", first.getAttribute("flag"));
+    assertEquals("basicRequest", first.getAttribute("name"));
+
+    Element second = (Element) nodes.item(1);
+    assertEquals("0x20", second.getAttribute("flag"));
+    assertEquals("appHandler", second.getAttribute("name"));
+  }
+
+  @Test
+  @DisplayName("help constructor is accepted without extra args")
+  void helpConstructorAccepted() throws Exception {
+    PSConsoleCommandTrace cmd = new PSConsoleCommandTrace("help");
+    assertNotNull(cmd);
+  }
+}


### PR DESCRIPTION
## Summary

Residual of #3213 / PR #3271 (maps-only) for parent epic #2022.

Types remaining **non-map** collections in `com.percussion.server.command`:

- `PSConsoleCommandLogDump` — `queryTypes` / `applications` as `List<Integer>`, recipients as `List<String>`, plus `toIntArray` for filter `int[]` conversion (empty → unrestricted `null`).
- `PSConsoleCommandTrace` — help output iterates `Iterable<PSTraceOption>` via `addTraceOptionElements`.
- `PSConsoleCommandFlushCache` — `Iterator<String>` for `getCacheTypes()` (already typed on the manager).

Did **not** retouch content/clone/actions or command-registry maps from #3213 / PR #3271. Did **not** absorb #3212 / #3270 `PSServer` dataHandlers.

No new blanket `@SuppressWarnings`. Remaining raw maps in this package (`ms_cmdSet`, `flushCache(Map)`) stay with #3213 / PR #3271.

Fixes #3272  
Parent: #2022

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (standalone perc-system).
2. Confirm `PSConsoleCommandLogDumpTypedTest` (8) and `PSConsoleCommandTraceTypedTest` (2).
3. Spot-check: `log dump type 1 type 4` and `trace help` still parse; no console command behavior change beyond generics.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal `-Xlint` generics cleanup; remote console argument parsing unchanged
- [x] **Unit / module tests** — `toIntArray`, LogDump token parsing, invalid tokens, Trace option XML attributes; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install`
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2006, Failures: 0, Errors: 0, Skipped: 241. New tests: LogDump 8 + Trace 2.
- **downstream_checked:** none — no public/protected signature change; no type made `final`/`sealed`. Package-visible helpers only.

### C5 UI proof

N/A — Java backend tech-debt only.

> Co-Authored by Grok Build using grok-4.5 with agent main.
