### PR TITLE
[8.2] utils: type ConfigurationContextAbstract CRTP (residual after batch 8)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3172-utils-safe-residual-generics-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3172-utils-safe-residual-generics-erlang.md
@@ -1,0 +1,61 @@
+# Erlang review: fix/issue-3172-utils-safe-residual-generics
+
+## Summary
+
+Conservative utils residual after batch 8 (#3015 / PR #3173). Removes the two remaining **product-safe** CRTP unchecked sites on `ConfigurationContextAbstract` with real typing: abstract `self()` (`return this` in the only subclass) and `cloneConfig` via `ctor.get()` + `PropertyUtils.copyProperties` (no `(U)` cast). Does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map APIs. Does **not** redesign `PSXmlSerializationHelper`. Leaves `PSItemIterator` / `PSCopier` / `PSConcurrentList.restoreList` scoped casts (inherent to `Map<?,?>` / `V`/generic deserialization). Module `mvnw clean install` green.
+
+## Scope
+
+- Branch: `fix/issue-3172-utils-safe-residual-generics`
+- Module: `modules/utils` only
+- Parent tracker: #2200 / module #2016 / residual #3172
+- Prior: batch 8 #3015 / PR #3173
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+- New test uses JUnit `@TempDir Path` only. No filesystem path concatenation or OS-specific roots.
+
+## Change map
+
+| Area | Fix |
+|------|-----|
+| `ConfigurationContextAbstract` | `protected abstract T self()`; `cloneConfig` uses supplier + `PropertyUtils.copyProperties` |
+| `DefaultConfigurationContextImpl` | `self()` returns `this` |
+| Tests | `ConfigurationContextAbstractCrtpTest` — self identity; copyFrom clones and does not alias |
+
+## Behavioral tests
+
+- `ConfigurationContextAbstractCrtpTest` (2) — `load`/`save` via typed `self()`; `copyFrom` clones flags without aliasing the source config
+- Existing adapter `copyFrom` suite still green
+
+## Residual (intentional — remain on #3172 / #2016)
+
+| Area | Notes |
+|------|-------|
+| `PSWorkflowUtilsBase` raw List/Map API | Source-compat; do **not** reparameterize without explicit policy |
+| `PSXmlSerializationHelper` class rawtypes/unchecked | Serialization helpers; larger redesign |
+| `PSItemIterator` method unchecked | Map value / multi-map Collection casts inherent to `Map<?,?>` + `setMap` |
+| `PSCopier` nested Map-as-V unchecked | Narrowing to `Map<K,Object>` would break `Map<String,String[]>` parameters |
+| `PSConcurrentList.restoreList` | Serialization cast residual (scoped); no `Class<E>` on the stream |
+
+## C2 API shape
+
+- Added `protected abstract T self()`. Grep monorepo `extends ConfigurationContextAbstract` / `new ConfigurationContextAbstract` → only `DefaultConfigurationContextImpl`. No anonymous subclasses. Reverse-deps (`system`, `perc-ant`) construct the concrete type only.
+
+## Verification
+
+- `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests: **384** run, **0** failures, **9** skips
+- Memory patterns hit: behavioral tests for changed logic; no path I/O; no new blanket suppressions
+
+## Issues
+
+None (bug).

--- a/modules/utils/src/main/java/com/percussion/utils/container/ConfigurationContextAbstract.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/ConfigurationContextAbstract.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
-import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils.PropertyUtils;
 
 /**
  * Abstract base class for configuration contexts.
@@ -72,13 +72,11 @@ public abstract class ConfigurationContextAbstract<
 
   @Override
   public void load() {
-    // CRTP residual: subclasses are typed as ConfigurationContextAbstract<Self, U>
     load(self());
   }
 
   @Override
   public void save() {
-    // CRTP residual: subclasses are typed as ConfigurationContextAbstract<Self, U>
     save(self());
   }
 
@@ -89,7 +87,6 @@ public abstract class ConfigurationContextAbstract<
    */
   public void copyFrom(ConfigurationContextAbstract<T, U> from) {
     try {
-      // BeanUtils.cloneBean returns Object; config type is U by construction of this hierarchy.
       this.config = cloneConfig(from.getConfig());
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -97,26 +94,25 @@ public abstract class ConfigurationContextAbstract<
   }
 
   /**
-   * CRTP self-view. Concrete contexts extend {@code ConfigurationContextAbstract<Self, U>} so this
-   * cast is the single residual for load/save without a class-level blanket suppress.
+   * CRTP self-view. Concrete contexts implement this as {@code return this} so {@link #load()} /
+   * {@link #save()} stay typed without an unchecked {@code (T) this} cast.
    *
    * @return {@code this} as {@code T}
    */
-  @SuppressWarnings("unchecked")
-  private T self() {
-    return (T) this;
-  }
+  protected abstract T self();
 
   /**
-   * Clone a config bean. {@link BeanUtils#cloneBean(Object)} returns {@link Object}; the cast is
-   * scoped here.
+   * Clone a config bean. Instantiates via this context's {@link #ctor} (same supplier used at
+   * construction) and copies properties with {@link PropertyUtils#copyProperties(Object, Object)},
+   * matching {@code BeanUtils.cloneBean} without an unchecked {@code (U)} cast.
    *
    * @param source config to clone, never {@code null}
    * @return cloned config as {@code U}
-   * @throws Exception if BeanUtils fails
+   * @throws Exception if property copy fails
    */
-  @SuppressWarnings("unchecked")
   private U cloneConfig(U source) throws Exception {
-    return (U) BeanUtils.cloneBean(source);
+    U copy = ctor.get();
+    PropertyUtils.copyProperties(copy, source);
+    return copy;
   }
 }

--- a/modules/utils/src/main/java/com/percussion/utils/container/DefaultConfigurationContextImpl.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/DefaultConfigurationContextImpl.java
@@ -39,6 +39,11 @@ public class DefaultConfigurationContextImpl
     this.encKey = key;
   }
 
+  @Override
+  protected DefaultConfigurationContextImpl self() {
+    return this;
+  }
+
   public Path getRootDir() {
     return rootDir;
   }

--- a/modules/utils/src/test/java/com/percussion/utils/container/ConfigurationContextAbstractCrtpTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/container/ConfigurationContextAbstractCrtpTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.container;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.utils.container.config.model.impl.BaseContainerUtils;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral coverage for CRTP {@code self()} and typed {@code cloneConfig} (#3172 residual after
+ * batch 8).
+ */
+@Tag("UnitTest")
+public class ConfigurationContextAbstractCrtpTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void selfReturnsThisForLoadAndSave() {
+    DefaultConfigurationContextImpl ctx = new DefaultConfigurationContextImpl(tempDir, "encKey");
+    // load/save pass self() into adapters; empty adapter list must still type-check at runtime.
+    ctx.load();
+    ctx.save();
+    assertSame(ctx, ctx.self());
+  }
+
+  @Test
+  public void copyFromClonesConfigAndDoesNotAliasSource() {
+    DefaultConfigurationContextImpl from = new DefaultConfigurationContextImpl(tempDir, "encKey");
+    DefaultConfigurationContextImpl to = new DefaultConfigurationContextImpl(tempDir, "encKey");
+
+    BaseContainerUtils source = from.getConfig();
+    source.setEnabled(true);
+    source.setLoaded(true);
+
+    to.copyFrom(from);
+
+    assertNotSame(source, to.getConfig());
+    assertTrue(to.getConfig().isEnabled());
+    assertTrue(to.getConfig().isLoaded());
+
+    to.getConfig().setEnabled(false);
+    assertTrue(source.isEnabled());
+    assertFalse(to.getConfig().isEnabled());
+    assertEquals(true, source.isLoaded());
+  }
+}


### PR DESCRIPTION
## Summary

Partial residual after utils batch 8 (#3015 / PR #3173). Clears the two **product-safe** CRTP unchecked sites on `ConfigurationContextAbstract`:

- `self()` is now `protected abstract T self()` implemented as `return this` on the only subclass (`DefaultConfigurationContextImpl`).
- `cloneConfig` instantiates via the existing `Supplier<U>` and copies with `PropertyUtils.copyProperties`, matching `BeanUtils.cloneBean` without an `(U)` cast.

**Not in this PR (policy / inherent / larger redesign):**

- `PSWorkflowUtilsBase` public raw `List`/`Map` APIs (source-compat; no reparameterize without explicit policy).
- `PSXmlSerializationHelper` class-level rawtypes/unchecked (redesign).
- `PSItemIterator` / `PSCopier` / `PSConcurrentList.restoreList` scoped casts (`Map<?,?>`, generic `V` nested maps, generic deserialization).

Parent tracker: #2200. Module parent: #2016.

Partial #3172

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd modules/utils && ..\..\mvnw.cmd clean install` (Windows) or `../../mvnw clean install` (Unix).
2. Confirm `ConfigurationContextAbstractCrtpTest` (self identity + copyFrom clone/no-alias) and existing `copyFrom` adapter tests pass.
3. No UI / Playwright — internal generics only.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal CRTP/generics cleanup; no operator/admin/API surface change
- [x] **Unit / module tests** — `ConfigurationContextAbstractCrtpTest`; standalone `modules/utils` `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install (no skipTests); C2 greps for `extends ConfigurationContextAbstract` / anonymous subclass
- [x] **Cross-platform** — N/A for production path I/O; test uses `@TempDir Path`

## C3 evidence

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **384**, Failures: **0**, Errors: **0**, Skipped: **9**
- **downstream_checked:** C2 applied (new `protected abstract T self()`). Grep monorepo `extends ConfigurationContextAbstract` and `new ConfigurationContextAbstract` → only `DefaultConfigurationContextImpl`. `system` / `perc-ant` construct the concrete type only (no subclass). Standalone utils install is sufficient.

## C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build using grok-4.5 with agent main.
