### PR TITLE
fix(cms): H2 qa-up PSX_OBJECTACL SYSID 1001 collision (#3282)

### DIFF
--- a/docs/ai-generated/code-reviews/3282-objectacl-sysid-collision-erlang.md
+++ b/docs/ai-generated/code-reviews/3282-objectacl-sysid-collision-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — #3282 PSX_OBJECTACL SYSID 1001 / qa-up H2
+
+**Scope:** uncommitted branch `fix/issue-3282-objectacl-sysid-collision` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** behavioral unit tests for new logic; seed/installer lockstep; swallowed exceptions must log; portable Path in tests; incomplete change-class (seed + runtime + tests).
+
+## Summary
+
+H2 qa-up failed because `NEXTNUMBER.PSX_OBJECTACL.NEXTNR=1000` allocates SYSID `1001`, already seeded as Everyone on CONTENTID=301. Folder 7 (Assets) ACL rewrite on `CORE_SERVER_INITIALIZED` then hits `PK_PSX_OBJECTACL`.
+
+The change:
+
+1. Bumps seed NEXTNR for `PSX_OBJECTACL` and `PSX_PROPERTIES` to 2000 (last-issued; first `createId` is 2001).
+2. Adds `PSNextNumberAligner` + `PSObjectAclNextNumberReconciler` so runtime still advances NEXTNUMBER past `max(SYSID)` when seed is stale.
+3. Makes `setDefaultPermissions` skip save when virtual Everyone already has ADMIN.
+4. Tests reproduce NEXTNR=1000 → 1001 collision, prove align to 1007, seed XML invariant, and idempotent skip.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Behavioral tests cover the collision arithmetic, reconcile decision, seed invariant, and skip-rewrite. Paths use `Path.of`. `reconcileOnServer` logs and swallows locator/JDBC failures (justified: folder persist still attempted; seed bump is the primary H2 path).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` filesystem joins
+- [x] Tests use `Path.of(...)` / `Files.isRegularFile`
+- [x] No Unix-only absolute path assertions
+- [x] Schema qualification uses connection origin, not hardcoded `/`
+
+## Issues
+
+None (hard-gate).
+
+### Suggestion (non-blocking)
+
+`reconcileOnServer` peeks NEXTNUMBER (may allocate a block) then `fixNextNumber`. Correct if `fix` wins before any insert; document that order in the listener if this class is reused outside folder save.
+
+## Product documentation
+
+N/A — allocator/seed fix; no operator-facing ACL semantics change (Everyone ADMIN on Assets is existing intent).

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -125,13 +125,14 @@
             <column name="KEYNAME">displayformatid</column>
             <column name="NEXTNR">1000</column>
         </row>
+        <!-- NEXTNR last-issued; createId = NEXTNR+1. Must be >= max seed SYSID (#3282). -->
         <row onTableCreateOnly="no" action="i">
             <column name="KEYNAME">PSX_PROPERTIES</column>
-            <column name="NEXTNR">1000</column>
+            <column name="NEXTNR">2000</column>
         </row>
         <row onTableCreateOnly="no" action="i">
             <column name="KEYNAME">PSX_OBJECTACL</column>
-            <column name="NEXTNR">1000</column>
+            <column name="NEXTNR">2000</column>
         </row>
         <row onTableCreateOnly="no" action="i">
             <column name="KEYNAME">log_seq_id</column>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CmsTableDataObjectAclNextNumberTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CmsTableDataObjectAclNextNumberTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Guard for #3282: {@code NEXTNUMBER.PSX_OBJECTACL} (and {@code PSX_PROPERTIES}) must sit at or
+ * above the highest seed {@code SYSID} so the first {@code createId} is not 1001 (Everyone on
+ * CONTENTID=301).
+ *
+ * <p>Paths use {@link Path#of(String, String...)} only (portable).
+ */
+@Tag("UnitTest")
+class CmsTableDataObjectAclNextNumberTest {
+
+  private static final Path CMS_TABLE_DATA =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml");
+
+  @Test
+  void objectAclNextNumberIsPastSeedSysids() throws Exception {
+    assertTrue(Files.isRegularFile(CMS_TABLE_DATA), CMS_TABLE_DATA.toAbsolutePath().toString());
+    Document doc = parse(CMS_TABLE_DATA);
+    int nextNr = nextNumber(doc, "PSX_OBJECTACL");
+    int maxSysid = maxColumn(doc, "PSX_OBJECTACL", "SYSID");
+    assertTrue(
+        nextNr >= maxSysid,
+        "NEXTNUMBER.PSX_OBJECTACL NEXTNR="
+            + nextNr
+            + " must be >= max seed SYSID="
+            + maxSysid
+            + " (#3282)");
+    // createId returns NEXTNR+1; keep a gap so 1001 cannot be reissued.
+    assertTrue(nextNr + 1 > maxSysid, "first allocated id must be free");
+  }
+
+  @Test
+  void propertiesNextNumberIsPastSeedSysids() throws Exception {
+    Document doc = parse(CMS_TABLE_DATA);
+    int nextNr = nextNumber(doc, "PSX_PROPERTIES");
+    int maxSysid = maxColumn(doc, "PSX_PROPERTIES", "SYSID");
+    assertTrue(
+        nextNr >= maxSysid,
+        "NEXTNUMBER.PSX_PROPERTIES NEXTNR="
+            + nextNr
+            + " must be >= max seed SYSID="
+            + maxSysid
+            + " (same collision class as #3282)");
+  }
+
+  private static Document parse(Path path) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    return factory.newDocumentBuilder().parse(path.toFile());
+  }
+
+  private static int nextNumber(Document doc, String keyName) {
+    for (Element row : tableRows(doc, "NEXTNUMBER")) {
+      if (keyName.equals(columnValue(row, "KEYNAME"))) {
+        return Integer.parseInt(columnValue(row, "NEXTNR"));
+      }
+    }
+    throw new AssertionError("NEXTNUMBER key missing: " + keyName);
+  }
+
+  private static int maxColumn(Document doc, String tableName, String column) {
+    int max = -1;
+    for (Element row : tableRows(doc, tableName)) {
+      String raw = columnValue(row, column);
+      if (raw == null || raw.isBlank()) {
+        continue;
+      }
+      max = Math.max(max, Integer.parseInt(raw.trim()));
+    }
+    return max;
+  }
+
+  private static List<Element> tableRows(Document doc, String tableName) {
+    List<Element> rows = new ArrayList<>();
+    NodeList tables = doc.getElementsByTagName("table");
+    for (int i = 0; i < tables.getLength(); i++) {
+      Node n = tables.item(i);
+      if (!(n instanceof Element table)) {
+        continue;
+      }
+      if (!tableName.equals(table.getAttribute("name"))) {
+        continue;
+      }
+      NodeList children = table.getChildNodes();
+      for (int j = 0; j < children.getLength(); j++) {
+        Node c = children.item(j);
+        if (c instanceof Element el && "row".equals(el.getTagName())) {
+          rows.add(el);
+        }
+      }
+    }
+    return rows;
+  }
+
+  private static String columnValue(Element row, String name) {
+    NodeList cols = row.getElementsByTagName("column");
+    for (int i = 0; i < cols.getLength(); i++) {
+      Node n = cols.item(i);
+      if (n instanceof Element col && name.equals(col.getAttribute("name"))) {
+        return col.getTextContent() == null ? "" : col.getTextContent().trim();
+      }
+    }
+    return null;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
@@ -376,6 +376,20 @@ public class PSFolderPermissionUtils {
   }
 
   /**
+   * {@code true} when the folder already has a virtual Everyone entry with ADMIN — used to skip the
+   * CORE_SERVER_INITIALIZED default-ACL rewrite so we do not insert a second Everyone row (#3282).
+   *
+   * @param folder may be {@code null}
+   */
+  public static boolean hasEveryoneAdminAccess(PSFolder folder) {
+    if (folder == null) {
+      return false;
+    }
+    var everyone = getVirtualAcl(folder.getAcl());
+    return everyone != null && everyone.hasAdminAccess();
+  }
+
+  /**
    * Gets the virtual ACL entry contained in the specified ACL.
    *
    * @param acl the ACL that may contain a virtual entry, it may be <code>null</code>.

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
@@ -20,6 +20,7 @@ package com.percussion.share.dao.impl;
 
 import static com.percussion.share.dao.PSFolderPermissionUtils.getFolderPermission;
 import static com.percussion.share.dao.PSFolderPermissionUtils.getUserAcl;
+import static com.percussion.share.dao.PSFolderPermissionUtils.hasEveryoneAdminAccess;
 import static com.percussion.share.dao.PSFolderPermissionUtils.setFolderPermission;
 import static com.percussion.share.service.exception.PSParameterValidationUtils.validateParameters;
 import static com.percussion.webservices.PSWebserviceUtils.getItemSummary;
@@ -36,6 +37,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.cms.objectstore.PSFolder;
 import com.percussion.cms.objectstore.PSObjectAclEntry;
+import com.percussion.cms.objectstore.PSObjectAclNextNumberReconciler;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.designmanagement.service.IPSFileSystemService.PSInvalidCharacterInFolderNameException;
@@ -1072,13 +1074,32 @@ public class PSFolderHelper implements IPSFolderHelper {
   public void setDefaultPermissions(String path) {
     notEmpty(path, "path");
 
+    // Seed NEXTNR=1000 allocates SYSID 1001, already used by cmsTableData Everyone (#3282).
+    boolean advanced = PSObjectAclNextNumberReconciler.reconcileOnServer();
+    if (advanced) {
+      log.info("Advanced PSX_OBJECTACL NEXTNUMBER past existing SYSID values before ACL persist");
+    }
+
     IPSGuid id = contentWs.getIdByPath(path);
     PSFolder folder = contentWs.loadFolder(id, false);
+
+    if (shouldSkipDefaultAclRewrite(folder)) {
+      log.info("Skipping default ACL rewrite for {} — Everyone already has ADMIN", path);
+      return;
+    }
 
     // Set ADMIN for everyone
     setFolderPermission(folder, PSFolderPermission.Access.ADMIN);
 
     contentWs.saveFolder(folder);
+  }
+
+  /**
+   * Default asset-root ACL rewrite is idempotent when virtual Everyone already has ADMIN. Adding
+   * Admin/Designer ROLE rows on every start would allocate new SYSIDs.
+   */
+  static boolean shouldSkipDefaultAclRewrite(PSFolder folder) {
+    return hasEveryoneAdminAccess(folder);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/PSFolderPermissionUtilsTest.java
@@ -17,6 +17,7 @@
 package com.percussion.share.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -187,5 +188,37 @@ class PSFolderPermissionUtilsTest {
     assertEquals(1, reread.getWritePrincipals().size());
     assertEquals("Contributor", reread.getWritePrincipals().get(0).getName());
     assertEquals(PrincipalType.ROLE, reread.getWritePrincipals().get(0).getType());
+  }
+
+  @Test
+  void hasEveryoneAdminAccess_emptyAcl_false() {
+    assertFalse(PSFolderPermissionUtils.hasEveryoneAdminAccess(newFolder()));
+    assertFalse(PSFolderPermissionUtils.hasEveryoneAdminAccess(null));
+  }
+
+  @Test
+  void hasEveryoneAdminAccess_readEveryone_false() {
+    PSFolder folder = newFolder();
+    folder
+        .getAcl()
+        .add(
+            new PSObjectAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+                PSObjectAclEntry.ACCESS_READ));
+    assertFalse(PSFolderPermissionUtils.hasEveryoneAdminAccess(folder));
+  }
+
+  @Test
+  void hasEveryoneAdminAccess_adminEveryone_true() {
+    PSFolder folder = newFolder();
+    folder
+        .getAcl()
+        .add(
+            new PSObjectAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+                PSFolderPermissionUtils.ADMIN_ACCESS));
+    assertTrue(PSFolderPermissionUtils.hasEveryoneAdminAccess(folder));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperDefaultPermissionsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperDefaultPermissionsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.PSFolder;
+import com.percussion.cms.objectstore.PSObjectAclEntry;
+import com.percussion.share.dao.PSFolderPermissionUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CORE_SERVER_INITIALIZED default ACL rewrite must be idempotent when Everyone already has ADMIN
+ * (#3282). Assets folder CONTENTID=7 has no seed ACL, so first persist still runs after NEXTNUMBER
+ * is aligned.
+ */
+@Tag("UnitTest")
+class PSFolderHelperDefaultPermissionsTest {
+
+  @Test
+  void skipRewriteWhenEveryoneAlreadyAdmin() {
+    PSFolder folder = new PSFolder("Assets", -1, PSObjectAclEntry.ACCESS_ADMIN, "assets");
+    folder
+        .getAcl()
+        .add(
+            new PSObjectAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+                PSFolderPermissionUtils.ADMIN_ACCESS));
+    assertTrue(PSFolderHelper.shouldSkipDefaultAclRewrite(folder));
+  }
+
+  @Test
+  void rewriteWhenFolderHasNoEveryoneAcl() {
+    PSFolder folder = new PSFolder("Assets", -1, PSObjectAclEntry.ACCESS_ADMIN, "assets");
+    assertFalse(PSFolderHelper.shouldSkipDefaultAclRewrite(folder));
+  }
+
+  @Test
+  void rewriteWhenEveryoneIsReadOnlySeed() {
+    PSFolder folder = new PSFolder("Assets", -1, PSObjectAclEntry.ACCESS_ADMIN, "assets");
+    folder
+        .getAcl()
+        .add(
+            new PSObjectAclEntry(
+                PSObjectAclEntry.ACL_ENTRY_TYPE_VIRTUAL,
+                PSObjectAclEntry.ACL_ENTRY_EVERYONE,
+                PSObjectAclEntry.ACCESS_READ));
+    assertFalse(PSFolderHelper.shouldSkipDefaultAclRewrite(folder));
+  }
+}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclNextNumberReconciler.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclNextNumberReconciler.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import com.percussion.data.PSNextNumberAligner;
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.services.guidmgr.PSGuidManagerLocator;
+import com.percussion.utils.jdbc.PSConnectionDetail;
+import com.percussion.utils.jdbc.PSConnectionHelper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.naming.NamingException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Advances {@code NEXTNUMBER} for {@code PSX_OBJECTACL} when seed / FastForward SYSIDs sit at or
+ * above the next allocated value so folder ACL inserts do not hit {@code PK_PSX_OBJECTACL} (#3282).
+ */
+public final class PSObjectAclNextNumberReconciler {
+
+  public static final String NEXTNUMBER_KEY = "PSX_OBJECTACL";
+
+  private static final String TABLE = "PSX_OBJECTACL";
+  private static final String SYSID_COL = "SYSID";
+
+  private static final Logger log = LogManager.getLogger(PSObjectAclNextNumberReconciler.class);
+
+  private PSObjectAclNextNumberReconciler() {}
+
+  /** NEXTNUMBER peek / advance used by unit tests and the server adapter. */
+  public interface NextNumberView {
+    int peek(String key);
+
+    void advanceTo(String key, int nextId);
+  }
+
+  /** Highest persisted {@code PSX_OBJECTACL.SYSID}, or {@code < 0} when the table is empty. */
+  public interface MaxSysidSource {
+    int maxSysid();
+  }
+
+  /**
+   * If {@code peek} would collide with {@code max(SYSID)}, advance NEXTNUMBER to the first free id.
+   *
+   * @return {@code true} when NEXTNUMBER was moved
+   */
+  public static boolean reconcile(NextNumberView numbers, MaxSysidSource used) {
+    if (numbers == null || used == null) {
+      throw new IllegalArgumentException("numbers and used are required");
+    }
+    int peek = numbers.peek(NEXTNUMBER_KEY);
+    int maxUsed = used.maxSysid();
+    if (!PSNextNumberAligner.wouldCollide(peek, maxUsed)) {
+      return false;
+    }
+    int free = PSNextNumberAligner.nextFreeId(peek, maxUsed);
+    numbers.advanceTo(NEXTNUMBER_KEY, free);
+    return true;
+  }
+
+  /**
+   * Best-effort runtime align using the live guid manager and JDBC. Failures are logged and
+   * swallowed so folder default-ACL persist can still attempt a save.
+   *
+   * @return {@code true} when NEXTNUMBER was moved
+   */
+  public static boolean reconcileOnServer() {
+    try {
+      IPSGuidManager gm = PSGuidManagerLocator.getGuidMgr();
+      NextNumberView view =
+          new NextNumberView() {
+            @Override
+            public int peek(String key) {
+              return gm.peekNextNumber(key);
+            }
+
+            @Override
+            public void advanceTo(String key, int nextId) {
+              gm.fixNextNumber(key, nextId);
+            }
+          };
+      return reconcile(view, PSObjectAclNextNumberReconciler::loadMaxSysid);
+    } catch (RuntimeException e) {
+      log.warn(
+          "Could not reconcile PSX_OBJECTACL NEXTNUMBER before folder ACL persist: {}",
+          e.getMessage());
+      return false;
+    }
+  }
+
+  static int loadMaxSysid() {
+    try {
+      Connection c = PSConnectionHelper.getDbConnection();
+      try {
+        String table = qualifiedTable(PSConnectionHelper.getConnectionDetail());
+        String sql = "select max(" + SYSID_COL + ") from " + table;
+        try (PreparedStatement st = c.prepareStatement(sql);
+            ResultSet rs = st.executeQuery()) {
+          if (!rs.next()) {
+            return -1;
+          }
+          int value = rs.getInt(1);
+          return rs.wasNull() ? -1 : value;
+        }
+      } finally {
+        c.close();
+      }
+    } catch (SQLException | NamingException e) {
+      throw new IllegalStateException("Failed to read max(PSX_OBJECTACL.SYSID)", e);
+    }
+  }
+
+  static String qualifiedTable(PSConnectionDetail details) {
+    if (details == null) {
+      return TABLE;
+    }
+    String schema = details.getOrigin();
+    if ("mysql".equalsIgnoreCase(details.getDriver()) && (schema == null || schema.isBlank())) {
+      schema = details.getDatabase();
+    }
+    if (schema == null || schema.isBlank()) {
+      return TABLE;
+    }
+    return schema + "." + TABLE;
+  }
+}

--- a/system/src/main/java/com/percussion/data/PSNextNumberAligner.java
+++ b/system/src/main/java/com/percussion/data/PSNextNumberAligner.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+/**
+ * Pure NEXTNUMBER / SYSID arithmetic used when seed rows occupy ids that the allocator would
+ * otherwise emit.
+ *
+ * <p>{@code PSGuidManager.updateNextNumber} treats {@code NEXTNUMBER.NEXTNR} as the last issued
+ * value and returns {@code NEXTNR + 1}. Seed {@code NEXTNR=1000} therefore allocates {@code 1001},
+ * which collides with FastForward / cmsTableData {@code PSX_OBJECTACL.SYSID=1001} (Everyone on
+ * CONTENTID=301) — H2 {@code 23505} / {@code PK_PSX_OBJECTACL} on folder save (#3282).
+ */
+public final class PSNextNumberAligner {
+
+  private PSNextNumberAligner() {}
+
+  /**
+   * First id {@link com.percussion.services.guidmgr.IPSGuidManager#createId(String)} issues for the
+   * given stored {@code NEXTNR}.
+   */
+  public static int firstAllocatedId(int storedNextNr) {
+    return storedNextNr + 1;
+  }
+
+  /**
+   * {@code true} when the next allocated id is already present as {@code maxUsedId} or below (dense
+   * or gapped tables — we never reuse below the high-water mark).
+   */
+  public static boolean wouldCollide(int nextCandidate, int maxUsedId) {
+    return maxUsedId >= nextCandidate;
+  }
+
+  /**
+   * Smallest id strictly greater than every used id, and not less than {@code nextCandidate}.
+   *
+   * @param nextCandidate next id the allocator would issue
+   * @param maxUsedId highest id already persisted, or {@code < 0} if the table is empty
+   */
+  public static int nextFreeId(int nextCandidate, int maxUsedId) {
+    if (maxUsedId < 0) {
+      return nextCandidate;
+    }
+    return Math.max(nextCandidate, maxUsedId + 1);
+  }
+}

--- a/system/src/test/java/com/percussion/cms/objectstore/PSObjectAclNextNumberReconcilerTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSObjectAclNextNumberReconcilerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.utils.jdbc.PSConnectionDetail;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral coverage for #3282 NEXTNUMBER vs seed {@code PSX_OBJECTACL.SYSID} reconcile. */
+@Tag("UnitTest")
+class PSObjectAclNextNumberReconcilerTest {
+
+  @Test
+  @DisplayName("peek 1001 + seed max 1006 advances NEXTNUMBER to 1007")
+  void reconcileAdvancesPastSeedEveryoneSysid() {
+    RecordingNextNumber numbers = new RecordingNextNumber(1001);
+    boolean moved = PSObjectAclNextNumberReconciler.reconcile(numbers, () -> 1006);
+    assertTrue(moved);
+    assertEquals(1007, numbers.peek(PSObjectAclNextNumberReconciler.NEXTNUMBER_KEY));
+    assertEquals(1007, numbers.lastAdvancedTo);
+  }
+
+  @Test
+  void reconcileNoOpWhenPeekAlreadyFree() {
+    RecordingNextNumber numbers = new RecordingNextNumber(2001);
+    boolean moved = PSObjectAclNextNumberReconciler.reconcile(numbers, () -> 1006);
+    assertFalse(moved);
+    assertEquals(-1, numbers.lastAdvancedTo);
+    assertEquals(2001, numbers.peek(PSObjectAclNextNumberReconciler.NEXTNUMBER_KEY));
+  }
+
+  @Test
+  void reconcileRejectsNullDeps() {
+    RecordingNextNumber numbers = new RecordingNextNumber(1001);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSObjectAclNextNumberReconciler.reconcile(null, () -> 1));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSObjectAclNextNumberReconciler.reconcile(numbers, null));
+  }
+
+  @Test
+  void qualifiedTableUsesSchemaWhenPresent() {
+    PSConnectionDetail details =
+        new PSConnectionDetail("rxdefault", "h2", "rx", "PUBLIC", "jdbc:h2:mem:t");
+    assertEquals("PUBLIC.PSX_OBJECTACL", PSObjectAclNextNumberReconciler.qualifiedTable(details));
+  }
+
+  @Test
+  void qualifiedTableOmitsBlankSchema() {
+    assertEquals("PSX_OBJECTACL", PSObjectAclNextNumberReconciler.qualifiedTable(null));
+    PSConnectionDetail details =
+        new PSConnectionDetail("rxdefault", "h2", "rx", null, "jdbc:h2:mem:t");
+    assertEquals("PSX_OBJECTACL", PSObjectAclNextNumberReconciler.qualifiedTable(details));
+  }
+
+  private static final class RecordingNextNumber
+      implements PSObjectAclNextNumberReconciler.NextNumberView {
+    private final Map<String, Integer> values = new HashMap<>();
+    private int lastAdvancedTo = -1;
+
+    RecordingNextNumber(int peek) {
+      values.put(PSObjectAclNextNumberReconciler.NEXTNUMBER_KEY, peek);
+    }
+
+    @Override
+    public int peek(String key) {
+      return values.getOrDefault(key, 0);
+    }
+
+    @Override
+    public void advanceTo(String key, int nextId) {
+      lastAdvancedTo = nextId;
+      values.put(key, nextId);
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/data/PSNextNumberAlignerTest.java
+++ b/system/src/test/java/com/percussion/data/PSNextNumberAlignerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces the H2 qa-up {@code PK_PSX_OBJECTACL} / SYSID 1001 collision (#3282) and proves the
+ * aligner yields a free id.
+ */
+@Tag("UnitTest")
+class PSNextNumberAlignerTest {
+
+  /** cmsTableData NEXTNUMBER.PSX_OBJECTACL before the #3282 seed bump. */
+  private static final int SEEDED_NEXTNR = 1000;
+
+  /** Highest SYSID in cmsTableData PSX_OBJECTACL (Everyone / admin1 on 301–303). */
+  private static final int SEEDED_MAX_SYSID = 1006;
+
+  @Test
+  @DisplayName("NEXTNR=1000 allocates 1001 which is already Everyone on CONTENTID=301")
+  void seedNextNumberCollidesWithEveryoneSysid1001() {
+    int next = PSNextNumberAligner.firstAllocatedId(SEEDED_NEXTNR);
+    assertEquals(1001, next);
+    assertTrue(
+        PSNextNumberAligner.wouldCollide(next, SEEDED_MAX_SYSID),
+        "allocator 1001 must collide with seed SYSID 1001–1006");
+  }
+
+  @Test
+  @DisplayName("aligned next id is past every seed ACL SYSID")
+  void nextFreeIdSkipsSeededObjectAclRange() {
+    int next = PSNextNumberAligner.firstAllocatedId(SEEDED_NEXTNR);
+    int free = PSNextNumberAligner.nextFreeId(next, SEEDED_MAX_SYSID);
+    assertEquals(1007, free);
+    assertFalse(PSNextNumberAligner.wouldCollide(free, SEEDED_MAX_SYSID));
+  }
+
+  @Test
+  void emptyTableLeavesCandidateUnchanged() {
+    assertEquals(1001, PSNextNumberAligner.nextFreeId(1001, -1));
+    assertFalse(PSNextNumberAligner.wouldCollide(1001, -1));
+  }
+
+  @Test
+  void candidateAlreadyPastHighWaterIsUnchanged() {
+    assertEquals(2001, PSNextNumberAligner.nextFreeId(2001, 1006));
+    assertFalse(PSNextNumberAligner.wouldCollide(2001, 1006));
+  }
+}


### PR DESCRIPTION
## Summary

H2 `qa-up` never became healthy: `PSServerFolderProcessor` failed to save Assets folder `CONTENTID=7` because `NEXTNUMBER.PSX_OBJECTACL` (`NEXTNR=1000`) allocated `SYSID=1001`, already seeded as virtual Everyone on `CONTENTID=301` (`PK_PSX_OBJECTACL` / H2 `23505`).

This change:

- Bumps installer seed `NEXTNR` for `PSX_OBJECTACL` and `PSX_PROPERTIES` to **2000** (createId is `NEXTNR+1`, so first id is 2001).
- Aligns live `NEXTNUMBER` past `max(PSX_OBJECTACL.SYSID)` before the `CORE_SERVER_INITIALIZED` default-ACL rewrite.
- Makes that rewrite **idempotent** when virtual Everyone already has ADMIN (no extra SYSID inserts).

Fixes #3282

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #3282

## Test plan

1. Unit: `PSNextNumberAlignerTest` reproduces `NEXTNR=1000` → 1001 vs seed max 1006 and proves next free is 1007.
2. Unit: `PSObjectAclNextNumberReconcilerTest` advances peek 1001 to 1007.
3. Unit: `PSFolderHelperDefaultPermissionsTest` / `PSFolderPermissionUtilsTest` skip rewrite when Everyone is already ADMIN.
4. Seed guard: `CmsTableDataObjectAclNextNumberTest` asserts seed NEXTNR ≥ max seed SYSID.
5. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2014, Failures: 0, Errors: 0, Skipped: 238).
6. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1087, Failures: 0, Errors: 0, Skipped: 125).
7. `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 255, Failures: 0, Errors: 0, Skipped: 5).
8. `python docker/scripts/perc-devctl.py qa-up` → `RESULT:OK` (printed `TEST_CMS_URL`, not hardcoded).
9. `python docker/scripts/perc-devctl.py qa-health` / login HTTP 200.
10. Playwright (`TEST_CMS_URL` from qa-up): `tests/golden-unattended-smoke.spec.js` (2 passed) and `tests/login.spec.js` (2 passed).
11. `server.log` had no `Failed to save folder` / `PK_PSX_OBJECTACL`.
12. Always `python docker/scripts/perc-devctl.py qa-down` (`RESULT:OK`).

## Checklist

- [x] **Product documentation** — N/A (not product-facing): allocator/seed collision fix; Everyone ADMIN on Assets is existing startup intent, no new operator procedure
- [x] **Unit / module tests** — behavioral tests for aligner, reconciler, skip-rewrite, seed invariant; standalone `mvnw clean install` green on changed modules
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change). Issue acceptance still required live H2 proof: golden-unattended-smoke + login (4 passed)
- [x] **Build gates** — standalone clean install on `system`, `projects/sitemanage`, `modules/perc-distribution-tree`; no `final`/signature C2 blast
- [x] **Cross-platform** — seed XML parse uses `Path.of`; schema qualification uses JDBC origin (not hardcoded separators)

### C3 evidence

- **modules_built:** system, projects/sitemanage, modules/perc-distribution-tree
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2014, Failures: 0, Errors: 0, Skipped: 238
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1087, Failures: 0, Errors: 0, Skipped: 125
  - `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 255, Failures: 0, Errors: 0, Skipped: 5
- **downstream_checked:** none (C2 did not apply — no existing type made final/sealed; no existing public/protected signature change). sitemanage consumer still clean-installed as the caller of the new reconciler.

### C5 UI proof (issue acceptance / qa-up cell)

- qa-up: `python docker/scripts/perc-devctl.py qa-up` → RESULT:OK; `TEST_CMS_URL` printed by qa-up (freeport; do not hardcode)
- Deploy: new `perc-system` / `sitemanage` SNAPSHOTs + seed XML packaged in perc-distribution-tree; matrix cell used that tree
- Playwright: `npm run test:surface -- --path tests/golden-unattended-smoke.spec.js` (2 passed); `npm run test:surface -- --path tests/login.spec.js` (2 passed)
- console-clean=yes
- server.log-clean=yes (no `Failed to save folder` / `PK_PSX_OBJECTACL`)
- qa-down: RESULT:OK

> Co-Authored by Grok Build using grok-4.5 with agent main.
