### PR TITLE
fix(perc-system): type remaining assembly/jexl maps (#3280)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3280-assembly-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3280-assembly-xlint-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3280 assembly PSNavHelper/assemblers/jexl Xlint
+
+**Scope:** uncommitted `fix/issue-3280-assembly-xlint` vs `origin/main`  
+**Module:** `system` / `perc-system`  
+**Change class:** residual `-Xlint` rawtypes/unchecked cleanup in `com.percussion.services.assembly`  
+**Memory patterns hit:** behavioral tests for changed helpers; prefer real generics over `@SuppressWarnings`; no public API blast radius; no path I/O
+
+## Summary
+
+Removes leftover unchecked map casts in assemblers, `PSAssemblyWorkItem.getMetaData`, nav (`PSNavHelper` / `PSNavonNodeInvocationHandler`), and jexl (`PSAssemblerUtils.combine` / `getTimers`). Introduces `PSAssemblyBindingMaps` (copy + live write-through view) and `PSBinaryAssemblerSupport.resolveSys` so named production files no longer use `@SuppressWarnings("unchecked")`. The single residual unchecked conversion is isolated in `LiveStringObjectMap.erase`. Tests cover copy/live maps, binary `$sys` resolution, nav params/base/property-map copy, jexl combine/timers, and metadata write-through.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction, installers, or path assertions.
+
+## Product documentation
+
+N/A — internal compiler-warning cleanup; no operator/user/API surface change.
+
+## Issues
+
+None.
+
+## Notes
+
+- `getMetaData()` still returns `Map<String, Object>`; the live view mutates the original `$sys.metadata` map (tested).
+- `PSContentFinderBase.find` now writes `$sys.hasMore` through the same live view (same `$sys` instance).
+- C2: no type made `final`/`sealed`; no public/protected method or ctor signature change. Downstream install not required.
+- Focused tests green (22). Module `clean install` is the remaining pre-PR gate.

--- a/system/services/src/com/percussion/services/assembly/PSAssemblyBindingMaps.java
+++ b/system/services/src/com/percussion/services/assembly/PSAssemblyBindingMaps.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Typed views of JEXL / assembly binding maps stored as {@code Object} ({@code $sys},
+ * {@code $sys.metadata}, nav variables). Prefer these over {@code @SuppressWarnings("unchecked")}.
+ */
+public final class PSAssemblyBindingMaps {
+
+  private PSAssemblyBindingMaps() {}
+
+  /**
+   * Defensive copy of string-keyed entries. Returns {@code null} when {@code value} is not a {@link
+   * Map}.
+   */
+  public static Map<String, Object> copyStringObjectMap(Object value) {
+    if (!(value instanceof Map<?, ?> raw)) {
+      return null;
+    }
+    Map<String, Object> typed = new LinkedHashMap<>();
+    for (Map.Entry<?, ?> entry : raw.entrySet()) {
+      if (entry.getKey() instanceof String key) {
+        typed.put(key, entry.getValue());
+      }
+    }
+    return typed;
+  }
+
+  /**
+   * Live {@code Map<String, Object>} view of an existing map. {@link Map#put} writes through to the
+   * original instance so JEXL {@code $sys} holders stay in sync.
+   *
+   * @return {@code null} when {@code value} is not a {@link Map}
+   */
+  public static Map<String, Object> liveStringObjectMap(Object value) {
+    if (!(value instanceof Map<?, ?> raw)) {
+      return null;
+    }
+    return new LiveStringObjectMap(raw);
+  }
+
+  /**
+   * {@code $sys} binding, or {@code null} when missing or not a map.
+   */
+  public static Map<String, Object> sysMap(Map<String, ?> bindings) {
+    if (bindings == null) {
+      return null;
+    }
+    return liveStringObjectMap(bindings.get("$sys"));
+  }
+
+  /**
+   * Nested map under {@code $sys} (live view). {@code null} when {@code $sys} or the nested value
+   * is missing or not a map.
+   */
+  public static Map<String, Object> sysNestedMap(Map<String, ?> bindings, String key) {
+    Map<String, Object> sys = sysMap(bindings);
+    if (sys == null || key == null) {
+      return null;
+    }
+    return liveStringObjectMap(sys.get(key));
+  }
+
+  /**
+   * Write-through view. The single residual unchecked conversion is isolated here: JEXL stores
+   * {@code HashMap} / {@code LinkedHashMap} nodes that accept {@link String} keys.
+   */
+  static final class LiveStringObjectMap extends AbstractMap<String, Object> {
+    private final Map<Object, Object> delegate;
+
+    LiveStringObjectMap(Map<?, ?> raw) {
+      this.delegate = erase(raw);
+    }
+
+    @Override
+    public Object get(Object key) {
+      return delegate.get(key);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return delegate.containsKey(key);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+      return delegate.put(key, value);
+    }
+
+    @Override
+    public Object remove(Object key) {
+      return delegate.remove(key);
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+      Set<Entry<String, Object>> entries = new LinkedHashSet<>();
+      for (Map.Entry<Object, Object> entry : delegate.entrySet()) {
+        if (entry.getKey() instanceof String key) {
+          entries.add(new SimpleEntry<>(key, entry.getValue()));
+        }
+      }
+      return entries;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Object, Object> erase(Map<?, ?> raw) {
+      return (Map<Object, Object>) raw;
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/assembly/data/PSAssemblyWorkItem.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSAssemblyWorkItem.java
@@ -27,6 +27,7 @@ import com.percussion.services.assembly.IPSAssemblyErrors;
 import com.percussion.services.assembly.IPSAssemblyItem;
 import com.percussion.services.assembly.IPSAssemblyResult;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
+import com.percussion.services.assembly.PSAssemblyBindingMaps;
 import com.percussion.services.assembly.PSAssemblyException;
 import com.percussion.services.assembly.impl.PSInlineLinkProcessor;
 import com.percussion.services.assembly.impl.nav.PSNavHelper;
@@ -641,32 +642,29 @@ public class PSAssemblyWorkItem implements IPSAssemblyResult
     */
    public Map<String, Object> getMetaData()
    {
-      Object sys = getBindings().get("$sys");
-      if (sys==null)
+      Map<String, Object> bindings = getBindings();
+      Object sys = bindings.get("$sys");
+      if (sys == null)
+      {
          return null;
-
-      if (!(sys instanceof Map))
+      }
+      if (!(sys instanceof Map<?, ?> sysmap))
       {
          ms_log.error("$sys is not a map");
          return null;
       }
-      @SuppressWarnings("unchecked")
-      Map<String, Object> sysmap = (Map<String, Object>) sys;
-
-
-      Object metadata = sysmap.get("metadata");
-
-      if (metadata==null)
-         return null;
-
-      if (metadata instanceof Map)
+      Object rawMeta = sysmap.get("metadata");
+      if (rawMeta == null)
       {
-         return (Map<String, Object>)metadata;
-      } else {
-         ms_log.error("$sys.metadata is not a map");
+         return null;
       }
-
-      return null;
+      Map<String, Object> metadata = PSAssemblyBindingMaps.liveStringObjectMap(rawMeta);
+      if (metadata == null)
+      {
+         ms_log.error("$sys.metadata is not a map");
+         return null;
+      }
+      return metadata;
 
 
    }

--- a/system/services/src/com/percussion/services/assembly/impl/finder/PSContentFinderBase.java
+++ b/system/services/src/com/percussion/services/assembly/impl/finder/PSContentFinderBase.java
@@ -22,6 +22,7 @@ import com.percussion.extension.IPSExtensionDef;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.services.assembly.IPSAssemblyErrors;
 import com.percussion.services.assembly.IPSAssemblyItem;
+import com.percussion.services.assembly.PSAssemblyBindingMaps;
 import com.percussion.services.assembly.IPSAssemblyResult;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSContentFinder;
@@ -232,7 +233,6 @@ public abstract class PSContentFinderBase<T extends Object>
     *         The set must be ordered if the containers are to be ordered. Use
     *         {@link ContentItemOrder} to order the items in the set.
     */   
-   @SuppressWarnings({"cast"})
    abstract protected Set<ContentItem> getContentItems(IPSAssemblyItem sourceItem,
          T slot, Map<String, Object> params) throws PSNotFoundException, RepositoryException, PSFilterException, PSAssemblyException;
 
@@ -283,7 +283,7 @@ public abstract class PSContentFinderBase<T extends Object>
          items.add(clone);
          index++;
       }
-      Map<String, Object> sys = (Map<String, Object>) sourceItem.getBindings().get("$sys");
+      Map<String, Object> sys = PSAssemblyBindingMaps.sysMap(sourceItem.getBindings());
       if (sys != null)
       {
          sys.put("hasMore", had_more);

--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavHelper.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavHelper.java
@@ -239,6 +239,24 @@ public class PSNavHelper
       return params;
    }
 
+   /**
+    * Copy {@code $sys.variables[variableName]} onto {@code navmap.base} using a typed
+    * {@code Map<?,?>} read (no unchecked cast of JEXL evaluate).
+    */
+   static void putNavBaseFromVariables(Map<String, Object> navmap, Object variables,
+         String variableName)
+   {
+      if (navmap == null || variableName == null || !(variables instanceof Map<?, ?> vars))
+      {
+         return;
+      }
+      Object value = vars.get(variableName);
+      if (value != null)
+      {
+         navmap.put("base", value);
+      }
+   }
+
    public static void init()
    {
       if (!m_isInited)
@@ -480,14 +498,8 @@ public class PSNavHelper
       {
          try
          {
-            Map<String, String> variables = (Map<String, String>) eval
-                  .evaluate(VARIABLES);
-            if (variables != null)
-            {
-               String value = variables.get(basevar.getString());
-               if (value != null)
-                  navmap.put("base", value);
-            }
+            putNavBaseFromVariables(navmap, eval.evaluate(VARIABLES),
+                  basevar.getString());
          }
          catch (Exception e)
          {
@@ -551,7 +563,7 @@ public class PSNavHelper
       boolean found = false;
       for (int i = folders.size() - 1; i >= 0; i--)
       {
-            final PSLocator folder = (PSLocator) folders.get(i);
+            final PSLocator folder = folders.get(i);
             PSLocator item = folderCache.findChildOfType(folder, m_navCtypes);
             if (item!=null)
             {

--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
@@ -211,13 +211,7 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
 
             // Add nav properties. Copy from Map<?,?> (PSItemIterator.getMap) into a
             // typed HashMap — diamond + wildcard source does not infer K=String.
-            Map<String, Property> map = new HashMap<>();
-            for (Map.Entry<?, ?> e : iter.getMap().entrySet())
-            {
-               @SuppressWarnings("unchecked")
-               Map.Entry<String, Property> entry = (Map.Entry<String, Property>) e;
-               map.put(entry.getKey(), entry.getValue());
-            }
+            Map<String, Property> map = copyPropertyMap(iter.getMap());
             for(String prop : NAV_PROPERTIES)
             {
                Property p = getNavProperty((Node) proxy, prop);
@@ -473,6 +467,27 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
     * @throws PSCmsException
     * @throws RepositoryException
     */
+   /**
+    * Copy a JCR property iterator backing map into a typed {@code Map<String, Property>}
+    * without an unchecked {@link Map.Entry} cast.
+    */
+   static Map<String, Property> copyPropertyMap(Map<?, ?> source)
+   {
+      Map<String, Property> map = new HashMap<>();
+      if (source == null)
+      {
+         return map;
+      }
+      for (Map.Entry<?, ?> entry : source.entrySet())
+      {
+         if (entry.getKey() instanceof String key && entry.getValue() instanceof Property property)
+         {
+            map.put(key, property);
+         }
+      }
+      return map;
+   }
+
    private Property loadLandingPage() throws PSCmsException,
          RepositoryException
    {

--- a/system/services/src/com/percussion/services/assembly/impl/plugin/PSBinaryAssembler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/plugin/PSBinaryAssembler.java
@@ -22,7 +22,6 @@ import com.percussion.services.assembly.IPSAssemblyResult;
 import com.percussion.services.assembly.IPSAssemblyResult.Status;
 
 import java.io.InputStream;
-import java.util.Map;
 
 import javax.jcr.Property;
 import javax.jcr.Value;
@@ -45,48 +44,18 @@ public class PSBinaryAssembler extends PSAssemblerBase
    {
       // Use the bound values $sys.binary and $sys.mimetype to
       // process the result
-      Map<String, Object> bindings = item.getBindings();
-      Object sys = bindings.get("$sys");
-
-      if (!(sys instanceof Map))
+      PSBinaryAssemblerSupport.ResolvedSys resolved =
+            PSBinaryAssemblerSupport.resolveSys(item.getBindings());
+      if (!resolved.success())
       {
-         return getFailureResult(item, "$sys was not bound to a map.");
+         return getFailureResult(item, resolved.error());
       }
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> sysmap = (Map<String, Object>) sys;
-      Object mtype = sysmap.get("mimetype");
-      Object data = sysmap.get("binary");
-      String mimetype;
-      
+      Object data = resolved.data();
+      String mimetype = resolved.mimetype();
 
       try
       {
-         if (mtype == null)
-         {
-            return getFailureResult(item, "$sys.mimetype was not bound");
-         }
-
-         if (data == null)
-         {
-            return getFailureResult(item, "$sys.binary was not bound");
-         }
-
-         if (mtype instanceof Property)
-         {
-            mimetype = ((Property) mtype).getString();
-         }
-         else if (mtype instanceof String)
-         {
-            mimetype = (String) mtype;
-         }
-         else
-         {
-            return getFailureResult(item,
-                  "$sys.mimetype must be bound to a property"
-                        + " or string value");
-         }
-
          if (data instanceof Property)
          {
             PSRequest req = (PSRequest) PSRequestInfo

--- a/system/services/src/com/percussion/services/assembly/impl/plugin/PSBinaryAssemblerSupport.java
+++ b/system/services/src/com/percussion/services/assembly/impl/plugin/PSBinaryAssemblerSupport.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly.impl.plugin;
+
+import java.util.Map;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+
+/**
+ * Binding resolution for {@link PSBinaryAssembler} without Spring / {@link PSAssemblerBase} static
+ * init. Reads {@code $sys.mimetype} and {@code $sys.binary} via {@code Map<?,?>} (no unchecked
+ * casts).
+ */
+public final class PSBinaryAssemblerSupport {
+
+  static final String ERR_SYS_NOT_MAP = "$sys was not bound to a map.";
+  static final String ERR_MIMETYPE_UNBOUND = "$sys.mimetype was not bound";
+  static final String ERR_BINARY_UNBOUND = "$sys.binary was not bound";
+  static final String ERR_MIMETYPE_TYPE =
+      "$sys.mimetype must be bound to a property" + " or string value";
+  static final String ERR_BINARY_TYPE = "$sys.binary must be bound to a property" + " or byte[] value";
+
+  private PSBinaryAssemblerSupport() {}
+
+  /**
+   * Resolved {@code $sys} binary bindings. {@link #error()} is non-null on failure.
+   *
+   * @param error failure message, or {@code null} on success
+   * @param mimetype resolved MIME type, {@code null} on failure
+   * @param data {@link Property}, {@link Value}, or {@code byte[]}, {@code null} on failure
+   */
+  public record ResolvedSys(String error, String mimetype, Object data) {
+    public boolean success() {
+      return error == null;
+    }
+  }
+
+  /**
+   * Resolve {@code $sys.mimetype} / {@code $sys.binary} from assembly bindings.
+   *
+   * @param bindings item bindings, may be {@code null}
+   * @return outcome, never {@code null}
+   */
+  public static ResolvedSys resolveSys(Map<String, ?> bindings) {
+    if (bindings == null) {
+      return new ResolvedSys(ERR_SYS_NOT_MAP, null, null);
+    }
+    Object sys = bindings.get("$sys");
+    if (!(sys instanceof Map<?, ?> sysmap)) {
+      return new ResolvedSys(ERR_SYS_NOT_MAP, null, null);
+    }
+    Object mtype = sysmap.get("mimetype");
+    Object data = sysmap.get("binary");
+    if (mtype == null) {
+      return new ResolvedSys(ERR_MIMETYPE_UNBOUND, null, null);
+    }
+    if (data == null) {
+      return new ResolvedSys(ERR_BINARY_UNBOUND, null, null);
+    }
+    String mimetype;
+    if (mtype instanceof Property property) {
+      try {
+        mimetype = property.getString();
+      } catch (RepositoryException e) {
+        return new ResolvedSys("Problem extracting data from property", null, null);
+      }
+    } else if (mtype instanceof String stringType) {
+      mimetype = stringType;
+    } else {
+      return new ResolvedSys(ERR_MIMETYPE_TYPE, null, null);
+    }
+    if (!(data instanceof Property || data instanceof Value || data instanceof byte[])) {
+      return new ResolvedSys(ERR_BINARY_TYPE, null, null);
+    }
+    return new ResolvedSys(null, mimetype, data);
+  }
+}

--- a/system/services/src/com/percussion/services/assembly/impl/plugin/PSHtmlAssembler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/plugin/PSHtmlAssembler.java
@@ -21,7 +21,6 @@ import com.percussion.services.assembly.IPSAssemblyItem;
 import com.percussion.services.assembly.IPSAssemblyResult;
 import com.percussion.services.assembly.IPSAssemblyResult.Status;
 import com.percussion.services.assembly.impl.plugin.PSTextAssemblerSupport.TextAssembleOutcome;
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,14 +41,12 @@ public class PSHtmlAssembler extends PSAssemblerBase {
   private static final Logger log = LogManager.getLogger(PSHtmlAssembler.class);
 
   @Override
-  @SuppressWarnings("unchecked")
   public IPSAssemblyResult assembleSingle(IPSAssemblyItem item) {
     try {
       String fallback =
           item.getTemplate() != null ? item.getTemplate().getTemplate() : null;
       TextAssembleOutcome outcome =
-          PSTextAssemblerSupport.assembleHtmlFirst(
-              (Map<String, Object>) item.getBindings(), fallback);
+          PSTextAssemblerSupport.assembleHtmlFirst(item.getBindings(), fallback);
       if (!outcome.success()) {
         return getFailureResult(item, outcome.errorMessage());
       }

--- a/system/services/src/com/percussion/services/assembly/impl/plugin/PSMarkdownAssembler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/plugin/PSMarkdownAssembler.java
@@ -21,7 +21,6 @@ import com.percussion.services.assembly.IPSAssemblyItem;
 import com.percussion.services.assembly.IPSAssemblyResult;
 import com.percussion.services.assembly.IPSAssemblyResult.Status;
 import com.percussion.services.assembly.impl.plugin.PSTextAssemblerSupport.TextAssembleOutcome;
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,14 +41,12 @@ public class PSMarkdownAssembler extends PSAssemblerBase {
   private static final Logger log = LogManager.getLogger(PSMarkdownAssembler.class);
 
   @Override
-  @SuppressWarnings("unchecked")
   public IPSAssemblyResult assembleSingle(IPSAssemblyItem item) {
     try {
       String fallback =
           item.getTemplate() != null ? item.getTemplate().getTemplate() : null;
       TextAssembleOutcome outcome =
-          PSTextAssemblerSupport.assembleMarkdown(
-              (Map<String, Object>) item.getBindings(), fallback);
+          PSTextAssemblerSupport.assembleMarkdown(item.getBindings(), fallback);
       if (!outcome.success()) {
         return getFailureResult(item, outcome.errorMessage());
       }

--- a/system/services/src/com/percussion/services/assembly/jexl/PSAssemblerUtils.java
+++ b/system/services/src/com/percussion/services/assembly/jexl/PSAssemblerUtils.java
@@ -39,6 +39,7 @@ import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
 import com.percussion.services.assembly.IPSSlotContentFinder;
 import com.percussion.services.assembly.IPSTemplateSlot;
+import com.percussion.services.assembly.PSAssemblyBindingMaps;
 import com.percussion.services.assembly.PSAssemblyException;
 import com.percussion.services.assembly.PSAssemblyServiceLocator;
 import com.percussion.services.assembly.data.PSSlotLayoutStyles;
@@ -570,19 +571,14 @@ public class PSAssemblerUtils extends PSJexlUtilBase
       {
          // Parse the query
          String pairs[] = urlquery.split("&");
-         Map<String, Object> urlmap = new HashMap<>();
+         Map<String, List<String>> collected = new HashMap<>();
          for (String pair : pairs)
          {
             String parts[] = pair.split("=");
             if (parts.length == 2)
             {
                String key = parts[0];
-               List<String> value = (List<String>) urlmap.get(key);
-               if (value == null)
-               {
-                  value = new ArrayList<>();
-                  urlmap.put(key, value);
-               }
+               List<String> value = collected.computeIfAbsent(key, k -> new ArrayList<>());
                value.add(parts[1]);
             }
             else if (StringUtils.isNotBlank(pair))
@@ -593,17 +589,12 @@ public class PSAssemblerUtils extends PSJexlUtilBase
             }
          }
 
-         // Walk the map and convert to array elements
-         for (String key : urlmap.keySet())
+         Map<String, Object> extra = new HashMap<>();
+         for (Map.Entry<String, List<String>> entry : collected.entrySet())
          {
-            List<String> value = (List<String>) urlmap.get(key);
-            String arr[] = new String[value.size()];
-            value.toArray(arr);
-            urlmap.put(key, arr);
+            extra.put(entry.getKey(), entry.getValue().toArray(String[]::new));
          }
-
-         Map<String, Object> casted = urlmap;
-         return combine(input, casted);
+         return combine(input, extra);
       }
       finally
       {
@@ -999,14 +990,42 @@ public class PSAssemblerUtils extends PSJexlUtilBase
 
    private HashMap<String, PSStopwatch> getTimers(IPSAssemblyItem item)
    {
-      HashMap<String,Object> sys = (HashMap<String,Object>)item.getBindings().get("$sys");
-      HashMap<String,PSStopwatch> timers = (HashMap<String,PSStopwatch>)sys.get("percTimers");
-      if (timers == null)
+      Map<String, Object> bindings = item.getBindings();
+      Object sysObj = bindings.get("$sys");
+      Map<String, Object> sys;
+      if (sysObj == null)
       {
-         timers = new HashMap<>();
-         sys.put("percTimers",timers);
+         sys = new HashMap<>();
+         bindings.put("$sys", sys);
       }
+      else
+      {
+         sys = PSAssemblyBindingMaps.liveStringObjectMap(sysObj);
+         if (sys == null)
+         {
+            throw new IllegalStateException("$sys is not a map");
+         }
+      }
+      HashMap<String, PSStopwatch> timers = copyTimers(sys.get("percTimers"));
+      sys.put("percTimers", timers);
+      return timers;
+   }
 
+   static HashMap<String, PSStopwatch> copyTimers(Object timersObj)
+   {
+      HashMap<String, PSStopwatch> timers = new HashMap<>();
+      if (!(timersObj instanceof Map<?, ?> raw))
+      {
+         return timers;
+      }
+      for (Map.Entry<?, ?> entry : raw.entrySet())
+      {
+         if (entry.getKey() instanceof String key
+               && entry.getValue() instanceof PSStopwatch watch)
+         {
+            timers.put(key, watch);
+         }
+      }
       return timers;
    }
 

--- a/system/src/test/java/com/percussion/services/PSServicesPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/services/PSServicesPackageTypedTest.java
@@ -135,4 +135,31 @@ class PSServicesPackageTypedTest {
     item.setBindings(bindings);
     assertEquals(null, item.getMetaData());
   }
+
+  @Test
+  @DisplayName("PSAssemblyWorkItem.getMetaData mutations write through $sys.metadata")
+  void assemblyWorkItemMetadataWriteThrough() {
+    PSAssemblyWorkItem item = new PSAssemblyWorkItem();
+    Map<String, Object> bindings = new HashMap<>();
+    Map<String, Object> sys = new HashMap<>();
+    Map<String, Object> meta = new HashMap<>();
+    sys.put("metadata", meta);
+    bindings.put("$sys", sys);
+    item.setBindings(bindings);
+
+    item.getMetaData().put("type", "page");
+    assertEquals("page", meta.get("type"));
+  }
+
+  @Test
+  @DisplayName("PSAssemblyWorkItem.getMetaData returns null when metadata is not a Map")
+  void assemblyWorkItemRejectsNonMapMetadata() {
+    PSAssemblyWorkItem item = new PSAssemblyWorkItem();
+    Map<String, Object> bindings = new HashMap<>();
+    Map<String, Object> sys = new HashMap<>();
+    sys.put("metadata", "nope");
+    bindings.put("$sys", sys);
+    item.setBindings(bindings);
+    assertEquals(null, item.getMetaData());
+  }
 }

--- a/system/src/test/java/com/percussion/services/assembly/PSAssemblyBindingMapsTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/PSAssemblyBindingMapsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Typed JEXL / assembly binding map helpers (#3280). */
+@Tag("UnitTest")
+class PSAssemblyBindingMapsTest {
+
+  @Test
+  @DisplayName("copyStringObjectMap copies string keys and skips others")
+  void copySkipsNonStringKeys() {
+    Map<Object, Object> raw = new HashMap<>();
+    raw.put("k", "v");
+    raw.put(1, "num");
+    raw.put(null, "n");
+
+    Map<String, Object> typed = PSAssemblyBindingMaps.copyStringObjectMap(raw);
+    assertEquals(1, typed.size());
+    assertEquals("v", typed.get("k"));
+    typed.put("k2", "v2");
+    assertNull(raw.get("k2"));
+  }
+
+  @Test
+  @DisplayName("copyStringObjectMap returns null for non-maps")
+  void copyNullForNonMap() {
+    assertNull(PSAssemblyBindingMaps.copyStringObjectMap(null));
+    assertNull(PSAssemblyBindingMaps.copyStringObjectMap("x"));
+  }
+
+  @Test
+  @DisplayName("liveStringObjectMap writes through to the original $sys map")
+  void liveWritesThrough() {
+    Map<String, Object> sys = new HashMap<>();
+    sys.put("mimetype", "image/png");
+    Map<String, Object> live = PSAssemblyBindingMaps.liveStringObjectMap(sys);
+    live.put("binary", new byte[] {1});
+    assertTrue(sys.get("binary") instanceof byte[]);
+    assertEquals("image/png", live.get("mimetype"));
+  }
+
+  @Test
+  @DisplayName("sysNestedMap returns live $sys.metadata")
+  void sysNestedMetadata() {
+    Map<String, Object> meta = new HashMap<>();
+    meta.put("k", "v");
+    Map<String, Object> sys = new HashMap<>();
+    sys.put("metadata", meta);
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$sys", sys);
+
+    Map<String, Object> nested = PSAssemblyBindingMaps.sysNestedMap(bindings, "metadata");
+    nested.put("type", "page");
+    assertEquals("page", meta.get("type"));
+    assertSame(meta.get("k"), nested.get("k"));
+  }
+}

--- a/system/src/test/java/com/percussion/services/assembly/impl/nav/PSNavHelperTypedTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/impl/nav/PSNavHelperTypedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly.impl.nav;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.assembly.IPSAssemblyItem;
+import com.percussion.system.utils.IPSHtmlParameters;
+import java.util.HashMap;
+import java.util.Map;
+import javax.jcr.Property;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Typed helpers for nav assembly leftovers (#3280). */
+@Tag("UnitTest")
+class PSNavHelperTypedTest {
+
+  @Test
+  @DisplayName("getParams flattens first values and optional user")
+  void getParamsFlattens() {
+    IPSAssemblyItem item = mock(IPSAssemblyItem.class);
+    Map<String, String[]> raw = new HashMap<>();
+    raw.put("sys_folderid", new String[] {"42", "99"});
+    raw.put("empty", new String[] {null});
+    when(item.getParameters()).thenReturn(raw);
+    when(item.getParameterValue("sys_folderid", null)).thenReturn("42");
+    when(item.getParameterValue("empty", null)).thenReturn(null);
+    when(item.getUserName()).thenReturn("editor");
+
+    Map<String, String> params = PSNavHelper.getParams(item);
+    assertEquals("42", params.get("sys_folderid"));
+    assertFalse(params.containsKey("empty"));
+    assertEquals("editor", params.get(IPSHtmlParameters.SYS_USER));
+  }
+
+  @Test
+  @DisplayName("putNavBaseFromVariables copies string (and non-string) values without cast")
+  void putNavBaseFromVariables() {
+    Map<String, Object> nav = new HashMap<>();
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("navbase", "/sites/site1");
+
+    PSNavHelper.putNavBaseFromVariables(nav, vars, "navbase");
+    assertEquals("/sites/site1", nav.get("base"));
+
+    nav.clear();
+    PSNavHelper.putNavBaseFromVariables(nav, vars, "missing");
+    assertFalse(nav.containsKey("base"));
+
+    PSNavHelper.putNavBaseFromVariables(nav, "not-a-map", "navbase");
+    assertFalse(nav.containsKey("base"));
+
+    PSNavHelper.putNavBaseFromVariables(nav, null, "navbase");
+    assertFalse(nav.containsKey("base"));
+  }
+
+  @Test
+  @DisplayName("copyPropertyMap keeps Property values and skips other entries")
+  void copyPropertyMap() {
+    Property prop = mock(Property.class);
+    Map<Object, Object> raw = new HashMap<>();
+    raw.put("rx:title", prop);
+    raw.put("nav:url", "not-a-property");
+    raw.put(3, prop);
+
+    Map<String, Property> typed = PSNavonNodeInvocationHandler.copyPropertyMap(raw);
+    assertEquals(1, typed.size());
+    assertEquals(prop, typed.get("rx:title"));
+
+    assertTrue(PSNavonNodeInvocationHandler.copyPropertyMap(null).isEmpty());
+  }
+}

--- a/system/src/test/java/com/percussion/services/assembly/impl/plugin/PSBinaryAssemblerSupportTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/impl/plugin/PSBinaryAssemblerSupportTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly.impl.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.assembly.impl.plugin.PSBinaryAssemblerSupport.ResolvedSys;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Binding resolution for the binary assembler without Spring (#3280). */
+@Tag("UnitTest")
+class PSBinaryAssemblerSupportTest {
+
+  @Test
+  @DisplayName("resolveSys accepts string mimetype and byte[] binary")
+  void successByteArray() {
+    Map<String, Object> sys = new HashMap<>();
+    sys.put("mimetype", "image/png");
+    sys.put("binary", new byte[] {9, 8});
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$sys", sys);
+
+    ResolvedSys resolved = PSBinaryAssemblerSupport.resolveSys(bindings);
+    assertTrue(resolved.success());
+    assertEquals("image/png", resolved.mimetype());
+    assertArrayEquals(new byte[] {9, 8}, (byte[]) resolved.data());
+  }
+
+  @Test
+  @DisplayName("resolveSys fails when $sys is missing or not a map")
+  void sysNotMap() {
+    assertFalse(PSBinaryAssemblerSupport.resolveSys(null).success());
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_SYS_NOT_MAP,
+        PSBinaryAssemblerSupport.resolveSys(Map.of()).error());
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_SYS_NOT_MAP,
+        PSBinaryAssemblerSupport.resolveSys(Map.of("$sys", "nope")).error());
+  }
+
+  @Test
+  @DisplayName("resolveSys fails when mimetype or binary missing or wrong type")
+  void missingOrWrongTypes() {
+    Map<String, Object> noMime = new HashMap<>();
+    noMime.put("binary", new byte[] {1});
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_MIMETYPE_UNBOUND,
+        PSBinaryAssemblerSupport.resolveSys(Map.of("$sys", noMime)).error());
+
+    Map<String, Object> noBin = new HashMap<>();
+    noBin.put("mimetype", "a/b");
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_BINARY_UNBOUND,
+        PSBinaryAssemblerSupport.resolveSys(Map.of("$sys", noBin)).error());
+
+    Map<String, Object> badMime = new HashMap<>();
+    badMime.put("mimetype", 12);
+    badMime.put("binary", new byte[] {1});
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_MIMETYPE_TYPE,
+        PSBinaryAssemblerSupport.resolveSys(Map.of("$sys", badMime)).error());
+
+    Map<String, Object> badBin = new HashMap<>();
+    badBin.put("mimetype", "a/b");
+    badBin.put("binary", "nope");
+    assertEquals(
+        PSBinaryAssemblerSupport.ERR_BINARY_TYPE,
+        PSBinaryAssemblerSupport.resolveSys(Map.of("$sys", badBin)).error());
+  }
+}

--- a/system/src/test/java/com/percussion/services/assembly/jexl/PSAssemblerUtilsTypedTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/jexl/PSAssemblerUtilsTypedTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.assembly.jexl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.assembly.IPSAssemblyItem;
+import com.percussion.util.PSStopwatch;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** JEXL residual typing for combine() / percTimers (#3280). */
+@Tag("UnitTest")
+class PSAssemblerUtilsTypedTest {
+
+  private final PSAssemblerUtils utils = new PSAssemblerUtils();
+
+  @Test
+  @DisplayName("combine(urlquery) collects repeated keys as String[] without unchecked List casts")
+  void combineUrlQueryRepeatedKeys() {
+    Map<String, String[]> input = new HashMap<>();
+    input.put("keep", new String[] {"orig"});
+    Map<String, Object> combined = utils.combine(input, "a=1&a=2&b=x");
+
+    assertArrayEquals(new String[] {"orig"}, (String[]) combined.get("keep"));
+    assertArrayEquals(new String[] {"1", "2"}, (String[]) combined.get("a"));
+    assertArrayEquals(new String[] {"x"}, (String[]) combined.get("b"));
+  }
+
+  @Test
+  @DisplayName("combine(urlquery) rejects malformed pairs")
+  void combineUrlQueryMalformed() {
+    assertThrows(
+        IllegalArgumentException.class, () -> utils.combine(Map.of(), "ok=1&badpair"));
+  }
+
+  @Test
+  @DisplayName("copyTimers keeps PSStopwatch entries and skips others")
+  void copyTimersTyped() {
+    PSStopwatch watch = new PSStopwatch();
+    Map<Object, Object> raw = new HashMap<>();
+    raw.put("render", watch);
+    raw.put(1, watch);
+    raw.put("other", "nope");
+
+    HashMap<String, PSStopwatch> typed = PSAssemblerUtils.copyTimers(raw);
+    assertEquals(1, typed.size());
+    assertEquals(watch, typed.get("render"));
+    assertTrue(PSAssemblerUtils.copyTimers(null).isEmpty());
+  }
+
+  @Test
+  @DisplayName("timerStart writes percTimers onto the live $sys map")
+  void timerStartWritesThroughSys() {
+    IPSAssemblyItem item = mock(IPSAssemblyItem.class);
+    Map<String, Object> sys = new HashMap<>();
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$sys", sys);
+    when(item.getBindings()).thenReturn(bindings);
+
+    utils.timerStart(item, "assemble");
+    Object percTimers = sys.get("percTimers");
+    assertTrue(percTimers instanceof Map<?, ?>);
+    assertTrue(((Map<?, ?>) percTimers).containsKey("assemble"));
+
+    utils.timerStop(item, "assemble");
+    assertTrue(utils.timerElapsed(item, "assemble") >= 0.0);
+    utils.timerReset(item);
+    assertTrue(((Map<?, ?>) sys.get("percTimers")).isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized residual of #3280 / leftover of #3265 / epic #2022: type remaining `com.percussion.services.assembly` rawtypes/unchecked map usage with real generics.

- **Assemblers:** drop redundant `getBindings()` casts on `PSHtmlAssembler` / `PSMarkdownAssembler`; extract `PSBinaryAssemblerSupport.resolveSys` (`Map<?,?>` reads)
- **Work item:** `PSAssemblyWorkItem.getMetaData` uses a live typed `$sys.metadata` view (`PSAssemblyBindingMaps`)
- **Nav:** `PSNavHelper.putNavBaseFromVariables` + `getParams`; `PSNavonNodeInvocationHandler.copyPropertyMap`
- **JEXL:** `PSAssemblerUtils.combine` uses `Map<String, List<String>>`; timers use the live `$sys` view
- **Finder:** `PSContentFinderBase.find` writes `$sys.hasMore` through the same helper
- **Tests:** binding maps, binary resolve, nav helpers, jexl combine/timers, metadata write-through

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent:** #2022
**Fixes:** #3280
**Related leftover of:** #3265

## Product documentation

- [x] N/A — pure tech-debt generics / no product behavior, UX, API, or operator-step change

## Test plan

1. From `system/`: `../mvnw.cmd clean install` (JDK 21)
2. Focused: `../mvnw.cmd "-Dtest=PSAssemblyBindingMapsTest,PSBinaryAssemblerSupportTest,PSNavHelperTypedTest,PSAssemblerUtilsTypedTest,PSServicesPackageTypedTest" test`
3. Confirm BUILD SUCCESS and new/updated tests green

## Checklist

- [x] **Product documentation** — N/A (not product-facing): pure tech-debt generics
- [x] **Unit / module tests** — new/extended unit tests; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## Gates evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **2073**, Failures: 0, Errors: 0, Skipped: 241
- **focused tests:** 22 green (`PSAssemblyBindingMapsTest` 4, `PSBinaryAssemblerSupportTest` 3, `PSNavHelperTypedTest` 3, `PSAssemblerUtilsTypedTest` 4, `PSServicesPackageTypedTest` 8)
- **downstream_checked:** none — no public type made `final`/`sealed`; no public/protected method or ctor signature change. Added new helper types only.
- **C5 UI:** N/A (backend tech-debt only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
