### PR TITLE
fix(dce): type display table and search unchecked residuals (#3287)

### DIFF
--- a/docs/ai-generated/code-reviews/3287-dce-display-search-unchecked-erlang.md
+++ b/docs/ai-generated/code-reviews/3287-dce-display-search-unchecked-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — #3287 DCE display table + search unchecked
+
+**Scope:** uncommitted `fix/issue-3287-dce-display-search-unchecked` vs `origin/main`  
+**Module:** `modules/DesktopContentExplorer`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for new helpers; no path I/O; change-class is local typed-copy helpers (peers: `PSSearchDialog` static helpers + unit tests)
+
+## Summary
+
+Removes leftover `@SuppressWarnings("unchecked")` / `rawtypes` on three Explorer display/search helpers by:
+
+- Reading `PSDisplayFormatTableModel.getData()` via `getValueAt` instead of casting `getDataVector()` rows
+- Copying `PSTableSorter.getSortingColumns()` through a typed `List<Integer>` helper
+- Copying the raw `getContentIdList()` through a typed helper; dropping obsolete suppressions on already-typed `ms_cxPropSet` / `ms_cxRCPropSet`
+
+No public/protected signatures changed. No UX change. C5/product-docs N/A.
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path construction or assertions.
+
+## Issues
+
+None.
+
+## Tests
+
+- `PSDisplayFormatTableModelTest.getDataOnEmptyModelReturnsEmptyIterator` plus existing `getData()` populated-row coverage
+- `PSMainDisplayPanelTest` for null/empty/skip-non-Integer sort indexes
+- `PSExecutableSearchTest` for null-preserving content-id copy and CX vs RC prop-set copies
+
+Standalone `modules/DesktopContentExplorer` `mvnw.cmd clean install`: **BUILD SUCCESS**, Surefire Failures: 0 (including new tests).

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatTableModel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatTableModel.java
@@ -272,13 +272,14 @@ public class PSDisplayFormatTableModel extends PSTableModel {
   @Override
   public Iterator<Object> getData() {
     List<Object> data = new ArrayList<>();
-
-    for (Object rowObj : getDataVector()) {
-      @SuppressWarnings("unchecked")
-      Vector<Object> rowData = (Vector<Object>) rowObj;
-      if (!rowData.isEmpty()) data.add(rowData.get(0));
+    // Prefer TableModel cell access over DefaultTableModel#getDataVector() so we
+    // do not need an unchecked cast of each raw row Vector.
+    int rowCount = getRowCount();
+    if (getColumnCount() > 0) {
+      for (int row = 0; row < rowCount; row++) {
+        data.add(getValueAt(row, 0));
+      }
     }
-
     return data.iterator();
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
@@ -315,8 +315,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
     List<Integer> contentIdList = new ArrayList<>();
     List<Integer> dirtyIds = new ArrayList<>();
     List<Integer> refreshIds = null;
-    @SuppressWarnings("unchecked")
-    List<Integer> origContentIdList = (List<Integer>) getContentIdList();
+    List<Integer> origContentIdList = copyContentIdList(getContentIdList());
     Map<String, String> origSearchState = null;
 
     boolean expandSynonyms = false;
@@ -667,9 +666,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
      * Generate a property set to add to node. The set is the static set
      * for the search type combined with the display columns.
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    Set<String> propList =
-        isRCSearch ? new HashSet<String>(ms_cxRCPropSet) : new HashSet<String>(ms_cxPropSet);
+    Set<String> propList = copySearchPropSet(isRCSearch);
     /*
      * With Rhythmyx 5.6, every display column by internal name is eleigible
      * to be submitted to server if a server action is configured to do so by
@@ -813,6 +810,41 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    */
   static Comparator<PSNode> categoryLabelComparator() {
     return (o1, o2) -> o1.toString().compareTo(o2.toString());
+  }
+
+  /**
+   * Copies a raw content-id list (from {@code getContentIdList()}) into a typed list. {@code null}
+   * is preserved so callers can distinguish "no id filter" from an empty filter.
+   *
+   * <p>Package-private static for unit tests (no instance state).
+   *
+   * @param ids may be {@code null}; non-{@link Integer} entries are skipped
+   * @return {@code null} if {@code ids} is {@code null}, otherwise a new typed list
+   */
+  static List<Integer> copyContentIdList(List<?> ids) {
+    if (ids == null) {
+      return null;
+    }
+    List<Integer> copy = new ArrayList<>(ids.size());
+    for (Object id : ids) {
+      if (id instanceof Integer contentId) {
+        copy.add(contentId);
+      }
+    }
+    return copy;
+  }
+
+  /**
+   * Mutable copy of the static CX or related-content property name set used when building search
+   * result nodes.
+   *
+   * <p>Package-private static for unit tests (no instance state).
+   *
+   * @param isRCSearch {@code true} for related-content property names
+   * @return a new {@link HashSet}, never {@code null}
+   */
+  static Set<String> copySearchPropSet(boolean isRCSearch) {
+    return isRCSearch ? new HashSet<>(ms_cxRCPropSet) : new HashSet<>(ms_cxPropSet);
   }
 
   /**

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainDisplayPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainDisplayPanel.java
@@ -229,11 +229,9 @@ public class PSMainDisplayPanel extends JScrollPane
               // save sorting info if we have any
               PSNode root = getDataModel().getRoot();
               if (root != null) {
-                // PSTableSorter still exposes raw List of Integer column indices
-                @SuppressWarnings("unchecked")
-                List<Integer> sortCols =
-                    (List<Integer>) m_childViewTableModel.getSortingColumns();
-                root.setLastSortColumns(sortCols);
+                // PSTableSorter still exposes a raw List of Integer column indices
+                root.setLastSortColumns(
+                    copySortColumnIndexes(m_childViewTableModel.getSortingColumns()));
                 root.setLastSortedAsc(m_childViewTableModel.isAscending());
               }
             }
@@ -1483,6 +1481,29 @@ public class PSMainDisplayPanel extends JScrollPane
    * through calls to <code>
    * setData(PSNode, PSNode)</code>.
    */
+  /**
+   * Copies sort-column indexes from {@link PSTableSorter#getSortingColumns()} (raw {@link List} of
+   * {@link Integer}) into a typed list. Non-{@link Integer} entries are skipped.
+   *
+   * <p>Package-private static for unit tests (no instance state).
+   *
+   * @param columns the sorter's column-index list, may be {@code null}
+   * @return a new typed list, never {@code null}; empty when {@code columns} is {@code null} or
+   *     empty
+   */
+  static List<Integer> copySortColumnIndexes(List<?> columns) {
+    if (columns == null || columns.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Integer> copy = new ArrayList<>(columns.size());
+    for (Object col : columns) {
+      if (col instanceof Integer index) {
+        copy.add(index);
+      }
+    }
+    return copy;
+  }
+
   PSTableSorter m_childViewTableModel;
 
   /**

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatTableModelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatTableModelTest.java
@@ -70,6 +70,13 @@ public class PSDisplayFormatTableModelTest {
   }
 
   @Test
+  public void getDataOnEmptyModelReturnsEmptyIterator() {
+    PSDisplayFormatTableModel model = newModel();
+    Iterator<Object> data = model.getData();
+    assertFalse(data.hasNext());
+  }
+
+  @Test
   public void setRootWithoutDisplayFormatUsesNameColumnAndNodeData() {
     PSDisplayFormatTableModel model = newModel();
     PSNode parent = folder("p", "Parent");

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExecutableSearchTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExecutableSearchTest.java
@@ -18,14 +18,17 @@ package com.percussion.cx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.cx.objectstore.PSNode;
+import com.percussion.search.PSBaseExecutableSearch;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -93,5 +96,37 @@ public class PSExecutableSearchTest {
     // items are not reordered (first child is not TYPE_CATEGORY)
     assertEquals("Beta", kids.next().getLabel());
     assertEquals("Alpha", kids.next().getLabel());
+  }
+
+  @Test
+  public void copyContentIdListNullReturnsNull() {
+    assertNull(PSExecutableSearch.copyContentIdList(null));
+  }
+
+  @Test
+  public void copyContentIdListCopiesIntegersAndSkipsNonIntegers() {
+    List<Object> raw = new ArrayList<>();
+    raw.add(Integer.valueOf(7));
+    raw.add("not-an-id");
+    raw.add(Integer.valueOf(9));
+    List<Integer> copy = PSExecutableSearch.copyContentIdList(raw);
+    assertEquals(Arrays.asList(7, 9), copy);
+    copy.add(11);
+    assertEquals(3, raw.size());
+    assertFalse(raw.contains(11));
+  }
+
+  @Test
+  public void copySearchPropSetUsesCxAndRelatedContentBases() {
+    Set<String> cx = PSExecutableSearch.copySearchPropSet(false);
+    Set<String> rc = PSExecutableSearch.copySearchPropSet(true);
+    assertTrue(cx.containsAll(PSBaseExecutableSearch.ms_cxPropSet));
+    assertTrue(rc.containsAll(PSBaseExecutableSearch.ms_cxRCPropSet));
+    assertTrue(cx.contains("sys_contentid"));
+    assertTrue(rc.contains("sys_variantid"));
+    cx.add("extra-cx");
+    rc.add("extra-rc");
+    assertFalse(PSBaseExecutableSearch.ms_cxPropSet.contains("extra-cx"));
+    assertFalse(PSBaseExecutableSearch.ms_cxRCPropSet.contains("extra-rc"));
   }
 }

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSMainDisplayPanelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSMainDisplayPanelTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed sort-column copy helpers on {@link PSMainDisplayPanel}. Does not
+ * construct the Swing panel (requires a live applet / action manager).
+ */
+public class PSMainDisplayPanelTest {
+
+  @Test
+  public void copySortColumnIndexesNullOrEmptyReturnsEmpty() {
+    assertTrue(PSMainDisplayPanel.copySortColumnIndexes(null).isEmpty());
+    assertTrue(PSMainDisplayPanel.copySortColumnIndexes(Collections.emptyList()).isEmpty());
+  }
+
+  @Test
+  public void copySortColumnIndexesCopiesIntegersAndSkipsOthers() {
+    List<Object> raw = new ArrayList<>();
+    raw.add(Integer.valueOf(2));
+    raw.add("skip");
+    raw.add(Integer.valueOf(0));
+    List<Integer> copy = PSMainDisplayPanel.copySortColumnIndexes(raw);
+    assertEquals(Arrays.asList(2, 0), copy);
+    copy.add(5);
+    assertEquals(3, raw.size());
+  }
+}


### PR DESCRIPTION
## Summary

Removes leftover unchecked/rawtypes suppressions on Desktop Content Explorer display-table and search helpers (parent #2045 / related #2326).

- `PSDisplayFormatTableModel.getData()` now walks rows via `getValueAt` instead of casting `getDataVector()` row vectors.
- `PSMainDisplayPanel` copies `PSTableSorter.getSortingColumns()` through `copySortColumnIndexes`.
- `PSExecutableSearch` copies the raw `getContentIdList()` through `copyContentIdList` and builds prop-name sets via `copySearchPropSet` (static sets were already `Set<String>`).

No product UX change. Does not touch `PSActionManager` (#3286) or this-escape (#3288).

Fixes #3287  
Parent: #2045

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Standalone module build (done in this session):
   - `cd modules/DesktopContentExplorer`
   - `..\..\mvnw.cmd clean install`
2. Confirm new tests: `PSDisplayFormatTableModelTest` (empty `getData()`), `PSMainDisplayPanelTest`, `PSExecutableSearchTest` content-id / prop-set helpers.
3. No live Explorer UX change to click-test; Swing panel construction is not required.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal generics / tech-debt only; no operator or UX change
- [x] **Unit / module tests** — helpers + `getData()` covered; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change; DCE Java-only)
- [x] **Build gates** — standalone `modules/DesktopContentExplorer` clean install (no skipTests); C2 N/A (no public API / `final` / signature change)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-13). Surefire: new tests pass (`PSDisplayFormatTableModelTest` 11, `PSMainDisplayPanelTest` 2, `PSExecutableSearchTest` 7); module suite Failures: 0, Errors: 0.
- **downstream_checked:** none (C2 did not apply — package-private helpers only)

### C5 UI proof

N/A — no browser/WebUI surface.

> Co-Authored by Grok Build using grok-4.5 with agent main.
