### PR TITLE
fix(perc-system): type CookieModule jar and folder locator paths (#3290)

### DIFF
--- a/docs/ai-generated/code-reviews/3290-httpclient-folder-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/3290-httpclient-folder-xlint-erlang.md
@@ -1,0 +1,44 @@
+# Erlang review: #3290 HTTPClient CookieModule + PSServerFolderProcessor Xlint
+
+**Branch:** `fix/issue-3290-httpclient-folder-xlint`  
+**Base:** `origin/main`  
+**Date:** 2026-08-13  
+**Reviewer:** Erlang (pre-commit)
+
+## Summary
+
+Typed cookie-jar deserialization in `CookieModule` (runtime-checked `ConcurrentHashMap` of `Cookie`) and extracted `PSFolderLocatorPaths` so folder locator paths are `List<List<PSLocator>>` without an unchecked dual-return helper. Public `getFolderLocatorPaths(PSLocator)` signature unchanged. HTTP/cookie send/accept behavior unchanged.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests cover new type-check and path-walk logic. Paths in new tests use `java.nio.file.Path` / `Files`. No product-facing surface; no WebUI.
+
+**Memory patterns hit:** missing behavioral tests; non-portable path joins (checked — not present); change-class closure for Xlint (tests + module suite, no Spring adaptor / Playwright companions required).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Cookie jar tests use `Path` / `Files`
+- [x] No Unix-only absolute path assertions
+- [x] Temp files via JUnit `@TempDir`
+
+## Issues
+
+None (blocking).
+
+### Suggestions (non-blocking)
+
+- `PSFolderLocatorPaths.collect` NPEs if `parentLookup` returns `null`; production lookup always returns a list. Could treat null as empty if a future caller is sloppy.
+- Folder ancestor walk still recurses without cycle detection (same as the previous private helper).
+
+## Tests / build
+
+- `CookieModuleCookieJarTest` — 4 tests
+- `PSServerFolderProcessorLocatorPathsTest` — 5 tests
+- `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: 2112, Failures: 0, Errors: 0, Skipped: 241

--- a/docs/ai-generated/code-reviews/3290-httpclient-folder-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/3290-httpclient-folder-xlint-erlang.md
@@ -37,6 +37,16 @@ None (blocking).
 - `PSFolderLocatorPaths.collect` NPEs if `parentLookup` returns `null`; production lookup always returns a list. Could treat null as empty if a future caller is sloppy.
 - Folder ancestor walk still recurses without cycle detection (same as the previous private helper).
 
+## Re-review (2026-08-13, PR #3293 kilo thread)
+
+Kilo flagged `collect` NPE if `FolderParentLookup.getImmediateParents` returns null. Follow-up:
+
+- `parentsOrEmpty` coerces null to `List.of()` at both `collect` and `appendAncestors` call sites.
+- Interface `@return` documents never-null; collect still treats null as empty (defense in depth).
+- Tests: `collect_nullImmediateParents_empty`, `collect_nullAncestorParents_stopsWalk`.
+
+**Recommendation:** approve. **May commit/push: yes.** No blocking bugs. Cycle-detection still a non-blocking suggestion.
+
 ## Tests / build
 
 - `CookieModuleCookieJarTest` — 4 tests

--- a/system/src/main/java/com/percussion/HTTPClient/CookieModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/CookieModule.java
@@ -31,6 +31,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ProtocolException;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -114,14 +115,38 @@ public class CookieModule implements HTTPClientModule {
         String filterSpec = SerializationValidation.buildPackageFilterSpec("com.percussion.**");
         ois.setObjectInputFilter(Config.createFilter(filterSpec));
 
-        @SuppressWarnings("unchecked")
-        ConcurrentHashMap<Cookie, Cookie> loaded =
-            (ConcurrentHashMap<Cookie, Cookie>) ois.readObject();
-        cookie_cntxt_list.put(HTTPConnection.getDefaultContext(), loaded);
+        cookie_cntxt_list.put(HTTPConnection.getDefaultContext(), readCookieJar(ois));
       } catch (IOException | ClassNotFoundException e) {
         cookie_jar = null;
       }
     }
+  }
+
+  /**
+   * Reads a cookie jar written by {@link #saveCookies()}. Rebuilds a typed map from runtime-checked
+   * entries so {@link ObjectInputStream#readObject()} does not require an unchecked cast.
+   *
+   * @param ois stream positioned at the serialized map, never {@code null}
+   * @return typed cookie map, never {@code null} (may be empty)
+   * @throws IOException if the payload is not a {@link ConcurrentHashMap} of {@link Cookie} entries
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  static ConcurrentHashMap<Cookie, Cookie> readCookieJar(ObjectInputStream ois)
+      throws IOException, ClassNotFoundException {
+    Object raw = ois.readObject();
+    if (!(raw instanceof ConcurrentHashMap<?, ?> rawMap)) {
+      throw new IOException("cookie jar is not a ConcurrentHashMap");
+    }
+    ConcurrentHashMap<Cookie, Cookie> loaded = new ConcurrentHashMap<>();
+    for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+      Object key = entry.getKey();
+      Object value = entry.getValue();
+      if (!(key instanceof Cookie cookieKey) || !(value instanceof Cookie cookieValue)) {
+        throw new IOException("cookie jar contains a non-Cookie entry");
+      }
+      loaded.put(cookieKey, cookieValue);
+    }
+    return loaded;
   }
 
   private static void saveCookies() {

--- a/system/src/main/java/com/percussion/server/webservices/PSFolderLocatorPaths.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSFolderLocatorPaths.java
@@ -33,6 +33,13 @@ final class PSFolderLocatorPaths {
   /** Immediate folder parents of a locator (community filtering is the caller's concern). */
   @FunctionalInterface
   interface FolderParentLookup {
+    /**
+     * Immediate folder parents of {@code locator}.
+     *
+     * @param locator item or folder locator, never {@code null}
+     * @return parent locators; never {@code null} (empty when the locator has no folder parent).
+     *     {@link #collect} and the ancestor walk treat a {@code null} return as empty.
+     */
     List<PSLocator> getImmediateParents(PSLocator locator) throws PSCmsException;
   }
 
@@ -54,7 +61,7 @@ final class PSFolderLocatorPaths {
     if (parentLookup == null) {
       throw new IllegalArgumentException("parentLookup cannot be null");
     }
-    List<PSLocator> immediate = parentLookup.getImmediateParents(itemLocator);
+    List<PSLocator> immediate = parentsOrEmpty(parentLookup.getImmediateParents(itemLocator));
     List<List<PSLocator>> idPaths = new ArrayList<>(immediate.size());
     for (PSLocator parent : immediate) {
       List<PSLocator> path = new ArrayList<>();
@@ -72,11 +79,16 @@ final class PSFolderLocatorPaths {
   private static void appendAncestors(
       PSLocator folderLocator, List<PSLocator> path, FolderParentLookup parentLookup)
       throws PSCmsException {
-    List<PSLocator> immediate = parentLookup.getImmediateParents(folderLocator);
+    List<PSLocator> immediate = parentsOrEmpty(parentLookup.getImmediateParents(folderLocator));
     if (!immediate.isEmpty()) {
       PSLocator owner = immediate.get(0);
       path.add(owner);
       appendAncestors(owner, path, parentLookup);
     }
+  }
+
+  /** Treats a null lookup result as no parents so callers cannot NPE on {@code size()}/{@code isEmpty()}. */
+  private static List<PSLocator> parentsOrEmpty(List<PSLocator> immediate) {
+    return immediate == null ? List.of() : immediate;
   }
 }

--- a/system/src/main/java/com/percussion/server/webservices/PSFolderLocatorPaths.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSFolderLocatorPaths.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.webservices;
+
+import com.percussion.cms.PSCmsException;
+import com.percussion.design.objectstore.PSLocator;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Typed folder-locator path collection used by {@link PSServerFolderProcessor}. Extracted so
+ * ancestor-walk behavior can be unit-tested without constructing the processor (which requires a
+ * live CMS object catalog).
+ */
+final class PSFolderLocatorPaths {
+
+  private PSFolderLocatorPaths() {}
+
+  /** Immediate folder parents of a locator (community filtering is the caller's concern). */
+  @FunctionalInterface
+  interface FolderParentLookup {
+    List<PSLocator> getImmediateParents(PSLocator locator) throws PSCmsException;
+  }
+
+  /**
+   * Builds all ancestor locator paths using the given immediate-parent lookup. Each path is
+   * parent-first, root-last. When walking a single path toward the root, only the first immediate
+   * parent is used (folders have one folder parent).
+   *
+   * @param itemLocator item or folder locator, never {@code null}
+   * @param parentLookup immediate folder parents of a locator, never {@code null}
+   * @return list of paths, never {@code null}, may be empty
+   * @throws PSCmsException if the lookup fails
+   */
+  static List<List<PSLocator>> collect(PSLocator itemLocator, FolderParentLookup parentLookup)
+      throws PSCmsException {
+    if (itemLocator == null) {
+      throw new IllegalArgumentException("itemLocator cannot be null");
+    }
+    if (parentLookup == null) {
+      throw new IllegalArgumentException("parentLookup cannot be null");
+    }
+    List<PSLocator> immediate = parentLookup.getImmediateParents(itemLocator);
+    List<List<PSLocator>> idPaths = new ArrayList<>(immediate.size());
+    for (PSLocator parent : immediate) {
+      List<PSLocator> path = new ArrayList<>();
+      path.add(parent);
+      appendAncestors(parent, path, parentLookup);
+      idPaths.add(path);
+    }
+    return idPaths;
+  }
+
+  /**
+   * Appends ancestors onto {@code path} until the lookup reports no parent. Only the first immediate
+   * parent is followed at each step.
+   */
+  private static void appendAncestors(
+      PSLocator folderLocator, List<PSLocator> path, FolderParentLookup parentLookup)
+      throws PSCmsException {
+    List<PSLocator> immediate = parentLookup.getImmediateParents(folderLocator);
+    if (!immediate.isEmpty()) {
+      PSLocator owner = immediate.get(0);
+      path.add(owner);
+      appendAncestors(owner, path, parentLookup);
+    }
+  }
+}

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -5046,57 +5046,27 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    *     locators to the root.
    * @throws PSCmsException if an error occurs.
    */
-  @SuppressWarnings("unchecked")
   public List<List<PSLocator>> getFolderLocatorPaths(PSLocator itemLocator) throws PSCmsException {
     if (itemLocator == null) throw new IllegalArgumentException("itemLocator cannot be null");
-    return (List<List<PSLocator>>) getFolderLocatorPaths(itemLocator, null);
+    return PSFolderLocatorPaths.collect(itemLocator, this::lookupImmediateFolderParents);
   }
 
   /**
-   * The utility method used by {@link #getFolderLocatorPaths(PSLocator)}. See {@link
-   * #getFolderLocatorPaths(PSLocator)} for detail.
-   *
-   * @param itemLocator the locator of an item or folder, assume not <code>null</code> and it is a
-   *     folder locator if the <code>parents</code> is not <code>null</code>.
-   * @param parents the parent locators. It is used to collect all parent locators for the supplied
-   *     folder if it is not <code>null</code>.
-   * @return a list of locator paths if <code>parents</code> is <code>null</code>; otherwise returns
-   *     the <code>parents</code>. Never <code>null</code>, may be empty.
-   * @throws PSCmsException if an error occurs.
+   * Looks up immediate folder-relationship owners of {@code itemLocator} (community filtering off).
    */
-  private List<?> getFolderLocatorPaths(PSLocator itemLocator, List<PSLocator> parents)
-      throws PSCmsException {
-    // get immediate parents
+  private List<PSLocator> lookupImmediateFolderParents(PSLocator itemLocator) throws PSCmsException {
     PSRelationshipFilter filter = new PSRelationshipFilter();
     filter.setName(FOLDER_RELATE_TYPE);
     filter.setDependent(itemLocator);
     filter.setCommunityFiltering(false);
 
     PSRelationshipSet relSet = PSRelationshipProcessor.getInstance().getRelationships(filter);
-    Iterator<?> rels = relSet.iterator();
-    PSRelationship rel;
-    if (parents == null) // 1st time come in, get paths for an item/folder
-    {
-      // get the folder paths (may be more than one) for the item locator.
-      List<List<PSLocator>> idPaths = new ArrayList<>(relSet.size());
-      while (rels.hasNext()) {
-        rel = (PSRelationship) rels.next();
-        parents = new ArrayList<>();
-        parents.add(rel.getOwner());
-        idPaths.add((List<PSLocator>) getFolderLocatorPaths(rel.getOwner(), parents));
-      }
-      return idPaths;
+    List<PSLocator> owners = new ArrayList<>(relSet.size());
+    Iterator<PSRelationship> rels = relSet.iterator();
+    while (rels.hasNext()) {
+      owners.add(rels.next().getOwner());
     }
-
-    // get one folder path to the root.
-    if (rels.hasNext()) {
-      // folder has only one immediate folder parent
-      rel = (PSRelationship) rels.next();
-      parents.add(rel.getOwner());
-      getFolderLocatorPaths(rel.getOwner(), parents);
-    }
-
-    return parents;
+    return owners;
   }
 
   /**

--- a/system/src/test/java/com/percussion/HTTPClient/CookieModuleCookieJarTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/CookieModuleCookieJarTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Behavioral tests for typed cookie-jar deserialization (#3290 / parent #2299). */
+@DisplayName("CookieModule cookie jar generics")
+class CookieModuleCookieJarTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  @DisplayName("round-trips ConcurrentHashMap of Cookie entries")
+  void readCookieJar_roundTripsTypedCookies() throws Exception {
+    Cookie cookie = new Cookie("sid", "abc123", "example.com", "/", null, false);
+    ConcurrentHashMap<Cookie, Cookie> written = new ConcurrentHashMap<>();
+    written.put(cookie, cookie);
+
+    ConcurrentHashMap<Cookie, Cookie> loaded = readJar(written);
+
+    assertEquals(1, loaded.size());
+    Cookie found = loaded.get(cookie);
+    assertEquals("sid", found.getName());
+    assertEquals("abc123", found.getValue());
+    assertEquals("example.com", found.getDomain());
+    assertEquals("/", found.getPath());
+  }
+
+  @Test
+  @DisplayName("empty ConcurrentHashMap is accepted")
+  void readCookieJar_emptyMap() throws Exception {
+    ConcurrentHashMap<Cookie, Cookie> loaded = readJar(new ConcurrentHashMap<Cookie, Cookie>());
+    assertTrue(loaded.isEmpty());
+  }
+
+  @Test
+  @DisplayName("HashMap payload is rejected (saveCookies writes ConcurrentHashMap)")
+  void readCookieJar_rejectsHashMap() throws Exception {
+    HashMap<Cookie, Cookie> wrongType = new HashMap<>();
+    Cookie cookie = new Cookie("sid", "x", "example.com", "/", null, false);
+    wrongType.put(cookie, cookie);
+
+    IOException ex = assertThrows(IOException.class, () -> readJar(wrongType));
+    assertTrue(ex.getMessage().contains("ConcurrentHashMap"));
+  }
+
+  @Test
+  @DisplayName("non-Cookie map entries are rejected")
+  void readCookieJar_rejectsNonCookieEntries() throws Exception {
+    ConcurrentHashMap<Object, Object> raw = new ConcurrentHashMap<>();
+    raw.put("JSESSIONID", "not-a-cookie");
+
+    IOException ex = assertThrows(IOException.class, () -> readJar(raw));
+    assertTrue(ex.getMessage().contains("non-Cookie"));
+  }
+
+  private ConcurrentHashMap<Cookie, Cookie> readJar(Object payload) throws Exception {
+    Path jar = tempDir.resolve("cookies.ser");
+    try (ObjectOutputStream oos = new ObjectOutputStream(Files.newOutputStream(jar))) {
+      oos.writeObject(payload);
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(jar))) {
+      return CookieModule.readCookieJar(ois);
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/server/webservices/PSServerFolderProcessorLocatorPathsTest.java
+++ b/system/src/test/java/com/percussion/server/webservices/PSServerFolderProcessorLocatorPathsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.webservices;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.PSCmsException;
+import com.percussion.design.objectstore.PSLocator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed folder locator path collection (#3290 / parent #2299). Lookup is
+ * injected so tests do not construct {@link PSServerFolderProcessor} (static singleton needs a live
+ * CMS object catalog).
+ */
+@DisplayName("PSServerFolderProcessor folder locator paths")
+class PSServerFolderProcessorLocatorPathsTest {
+
+  @Test
+  @DisplayName("null locator is rejected")
+  void collect_rejectsNullLocator() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSFolderLocatorPaths.collect(null, locator -> List.of()));
+  }
+
+  @Test
+  @DisplayName("null parent lookup is rejected")
+  void collect_rejectsNullLookup() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSFolderLocatorPaths.collect(new PSLocator(100, 1), null));
+  }
+
+  @Test
+  @DisplayName("item with no folder parents yields an empty path list")
+  void collect_noParents_empty() throws PSCmsException {
+    PSLocator item = new PSLocator(100, 1);
+    List<List<PSLocator>> paths = PSFolderLocatorPaths.collect(item, locator -> List.of());
+    assertTrue(paths.isEmpty());
+  }
+
+  @Test
+  @DisplayName("item in two folders yields one parent-first path per folder")
+  void collect_twoParents_twoPaths() throws PSCmsException {
+    PSLocator item = new PSLocator(100, 1);
+    PSLocator folderA = new PSLocator(10, 1);
+    PSLocator folderB = new PSLocator(20, 1);
+    PSLocator root = new PSLocator(1, 1);
+
+    Map<Integer, List<PSLocator>> tree = new HashMap<>();
+    tree.put(item.getId(), List.of(folderA, folderB));
+    tree.put(folderA.getId(), List.of(root));
+    tree.put(folderB.getId(), List.of());
+    tree.put(root.getId(), List.of());
+
+    List<List<PSLocator>> paths = PSFolderLocatorPaths.collect(item, lookup(tree));
+
+    assertEquals(2, paths.size());
+    assertEquals(List.of(folderA, root), paths.get(0));
+    assertEquals(List.of(folderB), paths.get(1));
+  }
+
+  @Test
+  @DisplayName("ancestor walk follows only the first immediate parent")
+  void collect_walkUsesFirstParentOnly() throws PSCmsException {
+    PSLocator item = new PSLocator(100, 1);
+    PSLocator folder = new PSLocator(10, 1);
+    PSLocator firstRoot = new PSLocator(1, 1);
+    PSLocator ignoredRoot = new PSLocator(2, 1);
+
+    Map<Integer, List<PSLocator>> tree = new HashMap<>();
+    tree.put(item.getId(), List.of(folder));
+    tree.put(folder.getId(), List.of(firstRoot, ignoredRoot));
+    tree.put(firstRoot.getId(), List.of());
+
+    List<List<PSLocator>> paths = PSFolderLocatorPaths.collect(item, lookup(tree));
+
+    assertEquals(1, paths.size());
+    assertEquals(List.of(folder, firstRoot), paths.get(0));
+  }
+
+  private static PSFolderLocatorPaths.FolderParentLookup lookup(
+      Map<Integer, List<PSLocator>> tree) {
+    return locator -> {
+      List<PSLocator> parents = tree.get(locator.getId());
+      return parents == null ? new ArrayList<>() : parents;
+    };
+  }
+}

--- a/system/src/test/java/com/percussion/server/webservices/PSServerFolderProcessorLocatorPathsTest.java
+++ b/system/src/test/java/com/percussion/server/webservices/PSServerFolderProcessorLocatorPathsTest.java
@@ -53,6 +53,26 @@ class PSServerFolderProcessorLocatorPathsTest {
   }
 
   @Test
+  @DisplayName("null immediate-parent list is treated as empty")
+  void collect_nullImmediateParents_empty() throws PSCmsException {
+    PSLocator item = new PSLocator(100, 1);
+    List<List<PSLocator>> paths = PSFolderLocatorPaths.collect(item, locator -> null);
+    assertTrue(paths.isEmpty());
+  }
+
+  @Test
+  @DisplayName("null ancestor-parent list stops the walk without NPE")
+  void collect_nullAncestorParents_stopsWalk() throws PSCmsException {
+    PSLocator item = new PSLocator(100, 1);
+    PSLocator folder = new PSLocator(10, 1);
+    List<List<PSLocator>> paths =
+        PSFolderLocatorPaths.collect(
+            item, locator -> locator.getId() == item.getId() ? List.of(folder) : null);
+    assertEquals(1, paths.size());
+    assertEquals(List.of(folder), paths.get(0));
+  }
+
+  @Test
   @DisplayName("item with no folder parents yields an empty path list")
   void collect_noParents_empty() throws PSCmsException {
     PSLocator item = new PSLocator(100, 1);


### PR DESCRIPTION
## Summary

Clears remaining unchecked/rawtypes suppressions on `CookieModule` and `PSServerFolderProcessor` for parent **#2299** (slice 5 of **#2022**).

- `CookieModule.loadCookies()` now rebuilds a typed `ConcurrentHashMap<Cookie, Cookie>` via runtime-checked `readCookieJar` (no `@SuppressWarnings("unchecked")`). Valid jars still load; non-map / non-Cookie payloads throw `IOException` (same catch path as other load failures).
- Folder locator paths no longer use a dual-return `List<?>` helper. `PSFolderLocatorPaths` collects parent-first / root-last paths with typed `List<List<PSLocator>>`. Public `getFolderLocatorPaths(PSLocator)` signature is unchanged.

No HTTP/cookie send-accept behavior change. Security catalogers (#3289) and assembly leftovers (#3291) are out of scope.

Fixes #3290  
Parent tracker: #2299  
Grandparent: #2022

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (JDK 21) — expect BUILD SUCCESS.
2. Confirm new tests: `CookieModuleCookieJarTest` (round-trip, empty map, reject HashMap, reject non-Cookie entries).
3. Confirm `PSServerFolderProcessorLocatorPathsTest` (null args, no parents, two-folder item, first-parent-only ancestor walk).
4. Spot-check: no remaining `@SuppressWarnings("unchecked")` on `CookieModule` or `getFolderLocatorPaths`.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal Xlint / generics cleanup; no operator, admin, REST, or UI surface change
- [x] **Unit / module tests** — behavioral tests for cookie-jar typing and folder path collection; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone `system` clean install (no skipTests); C2 reverse-deps N/A (no `final` / public signature / package-visible API used by other modules)
- [x] **Cross-platform** — new tests use `Path` / `Files` / `@TempDir`; no hardcoded OS path separators

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-13T02:41:24-04:00). Tests run: 2112, Failures: 0, Errors: 0, Skipped: 241. New: CookieModuleCookieJarTest 4/0/0, PSServerFolderProcessorLocatorPathsTest 5/0/0.
- **downstream_checked:** none (C2 did not apply: public `getFolderLocatorPaths` signature unchanged; no type made `final`/`sealed`; no protected/package-visible API used by other modules changed)

## C5 UI proof

N/A — Java backend Xlint only; no browser surface.

> Co-Authored by Grok Build using grok-4.5 with agent main.
