### PR TITLE
fix(perc-system): leftover assembly/EhCache Xlint after #3280 (#3291)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3291-assembly-leftover-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3291-assembly-leftover-xlint-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review — #3291 assembly leftover Xlint after #3280
+
+**Scope:** uncommitted `fix/issue-3291-assembly-leftover-xlint` vs `origin/main`  
+**Module:** `system` / `perc-system`  
+**Change class:** leftover `-Xlint` rawtypes/unchecked after #3280 / PR #3284  
+**Memory patterns hit:** behavioral tests for changed helpers; prefer real generics over `@SuppressWarnings`; orphaned javadoc after extract; C2 public signature grep; no path I/O
+
+## Summary
+
+#3284 already typed `PSHtmlAssembler` / `PSMarkdownAssembler` / `PSBinaryAssembler`, `PSAssemblyWorkItem.getMetaData`, and `PSNavonNodeInvocationHandler.copyPropertyMap`. This slice:
+
+- Removes the leftover `@SuppressWarnings("rawtypes")` on `PSEhCacheFactoryBean.getObjectType` by matching `FactoryBean#getObjectType()` (`Class<?>`) and returning `Cache.class`.
+- Documents the inherent `LiveStringObjectMap.erase` unchecked conversion as the remaining assembly map cast.
+- Restores orphaned `loadLandingPage` javadoc that was left above `copyPropertyMap`.
+- Adds `PSEhCacheFactoryBeanTest` covering object type, missing manager, create/put-get, existing-region reuse, and TTL/TTI/eternal branches.
+
+Virtual Site YAML loaders were not touched.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+N/A — tests use in-memory Ehcache `CacheManagerBuilder`; no filesystem path construction.
+
+## Product documentation
+
+N/A — internal compiler-warning cleanup; no operator/user/API/config change.
+
+## Issues
+
+None.
+
+## Notes
+
+- C2: `getObjectType()` return type changed from `Class<? extends Cache>` (raw `Cache`) to `Class<?>` (interface contract). Grep found no `extends PSEhCacheFactoryBean` and no `new PSEhCacheFactoryBean() {`. Downstream module install not required.
+- Assemblers/workitem/navon remain as typed in #3284; leftover unchecked is isolated in `PSAssemblyBindingMaps.LiveStringObjectMap.erase`.
+- `system` standalone `mvnw clean install`: BUILD SUCCESS; Tests run: 2108, Failures: 0, Errors: 0, Skipped: 241.

--- a/system/services/src/com/percussion/services/assembly/PSAssemblyBindingMaps.java
+++ b/system/services/src/com/percussion/services/assembly/PSAssemblyBindingMaps.java
@@ -83,8 +83,10 @@ public final class PSAssemblyBindingMaps {
   }
 
   /**
-   * Write-through view. The single residual unchecked conversion is isolated here: JEXL stores
-   * {@code HashMap} / {@code LinkedHashMap} nodes that accept {@link String} keys.
+   * Write-through view. The single residual unchecked conversion for assembly leftover #3291
+   * (after #3280) is isolated here: JEXL stores {@code HashMap} / {@code LinkedHashMap} nodes
+   * that accept {@link String} keys. A fully typed write-through {@code Map<String, Object>}
+   * cannot be built from {@code Map<?,?>} without this inherent cast.
    */
   static final class LiveStringObjectMap extends AbstractMap<String, Object> {
     private final Map<Object, Object> delegate;

--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
@@ -462,12 +462,6 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
    }
 
    /**
-    * Finds the landing page and returns it as Property object.
-    * @return landing page property may be <code>null</code>.
-    * @throws PSCmsException
-    * @throws RepositoryException
-    */
-   /**
     * Copy a JCR property iterator backing map into a typed {@code Map<String, Property>}
     * without an unchecked {@link Map.Entry} cast.
     */
@@ -488,6 +482,13 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
       return map;
    }
 
+   /**
+    * Finds the landing page and returns it as Property object.
+    *
+    * @return landing page property may be <code>null</code>.
+    * @throws PSCmsException
+    * @throws RepositoryException
+    */
    private Property loadLandingPage() throws PSCmsException,
          RepositoryException
    {

--- a/system/services/src/com/percussion/services/memory/PSEhCacheFactoryBean.java
+++ b/system/services/src/com/percussion/services/memory/PSEhCacheFactoryBean.java
@@ -87,9 +87,13 @@ public class PSEhCacheFactoryBean implements FactoryBean<Cache<Serializable, Ser
         return cache;
     }
 
+    /**
+     * Matches {@link FactoryBean#getObjectType()} ({@code Class<?>}). Returning the raw
+     * {@code Cache} class object is required by type erasure; do not use {@code Class<?
+     * extends Cache>} (that form is itself a raw type).
+     */
     @Override
-    @SuppressWarnings("rawtypes")
-    public Class<? extends Cache> getObjectType() {
+    public Class<?> getObjectType() {
         return Cache.class;
     }
 

--- a/system/src/test/java/com/percussion/services/memory/PSEhCacheFactoryBeanTest.java
+++ b/system/src/test/java/com/percussion/services/memory/PSEhCacheFactoryBeanTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * FactoryBean type + create/lookup branches without Spring (#3291 leftover rawtypes).
+ */
+@Tag("UnitTest")
+class PSEhCacheFactoryBeanTest {
+
+  @Test
+  @DisplayName("getObjectType matches FactoryBean Class<?> and returns Cache.class")
+  void objectTypeIsCacheClass() {
+    PSEhCacheFactoryBean bean = new PSEhCacheFactoryBean();
+    assertEquals(Cache.class, bean.getObjectType());
+    assertTrue(bean.isSingleton());
+  }
+
+  @Test
+  @DisplayName("afterPropertiesSet requires cacheManager")
+  void missingCacheManager() {
+    PSEhCacheFactoryBean bean = new PSEhCacheFactoryBean();
+    bean.setCacheName("missing-mgr");
+    IllegalStateException ex = assertThrows(IllegalStateException.class, bean::afterPropertiesSet);
+    assertEquals("cacheManager must be set", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("creates a heap cache and supports put/get")
+  void createsCache() {
+    try (CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder().build(true)) {
+      PSEhCacheFactoryBean bean = newFactory(manager, "created-region");
+      bean.setMaxElementsInMemory(32);
+      bean.afterPropertiesSet();
+
+      Cache<Serializable, Serializable> cache = bean.getObject();
+      assertNotNull(cache);
+      assertSame(manager.getCache("created-region", Serializable.class, Serializable.class), cache);
+      cache.put("k", "v");
+      assertEquals("v", cache.get("k"));
+    }
+  }
+
+  @Test
+  @DisplayName("reuses an existing named cache region")
+  void reusesExistingCache() {
+    try (CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder().build(true)) {
+      Cache<Serializable, Serializable> existing =
+          manager.createCache(
+              "existing-region",
+              CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                      Serializable.class, Serializable.class, ResourcePoolsBuilder.heap(8))
+                  .build());
+      existing.put("seed", 1);
+
+      PSEhCacheFactoryBean bean = newFactory(manager, "existing-region");
+      bean.afterPropertiesSet();
+      assertSame(existing, bean.getObject());
+      assertEquals(1, bean.getObject().get("seed"));
+    }
+  }
+
+  @Test
+  @DisplayName("TTL, TTI, and eternal expiry branches create a usable cache")
+  void expiryBranches() {
+    try (CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder().build(true)) {
+      PSEhCacheFactoryBean ttl = newFactory(manager, "ttl-region");
+      ttl.setTimeToLive(30);
+      ttl.afterPropertiesSet();
+      assertNotNull(ttl.getObject());
+
+      PSEhCacheFactoryBean tti = newFactory(manager, "tti-region");
+      tti.setTimeToLive(0);
+      tti.setTimeToIdle(15);
+      tti.afterPropertiesSet();
+      assertNotNull(tti.getObject());
+
+      PSEhCacheFactoryBean eternal = newFactory(manager, "eternal-region");
+      eternal.setEternal(true);
+      eternal.setTimeToLive(30);
+      eternal.afterPropertiesSet();
+      assertNotNull(eternal.getObject());
+    }
+  }
+
+  private static PSEhCacheFactoryBean newFactory(CacheManager manager, String name) {
+    PSEhCacheFactoryBean bean = new PSEhCacheFactoryBean();
+    bean.setCacheManager(manager);
+    bean.setCacheName(name);
+    bean.setMaxElementsInMemory(16);
+    return bean;
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized leftover of #3280 / PR #3284 (parent slice #2299 / epic #2022): clear remaining assembler/workitem/navon Xlint after that batch, plus the optional memory factory rawtypes.

#3284 already typed `PSHtmlAssembler` / `PSMarkdownAssembler` / `PSBinaryAssembler`, `PSAssemblyWorkItem.getMetaData`, and `PSNavonNodeInvocationHandler.copyPropertyMap`. This slice:

- Removes `@SuppressWarnings("rawtypes")` on `PSEhCacheFactoryBean.getObjectType` by matching `FactoryBean#getObjectType()` (`Class<?>`) and returning `Cache.class`
- Documents the inherent `LiveStringObjectMap.erase` unchecked conversion as the remaining assembly map cast
- Restores orphaned `loadLandingPage` javadoc left above `copyPropertyMap`
- Adds `PSEhCacheFactoryBeanTest` (object type, missing manager, create/put-get, existing-region reuse, TTL/TTI/eternal)

Virtual Site YAML loaders (`VirtualSiteConfigLoader` / `VirtualFrontmatterParser`) were **not** changed.

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent:** #2299 / #2022
**Fixes:** #3291
**Related leftover of:** #3280 / PR #3284

## Test plan

1. From `system/`: `../mvnw.cmd clean install` (JDK 21)
2. Focused: `../mvnw.cmd "-Dtest=PSEhCacheFactoryBeanTest,PSAssemblyBindingMapsTest,PSBinaryAssemblerSupportTest,PSNavHelperTypedTest,PSHtmlAssemblerTest,PSMarkdownAssemblerTest,PSServicesPackageTypedTest" test`
3. Confirm BUILD SUCCESS and new/updated tests green

## Checklist

- [x] **Product documentation** — N/A (not product-facing): leftover Xlint / generics; no operator, UX, REST, install, or config change
- [x] **Unit / module tests** — new `PSEhCacheFactoryBeanTest`; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (in-memory Ehcache only; no path/file I/O)

## Gates evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **2108**, Failures: 0, Errors: 0, Skipped: 241
- **focused tests:** 33 green (`PSEhCacheFactoryBeanTest` 5, `PSAssemblyBindingMapsTest` 4, `PSBinaryAssemblerSupportTest` 3, `PSNavHelperTypedTest` 3, `PSHtmlAssemblerTest` 6, `PSMarkdownAssemblerTest` 4, `PSServicesPackageTypedTest` 8)
- **downstream_checked:** C2 applied for `getObjectType()` return type `Class<? extends Cache>` → `Class<?>`. Grep: no `extends PSEhCacheFactoryBean`, no `new PSEhCacheFactoryBean() {`. No downstream module install required (interface already `Class<?>`).
- **C5 UI:** N/A (backend tech-debt only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
