### PR TITLE
fix(perc-system): type security cataloger iterators (#3289)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3289-security-cataloger-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3289-security-cataloger-xlint-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — issue #3289 security cataloger Xlint residual
+
+**Date:** 2026-08-13  
+**Scope:** remaining `@SuppressWarnings("unchecked")` on security catalogers after #3182/#2461  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Verdict
+
+**PASS** — no bug findings, portable paths N/A (no file I/O), behavioral unit tests present, change-class companions OK for generics tech-debt.
+
+## What changed
+
+- Added package-private `PSCatalogerTypes` adapters for raw design.objectstore iterators/comparators (`PSAttributeList`, `PSDirectorySet`, `PSCollection` group providers, `PSLiteralSet`, `PSJndiGroupProviderInstance` string iterators, `PSSubject.getSubjectIdentifierComparator()`).
+- Removed all listed-file `@SuppressWarnings("unchecked")` from `PSCataloger`, `PSRoleCataloger`, `PSRoleManager`, `PSJndiGroupProvider`, `PSBackendCataloger`, `PSBackEndDirectoryCataloger`, `PSBackEndTableDirectoryCataloger`, `PSThreadRequestUtils`, `PSDirectoryConnProviderMetaData`.
+- Typed iterator preserves null elements and throws `ClassCastException` on wrong runtime type (same as the previous unchecked cast).
+- Inherent leftover: two documented suppressions remain **inside** `PSCatalogerTypes` only (`rawtypes` + `unchecked` around the objectstore comparator). Objectstore APIs stay raw (owned by #2022 slices 1–2).
+- Added `PSCatalogerTypesTest` (10 tests). Existing `PSRoleManagerRawtypesTest` still covers merge behavior.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs | None. Adapter error path matches prior CCE/null semantics. |
+| Behavioral unit tests | Adapter iteration, CCE, null passthrough, directory/group/literal adapters, subject comparator ordering/case-distinct. |
+| Portable paths | N/A — no path/file I/O. |
+| API shape / C2 | Package-private helper only. No public/protected signatures changed; no type made final/sealed. |
+| Product docs | N/A — tech-debt only; no operator/user/API surface change. |
+
+## Residual
+
+None in listed cataloger files. Design.objectstore genericization of `PSCollectionComponent` / `PSSubject.getSubjectIdentifierComparator` / `PSJndiGroupProviderInstance` iterators remains a parent #2022 slice-1 concern.
+
+## Evidence
+
+- `cd system; ../mvnw.cmd test -Dtest=PSCatalogerTypesTest,PSRoleManagerRawtypesTest` → Tests run: 15, Failures: 0  
+- `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **2061**, Failures: 0, Errors: 0, Skipped: 238
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
@@ -78,8 +78,7 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
 
     PSSubject subject = getMatchingSubject(user.getName(), attributeNames);
     if (subject != null) {
-      @SuppressWarnings("unchecked")
-      Iterator<PSAttribute> attrs = subject.getAttributes().iterator();
+      Iterator<PSAttribute> attrs = PSCatalogerTypes.attributes(subject.getAttributes());
       while (attrs.hasNext()) {
         PSAttribute attr = attrs.next();
         userAttributes.setAttribute(attr.getName(), attr.getValues());

--- a/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
@@ -125,8 +125,7 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
       result = stmt.executeQuery();
 
       if (result.next()) {
-        @SuppressWarnings("unchecked")
-        Iterator<PSAttribute> attrs = attributes.iterator();
+        Iterator<PSAttribute> attrs = PSCatalogerTypes.attributes(attributes);
         while (attrs.hasNext()) {
           PSAttribute attr = attrs.next();
 

--- a/system/src/main/java/com/percussion/security/PSBackendCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackendCataloger.java
@@ -31,7 +31,6 @@ import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -205,8 +204,7 @@ public class PSBackendCataloger {
     }
 
     PSAttributeList attribs = getAttributes(el);
-    @SuppressWarnings("unchecked")
-    Iterator<PSAttribute> iter = attribs.iterator();
+    Iterator<PSAttribute> iter = PSCatalogerTypes.attributes(attribs);
     while (iter.hasNext()) results.add(iter.next());
 
     return results;
@@ -385,15 +383,12 @@ public class PSBackendCataloger {
    *    </code>.
    * @throws PSSecurityException If any of a Subject's attributes are not valid.
    */
-  @SuppressWarnings("unchecked")
   protected static Set<PSSubject> processCatalogedSubjects(
       Element parent, boolean includeEmptySubjects) {
     if (parent == null) throw new IllegalArgumentException("parent cannot be null");
 
     // use set to remove dups introduced with the fix for Rx-01-10-0104
-    Comparator<PSSubject> subjectComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    TreeSet<PSSubject> results = new TreeSet<>(subjectComparator);
+    TreeSet<PSSubject> results = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
 
     Map<String, PSSubject> subjectMap = new LinkedHashMap<>();
 
@@ -460,15 +455,12 @@ public class PSBackendCataloger {
    *     empty to get all attributes.
    * @return a set of <code>PSSubject</code> objects with the requested attributes.
    */
-  @SuppressWarnings("unchecked")
   protected static Set<PSSubject> getSubjects(
       Map<String, String> filters, Collection<?> attributeNames) {
     if (filters == null) throw new IllegalArgumentException("filters cannot be null");
 
     // use treeset to prevent duplicates and enforce ordering
-    Comparator<PSSubject> subjectComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    TreeSet<PSSubject> sortedSet = new TreeSet<>(subjectComparator);
+    TreeSet<PSSubject> sortedSet = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
 
     Document doc = getCatalogDocument("sys_catalogOuterJoinSubjectAttributes", filters);
     sortedSet.addAll(processSubjectAttributes(doc, true));

--- a/system/src/main/java/com/percussion/security/PSCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSCataloger.java
@@ -152,8 +152,7 @@ public abstract class PSCataloger {
     }
 
     // load and validate all referenced directories/authentications
-    @SuppressWarnings("unchecked")
-    Iterator<PSReference> directoryRefs = m_directorySet.iterator();
+    Iterator<PSReference> directoryRefs = PSCatalogerTypes.directoryRefs(m_directorySet);
     while (directoryRefs.hasNext()) {
       PSReference directoryRef = directoryRefs.next();
       PSDirectory directory = config.getDirectory(directoryRef.getName());
@@ -376,8 +375,8 @@ public abstract class PSCataloger {
   private static Map<String, IPSGroupProviderInstance> getGroupProviderInstances(
       PSServerConfiguration config) {
     Map<String, IPSGroupProviderInstance> result = new HashMap<>();
-    @SuppressWarnings("unchecked")
-    Iterator<IPSGroupProviderInstance> i = config.getGroupProviderInstances().iterator();
+    Iterator<IPSGroupProviderInstance> i =
+        PSCatalogerTypes.groupProviderInstances(config.getGroupProviderInstances());
     while (i.hasNext()) {
       IPSGroupProviderInstance inst = i.next();
       result.put(inst.getName(), inst);
@@ -398,7 +397,6 @@ public abstract class PSCataloger {
    * @return a collection with <code>PSSubject</code> objects, each subject with the requested
    *     attributes. Never <code>null</code>, may be empty.
    */
-  @SuppressWarnings("unchecked")
   protected Collection<PSSubject> getSubjects(
       PSDirectoryDefinition directory, Map<String, ?> filter, Collection<?> attributeNames) {
     Collection<PSSubject> resultList = new ArrayList<>();

--- a/system/src/main/java/com/percussion/security/PSCatalogerTypes.java
+++ b/system/src/main/java/com/percussion/security/PSCatalogerTypes.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.security;
+
+import com.percussion.design.objectstore.IPSGroupProviderInstance;
+import com.percussion.design.objectstore.PSAttribute;
+import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.design.objectstore.PSDirectorySet;
+import com.percussion.design.objectstore.PSLiteral;
+import com.percussion.design.objectstore.PSLiteralSet;
+import com.percussion.design.objectstore.PSReference;
+import com.percussion.design.objectstore.PSSubject;
+import com.percussion.util.PSCollection;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * Typed adapters over raw design.objectstore collections used by security catalogers.
+ *
+ * <p>Slice-5 (#2299 / #3289) keeps {@code com.percussion.design.objectstore} raw (owned by #2022
+ * slices 1–2). Cataloger code uses these adapters instead of {@code @SuppressWarnings("unchecked")}.
+ */
+final class PSCatalogerTypes {
+
+  private PSCatalogerTypes() {}
+
+  /**
+   * Subject identifier comparator used to order and de-duplicate cataloger results. Wraps the raw
+   * objectstore comparator without an unchecked cast at each call site.
+   */
+  static Comparator<PSSubject> subjectIdentifierComparator() {
+    Comparator<?> raw = wildcardComparator(PSSubject.getSubjectIdentifierComparator());
+    return (left, right) -> compareSubjects(raw, left, right);
+  }
+
+  static Iterator<PSAttribute> attributes(PSAttributeList attributes) {
+    Objects.requireNonNull(attributes, "attributes");
+    return typed(attributes.iterator(), PSAttribute.class);
+  }
+
+  static List<PSAttribute> attributeList(PSAttributeList attributes) {
+    return collect(attributes(attributes));
+  }
+
+  static Iterator<PSReference> directoryRefs(PSDirectorySet directorySet) {
+    Objects.requireNonNull(directorySet, "directorySet");
+    return typed(directorySet.iterator(), PSReference.class);
+  }
+
+  static Iterator<IPSGroupProviderInstance> groupProviderInstances(PSCollection raw) {
+    Objects.requireNonNull(raw, "raw");
+    return typed(raw.iterator(), IPSGroupProviderInstance.class);
+  }
+
+  static Iterator<PSLiteral> literals(PSLiteralSet literals) {
+    Objects.requireNonNull(literals, "literals");
+    return typed(literals.iterator(), PSLiteral.class);
+  }
+
+  static Iterator<String> strings(Iterator<?> raw) {
+    Objects.requireNonNull(raw, "raw");
+    return typed(raw, String.class);
+  }
+
+  static <T> Iterator<T> typed(Iterator<?> raw, Class<T> type) {
+    Objects.requireNonNull(raw, "raw");
+    Objects.requireNonNull(type, "type");
+    return new Iterator<>() {
+      private T next;
+      private boolean ready;
+
+      @Override
+      public boolean hasNext() {
+        advance();
+        return ready;
+      }
+
+      @Override
+      public T next() {
+        advance();
+        if (!ready) {
+          throw new NoSuchElementException();
+        }
+        T value = next;
+        next = null;
+        ready = false;
+        return value;
+      }
+
+      private void advance() {
+        if (ready) {
+          return;
+        }
+        if (!raw.hasNext()) {
+          return;
+        }
+        Object item = raw.next();
+        if (item != null && !type.isInstance(item)) {
+          throw new ClassCastException(
+              item.getClass().getName() + " cannot be cast to " + type.getName());
+        }
+        next = type.cast(item);
+        ready = true;
+      }
+    };
+  }
+
+  static <T> List<T> collect(Iterator<T> iterator) {
+    List<T> values = new ArrayList<>();
+    while (iterator.hasNext()) {
+      values.add(iterator.next());
+    }
+    return values;
+  }
+
+  /**
+   * Assigns the raw objectstore {@link Comparator} through a wildcard so callers do not need
+   * {@code @SuppressWarnings}.
+   */
+  @SuppressWarnings("rawtypes")
+  private static Comparator<?> wildcardComparator(Comparator raw) {
+    return raw;
+  }
+
+  /**
+   * Applies the objectstore subject comparator. The unchecked conversion is inherent: {@link
+   * PSSubject#getSubjectIdentifierComparator()} still returns a raw {@link Comparator}.
+   */
+  @SuppressWarnings("unchecked")
+  private static int compareSubjects(Comparator<?> comparator, PSSubject left, PSSubject right) {
+    return ((Comparator<PSSubject>) comparator).compare(left, right);
+  }
+}

--- a/system/src/main/java/com/percussion/security/PSDirectoryConnProviderMetaData.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryConnProviderMetaData.java
@@ -119,8 +119,7 @@ public class PSDirectoryConnProviderMetaData extends PSJndiProviderMetaData {
           directorySet.getRequiredAttributeName(PSDirectorySet.OBJECT_ATTRIBUTE_KEY);
       String[] attrIDs = {objectAttributeName};
 
-      @SuppressWarnings("unchecked")
-      Iterator<PSReference> references = directorySet.iterator();
+      Iterator<PSReference> references = PSCatalogerTypes.directoryRefs(directorySet);
       while (references.hasNext()) {
         PSReference reference = references.next();
         PSDirectory directory = config.getDirectory(reference.getName());

--- a/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
+++ b/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
@@ -78,8 +78,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     m_directoryDef = directoryDef;
     m_userObjectAttrName = userObjectAttrName;
 
-    @SuppressWarnings("unchecked")
-    Iterator<String> nodes = m_groupProviderInstance.getGroupNodes();
+    Iterator<String> nodes = PSCatalogerTypes.strings(m_groupProviderInstance.getGroupNodes());
     while (nodes.hasNext()) {
       String node = nodes.next();
       m_groupLocationInfo.add(new GroupLocationInfo(node));
@@ -572,8 +571,8 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     if (foundOcs.isEmpty()) return groupMembers;
 
     // walk supported object classes and see if in the list
-    @SuppressWarnings("unchecked")
-    Iterator<String> defOcs = m_groupProviderInstance.getObjectClassesNames();
+    Iterator<String> defOcs =
+        PSCatalogerTypes.strings(m_groupProviderInstance.getObjectClassesNames());
     while (defOcs.hasNext()) {
       String defOc = defOcs.next();
       if (foundOcs.contains(defOc.toLowerCase())) {
@@ -857,8 +856,8 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     if (foundOcs.isEmpty()) return false;
 
     // walk supported object classes and see if in the list
-    @SuppressWarnings("unchecked")
-    Iterator<String> defOcs = m_groupProviderInstance.getObjectClassesNames();
+    Iterator<String> defOcs =
+        PSCatalogerTypes.strings(m_groupProviderInstance.getObjectClassesNames());
     while (defOcs.hasNext()) {
       String defOc = defOcs.next();
       if (foundOcs.contains(defOc.toLowerCase())) {
@@ -1112,8 +1111,8 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
   private String getGroupsSearchFilter() {
     if (m_groupsSearchFilter == null) {
       StringBuilder buf = new StringBuilder();
-      @SuppressWarnings("unchecked")
-      Iterator<String> ocs = m_groupProviderInstance.getObjectClassesNames();
+      Iterator<String> ocs =
+          PSCatalogerTypes.strings(m_groupProviderInstance.getObjectClassesNames());
       while (ocs.hasNext()) {
         String oc = ocs.next();
         if (buf.length() == 0) buf.append("(|");
@@ -1143,8 +1142,8 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
   private String[] getMemberListAttributes() {
     if (m_memberListAttributes == null) {
       List<String> attrs = new ArrayList<>();
-      @SuppressWarnings("unchecked")
-      Iterator<String> ocs = m_groupProviderInstance.getObjectClassesNames();
+      Iterator<String> ocs =
+          PSCatalogerTypes.strings(m_groupProviderInstance.getObjectClassesNames());
       while (ocs.hasNext()) {
         String oc = ocs.next();
         attrs.add(m_groupProviderInstance.getMemberAttribute(oc));

--- a/system/src/main/java/com/percussion/security/PSRoleCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSRoleCataloger.java
@@ -25,7 +25,6 @@ import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSServer;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -251,7 +250,6 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    * @see IPSInternalRoleCataloger
    */
   @Override
-  @SuppressWarnings("unchecked")
   public Set<PSSubject> getSubjects(
       String roleName,
       String subjectNameFilter,
@@ -262,9 +260,7 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
     if (subjectType == PSSubject.SUBJECT_TYPE_GROUP) return new HashSet<>();
 
     // use treeset to prevent duplicates and enforce ordering
-    Comparator<PSSubject> subjectComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    Set<PSSubject> results = new TreeSet<>(subjectComparator);
+    Set<PSSubject> results = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
     String plainRoleName = roleName;
     if (roleName != null && m_roleProvider.isDelimited()) {
       roleName = "*" + roleName + "*";

--- a/system/src/main/java/com/percussion/security/PSRoleManager.java
+++ b/system/src/main/java/com/percussion/security/PSRoleManager.java
@@ -36,7 +36,6 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -400,9 +399,7 @@ public class PSRoleManager {
     for (PSSubject subject : subjects) {
       // pattern match on all attributes
       PSAttributeList newAttrs = new PSAttributeList();
-      // objectstore PSAttributeList.iterator() is raw; narrow at the boundary
-      @SuppressWarnings("unchecked")
-      Iterator<PSAttribute> attrs = subject.getAttributes().iterator();
+      Iterator<PSAttribute> attrs = PSCatalogerTypes.attributes(subject.getAttributes());
       while (attrs.hasNext()) {
         PSAttribute attr = attrs.next();
         if (!patternMatch.doesMatchPattern(attr.getName())) continue;
@@ -754,9 +751,8 @@ public class PSRoleManager {
       }
 
       // Prefer role attributes: only add global attributes that role subject does not define.
-      // objectstore PSAttributeList.iterator() is raw; narrow at the boundary.
-      @SuppressWarnings("unchecked")
-      Iterator<PSAttribute> globalAttrs = globalSubject.getAttributes().iterator();
+      Iterator<PSAttribute> globalAttrs =
+          PSCatalogerTypes.attributes(globalSubject.getAttributes());
       while (globalAttrs.hasNext()) {
         PSAttribute attr = globalAttrs.next();
         if (existing.getAttributes().getAttribute(attr.getName()) == null) {
@@ -846,11 +842,7 @@ public class PSRoleManager {
       boolean includeEmptySubjects,
       String communityId) {
     // use treeset to prevent duplicates and enforce ordering
-    // objectstore comparator is raw; narrow at the boundary
-    @SuppressWarnings("unchecked")
-    Comparator<PSSubject> subjectIdComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    Set<PSSubject> subjects = new TreeSet<>(subjectIdComparator);
+    Set<PSSubject> subjects = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
 
     // add all subjects from all security providers
     subjects.addAll(
@@ -891,11 +883,7 @@ public class PSRoleManager {
       String communityId,
       boolean includeEmpty) {
     // use treeset to prevent duplicates and enforce ordering
-    // objectstore comparator is raw; narrow at the boundary
-    @SuppressWarnings("unchecked")
-    Comparator<PSSubject> subjectIdComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    Set<PSSubject> results = new TreeSet<>(subjectIdComparator);
+    Set<PSSubject> results = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
 
     // add all subjects from all security providers
     results.addAll(
@@ -959,11 +947,7 @@ public class PSRoleManager {
     if (roleName.length() == 0) throw new IllegalArgumentException("roleName cannot be empty");
 
     // use treeset to prevent duplicates and enforce ordering
-    // objectstore comparator is raw; narrow at the boundary
-    @SuppressWarnings("unchecked")
-    Comparator<PSSubject> subjectIdComparator =
-        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
-    Set<PSSubject> subjects = new TreeSet<>(subjectIdComparator);
+    Set<PSSubject> subjects = new TreeSet<>(PSCatalogerTypes.subjectIdentifierComparator());
 
     // add all subjects from all security providers
     subjects.addAll(

--- a/system/src/main/java/com/percussion/security/PSThreadRequestUtils.java
+++ b/system/src/main/java/com/percussion/security/PSThreadRequestUtils.java
@@ -283,8 +283,7 @@ public class PSThreadRequestUtils {
             PSUserContextExtractor.getUserContextInformation(userCtx, getPSRequest(), null);
 
     if (userSet != null) {
-      @SuppressWarnings("unchecked")
-      Iterator<PSLiteral> userNames = userSet.iterator();
+      Iterator<PSLiteral> userNames = PSCatalogerTypes.literals(userSet);
 
       while (userNames.hasNext() && !isInternalUser) {
         String userName = userNames.next().getValueText();

--- a/system/src/test/java/com/percussion/security/PSCatalogerTypesTest.java
+++ b/system/src/test/java/com/percussion/security/PSCatalogerTypesTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.IPSGroupProviderInstance;
+import com.percussion.design.objectstore.PSAttribute;
+import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.design.objectstore.PSDirectory;
+import com.percussion.design.objectstore.PSDirectorySet;
+import com.percussion.design.objectstore.PSGlobalSubject;
+import com.percussion.design.objectstore.PSJndiGroupProviderInstance;
+import com.percussion.design.objectstore.PSJndiObjectClass;
+import com.percussion.design.objectstore.PSLiteral;
+import com.percussion.design.objectstore.PSLiteralSet;
+import com.percussion.design.objectstore.PSReference;
+import com.percussion.design.objectstore.PSSubject;
+import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.util.PSCollection;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link PSCatalogerTypes} adapters used by security catalogers (issue #3289,
+ * parent #2299 / #2022).
+ */
+@Tag("UnitTest")
+class PSCatalogerTypesTest {
+
+  @Test
+  void typedIteratorPreservesNullsAndThrowsOnWrongType() {
+    List<Object> withNull = new ArrayList<>();
+    withNull.add("alice");
+    withNull.add(null);
+    withNull.add("bob");
+
+    assertEquals(
+        java.util.Arrays.asList("alice", null, "bob"),
+        PSCatalogerTypes.collect(PSCatalogerTypes.typed(withNull.iterator(), String.class)));
+
+    List<Object> mixed = new ArrayList<>();
+    mixed.add("alice");
+    mixed.add(Integer.valueOf(42));
+    Iterator<String> it = PSCatalogerTypes.typed(mixed.iterator(), String.class);
+    assertEquals("alice", it.next());
+    assertThrows(ClassCastException.class, it::next);
+  }
+
+  @Test
+  void typedIteratorThrowsWhenExhausted() {
+    Iterator<String> empty = PSCatalogerTypes.typed(List.of().iterator(), String.class);
+    assertThrows(NoSuchElementException.class, empty::next);
+  }
+
+  @Test
+  void attributesIteratorReturnsNamedAttributes() {
+    PSAttributeList attrs = new PSAttributeList();
+    attrs.setAttribute("email", List.of("alice@example.com"));
+    attrs.setAttribute("dept", List.of("Engineering"));
+
+    List<PSAttribute> found = PSCatalogerTypes.attributeList(attrs);
+    assertEquals(2, found.size());
+    assertEquals("email", found.get(0).getName());
+    assertEquals(List.of("alice@example.com"), found.get(0).getValues());
+    assertEquals("dept", found.get(1).getName());
+  }
+
+  @Test
+  void directoryRefsIteratorYieldsReferences() {
+    PSDirectorySet set = new PSDirectorySet("corp", "uid");
+    set.add(new PSReference("dir1", PSDirectory.class.getName()));
+    set.add(new PSReference("dir2", PSDirectory.class.getName()));
+
+    List<PSReference> refs = PSCatalogerTypes.collect(PSCatalogerTypes.directoryRefs(set));
+    assertEquals(2, refs.size());
+    assertEquals("dir1", refs.get(0).getName());
+    assertEquals("dir2", refs.get(1).getName());
+  }
+
+  @Test
+  void groupProviderInstancesIteratorYieldsInstances() {
+    PSCollection raw = new PSCollection(IPSGroupProviderInstance.class);
+    raw.add(new PSJndiGroupProviderInstance("groups", PSSecurityProvider.SP_TYPE_DIRCONN));
+
+    List<IPSGroupProviderInstance> found =
+        PSCatalogerTypes.collect(PSCatalogerTypes.groupProviderInstances(raw));
+    assertEquals(1, found.size());
+    assertEquals("groups", found.get(0).getName());
+  }
+
+  @Test
+  void literalsIteratorYieldsValueText() {
+    PSLiteralSet literals = new PSLiteralSet(PSTextLiteral.class);
+    literals.add(new PSTextLiteral(PSSecurityProvider.INTERNAL_USER_NAME));
+    literals.add(new PSTextLiteral("alice"));
+
+    List<String> names = new ArrayList<>();
+    Iterator<PSLiteral> it = PSCatalogerTypes.literals(literals);
+    while (it.hasNext()) {
+      names.add(it.next().getValueText());
+    }
+
+    assertEquals(List.of(PSSecurityProvider.INTERNAL_USER_NAME, "alice"), names);
+  }
+
+  @Test
+  void stringsIteratorWrapsRawObjectstoreNames() {
+    PSJndiGroupProviderInstance gp =
+        new PSJndiGroupProviderInstance("groups", PSSecurityProvider.SP_TYPE_DIRCONN);
+    gp.addGroupNode("ou=groups,dc=example,dc=com");
+    gp.addObjectClass("groupOfNames", "member", PSJndiObjectClass.MEMBER_ATTR_STATIC);
+
+    List<String> nodes = PSCatalogerTypes.collect(PSCatalogerTypes.strings(gp.getGroupNodes()));
+    assertEquals(List.of("ou=groups,dc=example,dc=com"), nodes);
+
+    List<String> ocs = PSCatalogerTypes.collect(PSCatalogerTypes.strings(gp.getObjectClassesNames()));
+    assertEquals(List.of("groupOfNames"), ocs);
+  }
+
+  @Test
+  void subjectIdentifierComparatorOrdersByNameThenType() {
+    Comparator<PSSubject> cmp = PSCatalogerTypes.subjectIdentifierComparator();
+
+    PSSubject aliceUser = subject("alice", PSSubject.SUBJECT_TYPE_USER);
+    PSSubject aliceGroup = subject("alice", PSSubject.SUBJECT_TYPE_GROUP);
+    PSSubject bobUser = subject("bob", PSSubject.SUBJECT_TYPE_USER);
+
+    assertTrue(cmp.compare(aliceUser, bobUser) < 0);
+    assertTrue(cmp.compare(bobUser, aliceUser) > 0);
+    assertEquals(0, cmp.compare(aliceUser, subject("alice", PSSubject.SUBJECT_TYPE_USER)));
+    assertTrue(cmp.compare(aliceUser, aliceGroup) != 0);
+
+    Set<PSSubject> ordered = new TreeSet<>(cmp);
+    ordered.add(bobUser);
+    ordered.add(aliceGroup);
+    ordered.add(aliceUser);
+    List<String> keys = new ArrayList<>();
+    for (PSSubject s : ordered) {
+      keys.add(s.getName() + ":" + s.getType());
+    }
+    assertEquals(3, keys.size());
+    assertEquals("alice", keys.get(0).substring(0, 5));
+    assertEquals("alice", keys.get(1).substring(0, 5));
+    assertEquals("bob:" + PSSubject.SUBJECT_TYPE_USER, keys.get(2));
+  }
+
+  @Test
+  void subjectIdentifierComparatorTreatsCaseVariantsAsDistinct() {
+    Comparator<PSSubject> cmp = PSCatalogerTypes.subjectIdentifierComparator();
+    PSSubject lower = subject("alice", PSSubject.SUBJECT_TYPE_USER);
+    PSSubject mixed = subject("Alice", PSSubject.SUBJECT_TYPE_USER);
+
+    assertTrue(cmp.compare(lower, mixed) != 0);
+
+    Set<PSSubject> set = new TreeSet<>(cmp);
+    set.add(lower);
+    set.add(mixed);
+    assertEquals(2, set.size());
+  }
+
+  @Test
+  void adaptersRejectNullSources() {
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.attributes(null));
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.directoryRefs(null));
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.groupProviderInstances(null));
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.literals(null));
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.strings(null));
+    assertThrows(NullPointerException.class, () -> PSCatalogerTypes.typed(null, String.class));
+    assertThrows(
+        NullPointerException.class, () -> PSCatalogerTypes.typed(List.of().iterator(), null));
+  }
+
+  private static PSSubject subject(String name, int type) {
+    return new PSGlobalSubject(name, type, new PSAttributeList());
+  }
+}


### PR DESCRIPTION
## Summary

Clears remaining `-Xlint` unchecked/rawtypes suppressions on security catalogers (parent #2299 / grandparent #2022). Cataloger call sites now use package-private `PSCatalogerTypes` adapters over raw design.objectstore collections (`PSAttributeList`, `PSDirectorySet`, group-provider `PSCollection`, `PSLiteralSet`, JNDI group-provider name iterators, `PSSubject.getSubjectIdentifierComparator()`).

No authentication or catalog behavior change. Inherent leftover is documented on the two suppressions inside `PSCatalogerTypes` only (objectstore comparator is still a raw `Comparator`).

Fixes #3289  
Parent: #2299  
Grandparent: #2022

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd system` then `../mvnw.cmd clean install` (standalone; JDK 21).
2. Confirm `PSCatalogerTypesTest` (10) and `PSRoleManagerRawtypesTest` (5) pass.
3. No live LDAP / auth UAT required — types-only adapters; CCE/null semantics match prior unchecked casts.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): pure generics/tech-debt; no operator/user/API/auth behavior change
- [x] **Unit / module tests** — `PSCatalogerTypesTest` + existing role-merge tests; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install (no skipTests); C2 N/A (package-private helper only)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=` `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **2061**, Failures: 0, Errors: 0, Skipped: 238
- `downstream_checked=none` (C2 did not apply: no public/protected signature change, no type made final/sealed)

> Co-Authored by Grok Build using grok-4.5 with agent main.
