### PR TITLE
fix(dce): Xlint re-probe + this-escape/serial cluster (#3288)

### DIFF
--- a/docs/ai-generated/code-reviews/3288-dce-xlint-this-escape-erlang.md
+++ b/docs/ai-generated/code-reviews/3288-dce-xlint-this-escape-erlang.md
@@ -1,0 +1,24 @@
+# Erlang review — #3288 DCE Xlint this-escape/serial cluster
+
+**Branch:** `fix/issue-3288-dce-xlint-this-escape`  
+**Date:** 2026-08-13  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** this-escape remediations prefer `final` + transient collaborators (PSFolderDialog / status dialog peers); do not strip applet `removal` suppressions.
+
+## Summary
+
+Re-probed `perc-content-explorer` with `javac -Xlint -Xmaxwarns 10000` (289 warning lines). Cleared the next this-escape/serial cluster: real-fixed `PSNode` / `PSNavigationTree` (removed ctor suppressions via `final` + static folder-type helpers + lazy accessible context) and applied the same `final` + `serialVersionUID` + `transient` pattern to explorer chrome and option beans. `PSContentExplorerFrame` still implements `java.applet.AppletStub`/`AppletContext` (removal warnings left in place per issue).
+
+## Issues
+
+None (no bugs, no missing behavioral tests for new static helpers, no path I/O).
+
+## Cross-platform path checklist
+
+N/A — no file I/O or path construction in this diff.
+
+## Evidence
+
+- `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 184, Failures: 0
+- C2: grepped monorepo for `extends` / anonymous subclasses of finalized types — only `? extends PSNode` iterator bounds

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Element;
  * This class provides a way of constructing the Column Widths Option object from the XML document
  * and to get XML document from the Column Width object.
  */
-public class PSColumnWidthsOption implements IPSClientObjects {
+public final class PSColumnWidthsOption implements IPSClientObjects {
   static Logger log = LogManager.getLogger(PSColumnWidthsOption.class);
 
   /** Empty constructor. */

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerFrame.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerFrame.java
@@ -64,8 +64,12 @@ import org.apache.logging.log4j.Logger;
  * The main host frame for the Percussion Content Explorer. Provides the Swing and applet-stub
  * infrastructure used by the embedded {@link PSContentExplorerApplet} and acts as the top-level
  * window for the JavaFX application launch.
+ *
+ * <p>Declared {@code final} so Swing initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborators are
+ * {@code transient}. Does not remove the legacy {@code java.applet} stub/context surfaces.
  */
-public class PSContentExplorerFrame extends PSDesktopExplorerWindow
+public final class PSContentExplorerFrame extends PSDesktopExplorerWindow
     implements AppletStub, AppletContext {
 
   private static final long serialVersionUID = 1L;
@@ -73,13 +77,13 @@ public class PSContentExplorerFrame extends PSDesktopExplorerWindow
   static Logger log = LogManager.getLogger(PSContentExplorerFrame.class);
 
   /** Helper instance used to resolve resources and helper methods. */
-  private PSContentExplorerHelper helper = new PSContentExplorerHelper();
+  private transient PSContentExplorerHelper helper = new PSContentExplorerHelper();
 
   /** Hashmap containing all parameters needed for the applet. */
-  Map<String, String> parameters = new HashMap<String, String>();
+  private transient Map<String, String> parameters = new HashMap<>();
 
   /** The login panel containing all GUI elements for the login dialog, may be <code>null</code>. */
-  private PSContentExplorerLoginPanel loginPanel = null;
+  private transient PSContentExplorerLoginPanel loginPanel = null;
 
   /** The URI of the Rhythmyx server, may be <code>null</code>. */
   private URI serverUri = null;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerHeader.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerHeader.java
@@ -31,14 +31,17 @@ import org.apache.logging.log4j.Logger;
 /**
  * The top banner panel of the desktop content explorer. Shows the user/community/role/locale
  * information and exposes keyboard focus management for accessibility.
+ *
+ * <p>Declared {@code final} so Swing initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}).
  */
-public class PSContentExplorerHeader extends JPanel {
+public final class PSContentExplorerHeader extends JPanel {
   static Logger log = LogManager.getLogger(PSContentExplorerHeader.class);
 
   private static final long serialVersionUID = 1L;
 
   /** The content explorer applet this header is associated with. */
-  private PSContentExplorerApplet m_applet;
+  private transient PSContentExplorerApplet m_applet;
 
   /**
    * Constructs the header panel and initializes the sub-components for the supplied applet.
@@ -56,7 +59,7 @@ public class PSContentExplorerHeader extends JPanel {
   }
 
   /** Initializes the header layout, banner and info sub-panels using the configured options. */
-  protected void init() {
+  private void init() {
 
     this.setFont(m_applet.getOptionsManager().getDisplayOptions().getMenuFont());
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerLoginPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerLoginPanel.java
@@ -85,9 +85,15 @@ import org.json.JSONObject;
  * The LoginPanel creates the applets/applications first dialog shown to the user. It askes for
  * server name, user Id and password and provides a login button. AppletMainDialog will be started
  * on successful login.
+ *
+ * <p>Declared {@code final} so Swing initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborators that are
+ * not {@link java.io.Serializable} are {@code transient} (the login frame is never serialized).
  */
 ////////////////////////////////////////////////////////////////////////////////
-public class PSContentExplorerLoginPanel extends JFrame {
+public final class PSContentExplorerLoginPanel extends JFrame {
+  private static final long serialVersionUID = 1L;
+
   static Logger log = LogManager.getLogger(PSContentExplorerLoginPanel.class);
 
   /**
@@ -100,7 +106,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
   public static final String LAST_USER = "last_user_name";
 
   /** The content explorer applet this panel is associated with. */
-  public PSContentExplorerApplet applet;
+  public transient PSContentExplorerApplet applet;
 
   /** The bold font used by labels in the panel. */
   Font boldTextFont = new Font("Arial", Font.BOLD, 18);
@@ -404,7 +410,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
    */
   public void onOk() {
 
-    this.setCursor(getCursor().getPredefinedCursor(Cursor.WAIT_CURSOR));
+    this.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
     this.m_login.setEnabled(false);
     if (m_userId.getText() == null || m_userId.getText().trim().length() == 0) {
       JOptionPane.showMessageDialog(
@@ -412,7 +418,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
           ErrorDialogs.cropErrorMessage(m_res.getString("missUserId")),
           m_res.getString("error"),
           JOptionPane.ERROR_MESSAGE);
-      this.setCursor(getCursor().getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      this.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       m_statusBar.setText(m_res.getString("disconnectedStatus"));
       m_userId.requestFocus();
       this.m_login.setEnabled(true);
@@ -425,7 +431,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
           ErrorDialogs.cropErrorMessage(m_res.getString("missPassword")),
           m_res.getString("error"),
           JOptionPane.ERROR_MESSAGE);
-      this.setCursor(getCursor().getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      this.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       m_statusBar.setText(m_res.getString("disconnectedStatus"));
       m_password.requestFocus();
       this.m_login.setEnabled(true);
@@ -438,7 +444,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
           ErrorDialogs.cropErrorMessage(m_res.getString("missLocale")),
           m_res.getString("error"),
           JOptionPane.ERROR_MESSAGE);
-      this.setCursor(getCursor().getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      this.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       m_statusBar.setText(m_res.getString("disconnectedStatus"));
       m_locale.requestFocus();
       this.m_login.setEnabled(true);
@@ -472,7 +478,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
           ErrorDialogs.cropErrorMessage("Invalid URI. Please correct URI"),
           m_res.getString("error"),
           JOptionPane.ERROR_MESSAGE);
-      this.setCursor(getCursor().getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      this.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       this.m_login.setEnabled(true);
       return;
     }
@@ -716,22 +722,23 @@ public class PSContentExplorerLoginPanel extends JFrame {
     return locales;
   }
 
-  class PSLocaleRenderer extends BasicComboBoxRenderer {
+  private static final class PSLocaleRenderer extends BasicComboBoxRenderer {
+    private static final long serialVersionUID = 1L;
+
+    @Override
     public Component getListCellRendererComponent(
-        JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+        JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
       super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
-      if (value != null) {
-        PSLocale item = (PSLocale) value;
-
+      if (value instanceof PSLocale item) {
         setText(item.getLabel());
       }
       return this;
     }
   }
 
-  private JComboBox createLocaleComboBox() {
-    final JComboBox cbox = new JComboBox();
+  private JComboBox<Object> createLocaleComboBox() {
+    final JComboBox<Object> cbox = new JComboBox<>();
 
     cbox.setRenderer(new PSLocaleRenderer());
 
@@ -774,7 +781,7 @@ public class PSContentExplorerLoginPanel extends JFrame {
 
   //////////////////////////////////////////////////////////////////////////////
   /** the parent frame */
-  private PSContentExplorerFrame m_parent = null;
+  private transient PSContentExplorerFrame m_parent = null;
 
   /** editable text field for server url */
   private JTextField m_url = new JTextField("");
@@ -789,19 +796,19 @@ public class PSContentExplorerLoginPanel extends JFrame {
   private JButton m_login = null;
 
   /** the locale */
-  private JComboBox m_locale = null;
+  private JComboBox<Object> m_locale = null;
 
   /** THe currently selected locale */
-  private PSLocale selectedLocale = null;
+  private transient PSLocale selectedLocale = null;
 
   /** status bar, informing the user about the applets/applications state */
   private JLabel m_statusBar = null;
 
   /** Admin properties gets initialized in <code>initPanel</code> */
-  private PSProperties m_adminProps = null;
+  private transient PSProperties m_adminProps = null;
 
   /** Resources */
-  private ResourceBundle m_res = null;
+  private transient ResourceBundle m_res = null;
 
   /**
    * The main application. It is created after a successful login. Its valid until the user quits

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerMenuBar.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerMenuBar.java
@@ -26,8 +26,15 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JPopupMenu;
 
-/** The class that represents top-level menu bar in the applet. */
-public class PSContentExplorerMenuBar extends JMenuBar implements IPSSelectionListener {
+/**
+ * The class that represents top-level menu bar in the applet.
+ *
+ * <p>Declared {@code final} so Swing initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborators are
+ * {@code transient} (the menu bar is never serialized).
+ */
+public final class PSContentExplorerMenuBar extends JMenuBar implements IPSSelectionListener {
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs the global menu bar with supplied parameters.
    *
@@ -62,18 +69,18 @@ public class PSContentExplorerMenuBar extends JMenuBar implements IPSSelectionLi
 
   /** Create all menus for this menu bar */
   private void createMenus() {
-    Iterator actions = m_menuBar.getActions();
-    PSMenuAction action = null;
+    Iterator<?> actions = m_menuBar.getActions();
 
     while (actions.hasNext()) {
-      action = (PSMenuAction) actions.next();
-      if (action != null) {
-        PSContentExplorerMenu menu = new PSContentExplorerMenu(action, m_menuSource, m_actManager);
-        m_menus.add(menu);
-        m_menuActions.add(action);
-
-        add(menu.getMenu());
+      Object next = actions.next();
+      if (!(next instanceof PSMenuAction action)) {
+        continue;
       }
+      PSContentExplorerMenu menu = new PSContentExplorerMenu(action, m_menuSource, m_actManager);
+      m_menus.add(menu);
+      m_menuActions.add(action);
+
+      add(menu.getMenu());
     }
   }
 
@@ -99,22 +106,22 @@ public class PSContentExplorerMenuBar extends JMenuBar implements IPSSelectionLi
   }
 
   /** The underlying PS menu bar, may be <code>null</code>. */
-  private PSMenuBar m_menuBar;
+  private transient PSMenuBar m_menuBar;
 
   /** The source used to populate the menu bar dynamically. */
-  private PSMenuSource m_menuSource;
+  private transient PSMenuSource m_menuSource;
 
   /** The action manager used to look up menu actions. */
-  private PSActionManager m_actManager;
+  private transient PSActionManager m_actManager;
 
   /** The list of menus in the menu bar, may be <code>null</code>. */
-  private List<PSContentExplorerMenu> m_menus;
+  private transient List<PSContentExplorerMenu> m_menus;
 
   /**
    * The list of <code>PSContentExplorerMenu</code>s that represent that exists in this menu bar,
    * initialized and filled in the constructor and never <code>null</code> or modified after that.
    */
-  private List<PSMenuAction> m_menuActions = new ArrayList<PSMenuAction>();
+  private transient List<PSMenuAction> m_menuActions = new ArrayList<PSMenuAction>();
 
   /**
    * Notification event that the selection has changed in main view of applet. Updates the default

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * This class provides a way of constructing the Display Format Option object from the XML document
  * and to get XML document from the Display Format object.
  */
-public class PSDisplayFormatOption implements IPSClientObjects {
+public final class PSDisplayFormatOption implements IPSClientObjects {
   static Logger log = LogManager.getLogger(PSDisplayFormatOption.class);
 
   /** Empty constructor. */

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Text;
  * This class provides a way of constructing the Expanded object from the XML document and to get
  * XML document from the Expanded object.
  */
-public class PSExpandedOption implements IPSClientObjects {
+public final class PSExpandedOption implements IPSClientObjects {
   static Logger log = LogManager.getLogger(PSExpandedOption.class);
 
   /**
@@ -98,7 +98,7 @@ public class PSExpandedOption implements IPSClientObjects {
     Iterator<String> iter = m_paths.iterator();
     while (iter.hasNext()) {
       el = doc.createElement(ELEM_PATH);
-      StringNode = doc.createTextNode((String) iter.next());
+      StringNode = doc.createTextNode(iter.next());
 
       el.appendChild(StringNode);
       root.appendChild(el);

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMenuSource.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMenuSource.java
@@ -19,7 +19,7 @@ package com.percussion.cx;
 /**
  * The class that holds selection source for a menu and context selection source for a context menu.
  */
-public class PSMenuSource {
+public final class PSMenuSource {
 
   /** Default constructor for this object that represents no selection. */
   public PSMenuSource() {}

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationTree.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationTree.java
@@ -64,8 +64,12 @@ import org.apache.logging.log4j.Logger;
  * com.percussion.cx.objectstore.PSNode } for more information. Uses {@link
  * com.percussion.cx.PSNavTreeNodeRenderer } to render the nodes of the tree. Displays pop-up menu
  * for right-click on a node.
+ *
+ * <p>Declared {@code final} so Swing initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}).
  */
-public class PSNavigationTree extends JTree implements DragGestureListener, DropTargetListener {
+public final class PSNavigationTree extends JTree
+    implements DragGestureListener, DropTargetListener {
   static Logger log = LogManager.getLogger(PSNavigationTree.class);
 
   /** Serializable id */
@@ -83,7 +87,6 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param ignoreRoot supply <code>true</code> to not to show the root node in the tree and do not
    *     consider the root in the path, otherwise supply <code>false</code>
    */
-  @SuppressWarnings("this-escape") // Swing selection model / listeners registered in ctor
   public PSNavigationTree(PSNode root, String view, PSActionManager manager, boolean ignoreRoot) {
     if (root == null) throw new IllegalArgumentException("root may not be null.");
 
@@ -957,7 +960,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
   }
 
   /** Constructs the dyanmic tree node that loads children when it is expanded only. */
-  public class PSTreeNode extends JTree.DynamicUtilTreeNode implements Accessible {
+  public final class PSTreeNode extends JTree.DynamicUtilTreeNode implements Accessible {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -968,7 +971,6 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      * @param node the user object of the node, may not be <code>null</code>
      * @throws IllegalArgumentException if node is <code>null</code>
      */
-    @SuppressWarnings("this-escape") // associates this node with user object after super()
     public PSTreeNode(PSNode node) {
       super(node, new Vector<>());
 
@@ -1086,6 +1088,9 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      * @see javax.accessibility.Accessible#getAccessibleContext()
      */
     public AccessibleContext getAccessibleContext() {
+      if (m_accessibleContext == null) {
+        m_accessibleContext = new PSTreeNodeAccContext(PSNavigationTree.this, this);
+      }
       return m_accessibleContext;
     }
 
@@ -1114,10 +1119,8 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
       super.setUserObject(userObject);
     }
 
-    /** Create the accessible context for this node */
-    @SuppressWarnings("this-escape") // accessibility context needs outer/this refs
-    private final transient AccessibleContext m_accessibleContext =
-        new PSTreeNodeAccContext(PSNavigationTree.this, this);
+    /** Accessible context, created on first {@link #getAccessibleContext()} (avoids ctor leak). */
+    private transient AccessibleContext m_accessibleContext;
 
     /**
      * The flag to indicate that whether this node is currently under drag movement to represent a

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/objectstore/PSNode.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/objectstore/PSNode.java
@@ -37,8 +37,15 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
-/** The class that is used to represent menu actions as defined by 'sys_Node.dtd'. */
-public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTreeNodeAssociation {
+/**
+ * The class that is used to represent menu actions as defined by 'sys_Node.dtd'.
+ *
+ * <p>Declared {@code final} so constructors can call {@link #fromXml(Element)} and folder-type
+ * helpers without javac {@code this-escape} (no subclass can observe a partially constructed
+ * instance).
+ */
+public final class PSNode
+    implements IPSComponent, Cloneable, PSNavigationTree.IPSTreeNodeAssociation {
   // see PSNavigationTree.IPSTreeNodeAssociation
   public PSNavigationTree.PSTreeNode getAssociatedTreeNode() {
     return m_parentNode;
@@ -69,7 +76,6 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
    * @throws IllegalArgumentException if <code>name</code> or <code>label</code> or <code>type
    *     </code> or <code>permissions</code> is invalid
    */
-  @SuppressWarnings("this-escape")
   public PSNode(
       String name,
       String label,
@@ -96,8 +102,7 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
     m_childrenURL = (childrenURL == null) ? "" : childrenURL;
     m_isExpand = expand;
 
-    // isAnyFolderType() is overridable; intentional for legacy subclass wiring.
-    if (isAnyFolderType()) {
+    if (isAnyFolderType(type)) {
       if (permissions < 0)
         throw new IllegalArgumentException("Invalid permissions for folder : " + name);
       m_permissions = new PSFolderPermissions(permissions);
@@ -112,11 +117,9 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
    * @throws IllegalArgumentException if element is <code>null</code>
    * @throws PSUnknownNodeTypeException if element is not of expected format.
    */
-  @SuppressWarnings("this-escape")
   public PSNode(Element element) throws PSUnknownNodeTypeException {
     if (element == null) throw new IllegalArgumentException("element may not be null.");
 
-    // fromXml is overridable; intentional for legacy subclass wiring.
     fromXml(element);
   }
 
@@ -861,7 +864,18 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
    * @return <code>true</code> if it is of type system folder, <code>false</code> otherwise.
    */
   public boolean isSystemFolderType() {
-    return ms_systemFolderTypes.contains(getType());
+    return isSystemFolderType(getType());
+  }
+
+  /**
+   * Determine if the specified type is a system folder type ({@link #TYPE_SYS_FOLDERS} or {@link
+   * #TYPE_SYS_SITES}).
+   *
+   * @param type the type to check, may be {@code null} or empty
+   * @return {@code true} if {@code type} is a system folder type
+   */
+  public static boolean isSystemFolderType(String type) {
+    return type != null && ms_systemFolderTypes.contains(type);
   }
 
   /**
@@ -900,7 +914,18 @@ public class PSNode implements IPSComponent, Cloneable, PSNavigationTree.IPSTree
    * @return <code>true</code> if it is of any folder type, <code>false</code> otherwise.
    */
   public boolean isAnyFolderType() {
-    return isSystemFolderType() || isFolderType();
+    return isAnyFolderType(getType());
+  }
+
+  /**
+   * Determine if the specified type is any folder type (system folder or {@link
+   * #isFolderType(String)}).
+   *
+   * @param type the type to check, may be {@code null} or empty
+   * @return {@code true} if {@code type} is any folder type
+   */
+  public static boolean isAnyFolderType(String type) {
+    return isSystemFolderType(type) || (StringUtils.isNotBlank(type) && isFolderType(type));
   }
 
   /**

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSColumnWidthsOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSColumnWidthsOptionTest.java
@@ -22,12 +22,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Behavioral tests for typed column-width option map used by the applet display panels. */
 public class PSColumnWidthsOptionTest {
+
+  @Test
+  public void optionClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSColumnWidthsOption.class.getModifiers()),
+        "PSColumnWidthsOption must be final to avoid this-escape in the Element ctor");
+  }
 
   @Test
   public void addGetAndRemoveItemColumnWidths() {

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatOptionTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -30,6 +31,13 @@ import org.w3c.dom.NodeList;
 
 /** Behavioral tests for typed {@link PSDisplayFormatOption} map after rawtypes cleanup (#2939). */
 public class PSDisplayFormatOptionTest {
+
+  @Test
+  public void optionClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSDisplayFormatOption.class.getModifiers()),
+        "PSDisplayFormatOption must be final to avoid this-escape in the Element ctor");
+  }
 
   @Test
   public void emptyOptionHasNoDisplayFormats() {

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExpandedOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExpandedOptionTest.java
@@ -20,12 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /** Behavioral tests for typed expanded-path option APIs used by the nav tree. */
 public class PSExpandedOptionTest {
+
+  @Test
+  public void optionClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSExpandedOption.class.getModifiers()),
+        "PSExpandedOption must be final to avoid this-escape in constructors");
+  }
 
   @Test
   public void constructorAndGetPathsPreserveTypedPaths() {

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExplorerChromeXlintTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExplorerChromeXlintTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural coverage for DCE chrome this-escape/serial cleanup (#3288): types are {@code final}
+ * and non-serializable session collaborators are {@code transient}.
+ */
+public class PSExplorerChromeXlintTest {
+
+  @Test
+  public void chromeTypesAreFinal() {
+    assertFinal(PSContentExplorerLoginPanel.class);
+    assertFinal(PSContentExplorerMenuBar.class);
+    assertFinal(PSContentExplorerHeader.class);
+    assertFinal(PSContentExplorerFrame.class);
+    assertFinal(PSMenuSource.class);
+  }
+
+  @Test
+  public void loginPanelDeclaresSerialVersionUid() throws Exception {
+    Field uid = PSContentExplorerLoginPanel.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  @Test
+  public void menuBarDeclaresSerialVersionUid() throws Exception {
+    Field uid = PSContentExplorerMenuBar.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  @Test
+  public void loginPanelCollaboratorsAreTransient() throws Exception {
+    assertTransient(
+        PSContentExplorerLoginPanel.class,
+        Set.of("applet", "m_parent", "m_res", "m_adminProps", "selectedLocale"));
+  }
+
+  @Test
+  public void menuBarCollaboratorsAreTransient() throws Exception {
+    assertTransient(
+        PSContentExplorerMenuBar.class,
+        Set.of("m_menuBar", "m_menuSource", "m_actManager", "m_menus", "m_menuActions"));
+  }
+
+  @Test
+  public void frameCollaboratorsAreTransient() throws Exception {
+    assertTransient(
+        PSContentExplorerFrame.class, Set.of("helper", "parameters", "loginPanel"));
+  }
+
+  private static void assertFinal(Class<?> type) {
+    assertTrue(
+        Modifier.isFinal(type.getModifiers()),
+        () -> type.getSimpleName() + " must be final to avoid this-escape in constructors");
+  }
+
+  private static void assertTransient(Class<?> type, Set<String> names) throws Exception {
+    for (String name : names) {
+      Field f = type.getDeclaredField(name);
+      assertTrue(
+          Modifier.isTransient(f.getModifiers()),
+          () -> type.getSimpleName() + "." + name + " must be transient");
+    }
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSNavigationTreeTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSNavigationTreeTest.java
@@ -18,7 +18,9 @@ package com.percussion.cx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,6 +28,16 @@ import org.junit.jupiter.api.Test;
  * live {@link PSActionManager} HTTP session).
  */
 public class PSNavigationTreeTest {
+
+  @Test
+  public void treeAndNodeClassesAreFinal() {
+    assertTrue(
+        Modifier.isFinal(PSNavigationTree.class.getModifiers()),
+        "PSNavigationTree must be final to avoid this-escape in the ctor");
+    assertTrue(
+        Modifier.isFinal(PSNavigationTree.PSTreeNode.class.getModifiers()),
+        "PSTreeNode must be final to avoid this-escape in the ctor");
+  }
 
   @Test
   public void getRefreshNodeTypeMapsKnownHints() {

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/objectstore/PSNodeTest.java
@@ -19,6 +19,7 @@ package com.percussion.cx.objectstore;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import java.lang.reflect.Modifier;
 import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSEntrySet;
@@ -48,6 +49,33 @@ public class PSNodeTest {
    *
    * @throws Exception if there are any errors
    */
+  @Test
+  public void nodeClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSNode.class.getModifiers()),
+        "PSNode must be final to avoid this-escape in constructors");
+  }
+
+  @Test
+  public void staticFolderTypeHelpersMatchInstance() {
+    PSNode folder = new PSNode("p", "Parent", PSNode.TYPE_FOLDER, "url", null, false, 1);
+    PSNode item = new PSNode("i", "Item", PSNode.TYPE_ITEM, "", null, false, -1);
+    PSNode sys = new PSNode("s", "Sites", PSNode.TYPE_SYS_SITES, "url", null, false, 1);
+
+    assertTrue(PSNode.isAnyFolderType(PSNode.TYPE_FOLDER));
+    assertTrue(PSNode.isFolderType(PSNode.TYPE_SITE));
+    assertTrue(PSNode.isSystemFolderType(PSNode.TYPE_SYS_SITES));
+    assertTrue(PSNode.isAnyFolderType(PSNode.TYPE_SYS_FOLDERS));
+    assertFalse(PSNode.isAnyFolderType(PSNode.TYPE_ITEM));
+    assertFalse(PSNode.isAnyFolderType(null));
+    assertFalse(PSNode.isSystemFolderType(null));
+
+    assertTrue(folder.isAnyFolderType());
+    assertFalse(item.isAnyFolderType());
+    assertTrue(sys.isSystemFolderType());
+    assertTrue(sys.isAnyFolderType());
+  }
+
   @Test
   public void testClone() throws Exception {
     PSNode node1 = new PSNode("test1", "test 1", PSNode.TYPE_FOLDER, "url", "iconKey", true, 1);


### PR DESCRIPTION
## Summary

Parent: #2045. Slice: #3288.

Re-probed `perc-content-explorer` with `javac -Xlint -Xmaxwarns 10000` (289 warning lines: 110 serial, 64 this-escape, 37 rawtypes, 28 unchecked). `PSNode` / `PSNavigationTree` were already suppressed (0 live diags). This PR real-fixes that named this-escape pair and clears the next live this-escape/serial chrome + option cluster.

- `PSNode` / `PSNavigationTree` (+ nested `PSTreeNode`): `final`, static folder-type helpers, lazy accessible context; ctor `@SuppressWarnings("this-escape")` removed
- Explorer chrome: `PSContentExplorerLoginPanel`, `PSContentExplorerMenuBar`, `PSContentExplorerHeader`, `PSContentExplorerFrame` — `final` + `serialVersionUID` + transient session collaborators
- Option beans: `PSColumnWidthsOption`, `PSDisplayFormatOption`, `PSExpandedOption`, `PSMenuSource` — `final` (ctor `fromXml` / `setSource` no longer overridable)
- Did **not** strip `java.applet` `removal` warnings on `PSContentExplorerFrame` (legacy stub/context; sibling of applet JApplet `removal` on `PSContentExplorerApplet`)

Inventory after: 254 warning lines. Cluster files at 0 except Frame leftover `removal` + raw `Enumeration` from `AppletContext`.

Fixes #3288

## Test plan

1. `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` (JDK 21)
2. Confirm Tests run: 184, Failures: 0 (includes `PSNodeTest` static folder helpers, `PSExplorerChromeXlintTest`, final-class assertions)
3. Optional: `javac -Xlint -Xmaxwarns 10000` on DCE sources — cluster files listed above should be clean aside from Frame applet `removal`

## Checklist

- [x] **Product documentation** — N/A (not product-facing): compiler-warning / this-escape/serial tech-debt; no operator or UI behavior change
- [x] **Unit / module tests** — behavioral tests for static folder-type helpers; structural `final`/`transient` tests; module clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; DCE javac cleanup only)
- [x] **Build gates** — standalone `modules/DesktopContentExplorer` clean install; C2 greps for `extends` / anonymous subclasses of finalized types (none; only `? extends PSNode` iterator bounds)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: 184, Failures: 0
- **downstream_checked:** grepped monorepo for `extends PSNode|PSNavigationTree|PSContentExplorerLoginPanel|PSContentExplorerMenuBar|PSContentExplorerHeader|PSContentExplorerFrame|PSColumnWidthsOption|PSDisplayFormatOption|PSExpandedOption|PSMenuSource` and anonymous `new Type() {` — no subclasses; DCE is the consumer module (no extra reverse-dep install)

## C5 UI proof

N/A — not WebUI/Explorer SPA product-screen work.

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
