### PR TITLE
feat(sites): preview last Virtual Site build from Developer Sites (#3299)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -10,6 +10,7 @@ import type {
   SiteDef,
   VirtualSiteBuildRequest,
   VirtualSiteBuildResult,
+  VirtualSitePreviewStatus,
   VirtualSiteProperties,
 } from "./types";
 
@@ -258,6 +259,52 @@ export async function buildVirtualSite(
       : {};
   const payload = await post<unknown>(`${PATHS.SITES}/${key}/virtual/build`, body);
   return parseVirtualSiteBuildResult(payload);
+}
+
+/**
+ * Normalize Virtual Site preview status (Jackson root wrap or plain DTO).
+ */
+export function parseVirtualSitePreviewStatus(payload: unknown): VirtualSitePreviewStatus {
+  if (payload == null || typeof payload !== "object") {
+    return {};
+  }
+  const obj = payload as Record<string, unknown>;
+  const root =
+    (obj.VirtualSitePreviewStatus as Record<string, unknown> | undefined) ??
+    (obj.virtualSitePreviewStatus as Record<string, unknown> | undefined) ??
+    obj;
+  return {
+    available: typeof root.available === "boolean" ? root.available : undefined,
+    homePath: asNullableString(root.homePath),
+    outputPath: asNullableString(root.outputPath),
+    message: asNullableString(root.message),
+  };
+}
+
+/** GET /services/sites/{nameOrId}/virtual/preview — last-build availability (Admin). */
+export async function getVirtualSitePreviewStatus(
+  nameOrId: string,
+): Promise<VirtualSitePreviewStatus> {
+  const key = encodeURIComponent(nameOrId.trim());
+  const payload = await get<unknown>(`${PATHS.SITES}/${key}/virtual/preview`);
+  return parseVirtualSitePreviewStatus(payload);
+}
+
+/**
+ * Browser URL for the assembled preview file stream (same-origin cookies).
+ * {@code homePath} must be a relative path such as {@code 8.2/index.html}.
+ */
+export function virtualSitePreviewContentHref(nameOrId: string, homePath: string): string {
+  const key = encodeURIComponent(nameOrId.trim());
+  const rel = homePath
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((seg) => seg.length > 0 && seg !== "." && seg !== "..")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+  return `${PATHS.SITES}/${key}/virtual/preview/${rel}`;
 }
 
 function asNullableString(value: unknown): string | null | undefined {

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -751,3 +751,15 @@ export interface VirtualSiteBuildResult {
   writtenFiles?: string[] | null;
 }
 
+/**
+ * Last-build preview availability ({@code GET /services/sites/{nameOrId}/virtual/preview}).
+ * Missing output is HTTP 200 with {@code available=false} (not 500).
+ */
+export interface VirtualSitePreviewStatus {
+  available?: boolean | null;
+  /** Relative home under the output root, e.g. {@code 8.2/index.html}. */
+  homePath?: string | null;
+  outputPath?: string | null;
+  message?: string | null;
+}
+

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -18,8 +18,10 @@
 import React, { useCallback, useEffect, useState } from "react";
 import {
   buildVirtualSite,
+  getVirtualSitePreviewStatus,
   getVirtualSiteProperties,
   updateVirtualSiteProperties,
+  virtualSitePreviewContentHref,
 } from "../api/developer/sitesApi";
 import type { VirtualSiteBuildResult } from "../api/developer/types";
 import {
@@ -32,6 +34,7 @@ import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import {
   formatVirtualSiteBuildSummary,
+  sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
 } from "./virtualSiteBuild";
 import {
@@ -148,6 +151,8 @@ export function VirtualSiteSourcePanel({
   const [isVirtual, setIsVirtual] = useState(false);
   const [buildError, setBuildError] = useState<string | null>(null);
   const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
 
   const load = useCallback(() => {
     if (!siteName.trim()) {
@@ -162,6 +167,7 @@ export function VirtualSiteSourcePanel({
     setSavedNotice(null);
     setBuildError(null);
     setBuildResult(null);
+    setPreviewError(null);
     getVirtualSiteProperties(siteName)
       .then((props) => {
         if (cancelled) return;
@@ -222,6 +228,7 @@ export function VirtualSiteSourcePanel({
     setBuilding(true);
     setBuildError(null);
     setBuildResult(null);
+    setPreviewError(null);
     setFormError(null);
     try {
       const result = await buildVirtualSite(siteName);
@@ -230,6 +237,31 @@ export function VirtualSiteSourcePanel({
       setBuildError(panelErrMsg(e, DEV_MSG.SITE_VIRT_BUILD_ERROR));
     } finally {
       setBuilding(false);
+    }
+  }
+
+  async function onPreview(): Promise<void> {
+    setPreviewBusy(true);
+    setPreviewError(null);
+    try {
+      const status = await getVirtualSitePreviewStatus(siteName);
+      if (status.available !== true) {
+        setPreviewError(
+          status.message?.trim() || DEV_MSG.SITE_VIRT_PREVIEW_MISSING,
+        );
+        return;
+      }
+      const home = sanitizeVirtualPreviewHomePath(status.homePath);
+      if (!home) {
+        setPreviewError(DEV_MSG.SITE_VIRT_PREVIEW_MISSING);
+        return;
+      }
+      const href = virtualSitePreviewContentHref(siteName, home);
+      window.open(href, "_blank", "noopener,noreferrer");
+    } catch (e: unknown) {
+      setPreviewError(panelErrMsg(e, DEV_MSG.SITE_VIRT_PREVIEW_ERROR));
+    } finally {
+      setPreviewBusy(false);
     }
   }
 
@@ -391,15 +423,32 @@ export function VirtualSiteSourcePanel({
               <p style={{ ...mutedHintText, margin: "0 0 10px" }} data-testid="developer-site-virtual-build-save-first">
                 {DEV_MSG.SITE_VIRT_BUILD_SAVE_FIRST}
               </p>
-              <button
-                type="button"
-                data-testid="developer-site-virtual-build"
-                style={busy ? disabledSecondaryButton : secondaryButton}
-                disabled={busy}
-                onClick={() => void onBuild()}
+              <div style={{ display: "flex", gap: "12px", flexWrap: "wrap", alignItems: "center" }}>
+                <button
+                  type="button"
+                  data-testid="developer-site-virtual-build"
+                  style={busy ? disabledSecondaryButton : secondaryButton}
+                  disabled={busy}
+                  onClick={() => void onBuild()}
+                >
+                  {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
+                </button>
+                <button
+                  type="button"
+                  data-testid="developer-site-virtual-preview"
+                  style={busy || previewBusy ? disabledSecondaryButton : secondaryButton}
+                  disabled={busy || previewBusy}
+                  onClick={() => void onPreview()}
+                >
+                  {DEV_MSG.SITE_VIRT_PREVIEW}
+                </button>
+              </div>
+              <p
+                style={{ ...mutedHintText, margin: "8px 0 0" }}
+                data-testid="developer-site-virtual-preview-hint"
               >
-                {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
-              </button>
+                {DEV_MSG.SITE_VIRT_PREVIEW_HINT}
+              </p>
 
               {building ? (
                 <div data-testid="developer-site-virtual-build-busy" style={{ ...mutedText, marginTop: "10px" }}>
@@ -414,6 +463,16 @@ export function VirtualSiteSourcePanel({
                   style={{ ...errorAlert, marginTop: "10px" }}
                 >
                   {buildError}
+                </div>
+              ) : null}
+
+              {previewError ? (
+                <div
+                  role="alert"
+                  data-testid="developer-site-virtual-preview-error"
+                  style={{ ...errorAlert, marginTop: "10px" }}
+                >
+                  {previewError}
                 </div>
               ) : null}
 

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -776,6 +776,12 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_BUILD_LINK_PROBLEMS: "perc.ui.developer@Link problems",
   SITE_VIRT_BUILD_SAVE_FIRST:
     "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
+  SITE_VIRT_PREVIEW: "perc.ui.developer@Preview assembled site",
+  SITE_VIRT_PREVIEW_HINT:
+    "perc.ui.developer@Opens the last assembled documentation home in a new tab (same-origin preview of the build output). Requires Admin.",
+  SITE_VIRT_PREVIEW_MISSING:
+    "perc.ui.developer@No assembled site to preview. Run Build Virtual Site first.",
+  SITE_VIRT_PREVIEW_ERROR: "perc.ui.developer@Could not open Virtual Site preview.",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -67,3 +67,30 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
     hasLinkProblems,
   };
 }
+
+/**
+ * Safe relative home path for the preview stream. Rejects empty, absolute, and {@code ..}
+ * segments so the UI never opens a traversal URL.
+ */
+export function sanitizeVirtualPreviewHomePath(
+  homePath: string | null | undefined,
+): string | null {
+  if (typeof homePath !== "string") {
+    return null;
+  }
+  const trimmed = homePath.trim().replace(/\\/g, "/");
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.includes("://") || /^[a-zA-Z]:/.test(trimmed)) {
+    return null;
+  }
+  const parts = trimmed.split("/").filter((seg) => seg.length > 0);
+  if (parts.length === 0) {
+    return null;
+  }
+  if (parts.some((seg) => seg === ".." || seg === ".")) {
+    return null;
+  }
+  return parts.join("/");
+}

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -6,10 +6,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
   buildVirtualSite,
+  getVirtualSitePreviewStatus,
   getVirtualSiteProperties,
   parseVirtualSiteBuildResult,
+  parseVirtualSitePreviewStatus,
   parseVirtualSiteProperties,
   updateVirtualSiteProperties,
+  virtualSitePreviewContentHref,
 } from "../../../../main/ts/api/developer/sitesApi";
 
 vi.mock("../../../../main/ts/api/client", () => ({
@@ -146,5 +149,37 @@ describe("sitesApi virtual properties", () => {
       expect.stringMatching(/\/sites\/Help\/virtual\/build$/),
       { outputRoot: "C:/custom/out" },
     );
+  });
+
+  it("parseVirtualSitePreviewStatus handles wrap and missing payload", () => {
+    expect(
+      parseVirtualSitePreviewStatus({
+        available: true,
+        homePath: "8.2/index.html",
+      }),
+    ).toEqual(
+      expect.objectContaining({ available: true, homePath: "8.2/index.html" }),
+    );
+    expect(
+      parseVirtualSitePreviewStatus({
+        VirtualSitePreviewStatus: { available: false, message: "none" },
+      }),
+    ).toEqual(expect.objectContaining({ available: false, message: "none" }));
+    expect(parseVirtualSitePreviewStatus(null)).toEqual({});
+  });
+
+  it("getVirtualSitePreviewStatus GETs /virtual/preview", async () => {
+    get.mockResolvedValue({ available: false, message: "none" });
+    const out = await getVirtualSitePreviewStatus("Help Docs");
+    expect(get).toHaveBeenCalledWith(
+      expect.stringMatching(/\/sites\/Help%20Docs\/virtual\/preview$/),
+    );
+    expect(out.available).toBe(false);
+  });
+
+  it("virtualSitePreviewContentHref encodes site and relative home", () => {
+    const href = virtualSitePreviewContentHref("Help Docs", "8.2/index.html");
+    expect(href).toMatch(/\/sites\/Help%20Docs\/virtual\/preview\/8.2\/index.html$/);
+    expect(virtualSitePreviewContentHref("Help", "../secret")).not.toContain("..");
   });
 });

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -13,6 +13,10 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   getVirtualSiteProperties: vi.fn(),
   updateVirtualSiteProperties: vi.fn(),
   buildVirtualSite: vi.fn(),
+  getVirtualSitePreviewStatus: vi.fn(),
+  virtualSitePreviewContentHref: vi.fn(
+    (name: string, home: string) => `/services/sites/${encodeURIComponent(name)}/virtual/preview/${home}`,
+  ),
   listSites: vi.fn(),
   SITE_DESIGN_GAPS: [],
 }));
@@ -20,6 +24,7 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
 const getVirtual = sitesApi.getVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const updateVirtual = sitesApi.updateVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const buildVirtual = sitesApi.buildVirtualSite as ReturnType<typeof vi.fn>;
+const previewStatus = sitesApi.getVirtualSitePreviewStatus as ReturnType<typeof vi.fn>;
 
 describe("VirtualSiteSourcePanel", () => {
   beforeEach(() => {
@@ -29,6 +34,7 @@ describe("VirtualSiteSourcePanel", () => {
     getVirtual.mockReset();
     updateVirtual.mockReset();
     buildVirtual.mockReset();
+    previewStatus.mockReset();
   });
 
   it("shows loading then success form for traditional (repository) site", async () => {
@@ -51,6 +57,7 @@ describe("VirtualSiteSourcePanel", () => {
     // Repository sites must not show Build chrome
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
     expect(getVirtual).toHaveBeenCalledWith("Corporate");
   });
 
@@ -298,5 +305,54 @@ describe("VirtualSiteSourcePanel", () => {
       );
     });
     expect(buildVirtual).not.toHaveBeenCalled();
+  });
+
+  it("shows Preview chrome for virtual sites and opens home when available", async () => {
+    const open = vi.fn();
+    window.open = open;
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    previewStatus.mockResolvedValue({
+      available: true,
+      homePath: "8.2/index.html",
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
+    await waitFor(() => {
+      expect(open).toHaveBeenCalled();
+    });
+    expect(previewStatus).toHaveBeenCalledWith("Help");
+    expect(String(open.mock.calls[0][0])).toContain("8.2/index.html");
+    expect(open.mock.calls[0][1]).toBe("_blank");
+  });
+
+  it("shows empty preview state when no assembled site exists", async () => {
+    window.open = vi.fn();
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    previewStatus.mockResolvedValue({
+      available: false,
+      message: "No assembled Virtual Site to preview. Run Build Virtual Site first.",
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview-error").textContent).toContain(
+        "No assembled",
+      );
+    });
+    expect(window.open).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatVirtualSiteBuildSummary,
+  sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
@@ -46,5 +47,15 @@ describe("virtualSiteBuild helpers", () => {
     expect(missing.pagesLine).toBe("0");
     expect(missing.outputLine).toBeNull();
     expect(missing.hasLinkProblems).toBe(false);
+  });
+
+  it("sanitizeVirtualPreviewHomePath rejects traversal and absolute paths", () => {
+    expect(sanitizeVirtualPreviewHomePath("8.2/index.html")).toBe("8.2/index.html");
+    expect(sanitizeVirtualPreviewHomePath(" /8.2/admin/index.html ")).toBe("8.2/admin/index.html");
+    expect(sanitizeVirtualPreviewHomePath("../etc/passwd")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("C:/tmp/out/index.html")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("https://evil.example/x")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath(null)).toBeNull();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -49,6 +49,9 @@ function developerSectionUrl(section) {
 test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.__virtPageErrors = pageErrors;
     await loginAsAdmin(page);
   });
 
@@ -127,7 +130,19 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-preview-hint"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-hint"]')).toBeVisible();
+
+      // Preview without a last build: in-panel empty/error (no 500 / no crash)
+      await page.locator('[data-testid="developer-site-virtual-preview"]').click();
+      const previewChrome = page.locator(
+        [
+          '[data-testid="developer-site-virtual-preview-error"]',
+          '[data-testid="developer-site-virtual-build-error"]',
+        ].join(", "),
+      );
+      await expect(previewChrome.first()).toBeVisible({ timeout: 20_000 });
 
       // Optional: click Build without save — expect client validation or API error chrome
       // (H2 QA rarely has a saved virtual root; do not require full build success)
@@ -145,5 +160,8 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     }
+
+    const jsErrors = page.__virtPageErrors || [];
+    expect(jsErrors, `uncaught page errors: ${jsErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -132,6 +132,25 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
    - **Error** — clear message when the Site is not virtual, the root is missing/invalid,
      or the caller lacks Admin (for example 400/403 from REST).
 
+### Preview the assembled Virtual Site
+
+After a successful **Build Virtual Site**, operators can open the assembled documentation
+home from the same Site detail panel (no CLI, no `file://` path).
+
+1. Stay on **Developer → Sites → Site detail** for the Virtual Site (Admin).
+2. Choose **Preview assembled site**.
+3. The CMS opens the last build’s home (typically `8.2/index.html`, or root `index.html`
+   when present) in a new tab. Navigation stays on the same-origin preview URL
+   (`GET /services/sites/{name}/virtual/preview/{path}`).
+4. If no build has been run yet (or the last output is missing), the panel shows a clear
+   empty state — **No assembled site to preview. Run Build Virtual Site first.** — and
+   does not return HTTP 500.
+
+The preview stream reads the last recorded `outputPath` from the build (default
+`{install}/tmp/virtual-sites/{siteKey}`). It is **Admin-only**, path-traversal safe, and
+does not invent a second assembler. Traditional **Repository** Sites do not show Preview
+chrome.
+
 Integrators can call the same operation over REST:
 `POST /sites/{nameOrId}/virtual/build` (optional JSON body `outputRoot`). See
 [Site configuration reference](id:reference-site-config) and

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -109,6 +109,8 @@ Example create body:
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+| Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
+| Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
 only empty-catalog case. See [Sites & content structure](id:admin-sites).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -130,7 +130,12 @@ invalid/missing virtual configuration return **400**.
 
 Operators can run the same operation from **Developer → Sites → Site detail → Build Virtual Site**
 (visible only when source kind is Virtual). Save Virtual Site source before building so the server
-uses the latest properties. See [Sites & content structure](id:admin-sites) and
+uses the latest properties.
+
+After a successful build, **Preview assembled site** opens the last output home in a new tab
+(`GET /sites/{nameOrId}/virtual/preview` for status; `GET …/virtual/preview/{relPath}` for the
+assembled file stream). Missing output returns status `available=false` (HTTP 200) or file HTTP
+404 — not 500. See [Sites & content structure](id:admin-sites) and
 [Site configuration](id:reference-site-config).
 
 ## What is not in Phase 1

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -70,6 +70,8 @@ Integrators can read and write these keys via public Site REST:
 - `GET /sites/{nameOrId}/virtual`
 - `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
 - `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
+- `GET /sites/{nameOrId}/virtual/preview` (last-build preview status)
+- `GET /sites/{nameOrId}/virtual/preview/{relPath}` (assembled file stream)
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable
@@ -94,6 +96,17 @@ the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
 Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+
+#### Preview assembled Virtual Site (`GET …/virtual/preview`)
+
+Admin-only. Reports whether the last build output can be opened (`available`, `homePath`,
+`outputPath`). Missing or failed builds return **200** with `available=false` and a message
+(not 500). Traditional repository Sites return **400**.
+
+`GET …/virtual/preview/{relPath}` streams one file from that last output root (portable NIO
+resolution, no `..` after normalize). HTML root-relative `href`/`src` values are rewritten to
+the preview prefix so the assembled site is navigable in the browser. Missing files return
+**404**. The Developer UI **Preview assembled site** control uses these endpoints.
 
 ## Related
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -25,6 +25,8 @@ import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.SiteList;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewFile;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
 import com.percussion.rest.sites.VirtualSiteProperties;
 import com.percussion.server.PSServer;
 import com.percussion.services.error.PSNotFoundException;
@@ -55,11 +57,15 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -80,6 +86,14 @@ public class SitesAdaptor implements ISiteAdaptor {
 
   /** Max link-problem / written-file lines returned on the wire (full report is on disk). */
   static final int MAX_RESULT_LINES = 200;
+
+  /** Sidecar under default output {@code _meta} pointing at the last successful build root. */
+  static final String LAST_OUTPUT_POINTER_FILE = "last-output-root.txt";
+
+  static final String MISSING_PREVIEW_MESSAGE =
+      "No assembled Virtual Site to preview. Run Build Virtual Site first.";
+
+  static final long MAX_PREVIEW_FILE_BYTES = 20L * 1024 * 1024;
 
   @Autowired private IPSPublishingWs publishingWs;
 
@@ -345,6 +359,7 @@ public class SitesAdaptor implements ISiteAdaptor {
 
       VirtualSiteConfig config = VirtualSiteConfigLoader.load(siteRoot, configFile, siteKey);
       PSVirtualSiteBuildResult built = runBuild(config, outputRoot, metaDir);
+      recordLastOutputRoot(siteKey, outputRoot);
       return toWireResult(site.getName(), siteKey, built);
     } catch (VirtualSiteException e) {
       throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
@@ -432,6 +447,258 @@ public class SitesAdaptor implements ISiteAdaptor {
         .ifPresent(v::setSiteKey);
     v.setVirtual(PSVirtualSiteHelper.isVirtual(site));
     return v;
+  }
+
+  @Override
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId) {
+    IPSSite site = requireVirtualAdminSite(nameOrId);
+    String siteKey = PSVirtualSiteHelper.siteKey(site);
+    Path outputRoot = resolveLastOutputRoot(siteKey);
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    if (outputRoot != null) {
+      status.setOutputPath(outputRoot.toAbsolutePath().normalize().toString());
+    }
+    String home = outputRoot == null ? null : findHomeRelativePath(outputRoot);
+    if (home == null) {
+      status.setAvailable(false);
+      status.setMessage(MISSING_PREVIEW_MESSAGE);
+      return status;
+    }
+    status.setAvailable(true);
+    status.setHomePath(home);
+    return status;
+  }
+
+  @Override
+  public VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath) {
+    IPSSite site = requireVirtualAdminSite(nameOrId);
+    String siteKey = PSVirtualSiteHelper.siteKey(site);
+    Path outputRoot = resolveLastOutputRoot(siteKey);
+    if (outputRoot == null || !Files.isDirectory(outputRoot)) {
+      throw new WebApplicationException(MISSING_PREVIEW_MESSAGE, Response.Status.NOT_FOUND);
+    }
+    String rel = blankToNull(relativePath);
+    if (rel == null) {
+      String home = findHomeRelativePath(outputRoot);
+      if (home == null) {
+        throw new WebApplicationException(MISSING_PREVIEW_MESSAGE, Response.Status.NOT_FOUND);
+      }
+      rel = home;
+    }
+    Path file = resolvePreviewFile(outputRoot, rel);
+    if (file == null) {
+      throw new WebApplicationException(
+          "Preview file not found: " + rel, Response.Status.NOT_FOUND);
+    }
+    try {
+      long size = Files.size(file); // codeql[java/path-injection]
+      if (size > MAX_PREVIEW_FILE_BYTES) {
+        throw new WebApplicationException(
+            "Preview file is too large to stream", Response.Status.BAD_REQUEST);
+      }
+      byte[] bytes = Files.readAllBytes(file); // codeql[java/path-injection]
+      return new VirtualSitePreviewFile(mediaTypeFor(file), toWirePath(outputRoot, file), bytes);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IOException e) {
+      throw new WebApplicationException(
+          "Could not read preview file", Response.Status.NOT_FOUND);
+    }
+  }
+
+  /**
+   * Admin + Virtual Site gate shared by preview status/file (missing output is handled by callers).
+   */
+  IPSSite requireVirtualAdminSite(String nameOrId) {
+    requireAdmin();
+    IPSSite site = requireSite(nameOrId);
+    if (!PSVirtualSiteHelper.isVirtual(site)) {
+      throw new WebApplicationException(
+          "Site '"
+              + site.getName()
+              + "' is not a Virtual Site (virtual.sourceKind is blank or '"
+              + PSVirtualSiteHelper.SOURCE_KIND_REPOSITORY
+              + "'). Configure virtual.* properties before previewing.",
+          Response.Status.BAD_REQUEST);
+    }
+    try {
+      PSVirtualSiteHelper.validate(site);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+    return site;
+  }
+
+  /**
+   * Persist the last successful build output root so preview can reuse {@code result.outputPath}
+   * (including custom {@code outputRoot}).
+   */
+  void recordLastOutputRoot(String siteKey, Path outputRoot) {
+    Path pointerDir =
+        defaultOutputRootResolver.apply(safePathSegment(siteKey)).resolve("_meta");
+    try {
+      Path safeOut = requireSafeOutputRoot(outputRoot.toAbsolutePath().normalize());
+      Files.createDirectories(pointerDir); // codeql[java/path-injection]
+      Files.writeString(
+          pointerDir.resolve(LAST_OUTPUT_POINTER_FILE),
+          safeOut.toString(),
+          StandardCharsets.UTF_8); // codeql[java/path-injection]
+    } catch (RuntimeException | IOException e) {
+      log.debug("Could not record last Virtual Site output path: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Last recorded output root when the pointer is a safe existing directory; otherwise the default
+   * output directory when it exists.
+   */
+  Path resolveLastOutputRoot(String siteKey) {
+    Path defaultRoot =
+        requireSafeOutputRoot(defaultOutputRootResolver.apply(safePathSegment(siteKey)));
+    Path pointer = defaultRoot.resolve("_meta").resolve(LAST_OUTPUT_POINTER_FILE);
+    if (Files.isRegularFile(pointer)) {
+      try {
+        String raw = Files.readString(pointer, StandardCharsets.UTF_8).trim(); // codeql[java/path-injection]
+        if (!raw.isEmpty()) {
+          Path candidate = Path.of(raw).toAbsolutePath().normalize();
+          if (PSVirtualSiteHelper.isSafeRootPath(candidate) && Files.isDirectory(candidate)) {
+            return candidate;
+          }
+        }
+      } catch (RuntimeException | IOException e) {
+        log.debug("Ignoring invalid last-output pointer: {}", e.getMessage());
+      }
+    }
+    if (Files.isDirectory(defaultRoot)) {
+      return defaultRoot;
+    }
+    return null;
+  }
+
+  static String findHomeRelativePath(Path outputRoot) {
+    if (outputRoot == null || !Files.isDirectory(outputRoot)) {
+      return null;
+    }
+    Path root = outputRoot.toAbsolutePath().normalize();
+    if (Files.isRegularFile(root.resolve("index.html"))) {
+      return "index.html";
+    }
+    if (Files.isRegularFile(root.resolve("8.2").resolve("index.html"))) {
+      return "8.2/index.html";
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+      List<Path> dirs = new ArrayList<>();
+      for (Path p : stream) {
+        if (Files.isDirectory(p)) {
+          dirs.add(p);
+        }
+      }
+      dirs.sort(Comparator.comparing(p -> p.getFileName().toString()));
+      for (Path dir : dirs) {
+        Path idx = dir.resolve("index.html");
+        if (Files.isRegularFile(idx)) {
+          return toWirePath(root, idx);
+        }
+      }
+    } catch (IOException e) {
+      return null;
+    }
+    return null;
+  }
+
+  static Path resolvePreviewFile(Path outputRoot, String relativePath) {
+    Path root = requireSafeOutputRoot(outputRoot.toAbsolutePath().normalize());
+    Path rel = requireSafeRelativePreviewPath(relativePath);
+    Path resolved = root.resolve(rel).normalize(); // codeql[java/path-injection]
+    if (!resolved.startsWith(root)) {
+      throw new WebApplicationException(
+          "Preview path is outside the build output", Response.Status.BAD_REQUEST);
+    }
+    if (Files.isDirectory(resolved)) {
+      Path index = resolved.resolve("index.html").normalize(); // codeql[java/path-injection]
+      if (!index.startsWith(root) || !Files.isRegularFile(index)) {
+        return null;
+      }
+      return index;
+    }
+    if (!Files.isRegularFile(resolved)) {
+      return null;
+    }
+    return resolved;
+  }
+
+  static Path requireSafeRelativePreviewPath(String relativePath) {
+    if (relativePath == null || relativePath.isBlank() || relativePath.indexOf('\0') >= 0) {
+      throw new WebApplicationException("Preview path is required", Response.Status.BAD_REQUEST);
+    }
+    String cleaned = relativePath.trim().replace('\\', '/');
+    while (cleaned.startsWith("/")) {
+      cleaned = cleaned.substring(1);
+    }
+    Path path;
+    try {
+      path = Path.of(cleaned).normalize();
+    } catch (InvalidPathException e) {
+      throw new WebApplicationException("Preview path is not valid", Response.Status.BAD_REQUEST);
+    }
+    if (path.isAbsolute()) {
+      throw new WebApplicationException(
+          "Preview path must be relative", Response.Status.BAD_REQUEST);
+    }
+    for (Path part : path) {
+      String name = part.toString();
+      if ("..".equals(name) || name.isEmpty()) {
+        throw new WebApplicationException(
+            "Preview path must not contain '..'", Response.Status.BAD_REQUEST);
+      }
+    }
+    return path;
+  }
+
+  static String toWirePath(Path outputRoot, Path file) {
+    Path root = outputRoot.toAbsolutePath().normalize();
+    Path resolved = file.toAbsolutePath().normalize();
+    Path rel = root.relativize(resolved);
+    return rel.toString().replace('\\', '/');
+  }
+
+  static String mediaTypeFor(Path file) {
+    String name = file.getFileName() != null ? file.getFileName().toString() : "";
+    String lower = name.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+      return "text/html; charset=UTF-8";
+    }
+    if (lower.endsWith(".css")) {
+      return "text/css; charset=UTF-8";
+    }
+    if (lower.endsWith(".js")) {
+      return "application/javascript; charset=UTF-8";
+    }
+    if (lower.endsWith(".json")) {
+      return "application/json; charset=UTF-8";
+    }
+    if (lower.endsWith(".svg")) {
+      return "image/svg+xml";
+    }
+    if (lower.endsWith(".png")) {
+      return "image/png";
+    }
+    if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+      return "image/jpeg";
+    }
+    if (lower.endsWith(".gif")) {
+      return "image/gif";
+    }
+    if (lower.endsWith(".woff2")) {
+      return "font/woff2";
+    }
+    if (lower.endsWith(".woff")) {
+      return "font/woff";
+    }
+    if (lower.endsWith(".txt")) {
+      return "text/plain; charset=UTF-8";
+    }
+    return "application/octet-stream";
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.when;
 import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewFile;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
 import com.percussion.rest.sites.VirtualSiteProperties;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
@@ -412,6 +414,118 @@ class SitesAdaptorTest {
     VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
     req.setOutputRoot(out.toString());
     assertEquals(out, adaptor.resolveOutputRoot(req, "help").normalize());
+  }
+
+  @Test
+  void previewStatus_missingBuildIsUnavailableNot500() {
+    Path defaultOut = tempDir.resolve("preview-default-empty");
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+
+    VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.FALSE, status.getAvailable());
+    assertTrue(status.getMessage().orElse("").contains("No assembled"));
+  }
+
+  @Test
+  void previewStatus_findsVersionHomeAfterPointer() throws Exception {
+    Path defaultOut = tempDir.resolve("preview-default");
+    Path built = tempDir.resolve("preview-built");
+    Files.createDirectories(built.resolve("8.2"));
+    Files.writeString(built.resolve("8.2").resolve("index.html"), "<html>home</html>");
+
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+    previewing.recordLastOutputRoot("help-docs", built);
+
+    VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.TRUE, status.getAvailable());
+    assertEquals("8.2/index.html", status.getHomePath().orElse(null));
+  }
+
+  @Test
+  void previewFile_servesHtmlAndRejectsTraversal() throws Exception {
+    Path defaultOut = tempDir.resolve("preview-files");
+    Files.createDirectories(defaultOut.resolve("8.2"));
+    Files.writeString(
+        defaultOut.resolve("8.2").resolve("index.html"), "<html><a href=\"/8.2/x.html\">x</a>");
+
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+
+    VirtualSitePreviewFile file = previewing.previewVirtualSiteFile("Help", "8.2/index.html");
+    assertTrue(file.isHtml());
+    assertEquals("8.2/index.html", file.getRelativePath());
+    assertTrue(new String(file.getContent(), StandardCharsets.UTF_8).contains("href="));
+
+    WebApplicationException traversal =
+        assertThrows(
+            WebApplicationException.class,
+            () -> previewing.previewVirtualSiteFile("Help", "../secret.txt"));
+    assertEquals(400, traversal.getResponse().getStatus());
+
+    WebApplicationException missing =
+        assertThrows(
+            WebApplicationException.class,
+            () -> previewing.previewVirtualSiteFile("Help", "no-such.html"));
+    assertEquals(404, missing.getResponse().getStatus());
+  }
+
+  @Test
+  void preview_forbiddenWhenNotAdmin() {
+    SitesAdaptor denied =
+        new SitesAdaptor(siteManager, () -> false, SitesAdaptor::defaultOutputRootForSiteKey, null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.getVirtualSitePreviewStatus("Help"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void preview_rejectsRepositorySite() {
+    PSSite site = new PSSite();
+    site.setName("Corp");
+    site.setGUID(siteGuid);
+    when(siteManager.findSite("Corp")).thenReturn(site);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.getVirtualSitePreviewStatus("Corp"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void requireSafeRelativePreviewPath_rejectsAbsoluteAndDotDot() {
+    WebApplicationException dots =
+        assertThrows(
+            WebApplicationException.class,
+            () -> SitesAdaptor.requireSafeRelativePreviewPath("a/../../etc/passwd"));
+    assertEquals(400, dots.getResponse().getStatus());
+  }
+
+  @Test
+  void findHomeRelativePath_prefersRootThen82() throws Exception {
+    Path out = tempDir.resolve("homes");
+    Files.createDirectories(out.resolve("8.2"));
+    Files.writeString(out.resolve("8.2").resolve("index.html"), "v");
+    assertEquals("8.2/index.html", SitesAdaptor.findHomeRelativePath(out));
+    Files.writeString(out.resolve("index.html"), "root");
+    assertEquals("index.html", SitesAdaptor.findHomeRelativePath(out));
+  }
+
+  private PSSite virtualHelpSite() {
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, tempDir.resolve("virt-root").toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "help-docs");
+    return site;
   }
 
   private static Path createMinimalVirtualTree(Path siteRoot) throws Exception {

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -107,4 +107,28 @@ public interface ISiteAdaptor {
    *     path issues, 403 when not authorized, 404 when site not found
    */
   VirtualSiteBuildResult buildVirtualSite(String nameOrId, VirtualSiteBuildRequest request);
+
+  /**
+   * Reports whether the last Virtual Site static build can be previewed (assembled home exists).
+   *
+   * <p>Missing output is {@code available=false} with a message (not a 500). Requires Admin.
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @return status (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 when the site is not Virtual, 403 when not
+   *     authorized, 404 when site not found
+   */
+  VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId);
+
+  /**
+   * Streams one file from the last Virtual Site build output (path-traversal safe).
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @param relativePath path under the output root ({@code 8.2/index.html}); blank means assembled
+   *     home
+   * @return file bytes and media type (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 unsafe path / not virtual, 403 not Admin, 404
+   *     site or file missing
+   */
+  VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath);
 }

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -32,8 +32,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -58,6 +60,8 @@ public class SitesResource {
   static Logger log = LogManager.getLogger(IPSConstants.API_LOG);
 
   private final ISiteAdaptor adaptor;
+
+  @Context private UriInfo uriInfo;
 
   public SitesResource() {
     this.adaptor = null;
@@ -279,6 +283,106 @@ public class SitesResource {
       log.error(
           "Failed to build virtual site '{}' ({}): {}",
           nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Last-build preview availability (JSON). Missing assembled output is HTTP 200 with {@code
+   * available=false}.
+   *
+   * @param nameOrId site name or GUID
+   * @return preview status
+   */
+  @GET
+  @Path("/{nameOrId}/virtual/preview")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Operation(
+      summary = "Virtual Site preview status",
+      description =
+          "Reports whether the last Admin Virtual Site build can be opened from the product UI."
+              + " Uses the last build output path (default {install}/tmp/virtual-sites/{siteKey})."
+              + " Missing or failed builds return 200 with available=false (not 500). Requires"
+              + " Admin. Traditional repository Sites return 400.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Status (check available / homePath)",
+            content = @Content(schema = @Schema(implementation = VirtualSitePreviewStatus.class))),
+        @ApiResponse(responseCode = "400", description = "Not virtual / validation failure"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(
+      @PathParam("nameOrId") String nameOrId) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      // JSON/XML DTO via Jackson/JAXB/CXF — not HTML body (see suppressions.md)
+      return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to load virtual site preview status '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Streams one assembled file from the last Virtual Site build (navigable preview).
+   *
+   * @param nameOrId site name or GUID
+   * @param relPath path under the output root; blank uses assembled home
+   * @return file bytes
+   */
+  @GET
+  @Path("/{nameOrId}/virtual/preview/{relPath:.*}")
+  @Produces(MediaType.WILDCARD)
+  @Operation(
+      summary = "Preview Virtual Site file",
+      description =
+          "Streams a file from the last Virtual Site build output. Paths are resolved with portable"
+              + " NIO Path under the last output root (no '..' after normalize). HTML root-relative"
+              + " href/src/url() values are rewritten to this preview prefix so navigation works."
+              + " Requires Admin. Missing files return 404 (not 500).",
+      responses = {
+        @ApiResponse(responseCode = "200", description = "File bytes"),
+        @ApiResponse(responseCode = "400", description = "Not virtual / unsafe path"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site or file not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response previewVirtualSiteFile(
+      @PathParam("nameOrId") String nameOrId, @PathParam("relPath") String relPath) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      VirtualSitePreviewFile file = requireAdaptor().previewVirtualSiteFile(nameOrId, relPath);
+      byte[] body = file.getContent();
+      if (file.isHtml()) {
+        String base = uriInfo != null ? uriInfo.getBaseUri().getPath() : "/services/";
+        String prefix = VirtualSitePreviewHtml.previewPrefix(base, nameOrId);
+        body = VirtualSitePreviewHtml.rewriteRootRelative(body, prefix);
+      }
+      return Response.ok(body, file.getMediaType())
+          .header("Cache-Control", "no-store")
+          .build(); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to preview virtual site file '{}' path='{}' ({}): {}",
+          nameOrId,
+          relPath,
           e.getClass().getName(),
           e.getMessage(),
           e);

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewFile.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewFile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import java.util.Objects;
+
+/**
+ * Bytes of one assembled Virtual Site file for the Admin preview stream.
+ *
+ * <p>Not a public JSON entity — {@link SitesResource} maps this to an HTTP {@code Response}.
+ */
+public class VirtualSitePreviewFile {
+
+  private final String mediaType;
+  private final String relativePath;
+  private final byte[] content;
+
+  public VirtualSitePreviewFile(String mediaType, String relativePath, byte[] content) {
+    this.mediaType = mediaType != null && !mediaType.isBlank() ? mediaType : "application/octet-stream";
+    this.relativePath = relativePath != null ? relativePath : "";
+    this.content = content != null ? content : new byte[0];
+  }
+
+  public String getMediaType() {
+    return mediaType;
+  }
+
+  public String getRelativePath() {
+    return relativePath;
+  }
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public boolean isHtml() {
+    return mediaType.toLowerCase().startsWith("text/html");
+  }
+
+  @Override
+  public String toString() {
+    return "VirtualSitePreviewFile{mediaType="
+        + mediaType
+        + ", relativePath="
+        + relativePath
+        + ", bytes="
+        + content.length
+        + "}";
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mediaType, relativePath, content.length);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites assembled Virtual Site HTML so root-relative {@code href}/{@code src}/{@code url()}
+ * values stay under the preview URL prefix (assembler emits site-root paths like {@code
+ * /8.2/index.html}).
+ */
+public final class VirtualSitePreviewHtml {
+
+  private static final Pattern ROOT_HREF_SRC =
+      Pattern.compile("(?i)(\\b(?:href|src)\\s*=\\s*[\"'])/(?!/)");
+  private static final Pattern ROOT_CSS_URL = Pattern.compile("(?i)(url\\(\\s*)/(?!/)");
+
+  private VirtualSitePreviewHtml() {}
+
+  /**
+   * Prefix must be an absolute URL path without a trailing slash (for example {@code
+   * /services/sites/Help/virtual/preview}).
+   *
+   * @param html assembled page bytes (UTF-8)
+   * @param previewPrefix URL path prefix for this site's preview stream
+   * @return rewritten HTML bytes
+   */
+  public static byte[] rewriteRootRelative(byte[] html, String previewPrefix) {
+    if (html == null || html.length == 0) {
+      return html == null ? new byte[0] : html;
+    }
+    String prefix = normalizePrefix(previewPrefix);
+    if (prefix.isEmpty()) {
+      return html;
+    }
+    String text = new String(html, StandardCharsets.UTF_8);
+    String withHref = ROOT_HREF_SRC.matcher(text).replaceAll("$1" + Matcher.quoteReplacement(prefix) + "/");
+    String withUrl = ROOT_CSS_URL.matcher(withHref).replaceAll("$1" + Matcher.quoteReplacement(prefix) + "/");
+    return withUrl.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Build the preview URL prefix from the JAX-RS application base path and site name.
+   *
+   * @param basePath {@link jakarta.ws.rs.core.UriInfo#getBaseUri()} path (may end with {@code /})
+   * @param siteNameOrId site name or GUID (decoded)
+   * @return prefix without trailing slash
+   */
+  public static String previewPrefix(String basePath, String siteNameOrId) {
+    String base = basePath == null ? "" : basePath.trim();
+    if (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    String name = siteNameOrId == null ? "" : siteNameOrId.trim();
+    String encoded = encodePathSegment(name);
+    return base + "/sites/" + encoded + "/virtual/preview";
+  }
+
+  static String normalizePrefix(String previewPrefix) {
+    if (previewPrefix == null) {
+      return "";
+    }
+    String p = previewPrefix.trim();
+    if (p.endsWith("/")) {
+      p = p.substring(0, p.length() - 1);
+    }
+    if (!p.startsWith("/") || p.contains("..") || p.indexOf('\0') >= 0) {
+      return "";
+    }
+    return p;
+  }
+
+  static String encodePathSegment(String raw) {
+    if (raw == null || raw.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder(raw.length() + 8);
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (isUnreservedPathChar(c)) {
+        sb.append(c);
+      } else if (c == ' ') {
+        sb.append("%20");
+      } else {
+        byte[] bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+        for (byte b : bytes) {
+          sb.append('%');
+          String hex = Integer.toHexString(b & 0xff).toUpperCase();
+          if (hex.length() == 1) {
+            sb.append('0');
+          }
+          sb.append(hex);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  private static boolean isUnreservedPathChar(char c) {
+    return (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || c == '-'
+        || c == '_'
+        || c == '.'
+        || c == '~';
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Optional;
+
+/**
+ * Whether a last Virtual Site static build can be previewed from the product UI ({@code GET
+ * /sites/{nameOrId}/virtual/preview}).
+ *
+ * <p>Missing or failed builds return HTTP 200 with {@code available=false} and a message — not 500.
+ */
+@XmlRootElement(name = "VirtualSitePreviewStatus")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(
+    name = "VirtualSitePreviewStatus",
+    description = "Last Virtual Site build preview availability and assembled home path")
+public class VirtualSitePreviewStatus {
+
+  @Schema(description = "True when an assembled index/home file exists under the last output root")
+  private Boolean available;
+
+  @Schema(
+      description = "Relative home path under the output root (forward slashes)",
+      example = "8.2/index.html")
+  private String homePath;
+
+  @Schema(
+      description = "Absolute filesystem path of the last build output root",
+      example = "C:/Rhythmyx/tmp/virtual-sites/product-docs")
+  private String outputPath;
+
+  @Schema(description = "Operator-facing reason when available is false")
+  private String message;
+
+  public VirtualSitePreviewStatus() {
+    // Default constructor for JAX-RS / Jackson
+  }
+
+  public Boolean getAvailable() {
+    return available;
+  }
+
+  public void setAvailable(Boolean available) {
+    this.available = available;
+  }
+
+  public Optional<String> getHomePath() {
+    return Optional.ofNullable(homePath);
+  }
+
+  public void setHomePath(String homePath) {
+    this.homePath = homePath;
+  }
+
+  public Optional<String> getOutputPath() {
+    return Optional.ofNullable(outputPath);
+  }
+
+  public void setOutputPath(String outputPath) {
+    this.outputPath = outputPath;
+  }
+
+  public Optional<String> getMessage() {
+    return Optional.ofNullable(message);
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -188,6 +189,51 @@ public class SitesResourceTest {
   }
 
   @Test
+  public void previewStatusDelegates() {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(true);
+    status.setHomePath("8.2/index.html");
+    when(adaptor.getVirtualSitePreviewStatus("Help")).thenReturn(status);
+
+    VirtualSitePreviewStatus out = resource.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.TRUE, out.getAvailable());
+    assertEquals("8.2/index.html", out.getHomePath().orElse(null));
+    verify(adaptor).getVirtualSitePreviewStatus("Help");
+  }
+
+  @Test
+  public void previewStatusBlankName400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.getVirtualSitePreviewStatus(" "));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).getVirtualSitePreviewStatus(any());
+  }
+
+  @Test
+  public void previewFileDelegatesAndRewritesHtml() {
+    byte[] html = "<a href=\"/8.2/index.html\">Home</a>".getBytes(StandardCharsets.UTF_8);
+    when(adaptor.previewVirtualSiteFile(eq("Help"), eq("8.2/index.html")))
+        .thenReturn(new VirtualSitePreviewFile("text/html; charset=UTF-8", "8.2/index.html", html));
+
+    Response out = resource.previewVirtualSiteFile("Help", "8.2/index.html");
+    assertEquals(200, out.getStatus());
+    byte[] body = (byte[]) out.getEntity();
+    String text = new String(body, StandardCharsets.UTF_8);
+    assertTrue(text.contains("/services/sites/Help/virtual/preview/8.2/index.html"), text);
+    verify(adaptor).previewVirtualSiteFile("Help", "8.2/index.html");
+  }
+
+  @Test
+  public void previewFileBlankName400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.previewVirtualSiteFile(" ", "index.html"));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).previewVirtualSiteFile(any(), any());
+  }
+
+  @Test
   public void buildVirtualSiteBlankName400() {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.buildVirtualSite(" ", null));
@@ -213,6 +259,13 @@ public class SitesResourceTest {
         text.contains(
             "return requireAdaptor().buildVirtualSite(nameOrId, request); // codeql[java/xss]"),
         "buildVirtualSite return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains(
+            "return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]"),
+        "getVirtualSitePreviewStatus return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains(".build(); // codeql[java/xss]"),
+        "previewVirtualSiteFile Response.ok sink must carry same-line codeql[java/xss]");
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -85,4 +85,18 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     }
     return result;
   }
+
+  @Override
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId) {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(false);
+    status.setMessage("No assembled Virtual Site to preview.");
+    return status;
+  }
+
+  @Override
+  public VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath) {
+    throw new jakarta.ws.rs.WebApplicationException(
+        "No assembled Virtual Site to preview.", jakarta.ws.rs.core.Response.Status.NOT_FOUND);
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class VirtualSitePreviewHtmlTest {
+
+  @Test
+  public void rewriteRootRelativeHrefAndCssUrl() {
+    String html =
+        "<a href=\"/8.2/index.html\">Home</a>"
+            + "<img src='/assets/logo.png'/>"
+            + "<style>body{background:url(/assets/bg.png)}</style>"
+            + "<a href=\"//cdn.example/x\">ext</a>";
+    byte[] out =
+        VirtualSitePreviewHtml.rewriteRootRelative(
+            html.getBytes(StandardCharsets.UTF_8), "/services/sites/Help/virtual/preview");
+    String text = new String(out, StandardCharsets.UTF_8);
+    assertTrue(text.contains("href=\"/services/sites/Help/virtual/preview/8.2/index.html\""), text);
+    assertTrue(text.contains("src='/services/sites/Help/virtual/preview/assets/logo.png'"), text);
+    assertTrue(text.contains("url(/services/sites/Help/virtual/preview/assets/bg.png)"), text);
+    assertTrue(text.contains("href=\"//cdn.example/x\""), text);
+  }
+
+  @Test
+  public void rewriteRejectsUnsafePrefix() {
+    String html = "<a href=\"/8.2/index.html\">x</a>";
+    byte[] out =
+        VirtualSitePreviewHtml.rewriteRootRelative(
+            html.getBytes(StandardCharsets.UTF_8), "../evil");
+    assertEquals(html, new String(out, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void previewPrefixJoinsBaseAndEncodedName() {
+    assertEquals(
+        "/services/sites/Help/virtual/preview",
+        VirtualSitePreviewHtml.previewPrefix("/services/", "Help"));
+    assertEquals(
+        "/Rhythmyx/services/sites/Help%20Docs/virtual/preview",
+        VirtualSitePreviewHtml.previewPrefix("/Rhythmyx/services", "Help Docs"));
+    assertFalse(VirtualSitePreviewHtml.previewPrefix("/services/", "Help").endsWith("/"));
+  }
+}


### PR DESCRIPTION
## Summary

After **Build Virtual Site**, operators can **Preview assembled site** from **Developer → Sites** and open the last assembled documentation home in a new tab (no CLI / no `file://`).

Adds a safe Admin-only preview surface:

- `GET /services/sites/{nameOrId}/virtual/preview` — last-build availability (`available`, `homePath`, `outputPath`). Missing output is **HTTP 200** with `available=false` (not 500).
- `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` — streams one file from the last recorded build `outputPath` (default `{install}/tmp/virtual-sites/{siteKey}`). Path-traversal safe (NIO, no `..` after normalize). HTML root-relative `href`/`src`/`url()` values are rewritten to the preview prefix so navigation works.

Parent tracker: #2678. Fixes #3299.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Standalone `mvnw clean install` in `rest`, `projects/sitemanage`, and `WebUI` (included tests).
2. Unit: preview status missing-build, path traversal 400, HTML rewrite, Vitest Preview chrome + empty state.
3. QA H2: `python docker/scripts/perc-devctl.py qa-up` → hot-copy WebUI modern assets + `rest`/`sitemanage` jars → Jetty restart → `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → `qa-down`.
4. Manual (human QA candidate): sign in Admin → Developer → Sites → open a Virtual Site → Build → Preview assembled site → new tab shows assembled home; without a build, panel shows empty/error (no 500).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `developer/virtual-sites.md`, `developer/rest.md`, `reference/site-config.md`
- [x] **Unit / module tests** — rest / sitemanage / WebUI standalone clean install green
- [x] **WebUI + Playwright** — `developer-site-virtual-source.spec.js` preview chrome + empty/error
- [x] **Build gates** — standalone clean install (no skipTests); C2 interface add grepped
- [x] **Cross-platform** — preview I/O uses NIO `Path` / `Files`; no hardcoded OS separators

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 347, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1170, Failures: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Java Tests run: 51, Failures: 0; Vitest 2206 passed (305 files)
  - `scripts/ci-smoke-product-docs.bat` → OK
- **downstream_checked:** `implements ISiteAdaptor` → only `SitesAdaptor` + `SitesTestAdaptor` (both updated). sitemanage standalone clean install green against new rest SNAPSHOT.

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:<freeport>` (this run used 9993)
- Deploy: `docker cp` generated WebUI `cm/modern` + `rest-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` into `perc-matrix-cms-h2`; Jetty restart; login 200
- `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **1 passed** (2.1s)
- console-clean=yes (pageerror empty; expected 400/404 resource logs from preview-before-build ignored)
- server.log-clean=yes (no ERROR/FATAL matching virtual|preview|SitesResource|SitesAdaptor)
- `python docker/scripts/perc-devctl.py qa-down`

> Co-Authored by Grok Build using grok-4.5 with agent main.
