### PR TITLE
feat(webui): list Virtual Site linkProblems in Sites UI (#3300)

### DIFF
--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -30,6 +30,7 @@ import {
 } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { copyTextToClipboard } from "./templateSourceViewer";
 import {
   formatVirtualSiteBuildSummary,
   shouldShowVirtualBuildChrome,
@@ -148,6 +149,7 @@ export function VirtualSiteSourcePanel({
   const [isVirtual, setIsVirtual] = useState(false);
   const [buildError, setBuildError] = useState<string | null>(null);
   const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
+  const [linkCopyNotice, setLinkCopyNotice] = useState<string | null>(null);
 
   const load = useCallback(() => {
     if (!siteName.trim()) {
@@ -162,6 +164,7 @@ export function VirtualSiteSourcePanel({
     setSavedNotice(null);
     setBuildError(null);
     setBuildResult(null);
+    setLinkCopyNotice(null);
     getVirtualSiteProperties(siteName)
       .then((props) => {
         if (cancelled) return;
@@ -222,6 +225,7 @@ export function VirtualSiteSourcePanel({
     setBuilding(true);
     setBuildError(null);
     setBuildResult(null);
+    setLinkCopyNotice(null);
     setFormError(null);
     try {
       const result = await buildVirtualSite(siteName);
@@ -231,6 +235,14 @@ export function VirtualSiteSourcePanel({
     } finally {
       setBuilding(false);
     }
+  }
+
+  async function onCopyLinkProblems(lines: string[]): Promise<void> {
+    if (lines.length === 0) {
+      return;
+    }
+    const ok = await copyTextToClipboard(lines.join("\n"));
+    setLinkCopyNotice(ok ? DEV_MSG.SITE_VIRT_BUILD_LINK_COPIED : null);
   }
 
   const virtualMode = isVirtualSourceKind(form.sourceKind);
@@ -439,9 +451,74 @@ export function VirtualSiteSourcePanel({
                   {buildSummary.hasLinkProblems && buildSummary.linkLine ? (
                     <div
                       data-testid="developer-site-virtual-build-link-problems"
-                      style={{ marginTop: "4px", color: catalogColors.error }}
+                      style={{ marginTop: "8px", color: catalogColors.error }}
                     >
-                      {DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS}: {buildSummary.linkLine}
+                      <div>
+                        {DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS}: {buildSummary.linkLine}
+                      </div>
+                      <p
+                        style={{ ...mutedHintText, margin: "6px 0 0", color: catalogColors.error }}
+                        data-testid="developer-site-virtual-build-link-report-hint"
+                      >
+                        {DEV_MSG.SITE_VIRT_BUILD_LINK_REPORT_HINT}
+                      </p>
+                      {buildSummary.linkProblems.length > 0 ? (
+                        <details
+                          data-testid="developer-site-virtual-build-link-details"
+                          style={{ marginTop: "8px" }}
+                        >
+                          <summary
+                            data-testid="developer-site-virtual-build-link-toggle"
+                            style={{ cursor: "pointer" }}
+                          >
+                            {DEV_MSG.SITE_VIRT_BUILD_LINK_DETAILS}
+                          </summary>
+                          <div
+                            style={{
+                              display: "flex",
+                              gap: "12px",
+                              alignItems: "center",
+                              marginTop: "8px",
+                              flexWrap: "wrap",
+                            }}
+                          >
+                            <button
+                              type="button"
+                              data-testid="developer-site-virtual-build-link-copy"
+                              style={secondaryButton}
+                              onClick={() =>
+                                void onCopyLinkProblems(buildSummary.linkProblems)
+                              }
+                            >
+                              {DEV_MSG.SITE_VIRT_BUILD_LINK_COPY}
+                            </button>
+                            {linkCopyNotice ? (
+                              <span data-testid="developer-site-virtual-build-link-copied">
+                                {linkCopyNotice}
+                              </span>
+                            ) : null}
+                          </div>
+                          <ul
+                            data-testid="developer-site-virtual-build-link-list"
+                            style={{
+                              ...buildResultMono,
+                              margin: "8px 0 0",
+                              paddingLeft: "1.25rem",
+                              maxHeight: "16rem",
+                              overflow: "auto",
+                            }}
+                          >
+                            {buildSummary.linkProblems.map((line, index) => (
+                              <li
+                                key={`${index}:${line}`}
+                                data-testid="developer-site-virtual-build-link-line"
+                              >
+                                {line}
+                              </li>
+                            ))}
+                          </ul>
+                        </details>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -774,6 +774,11 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_BUILD_PAGES: "perc.ui.developer@Pages written",
   SITE_VIRT_BUILD_OUTPUT: "perc.ui.developer@Output path",
   SITE_VIRT_BUILD_LINK_PROBLEMS: "perc.ui.developer@Link problems",
+  SITE_VIRT_BUILD_LINK_DETAILS: "perc.ui.developer@Show link problem details",
+  SITE_VIRT_BUILD_LINK_COPY: "perc.ui.developer@Copy link problems",
+  SITE_VIRT_BUILD_LINK_COPIED: "perc.ui.developer@Copied.",
+  SITE_VIRT_BUILD_LINK_REPORT_HINT:
+    "perc.ui.developer@Same lines as link-report.txt under the output directory. Link problems do not fail the build (HTTP 200).",
   SITE_VIRT_BUILD_SAVE_FIRST:
     "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -29,6 +29,30 @@ export function shouldShowVirtualBuildChrome(
 }
 
 /**
+ * Trim and drop empty {@code linkProblems} lines from a build result.
+ * HTTP 200 + {@code hasLinkProblems} is still a completed build — this is
+ * presentation only (same text as {@code link-report.txt}).
+ */
+export function normalizeVirtualSiteLinkProblems(
+  result: VirtualSiteBuildResult | null | undefined,
+): string[] {
+  if (!result || !Array.isArray(result.linkProblems)) {
+    return [];
+  }
+  const lines: string[] = [];
+  for (const raw of result.linkProblems) {
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const line = raw.trim();
+    if (line.length > 0) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+/**
  * Build a short operator-facing success summary from a build result DTO.
  * Pure helper for Vitest and the panel (no i18n — callers prefix labels).
  */
@@ -37,6 +61,7 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
   outputLine: string | null;
   linkLine: string | null;
   hasLinkProblems: boolean;
+  linkProblems: string[];
 } {
   const pages =
     typeof result.pagesWritten === "number" && Number.isFinite(result.pagesWritten)
@@ -49,21 +74,22 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
       ? result.outputPath.trim()
       : null;
 
+  const linkProblems = normalizeVirtualSiteLinkProblems(result);
   const linkCount =
     typeof result.linkProblemCount === "number" && Number.isFinite(result.linkProblemCount)
       ? result.linkProblemCount
       : 0;
   const hasLinkProblems =
-    result.hasLinkProblems === true ||
-    linkCount > 0 ||
-    (Array.isArray(result.linkProblems) && result.linkProblems.length > 0);
+    result.hasLinkProblems === true || linkCount > 0 || linkProblems.length > 0;
 
-  const linkLine = hasLinkProblems ? String(linkCount > 0 ? linkCount : result.linkProblems?.length ?? 0) : null;
+  const resolvedCount = linkCount > 0 ? linkCount : linkProblems.length;
+  const linkLine = hasLinkProblems ? String(resolvedCount) : null;
 
   return {
     pagesLine,
     outputLine: output,
     linkLine,
     hasLinkProblems,
+    linkProblems,
   };
 }

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as sitesApi from "../../../main/ts/api/developer/sitesApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
+import * as sourceViewer from "../../../main/ts/developer/templateSourceViewer";
 import { VirtualSiteSourcePanel } from "../../../main/ts/developer/VirtualSiteSourcePanel";
 
 vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
@@ -232,6 +233,61 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-build-output").textContent).toContain(
       "product-docs",
     );
+    expect(screen.queryByTestId("developer-site-virtual-build-link-problems")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build-link-list")).toBeNull();
+  });
+
+  it("lists link problem details on HTTP 200 with hasLinkProblems", async () => {
+    const copySpy = vi.spyOn(sourceViewer, "copyTextToClipboard").mockResolvedValue(true);
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    buildVirtual.mockResolvedValue({
+      siteName: "Help",
+      siteKey: "product-docs",
+      outputPath: "C:/tmp/virtual-sites/product-docs",
+      pagesWritten: 4,
+      linkProblemCount: 2,
+      hasLinkProblems: true,
+      linkProblems: [
+        "broken id:missing-page from 8.2/index.md",
+        "  unresolved relative ./gone.md  ",
+      ],
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-result")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-build-success")).toBeTruthy();
+    expect(screen.getByTestId("developer-site-virtual-build-link-problems").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS,
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-link-problems").textContent).toContain(
+      "2",
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-link-report-hint").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_LINK_REPORT_HINT,
+    );
+    const lines = screen.getAllByTestId("developer-site-virtual-build-link-line");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].textContent).toBe("broken id:missing-page from 8.2/index.md");
+    expect(lines[1].textContent).toBe("unresolved relative ./gone.md");
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build-link-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-link-copied").textContent).toContain(
+        DEV_MSG.SITE_VIRT_BUILD_LINK_COPIED,
+      );
+    });
+    expect(copySpy).toHaveBeenCalledWith(
+      "broken id:missing-page from 8.2/index.md\nunresolved relative ./gone.md",
+    );
+    copySpy.mockRestore();
   });
 
   it("surfaces build API errors", async () => {

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatVirtualSiteBuildSummary,
+  normalizeVirtualSiteLinkProblems,
   shouldShowVirtualBuildChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
@@ -29,6 +30,7 @@ describe("virtualSiteBuild helpers", () => {
     expect(clean.outputLine).toBe("C:/tmp/out");
     expect(clean.hasLinkProblems).toBe(false);
     expect(clean.linkLine).toBeNull();
+    expect(clean.linkProblems).toEqual([]);
 
     const dirty = formatVirtualSiteBuildSummary({
       pagesWritten: 2,
@@ -41,10 +43,21 @@ describe("virtualSiteBuild helpers", () => {
     expect(dirty.outputLine).toBe("/docs/out");
     expect(dirty.hasLinkProblems).toBe(true);
     expect(dirty.linkLine).toBe("3");
+    expect(dirty.linkProblems).toEqual(["a", "b", "c"]);
 
     const missing = formatVirtualSiteBuildSummary({});
     expect(missing.pagesLine).toBe("0");
     expect(missing.outputLine).toBeNull();
     expect(missing.hasLinkProblems).toBe(false);
+    expect(missing.linkProblems).toEqual([]);
+  });
+
+  it("normalizeVirtualSiteLinkProblems drops blanks and non-strings", () => {
+    expect(normalizeVirtualSiteLinkProblems(null)).toEqual([]);
+    expect(
+      normalizeVirtualSiteLinkProblems({
+        linkProblems: ["  missing id:foo  ", "", "   ", "ok", 7 as unknown as string],
+      }),
+    ).toEqual(["missing id:foo", "ok"]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Developer Sites → Virtual Site source panel (#2956 / #3020 / epic #2678).
+ * Developer Sites → Virtual Site source panel (#2956 / #3020 / #3300 / epic #2678).
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
  * with source-kind control (repository default), save chrome, and Build Virtual
  * Site chrome only when source kind is virtual (never for repository).
+ * Also intercepts build REST to prove link-problem detail lines render on HTTP 200.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -145,5 +146,141 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     }
+  });
+
+  test("build result lists linkProblems on HTTP 200", async ({ page }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      // Mocked catalog site has no GUID; ACL GET 404 is expected host noise, not a JS exception.
+      if (/Failed to load resource:.*404/.test(text)) {
+        return;
+      }
+      consoleErrors.push(text);
+    });
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual/build", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          siteName: "Help",
+          siteKey: "product-docs",
+          outputPath: "C:/tmp/virtual-sites/product-docs",
+          pagesWritten: 3,
+          linkProblemCount: 2,
+          hasLinkProblems: true,
+          linkProblems: [
+            "broken id:missing-page from 8.2/index.md",
+            "unresolved relative ./gone.md",
+          ],
+        }),
+      });
+    });
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/virtual/build")) {
+        await route.fallback();
+        return;
+      }
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sourceKind: "git-filesystem",
+          rootPath: "C:/docs",
+          configFile: "_config.yaml",
+          siteKey: "product-docs",
+          virtual: true,
+        }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const empty = page.locator('[data-testid="developer-site-empty"]');
+    if (await empty.isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — Virtual Site link-problem list requires a site row",
+      });
+      return;
+    }
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.locator('[data-testid="developer-site-virtual-build"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-result"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build-success"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-problems"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]'),
+    ).toHaveCount(2);
+    await page.locator('[data-testid="developer-site-virtual-build-link-toggle"]').click();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]').nth(0),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]').nth(0),
+    ).toHaveText("broken id:missing-page from 8.2/index.md");
+    expect(consoleErrors).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -127,8 +127,12 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
 5. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).
-   - **Link problems** — reported in the result panel when internal links fail
-     (the build may still complete with HTTP 200).
+   - **Link problems** — a count appears when internal `id:` or relative links fail.
+     Expand **Show link problem details** to read the same lines written to
+     `link-report.txt` in the output directory. **Copy link problems** puts those
+     lines on the clipboard. The build still completes with HTTP 200
+     (`hasLinkProblems=true`); this is not a 500 and is not a failed save.
+     A clean build does **not** show a link-problem banner.
    - **Error** — clear message when the Site is not virtual, the root is missing/invalid,
      or the caller lacks Admin (for example 400/403 from REST).
 

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -128,6 +128,12 @@ The body is optional. Without `outputRoot`, the server writes under
 `pagesWritten`, link problems, and the absolute `outputPath`. Traditional repository Sites and
 invalid/missing virtual configuration return **400**.
 
+A successful assemble with unresolved internal links still returns **HTTP 200** with
+`hasLinkProblems=true` and a `linkProblems` array (the same lines as `link-report.txt` under
+the output root). The Sites UI lists those lines in an expandable **Link problems** block so
+operators do not have to open the report file on the server. Do not treat that 200 as a
+server error.
+
 Operators can run the same operation from **Developer → Sites → Site detail → Build Virtual Site**
 (visible only when source kind is Virtual). Save Virtual Site source before building so the server
 uses the latest properties. See [Sites & content structure](id:admin-sites) and

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -93,7 +93,10 @@ unavailable). Link problems are reported in the JSON result (and in `link-report
 the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
-Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+Virtual (never for traditional repository Sites). When `hasLinkProblems` is true, the result
+panel shows the problem **count** and an expandable list of `linkProblems` (same text as
+`link-report.txt`). A clean build does not show that banner. See
+[Sites & content structure](id:admin-sites).
 
 ## Related
 


### PR DESCRIPTION
## Summary

Surfaces `VirtualSiteBuildResult.linkProblems` on Developer **Sites → Virtual Site source** as an expandable detail list (plus copy), not only a count. HTTP **200** + `hasLinkProblems=true` is unchanged — link problems are not treated as a 500. Clean builds show no link-problem banner.

Parent tracker: #2678. Slice: #3300.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Vitest: `VirtualSiteSourcePanel` lists sanitized problem lines and copies them; clean build has no banner.
2. `cd WebUI && ../mvnw clean install` — BUILD SUCCESS (Java 51 + Vitest 2202).
3. `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS.
4. H2 QA (`perc-devctl qa-up`, `TEST_CMS_URL=http://127.0.0.1:9993`): hot-copy `WebUI/target/generated-webui/cm/modern` into the cell; Playwright `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — **2 passed**.
5. Console-clean (no JS pageerror; ignored expected ACL 404 on mocked site without GUID). server.log ERROR/FATAL for the window: none.
6. `scripts/ci-smoke-product-docs.bat` — OK (22 pages).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `product-docs/8.2/developer/virtual-sites.md`, `product-docs/8.2/reference/site-config.md` (interpret link report in Sites UI)
- [x] **Unit / module tests** — Vitest list rendering + helper sanitize; WebUI + perc-qa-automation standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `developer-site-virtual-source.spec.js` intercepts build REST and asserts detail lines on HTTP 200
- [x] **Build gates** — standalone clean install on changed modules; no public Java API shape change
- [x] **Cross-platform** — N/A (no new filesystem I/O; UI lists strings from REST)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-13T05:16:14-04:00). Surefire Tests run: 51, Failures: 0. Vitest Test Files 305 passed, Tests 2202 passed.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-13T05:20:33-04:00). Surefire: No tests to run (Playwright is not Maven-default).
- **downstream_checked:** none (no Java public/protected signature or `final`/`sealed` type change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CMS_HOST_PORT=9993`, container `perc-matrix-cms-h2`)
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **2 passed** (3.6s)
- console-clean=yes (no pageerror; 404 ACL noise on GUID-less mock filtered)
- server.log-clean=yes (no ERROR/FATAL in `/opt/Percussion/jetty/base/logs/server.log`)
- Tear-down: `python docker/scripts/perc-devctl.py qa-down` → RESULT:OK

Fixes #3300

> Co-Authored by Grok Build using grok-4.5 with agent main.
