### PR TITLE
feat(virtual-sites): publish assembled docs to Site filesystem root (#3301)

### DIFF
--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -34,7 +34,32 @@ channels (static files, FTP, database, custom locations).
 For Git/filesystem Virtual Sites such as product documentation:
 
 - Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session.
-- Runtime virtual assemble paths (when configured on a Site) participate in normal Site-level publishing configuration where applicable.
+- **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
+  `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`).
+- **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
+  assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
+  publishing root). Staging `_meta` files are not copied.
+
+### Publish a Virtual Site to the Site filesystem target
+
+1. Sign in as **Admin**.
+2. Configure the Site as a Git-filesystem Virtual Site (see [Sites](id:admin-sites)).
+3. Set the Site **publishing filesystem root** (Site root) to a dedicated directory on the CMS
+   host. Do **not** point it at `virtual.rootPath` (the Markdown source tree).
+4. Confirm the source root exists on the host and that the publish directory is writable.
+5. Call `POST /services/sites/{nameOrId}/virtual/publish` (or run **Build Virtual Site** first if
+   you only want staging output).
+6. On success, the JSON result includes `publishPath`, `filesCopied`, `pagesWritten`, and any
+   link problems (`hasLinkProblems` can be true with HTTP 200).
+7. Spot-check `index.html` (and version folders such as `8.2/`) under the Site root.
+
+**Clear operator errors (HTTP 400, not a silent no-op):**
+
+- Site is not Virtual (`virtual.sourceKind` blank or `repository`)
+- Site filesystem publish root is not configured
+- Publish root is unsafe (`..` after normalize) or is a file rather than a directory
+- Publish root overlaps `virtual.rootPath` or the build staging tree
+- Caller is not Admin (403)
 
 See [Virtual Sites](id:developer-virtual-sites) and [Build product docs](id:developer-build-source#product-docs-build).
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -137,6 +137,20 @@ Integrators can call the same operation over REST:
 [Site configuration reference](id:reference-site-config) and
 [Virtual Sites (developer)](id:developer-virtual-sites).
 
+### Publish a Virtual Site to the Site filesystem target
+
+Build output under `{install}/tmp/virtual-sites/` is **staging**. To deliver a navigable static
+site to the Site's configured filesystem publish location:
+
+1. Set the Site **publishing filesystem root** (Site root / `IPSSite.root`) to a dedicated
+   directory on the CMS host (not the Markdown `virtual.rootPath`).
+2. As **Admin**, call `POST /sites/{nameOrId}/virtual/publish`.
+3. The server **builds then copies** HTML/assets to that Site root and returns `publishPath`
+   and `filesCopied`. Missing or unsafe Site root, overlap with the source tree, or a
+   non-virtual Site returns **400** with a readable message (not HTTP 500 / silent no-op).
+
+See [Publishing](id:admin-publishing) for the operator checklist.
+
 Offline scripts (`scripts/build-cms-docs.*`) remain available for developer workstations
 without a running CMS.
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -109,6 +109,7 @@ Example create body:
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
 only empty-catalog case. See [Sites & content structure](id:admin-sites).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -133,6 +133,27 @@ Operators can run the same operation from **Developer → Sites → Site detail 
 uses the latest properties. See [Sites & content structure](id:admin-sites) and
 [Site configuration](id:reference-site-config).
 
+## CMS-integrated publish (Site filesystem target)
+
+Build writes a **staging** tree. To publish that tree to the Site's configured filesystem
+location (`IPSSite.root` / Site publishing root), an **Admin** calls:
+
+```http
+POST /sites/{nameOrId}/virtual/publish
+```
+
+The server:
+
+1. Validates the Site is a Git-filesystem Virtual Site.
+2. Selects the Site filesystem publish root (must be configured, safe after NIO normalize, and
+   distinct from `virtual.rootPath`).
+3. Runs the same build as `POST …/virtual/build`.
+4. Copies assembled HTML/assets (not `_meta`) to the Site root using portable `java.nio.file.Path`.
+
+The response includes `publishPath`, `buildOutputPath`, `pagesWritten`, `filesCopied`, and
+link-problem fields. Failures return **400/403/404** with an operator-readable message (never a
+silent no-op). See [Publishing](id:admin-publishing).
+
 ## What is not in Phase 1
 
 - CMS UI editing of Virtual items as normal content types

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -70,6 +70,7 @@ Integrators can read and write these keys via public Site REST:
 - `GET /sites/{nameOrId}/virtual`
 - `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
 - `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
+- `POST /sites/{nameOrId}/virtual/publish` (build then copy to Site filesystem root)
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable
@@ -94,6 +95,20 @@ the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
 Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+
+#### Publish Virtual Site (`POST …/virtual/publish`)
+
+Runs the same build, then copies the assembled tree to the Site **filesystem publish location**
+(`IPSSite.root`). Requires **Admin**. Staging `_meta` is not copied.
+
+| Status | When |
+|--------|------|
+| `200` | Published; response includes `publishPath`, `filesCopied`, `pagesWritten`, `hasLinkProblems` |
+| `400` | Not a Virtual Site, Site root missing/unsafe/not a directory, or overlap with `virtual.rootPath` / build output |
+| `403` | Caller is not Admin |
+| `404` | Site not found |
+
+Configure a dedicated Site root (not the Markdown source path). See [Publishing](id:admin-publishing).
 
 ## Related
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -26,6 +26,7 @@ import com.percussion.rest.sites.SiteList;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
 import com.percussion.rest.sites.VirtualSiteProperties;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.server.PSServer;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -38,7 +39,9 @@ import com.percussion.services.virtualsite.PSGitFilesystemVirtualSiteSource;
 import com.percussion.services.virtualsite.PSInMemoryVirtualParticipantService;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildService;
+import com.percussion.services.virtualsite.PSVirtualSiteFilesystemPublisher;
 import com.percussion.services.virtualsite.PSVirtualSiteHelper;
+import com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult;
 import com.percussion.services.virtualsite.VirtualSiteConfig;
 import com.percussion.services.virtualsite.VirtualSiteConfigLoader;
 import com.percussion.services.virtualsite.VirtualSiteException;
@@ -371,6 +374,69 @@ public class SitesAdaptor implements ISiteAdaptor {
     }
   }
 
+  @Override
+  public VirtualSitePublishResult publishVirtualSite(String nameOrId) {
+    requireAdmin();
+    IPSSite site = requireSite(nameOrId);
+
+    if (!PSVirtualSiteHelper.isVirtual(site)) {
+      throw new WebApplicationException(
+          "Site '"
+              + site.getName()
+              + "' is not a Virtual Site (virtual.sourceKind is blank or '"
+              + PSVirtualSiteHelper.SOURCE_KIND_REPOSITORY
+              + "'). Configure virtual.* properties before publishing.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    Path publishRoot;
+    try {
+      publishRoot = PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+    Path safePublishRoot = requireSafeOutputRoot(publishRoot);
+
+    VirtualSiteBuildResult built = buildVirtualSite(nameOrId, null);
+    Path buildOutput =
+        built.getOutputPath()
+            .filter(StringUtils::isNotBlank)
+            .map(Path::of)
+            .orElseThrow(
+                () ->
+                    new WebApplicationException(
+                        "Virtual Site build did not report an output path.",
+                        Response.Status.INTERNAL_SERVER_ERROR));
+
+    try {
+      PSVirtualSitePublishCopyResult copied =
+          PSVirtualSiteFilesystemPublisher.copyBuildToTarget(buildOutput, safePublishRoot);
+      return toWirePublishResult(site.getName(), PSVirtualSiteHelper.siteKey(site), built, copied);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (IOException e) {
+      log.error(
+          "Virtual Site publish I/O failed for '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(
+          "Virtual Site publish failed: " + e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Virtual Site publish failed for '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(
+          "Virtual Site publish failed: " + e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
   private PSVirtualSiteBuildResult runBuild(
       VirtualSiteConfig config, Path outputRoot, Path metaDir) throws Exception {
     if (buildRunner != null) {
@@ -443,11 +509,11 @@ public class SitesAdaptor implements ISiteAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to build Virtual Sites", Response.Status.FORBIDDEN);
+          "Admin role required to build or publish Virtual Sites", Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to build Virtual Sites", Response.Status.FORBIDDEN);
+          "Admin role required to build or publish Virtual Sites", Response.Status.FORBIDDEN);
     }
   }
 
@@ -545,6 +611,28 @@ public class SitesAdaptor implements ISiteAdaptor {
     dto.setHasLinkProblems(!problems.isEmpty());
     dto.setLinkProblems(truncate(problems, MAX_RESULT_LINES));
     dto.setWrittenFiles(truncate(built.writtenFiles(), MAX_RESULT_LINES));
+    return dto;
+  }
+
+  static VirtualSitePublishResult toWirePublishResult(
+      String siteName,
+      String siteKey,
+      VirtualSiteBuildResult built,
+      PSVirtualSitePublishCopyResult copied) {
+    VirtualSitePublishResult dto = new VirtualSitePublishResult();
+    dto.setSiteName(siteName);
+    dto.setSiteKey(siteKey);
+    if (copied != null && copied.publishRoot() != null) {
+      dto.setPublishPath(copied.publishRoot().toAbsolutePath().normalize().toString());
+    }
+    if (built != null) {
+      built.getOutputPath().ifPresent(dto::setBuildOutputPath);
+      dto.setPagesWritten(built.getPagesWritten());
+      dto.setLinkProblemCount(built.getLinkProblemCount());
+      dto.setHasLinkProblems(built.getHasLinkProblems());
+      dto.setLinkProblems(built.getLinkProblems());
+    }
+    dto.setFilesCopied(copied != null ? copied.filesCopied() : 0);
     return dto;
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -32,6 +32,7 @@ import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
 import com.percussion.rest.sites.VirtualSiteProperties;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -367,6 +368,79 @@ class SitesAdaptorTest {
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(out.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(out.resolve("link-report.txt")));
+  }
+
+  @Test
+  void publishVirtualSite_rejectsRepositorySite() {
+    PSSite site = new PSSite();
+    site.setName("Corp");
+    site.setGUID(siteGuid);
+    site.setRoot(tempDir.resolve("pub").toString());
+    when(siteManager.findSite("Corp")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.publishVirtualSite("Corp"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("not a virtual"));
+  }
+
+  @Test
+  void publishVirtualSite_rejectsMissingSiteRoot() {
+    Path siteRoot = tempDir.resolve("src-no-root");
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toString());
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.publishVirtualSite("Help"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("not configured"));
+  }
+
+  @Test
+  void publishVirtualSite_forbiddenWhenNotAdmin() {
+    SitesAdaptor denied =
+        new SitesAdaptor(siteManager, () -> false, SitesAdaptor::defaultOutputRootForSiteKey, null);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.publishVirtualSite("Help"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void publishVirtualSite_buildsThenCopiesToSiteRoot() throws Exception {
+    Path siteRoot = createMinimalVirtualTree(tempDir.resolve("pub-src"));
+    Path staging = tempDir.resolve("pub-staging");
+    Path publishTo = tempDir.resolve("pub-target");
+
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    site.setRoot(publishTo.toString());
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "help-docs");
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    SitesAdaptor publishing =
+        new SitesAdaptor(siteManager, () -> true, key -> staging, null);
+
+    VirtualSitePublishResult result = publishing.publishVirtualSite("Help");
+    assertEquals("Help", result.getSiteName().orElse(null));
+    assertEquals("help-docs", result.getSiteKey().orElse(null));
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(result.getFilesCopied() >= 1);
+    assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
+    assertTrue(Files.isRegularFile(publishTo.resolve("8.2").resolve("index.html")));
+    assertTrue(Files.isRegularFile(staging.resolve("8.2").resolve("index.html")));
+    assertFalse(Files.exists(publishTo.resolve("_meta")));
+    assertTrue(result.getPublishPath().isPresent());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -107,4 +107,20 @@ public interface ISiteAdaptor {
    *     path issues, 403 when not authorized, 404 when site not found
    */
   VirtualSiteBuildResult buildVirtualSite(String nameOrId, VirtualSiteBuildRequest request);
+
+  /**
+   * Builds a Virtual Site and copies the static output to the Site filesystem publish root ({@code
+   * IPSSite.getRoot()}).
+   *
+   * <p>Publish-includes-build: operators get a published docs tree at the configured Site
+   * publishing location, not only {@code tmp/virtual-sites}. Failures are operator-facing 4xx (not
+   * a silent no-op). Requires Admin.
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @return publish summary (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 when the Site is not virtual, publish root is
+   *     missing/unsafe, or the source tree overlaps the target; 403 when not authorized; 404 when
+   *     site not found
+   */
+  VirtualSitePublishResult publishVirtualSite(String nameOrId);
 }

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -286,6 +286,54 @@ public class SitesResource {
     }
   }
 
+  /**
+   * Builds a Virtual Site and publishes the static output to the Site filesystem publish root.
+   *
+   * @param nameOrId site name or GUID
+   * @return pages written, files copied, and publish path
+   */
+  @POST
+  @Path("/{nameOrId}/virtual/publish")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Operation(
+      summary = "Publish Virtual Site to Site filesystem target",
+      description =
+          "Runs the Phase 1 Virtual Site static build (same as POST …/virtual/build) then copies"
+              + " assembled HTML/assets to the Site publishing filesystem location (IPSSite.root)."
+              + " Requires Admin. Traditional repository Sites, missing/unsafe Site root, or"
+              + " overlap with virtual.rootPath return 4xx with an operator-readable message"
+              + " (never a silent no-op).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Published (check hasLinkProblems / filesCopied)",
+            content = @Content(schema = @Schema(implementation = VirtualSitePublishResult.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Not virtual / missing Site root / unsafe path / overlap"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public VirtualSitePublishResult publishVirtualSite(@PathParam("nameOrId") String nameOrId) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      // JSON/XML DTO via Jackson/JAXB/CXF — not HTML body (see suppressions.md)
+      return requireAdaptor().publishVirtualSite(nameOrId); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to publish virtual site '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
   private Site resolveSite(String nameOrId) {
     ISiteAdaptor a = requireAdaptor();
     Site byName = a.findByName(nameOrId);

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outcome of {@code POST /sites/{nameOrId}/virtual/publish}: build-then-copy to the Site filesystem
+ * publish root ({@code IPSSite.root}).
+ */
+@XmlRootElement(name = "VirtualSitePublishResult")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(
+    name = "VirtualSitePublishResult",
+    description =
+        "Virtual Site publish summary: Site filesystem target, files copied, and build extras")
+public class VirtualSitePublishResult {
+
+  @Schema(description = "CMS Site name that was published", example = "Help")
+  private String siteName;
+
+  @Schema(description = "Participant registry site key used for the build", example = "product-docs")
+  private String siteKey;
+
+  @Schema(
+      description = "Absolute filesystem path of the Site publishing location (IPSSite.root)",
+      example = "C:/inetpub/wwwroot/help")
+  private String publishPath;
+
+  @Schema(
+      description = "Absolute filesystem path of the staging build output (tmp/virtual-sites)",
+      example = "C:/Rhythmyx/tmp/virtual-sites/product-docs")
+  private String buildOutputPath;
+
+  @Schema(description = "Number of Markdown pages assembled to HTML", example = "42")
+  private Integer pagesWritten;
+
+  @Schema(description = "Number of regular files copied to the Site publish root", example = "50")
+  private Integer filesCopied;
+
+  @Schema(description = "Number of unresolved internal id: / relative Markdown links", example = "0")
+  private Integer linkProblemCount;
+
+  @Schema(description = "True when one or more link problems were reported")
+  private Boolean hasLinkProblems;
+
+  @Schema(description = "Human-readable link problem lines from the build")
+  private List<String> linkProblems = new ArrayList<>();
+
+  public VirtualSitePublishResult() {
+    // Default constructor for JAX-RS / Jackson
+  }
+
+  public Optional<String> getSiteName() {
+    return Optional.ofNullable(siteName);
+  }
+
+  public void setSiteName(String siteName) {
+    this.siteName = siteName;
+  }
+
+  public Optional<String> getSiteKey() {
+    return Optional.ofNullable(siteKey);
+  }
+
+  public void setSiteKey(String siteKey) {
+    this.siteKey = siteKey;
+  }
+
+  public Optional<String> getPublishPath() {
+    return Optional.ofNullable(publishPath);
+  }
+
+  public void setPublishPath(String publishPath) {
+    this.publishPath = publishPath;
+  }
+
+  public Optional<String> getBuildOutputPath() {
+    return Optional.ofNullable(buildOutputPath);
+  }
+
+  public void setBuildOutputPath(String buildOutputPath) {
+    this.buildOutputPath = buildOutputPath;
+  }
+
+  public Integer getPagesWritten() {
+    return pagesWritten;
+  }
+
+  public void setPagesWritten(Integer pagesWritten) {
+    this.pagesWritten = pagesWritten;
+  }
+
+  public Integer getFilesCopied() {
+    return filesCopied;
+  }
+
+  public void setFilesCopied(Integer filesCopied) {
+    this.filesCopied = filesCopied;
+  }
+
+  public Integer getLinkProblemCount() {
+    return linkProblemCount;
+  }
+
+  public void setLinkProblemCount(Integer linkProblemCount) {
+    this.linkProblemCount = linkProblemCount;
+  }
+
+  public Boolean getHasLinkProblems() {
+    return hasLinkProblems;
+  }
+
+  public void setHasLinkProblems(Boolean hasLinkProblems) {
+    this.hasLinkProblems = hasLinkProblems;
+  }
+
+  public List<String> getLinkProblems() {
+    return linkProblems;
+  }
+
+  public void setLinkProblems(List<String> linkProblems) {
+    this.linkProblems = linkProblems != null ? new ArrayList<>(linkProblems) : new ArrayList<>();
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -195,6 +195,30 @@ public class SitesResourceTest {
     verify(adaptor, never()).buildVirtualSite(any(), any());
   }
 
+  @Test
+  public void publishVirtualSiteDelegates() {
+    VirtualSitePublishResult published = new VirtualSitePublishResult();
+    published.setSiteName("Help");
+    published.setPagesWritten(3);
+    published.setFilesCopied(5);
+    published.setPublishPath("C:/pub/help");
+    when(adaptor.publishVirtualSite("Help")).thenReturn(published);
+
+    VirtualSitePublishResult out = resource.publishVirtualSite("Help");
+    assertEquals(3, out.getPagesWritten().intValue());
+    assertEquals(5, out.getFilesCopied().intValue());
+    assertEquals("C:/pub/help", out.getPublishPath().orElse(null));
+    verify(adaptor).publishVirtualSite("Help");
+  }
+
+  @Test
+  public void publishVirtualSiteBlankName400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.publishVirtualSite(" "));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).publishVirtualSite(any());
+  }
+
   /**
    * CodeQL #1949: Jackson/JAXB JSON/XML DTO return must keep same-line {@code // codeql[java/xss]}
    * on the updateVirtual sink (not HTML body construction).
@@ -213,6 +237,9 @@ public class SitesResourceTest {
         text.contains(
             "return requireAdaptor().buildVirtualSite(nameOrId, request); // codeql[java/xss]"),
         "buildVirtualSite return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains("return requireAdaptor().publishVirtualSite(nameOrId); // codeql[java/xss]"),
+        "publishVirtualSite return sink must carry same-line codeql[java/xss]");
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -85,4 +85,16 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     }
     return result;
   }
+
+  @Override
+  public VirtualSitePublishResult publishVirtualSite(String nameOrId) {
+    VirtualSitePublishResult result = new VirtualSitePublishResult();
+    result.setSiteName(nameOrId);
+    result.setSiteKey(nameOrId);
+    result.setPagesWritten(0);
+    result.setFilesCopied(0);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+    return result;
+  }
 }

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.sitemgr.IPSSite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Selects the Site filesystem publish target and copies a Virtual Site build tree there.
+ *
+ * <p>The target is {@link IPSSite#getRoot()} (the Site publishing filesystem location), resolved
+ * with portable NIO {@link Path} I/O. Does not invent OS path separators.
+ */
+public final class PSVirtualSiteFilesystemPublisher {
+
+  /** Build-staging directory that is not copied to the published site. */
+  public static final String META_DIR_NAME = "_meta";
+
+  private PSVirtualSiteFilesystemPublisher() {}
+
+  /**
+   * Resolve the Site filesystem publish target from {@link IPSSite#getRoot()}.
+   *
+   * @param site CMS Site, not null
+   * @return normalized target path (not required to exist yet)
+   * @throws VirtualSiteException when root is blank, unsafe, or overlaps the Virtual source tree
+   */
+  public static Path selectFilesystemTarget(IPSSite site) throws VirtualSiteException {
+    if (site == null) {
+      throw new VirtualSiteException("Site is required to select a filesystem publish target.");
+    }
+    String raw = site.getRoot();
+    if (StringUtils.isBlank(raw)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is not configured. Set the Site publishing filesystem"
+              + " location (Site root) to a directory, then publish again.");
+    }
+    Path target;
+    try {
+      target = Path.of(raw.trim()).normalize();
+    } catch (InvalidPathException e) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is not a valid path: '" + raw.trim() + "'.", e);
+    }
+    if (!PSVirtualSiteHelper.isSafeRootPath(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root must be a non-empty path with no '..' segments after"
+              + " normalize. Rejected: '"
+              + raw.trim()
+              + "'.");
+    }
+    Optional<Path> source = PSVirtualSiteHelper.rootPath(site);
+    if (source.isPresent()) {
+      Path src = source.get().normalize();
+      if (sameOrNested(src, target)) {
+        throw new VirtualSiteException(
+            "Site filesystem publish root must be distinct from virtual.rootPath (publishing would"
+                + " overwrite or nest inside the Markdown source tree). Configure a dedicated"
+                + " publishing directory.");
+      }
+    }
+    return target;
+  }
+
+  /**
+   * Copy assembled static files from {@code buildOutput} into {@code target}.
+   *
+   * <p>Skips the {@code _meta} participant-registry directory. Overwrites existing files; does not
+   * delete stale files already under the target.
+   *
+   * @param buildOutput directory written by {@link PSVirtualSiteBuildService}
+   * @param target Site filesystem publish root
+   * @return copy summary
+   * @throws VirtualSiteException when inputs are missing, unsafe, or overlap
+   * @throws IOException on filesystem I/O failure
+   */
+  public static PSVirtualSitePublishCopyResult copyBuildToTarget(Path buildOutput, Path target)
+      throws VirtualSiteException, IOException {
+    if (buildOutput == null || !Files.isDirectory(buildOutput)) {
+      throw new VirtualSiteException(
+          "Virtual Site build output is missing or is not a directory: '" + buildOutput + "'.");
+    }
+    if (target == null || !PSVirtualSiteHelper.isSafeRootPath(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is missing or unsafe: '" + target + "'.");
+    }
+    if (Files.exists(target) && !Files.isDirectory(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root exists and is not a directory: '" + target + "'.");
+    }
+
+    Path srcAbs = buildOutput.toAbsolutePath().normalize();
+    Path destAbs = target.toAbsolutePath().normalize();
+    if (sameOrNested(srcAbs, destAbs)) {
+      throw new VirtualSiteException(
+          "Build output and Site filesystem publish root overlap. Use a distinct publish directory"
+              + " (not the build staging tree).");
+    }
+
+    Files.createDirectories(destAbs); // codeql[java/path-injection]
+
+    int copied = 0;
+    try (Stream<Path> walk = Files.walk(srcAbs)) {
+      for (Path src : (Iterable<Path>) walk::iterator) {
+        Path rel = srcAbs.relativize(src);
+        if (isMetaTree(rel)) {
+          continue;
+        }
+        Path dest = destAbs.resolve(rel).normalize(); // codeql[java/path-injection]
+        if (!dest.startsWith(destAbs)) {
+          throw new VirtualSiteException(
+              "Refusing to write outside the Site filesystem publish root: '" + dest + "'.");
+        }
+        if (Files.isDirectory(src)) {
+          Files.createDirectories(dest); // codeql[java/path-injection]
+        } else if (Files.isRegularFile(src)) {
+          Path parent = dest.getParent();
+          if (parent != null) {
+            Files.createDirectories(parent); // codeql[java/path-injection]
+          }
+          Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING); // codeql[java/path-injection]
+          copied++;
+        }
+      }
+    }
+    return new PSVirtualSitePublishCopyResult(destAbs, copied);
+  }
+
+  static boolean isMetaTree(Path relative) {
+    if (relative == null || relative.getNameCount() < 1) {
+      return false;
+    }
+    Path first = relative.getName(0);
+    return first != null && META_DIR_NAME.equals(first.toString());
+  }
+
+  /**
+   * True when the two paths are equal after normalize, or either is a child of the other.
+   *
+   * <p>Does not call {@code toAbsolutePath()} so relative configs do not depend on process cwd.
+   */
+  static boolean sameOrNested(Path a, Path b) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Path left = a.normalize();
+    Path right = b.normalize();
+    if (left.equals(right)) {
+      return true;
+    }
+    try {
+      return left.startsWith(right) || right.startsWith(left);
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSitePublishCopyResult.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSitePublishCopyResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Outcome of copying a Virtual Site build tree to a Site filesystem publish target.
+ *
+ * @param publishRoot normalized absolute publish directory
+ * @param filesCopied number of regular files written (directories are created but not counted)
+ */
+public record PSVirtualSitePublishCopyResult(Path publishRoot, int filesCopied) {
+
+  public PSVirtualSitePublishCopyResult {
+    Objects.requireNonNull(publishRoot, "publishRoot");
+    if (filesCopied < 0) {
+      throw new IllegalArgumentException("filesCopied must be >= 0");
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.sitemgr.data.PSSite;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class PSVirtualSiteFilesystemPublisherTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void selectFilesystemTarget_requiresConfiguredRoot() {
+    PSSite site = virtualSite(tempDir.resolve("src"), null);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().toLowerCase().contains("not configured"));
+  }
+
+  @Test
+  void selectFilesystemTarget_rejectsUnsafeRoot() {
+    PSSite site = virtualSite(tempDir.resolve("src"), Path.of("a", "..", "..", "etc").toString());
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().contains(".."));
+  }
+
+  @Test
+  void selectFilesystemTarget_rejectsSameAsVirtualSource() {
+    Path src = tempDir.resolve("docs").normalize();
+    PSSite site = virtualSite(src, src.toString());
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().contains("virtual.rootPath"));
+  }
+
+  @Test
+  void selectFilesystemTarget_returnsNormalizedSiteRoot() throws Exception {
+    Path pub = tempDir.resolve("pub").resolve("site").normalize();
+    PSSite site = virtualSite(tempDir.resolve("src"), pub.toString());
+    Path selected = PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site);
+    assertEquals(pub, selected);
+  }
+
+  @Test
+  void copyBuildToTarget_copiesHtmlAndSkipsMeta() throws Exception {
+    Path build = tempDir.resolve("build");
+    Path pub = tempDir.resolve("published");
+    Path html = build.resolve("8.2").resolve("index.html");
+    Files.createDirectories(html.getParent());
+    Files.writeString(html, "<html>ok</html>", StandardCharsets.UTF_8);
+    Files.writeString(build.resolve("link-report.txt"), "clean", StandardCharsets.UTF_8);
+    Path meta = build.resolve("_meta").resolve("participants.jsonl");
+    Files.createDirectories(meta.getParent());
+    Files.writeString(meta, "{}", StandardCharsets.UTF_8);
+
+    PSVirtualSitePublishCopyResult result =
+        PSVirtualSiteFilesystemPublisher.copyBuildToTarget(build, pub);
+
+    assertEquals(2, result.filesCopied());
+    assertTrue(Files.isRegularFile(pub.resolve("8.2").resolve("index.html")));
+    assertEquals(
+        "<html>ok</html>",
+        Files.readString(pub.resolve("8.2").resolve("index.html"), StandardCharsets.UTF_8)
+            .replace("\r\n", "\n"));
+    assertTrue(Files.isRegularFile(pub.resolve("link-report.txt")));
+    assertFalse(Files.exists(pub.resolve("_meta")));
+    assertEquals(pub.toAbsolutePath().normalize(), result.publishRoot());
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsMissingBuildDir() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                PSVirtualSiteFilesystemPublisher.copyBuildToTarget(
+                    tempDir.resolve("missing-build"), tempDir.resolve("pub")));
+    assertTrue(ex.getMessage().toLowerCase().contains("build output"));
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsTargetThatIsAFile() throws Exception {
+    Path build = tempDir.resolve("b");
+    Files.createDirectories(build);
+    Files.writeString(build.resolve("index.html"), "x", StandardCharsets.UTF_8);
+    Path fileTarget = tempDir.resolve("not-a-dir");
+    Files.writeString(fileTarget, "nope", StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.copyBuildToTarget(build, fileTarget));
+    assertTrue(ex.getMessage().toLowerCase().contains("not a directory"));
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsOverlappingTrees() throws Exception {
+    Path build = tempDir.resolve("overlap");
+    Files.createDirectories(build);
+    Files.writeString(build.resolve("index.html"), "x", StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                PSVirtualSiteFilesystemPublisher.copyBuildToTarget(
+                    build, build.resolve("nested-pub")));
+    assertTrue(ex.getMessage().toLowerCase().contains("overlap"));
+  }
+
+  @Test
+  void isMetaTree_onlyTopLevelMeta() {
+    assertTrue(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("_meta")));
+    assertTrue(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("_meta", "x.jsonl")));
+    assertFalse(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("8.2", "index.html")));
+    assertFalse(PSVirtualSiteFilesystemPublisher.isMetaTree(null));
+  }
+
+  private static PSSite virtualSite(Path virtualRoot, String publishRoot) {
+    PSGuid ctx = new PSGuid(PSTypeEnum.CONTEXT, 1L);
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setRoot(publishRoot);
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_ROOT_PATH, virtualRoot.toString());
+    return site;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 Virtual Site **publish** for parent epic #2678 / slice #3301.

Operators can **build then publish** a git-filesystem Virtual Site to the Site’s configured **filesystem publish location** (`IPSSite.root`), not only `{install}/tmp/virtual-sites/{siteKey}`.

- New Admin REST: `POST /services/sites/{nameOrId}/virtual/publish`
- `PSVirtualSiteFilesystemPublisher` selects the Site root with portable NIO `Path` I/O and copies assembled HTML/assets (skips `_meta`)
- Clear 4xx operator errors (not 500 / silent no-op) when the Site is not Virtual, the Site root is missing/unsafe, or it overlaps `virtual.rootPath`

Out of scope (unchanged): Markdown ingest, SQL/API adapters, preview-in-panel (#3299).

Fixes #3301  
Parent: #2678

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Unit: `PSVirtualSiteFilesystemPublisherTest` (target select + copy, skip `_meta`, reject overlap / missing root).
2. `SitesAdaptorTest` publish: Admin 403, repository 400, missing Site root 400, real filesystem build-then-copy.
3. `SitesResourceTest` + `SitesTestAdaptor` Spring stub for `publishVirtualSite`.
4. Standalone `mvnw clean install` on `system`, `rest`, `projects/sitemanage` (see C3).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/publishing.md`, `admin/sites.md`, `developer/virtual-sites.md`, `developer/rest.md`, `reference/site-config.md`
- [x] **Unit / module tests** — new/changed logic covered; module clean installs green
- [x] **WebUI + Playwright** — **N/A** (REST + backend + product-docs only; no WebUI screen change)
- [x] **Build gates** — standalone clean install on each changed module; C2 reverse-dep `sitemanage` after `ISiteAdaptor` method add
- [x] **Cross-platform** — `Path` / `Files` only; no hardcoded filesystem separators

### C3 evidence

- **modules_built:** `system`, `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (publisher tests 9/9; suite green)
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 342, Failures: 0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (`SitesAdaptorTest` Tests run: 24, Failures: 0)
- **downstream_checked:** `ISiteAdaptor.publishVirtualSite` added; grepped `implements ISiteAdaptor` → `SitesAdaptor` + `SitesTestAdaptor` updated; sitemanage standalone clean install after rest+system install. No `final`/`sealed` type changes.

### C5 UI proof

N/A — no WebUI / Playwright surface in this slice.

> Co-Authored by Grok Build using grok-4.5 with agent main.
