### PR TITLE
feat(WebUI): Navigation Copy Site + Delete Site chrome (#3303)

### DIFF
--- a/WebUI/src/main/ts/api/architecture/index.ts
+++ b/WebUI/src/main/ts/api/architecture/index.ts
@@ -42,6 +42,21 @@ export {
   sectionLoadUrl,
 } from "./sectionApi";
 export {
+  buildSiteCopyRequestBody,
+  copyManagedSite,
+  deleteManagedSite,
+  isSiteBeingImported,
+  isSiteCopyInProgress,
+  loadSiteCopyInfo,
+  normalizeCopyAssetFolder,
+  siteCopyInfoUrl,
+  siteCopyUrl,
+  siteDeleteUrl,
+  siteImportingUrl,
+  suggestCopySiteName,
+} from "./siteAdminApi";
+export type { SiteCopyFields } from "./siteAdminApi";
+export {
   countNavTreeNodes,
   flattenNavTree,
   isNavBranch,

--- a/WebUI/src/main/ts/api/architecture/siteAdminApi.ts
+++ b/WebUI/src/main/ts/api/architecture/siteAdminApi.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Site-level copy / delete for Navigation chrome (#3303 / parent #3092).
+ *
+ * Reuses sitemanage site REST — same contract as CM1 Architecture
+ * ({@code PercSiteService} / {@code perc_page_manager.delete_site}).
+ */
+
+import { del, get, post } from "../client";
+import type { PSSiteCopyRequest } from "../contentExplorer/types";
+import { PATHS } from "../paths";
+
+/** Fields expected by {@code PSSiteCopyRequest} (srcSite / copySite / assetFolder). */
+export interface SiteCopyFields {
+  srcSite: string;
+  copySite: string;
+  assetFolder?: string;
+}
+
+export function siteCopyUrl(): string {
+  return `${PATHS.SITES_ALL}/copy`;
+}
+
+export function siteCopyInfoUrl(): string {
+  return `${PATHS.SITES_ALL}/copysiteinfo`;
+}
+
+export function siteDeleteUrl(siteName: string): string {
+  const name = siteName.trim();
+  if (!name) {
+    throw new Error("Site name is required");
+  }
+  return `${PATHS.SITES_ALL}/${encodeURIComponent(name)}`;
+}
+
+export function siteImportingUrl(siteName: string): string {
+  const name = siteName.trim();
+  if (!name) {
+    throw new Error("Site name is required");
+  }
+  return `${PATHS.SITES_ALL}/isSiteImporting/${encodeURIComponent(name)}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function hasMapEntries(entries: unknown): boolean {
+  if (entries == null) {
+    return false;
+  }
+  if (Array.isArray(entries)) {
+    return entries.length > 0;
+  }
+  if (typeof entries === "object") {
+    return Object.keys(entries as Record<string, unknown>).length > 0;
+  }
+  return String(entries).trim().length > 0;
+}
+
+/**
+ * True when {@code GET /sitemanage/site/copysiteinfo} reports an in-flight copy
+ * (legacy {@code result.psmap.entries} non-empty).
+ */
+export function isSiteCopyInProgress(payload: unknown): boolean {
+  if (payload == null) {
+    return false;
+  }
+  if (typeof payload === "boolean") {
+    return payload;
+  }
+  const root = asRecord(payload);
+  if (!root) {
+    return false;
+  }
+  const map =
+    asRecord(root.psmap) ??
+    asRecord(root.PSMapWrapper) ??
+    asRecord(root.psMapWrapper) ??
+    root;
+  return (
+    hasMapEntries(map.entries) ||
+    hasMapEntries(map.Entries) ||
+    hasMapEntries(root.entries)
+  );
+}
+
+/** Optional asset folder: omit empty / root-only paths. */
+export function normalizeCopyAssetFolder(
+  folder: string | undefined | null,
+): string | undefined {
+  if (folder == null) {
+    return undefined;
+  }
+  const t = folder.trim();
+  if (t.length === 0 || t === "/" || t === "\\") {
+    return undefined;
+  }
+  return t;
+}
+
+/**
+ * Map Explorer {@link PSSiteCopyRequest} (source/target) onto the sitemanage
+ * {@code SiteCopyRequest} wire body.
+ */
+export function buildSiteCopyRequestBody(
+  fields: SiteCopyFields | PSSiteCopyRequest,
+): { SiteCopyRequest: { srcSite: string; copySite: string; assetFolder?: string } } {
+  const rec = fields as SiteCopyFields & PSSiteCopyRequest;
+  const src = String(rec.srcSite ?? rec.sourceSite ?? "").trim();
+  const dest = String(rec.copySite ?? rec.targetSite ?? "").trim();
+  if (!src) {
+    throw new Error("Source site is required");
+  }
+  if (!dest) {
+    throw new Error("Copy site name is required");
+  }
+  const assetFolder = normalizeCopyAssetFolder(
+    rec.assetFolder ?? rec.targetFolder,
+  );
+  const inner: { srcSite: string; copySite: string; assetFolder?: string } = {
+    srcSite: src,
+    copySite: dest,
+  };
+  if (assetFolder) {
+    inner.assetFolder = assetFolder;
+  }
+  return { SiteCopyRequest: inner };
+}
+
+export function suggestCopySiteName(srcSite: string): string {
+  const src = srcSite.trim();
+  if (!src) {
+    return "";
+  }
+  return `${src}-copy`;
+}
+
+export async function loadSiteCopyInfo(): Promise<unknown> {
+  return get<unknown>(siteCopyInfoUrl());
+}
+
+export async function isSiteBeingImported(siteName: string): Promise<boolean> {
+  const payload = await get<unknown>(siteImportingUrl(siteName));
+  if (typeof payload === "boolean") {
+    return payload;
+  }
+  const text = String(payload ?? "")
+    .trim()
+    .toLowerCase();
+  return text === "true" || text === "1" || text === "yes";
+}
+
+export async function deleteManagedSite(siteName: string): Promise<void> {
+  await del<unknown>(siteDeleteUrl(siteName));
+}
+
+export async function copyManagedSite(
+  fields: SiteCopyFields | PSSiteCopyRequest,
+): Promise<unknown> {
+  return post<unknown>(siteCopyUrl(), buildSiteCopyRequestBody(fields));
+}

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -54,7 +54,17 @@ import {
   resolveCreateParentFolderPath,
 } from "../api/architecture/sectionMutations";
 import type { NavTreeNode } from "../api/architecture/types";
+import {
+  copyManagedSite,
+  deleteManagedSite,
+  isSiteBeingImported,
+  isSiteCopyInProgress,
+  loadSiteCopyInfo,
+  suggestCopySiteName,
+} from "../api/architecture/siteAdminApi";
+import type { PSSiteCopyRequest } from "../api/contentExplorer/types";
 import { fetchSites } from "../api/home/homeApi";
+import { SiteCopyWizard } from "../contentExplorer/wizards/SiteCopyWizard";
 import { SiteCreateWizard } from "../contentExplorer/wizards/SiteCreateWizard";
 import { catalogColors } from "../developer/catalogStyles";
 import { CreateSectionDialog } from "./CreateSectionDialog";
@@ -88,8 +98,8 @@ export interface ArchitectureShellProps {
    */
   useLandingContentBrowser?: boolean;
   /**
-   * Show New Site (Explorer SiteCreateWizard) for entitled roles.
-   * Default true — Architecture is already Admin/Designer gated (#3219).
+   * Show New / Copy / Delete Site for entitled roles.
+   * Default true — Architecture is already Admin/Designer gated (#3219 / #3303).
    */
   allowNewSite?: boolean;
 }
@@ -150,10 +160,15 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     target: string;
   } | null>(null);
   const [showNewSite, setShowNewSite] = useState(false);
+  const [showCopySite, setShowCopySite] = useState(false);
   const newSiteToggleRef = useRef<HTMLButtonElement>(null);
   const newSitePanelRef = useRef<HTMLElement>(null);
+  const copySiteToggleRef = useRef<HTMLButtonElement>(null);
+  const copySitePanelRef = useRef<HTMLElement>(null);
+  const copyTargetRef = useRef<string | null>(null);
 
   useDialogEscape(showNewSite, mutationBusy, () => setShowNewSite(false));
+  useDialogEscape(showCopySite, mutationBusy, () => setShowCopySite(false));
 
   useEffect(() => {
     if (!showNewSite) {
@@ -194,6 +209,46 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
       newSiteToggleRef.current?.focus();
     };
   }, [showNewSite]);
+
+  useEffect(() => {
+    if (!showCopySite) {
+      return;
+    }
+    const root = copySitePanelRef.current;
+    if (!root) {
+      return;
+    }
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+    focusables()[0]?.focus();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key !== "Tab") {
+        return;
+      }
+      const list = focusables();
+      if (list.length === 0) {
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => {
+      root.removeEventListener("keydown", onKey);
+      copySiteToggleRef.current?.focus();
+    };
+  }, [showCopySite]);
 
   // Honor route/deep-link site when prop changes
   useEffect(() => {
@@ -287,7 +342,10 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   }, []);
 
   const reloadSites = useCallback(
-    async (preferSite?: string | null) => {
+    async (
+      preferSite?: string | null,
+      reloadErrorTemplate: string = ARCH_MSG.NEW_SITE_RELOAD_ERROR,
+    ) => {
       const preferred = preferSite != null ? String(preferSite).trim() : "";
       try {
         const names = await loadSiteNames();
@@ -302,13 +360,40 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
           message: formatApiError(err, ARCH_MSG.SITES_ERROR),
         });
         if (preferred) {
-          setMutationError(
-            ARCH_MSG.NEW_SITE_RELOAD_ERROR.split("{0}").join(preferred),
-          );
+          setMutationError(reloadErrorTemplate.split("{0}").join(preferred));
         }
       }
     },
     [applySiteNames, loadSiteNames],
+  );
+
+  const reloadSitesAfterDelete = useCallback(
+    async (deletedName: string) => {
+      const gone = deletedName.trim();
+      try {
+        const names = await loadSiteNames();
+        const remaining = names.filter((n) => n !== gone);
+        setSitesState({ status: "ready", names: remaining });
+        setSelectedSite((prev) => {
+          if (prev && remaining.includes(prev)) {
+            return prev;
+          }
+          return remaining[0] ?? null;
+        });
+        setMutationError(null);
+      } catch (err) {
+        if (isSessionRedirectError(err)) return;
+        setSitesState({
+          status: "error",
+          message: formatApiError(err, ARCH_MSG.SITES_ERROR),
+        });
+        setSelectedSite((prev) => (prev === gone ? null : prev));
+        setMutationError(
+          ARCH_MSG.DELETE_SITE_RELOAD_ERROR.split("{0}").join(gone),
+        );
+      }
+    },
+    [loadSiteNames],
   );
 
   const treeRoot =
@@ -451,6 +536,98 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
       setSelectedNodeId(null);
     });
   }, [selectedNode, treeRoot, confirmAction, runMutation]);
+
+  const onCopySite = useCallback(() => {
+    if (!selectedSite) {
+      setMutationError(ARCH_MSG.COPY_SITE_NEED_SELECTION);
+      return;
+    }
+    if (mutationBusy) {
+      return;
+    }
+    setMutationBusy(true);
+    setMutationError(null);
+    void (async () => {
+      try {
+        const info = await loadSiteCopyInfo();
+        if (isSiteCopyInProgress(info)) {
+          setMutationError(ARCH_MSG.COPY_SITE_IN_PROGRESS);
+          return;
+        }
+        setShowNewSite(false);
+        setShowCopySite(true);
+      } catch (err) {
+        if (isSessionRedirectError(err)) return;
+        setMutationError(formatApiError(err, ARCH_MSG.COPY_SITE_ERROR));
+      } finally {
+        setMutationBusy(false);
+      }
+    })();
+  }, [selectedSite, mutationBusy]);
+
+  const submitCopySite = useCallback(
+    async (req: PSSiteCopyRequest) => {
+      const dest = String(req.targetSite ?? "").trim();
+      copyTargetRef.current = dest;
+      await copyManagedSite({
+        sourceSite: req.sourceSite ?? selectedSite ?? "",
+        targetSite: dest,
+        targetFolder: req.targetFolder,
+      });
+    },
+    [selectedSite],
+  );
+
+  const onCopySiteSettled = useCallback(
+    (ok: boolean) => {
+      if (!ok) {
+        return;
+      }
+      setShowCopySite(false);
+      const dest = copyTargetRef.current || selectedSite;
+      void reloadSites(dest, ARCH_MSG.COPY_SITE_RELOAD_ERROR);
+    },
+    [reloadSites, selectedSite],
+  );
+
+  const onDeleteSite = useCallback(() => {
+    if (!selectedSite) {
+      setMutationError(ARCH_MSG.DELETE_SITE_NEED_SELECTION);
+      return;
+    }
+    if (mutationBusy) {
+      return;
+    }
+    const name = selectedSite;
+    const msg = ARCH_MSG.DELETE_SITE_CONFIRM.split("{0}").join(name);
+    if (!confirmAction(msg)) {
+      return;
+    }
+    setMutationBusy(true);
+    setMutationError(null);
+    void (async () => {
+      try {
+        const info = await loadSiteCopyInfo();
+        if (isSiteCopyInProgress(info)) {
+          setMutationError(ARCH_MSG.COPY_SITE_IN_PROGRESS);
+          return;
+        }
+        if (await isSiteBeingImported(name)) {
+          setMutationError(ARCH_MSG.DELETE_SITE_IMPORTING);
+          return;
+        }
+        await deleteManagedSite(name);
+        setShowCopySite(false);
+        setShowNewSite(false);
+        await reloadSitesAfterDelete(name);
+      } catch (err) {
+        if (isSessionRedirectError(err)) return;
+        setMutationError(formatApiError(err, ARCH_MSG.DELETE_SITE_ERROR));
+      } finally {
+        setMutationBusy(false);
+      }
+    })();
+  }, [selectedSite, mutationBusy, confirmAction, reloadSitesAfterDelete]);
 
   const onLandingSubmit = useCallback(
     (newLandingPageId: string) => {
@@ -723,7 +900,10 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             aria-controls={
               showNewSite ? "architecture-new-site-panel" : undefined
             }
-            onClick={() => setShowNewSite((open) => !open)}
+            onClick={() => {
+              setShowCopySite(false);
+              setShowNewSite((open) => !open);
+            }}
             style={{
               padding: "0.4rem 0.85rem",
               border: `1px solid ${catalogColors.softBorder}`,
@@ -735,6 +915,52 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             }}
           >
             {ARCH_MSG.ACTION_NEW_SITE}
+          </button>
+        ) : null}
+        {allowNewSite ? (
+          <button
+            type="button"
+            ref={copySiteToggleRef}
+            data-testid="architecture-action-copy-site"
+            aria-expanded={showCopySite}
+            aria-haspopup="dialog"
+            aria-controls={
+              showCopySite ? "architecture-copy-site-panel" : undefined
+            }
+            disabled={!selectedSite || mutationBusy}
+            onClick={onCopySite}
+            style={{
+              padding: "0.4rem 0.85rem",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: 4,
+              background: showCopySite ? "#e8eef8" : "#fff",
+              color: !selectedSite || mutationBusy ? "#999" : "#222",
+              cursor:
+                !selectedSite || mutationBusy ? "not-allowed" : "pointer",
+              fontSize: "0.9rem",
+            }}
+          >
+            {ARCH_MSG.ACTION_COPY_SITE}
+          </button>
+        ) : null}
+        {allowNewSite ? (
+          <button
+            type="button"
+            data-testid="architecture-action-delete-site"
+            disabled={!selectedSite || mutationBusy}
+            onClick={onDeleteSite}
+            style={{
+              padding: "0.4rem 0.85rem",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: 4,
+              background: "#fff",
+              color: !selectedSite || mutationBusy ? "#999" : "#a11",
+              cursor:
+                !selectedSite || mutationBusy ? "not-allowed" : "pointer",
+              fontSize: "0.9rem",
+            }}
+          >
+            {ARCH_MSG.ACTION_DELETE_SITE}
           </button>
         ) : null}
       </section>
@@ -806,6 +1032,64 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
               setShowNewSite(false);
               void reloadSites(siteName);
             }}
+          />
+        </section>
+      ) : null}
+
+      {allowNewSite && showCopySite && selectedSite ? (
+        <section
+          id="architecture-copy-site-panel"
+          ref={copySitePanelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="architecture-copy-site-title"
+          aria-label={ARCH_MSG.COPY_SITE_REGION}
+          data-testid="architecture-copy-site-panel"
+          style={{
+            border: `1px solid ${catalogColors.headerBorder}`,
+            borderRadius: 8,
+            padding: "1rem 1.25rem",
+            marginBottom: "12px",
+            background: "#fff",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "0.75rem",
+              marginBottom: "0.75rem",
+            }}
+          >
+            <h2
+              id="architecture-copy-site-title"
+              style={{ margin: 0, fontSize: "1.05rem", color: "#1a202c" }}
+              data-testid="architecture-copy-site-title"
+            >
+              {ARCH_MSG.ACTION_COPY_SITE}
+            </h2>
+            <button
+              type="button"
+              data-testid="architecture-copy-site-close"
+              onClick={() => setShowCopySite(false)}
+              style={{
+                padding: "0.3rem 0.7rem",
+                border: `1px solid ${catalogColors.softBorder}`,
+                borderRadius: 4,
+                background: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              {ARCH_MSG.COPY_SITE_CLOSE}
+            </button>
+          </div>
+          <SiteCopyWizard
+            key={selectedSite}
+            initialSource={selectedSite}
+            initialTarget={suggestCopySiteName(selectedSite)}
+            submit={submitCopySite}
+            onSettled={onCopySiteSettled}
           />
         </section>
       ) : null}

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -53,6 +53,26 @@ const KEYS = {
   NEW_SITE_REGION: "perc.ui.architecture.modern@New Site panel",
   NEW_SITE_RELOAD_ERROR:
     "perc.ui.architecture.modern@Site {0} was created, but the site list could not be refreshed.",
+  ACTION_COPY_SITE: "perc.ui.architecture.modern@Copy Site",
+  ACTION_DELETE_SITE: "perc.ui.architecture.modern@Delete Site",
+  COPY_SITE_REGION: "perc.ui.architecture.modern@Copy Site panel",
+  COPY_SITE_CLOSE: "perc.ui.architecture.modern@Close",
+  COPY_SITE_IN_PROGRESS:
+    "perc.ui.architecture.modern@A site copy is already in progress. Wait for it to finish before copying or deleting a site.",
+  COPY_SITE_ERROR: "perc.ui.architecture.modern@Could not copy the site.",
+  COPY_SITE_RELOAD_ERROR:
+    "perc.ui.architecture.modern@Site {0} was copied, but the site list could not be refreshed.",
+  COPY_SITE_NEED_SELECTION:
+    "perc.ui.architecture.modern@Select a site before copying.",
+  DELETE_SITE_CONFIRM:
+    "perc.ui.architecture.modern@Delete site \"{0}\"? This removes the site and cannot be undone.",
+  DELETE_SITE_ERROR: "perc.ui.architecture.modern@Could not delete the site.",
+  DELETE_SITE_IMPORTING:
+    "perc.ui.architecture.modern@This site is still being imported and cannot be deleted.",
+  DELETE_SITE_NEED_SELECTION:
+    "perc.ui.architecture.modern@Select a site before deleting.",
+  DELETE_SITE_RELOAD_ERROR:
+    "perc.ui.architecture.modern@Site {0} was deleted, but the site list could not be refreshed.",
   // Kept for older tests / deep links that still assert empty-shell keys
   EMPTY_TITLE: "perc.ui.architecture.modern@No site selected",
   EMPTY_BODY:
@@ -196,6 +216,19 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   NEW_SITE_CLOSE: message(KEYS.NEW_SITE_CLOSE),
   NEW_SITE_REGION: message(KEYS.NEW_SITE_REGION),
   NEW_SITE_RELOAD_ERROR: message(KEYS.NEW_SITE_RELOAD_ERROR),
+  ACTION_COPY_SITE: message(KEYS.ACTION_COPY_SITE),
+  ACTION_DELETE_SITE: message(KEYS.ACTION_DELETE_SITE),
+  COPY_SITE_REGION: message(KEYS.COPY_SITE_REGION),
+  COPY_SITE_CLOSE: message(KEYS.COPY_SITE_CLOSE),
+  COPY_SITE_IN_PROGRESS: message(KEYS.COPY_SITE_IN_PROGRESS),
+  COPY_SITE_ERROR: message(KEYS.COPY_SITE_ERROR),
+  COPY_SITE_RELOAD_ERROR: message(KEYS.COPY_SITE_RELOAD_ERROR),
+  COPY_SITE_NEED_SELECTION: message(KEYS.COPY_SITE_NEED_SELECTION),
+  DELETE_SITE_CONFIRM: message(KEYS.DELETE_SITE_CONFIRM),
+  DELETE_SITE_ERROR: message(KEYS.DELETE_SITE_ERROR),
+  DELETE_SITE_IMPORTING: message(KEYS.DELETE_SITE_IMPORTING),
+  DELETE_SITE_NEED_SELECTION: message(KEYS.DELETE_SITE_NEED_SELECTION),
+  DELETE_SITE_RELOAD_ERROR: message(KEYS.DELETE_SITE_RELOAD_ERROR),
   EMPTY_TITLE: message(KEYS.EMPTY_TITLE),
   EMPTY_BODY: message(KEYS.EMPTY_BODY),
   ACTIONS_LABEL: message(KEYS.ACTIONS_LABEL),

--- a/WebUI/src/test/ts/api/architecture/siteAdminApi.test.ts
+++ b/WebUI/src/test/ts/api/architecture/siteAdminApi.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as client from "../../../../main/ts/api/client";
+import {
+  buildSiteCopyRequestBody,
+  copyManagedSite,
+  deleteManagedSite,
+  isSiteBeingImported,
+  isSiteCopyInProgress,
+  loadSiteCopyInfo,
+  normalizeCopyAssetFolder,
+  siteCopyInfoUrl,
+  siteCopyUrl,
+  siteDeleteUrl,
+  siteImportingUrl,
+  suggestCopySiteName,
+} from "../../../../main/ts/api/architecture/siteAdminApi";
+import { PATHS } from "../../../../main/ts/api/paths";
+
+describe("siteAdminApi (#3303)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds copy/delete/import URLs", () => {
+    expect(siteCopyUrl()).toBe(`${PATHS.SITES_ALL}/copy`);
+    expect(siteCopyInfoUrl()).toBe(`${PATHS.SITES_ALL}/copysiteinfo`);
+    expect(siteDeleteUrl("Demo Site")).toBe(
+      `${PATHS.SITES_ALL}/${encodeURIComponent("Demo Site")}`,
+    );
+    expect(siteImportingUrl("Acme")).toBe(
+      `${PATHS.SITES_ALL}/isSiteImporting/Acme`,
+    );
+    expect(() => siteDeleteUrl("  ")).toThrow(/name/i);
+  });
+
+  it("maps explorer wizard fields onto SiteCopyRequest wire body", () => {
+    expect(
+      buildSiteCopyRequestBody({
+        sourceSite: "Demo",
+        targetSite: "Demo-copy",
+        targetFolder: "/",
+      }),
+    ).toEqual({
+      SiteCopyRequest: { srcSite: "Demo", copySite: "Demo-copy" },
+    });
+    expect(
+      buildSiteCopyRequestBody({
+        srcSite: "A",
+        copySite: "B",
+        assetFolder: "Shared",
+      }),
+    ).toEqual({
+      SiteCopyRequest: { srcSite: "A", copySite: "B", assetFolder: "Shared" },
+    });
+    expect(() =>
+      buildSiteCopyRequestBody({ sourceSite: "", targetSite: "X" }),
+    ).toThrow(/source/i);
+    expect(() =>
+      buildSiteCopyRequestBody({ srcSite: "A", copySite: "  " }),
+    ).toThrow(/copy site/i);
+  });
+
+  it("normalizes asset folders and copy name suggestion", () => {
+    expect(normalizeCopyAssetFolder("/")).toBeUndefined();
+    expect(normalizeCopyAssetFolder("  ")).toBeUndefined();
+    expect(normalizeCopyAssetFolder("Assets/x")).toBe("Assets/x");
+    expect(suggestCopySiteName(" Demo ")).toBe("Demo-copy");
+    expect(suggestCopySiteName("")).toBe("");
+  });
+
+  it("detects copy-in-progress from copysiteinfo envelopes", () => {
+    expect(isSiteCopyInProgress(null)).toBe(false);
+    expect(isSiteCopyInProgress({})).toBe(false);
+    expect(isSiteCopyInProgress({ entries: {} })).toBe(false);
+    expect(isSiteCopyInProgress({ psmap: { entries: {} } })).toBe(false);
+    expect(isSiteCopyInProgress({ psmap: { entries: [] } })).toBe(false);
+    expect(
+      isSiteCopyInProgress({ psmap: { entries: { src: "Demo" } } }),
+    ).toBe(true);
+    expect(isSiteCopyInProgress({ entries: [{ k: "v" }] })).toBe(true);
+    expect(isSiteCopyInProgress({ PSMapWrapper: { Entries: { a: 1 } } })).toBe(
+      true,
+    );
+  });
+
+  it("copyManagedSite POSTs wrapped SiteCopyRequest", async () => {
+    const spy = vi.spyOn(client, "post").mockResolvedValue({ name: "B" });
+    await copyManagedSite({ srcSite: "A", copySite: "B" });
+    expect(spy).toHaveBeenCalledWith(`${PATHS.SITES_ALL}/copy`, {
+      SiteCopyRequest: { srcSite: "A", copySite: "B" },
+    });
+  });
+
+  it("deleteManagedSite DELETEs the site name path", async () => {
+    const spy = vi.spyOn(client, "del").mockResolvedValue(undefined);
+    await deleteManagedSite("Demo");
+    expect(spy).toHaveBeenCalledWith(`${PATHS.SITES_ALL}/Demo`);
+  });
+
+  it("loadSiteCopyInfo and isSiteBeingImported call GET", async () => {
+    const spy = vi
+      .spyOn(client, "get")
+      .mockResolvedValueOnce({ entries: {} })
+      .mockResolvedValueOnce("true");
+    await expect(loadSiteCopyInfo()).resolves.toEqual({ entries: {} });
+    await expect(isSiteBeingImported("Demo")).resolves.toBe(true);
+    expect(spy).toHaveBeenNthCalledWith(1, `${PATHS.SITES_ALL}/copysiteinfo`);
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      `${PATHS.SITES_ALL}/isSiteImporting/Demo`,
+    );
+  });
+
+  it("isSiteBeingImported treats false/empty as not importing", async () => {
+    vi.spyOn(client, "get").mockResolvedValue("false");
+    await expect(isSiteBeingImported("Demo")).resolves.toBe(false);
+    vi.spyOn(client, "get").mockResolvedValue(false);
+    await expect(isSiteBeingImported("Demo")).resolves.toBe(false);
+  });
+});

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -677,5 +677,127 @@ describe("ArchitectureShell (#3095/#3096)", () => {
       expect(screen.getByTestId("architecture-sites-empty")).toBeTruthy();
     });
     expect(screen.queryByTestId("architecture-action-new-site")).toBeNull();
+    expect(screen.queryByTestId("architecture-action-copy-site")).toBeNull();
+    expect(screen.queryByTestId("architecture-action-delete-site")).toBeNull();
+  });
+
+  it("opens Copy Site wizard after copysiteinfo is idle (#3303)", async () => {
+    const siteAdmin = await import(
+      "../../../main/ts/api/architecture/siteAdminApi"
+    );
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    vi.spyOn(siteAdmin, "loadSiteCopyInfo").mockResolvedValue({ entries: {} });
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("architecture-action-copy-site") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-copy-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-copy-site-panel")).toBeTruthy();
+    });
+    expect(screen.getByTestId("site-copy-wizard")).toBeTruthy();
+    expect(
+      (screen.getByTestId("site-copy-source") as HTMLInputElement).value,
+    ).toBe("Demo");
+    fireEvent.click(screen.getByTestId("site-copy-next"));
+    expect(
+      (screen.getByTestId("site-copy-target") as HTMLInputElement).value,
+    ).toBe("Demo-copy");
+    fireEvent.click(screen.getByTestId("architecture-copy-site-close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-copy-site-panel")).toBeNull();
+    });
+  });
+
+  it("blocks Copy Site when a copy is already in progress (#3303)", async () => {
+    const siteAdmin = await import(
+      "../../../main/ts/api/architecture/siteAdminApi"
+    );
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    vi.spyOn(siteAdmin, "loadSiteCopyInfo").mockResolvedValue({
+      psmap: { entries: { src: "Other" } },
+    });
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-copy-site")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-copy-site"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-mutation-error").textContent).toMatch(
+        /copy is already in progress/i,
+      );
+    });
+    expect(screen.queryByTestId("architecture-copy-site-panel")).toBeNull();
+  });
+
+  it("confirms Delete Site, calls delete, and refreshes the picker (#3303)", async () => {
+    const siteAdmin = await import(
+      "../../../main/ts/api/architecture/siteAdminApi"
+    );
+    const fetchSites = vi
+      .spyOn(homeApi, "fetchSites")
+      .mockResolvedValue([{ name: "Demo" }, { name: "Keep" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    vi.spyOn(siteAdmin, "loadSiteCopyInfo").mockResolvedValue({ entries: {} });
+    vi.spyOn(siteAdmin, "isSiteBeingImported").mockResolvedValue(false);
+    const delSpy = vi
+      .spyOn(siteAdmin, "deleteManagedSite")
+      .mockResolvedValue(undefined);
+
+    render(
+      <ArchitectureShell
+        embedded
+        initialSite="Demo"
+        confirmFn={() => true}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId(
+          "architecture-action-delete-site",
+        ) as HTMLButtonElement).disabled,
+      ).toBe(false);
+    });
+    fetchSites.mockResolvedValue([{ name: "Keep" }]);
+    fireEvent.click(screen.getByTestId("architecture-action-delete-site"));
+    await waitFor(() => {
+      expect(delSpy).toHaveBeenCalledWith("Demo");
+    });
+    await waitFor(() => {
+      const picker = screen.getByTestId(
+        "architecture-site-select",
+      ) as HTMLSelectElement;
+      expect(picker.value).toBe("Keep");
+      expect(picker.textContent).not.toMatch(/Demo/);
+    });
+  });
+
+  it("does not delete when the operator cancels confirmation (#3303)", async () => {
+    const siteAdmin = await import(
+      "../../../main/ts/api/architecture/siteAdminApi"
+    );
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    const delSpy = vi.spyOn(siteAdmin, "deleteManagedSite");
+
+    render(
+      <ArchitectureShell
+        embedded
+        initialSite="Demo"
+        confirmFn={() => false}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-action-delete-site")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-delete-site"));
+    expect(delSpy).not.toHaveBeenCalled();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-copy-delete-site.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-copy-delete-site.spec.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Navigation Copy Site + Delete Site chrome (#3303 / parent #3092).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-copy-delete-site.spec.js
+ *
+ * Does not submit a live site copy or delete a demo site. Proves chrome,
+ * wizard open/close, and cancel-confirm on Delete Site.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Navigation Copy Site + Delete Site (#3303)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("Copy Site wizard and Delete Site confirm chrome @smoke @ui", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const copyBtn = page.getByTestId("architecture-action-copy-site");
+    const deleteBtn = page.getByTestId("architecture-action-delete-site");
+    await expect(copyBtn).toBeVisible();
+    await expect(deleteBtn).toBeVisible();
+    await expect(copyBtn).toContainText(/Copy Site/i);
+    await expect(deleteBtn).toContainText(/Delete Site/i);
+
+    const picker = page.getByTestId("architecture-site-select");
+    const empty = page.getByTestId("architecture-sites-empty");
+    await expect(picker.or(empty)).toBeVisible({ timeout: 15_000 });
+
+    if (await empty.isVisible().catch(() => false)) {
+      await expect(copyBtn).toBeDisabled();
+      await expect(deleteBtn).toBeDisabled();
+      expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+      return;
+    }
+
+    await expect(copyBtn).toBeEnabled();
+    await expect(deleteBtn).toBeEnabled();
+
+    await copyBtn.click();
+    await expect(page.getByTestId("architecture-copy-site-panel")).toBeVisible();
+    await expect(page.getByTestId("site-copy-wizard")).toBeVisible();
+    const source = page.getByTestId("site-copy-source");
+    await expect(source).toBeVisible();
+    const sourceVal = (await source.inputValue()).trim();
+    expect(sourceVal.length).toBeGreaterThan(0);
+    await page.getByTestId("architecture-copy-site-close").click();
+    await expect(page.getByTestId("architecture-copy-site-panel")).toHaveCount(
+      0,
+    );
+
+    page.once("dialog", (dialog) => {
+      expect(dialog.message()).toMatch(/Delete site/i);
+      void dialog.dismiss();
+    });
+    await deleteBtn.click();
+    await expect(deleteBtn).toBeVisible();
+    await expect(picker).toBeVisible();
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -65,7 +65,11 @@ test.describe("Architecture SPA shell (#3094)", () => {
     const emptyState = page.getByTestId("architecture-empty-state");
     const picker = page.getByTestId("architecture-site-picker");
     const tree = page.getByTestId("architecture-tree-panel");
-    await expect(emptyState.or(picker).or(tree)).toBeVisible({ timeout: 15_000 });
+    // Demo-site cells show picker + tree together; Playwright .or() is strict
+    // when more than one locator matches.
+    await expect(emptyState.or(picker).or(tree).first()).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(page.getByTestId("architecture-shell-title")).toContainText(
       /Navigation/i,
     );

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -42,11 +42,20 @@ dispatcher applies that preference and opens the Navigation SPA — not Home.
 6. Use **New Site** (Admin or Designer) to open the same traditional-site wizard
    used in Content Explorer. After a successful create, the new site is selected
    in this shell.
+7. Use **Copy Site** (Admin or Designer) with a site selected to open the
+   existing site-copy wizard (same sitemanage copy service as Explorer). The
+   source is prefilled from the current site. A copy already in progress blocks
+   a new copy until it finishes. After a successful copy, the site list
+   refreshes and the new site is selected.
+8. Use **Delete Site** (Admin or Designer) with a site selected. Confirm the
+   prompt. Delete is blocked while a site copy is in progress or while the site
+   is still importing. After a successful delete, the site picker refreshes and
+   selects another remaining site (or the empty state if none remain).
 
 Empty, loading, and error states are shown explicitly when the site list or tree
 cannot be loaded, or when a site has no sections. **New Site** remains available
 when the site list is empty so operators can create the first site from this
-screen.
+screen. **Copy Site** and **Delete Site** stay disabled until a site is selected.
 
 ### Site without a navigation tree
 
@@ -78,10 +87,10 @@ The navigation tree follows the ARIA tree pattern:
 | **Enter / Space** | Select the focused section (and toggle expand on branches). |
 
 Structure dialogs (create, rename, landing page, section link, external link, the
-section picker, and **New Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
-closes the open dialog when a mutation is not in progress. Closing **New Site**
-returns keyboard focus to the **New Site** button. Primary structure actions live in a toolbar
-with an accessible name (**Structure actions**).
+section picker, **New Site**, and **Copy Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
+closes the open dialog when a mutation is not in progress. Closing **New Site** or
+**Copy Site** returns keyboard focus to the matching toolbar button. Primary
+structure actions live in a toolbar with an accessible name (**Structure actions**).
 
 Chrome strings (shell, tree states, actions, dialogs, validation) use the
 `perc.ui.architecture.modern` message catalog so they follow the session locale when
@@ -124,6 +133,8 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | Role gate (Admin / Designer) | **Available** |
 | Site picker | **Available** |
 | New Site (Explorer create-site wizard) | **Available** |
+| Copy Site (existing sitemanage copy wizard) | **Available** |
+| Delete Site (confirm + picker refresh) | **Available** |
 | Site navigation tree browse (navons / sections) | **Available** |
 | Structure editing (create / rename / reorder / delete) | **Available** |
 | Landing page / section-link / external-link parity | **Available** |


### PR DESCRIPTION
## Summary

Navigation SPA now exposes **Copy Site** and **Delete Site** next to **New Site** (Admin/Designer chrome; same `allowNewSite` gate as #3219). This is parent **#3092** inventory §2.3 — site-level actions, not navon edit.

- **Copy Site** reuses the existing Explorer `SiteCopyWizard` and POSTs the real sitemanage `SiteCopyRequest` (`srcSite` / `copySite` / `assetFolder`). `GET /sitemanage/site/copysiteinfo` blocks a second copy while one is in flight. After success the picker refreshes and selects the new site.
- **Delete Site** confirms, then `DELETE /sitemanage/site/{name}` (same path as CM1 `perc_page_manager.delete_site`). Blocked while a copy is in progress or the site is still importing. After success the picker drops the deleted site and selects another remaining site.
- Does **not** invent a new site-copy engine.

Fixes #3303  
Parent tracker: #3092

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Sign in as Admin on QA H2 (`perc-devctl qa-up` → `TEST_CMS_URL`).
2. Open **Navigation**. Confirm **Copy Site** and **Delete Site** appear; they stay disabled until a site is selected.
3. With a site selected, **Copy Site** opens the existing copy wizard (source prefilled). Close without submitting.
4. **Delete Site** shows a confirm dialog. Cancel — the site remains in the picker.
5. (Human QA) Copy a throwaway site and delete it; picker/tree refresh. Do not delete demo sample sites.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md`
- [x] **Unit / module tests** — `siteAdminApi.test.ts` + ArchitectureShell copy/delete cases; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `architecture-nav-copy-delete-site.spec.js` + `architecture-shell-smoke.spec.js`
- [x] **Build gates** — WebUI + perc-qa-automation standalone clean install
- [x] **Cross-platform** — N/A for OS filesystem paths (REST URL join + `encodeURIComponent` only)

## C3 evidence

- `modules_built=WebUI,modules/perc-qa-automation`
- `build_evidence=`
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Surefire Java Tests run: 51, Failures: 0. Vitest Test Files 306 passed, Tests **2212** passed.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (No tests to run / npm ci only).
- `downstream_checked=none` (no public Java API / `final` / signature change)

## C5 UI proof (H2 Docker QA)

- `python docker/scripts/perc-devctl.py qa-up` started cell `perc-matrix-cms-h2`; host **TEST_CMS_URL=http://127.0.0.1:9993** (freeport preferred 9993). Cell became `healthy` / login HTTP 200 after install.
- Hot-deploy: copied `WebUI/target/generated-webui/cm/modern/` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/` (entry `perc-modern-ui.js` + `architecture-BrZ-XrqM.js`).
- Playwright (`modules/perc-qa-automation/frontend`):
  - `npm run test:surface -- --path tests/architecture-nav-copy-delete-site.spec.js` → **1 passed**
  - `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` → **2 passed**
- `console-clean=yes` (pageerror listener empty on feature spec)
- `server.log-clean=yes` for the feature window. Install-time `PSServerFolderProcessor` / `PSX_OBJECTACL` ERROR at 10:14 is pre-existing H2 seed noise (see #3282), not Copy/Delete Site.

## QA candidacy

Product Navigation chrome — eligible for post-cycle-verify Human QA. Do **not** assign in this phase.

> Co-Authored by Grok Build using grok-4.5 with agent main.
