### PR TITLE
feat(design): Design SPA create template without Widget XML (#3305)

### DIFF
--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -87,7 +87,14 @@ export function wrapTemplateDetailForWire(
   body: Partial<
     Pick<
       TemplateDetail,
-      "label" | "description" | "templateSource" | "assembler" | "bindings" | "slots"
+      | "name"
+      | "label"
+      | "description"
+      | "templateSource"
+      | "assembler"
+      | "mimeType"
+      | "bindings"
+      | "slots"
     >
   >,
 ): Record<string, typeof body> {
@@ -180,6 +187,30 @@ export async function updateTemplateDetail(
   const key = encodeURIComponent(idOrName);
   const payload = await put<unknown>(
     `${PATHS.TEMPLATES}/${key}`,
+    wrapTemplateDetailForWire(body),
+  );
+  return unwrapTemplateDetail(payload);
+}
+
+/** Fields accepted on POST /services/templates (modern create — no Widget XML). */
+export type TemplateCreateBody = Partial<
+  Pick<
+    TemplateDetail,
+    "name" | "label" | "description" | "assembler" | "templateSource" | "mimeType"
+  >
+> & {
+  name: string;
+};
+
+/**
+ * POST /services/templates — create a modern assembly template.
+ * Request is root-wrapped; response is unwrapped like GET/PUT.
+ */
+export async function createTemplate(
+  body: TemplateCreateBody,
+): Promise<TemplateDetail> {
+  const payload = await post<unknown>(
+    PATHS.TEMPLATES,
     wrapTemplateDetailForWire(body),
   );
   return unwrapTemplateDetail(payload);

--- a/WebUI/src/main/ts/design/CreateTemplateDialog.tsx
+++ b/WebUI/src/main/ts/design/CreateTemplateDialog.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { useDialogEscape } from "../architecture/useDialogEscape";
+import { catalogColors } from "../developer/catalogStyles";
+import {
+  ASSEMBLER_OPTIONS,
+  DEFAULT_CREATE_ASSEMBLER,
+} from "./assemblerOptions";
+import { DESIGN_MSG } from "./messages";
+import { validateTemplateCreateInput } from "./templateCreate";
+
+export interface CreateTemplateDialogProps {
+  open: boolean;
+  busy: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onSubmit: (input: {
+    name: string;
+    label: string;
+    description: string;
+    assembler: string;
+  }) => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  border: `1px solid ${catalogColors.headerBorder}`,
+  maxWidth: 480,
+  width: "100%",
+  padding: "1.25rem 1.5rem",
+  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  marginTop: 4,
+  marginBottom: 12,
+  padding: "0.4rem 0.5rem",
+  fontSize: "0.95rem",
+  boxSizing: "border-box",
+};
+
+/**
+ * Design SPA create-template dialog (#3305). Persists via POST /services/templates.
+ */
+export function CreateTemplateDialog({
+  open,
+  busy,
+  error,
+  onCancel,
+  onSubmit,
+}: CreateTemplateDialogProps): React.ReactElement | null {
+  const [name, setName] = useState("");
+  const [label, setLabel] = useState("");
+  const [description, setDescription] = useState("");
+  const [assembler, setAssembler] = useState(DEFAULT_CREATE_ASSEMBLER);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useDialogEscape(open, busy, onCancel);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setName("");
+    setLabel("");
+    setDescription("");
+    setAssembler(DEFAULT_CREATE_ASSEMBLER);
+    setLocalError(null);
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const shownError = localError || error;
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="design-tpl-create-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="design-tpl-create-title"
+    >
+      <div style={panelStyle}>
+        <h2 id="design-tpl-create-title" style={{ marginTop: 0 }}>
+          {DESIGN_MSG.TPL_CREATE_TITLE}
+        </h2>
+        <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DESIGN_MSG.TPL_CREATE_HINT}
+        </p>
+        <label htmlFor="design-tpl-create-name">
+          {DESIGN_MSG.TPL_CREATE_NAME}
+        </label>
+        <input
+          id="design-tpl-create-name"
+          data-testid="design-tpl-create-name"
+          style={fieldStyle}
+          value={name}
+          disabled={busy}
+          autoComplete="off"
+          onChange={(e) => setName(e.target.value)}
+        />
+        <label htmlFor="design-tpl-create-label">
+          {DESIGN_MSG.TPL_CREATE_LABEL}
+        </label>
+        <input
+          id="design-tpl-create-label"
+          data-testid="design-tpl-create-label"
+          style={fieldStyle}
+          value={label}
+          disabled={busy}
+          autoComplete="off"
+          onChange={(e) => setLabel(e.target.value)}
+        />
+        <label htmlFor="design-tpl-create-description">
+          {DESIGN_MSG.TPL_CREATE_DESCRIPTION}
+        </label>
+        <input
+          id="design-tpl-create-description"
+          data-testid="design-tpl-create-description"
+          style={fieldStyle}
+          value={description}
+          disabled={busy}
+          autoComplete="off"
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <label htmlFor="design-tpl-create-assembler">
+          {DESIGN_MSG.TPL_CREATE_ASSEMBLER}
+        </label>
+        <select
+          id="design-tpl-create-assembler"
+          data-testid="design-tpl-create-assembler"
+          style={fieldStyle}
+          value={assembler}
+          disabled={busy}
+          onChange={(e) => setAssembler(e.target.value)}
+        >
+          {ASSEMBLER_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value} title={o.hint}>
+              {o.label}
+              {o.recommended ? " ★" : ""}
+            </option>
+          ))}
+        </select>
+        {shownError ? (
+          <div
+            role="alert"
+            data-testid="design-tpl-create-error"
+            style={{ color: catalogColors.error, marginBottom: 12 }}
+          >
+            {shownError}
+          </div>
+        ) : null}
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            data-testid="design-tpl-create-cancel"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            {DESIGN_MSG.TPL_CREATE_CANCEL}
+          </button>
+          <button
+            type="button"
+            data-testid="design-tpl-create-submit"
+            disabled={busy}
+            onClick={() => {
+              const v = validateTemplateCreateInput(name, assembler);
+              if (!v.ok) {
+                setLocalError(v.message);
+                return;
+              }
+              setLocalError(null);
+              onSubmit({
+                name: v.name,
+                label: label.trim(),
+                description: description.trim(),
+                assembler,
+              });
+            }}
+          >
+            {DESIGN_MSG.TPL_CREATE_SUBMIT}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/design/CreateTemplateDialog.tsx
+++ b/WebUI/src/main/ts/design/CreateTemplateDialog.tsx
@@ -111,12 +111,16 @@ export function CreateTemplateDialog({
       role="dialog"
       aria-modal="true"
       aria-labelledby="design-tpl-create-title"
+      aria-describedby="design-tpl-create-hint"
     >
       <div style={panelStyle}>
         <h2 id="design-tpl-create-title" style={{ marginTop: 0 }}>
           {DESIGN_MSG.TPL_CREATE_TITLE}
         </h2>
-        <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
+        <p
+          id="design-tpl-create-hint"
+          style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+        >
           {DESIGN_MSG.TPL_CREATE_HINT}
         </p>
         <label htmlFor="design-tpl-create-name">

--- a/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
+++ b/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useState } from "react";
-import { listTemplates } from "../api/developer/assemblyApi";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createTemplate,
+  listTemplates,
+} from "../api/developer/assemblyApi";
 import type { TemplateSummary } from "../api/developer/types";
 import {
   extractRestErrorMessage,
@@ -28,7 +31,13 @@ import {
   CatalogStatus,
   SimpleCatalogTable,
 } from "../developer/CatalogTable";
-import { monoCell, mutedCell, openButtonStyle } from "../developer/catalogStyles";
+import {
+  catalogColors,
+  monoCell,
+  mutedCell,
+  openButtonStyle,
+} from "../developer/catalogStyles";
+import { CreateTemplateDialog } from "./CreateTemplateDialog";
 import { DESIGN_MSG } from "./messages";
 import { TemplateSourceEditor } from "./TemplateSourceEditor";
 
@@ -51,16 +60,25 @@ function listErrMsg(err: unknown, fallback: string): string {
 }
 
 /**
- * Design template library (#2808 list + #2809 source/JEXL + #2810 assembler/slots):
- * browse catalog, empty/error states, open row to edit via public REST.
+ * Design template library (#2808 list + #2809 source/JEXL + #2810 assembler/slots
+ * + #3305 create without Widget XML).
  */
 export function TemplateLibraryPanel(): React.ReactElement {
   const [items, setItems] = useState<TemplateSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const reload = useCallback(() => {
+    setReloadTick((n) => n + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    setError(null);
     listTemplates()
       .then((list) => {
         if (!cancelled) setItems(list);
@@ -73,7 +91,7 @@ export function TemplateLibraryPanel(): React.ReactElement {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadTick]);
 
   const sorted = useMemo(() => {
     if (!items) return [];
@@ -95,11 +113,77 @@ export function TemplateLibraryPanel(): React.ReactElement {
     );
   }
 
+  const toolbar = (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "flex-end",
+        marginBottom: 12,
+      }}
+    >
+      <button
+        type="button"
+        data-testid="design-tpl-create"
+        aria-label={DESIGN_MSG.TPL_CREATE_ARIA}
+        style={{
+          background: catalogColors.accent,
+          color: "#fff",
+          border: "none",
+          borderRadius: 4,
+          padding: "8px 14px",
+          cursor: "pointer",
+          font: "inherit",
+        }}
+        onClick={() => {
+          setCreateError(null);
+          setCreateOpen(true);
+        }}
+      >
+        {DESIGN_MSG.TPL_CREATE}
+      </button>
+    </div>
+  );
+
+  const dialog = (
+    <CreateTemplateDialog
+      open={createOpen}
+      busy={createBusy}
+      error={createError}
+      onCancel={() => {
+        if (!createBusy) setCreateOpen(false);
+      }}
+      onSubmit={(input) => {
+        setCreateBusy(true);
+        setCreateError(null);
+        createTemplate({
+          name: input.name,
+          label: input.label || input.name,
+          description: input.description,
+          assembler: input.assembler,
+        })
+          .then(() => {
+            setCreateOpen(false);
+            reload();
+          })
+          .catch((e: unknown) => {
+            setCreateError(listErrMsg(e, DESIGN_MSG.TPL_CREATE_ERROR));
+          })
+          .finally(() => {
+            setCreateBusy(false);
+          });
+      }}
+    />
+  );
+
   if (error) {
     return (
-      <CatalogStatus testId="design-tpl-error" error>
-        {error}
-      </CatalogStatus>
+      <div data-testid="design-tpl-panel">
+        {toolbar}
+        <CatalogStatus testId="design-tpl-error" error>
+          {error}
+        </CatalogStatus>
+        {dialog}
+      </div>
     );
   }
   if (items == null) {
@@ -109,12 +193,18 @@ export function TemplateLibraryPanel(): React.ReactElement {
   }
   if (items.length === 0) {
     return (
-      <CatalogStatus testId="design-tpl-empty">{DESIGN_MSG.TPL_EMPTY}</CatalogStatus>
+      <div data-testid="design-tpl-panel">
+        {toolbar}
+        <CatalogHint>{DESIGN_MSG.TPL_HINT}</CatalogHint>
+        <CatalogStatus testId="design-tpl-empty">{DESIGN_MSG.TPL_EMPTY}</CatalogStatus>
+        {dialog}
+      </div>
     );
   }
 
   return (
     <div data-testid="design-tpl-panel">
+      {toolbar}
       <CatalogHint>{DESIGN_MSG.TPL_HINT}</CatalogHint>
       <SimpleCatalogTable
         tableTestId="design-tpl-table"
@@ -158,6 +248,7 @@ export function TemplateLibraryPanel(): React.ReactElement {
           };
         })}
       />
+      {dialog}
     </div>
   );
 }

--- a/WebUI/src/main/ts/design/assemblerOptions.ts
+++ b/WebUI/src/main/ts/design/assemblerOptions.ts
@@ -34,6 +34,9 @@ export interface AssemblerOption {
 
 const PREFIX = "Java/global/percussion/assembly/";
 
+/** Default assembler for Design SPA create (matches TemplateAdaptor). */
+export const DEFAULT_CREATE_ASSEMBLER = `${PREFIX}htmlAssembler`;
+
 export const ASSEMBLER_OPTIONS: readonly AssemblerOption[] = [
   {
     value: `${PREFIX}htmlAssembler`,

--- a/WebUI/src/main/ts/design/index.ts
+++ b/WebUI/src/main/ts/design/index.ts
@@ -18,6 +18,9 @@
 export { DesignShell, normalizeDesignSection } from "./DesignShell";
 export type { DesignShellProps, DesignSection } from "./DesignShell";
 export { TemplateLibraryPanel, templateSelectionKey } from "./TemplateLibraryPanel";
+export { CreateTemplateDialog } from "./CreateTemplateDialog";
+export { validateTemplateCreateInput } from "./templateCreate";
+export { DEFAULT_CREATE_ASSEMBLER } from "./assemblerOptions";
 export { TemplateDetailDrawer } from "./TemplateDetailDrawer";
 export { TemplateSourceEditor } from "./TemplateSourceEditor";
 export { AssemblerPicker } from "./AssemblerPicker";

--- a/WebUI/src/main/ts/design/messages.ts
+++ b/WebUI/src/main/ts/design/messages.ts
@@ -25,11 +25,28 @@ import { message } from "../i18n/message";
 const KEYS = {
   TITLE: "perc.ui.design.modern@Design",
   INTRO:
-    "perc.ui.design.modern@Browse modern templates from the design catalog. Open a row to edit assembler, slots, source, and JEXL bindings.",
+    "perc.ui.design.modern@Browse modern templates from the design catalog. Create a new template without Widget XML, or open a row to edit assembler, slots, source, and JEXL bindings.",
   SHELL_LOADING: "perc.ui.design.modern@Loading Design…",
   TAB_TEMPLATES: "perc.ui.design.modern@Templates",
   TPL_HINT:
-    "perc.ui.design.modern@Assembly templates available in this CMS. Open a template to edit assembler, slots (layout/styles), source, and JEXL bindings.",
+    "perc.ui.design.modern@Assembly templates available in this CMS. Create a modern template (no Widget XML) or open a row to edit assembler, slots, source, and JEXL bindings.",
+  TPL_CREATE: "perc.ui.design.modern@Create template",
+  TPL_CREATE_ARIA: "perc.ui.design.modern@Create a new assembly template",
+  TPL_CREATE_TITLE: "perc.ui.design.modern@Create template",
+  TPL_CREATE_HINT:
+    "perc.ui.design.modern@Creates a modern assembly template in the catalog. No Widget definition XML is written.",
+  TPL_CREATE_NAME: "perc.ui.design.modern@Name",
+  TPL_CREATE_LABEL: "perc.ui.design.modern@Label",
+  TPL_CREATE_DESCRIPTION: "perc.ui.design.modern@Description",
+  TPL_CREATE_ASSEMBLER: "perc.ui.design.modern@Assembler",
+  TPL_CREATE_SUBMIT: "perc.ui.design.modern@Create",
+  TPL_CREATE_CANCEL: "perc.ui.design.modern@Cancel",
+  TPL_CREATE_ERROR: "perc.ui.design.modern@Could not create template.",
+  TPL_CREATE_NAME_REQUIRED: "perc.ui.design.modern@Name is required.",
+  TPL_CREATE_NAME_SPACES: "perc.ui.design.modern@Name cannot contain spaces.",
+  TPL_CREATE_NAME_FORMAT:
+    "perc.ui.design.modern@Name must start with a letter and use only letters, digits, '.', '_' or '-'.",
+  TPL_CREATE_ASSEMBLER_REQUIRED: "perc.ui.design.modern@Choose an assembler.",
   TPL_LOADING: "perc.ui.design.modern@Loading templates…",
   TPL_EMPTY: "perc.ui.design.modern@No templates found.",
   TPL_ERROR: "perc.ui.design.modern@Could not load templates.",

--- a/WebUI/src/main/ts/design/templateCreate.ts
+++ b/WebUI/src/main/ts/design/templateCreate.ts
@@ -18,7 +18,10 @@
 import { isValidAssemblerValue } from "./assemblerOptions";
 import { DESIGN_MSG } from "./messages";
 
-/** Same rules as TemplateAdaptor.validateCreateName. */
+/**
+ * Must stay identical to {@code TemplateAdaptor.validateCreateName}
+ * Java regex {@code [A-Za-z][A-Za-z0-9._-]*} (backend is the source of truth).
+ */
 const NAME_RE = /^[A-Za-z][A-Za-z0-9._-]*$/;
 
 export type TemplateCreateFieldError = "name" | "assembler" | null;

--- a/WebUI/src/main/ts/design/templateCreate.ts
+++ b/WebUI/src/main/ts/design/templateCreate.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidAssemblerValue } from "./assemblerOptions";
+import { DESIGN_MSG } from "./messages";
+
+/** Same rules as TemplateAdaptor.validateCreateName. */
+const NAME_RE = /^[A-Za-z][A-Za-z0-9._-]*$/;
+
+export type TemplateCreateFieldError = "name" | "assembler" | null;
+
+export interface TemplateCreateValidation {
+  ok: boolean;
+  field: TemplateCreateFieldError;
+  message: string | null;
+  name: string;
+}
+
+/**
+ * Validate create-template form fields (operator-facing messages).
+ */
+export function validateTemplateCreateInput(
+  rawName: string,
+  assembler: string,
+): TemplateCreateValidation {
+  const name = (rawName || "").trim();
+  if (!name) {
+    return {
+      ok: false,
+      field: "name",
+      message: DESIGN_MSG.TPL_CREATE_NAME_REQUIRED,
+      name,
+    };
+  }
+  if (/\s/.test(name)) {
+    return {
+      ok: false,
+      field: "name",
+      message: DESIGN_MSG.TPL_CREATE_NAME_SPACES,
+      name,
+    };
+  }
+  if (!NAME_RE.test(name)) {
+    return {
+      ok: false,
+      field: "name",
+      message: DESIGN_MSG.TPL_CREATE_NAME_FORMAT,
+      name,
+    };
+  }
+  if (!isValidAssemblerValue(assembler)) {
+    return {
+      ok: false,
+      field: "assembler",
+      message: DESIGN_MSG.TPL_CREATE_ASSEMBLER_REQUIRED,
+      name,
+    };
+  }
+  return { ok: true, field: null, message: null, name };
+}

--- a/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
@@ -18,6 +18,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   TEMPLATE_DETAIL_ROOT,
+  createTemplate,
   getTemplateDetail,
   unwrapTemplateDetail,
   updateTemplateDetail,
@@ -130,5 +131,33 @@ describe("getTemplateDetail / updateTemplateDetail wire binding (#3039)", () => 
     expect(sent).toEqual({
       TemplateDetail: { templateSource: savedSource },
     });
+  });
+
+  it("createTemplate wraps request and unwraps response", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        TemplateDetail: {
+          name: "site.html.snippet",
+          assembler: "Java/global/percussion/assembly/htmlAssembler",
+        },
+      }),
+    );
+
+    const out = await createTemplate({
+      name: "site.html.snippet",
+      assembler: "Java/global/percussion/assembly/htmlAssembler",
+    });
+    expect(out.name).toBe("site.html.snippet");
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(String(init.body));
+    expect(sent).toEqual({
+      TemplateDetail: {
+        name: "site.html.snippet",
+        assembler: "Java/global/percussion/assembly/htmlAssembler",
+      },
+    });
+    expect(String(fetchMock.mock.calls[0][0])).toContain(PATHS.TEMPLATES);
   });
 });

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -89,6 +89,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn().mockResolvedValue([]),
   getTemplateDetail: vi.fn().mockResolvedValue({ templateName: "x" }),
+  createTemplate: vi.fn(),
+  updateTemplateDetail: vi.fn(),
   listSlots: vi.fn().mockResolvedValue([]),
   getSlotDetail: vi.fn().mockResolvedValue({}),
   listCommunities: vi.fn().mockResolvedValue([]),

--- a/WebUI/src/test/ts/design/DesignShell.test.tsx
+++ b/WebUI/src/test/ts/design/DesignShell.test.tsx
@@ -27,6 +27,10 @@ import {
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn(),
   getTemplateDetail: vi.fn(),
+  createTemplate: vi.fn(),
+  updateTemplateDetail: vi.fn(),
+  getSlotDetail: vi.fn(),
+  updateSlotDetail: vi.fn(),
 }));
 
 const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;

--- a/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
@@ -30,11 +30,13 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn(),
   getTemplateDetail: vi.fn(),
   updateTemplateDetail: vi.fn(),
+  createTemplate: vi.fn(),
   getSlotDetail: vi.fn(),
   updateSlotDetail: vi.fn(),
 }));
 
 const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
+const createTemplate = assemblyApi.createTemplate as ReturnType<typeof vi.fn>;
 const getTemplateDetail = assemblyApi.getTemplateDetail as ReturnType<
   typeof vi.fn
 >;
@@ -56,6 +58,7 @@ describe("TemplateLibraryPanel (#2808)", () => {
       message: (key: string) => key,
     };
     listTemplates.mockReset();
+    createTemplate.mockReset();
     getTemplateDetail.mockReset();
     getSlotDetail.mockReset();
     getSlotDetail.mockResolvedValue({
@@ -162,6 +165,68 @@ describe("TemplateLibraryPanel (#2808)", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("design-tpl-editor")).toBeNull();
       expect(screen.getByTestId("design-tpl-table")).toBeTruthy();
+    });
+  });
+
+  it("creates a template and refreshes the list", async () => {
+    listTemplates
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          templateId: 101,
+          templateName: "site.html.snippet",
+          templateLabel: "site.html.snippet",
+        },
+      ]);
+    createTemplate.mockResolvedValue({
+      name: "site.html.snippet",
+      assembler: "Java/global/percussion/assembly/htmlAssembler",
+    });
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-create")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-create"));
+    fireEvent.change(screen.getByTestId("design-tpl-create-name"), {
+      target: { value: "site.html.snippet" },
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-create-submit"));
+    await waitFor(() => {
+      expect(createTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "site.html.snippet",
+          assembler: "Java/global/percussion/assembly/htmlAssembler",
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("design-tpl-create-dialog")).toBeNull();
+      expect(screen.getByTestId("design-tpl-table").textContent).toContain(
+        "site.html.snippet",
+      );
+    });
+  });
+
+  it("shows operator-facing create errors", async () => {
+    listTemplates.mockResolvedValue([]);
+    createTemplate.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "template name already exists: site.html.snippet" },
+    });
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-create")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-create"));
+    fireEvent.change(screen.getByTestId("design-tpl-create-name"), {
+      target: { value: "site.html.snippet" },
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-create-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-create-error").textContent).toContain(
+        "already exists",
+      );
     });
   });
 });

--- a/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
@@ -187,6 +187,9 @@ describe("TemplateLibraryPanel (#2808)", () => {
       expect(screen.getByTestId("design-tpl-create")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("design-tpl-create"));
+    expect(
+      screen.getByTestId("design-tpl-create-dialog").getAttribute("aria-describedby"),
+    ).toBe("design-tpl-create-hint");
     fireEvent.change(screen.getByTestId("design-tpl-create-name"), {
       target: { value: "site.html.snippet" },
     });

--- a/WebUI/src/test/ts/design/templateCreate.test.ts
+++ b/WebUI/src/test/ts/design/templateCreate.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_CREATE_ASSEMBLER } from "../../../main/ts/design/assemblerOptions";
+import { DESIGN_MSG } from "../../../main/ts/design/messages";
+import { validateTemplateCreateInput } from "../../../main/ts/design/templateCreate";
+
+describe("validateTemplateCreateInput (#3305)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
+  it("accepts a modern catalog name and default assembler", () => {
+    const v = validateTemplateCreateInput(
+      " site.html.snippet ",
+      DEFAULT_CREATE_ASSEMBLER,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.name).toBe("site.html.snippet");
+    expect(v.message).toBeNull();
+  });
+
+  it("rejects blank, spaces, and illegal characters", () => {
+    expect(validateTemplateCreateInput("", DEFAULT_CREATE_ASSEMBLER).message).toBe(
+      DESIGN_MSG.TPL_CREATE_NAME_REQUIRED,
+    );
+    expect(
+      validateTemplateCreateInput("has space", DEFAULT_CREATE_ASSEMBLER).message,
+    ).toBe(DESIGN_MSG.TPL_CREATE_NAME_SPACES);
+    expect(
+      validateTemplateCreateInput("1bad", DEFAULT_CREATE_ASSEMBLER).message,
+    ).toBe(DESIGN_MSG.TPL_CREATE_NAME_FORMAT);
+  });
+
+  it("rejects a blank assembler", () => {
+    const v = validateTemplateCreateInput("site.html.snippet", "  ");
+    expect(v.ok).toBe(false);
+    expect(v.field).toBe("assembler");
+    expect(v.message).toBe(DESIGN_MSG.TPL_CREATE_ASSEMBLER_REQUIRED);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
@@ -77,6 +77,9 @@ test.describe("Design template create (#3305)", () => {
     await expect(
       page.locator('[data-testid="design-tpl-create-dialog"]'),
     ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator('[data-testid="design-tpl-create-dialog"]'),
+    ).toHaveAttribute("aria-describedby", "design-tpl-create-hint");
     await page.locator('[data-testid="design-tpl-create-name"]').fill(name);
     await page.locator('[data-testid="design-tpl-create-submit"]').click();
 

--- a/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Design SPA create template without Widget XML (#3305 / parent #2631).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/design-template-create.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Entry: spa.jsp?entry=design&section=templates
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function designTemplatesUrl() {
+  const q = new URLSearchParams({
+    entry: "design",
+    section: "templates",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Design template create (#3305)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+  });
+
+  test("creates a modern template and refreshes the list @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    const name = `qa.create.tpl.${Date.now()}`;
+
+    await page.goto(designTemplatesUrl(), { waitUntil: "networkidle" });
+
+    await expect(page.locator('[data-testid="perc-design-shell"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const error = page.locator('[data-testid="design-tpl-error"]');
+    const createBtn = page.locator('[data-testid="design-tpl-create"]');
+    await expect(createBtn).toBeVisible({ timeout: 30_000 });
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Design templates catalog error: ${msg}`);
+    }
+
+    await createBtn.click();
+    await expect(
+      page.locator('[data-testid="design-tpl-create-dialog"]'),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.locator('[data-testid="design-tpl-create-name"]').fill(name);
+    await page.locator('[data-testid="design-tpl-create-submit"]').click();
+
+    await expect(
+      page.locator('[data-testid="design-tpl-create-dialog"]'),
+    ).toHaveCount(0, { timeout: 20_000 });
+    await expect(page.locator('[data-testid="design-tpl-table"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="design-tpl-table"]')).toContainText(
+      name,
+    );
+
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            String(e),
+          ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -1,0 +1,60 @@
+---
+id: admin-design-templates
+title: Design templates
+description: Create and edit modern assembly templates in the Design SPA without Widget definition XML
+version: "8.2"
+order: 44
+tags: [admin, design, templates, ui]
+---
+
+# Design templates
+
+**Design** is the SPA surface for the modern assembly **template library**. Designers and
+administrators list existing templates and **create new templates** using the public REST
+catalog (`/services/templates`). Create does **not** author Widget definition XML.
+
+## Open Design (SPA)
+
+1. Sign in as an **Admin** or **Designer**.
+2. Choose **Design** in the product top navigation, or open:
+   - Query contract: `spa.jsp?entry=design&section=templates`
+   - Path route: `/cm/app/design` or `/cm/app/design/templates`
+3. The **Templates** tab lists assembly templates (label, name, id, description).
+
+## Create a template (no Widget XML)
+
+1. On the Templates library, choose **Create template**.
+2. Enter a **Name** that starts with a letter and uses only letters, digits, `.`, `_`, or `-`.
+   Names cannot contain spaces and must be unique.
+3. Optionally enter a **Label** and **Description**. If you leave the label empty, the
+   server uses the name.
+4. Choose an **Assembler**. New templates default to **HTML-first** (recommended). Markdown
+   and Velocity are also supported modern assemblers. Prefer those over Legacy / XSL.
+5. Choose **Create**.
+
+The catalog list refreshes and shows the new row. Open the row to edit assembler, slots,
+source, and JEXL bindings.
+
+Create persists through `POST /services/templates` with a `TemplateDetail` body. The server
+stores a shared assembly template (package/manifest model). **No Widget Builder XML file is
+written.**
+
+If create fails (duplicate name, invalid name, or server error), the dialog stays open and
+shows an operator-facing message. Correct the fields and try again.
+
+## After create
+
+Use the template editor on the same Design tab to:
+
+- Change the assembler
+- Edit slot layout and styles
+- Edit Velocity / HTML / Markdown source
+- Maintain JEXL bindings
+
+Content-type associations, delete, and lock are not available on this REST surface yet.
+
+## Related
+
+- [REST API](id:developer-rest) — `GET`/`POST`/`PUT /services/templates`
+- [Extensions & packages](id:developer-extensions)
+- [Navigation & site structure](id:admin-architecture-navigation)

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -65,6 +65,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Sites & content structure](id:admin-sites)
 - [Content Explorer](id:admin-content-explorer)
 - [Navigation & site structure](id:admin-architecture-navigation)
+- [Design templates](id:admin-design-templates)
 - [Users, roles & security](id:admin-users-roles) (includes Developer Object ACL for Sites and Display Formats)
 - [Object ACL & default template](id:admin-object-acl)
 - [Publishing](id:admin-publishing)

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -138,6 +138,40 @@ These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They 
 writable via `PUT` — rule write/save and full control property editors remain Workbench /
 future design APIs. `designGaps` on detail still calls out write and catalog gaps.
 
+## Templates (assembly catalog)
+
+Assembly templates used by Design and Developer are exposed under `/services/templates`.
+Create uses the modern package/manifest model — **no Widget definition XML**.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/templates` | List template summaries (design catalog) |
+| `POST` | `/services/templates/summaries-by-filter` | Filter summaries (for example by content id) |
+| `GET` | `/services/templates/{idOrName}` | Load design detail (source, bindings, slots, assembler) |
+| `PUT` | `/services/templates/{idOrName}` | Update label, description, source, assembler, bindings, slots |
+| `POST` | `/services/templates` | Create a modern assembly template (`name` required, unique, no spaces) |
+
+Create body is a Jackson-wrapped `TemplateDetail`:
+
+```json
+{
+  "TemplateDetail": {
+    "name": "site.html.snippet",
+    "label": "HTML snippet",
+    "description": "Modern HTML-first template",
+    "assembler": "Java/global/percussion/assembly/htmlAssembler"
+  }
+}
+```
+
+When `assembler` is omitted, the server defaults to HTML-first
+(`Java/global/percussion/assembly/htmlAssembler`). `400` is returned for a missing or
+invalid name or a duplicate name. Delete and lock remain out of scope (`designGaps` code
+`TPL_DELETE_LOCK`).
+
+The Design SPA **Create template** action uses this POST. See
+[Design templates](id:admin-design-templates).
+
 ## Display formats (design catalog)
 
 Content Explorer **display format** definitions (Developer **Display Formats**) are exposed

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -26,6 +26,7 @@ import com.percussion.rest.templates.TemplateDetail;
 import com.percussion.rest.templates.TemplateFilter;
 import com.percussion.rest.templates.TemplateSlotSummary;
 import com.percussion.rest.templates.TemplateSummary;
+import com.percussion.services.assembly.IPSAssemblyErrors;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
 import com.percussion.services.assembly.IPSTemplateSlot;
@@ -228,6 +229,9 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
     } catch (IllegalArgumentException e) {
       throw e;
     } catch (PSAssemblyException e) {
+      if (templatePresent(name)) {
+        throw new IllegalArgumentException("template name already exists: " + name, e);
+      }
       log.error("Failed to create template {}: {}", name, e.getMessage(), e);
       throw new IllegalStateException("Failed to create template", e);
     } catch (Exception e) {
@@ -261,6 +265,20 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
   }
 
   private boolean templateNameExists(String name) {
+    try {
+      return asmSvc.findTemplateByName(name) != null;
+    } catch (PSAssemblyException e) {
+      if (e.getErrorCode() == IPSAssemblyErrors.TEMPLATE_MISSING) {
+        return false;
+      }
+      throw new IllegalStateException("Failed to look up template name: " + name, e);
+    } catch (PSNotFoundException e) {
+      return false;
+    }
+  }
+
+  /** True when the name is loadable after a failed save (concurrent duplicate). */
+  private boolean templatePresent(String name) {
     try {
       return asmSvc.findTemplateByName(name) != null;
     } catch (PSAssemblyException e) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -60,10 +60,14 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
 
   private static final Logger log = LogManager.getLogger(TemplateAdaptor.class);
 
+  /** Default assembler for Design SPA / REST create (HTML-first, no Widget XML). */
+  public static final String DEFAULT_CREATE_ASSEMBLER =
+      "Java/global/percussion/assembly/htmlAssembler";
+
   /** API capability notes shared by every detail payload (not per-template data). */
   static final List<DesignGap> TEMPLATE_DESIGN_GAPS =
       List.of(
-          DesignGap.of("TPL_CREATE_DELETE_LOCK", "Create / delete / lock not supported via this API"),
+          DesignGap.of("TPL_DELETE_LOCK", "Delete / lock not supported via this API"),
           DesignGap.of(
               "TPL_CONTENT_TYPE_ASSOC", "Content-type associations not listed on this payload"));
 
@@ -174,6 +178,95 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
           e.getMessage(),
           e);
       throw new IllegalStateException("Failed to update template", e);
+    }
+  }
+
+  @Override
+  public TemplateDetail createTemplate(URI baseUri, TemplateDetail body) {
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = validateCreateName(body.getName());
+    if (templateNameExists(name)) {
+      throw new IllegalArgumentException("template name already exists: " + name);
+    }
+    String assembler =
+        StringUtils.isNotBlank(body.getAssembler())
+            ? body.getAssembler().trim()
+            : DEFAULT_CREATE_ASSEMBLER;
+    if (StringUtils.isBlank(assembler)) {
+      throw new IllegalArgumentException("assembler must not be blank when provided");
+    }
+    String label =
+        StringUtils.isNotBlank(body.getLabel()) ? body.getLabel().trim() : name;
+    try {
+      IPSAssemblyTemplate t = asmSvc.createTemplate();
+      t.setName(name);
+      t.setLabel(label);
+      if (body.getDescription() != null) {
+        t.setDescription(body.getDescription());
+      }
+      t.setAssembler(assembler);
+      t.setMimeType(
+          StringUtils.isNotBlank(body.getMimeType()) ? body.getMimeType().trim() : "text/html");
+      t.setOutputFormat(IPSAssemblyTemplate.OutputFormat.Snippet);
+      t.setTemplateType(IPSAssemblyTemplate.TemplateType.Shared);
+      if (body.getTemplateSource() != null) {
+        t.setTemplate(body.getTemplateSource());
+      } else {
+        t.setTemplate("");
+      }
+      if (body.getBindings() != null) {
+        t.setBindings(toBindings(body.getBindings()));
+      }
+      if (body.getSlots() != null) {
+        t.setSlots(toSlots(body.getSlots()));
+      }
+      asmSvc.saveTemplate(t);
+      IPSAssemblyTemplate reloaded = resolveTemplate(name);
+      return reloaded != null ? toDetail(reloaded) : toDetail(t);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSAssemblyException e) {
+      log.error("Failed to create template {}: {}", name, e.getMessage(), e);
+      throw new IllegalStateException("Failed to create template", e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to create template {} ({}): {}",
+          name,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new IllegalStateException("Failed to create template", e);
+    }
+  }
+
+  /**
+   * Unique assembly-template name: required, trimmed, no whitespace. Starts with a letter; then
+   * letters, digits, {@code .}, {@code _}, or {@code -}.
+   */
+  static String validateCreateName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (name.chars().anyMatch(Character::isWhitespace)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (!name.matches("[A-Za-z][A-Za-z0-9._-]*")) {
+      throw new IllegalArgumentException(
+          "name must start with a letter and contain only letters, digits, '.', '_' or '-'");
+    }
+    return name;
+  }
+
+  private boolean templateNameExists(String name) {
+    try {
+      return asmSvc.findTemplateByName(name) != null;
+    } catch (PSAssemblyException e) {
+      return false;
+    } catch (PSNotFoundException e) {
+      return false;
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -61,8 +61,8 @@ class DesignGapsStructuredTest {
   void templateDesignGaps_areStructured() {
     assertEquals(2, TemplateAdaptor.TEMPLATE_DESIGN_GAPS.size());
     DesignGap first = TemplateAdaptor.TEMPLATE_DESIGN_GAPS.get(0);
-    assertEquals("TPL_CREATE_DELETE_LOCK", first.getCode());
-    assertTrue(first.getMessage().contains("Create"));
+    assertEquals("TPL_DELETE_LOCK", first.getCode());
+    assertTrue(first.getMessage().contains("Delete"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorCreateTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorCreateTest.java
@@ -130,4 +130,46 @@ class TemplateAdaptorCreateTest {
     verify(created).setAssembler("Java/global/percussion/assembly/markdownAssembler");
     verify(asm).saveTemplate(created);
   }
+
+  @Test
+  void createTemplate_lookupFailureIsNotTreatedAsAvailable() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    when(asm.findTemplateByName("site.html.snippet"))
+        .thenThrow(new PSAssemblyException(IPSAssemblyErrors.UNKNOWN_ERROR, "db down"));
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail body = new TemplateDetail();
+    body.setName("site.html.snippet");
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createTemplate(null, body));
+    assertEquals("Failed to look up template name: site.html.snippet", ex.getMessage());
+    verify(asm, never()).createTemplate();
+    verify(asm, never()).saveTemplate(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void createTemplate_saveRaceMapsDuplicateTo400() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate created = mockTemplate("site.html.snippet");
+    PSAssemblyTemplate existing = mockTemplate("site.html.snippet");
+    when(asm.createTemplate()).thenReturn(created);
+    when(asm.findTemplateByName("site.html.snippet"))
+        .thenThrow(new PSAssemblyException(IPSAssemblyErrors.TEMPLATE_MISSING, "site.html.snippet"))
+        .thenReturn(existing);
+    org.mockito.Mockito.doThrow(
+            new PSAssemblyException(IPSAssemblyErrors.UNKNOWN_CRUD_ERROR, "constraint"))
+        .when(asm)
+        .saveTemplate(created);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail body = new TemplateDetail();
+    body.setName("site.html.snippet");
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createTemplate(null, body));
+    assertEquals("template name already exists: site.html.snippet", ex.getMessage());
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorCreateTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorCreateTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.templates.TemplateDetail;
+import com.percussion.services.assembly.IPSAssemblyErrors;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.PSAssemblyException;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class TemplateAdaptorCreateTest {
+
+  private static PSAssemblyTemplate mockTemplate(String name) {
+    PSAssemblyTemplate template = mock(PSAssemblyTemplate.class);
+    PSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, 99L);
+    when(template.getGUID()).thenReturn(guid);
+    when(template.getName()).thenReturn(name);
+    when(template.getLabel()).thenReturn(name);
+    when(template.getAssembler()).thenReturn(TemplateAdaptor.DEFAULT_CREATE_ASSEMBLER);
+    when(template.getBindings()).thenReturn(new ArrayList<>());
+    when(template.getSlots()).thenReturn(new HashSet<>());
+    when(template.getTemplate()).thenReturn("");
+    return template;
+  }
+
+  @Test
+  void validateCreateName_requiresLetterStart() {
+    assertEquals("site.html.snippet", TemplateAdaptor.validateCreateName(" site.html.snippet "));
+    assertThrows(IllegalArgumentException.class, () -> TemplateAdaptor.validateCreateName(""));
+    assertThrows(IllegalArgumentException.class, () -> TemplateAdaptor.validateCreateName("has space"));
+    assertThrows(IllegalArgumentException.class, () -> TemplateAdaptor.validateCreateName("1bad"));
+  }
+
+  @Test
+  void createTemplate_savesHtmlFirstDefault() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate created = mockTemplate("site.html.snippet");
+    when(asm.createTemplate()).thenReturn(created);
+    when(asm.findTemplateByName("site.html.snippet"))
+        .thenThrow(new PSAssemblyException(IPSAssemblyErrors.TEMPLATE_MISSING, "site.html.snippet"))
+        .thenReturn(created);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail body = new TemplateDetail();
+    body.setName("site.html.snippet");
+
+    TemplateDetail out = adaptor.createTemplate(null, body);
+
+    verify(created).setName("site.html.snippet");
+    verify(created).setAssembler(TemplateAdaptor.DEFAULT_CREATE_ASSEMBLER);
+    verify(asm).saveTemplate(created);
+    assertEquals("site.html.snippet", out.getName());
+  }
+
+  @Test
+  void createTemplate_rejectsDuplicateName() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate existing = mockTemplate("site.html.snippet");
+    when(asm.findTemplateByName("site.html.snippet")).thenReturn(existing);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail body = new TemplateDetail();
+    body.setName("site.html.snippet");
+
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createTemplate(null, body));
+    verify(asm, never()).createTemplate();
+    verify(asm, never()).saveTemplate(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void createTemplate_rejectsBlankBody() {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createTemplate(null, null));
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.createTemplate(null, new TemplateDetail()));
+    verify(asm, never()).createTemplate();
+  }
+
+  @Test
+  void createTemplate_usesProvidedAssembler() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate created = mockTemplate("md.note");
+    when(asm.createTemplate()).thenReturn(created);
+    when(asm.findTemplateByName("md.note"))
+        .thenThrow(new PSAssemblyException(IPSAssemblyErrors.TEMPLATE_MISSING, "md.note"))
+        .thenReturn(created);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail body = new TemplateDetail();
+    body.setName("md.note");
+    body.setAssembler("Java/global/percussion/assembly/markdownAssembler");
+
+    adaptor.createTemplate(null, body);
+
+    verify(created).setAssembler("Java/global/percussion/assembly/markdownAssembler");
+    verify(asm).saveTemplate(created);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
@@ -58,10 +58,21 @@ public interface ITemplatesAdaptor {
    * Update mutable template design fields (label, description, source, assembler) and optionally
    * bindings / contained slots. When {@code body.assembler} is non-null, sets the assembler
    * extension name (must be non-blank). When {@code body.bindings} or {@code body.slots} is
-   * non-null, that collection is fully replaced (empty list clears). Name/id and create/delete
-   * remain out of scope.
+   * non-null, that collection is fully replaced (empty list clears). Name/id and delete remain
+   * out of scope.
    *
    * @return updated detail, or {@code null} if not found
    */
   TemplateDetail updateTemplate(URI baseUri, String idOrName, TemplateDetail body);
+
+  /**
+   * Create a modern assembly template (package/manifest model — no Widget definition XML).
+   *
+   * <p>{@code body.name} is required (no spaces; unique). Optional label, description, assembler,
+   * and templateSource. When assembler is omitted, the adaptor uses the HTML-first default.
+   *
+   * @return created detail (never {@code null})
+   * @throws IllegalArgumentException when the name is invalid or already exists
+   */
+  TemplateDetail createTemplate(URI baseUri, TemplateDetail body);
 }

--- a/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
@@ -182,8 +182,8 @@ public class TemplatesResource {
   @Operation(
       summary = "Get template design detail",
       description =
-          "Read-only template detail including bindings and slots. Source is included when"
-              + " present. Create/update/delete/lock not supported (see designGaps).",
+          "Template detail including bindings and slots. Source is included when present."
+              + " Create is POST /templates. Delete/lock remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -217,7 +217,7 @@ public class TemplatesResource {
           "Updates mutable template fields: label, description, templateSource, and/or"
               + " assembler. When assembler is present it must be non-blank. When bindings or"
               + " slots is present (including empty), replaces that collection. Omit fields to"
-              + " leave unchanged. Name/id and create/delete remain unsupported (see designGaps).",
+              + " leave unchanged. Name/id and delete remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -233,6 +233,46 @@ public class TemplatesResource {
       TemplateDetail detail = adaptor.updateTemplate(uriInfo.getBaseUri(), idOrName, body);
       if (detail == null) {
         throw new WebApplicationException("Template not found: " + idOrName, 404);
+      }
+      return detail;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Creates a modern assembly template (no Widget definition XML).
+   *
+   * @param body TemplateDetail; {@code name} required
+   * @return created TemplateDetail
+   */
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create assembly template",
+      description =
+          "Creates a template via the modern assembly catalog (package/manifest). Name is"
+              + " required and must be unique with no spaces. Optional label, description,"
+              + " assembler (defaults to HTML-first), and templateSource. Does not write Widget"
+              + " definition XML.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = TemplateDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input or duplicate name"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public TemplateDetail createTemplate(TemplateDetail body) {
+    try {
+      TemplateDetail detail = adaptor.createTemplate(uriInfo.getBaseUri(), body);
+      if (detail == null) {
+        throw new WebApplicationException("Failed to create template", 500);
       }
       return detail;
     } catch (WebApplicationException e) {

--- a/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
@@ -163,4 +163,35 @@ public class TemplatesResourceDetailTest {
         "Java/global/percussion/assembly/htmlAssembler",
         resource.updateTemplate("perc.page", body).getAssembler());
   }
+
+  @Test
+  public void createTemplateSuccess() {
+    TemplateDetail body = new TemplateDetail();
+    body.setName("site.html.snippet");
+    TemplateDetail created = new TemplateDetail();
+    created.setName("site.html.snippet");
+    created.setAssembler("Java/global/percussion/assembly/htmlAssembler");
+    when(adaptor.createTemplate(any(), any())).thenReturn(created);
+    TemplateDetail out = resource.createTemplate(body);
+    assertEquals("site.html.snippet", out.getName());
+    assertEquals("Java/global/percussion/assembly/htmlAssembler", out.getAssembler());
+  }
+
+  @Test
+  public void createTemplateBadRequest() {
+    when(adaptor.createTemplate(any(), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createTemplate(null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createTemplateWrapsFailures() {
+    when(adaptor.createTemplate(any(), any())).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createTemplate(new TemplateDetail()));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
@@ -50,4 +50,9 @@ public class TestTemplatesAdaptor implements ITemplatesAdaptor {
   public TemplateDetail updateTemplate(URI baseUri, String idOrName, TemplateDetail body) {
     return null;
   }
+
+  @Override
+  public TemplateDetail createTemplate(URI baseUri, TemplateDetail body) {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

Design SPA can **create a modern assembly template** from the template library without authoring Widget definition XML (parent #2631 / slice #3305).

Operators open **Design → Templates → Create template**, enter a unique name (and optional label/description/assembler), and persist via **`POST /services/templates`**. The catalog list refreshes; validation and REST failures stay operator-facing in the dialog.

Default assembler is HTML-first (`Java/global/percussion/assembly/htmlAssembler`). Create writes an assembly catalog row only — **no Widget XML**.

Parent tracker: #2631.

Fixes #3305

## Test plan

1. Standalone `mvnw clean install` in `rest`, `projects/sitemanage`, and `WebUI` (done).
2. QA H2: `python docker/scripts/perc-devctl.py qa-up` → hot-copy rest + sitemanage jars + `cm/modern/assets` → restart Jetty.
3. Playwright: `npm run test:surface -- --path tests/design-template-create.spec.js` against printed `TEST_CMS_URL`.
4. Manual: sign in as Admin/Designer → Design → Create template → unique name → list shows the new row → open editor.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/design-templates.md` + REST table in `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — REST resource, TestTemplatesAdaptor stub, TemplateAdaptor create tests, Vitest create/dialog/API
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/design-template-create.spec.js`
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — N/A for path I/O (name validation is regex-only)

### C3 build evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 343, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1168, Failures: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests 2206 passed
- **downstream_checked:** `implements ITemplatesAdaptor` → TemplateAdaptor + TestTemplatesAdaptor only; sitemanage standalone install after rest SNAPSHOT

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` (freeport this run)
- Deploy: `docker cp` `rest-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` + `WebUI/target/generated-webui/cm/modern/assets` into `perc-matrix-cms-h2`; `StopJetty.sh` / `StartJetty.sh`
- Playwright: `npm run test:surface -- --path tests/design-template-create.spec.js` → **1 passed**
- console-clean=yes; server.log-clean=yes (no ERROR/FATAL after create)
- `python docker/scripts/perc-devctl.py qa-down`

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
