### PR TITLE
fix(WebUI): wrap view execute POST as ViewExecuteRequest (#3318)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/viewsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/viewsApi.ts
@@ -37,6 +37,43 @@ import type {
 export { listViews };
 
 /**
+ * Jackson / JAXB root for {@link ViewExecuteRequest}
+ * ({@code @XmlRootElement(name = "ViewExecuteRequest")}). CXF
+ * {@code UNWRAP_ROOT_VALUE} rejects a bare {@code startIndex} field
+ * (QA #3244 / #3318).
+ */
+export const VIEW_EXECUTE_REQUEST_ROOT = "ViewExecuteRequest";
+
+/** Wire envelope required by WRAP_ROOT_VALUE / JAXB on view execute. */
+export type ViewExecuteRequestEnvelope = {
+  ViewExecuteRequest: ViewExecuteRequest;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Wrap execute overrides under {@link VIEW_EXECUTE_REQUEST_ROOT}.
+ * Does not double-wrap an already-enveloped payload.
+ */
+export function wrapViewExecuteRequest(
+  request?: ViewExecuteRequest | ViewExecuteRequestEnvelope | null,
+): ViewExecuteRequestEnvelope {
+  const rec = asRecord(request);
+  if (rec != null) {
+    const nested = rec[VIEW_EXECUTE_REQUEST_ROOT];
+    if (asRecord(nested) != null) {
+      return { ViewExecuteRequest: nested as ViewExecuteRequest };
+    }
+  }
+  return { ViewExecuteRequest: (request as ViewExecuteRequest) ?? {} };
+}
+
+/**
  * Unwrap Jackson root-name wrapping for {@link ViewExecuteResult}
  * ({@code ViewExecuteResult} / camelCase aliases) while accepting a flat
  * payload when root wrapping is off.
@@ -85,10 +122,9 @@ export async function executeView(
     throw new Error("View id or name is required");
   }
   const pathKey = encodeURIComponent(key);
-  const body = request ?? {};
   const payload = await post<unknown>(
     `${PATHS.VIEWS}/${pathKey}/execute`,
-    body,
+    wrapViewExecuteRequest(request),
   );
   return unwrapViewExecuteResult(payload);
 }

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -547,6 +547,7 @@ export interface ViewDef {
 /**
  * Optional overrides for {@code POST /services/views/{idOrName}/execute}.
  * Mirrors {@code com.percussion.rest.views.ViewExecuteRequest} (V1 / #3115).
+ * The SPA wraps this under the JAXB root {@code ViewExecuteRequest} (#3318).
  */
 export interface ViewExecuteRequest {
   folderPath?: string;

--- a/WebUI/src/test/ts/contentExplorer/viewsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/viewsApi.test.ts
@@ -19,11 +19,45 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   executeView,
   unwrapViewExecuteResult,
+  wrapViewExecuteRequest,
 } from "../../../main/ts/api/contentExplorer/viewsApi";
 import { PATHS } from "../../../main/ts/api/paths";
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("wrapViewExecuteRequest", () => {
+  it("wraps flat overrides under ViewExecuteRequest for JAXB", () => {
+    expect(
+      wrapViewExecuteRequest({
+        folderPath: "/Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      }),
+    ).toEqual({
+      ViewExecuteRequest: {
+        folderPath: "/Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      },
+    });
+  });
+
+  it("sends an empty ViewExecuteRequest root when overrides are omitted", () => {
+    expect(wrapViewExecuteRequest()).toEqual({ ViewExecuteRequest: {} });
+    expect(wrapViewExecuteRequest(null)).toEqual({ ViewExecuteRequest: {} });
+  });
+
+  it("does not double-wrap an already enveloped body", () => {
+    expect(
+      wrapViewExecuteRequest({
+        ViewExecuteRequest: { startIndex: 2, maxResults: 10 },
+      }),
+    ).toEqual({
+      ViewExecuteRequest: { startIndex: 2, maxResults: 10 },
+    });
+  });
 });
 
 describe("unwrapViewExecuteResult", () => {
@@ -92,13 +126,27 @@ describe("executeView", () => {
     );
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual({
-      folderPath: "/Sites/Foo",
-      startIndex: 1,
-      maxResults: 25,
+      ViewExecuteRequest: {
+        folderPath: "/Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      },
     });
     expect(result.children).toHaveLength(1);
     expect(result.children?.[0]?.title).toBe("Welcome");
     expect(result.viewName).toBe("View_All");
+  });
+
+  it("POSTs an empty ViewExecuteRequest envelope when overrides are omitted", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ children: [], totalCount: 0, startIndex: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await executeView("Inbox");
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toEqual({ ViewExecuteRequest: {} });
   });
 
   it("rejects blank idOrName without calling the network", async () => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-views-catalog.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-views-catalog.spec.js
@@ -97,10 +97,27 @@ test.describe("Explorer Views catalog tree (#3116)", () => {
       "//Views//MyContent/Inbox",
     );
 
+    const executeBodies = [];
+    page.on("request", (req) => {
+      if (req.method() !== "POST") return;
+      const url = req.url();
+      if (!/\/services\/views\/[^/]+\/execute(?:\?|$)/i.test(url)) return;
+      executeBodies.push(req.postData() || "");
+    });
+
     await inboxLeaf.click();
     await expect(page.getByTestId(TEST_IDS.results)).toBeVisible({
       timeout: 20_000,
     });
+    expect(executeBodies.length, "Inbox execute should POST").toBeGreaterThan(0);
+    for (const raw of executeBodies) {
+      const parsed = JSON.parse(raw);
+      expect(
+        parsed.ViewExecuteRequest,
+        "JAXB root ViewExecuteRequest required (#3318 / QA #3244)",
+      ).toBeTruthy();
+      expect(parsed.startIndex, "bare startIndex must not be the JSON root").toBeUndefined();
+    }
     const unsupported = page.getByTestId(TEST_IDS.resultsError);
     if (await unsupported.count()) {
       await expect(unsupported).not.toContainText(

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-views.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-views.js
@@ -106,6 +106,25 @@ function viewsExecuteUrl(baseUrl, idOrName) {
 }
 
 /**
+ * JAXB / Jackson root envelope for POST /views/{id}/execute (#3318 / QA #3244).
+ * Do not POST a bare { startIndex, maxResults } object.
+ *
+ * @param {Record<string, unknown> | null | undefined} request
+ * @returns {{ ViewExecuteRequest: Record<string, unknown> }}
+ */
+function wrapViewExecuteRequest(request) {
+  if (
+    request != null &&
+    typeof request === "object" &&
+    request.ViewExecuteRequest != null &&
+    typeof request.ViewExecuteRequest === "object"
+  ) {
+    return { ViewExecuteRequest: request.ViewExecuteRequest };
+  }
+  return { ViewExecuteRequest: request && typeof request === "object" ? request : {} };
+}
+
+/**
  * Unwrap Jackson / list wrappers for {@code ViewDef[]} catalog payloads.
  *
  * @param {unknown} payload
@@ -365,6 +384,7 @@ module.exports = {
   explorerEntryUrl,
   viewsCatalogUrl,
   viewsExecuteUrl,
+  wrapViewExecuteRequest,
   unwrapViewDefs,
   viewDefKey,
   viewDefLabel,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-views.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-views.test.js
@@ -34,6 +34,7 @@ const {
   explorerEntryUrl,
   viewsCatalogUrl,
   viewsExecuteUrl,
+  wrapViewExecuteRequest,
   unwrapViewDefs,
   viewDefKey,
   viewDefLabel,
@@ -71,6 +72,17 @@ describe("explorer-views helpers (#3117)", () => {
     assert.equal(
       explorerEntryUrl("http://localhost:9992/", { cacheBuster: "a b" }),
       "http://localhost:9992/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=a%20b",
+    );
+  });
+
+  it("wrapViewExecuteRequest uses the JAXB ViewExecuteRequest root (#3318)", () => {
+    assert.deepEqual(wrapViewExecuteRequest({ startIndex: 1, maxResults: 50 }), {
+      ViewExecuteRequest: { startIndex: 1, maxResults: 50 },
+    });
+    assert.deepEqual(wrapViewExecuteRequest(null), { ViewExecuteRequest: {} });
+    assert.deepEqual(
+      wrapViewExecuteRequest({ ViewExecuteRequest: { startIndex: 2 } }),
+      { ViewExecuteRequest: { startIndex: 2 } },
     );
   });
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -174,7 +174,22 @@ with the execute call below.
 
 ### Execute request / response
 
-Optional JSON body (all fields optional):
+The execute body must use the Jackson / JAXB root name `ViewExecuteRequest`. A
+bare `{ "startIndex": 1, "maxResults": 50 }` object is rejected (`unexpected
+element startIndex`). An empty body is allowed when you need design defaults
+only; if you send JSON, wrap the fields:
+
+```json
+{
+  "ViewExecuteRequest": {
+    "folderPath": "/Sites/Demo",
+    "startIndex": 1,
+    "maxResults": 50
+  }
+}
+```
+
+All fields inside `ViewExecuteRequest` are optional:
 
 | Field | Meaning |
 |-------|---------|


### PR DESCRIPTION
## Summary

Explorer view execute (`POST /services/views/{idOrName}/execute`) posted a **bare** `{ startIndex, maxResults }` JSON object. CXF JAXB with `UNWRAP_ROOT_VALUE` expects the `@XmlRootElement` root `ViewExecuteRequest`, which produced QA #3244:

`unexpected element startIndex / expected ViewExecuteRequest`

This PR wraps the SPA `executeView` body as `{ "ViewExecuteRequest": { ... } }` (peer of `SearchCriteria` search POST). Inbox stays on the C1 execute path; other custom-URL views still show the unsupported message. Integrator docs now show the required envelope.

Does **not** claim DCE gap-matrix Present.

Parent tracker: #3116 (QA #3244). Residual slice: #3318.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3318
Partial #3116
Related #3244

## Test plan

1. Vitest: `wrapViewExecuteRequest` + `executeView` POST body (`WebUI` standalone clean install).
2. Node unit: `modules/perc-qa-automation/frontend` `node --test tests/unit/explorer-views.test.js`.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993`.
4. Hot-copy `WebUI/target/generated-webui/cm/modern` into `perc-matrix-cms-h2` `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern`.
5. `npm run test:surface -- --path tests/explorer-views-catalog.spec.js` (asserts POST body has `ViewExecuteRequest` and Inbox is not a no-op).
6. `npm run test:golden` (login + Explorer shell).
7. Confirm results list / empty state — no JAXB `startIndex` error.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` execute envelope
- [x] **Unit / module tests** — Vitest wrap/POST shape; QA helper unit; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `explorer-views-catalog.spec.js` intercepts execute POST
- [x] **Build gates** — standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire `Tests run: 51, Failures: 0`; Vitest `Test Files 305 passed`, `Tests 2204 passed`
  - `cd modules/perc-qa-automation && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
  - `node --test tests/unit/explorer-views.test.js` → 13 passed
  - `scripts\ci-smoke-product-docs.bat` → OK
- **downstream_checked:** none (no Java public API / `final` / signature change; rest module not modified)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Hot-deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- Playwright: `npm run test:surface -- --path tests/explorer-views-catalog.spec.js` → **2 passed** (groups chrome + Inbox execute wrap)
- Golden: `npm run test:golden` → **2 passed**
- `explorer-inbox.spec.js`: 2 skipped (existing spec soft-skip; catalog spec covers Inbox execute)
- console-clean=yes (spec pageerror/console error collectors empty)
- server.log-clean=yes for this feature (no `ViewExecuteRequest` / `unexpected element startIndex` / JAXB lines). Pre-existing login-adjacent `PSRuntimeExceptionMapper … validated object is null` noise only.

> Co-Authored by Grok Build using grok-4.5 with agent main.