### PR TITLE
fix(webui): resolve CT/Template Object GUID for ACL (#3319)

### DIFF
--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -16,6 +16,10 @@
  */
 
 import { get, post, put } from "../client";
+import {
+  normalizeDesignObjectGuid,
+  resolveTemplateObjectGuid,
+} from "../displayFormatGuid";
 import { PATHS } from "../paths";
 import type {
   CommunityDetail,
@@ -55,6 +59,11 @@ function asRecord(value: unknown): Record<string, unknown> | null {
  * <p>Prefers {@code { "TemplateDetail": { … } }}; also accepts a flat body
  * (unit tests / proxies that already unwrapped).
  */
+function normalizeTemplateDetail(body: TemplateDetail): TemplateDetail {
+  const catalog = resolveTemplateObjectGuid(body);
+  return normalizeDesignObjectGuid(body, catalog);
+}
+
 export function unwrapTemplateDetail(payload: unknown): TemplateDetail {
   const root = asRecord(payload);
   if (!root) {
@@ -62,7 +71,7 @@ export function unwrapTemplateDetail(payload: unknown): TemplateDetail {
   }
   const nested = asRecord(root[TEMPLATE_DETAIL_ROOT] ?? root.templateDetail);
   if (nested) {
-    return nested as TemplateDetail;
+    return normalizeTemplateDetail(nested as TemplateDetail);
   }
   // Flat body: only treat as detail when it looks like one (has template identity
   // or source/bindings fields). Bare error envelopes stay empty.
@@ -71,9 +80,11 @@ export function unwrapTemplateDetail(payload: unknown): TemplateDetail {
     "templateId" in root ||
     "templateSource" in root ||
     "label" in root ||
-    "bindings" in root
+    "bindings" in root ||
+    "guid" in root ||
+    "guidString" in root
   ) {
-    return root as TemplateDetail;
+    return normalizeTemplateDetail(root as TemplateDetail);
   }
   return {};
 }

--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { normalizeDesignObjectGuid } from "../displayFormatGuid";
 import { get, put } from "../client";
 import { PATHS } from "../paths";
 import type {
@@ -25,6 +26,20 @@ import type {
   NamedObjectRef,
 } from "./types";
 
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeDetail}. */
+export const CONTENT_TYPE_DETAIL_ROOT = "ContentTypeDetail";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function normalizeContentTypeSummary(item: ContentTypeSummary): ContentTypeSummary {
+  return normalizeDesignObjectGuid(item);
+}
+
 /**
  * Normalize list responses that may be a bare array or a JAXB envelope.
  */
@@ -33,7 +48,7 @@ export function unwrapContentTypeList(payload: unknown): ContentTypeSummary[] {
     return [];
   }
   if (Array.isArray(payload)) {
-    return payload as ContentTypeSummary[];
+    return (payload as ContentTypeSummary[]).map(normalizeContentTypeSummary);
   }
   if (typeof payload === "object") {
     const env = payload as ContentTypeListEnvelope & {
@@ -43,9 +58,40 @@ export function unwrapContentTypeList(payload: unknown): ContentTypeSummary[] {
     if (raw == null) {
       return [];
     }
-    return Array.isArray(raw) ? raw : [raw];
+    const list = Array.isArray(raw) ? raw : [raw];
+    return list.map(normalizeContentTypeSummary);
   }
   return [];
+}
+
+/**
+ * Normalize a content-type GET/PUT response to a flat {@link ContentTypeDetail}.
+ *
+ * <p>Prefers {@code { "ContentTypeDetail": { … } }} (Jackson WRAP_ROOT_VALUE);
+ * also accepts a flat body. Fills {@code guid.stringValue} / {@code guidString}
+ * from nested Guid parts (#3319).
+ */
+export function unwrapContentTypeDetail(payload: unknown): ContentTypeDetail {
+  const root = asRecord(payload);
+  if (!root) {
+    return {};
+  }
+  const nested = asRecord(root[CONTENT_TYPE_DETAIL_ROOT] ?? root.contentTypeDetail);
+  let body: ContentTypeDetail;
+  if (nested) {
+    body = nested as ContentTypeDetail;
+  } else if (
+    "name" in root ||
+    "guid" in root ||
+    "guidString" in root ||
+    "fields" in root ||
+    "label" in root
+  ) {
+    body = root as ContentTypeDetail;
+  } else {
+    return {};
+  }
+  return normalizeDesignObjectGuid(body);
 }
 
 /**
@@ -69,7 +115,8 @@ export async function getContentTypeDetail(
   idOrName: string,
 ): Promise<ContentTypeDetail> {
   const key = encodeURIComponent(idOrName);
-  return get<ContentTypeDetail>(`${PATHS.CONTENT_TYPES}/${key}`);
+  const payload = await get<unknown>(`${PATHS.CONTENT_TYPES}/${key}`);
+  return unwrapContentTypeDetail(payload);
 }
 
 export type ContentTypeUpdateBody = {
@@ -95,5 +142,6 @@ export async function updateContentTypeDetail(
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
   const key = encodeURIComponent(idOrName);
-  return put<ContentTypeDetail>(`${PATHS.CONTENT_TYPES}/${key}`, body);
+  const payload = await put<unknown>(`${PATHS.CONTENT_TYPES}/${key}`, body);
+  return unwrapContentTypeDetail(payload);
 }

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -33,6 +33,8 @@ export interface RestGuid {
 /** Content type summary from {@code GET /services/contenttypes}. */
 export interface ContentTypeSummary {
   guid?: RestGuid;
+  /** Plain host-type-uuid when nested Guid is hard to bind (#3319). */
+  guidString?: string;
   objectType?: RestGuid;
   name?: string;
   label?: string;
@@ -77,6 +79,8 @@ export interface NamedObjectRef {
 /** Read-only design detail for one content type. */
 export interface ContentTypeDetail {
   guid?: RestGuid;
+  /** Plain host-type-uuid when nested Guid is hard to bind (#3319). */
+  guidString?: string;
   name?: string;
   label?: string;
   description?: string;
@@ -111,6 +115,8 @@ export interface KeywordSummary {
 
 export interface TemplateSummary {
   templateId?: number;
+  /** Plain host-type-uuid when the list omits nested Guid (#3319). */
+  guidString?: string;
   templateName?: string;
   templateLabel?: string;
   templateDescription?: string;
@@ -131,6 +137,8 @@ export interface TemplateSlotSummary {
 
 export interface TemplateDetail {
   guid?: RestGuid;
+  /** Plain host-type-uuid when nested Guid is hard to bind (#3319). */
+  guidString?: string;
   templateId?: number;
   name?: string;
   label?: string;

--- a/WebUI/src/main/ts/api/displayFormatGuid.ts
+++ b/WebUI/src/main/ts/api/displayFormatGuid.ts
@@ -30,6 +30,12 @@ import type { DisplayFormat, RestGuid } from "./developer/types";
  */
 export const DISPLAY_FORMAT_TYPE = 31;
 
+/** {@code PSTypeEnum.NODEDEF} — content type GUID type. */
+export const CONTENT_TYPE_TYPE = 2;
+
+/** {@code PSTypeEnum.TEMPLATE} — assembly template GUID type. */
+export const TEMPLATE_TYPE = 4;
+
 function firstNonBlankString(value: unknown): string | undefined {
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -131,11 +137,112 @@ export function objectGuidString(guid: unknown): string | undefined {
 export function synthesizeDisplayFormatGuidFromDisplayId(
   displayId: unknown,
 ): string | undefined {
-  const n = asFiniteNumber(displayId);
+  return synthesizeTypedObjectGuid(DISPLAY_FORMAT_TYPE, displayId);
+}
+
+/**
+ * Synthesize {@code 0-{type}-{uuid}} when the wire omitted Guid but still
+ * sent a native numeric id (content type typeId, templateId, displayId).
+ */
+export function synthesizeTypedObjectGuid(
+  type: number,
+  uuid: unknown,
+): string | undefined {
+  const n = asFiniteNumber(uuid);
   if (n == null || n <= 0) {
     return undefined;
   }
-  return `0-${DISPLAY_FORMAT_TYPE}-${n}`;
+  return `0-${type}-${n}`;
+}
+
+/** Shared detail / list shapes that may carry a nested Guid or plain guidString. */
+export type DesignObjectGuidSource = {
+  guid?: unknown;
+  guidString?: string | null;
+};
+
+/**
+ * Resolve the GUID Object ACL / detail header should use (CT, template, peers).
+ *
+ * <p>Order: nested Guid ({@link objectGuidString}) → plain {@code guidString}
+ * → catalog list fallback. Never returns a blank string. Issue #3319 / #3200.
+ */
+export function resolveDesignObjectGuid(
+  obj: DesignObjectGuidSource | null | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  if (obj != null) {
+    const fromGuid = objectGuidString(obj.guid);
+    if (fromGuid) {
+      return fromGuid;
+    }
+    const fromPlain = firstNonBlankString(obj.guidString);
+    if (fromPlain) {
+      return fromPlain;
+    }
+  }
+  return firstNonBlankString(catalogGuid);
+}
+
+/**
+ * Content type Object ACL GUID: detail Guid / guidString, then catalog, then
+ * {@code 0-2-{uuid}} when only the type id is present (#3319).
+ */
+export function resolveContentTypeObjectGuid(
+  ct: DesignObjectGuidSource | null | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  const resolved = resolveDesignObjectGuid(ct, catalogGuid);
+  if (resolved) {
+    return resolved;
+  }
+  const guid = ct?.guid;
+  if (guid != null && typeof guid === "object" && !Array.isArray(guid)) {
+    const uuid = (guid as RestGuid).uuid;
+    return synthesizeTypedObjectGuid(CONTENT_TYPE_TYPE, uuid);
+  }
+  return undefined;
+}
+
+/**
+ * Template Object ACL GUID: detail Guid / guidString, then catalog, then
+ * {@code 0-4-{templateId}} from the list/detail native id (#3319).
+ */
+export function resolveTemplateObjectGuid(
+  tpl:
+    | (DesignObjectGuidSource & { templateId?: number | null })
+    | null
+    | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  const resolved = resolveDesignObjectGuid(tpl, catalogGuid);
+  if (resolved) {
+    return resolved;
+  }
+  return synthesizeTypedObjectGuid(TEMPLATE_TYPE, tpl?.templateId);
+}
+
+/**
+ * Ensure {@code guid.stringValue} / {@code guidString} are populated from
+ * nested Guid parts or a catalog fallback (same contract as display format).
+ */
+export function normalizeDesignObjectGuid<T extends DesignObjectGuidSource>(
+  obj: T,
+  catalogGuid?: string | null,
+): T {
+  const gs = resolveDesignObjectGuid(obj, catalogGuid);
+  if (!gs) {
+    return obj;
+  }
+  const nextGuidString = firstNonBlankString(obj.guidString) || gs;
+  if (obj.guid != null && typeof obj.guid === "object" && !Array.isArray(obj.guid)) {
+    const existing = obj.guid as RestGuid;
+    if (existing.stringValue === gs && obj.guidString === nextGuidString) {
+      return obj;
+    }
+    return { ...obj, guidString: nextGuidString, guid: { ...existing, stringValue: gs } };
+  }
+  return { ...obj, guidString: nextGuidString, guid: { stringValue: gs } };
 }
 
 /**

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   getContentTypeDetail,
   updateContentTypeDetail,
@@ -137,9 +138,12 @@ function toRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
 
 export function ContentTypeDetailPanel({
   idOrName,
+  catalogGuid,
   onBack,
 }: {
   idOrName: string;
+  /** GUID from catalog list row when detail wire omits stringValue (#3319). */
+  catalogGuid?: string | null;
   onBack: () => void;
 }): React.ReactElement {
   const [detail, setDetail] = useState<ContentTypeDetail | null>(null);
@@ -207,6 +211,8 @@ export function ContentTypeDetailPanel({
       fieldsDirty ||
       workflowsDirty ||
       templatesDirty);
+
+  const objectGuid = resolveContentTypeObjectGuid(detail, catalogGuid);
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -370,7 +376,8 @@ export function ContentTypeDetailPanel({
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
               {detail.name}
-              {detail.guid?.stringValue ? ` · ${detail.guid.stringValue}` : ""}
+              {" · "}
+              <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>
             <div style={{ marginTop: "12px" }}>
               <label htmlFor="ct-label" style={{ display: "block", marginBottom: 4 }}>
@@ -781,7 +788,7 @@ export function ContentTypeDetailPanel({
           </div>
 
           <ObjectAclSection
-            objectGuid={detail.guid?.stringValue}
+            objectGuid={objectGuid}
             objectKind="content-type"
             testIdPrefix="developer-ct-acl"
           />

--- a/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import { listContentTypes } from "../api/developer/contentTypesApi";
 import type { ContentTypeSummary } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
@@ -25,17 +26,17 @@ import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
 function displayId(ct: ContentTypeSummary): string {
-  const g = ct.guid;
-  if (!g) return "—";
-  if (g.stringValue) return g.stringValue;
-  if (g.uuid != null) return String(g.uuid);
-  if (g.longValue != null) return String(g.longValue);
-  return "—";
+  return resolveContentTypeObjectGuid(ct) || "—";
 }
 
 function selectionKey(ct: ContentTypeSummary): string {
-  return ct.name || ct.guid?.stringValue || displayId(ct);
+  return ct.name || resolveContentTypeObjectGuid(ct) || displayId(ct);
 }
+
+type SelectedContentType = {
+  idOrName: string;
+  catalogGuid?: string;
+};
 
 /**
  * P0.1 list + P0.2 read-only field catalog detail.
@@ -43,7 +44,7 @@ function selectionKey(ct: ContentTypeSummary): string {
 export function ContentTypesPanel(): React.ReactElement {
   const [items, setItems] = useState<ContentTypeSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SelectedContentType | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -67,10 +68,20 @@ export function ContentTypesPanel(): React.ReactElement {
     };
   }, []);
 
+  function openContentType(ct: ContentTypeSummary) {
+    const idOrName = selectionKey(ct);
+    if (!idOrName || idOrName === "—") return;
+    setSelected({
+      idOrName,
+      catalogGuid: resolveContentTypeObjectGuid(ct),
+    });
+  }
+
   if (selected) {
     return (
       <ContentTypeDetailPanel
-        idOrName={selected}
+        idOrName={selected.idOrName}
+        catalogGuid={selected.catalogGuid}
         onBack={() => setSelected(null)}
       />
     );
@@ -111,15 +122,16 @@ export function ContentTypesPanel(): React.ReactElement {
           DEV_MSG.CT_COL_DESCRIPTION,
         ]}
         rows={sorted.map((ct) => {
+          const resolved = resolveContentTypeObjectGuid(ct);
           const key =
-            ct.guid?.stringValue ||
+            resolved ||
             ct.name ||
             `${ct.label ?? "ct"}-${displayId(ct)}`;
           const openKey = selectionKey(ct);
           const interactive = openKey !== "—";
           return {
             key,
-            onClick: interactive ? () => setSelected(openKey) : undefined,
+            onClick: interactive ? () => openContentType(ct) : undefined,
             cells: [
               interactive ? (
                 <button
@@ -129,7 +141,7 @@ export function ContentTypesPanel(): React.ReactElement {
                   aria-label={`Open ${ct.label || ct.name || openKey}`}
                   onClick={(e) => {
                     e.stopPropagation();
-                    setSelected(openKey);
+                    openContentType(ct);
                   }}
                 >
                   {ct.label || "—"}

--- a/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { resolveTemplateObjectGuid } from "../api/displayFormatGuid";
 import {
   getTemplateDetail,
   listSlots,
@@ -199,9 +200,12 @@ function slotsEqual(a: Set<string>, b: Set<string>): boolean {
 
 export function TemplateDetailPanel({
   idOrName,
+  catalogGuid,
   onBack,
 }: {
   idOrName: string;
+  /** GUID from catalog list (templateId synthesis) when detail omits Guid (#3319). */
+  catalogGuid?: string | null;
   onBack: () => void;
 }): React.ReactElement {
   const [detail, setDetail] = useState<TemplateDetail | null>(null);
@@ -279,6 +283,8 @@ export function TemplateDetailPanel({
       source !== (detail.templateSource || "") ||
       !bindingsEqual(bindings, initialBindings) ||
       !slotsEqual(slotKeys, initialSlotKeys));
+
+  const objectGuid = resolveTemplateObjectGuid(detail, catalogGuid);
 
   function updateBinding(index: number, patch: Partial<TemplateBindingSummary>) {
     setBindings((prev) => prev.map((b, i) => (i === index ? { ...b, ...patch } : b)));
@@ -469,7 +475,8 @@ export function TemplateDetailPanel({
               <span style={monoCell}>
                 {detail.name}
                 {detail.templateId != null ? ` · ${detail.templateId}` : ""}
-                {detail.guid?.stringValue ? ` · ${detail.guid.stringValue}` : ""}
+                {" · "}
+                <span data-testid="developer-tpl-detail-guid">{objectGuid || "—"}</span>
               </span>
             </div>
             <div style={{ marginTop: "12px" }}>
@@ -816,7 +823,7 @@ export function TemplateDetailPanel({
           </div>
 
           <ObjectAclSection
-            objectGuid={detail.guid?.stringValue}
+            objectGuid={objectGuid}
             objectKind="template"
             testIdPrefix="developer-tpl-acl"
           />

--- a/WebUI/src/main/ts/developer/TemplatesPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplatesPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
+import { resolveTemplateObjectGuid } from "../api/displayFormatGuid";
 import { listTemplates } from "../api/developer/assemblyApi";
 import type { TemplateSummary } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
@@ -31,10 +32,15 @@ function selectionKey(t: TemplateSummary): string | null {
   return null;
 }
 
+type SelectedTemplate = {
+  idOrName: string;
+  catalogGuid?: string;
+};
+
 export function TemplatesPanel(): React.ReactElement {
   const [items, setItems] = useState<TemplateSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SelectedTemplate | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,9 +69,22 @@ export function TemplatesPanel(): React.ReactElement {
     );
   }, [items]);
 
+  function openTemplate(t: TemplateSummary) {
+    const idOrName = selectionKey(t);
+    if (!idOrName) return;
+    setSelected({
+      idOrName,
+      catalogGuid: resolveTemplateObjectGuid(t),
+    });
+  }
+
   if (selected) {
     return (
-      <TemplateDetailPanel idOrName={selected} onBack={() => setSelected(null)} />
+      <TemplateDetailPanel
+        idOrName={selected.idOrName}
+        catalogGuid={selected.catalogGuid}
+        onBack={() => setSelected(null)}
+      />
     );
   }
 
@@ -98,7 +117,7 @@ export function TemplatesPanel(): React.ReactElement {
                   type="button"
                   style={openButtonStyle}
                   aria-label={`Open ${t.templateLabel || t.templateName || openKey}`}
-                  onClick={() => setSelected(openKey)}
+                  onClick={() => openTemplate(t)}
                 >
                   {t.templateLabel || "—"}
                 </button>

--- a/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
@@ -61,6 +61,24 @@ describe("unwrapTemplateDetail / wrapTemplateDetailForWire (#3039)", () => {
     expect(unwrapTemplateDetail(null)).toEqual({});
   });
 
+  it("fills guid.stringValue from parts and templateId (#3319)", () => {
+    const fromParts = unwrapTemplateDetail({
+      TemplateDetail: {
+        name: "perc.page",
+        guid: { hostId: 0, type: 4, uuid: 42 },
+      },
+    });
+    expect(fromParts.guid?.stringValue).toBe("0-4-42");
+    expect(fromParts.guidString).toBe("0-4-42");
+
+    const fromId = unwrapTemplateDetail({
+      name: "perc.page",
+      templateId: 12,
+    });
+    expect(fromId.guid?.stringValue).toBe("0-4-12");
+    expect(fromId.guidString).toBe("0-4-12");
+  });
+
   it("wrapTemplateDetailForWire nests under TemplateDetail root", () => {
     const body = { templateSource: "#new\n", label: "L" };
     expect(wrapTemplateDetailForWire(body)).toEqual({

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -3,7 +3,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { unwrapContentTypeList } from "../../../../main/ts/api/developer/contentTypesApi";
+import {
+  unwrapContentTypeDetail,
+  unwrapContentTypeList,
+} from "../../../../main/ts/api/developer/contentTypesApi";
 
 describe("unwrapContentTypeList", () => {
   it("returns bare arrays", () => {
@@ -27,5 +30,60 @@ describe("unwrapContentTypeList", () => {
   it("handles null and empty", () => {
     expect(unwrapContentTypeList(null)).toEqual([]);
     expect(unwrapContentTypeList({})).toEqual([]);
+  });
+
+  it("fills guid.stringValue from host/type/uuid on list rows (#3319)", () => {
+    expect(
+      unwrapContentTypeList([
+        { name: "percPage", guid: { hostId: 0, type: 2, uuid: 301 } },
+      ]),
+    ).toEqual([
+      {
+        name: "percPage",
+        guid: { hostId: 0, type: 2, uuid: 301, stringValue: "0-2-301" },
+        guidString: "0-2-301",
+      },
+    ]);
+  });
+});
+
+describe("unwrapContentTypeDetail (#3319)", () => {
+  it("unwraps Jackson ContentTypeDetail root so guid is reachable", () => {
+    const flat = unwrapContentTypeDetail({
+      ContentTypeDetail: {
+        name: "percPage",
+        guid: { stringValue: "0-2-301", type: 2, uuid: 301 },
+        fields: [{ name: "sys_title" }],
+      },
+    });
+    expect(flat.name).toBe("percPage");
+    expect(flat.guid?.stringValue).toBe("0-2-301");
+    expect(flat.guidString).toBe("0-2-301");
+    expect(flat.fields).toHaveLength(1);
+  });
+
+  it("synthesizes guid.stringValue from numeric parts under root wrap", () => {
+    const flat = unwrapContentTypeDetail({
+      ContentTypeDetail: {
+        name: "percPage",
+        guid: { hostId: 0, type: 2, uuid: 301 },
+      },
+    });
+    expect(flat.guid?.stringValue).toBe("0-2-301");
+    expect(flat.guidString).toBe("0-2-301");
+  });
+
+  it("accepts flat payload and copies guidString", () => {
+    const flat = unwrapContentTypeDetail({
+      name: "percPage",
+      guidString: "0-2-8",
+    });
+    expect(flat.guid?.stringValue).toBe("0-2-8");
+    expect(flat.guidString).toBe("0-2-8");
+  });
+
+  it("returns empty object for unrelated envelopes", () => {
+    expect(unwrapContentTypeDetail({ Error: { message: "x" } })).toEqual({});
+    expect(unwrapContentTypeDetail(null)).toEqual({});
   });
 });

--- a/WebUI/src/test/ts/api/displayFormatGuid.test.ts
+++ b/WebUI/src/test/ts/api/displayFormatGuid.test.ts
@@ -16,8 +16,12 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  normalizeDesignObjectGuid,
   normalizeDisplayFormatGuid,
   objectGuidString,
+  resolveContentTypeObjectGuid,
+  resolveTemplateObjectGuid,
+  synthesizeTypedObjectGuid,
   unwrapDisplayFormat,
 } from "../../../main/ts/api/displayFormatGuid";
 
@@ -47,6 +51,32 @@ describe("objectGuidString", () => {
     expect(objectGuidString(undefined)).toBeUndefined();
     expect(objectGuidString({})).toBeUndefined();
     expect(objectGuidString("")).toBeUndefined();
+  });
+});
+
+describe("resolveContentTypeObjectGuid / resolveTemplateObjectGuid (#3319)", () => {
+  it("prefers nested guid then guidString then catalog then type-uuid", () => {
+    expect(
+      resolveContentTypeObjectGuid({ guid: { stringValue: "0-2-1" }, guidString: "0-2-9" }),
+    ).toBe("0-2-1");
+    expect(resolveContentTypeObjectGuid({ guidString: "0-2-9" })).toBe("0-2-9");
+    expect(resolveContentTypeObjectGuid({}, "0-2-3")).toBe("0-2-3");
+    expect(resolveContentTypeObjectGuid({ guid: { uuid: 5 } })).toBe("0-2-5");
+  });
+
+  it("synthesizes template GUID from templateId", () => {
+    expect(resolveTemplateObjectGuid({ templateId: 12 })).toBe("0-4-12");
+    expect(resolveTemplateObjectGuid({ guidString: "0-4-8", templateId: 12 })).toBe("0-4-8");
+    expect(synthesizeTypedObjectGuid(4, 12)).toBe("0-4-12");
+    expect(synthesizeTypedObjectGuid(2, 0)).toBeUndefined();
+  });
+
+  it("normalizeDesignObjectGuid fills stringValue and guidString", () => {
+    const out = normalizeDesignObjectGuid({
+      guid: { hostId: 0, type: 2, uuid: 301 },
+    });
+    expect(out.guid?.stringValue).toBe("0-2-301");
+    expect(out.guidString).toBe("0-2-301");
   });
 });
 

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -17,7 +17,17 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
 
 // ObjectAclSection loads ACL via separate API; stub so detail success path stays isolated.
 vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
-  ObjectAclSection: () => <div data-testid="developer-ct-acl-stub" />,
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
 }));
 
 const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<typeof vi.fn>;
@@ -127,6 +137,84 @@ describe("ContentTypeDetailPanel", () => {
     expect(screen.getByTestId("developer-ct-detail-error").textContent).toBe(
       DEV_MSG.CT_DETAIL_ERROR,
     );
+  });
+
+  it("mounts ObjectAclSection with content-type kind and object guid (#3319)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    });
+    const acl = screen.getByTestId("developer-ct-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("content-type");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-2-301");
+    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-301");
+  });
+
+  it("uses catalogGuid fallback when detail guid has no stringValue (#3319)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+    });
+    render(
+      <ContentTypeDetailPanel
+        idOrName="percPage"
+        catalogGuid="0-2-9"
+        onBack={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-9");
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-2-9",
+    );
+  });
+
+  it("uses guidString when nested guid is absent (#3319)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: "0-2-88",
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-88");
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-2-88",
+    );
+  });
+
+  it("synthesizes object guid from host/type/uuid parts on detail (#3319)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: { hostId: 0, type: 2, uuid: 301 },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-301");
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-2-301",
+    );
+  });
+
+  it("passes empty guid to ObjectAclSection when none can be resolved (#3319)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: undefined,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("—");
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe("");
   });
 
   it("renders structured designGaps message with data-gap-code (REST-GAPS-01)", async () => {

--- a/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
@@ -22,7 +22,17 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
 
 // ObjectAclSection loads ACL via separate API; stub so detail-load stays isolated.
 vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
-  ObjectAclSection: () => <div data-testid="developer-tpl-acl-stub" />,
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
 }));
 
 const getTemplateDetailMock = vi.mocked(getTemplateDetail);
@@ -179,6 +189,90 @@ describe("TemplateDetailPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-tpl-source-edit")).toBeTruthy();
     });
+  });
+
+  it("mounts ObjectAclSection with template kind and object guid (#3319)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      ...sampleDetail,
+      guid: { stringValue: "0-4-42" },
+    });
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-stub")).toBeTruthy();
+    });
+    const acl = screen.getByTestId("developer-tpl-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("template");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-4-42");
+    expect(screen.getByTestId("developer-tpl-detail-guid").textContent).toBe("0-4-42");
+  });
+
+  it("uses catalogGuid fallback when detail guid has no stringValue (#3319)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+    });
+    render(
+      <TemplateDetailPanel
+        idOrName="perc.page"
+        catalogGuid="0-4-7"
+        onBack={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-guid").textContent).toBe("0-4-7");
+    expect(screen.getByTestId("developer-tpl-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-4-7",
+    );
+  });
+
+  it("uses guidString when nested guid is absent (#3319)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: "0-4-19",
+    });
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-guid").textContent).toBe("0-4-19");
+    expect(screen.getByTestId("developer-tpl-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-4-19",
+    );
+  });
+
+  it("synthesizes object guid from templateId when guid is omitted (#3319)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+      guidString: undefined,
+      templateId: 12,
+    });
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-guid").textContent).toBe("0-4-12");
+    expect(screen.getByTestId("developer-tpl-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-4-12",
+    );
+  });
+
+  it("passes empty guid to ObjectAclSection when none can be resolved (#3319)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      name: "perc.empty",
+      label: "Empty",
+      guid: undefined,
+      guidString: undefined,
+    });
+    render(<TemplateDetailPanel idOrName="perc.empty" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-guid").textContent).toBe("—");
+    expect(screen.getByTestId("developer-tpl-acl-stub").getAttribute("data-object-guid")).toBe("");
   });
 
   it("shows session-redirect message via panelErrMsg", async () => {

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -38,7 +38,7 @@
  * QA mode:
  *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js → qa-down
  *
- * Refs #3204, #2643, #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
+ * Refs #3319, #3204, #2643, #2642, #2605, #2604, #2639, #2274, #2262, #1690 (builds on #2283 / PR #2342).
  */
 
 const { test, expect } = require("@playwright/test");
@@ -294,15 +294,29 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       empty: "developer-ct-empty",
       error: "developer-ct-error",
       detail: "developer-ct-detail",
+      detailLoading: "developer-ct-detail-loading",
+      detailError: "developer-ct-detail-error",
       catalogLabel: "content types",
     });
     if (!opened) return;
 
+    const guidCell = page.locator('[data-testid="developer-ct-detail-guid"]');
+    await expect(guidCell).toBeVisible({ timeout: 15_000 });
+    const guidText = (await guidCell.innerText()).trim();
     const mode = await assertLayeredObjectAcl(
       page,
       "developer-ct-acl",
       "content-type",
     );
+    // Detail / catalog GUID resolver (#3319): when a GUID is present, ACL must load.
+    if (guidText && guidText !== "—" && guidText !== "-") {
+      expect(
+        ["table", "empty", "no-entries"],
+        `content-type Object ACL must load with GUID "${guidText}" (got mode=${mode})`,
+      ).toContain(mode);
+    } else {
+      expect(["table", "no-guid", "empty", "no-entries"]).toContain(mode);
+    }
     if (mode === "table") {
       await expect(
         page.locator('[data-testid="developer-ct-acl-special-hint"]'),
@@ -326,11 +340,25 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       empty: "developer-tpl-empty",
       error: "developer-tpl-error",
       detail: "developer-tpl-detail",
+      detailLoading: "developer-tpl-detail-loading",
+      detailError: "developer-tpl-detail-error",
       catalogLabel: "templates",
     });
     if (!opened) return;
 
-    await assertLayeredObjectAcl(page, "developer-tpl-acl", "template");
+    const guidCell = page.locator('[data-testid="developer-tpl-detail-guid"]');
+    await expect(guidCell).toBeVisible({ timeout: 15_000 });
+    const guidText = (await guidCell.innerText()).trim();
+    const mode = await assertLayeredObjectAcl(page, "developer-tpl-acl", "template");
+    // templateId / Guid / catalog fallback (#3319): when a GUID is present, ACL must load.
+    if (guidText && guidText !== "—" && guidText !== "-") {
+      expect(
+        ["table", "empty", "no-entries"],
+        `template Object ACL must load with GUID "${guidText}" (got mode=${mode})`,
+      ).toContain(mode);
+    } else {
+      expect(["table", "no-guid", "empty", "no-entries"]).toContain(mode);
+    }
   });
 
   test("site peer ACL mounts objectKind=site with runtime-relevant Design/Runtime policy (B4)", async ({

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -29,8 +29,12 @@ those system principals.
 3. Open a catalog that supports Object ACL:
    - **Content types** → first type → **Open**
    - **Templates** → first template → **Open**
-4. On the detail panel, expand **Object ACL**.
-5. Confirm the table shows **Design access** and **Runtime visibility** column groups
+4. On the detail panel, confirm the header **GUID** (content type or template) is
+   populated when the object has an id — the product uses the nested Guid,
+   a plain `guidString`, the catalog list GUID, or (for templates) `0-4-{templateId}`.
+5. Expand **Object ACL**. When that GUID is present, the table (or empty create
+   path) loads — it must **not** say “Object GUID not available”.
+6. Confirm the table shows **Design access** and **Runtime visibility** column groups
    (runtime-relevant object kinds such as content type and template always show
    **Visible**).
 

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -86,7 +86,20 @@ not this profile control. See [Architecture & site navigation](id:admin-architec
 ## Design-object ACL (Developer)
 
 System Definition (**Developer**) shows an **Object ACL** section on securable design
-objects, including **Display Formats** and **Sites**.
+objects, including **Content types**, **Templates**, **Display Formats**, and **Sites**.
+
+### Content types and Templates
+
+1. Open **Developer → Content types** or **Developer → Templates**.
+2. Open a catalog row.
+3. The detail header **GUID** field shows the object GUID when the server has one
+   (nested `guid.stringValue`, synthesizable `hostId` / `type` / `uuid`, list-row
+   fallback, or — for templates — `0-4-{templateId}` when only the numeric id is
+   present).
+4. **Object ACL** below the detail form:
+   - Shows the ACL table when entries exist (Design access and Runtime visibility).
+   - Shows an empty create path when the object has no ACL yet.
+   - Does **not** say “Object GUID not available” when the header GUID is present.
 
 ### Display Formats
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -120,6 +120,12 @@ only empty-catalog case. See [Sites & content structure](id:admin-sites).
 | List | `GET /services/contenttypes` | Name, label, description, guid |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `designGaps` |
 
+JSON may wrap a single item as `ContentTypeDetail`. Integrators and the Developer
+SPA unwrap that envelope and read `guid.stringValue` (or synthesize
+`hostId-type-uuid` when `stringValue` is omitted) before calling
+`GET /services/acls/object/{guid}` for **Object ACL**. The list `guid` is a
+fallback when detail omits Guid parts.
+
 ### Field rule expressions (read-only)
 
 Content type **detail** field rows include boolean rule **flags** and, when rules exist,


### PR DESCRIPTION
## Summary

Developer **Content types** and **Templates** Object ACL failed human QA (#3261) with `Object GUID not available - cannot load ACL` because detail panels passed only `detail.guid?.stringValue` into `ObjectAclSection`.

This slice applies the Display Format GUID peer (#3200):

- Unwrap Jackson `ContentTypeDetail` WRAP_ROOT_VALUE and normalize Guid parts / `guidString`
- Resolve Object ACL GUID from nested Guid → `guidString` → catalog list fallback → `0-4-{templateId}` for templates
- Header GUID testids + Vitest coverage for present / missing GUID
- Playwright `developer-object-acl-product-path` now requires ACL table/empty/no-entries when the header GUID is present

REST `guidString` was **not** added: existing nested `Guid` plus client unwrap/synthesis is sufficient.

**Operator:** Grok: night-issue-prs (model grok-4.5)

Partial #3319  
Parent: #3204 (closed) / QA #3261 / epic #2274

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest 2219 passed)
2. H2 QA: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993`
3. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into the QA Rhythmyx webapp
4. `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js` — 7 passed (CT + Template GUID/ACL must load)
5. Confirm Developer → Content types / Templates detail Object ACL shows Design/Runtime columns (not ACL_NO_GUID)

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/object-acl.md`, `users-roles.md`, `developer/rest.md`
- [x] **Unit / module tests** — Vitest GUID resolver + panel ACL wiring; WebUI standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `developer-object-acl-product-path.spec.js` CT/template asserts
- [x] **Build gates** — WebUI standalone clean install, no skipTests
- [x] **Cross-platform** — N/A (no new path/file I/O)

## C3 evidence

- `modules_built=WebUI`
- `build_evidence=cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 51 (Java Surefire aggregate) + Vitest Test Files 305 / Tests 2219 passed; focused Vitest 71 passed
- `downstream_checked=none` (no Java public API / final/sealed change; REST/sitemanage unchanged)

## C5 UI proof

- `qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- Playwright: `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js` → **7 passed**
- `console-clean=yes`
- `server.log-clean=yes` (no ERROR/FATAL in QA `server.log`)
- `qa-down` after the run

> Co-Authored by Grok Build using grok-4.5 with agent main.
