### PR TITLE
fix(dce): wizard + ActionBar this-escape/serial cluster (#3298)

### DIFF
--- a/docs/ai-generated/code-reviews/3298-dce-wizard-actionbar-this-escape-erlang.md
+++ b/docs/ai-generated/code-reviews/3298-dce-wizard-actionbar-this-escape-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — #3298 DCE wizard + ActionBar this-escape/serial
+
+**Scope:** uncommitted / branch `fix/issue-3298-dce-wizard-actionbar-this-escape` vs `origin/main`  
+**Module:** `modules/DesktopContentExplorer`  
+**Date:** 2026-08-13  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** final + serialVersionUID + transient for Swing this-escape/serial (PSFolderDialog / #3288 cluster); do not finalize abstract bases that still have product subclasses.
+
+## Summary
+
+PR-sized Xlint cluster: wizard shell (`cx.PSWizardDialog`, `wizard.PSWizardDialog`, `PSWizardCommandPanel`, `PSWizardPanel`, `PSWizardStartFinishPanel`, `PSWizardValidationError`) plus `PSActionBar` and one leftover leaf (`PSCopySiteNamePage`). Leaf Swing types are `final` with `serialVersionUID`; session collaborators and `IPSWizardPanel` maps are `transient`. Abstract `PSWizardPanel` stays open; `initPanel` is `final`. No product behavior / DCE UX change. Standalone `mvnw clean install` **BUILD SUCCESS**, Tests run: 187, Failures: 0. Cluster files have 0 new javac warnings.
+
+## Cross-platform path checklist
+
+N/A — no path or file I/O changes.
+
+## C2 blast radius
+
+Types made `final`: both `PSWizardDialog`s, `PSWizardCommandPanel`, `PSWizardStartFinishPanel`, `PSWizardValidationError`, `PSActionBar`, `PSCopySiteNamePage`. Protected `PSWizardPanel.initPanel` made `final`. Grep monorepo: no `extends` / anonymous subclasses of those types. DCE is the consumer; no extra reverse-dep install.
+
+## Issues
+
+None (hard-gate).
+
+## Suggestions
+
+- Remaining copy-site wizard pages and `PSContentExplorerMenu` still have this-escape/rawtypes; tracked on parent #2045, not this slice.
+- `PSRelationshipInfoSet.getComponents()` remains a raw `Iterator`; ActionBar uses a local unchecked cast (system API out of scope).

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionBar.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionBar.java
@@ -55,8 +55,15 @@ import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import org.apache.commons.lang3.StringUtils;
 
-/** The top-level action bar for the applet. */
-public class PSActionBar extends JPanel
+/**
+ * The top-level action bar for the applet.
+ *
+ * <p>Declared {@code final} so Swing/UI initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborator fields that
+ * are not {@link java.io.Serializable} are {@code transient} (the bar is never serialized in
+ * practice).
+ */
+public final class PSActionBar extends JPanel
     implements IPSSelectionListener, ItemListener, IPSSearchListener {
   /**
    * Constructs the action bar with supplied view.
@@ -142,7 +149,7 @@ public class PSActionBar extends JPanel
       rsPanel.add(rsLabel);
       rsPanel.add(makeFillerOpaque(Box.createHorizontalStrut(5)));
 
-      m_rsCombo = new JComboBox();
+      m_rsCombo = new JComboBox<>();
       rsLabel.setLabelFor(m_rsCombo); // Associate label with combobox
       if (mnemonic != 0) {
         rsLabel.setDisplayedMnemonic(mnemonic);
@@ -150,9 +157,11 @@ public class PSActionBar extends JPanel
       focusBorder.addToComponent(m_rsCombo, false);
       m_rsCombo.setRenderer(
           new DefaultListCellRenderer() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Component getListCellRendererComponent(
-                JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
               super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
               if (value instanceof PSRelationshipInfo) {
                 PSRelationshipInfo relInfo = (PSRelationshipInfo) value;
@@ -173,7 +182,9 @@ public class PSActionBar extends JPanel
       m_rsCombo.setMaximumSize(new Dimension(180, 20));
       m_rsCombo.addItemListener(this);
 
-      Iterator<PSRelationshipInfo> relationships = relationshipSet.getComponents();
+      @SuppressWarnings("unchecked")
+      Iterator<PSRelationshipInfo> relationships =
+          (Iterator<PSRelationshipInfo>) relationshipSet.getComponents();
       List<PSRelationshipInfo> orderedRels = new ArrayList<PSRelationshipInfo>();
       if (!relationships.hasNext()) throw new IllegalStateException("No relationships found");
       while (relationships.hasNext()) {
@@ -349,7 +360,7 @@ public class PSActionBar extends JPanel
     PSNode node = null;
 
     if (selection.getNodeListSize() == 1) {
-      node = (PSNode) selection.getNodeList().next();
+      node = selection.getNodeList().next();
     }
 
     if (node != null && node.getSearchResultCount() >= 0) {
@@ -387,9 +398,8 @@ public class PSActionBar extends JPanel
       props.setProperty(
           IPSConstants.PROPERTY_REVISION, String.valueOf(m_contentItem.getRevision()));
 
-      Iterator viewChangeListeners = m_viewChangeListeners.iterator();
-      while (viewChangeListeners.hasNext()) {
-        ((IPSViewChangeListener) viewChangeListeners.next()).viewDataChanged(props);
+      for (IPSViewChangeListener viewChangeListener : m_viewChangeListeners) {
+        viewChangeListener.viewDataChanged(props);
       }
 
       // Update accessibility information on combobox
@@ -447,13 +457,13 @@ public class PSActionBar extends JPanel
    * view. Initialized in <code>
    * init(JMenuBar)</code> and never <code>null</code> or modified after that.
    */
-  private PSLocator m_contentItem;
+  private transient PSLocator m_contentItem;
 
   /**
    * The container applet to get the applet context and its parameters, initialized in the ctor and
    * never <code>null</code> or modified after that.
    */
-  PSContentExplorerApplet m_applet;
+  transient PSContentExplorerApplet m_applet;
 
   /**
    * The current view of UI, initialized in the constructor and never <code>
@@ -480,7 +490,7 @@ public class PSActionBar extends JPanel
    * relationship to view its dependencies, initialized in the <code>init(JMenuBar)</code> in case
    * of <code>PSUiMode.TYPE_VIEW_DT</code> and never <code>null</code> or modified after that.
    */
-  private JComboBox m_rsCombo;
+  private JComboBox<PSRelationshipInfo> m_rsCombo;
 
   /**
    * The list of listeners that are interested in their view changes when any action is executed in
@@ -488,7 +498,7 @@ public class PSActionBar extends JPanel
    * addViewChangeListener(IPSViewChangeListener)</code>, never <code>
    * null</code>, may be empty.
    */
-  private List m_viewChangeListeners = new ArrayList();
+  private final transient List<IPSViewChangeListener> m_viewChangeListeners = new ArrayList<>();
 
   /**
    * Name of the image file to separate the content path and the menu bar. Image is loaded on
@@ -512,5 +522,8 @@ public class PSActionBar extends JPanel
    * Current selection in the nav tree, intially <code>null</code>, modified by calls to {@link
    * #selectionChanged(PSSelection)}.
    */
-  PSSelection m_navSelection = null;
+  transient PSSelection m_navSelection = null;
+
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSWizardDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSWizardDialog.java
@@ -39,8 +39,13 @@ import javax.swing.JPanel;
  *
  * <p>Pure typing helpers live on {@link com.percussion.wizard.PSWizardDialog} so both CX and
  * wizard-package dialogs share one tested implementation.
+ *
+ * <p>Declared {@code final} so Swing/UI initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborator fields that
+ * are not {@link java.io.Serializable} are {@code transient} (dialogs are never serialized in
+ * practice).
  */
-public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
+public final class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   /**
    * Construct a new wizard dialog for the supplied pages.
    *
@@ -282,14 +287,14 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * 0) while the map value is the page as <code>IPSWizardPanel</code>. Initialized in {@link
    * #createMainPanel(Object[][])}, never changed after that.
    */
-  private final Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
+  private final transient Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
 
   /**
    * The map used to keep track of skipped wizard pages. The map key is an <code>Integer</code> with
    * the page index (starting at 0) while the map value is the page as <code>IPSWizardPanel</code>.
    * Initialized to an empty map, updated on calls to {@link #onNext()} or {@link #onBack()}.
    */
-  private final Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
+  private final transient Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
 
   /** The card layout used for the wizards main panel. */
   private final CardLayout m_cards = new CardLayout();
@@ -304,7 +309,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * The wizards command panel, initialized during construction, never <code>null</code> or changed
    * after that.
    */
-  private PSWizardCommandPanel m_wizardCommands = null;
+  private transient PSWizardCommandPanel m_wizardCommands = null;
 
   /** The index of the page panel for the page array as supplied in constructor. */
   private static final int PAGE_PANEL = 0;
@@ -315,6 +320,9 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   /** The index of the page instruction for the page array as supplied in constructor. */
   private static final int PAGE_INSTRUCTION = 2;
 
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
+
   /** A reference back to the applet that initiated this action manager. */
-  private PSContentExplorerApplet m_applet;
+  private transient PSContentExplorerApplet m_applet;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
@@ -32,8 +32,13 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-/** The wizard page to request the new site name and site folder name from the user. */
-public class PSCopySiteNamePage extends PSWizardPanel {
+/**
+ * The wizard page to request the new site name and site folder name from the user.
+ *
+ * <p>Declared {@code final} so constructor {@link #initPanel(JPanel)} cannot observe a partially
+ * constructed subclass (javac {@code this-escape}).
+ */
+public final class PSCopySiteNamePage extends PSWizardPanel {
   /**
    * Instantiate with applet to make config options from applet available to panel.
    *
@@ -356,7 +361,7 @@ public class PSCopySiteNamePage extends PSWizardPanel {
    * This combo box shows all site definitions that are referenced by the source site folder being
    * copied. The user can select the one that will be copied together with the site folder.
    */
-  private JComboBox m_siteSelector = new JComboBox();
+  private final JComboBox<PSSite> m_siteSelector = new JComboBox<>();
 
   /** A text field to request the new site name from the user, never <code>null</code>. */
   private JTextField m_siteName = new JTextField();
@@ -368,5 +373,8 @@ public class PSCopySiteNamePage extends PSWizardPanel {
    * The input data, set with the first call to {@link setData(Object)}, never <code>null</code>
    * after that.
    */
-  private InputData m_input = null;
+  private transient InputData m_input = null;
+
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardCommandPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardCommandPanel.java
@@ -31,8 +31,12 @@ import javax.swing.JPanel;
 /**
  * This class provides a command panel as used in wizard dialogs. It will handle the wizard buttons
  * 'Next', 'Back', 'Finish' and 'Cancel'.
+ *
+ * <p>Declared {@code final} so Swing/UI initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). The dialog collaborator is {@code
+ * transient} (panels are never serialized in practice).
  */
-public class PSWizardCommandPanel extends JPanel implements ActionListener {
+public final class PSWizardCommandPanel extends JPanel implements ActionListener {
   /* (non-Javadoc)
    * @see ActionListener#actionPerformed(ActionEvent)
    */
@@ -188,11 +192,14 @@ public class PSWizardCommandPanel extends JPanel implements ActionListener {
     return panel;
   }
 
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * A reference to the wizard dialog which contains this panel. Initialized during construction,
    * never <code>null</code> or changed after that.
    */
-  private IPSWizardDialog m_dialog = null;
+  private transient IPSWizardDialog m_dialog = null;
 
   /**
    * The command panel 'Back' button, initialized in {@link #initPanel()}, never <code>null</code>

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardDialog.java
@@ -33,8 +33,13 @@ import javax.swing.JPanel;
 
 /**
  * A standard wizard dialog using the card layout for easy 'next' and 'back' wizard functonality.
+ *
+ * <p>Declared {@code final} so Swing/UI initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborator fields that
+ * are not {@link java.io.Serializable} are {@code transient} (dialogs are never serialized in
+ * practice).
  */
-public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
+public final class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   /**
    * Construct a new wizard dialog for the supplied pages.
    *
@@ -402,14 +407,14 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * 0) while the map value is the page as <code>IPSWizardPanel</code>. Initialized in {@link
    * #createMainPanel(Object[][])}, never changed after that.
    */
-  private final Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
+  private final transient Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
 
   /**
    * The map used to keep track of skipped wizard pages. The map key is an <code>Integer</code> with
    * the page index (starting at 0) while the map value is the page as <code>IPSWizardPanel</code>.
    * Initialized to an empty map, updated on calls to {@link #onNext()} or {@link #onBack()}.
    */
-  private final Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
+  private final transient Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
 
   /** The card layout used for the wizards main panel. */
   private final CardLayout m_cards = new CardLayout();
@@ -424,7 +429,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * The wizards command panel, initialized during construction, never <code>null</code> or changed
    * after that.
    */
-  private PSWizardCommandPanel m_wizardCommands = null;
+  private transient PSWizardCommandPanel m_wizardCommands = null;
 
   /** The index of the page panel for the page array as supplied in constructor. */
   private static final int PAGE_PANEL = 0;
@@ -435,6 +440,9 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   /** The index of the page instruction for the page array as supplied in constructor. */
   private static final int PAGE_INSTRUCTION = 2;
 
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
+
   /** A reference back to the applet that initiated this action manager. */
-  private PSContentExplorerApplet m_applet;
+  private transient PSContentExplorerApplet m_applet;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardPanel.java
@@ -28,6 +28,10 @@ import javax.swing.JTextArea;
 /**
  * An abstract base class that can be used to derive all wizard pages from. It creates the correct
  * layout and provides the controls to display the user instuctions.
+ *
+ * <p>Not {@code final}: copy-site and start/finish pages must subclass this type. Leaf pages are
+ * made {@code final} to close javac {@code this-escape}. Session-only applet collaborator is {@code
+ * transient} (panels are never serialized in practice).
  */
 public abstract class PSWizardPanel extends JPanel implements IPSWizardPanel {
   /**
@@ -46,10 +50,13 @@ public abstract class PSWizardPanel extends JPanel implements IPSWizardPanel {
    * Creates the panel for the supplied main panel. The panel constructed shows an instruction panel
    * on top and the supplied main panel on the botton.
    *
+   * <p>Final so subclass constructors calling this helper cannot observe overridable layout hooks
+   * (javac {@code this-escape}).
+   *
    * @param mainPanel the main panel to be displayed at the bottom, may be <code>null</code> for the
    *     start and finish pages in which case a picture panel is shown to the left.
    */
-  protected void initPanel(JPanel mainPanel) {
+  protected final void initPanel(JPanel mainPanel) {
     m_instructions.setTabSize(2);
     m_mainPanel = mainPanel;
 
@@ -172,7 +179,7 @@ public abstract class PSWizardPanel extends JPanel implements IPSWizardPanel {
    * The panel data with which it will be initialized, set during construction, may be <code>null
    * </code> after that.
    */
-  protected Object m_data = null;
+  protected transient Object m_data = null;
 
   /**
    * The instructions shown to the user on every wizard page, never <code>null</code>, may be empty.
@@ -185,6 +192,9 @@ public abstract class PSWizardPanel extends JPanel implements IPSWizardPanel {
    */
   protected JPanel m_mainPanel = null;
 
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
+
   /** A reference back to the applet that initiated this action manager. */
-  protected PSContentExplorerApplet m_applet;
+  protected transient PSContentExplorerApplet m_applet;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardStartFinishPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardStartFinishPanel.java
@@ -18,8 +18,13 @@ package com.percussion.wizard;
 
 import com.percussion.cx.PSContentExplorerApplet;
 
-/** A standard wizard start or finish panel which does only show user instructions. */
-public class PSWizardStartFinishPanel extends PSWizardPanel {
+/**
+ * A standard wizard start or finish panel which does only show user instructions.
+ *
+ * <p>Declared {@code final} so constructor {@link #initPanel(JPanel)} cannot observe a partially
+ * constructed subclass (javac {@code this-escape}).
+ */
+public final class PSWizardStartFinishPanel extends PSWizardPanel {
 
   /**
    * Instantiates with applet to make config options from applet available to the panel.
@@ -35,4 +40,7 @@ public class PSWizardStartFinishPanel extends PSWizardPanel {
   public PSWizardStartFinishPanel() {
     initPanel(null);
   }
+
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
@@ -18,8 +18,13 @@ package com.percussion.wizard;
 
 import com.percussion.error.PSException;
 
-/** This exception must be thrown for wizard page validation errors. */
-public class PSWizardValidationError extends PSException {
+/**
+ * This exception must be thrown for wizard page validation errors.
+ *
+ * <p>Declared {@code final} so constructors cannot observe a partially constructed subclass (javac
+ * {@code this-escape}).
+ */
+public final class PSWizardValidationError extends PSException {
   /**
    * Constructs the exception with the supplied code and argument.
    *
@@ -39,4 +44,7 @@ public class PSWizardValidationError extends PSException {
   public PSWizardValidationError(int code, Object[] args) {
     super(code, args);
   }
+
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
+  private static final long serialVersionUID = 1L;
 }

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSActionBarXlintTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSActionBarXlintTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.wizards.PSCopySiteNamePage;
+import com.percussion.wizard.PSWizardPanel;
+import com.percussion.wizard.PSWizardStartFinishPanel;
+import com.percussion.wizard.PSWizardValidationError;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural coverage for the DCE wizard + ActionBar this-escape/serial cluster (#3298): leaf
+ * Swing types are {@code final}, session collaborators are {@code transient}, and the abstract
+ * wizard page base stays open for copy-site subclasses.
+ */
+public class PSActionBarXlintTest {
+
+  @Test
+  public void actionBarClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSActionBar.class.getModifiers()),
+        "PSActionBar must be final to avoid this-escape in the ctor");
+  }
+
+  @Test
+  public void actionBarDeclaresSerialVersionUid() throws Exception {
+    assertSerialVersionUid(PSActionBar.class);
+  }
+
+  @Test
+  public void actionBarCollaboratorsAreTransient() throws Exception {
+    assertTransientFields(
+        PSActionBar.class, Set.of("m_applet", "m_navSelection", "m_viewChangeListeners", "m_contentItem"));
+  }
+
+  @Test
+  public void cxWizardDialogClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSWizardDialog.class.getModifiers()),
+        "cx PSWizardDialog must be final to avoid this-escape in the ctor");
+  }
+
+  @Test
+  public void cxWizardDialogCollaboratorsAreTransient() throws Exception {
+    assertSerialVersionUid(PSWizardDialog.class);
+    assertTransientFields(
+        PSWizardDialog.class, Set.of("m_applet", "m_wizardCommands", "m_pages", "m_skippedPages"));
+  }
+
+  @Test
+  public void startFinishPanelIsFinalWithSerialUid() throws Exception {
+    assertTrue(Modifier.isFinal(PSWizardStartFinishPanel.class.getModifiers()));
+    assertSerialVersionUid(PSWizardStartFinishPanel.class);
+  }
+
+  @Test
+  public void copySiteNamePageIsFinalWithSerialUid() throws Exception {
+    assertTrue(Modifier.isFinal(PSCopySiteNamePage.class.getModifiers()));
+    assertSerialVersionUid(PSCopySiteNamePage.class);
+    Field input = PSCopySiteNamePage.class.getDeclaredField("m_input");
+    assertTrue(Modifier.isTransient(input.getModifiers()));
+  }
+
+  @Test
+  public void validationErrorIsFinalWithSerialUid() throws Exception {
+    assertTrue(Modifier.isFinal(PSWizardValidationError.class.getModifiers()));
+    assertSerialVersionUid(PSWizardValidationError.class);
+  }
+
+  @Test
+  public void wizardPanelStaysOpenForPageSubclasses() throws Exception {
+    assertFalse(
+        Modifier.isFinal(PSWizardPanel.class.getModifiers()),
+        "PSWizardPanel must remain non-final for copy-site / start-finish pages");
+    assertTrue(Modifier.isAbstract(PSWizardPanel.class.getModifiers()));
+    assertSerialVersionUid(PSWizardPanel.class);
+    Field applet = PSWizardPanel.class.getDeclaredField("m_applet");
+    assertTrue(Modifier.isTransient(applet.getModifiers()));
+    Field data = PSWizardPanel.class.getDeclaredField("m_data");
+    assertTrue(Modifier.isTransient(data.getModifiers()));
+    Method init = PSWizardPanel.class.getDeclaredMethod("initPanel", javax.swing.JPanel.class);
+    assertTrue(Modifier.isFinal(init.getModifiers()), "initPanel must be final (this-escape)");
+  }
+
+  private static void assertSerialVersionUid(Class<?> type) throws Exception {
+    Field uid = type.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  private static void assertTransientFields(Class<?> type, Set<String> names) throws Exception {
+    for (String name : names) {
+      Field f = type.getDeclaredField(name);
+      assertTrue(
+          Modifier.isTransient(f.getModifiers()),
+          () -> name + " must be transient (non-serializable collaborator)");
+    }
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardCommandPanelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardCommandPanelTest.java
@@ -16,8 +16,12 @@
  */
 package com.percussion.wizard;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 /** Construction / type validation coverage for {@link PSWizardCommandPanel}. */
@@ -26,5 +30,26 @@ public class PSWizardCommandPanelTest {
   @Test
   public void constructorRejectsNullDialog() {
     assertThrows(IllegalArgumentException.class, () -> new PSWizardCommandPanel(null));
+  }
+
+  @Test
+  public void commandPanelClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSWizardCommandPanel.class.getModifiers()),
+        "PSWizardCommandPanel must be final to avoid this-escape in the ctor");
+  }
+
+  @Test
+  public void commandPanelDeclaresSerialVersionUid() throws Exception {
+    Field uid = PSWizardCommandPanel.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  @Test
+  public void dialogCollaboratorIsTransient() throws Exception {
+    Field f = PSWizardCommandPanel.class.getDeclaredField("m_dialog");
+    assertTrue(Modifier.isTransient(f.getModifiers()), "m_dialog must be transient");
   }
 }

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardDialogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardDialogTest.java
@@ -19,13 +19,17 @@ package com.percussion.wizard;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +113,31 @@ public class PSWizardDialogTest {
 
     assertArrayEquals(new Object[] {"d0", "d1"}, PSWizardDialog.collectPageData(pages));
     assertThrows(IllegalArgumentException.class, () -> PSWizardDialog.collectPageData(null));
+  }
+
+  @Test
+  public void wizardDialogClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSWizardDialog.class.getModifiers()),
+        "PSWizardDialog must be final to avoid this-escape in the ctor");
+  }
+
+  @Test
+  public void wizardDialogDeclaresSerialVersionUid() throws Exception {
+    Field uid = PSWizardDialog.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  @Test
+  public void wizardDialogCollaboratorsAreTransient() throws Exception {
+    for (String name : Set.of("m_applet", "m_wizardCommands", "m_pages", "m_skippedPages")) {
+      Field f = PSWizardDialog.class.getDeclaredField(name);
+      assertTrue(
+          Modifier.isTransient(f.getModifiers()),
+          () -> name + " must be transient (non-serializable collaborator)");
+    }
   }
 
   private static IPSWizardPanel stubPanel(String summary, Object data) {


### PR DESCRIPTION
## Summary

Parent: #2045. Slice: #3298.

Clears the next DCE this-escape/serial cluster after #3288 / #3297: wizard shell plus `PSActionBar`, and one leftover copy-site leaf.

- Wizard dialogs (`com.percussion.cx.PSWizardDialog`, `com.percussion.wizard.PSWizardDialog`): `final` + `serialVersionUID` + transient applet, command panel, and page maps
- `PSWizardCommandPanel`, `PSWizardStartFinishPanel`, `PSWizardValidationError`: `final` + `serialVersionUID` (+ transient dialog)
- `PSWizardPanel` stays **non-final** (copy-site pages subclass it); `initPanel` is `final`; applet/data fields are transient + `serialVersionUID`
- `PSActionBar`: `final` + uid + transient collaborators; typed `JComboBox<PSRelationshipInfo>` / listener list; local cast for raw `PSRelationshipInfoSet.getComponents()`
- Leftover one Swing file: `PSCopySiteNamePage` (`final` + uid + typed `JComboBox<PSSite>`)
- Did **not** touch `PSActionManager` (#3286), display-table/search (#3287), or `java.applet` removal

Fixes #3298

## Test plan

1. `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` (JDK 21)
2. Confirm Tests run: 187, Failures: 0 (`PSWizardDialogTest`, `PSWizardCommandPanelTest`, `PSActionBarXlintTest` structural coverage)
3. Optional: confirm cluster files have 0 new javac this-escape/serial warnings

## Checklist

- [x] **Product documentation** — N/A (not product-facing): compiler-warning / this-escape/serial tech-debt; no operator or UI behavior change
- [x] **Unit / module tests** — structural `final`/`transient`/`serialVersionUID` tests; existing wizard helper tests kept; module clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; DCE javac cleanup only)
- [x] **Build gates** — standalone `modules/DesktopContentExplorer` clean install; C2 greps for `extends` / anonymous subclasses of finalized types (none)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: 187, Failures: 0
- **downstream_checked:** grepped monorepo for `extends PSActionBar|PSWizardDialog|PSWizardCommandPanel|PSWizardStartFinishPanel|PSWizardValidationError|PSCopySiteNamePage` and anonymous `new Type() {` — no subclasses; DCE is the consumer module (no extra reverse-dep install)

## C5 UI proof

N/A — not WebUI/Explorer SPA product-screen work.

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
