### PR TITLE
cluster: absorb Virtual Site thrash (#3309 #3310 #3311)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -10,6 +10,7 @@ import type {
   SiteDef,
   VirtualSiteBuildRequest,
   VirtualSiteBuildResult,
+  VirtualSitePreviewStatus,
   VirtualSiteProperties,
 } from "./types";
 
@@ -258,6 +259,52 @@ export async function buildVirtualSite(
       : {};
   const payload = await post<unknown>(`${PATHS.SITES}/${key}/virtual/build`, body);
   return parseVirtualSiteBuildResult(payload);
+}
+
+/**
+ * Normalize Virtual Site preview status (Jackson root wrap or plain DTO).
+ */
+export function parseVirtualSitePreviewStatus(payload: unknown): VirtualSitePreviewStatus {
+  if (payload == null || typeof payload !== "object") {
+    return {};
+  }
+  const obj = payload as Record<string, unknown>;
+  const root =
+    (obj.VirtualSitePreviewStatus as Record<string, unknown> | undefined) ??
+    (obj.virtualSitePreviewStatus as Record<string, unknown> | undefined) ??
+    obj;
+  return {
+    available: typeof root.available === "boolean" ? root.available : undefined,
+    homePath: asNullableString(root.homePath),
+    outputPath: asNullableString(root.outputPath),
+    message: asNullableString(root.message),
+  };
+}
+
+/** GET /services/sites/{nameOrId}/virtual/preview — last-build availability (Admin). */
+export async function getVirtualSitePreviewStatus(
+  nameOrId: string,
+): Promise<VirtualSitePreviewStatus> {
+  const key = encodeURIComponent(nameOrId.trim());
+  const payload = await get<unknown>(`${PATHS.SITES}/${key}/virtual/preview`);
+  return parseVirtualSitePreviewStatus(payload);
+}
+
+/**
+ * Browser URL for the assembled preview file stream (same-origin cookies).
+ * {@code homePath} must be a relative path such as {@code 8.2/index.html}.
+ */
+export function virtualSitePreviewContentHref(nameOrId: string, homePath: string): string {
+  const key = encodeURIComponent(nameOrId.trim());
+  const rel = homePath
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((seg) => seg.length > 0 && seg !== "." && seg !== "..")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+  return `${PATHS.SITES}/${key}/virtual/preview/${rel}`;
 }
 
 function asNullableString(value: unknown): string | null | undefined {

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -751,3 +751,15 @@ export interface VirtualSiteBuildResult {
   writtenFiles?: string[] | null;
 }
 
+/**
+ * Last-build preview availability ({@code GET /services/sites/{nameOrId}/virtual/preview}).
+ * Missing output is HTTP 200 with {@code available=false} (not 500).
+ */
+export interface VirtualSitePreviewStatus {
+  available?: boolean | null;
+  /** Relative home under the output root, e.g. {@code 8.2/index.html}. */
+  homePath?: string | null;
+  outputPath?: string | null;
+  message?: string | null;
+}
+

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -18,8 +18,10 @@
 import React, { useCallback, useEffect, useState } from "react";
 import {
   buildVirtualSite,
+  getVirtualSitePreviewStatus,
   getVirtualSiteProperties,
   updateVirtualSiteProperties,
+  virtualSitePreviewContentHref,
 } from "../api/developer/sitesApi";
 import type { VirtualSiteBuildResult } from "../api/developer/types";
 import {
@@ -32,6 +34,7 @@ import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import {
   formatVirtualSiteBuildSummary,
+  sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
 } from "./virtualSiteBuild";
 import {
@@ -148,6 +151,8 @@ export function VirtualSiteSourcePanel({
   const [isVirtual, setIsVirtual] = useState(false);
   const [buildError, setBuildError] = useState<string | null>(null);
   const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
 
   const load = useCallback(() => {
     if (!siteName.trim()) {
@@ -162,6 +167,7 @@ export function VirtualSiteSourcePanel({
     setSavedNotice(null);
     setBuildError(null);
     setBuildResult(null);
+    setPreviewError(null);
     getVirtualSiteProperties(siteName)
       .then((props) => {
         if (cancelled) return;
@@ -222,6 +228,7 @@ export function VirtualSiteSourcePanel({
     setBuilding(true);
     setBuildError(null);
     setBuildResult(null);
+    setPreviewError(null);
     setFormError(null);
     try {
       const result = await buildVirtualSite(siteName);
@@ -230,6 +237,31 @@ export function VirtualSiteSourcePanel({
       setBuildError(panelErrMsg(e, DEV_MSG.SITE_VIRT_BUILD_ERROR));
     } finally {
       setBuilding(false);
+    }
+  }
+
+  async function onPreview(): Promise<void> {
+    setPreviewBusy(true);
+    setPreviewError(null);
+    try {
+      const status = await getVirtualSitePreviewStatus(siteName);
+      if (status.available !== true) {
+        setPreviewError(
+          status.message?.trim() || DEV_MSG.SITE_VIRT_PREVIEW_MISSING,
+        );
+        return;
+      }
+      const home = sanitizeVirtualPreviewHomePath(status.homePath);
+      if (!home) {
+        setPreviewError(DEV_MSG.SITE_VIRT_PREVIEW_MISSING);
+        return;
+      }
+      const href = virtualSitePreviewContentHref(siteName, home);
+      window.open(href, "_blank", "noopener,noreferrer");
+    } catch (e: unknown) {
+      setPreviewError(panelErrMsg(e, DEV_MSG.SITE_VIRT_PREVIEW_ERROR));
+    } finally {
+      setPreviewBusy(false);
     }
   }
 
@@ -391,15 +423,32 @@ export function VirtualSiteSourcePanel({
               <p style={{ ...mutedHintText, margin: "0 0 10px" }} data-testid="developer-site-virtual-build-save-first">
                 {DEV_MSG.SITE_VIRT_BUILD_SAVE_FIRST}
               </p>
-              <button
-                type="button"
-                data-testid="developer-site-virtual-build"
-                style={busy ? disabledSecondaryButton : secondaryButton}
-                disabled={busy}
-                onClick={() => void onBuild()}
+              <div style={{ display: "flex", gap: "12px", flexWrap: "wrap", alignItems: "center" }}>
+                <button
+                  type="button"
+                  data-testid="developer-site-virtual-build"
+                  style={busy ? disabledSecondaryButton : secondaryButton}
+                  disabled={busy}
+                  onClick={() => void onBuild()}
+                >
+                  {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
+                </button>
+                <button
+                  type="button"
+                  data-testid="developer-site-virtual-preview"
+                  style={busy || previewBusy ? disabledSecondaryButton : secondaryButton}
+                  disabled={busy || previewBusy}
+                  onClick={() => void onPreview()}
+                >
+                  {DEV_MSG.SITE_VIRT_PREVIEW}
+                </button>
+              </div>
+              <p
+                style={{ ...mutedHintText, margin: "8px 0 0" }}
+                data-testid="developer-site-virtual-preview-hint"
               >
-                {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
-              </button>
+                {DEV_MSG.SITE_VIRT_PREVIEW_HINT}
+              </p>
 
               {building ? (
                 <div data-testid="developer-site-virtual-build-busy" style={{ ...mutedText, marginTop: "10px" }}>
@@ -414,6 +463,16 @@ export function VirtualSiteSourcePanel({
                   style={{ ...errorAlert, marginTop: "10px" }}
                 >
                   {buildError}
+                </div>
+              ) : null}
+
+              {previewError ? (
+                <div
+                  role="alert"
+                  data-testid="developer-site-virtual-preview-error"
+                  style={{ ...errorAlert, marginTop: "10px" }}
+                >
+                  {previewError}
                 </div>
               ) : null}
 

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -30,6 +30,7 @@ import {
 } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { copyTextToClipboard } from "./templateSourceViewer";
 import {
   formatVirtualSiteBuildSummary,
   shouldShowVirtualBuildChrome,
@@ -148,6 +149,7 @@ export function VirtualSiteSourcePanel({
   const [isVirtual, setIsVirtual] = useState(false);
   const [buildError, setBuildError] = useState<string | null>(null);
   const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
+  const [linkCopyNotice, setLinkCopyNotice] = useState<string | null>(null);
 
   const load = useCallback(() => {
     if (!siteName.trim()) {
@@ -162,6 +164,7 @@ export function VirtualSiteSourcePanel({
     setSavedNotice(null);
     setBuildError(null);
     setBuildResult(null);
+    setLinkCopyNotice(null);
     getVirtualSiteProperties(siteName)
       .then((props) => {
         if (cancelled) return;
@@ -222,6 +225,7 @@ export function VirtualSiteSourcePanel({
     setBuilding(true);
     setBuildError(null);
     setBuildResult(null);
+    setLinkCopyNotice(null);
     setFormError(null);
     try {
       const result = await buildVirtualSite(siteName);
@@ -231,6 +235,14 @@ export function VirtualSiteSourcePanel({
     } finally {
       setBuilding(false);
     }
+  }
+
+  async function onCopyLinkProblems(lines: string[]): Promise<void> {
+    if (lines.length === 0) {
+      return;
+    }
+    const ok = await copyTextToClipboard(lines.join("\n"));
+    setLinkCopyNotice(ok ? DEV_MSG.SITE_VIRT_BUILD_LINK_COPIED : null);
   }
 
   const virtualMode = isVirtualSourceKind(form.sourceKind);
@@ -439,9 +451,74 @@ export function VirtualSiteSourcePanel({
                   {buildSummary.hasLinkProblems && buildSummary.linkLine ? (
                     <div
                       data-testid="developer-site-virtual-build-link-problems"
-                      style={{ marginTop: "4px", color: catalogColors.error }}
+                      style={{ marginTop: "8px", color: catalogColors.error }}
                     >
-                      {DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS}: {buildSummary.linkLine}
+                      <div>
+                        {DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS}: {buildSummary.linkLine}
+                      </div>
+                      <p
+                        style={{ ...mutedHintText, margin: "6px 0 0", color: catalogColors.error }}
+                        data-testid="developer-site-virtual-build-link-report-hint"
+                      >
+                        {DEV_MSG.SITE_VIRT_BUILD_LINK_REPORT_HINT}
+                      </p>
+                      {buildSummary.linkProblems.length > 0 ? (
+                        <details
+                          data-testid="developer-site-virtual-build-link-details"
+                          style={{ marginTop: "8px" }}
+                        >
+                          <summary
+                            data-testid="developer-site-virtual-build-link-toggle"
+                            style={{ cursor: "pointer" }}
+                          >
+                            {DEV_MSG.SITE_VIRT_BUILD_LINK_DETAILS}
+                          </summary>
+                          <div
+                            style={{
+                              display: "flex",
+                              gap: "12px",
+                              alignItems: "center",
+                              marginTop: "8px",
+                              flexWrap: "wrap",
+                            }}
+                          >
+                            <button
+                              type="button"
+                              data-testid="developer-site-virtual-build-link-copy"
+                              style={secondaryButton}
+                              onClick={() =>
+                                void onCopyLinkProblems(buildSummary.linkProblems)
+                              }
+                            >
+                              {DEV_MSG.SITE_VIRT_BUILD_LINK_COPY}
+                            </button>
+                            {linkCopyNotice ? (
+                              <span data-testid="developer-site-virtual-build-link-copied">
+                                {linkCopyNotice}
+                              </span>
+                            ) : null}
+                          </div>
+                          <ul
+                            data-testid="developer-site-virtual-build-link-list"
+                            style={{
+                              ...buildResultMono,
+                              margin: "8px 0 0",
+                              paddingLeft: "1.25rem",
+                              maxHeight: "16rem",
+                              overflow: "auto",
+                            }}
+                          >
+                            {buildSummary.linkProblems.map((line, index) => (
+                              <li
+                                key={`${index}:${line}`}
+                                data-testid="developer-site-virtual-build-link-line"
+                              >
+                                {line}
+                              </li>
+                            ))}
+                          </ul>
+                        </details>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -776,6 +776,12 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_BUILD_LINK_PROBLEMS: "perc.ui.developer@Link problems",
   SITE_VIRT_BUILD_SAVE_FIRST:
     "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
+  SITE_VIRT_PREVIEW: "perc.ui.developer@Preview assembled site",
+  SITE_VIRT_PREVIEW_HINT:
+    "perc.ui.developer@Opens the last assembled documentation home in a new tab (same-origin preview of the build output). Requires Admin.",
+  SITE_VIRT_PREVIEW_MISSING:
+    "perc.ui.developer@No assembled site to preview. Run Build Virtual Site first.",
+  SITE_VIRT_PREVIEW_ERROR: "perc.ui.developer@Could not open Virtual Site preview.",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -774,6 +774,11 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_BUILD_PAGES: "perc.ui.developer@Pages written",
   SITE_VIRT_BUILD_OUTPUT: "perc.ui.developer@Output path",
   SITE_VIRT_BUILD_LINK_PROBLEMS: "perc.ui.developer@Link problems",
+  SITE_VIRT_BUILD_LINK_DETAILS: "perc.ui.developer@Show link problem details",
+  SITE_VIRT_BUILD_LINK_COPY: "perc.ui.developer@Copy link problems",
+  SITE_VIRT_BUILD_LINK_COPIED: "perc.ui.developer@Copied.",
+  SITE_VIRT_BUILD_LINK_REPORT_HINT:
+    "perc.ui.developer@Same lines as link-report.txt under the output directory. Link problems do not fail the build (HTTP 200).",
   SITE_VIRT_BUILD_SAVE_FIRST:
     "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -67,3 +67,30 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
     hasLinkProblems,
   };
 }
+
+/**
+ * Safe relative home path for the preview stream. Rejects empty, absolute, and {@code ..}
+ * segments so the UI never opens a traversal URL.
+ */
+export function sanitizeVirtualPreviewHomePath(
+  homePath: string | null | undefined,
+): string | null {
+  if (typeof homePath !== "string") {
+    return null;
+  }
+  const trimmed = homePath.trim().replace(/\\/g, "/");
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.includes("://") || /^[a-zA-Z]:/.test(trimmed)) {
+    return null;
+  }
+  const parts = trimmed.split("/").filter((seg) => seg.length > 0);
+  if (parts.length === 0) {
+    return null;
+  }
+  if (parts.some((seg) => seg === ".." || seg === ".")) {
+    return null;
+  }
+  return parts.join("/");
+}

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -29,6 +29,30 @@ export function shouldShowVirtualBuildChrome(
 }
 
 /**
+ * Trim and drop empty {@code linkProblems} lines from a build result.
+ * HTTP 200 + {@code hasLinkProblems} is still a completed build — this is
+ * presentation only (same text as {@code link-report.txt}).
+ */
+export function normalizeVirtualSiteLinkProblems(
+  result: VirtualSiteBuildResult | null | undefined,
+): string[] {
+  if (!result || !Array.isArray(result.linkProblems)) {
+    return [];
+  }
+  const lines: string[] = [];
+  for (const raw of result.linkProblems) {
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const line = raw.trim();
+    if (line.length > 0) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+/**
  * Build a short operator-facing success summary from a build result DTO.
  * Pure helper for Vitest and the panel (no i18n — callers prefix labels).
  */
@@ -37,6 +61,7 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
   outputLine: string | null;
   linkLine: string | null;
   hasLinkProblems: boolean;
+  linkProblems: string[];
 } {
   const pages =
     typeof result.pagesWritten === "number" && Number.isFinite(result.pagesWritten)
@@ -49,21 +74,22 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
       ? result.outputPath.trim()
       : null;
 
+  const linkProblems = normalizeVirtualSiteLinkProblems(result);
   const linkCount =
     typeof result.linkProblemCount === "number" && Number.isFinite(result.linkProblemCount)
       ? result.linkProblemCount
       : 0;
   const hasLinkProblems =
-    result.hasLinkProblems === true ||
-    linkCount > 0 ||
-    (Array.isArray(result.linkProblems) && result.linkProblems.length > 0);
+    result.hasLinkProblems === true || linkCount > 0 || linkProblems.length > 0;
 
-  const linkLine = hasLinkProblems ? String(linkCount > 0 ? linkCount : result.linkProblems?.length ?? 0) : null;
+  const resolvedCount = linkCount > 0 ? linkCount : linkProblems.length;
+  const linkLine = hasLinkProblems ? String(resolvedCount) : null;
 
   return {
     pagesLine,
     outputLine: output,
     linkLine,
     hasLinkProblems,
+    linkProblems,
   };
 }

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -6,10 +6,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
   buildVirtualSite,
+  getVirtualSitePreviewStatus,
   getVirtualSiteProperties,
   parseVirtualSiteBuildResult,
+  parseVirtualSitePreviewStatus,
   parseVirtualSiteProperties,
   updateVirtualSiteProperties,
+  virtualSitePreviewContentHref,
 } from "../../../../main/ts/api/developer/sitesApi";
 
 vi.mock("../../../../main/ts/api/client", () => ({
@@ -146,5 +149,37 @@ describe("sitesApi virtual properties", () => {
       expect.stringMatching(/\/sites\/Help\/virtual\/build$/),
       { outputRoot: "C:/custom/out" },
     );
+  });
+
+  it("parseVirtualSitePreviewStatus handles wrap and missing payload", () => {
+    expect(
+      parseVirtualSitePreviewStatus({
+        available: true,
+        homePath: "8.2/index.html",
+      }),
+    ).toEqual(
+      expect.objectContaining({ available: true, homePath: "8.2/index.html" }),
+    );
+    expect(
+      parseVirtualSitePreviewStatus({
+        VirtualSitePreviewStatus: { available: false, message: "none" },
+      }),
+    ).toEqual(expect.objectContaining({ available: false, message: "none" }));
+    expect(parseVirtualSitePreviewStatus(null)).toEqual({});
+  });
+
+  it("getVirtualSitePreviewStatus GETs /virtual/preview", async () => {
+    get.mockResolvedValue({ available: false, message: "none" });
+    const out = await getVirtualSitePreviewStatus("Help Docs");
+    expect(get).toHaveBeenCalledWith(
+      expect.stringMatching(/\/sites\/Help%20Docs\/virtual\/preview$/),
+    );
+    expect(out.available).toBe(false);
+  });
+
+  it("virtualSitePreviewContentHref encodes site and relative home", () => {
+    const href = virtualSitePreviewContentHref("Help Docs", "8.2/index.html");
+    expect(href).toMatch(/\/sites\/Help%20Docs\/virtual\/preview\/8.2\/index.html$/);
+    expect(virtualSitePreviewContentHref("Help", "../secret")).not.toContain("..");
   });
 });

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as sitesApi from "../../../main/ts/api/developer/sitesApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
+import * as sourceViewer from "../../../main/ts/developer/templateSourceViewer";
 import { VirtualSiteSourcePanel } from "../../../main/ts/developer/VirtualSiteSourcePanel";
 
 vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
@@ -232,6 +233,61 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-build-output").textContent).toContain(
       "product-docs",
     );
+    expect(screen.queryByTestId("developer-site-virtual-build-link-problems")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build-link-list")).toBeNull();
+  });
+
+  it("lists link problem details on HTTP 200 with hasLinkProblems", async () => {
+    const copySpy = vi.spyOn(sourceViewer, "copyTextToClipboard").mockResolvedValue(true);
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    buildVirtual.mockResolvedValue({
+      siteName: "Help",
+      siteKey: "product-docs",
+      outputPath: "C:/tmp/virtual-sites/product-docs",
+      pagesWritten: 4,
+      linkProblemCount: 2,
+      hasLinkProblems: true,
+      linkProblems: [
+        "broken id:missing-page from 8.2/index.md",
+        "  unresolved relative ./gone.md  ",
+      ],
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-result")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-build-success")).toBeTruthy();
+    expect(screen.getByTestId("developer-site-virtual-build-link-problems").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS,
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-link-problems").textContent).toContain(
+      "2",
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-link-report-hint").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_LINK_REPORT_HINT,
+    );
+    const lines = screen.getAllByTestId("developer-site-virtual-build-link-line");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].textContent).toBe("broken id:missing-page from 8.2/index.md");
+    expect(lines[1].textContent).toBe("unresolved relative ./gone.md");
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build-link-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-link-copied").textContent).toContain(
+        DEV_MSG.SITE_VIRT_BUILD_LINK_COPIED,
+      );
+    });
+    expect(copySpy).toHaveBeenCalledWith(
+      "broken id:missing-page from 8.2/index.md\nunresolved relative ./gone.md",
+    );
+    copySpy.mockRestore();
   });
 
   it("surfaces build API errors", async () => {

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -13,6 +13,10 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   getVirtualSiteProperties: vi.fn(),
   updateVirtualSiteProperties: vi.fn(),
   buildVirtualSite: vi.fn(),
+  getVirtualSitePreviewStatus: vi.fn(),
+  virtualSitePreviewContentHref: vi.fn(
+    (name: string, home: string) => `/services/sites/${encodeURIComponent(name)}/virtual/preview/${home}`,
+  ),
   listSites: vi.fn(),
   SITE_DESIGN_GAPS: [],
 }));
@@ -20,6 +24,7 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
 const getVirtual = sitesApi.getVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const updateVirtual = sitesApi.updateVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const buildVirtual = sitesApi.buildVirtualSite as ReturnType<typeof vi.fn>;
+const previewStatus = sitesApi.getVirtualSitePreviewStatus as ReturnType<typeof vi.fn>;
 
 describe("VirtualSiteSourcePanel", () => {
   beforeEach(() => {
@@ -29,6 +34,7 @@ describe("VirtualSiteSourcePanel", () => {
     getVirtual.mockReset();
     updateVirtual.mockReset();
     buildVirtual.mockReset();
+    previewStatus.mockReset();
   });
 
   it("shows loading then success form for traditional (repository) site", async () => {
@@ -51,6 +57,7 @@ describe("VirtualSiteSourcePanel", () => {
     // Repository sites must not show Build chrome
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
     expect(getVirtual).toHaveBeenCalledWith("Corporate");
   });
 
@@ -298,5 +305,54 @@ describe("VirtualSiteSourcePanel", () => {
       );
     });
     expect(buildVirtual).not.toHaveBeenCalled();
+  });
+
+  it("shows Preview chrome for virtual sites and opens home when available", async () => {
+    const open = vi.fn();
+    window.open = open;
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    previewStatus.mockResolvedValue({
+      available: true,
+      homePath: "8.2/index.html",
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
+    await waitFor(() => {
+      expect(open).toHaveBeenCalled();
+    });
+    expect(previewStatus).toHaveBeenCalledWith("Help");
+    expect(String(open.mock.calls[0][0])).toContain("8.2/index.html");
+    expect(open.mock.calls[0][1]).toBe("_blank");
+  });
+
+  it("shows empty preview state when no assembled site exists", async () => {
+    window.open = vi.fn();
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    previewStatus.mockResolvedValue({
+      available: false,
+      message: "No assembled Virtual Site to preview. Run Build Virtual Site first.",
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview-error").textContent).toContain(
+        "No assembled",
+      );
+    });
+    expect(window.open).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatVirtualSiteBuildSummary,
+  normalizeVirtualSiteLinkProblems,
   shouldShowVirtualBuildChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
@@ -29,6 +30,7 @@ describe("virtualSiteBuild helpers", () => {
     expect(clean.outputLine).toBe("C:/tmp/out");
     expect(clean.hasLinkProblems).toBe(false);
     expect(clean.linkLine).toBeNull();
+    expect(clean.linkProblems).toEqual([]);
 
     const dirty = formatVirtualSiteBuildSummary({
       pagesWritten: 2,
@@ -41,10 +43,21 @@ describe("virtualSiteBuild helpers", () => {
     expect(dirty.outputLine).toBe("/docs/out");
     expect(dirty.hasLinkProblems).toBe(true);
     expect(dirty.linkLine).toBe("3");
+    expect(dirty.linkProblems).toEqual(["a", "b", "c"]);
 
     const missing = formatVirtualSiteBuildSummary({});
     expect(missing.pagesLine).toBe("0");
     expect(missing.outputLine).toBeNull();
     expect(missing.hasLinkProblems).toBe(false);
+    expect(missing.linkProblems).toEqual([]);
+  });
+
+  it("normalizeVirtualSiteLinkProblems drops blanks and non-strings", () => {
+    expect(normalizeVirtualSiteLinkProblems(null)).toEqual([]);
+    expect(
+      normalizeVirtualSiteLinkProblems({
+        linkProblems: ["  missing id:foo  ", "", "   ", "ok", 7 as unknown as string],
+      }),
+    ).toEqual(["missing id:foo", "ok"]);
   });
 });

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatVirtualSiteBuildSummary,
+  sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
@@ -46,5 +47,15 @@ describe("virtualSiteBuild helpers", () => {
     expect(missing.pagesLine).toBe("0");
     expect(missing.outputLine).toBeNull();
     expect(missing.hasLinkProblems).toBe(false);
+  });
+
+  it("sanitizeVirtualPreviewHomePath rejects traversal and absolute paths", () => {
+    expect(sanitizeVirtualPreviewHomePath("8.2/index.html")).toBe("8.2/index.html");
+    expect(sanitizeVirtualPreviewHomePath(" /8.2/admin/index.html ")).toBe("8.2/admin/index.html");
+    expect(sanitizeVirtualPreviewHomePath("../etc/passwd")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("C:/tmp/out/index.html")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("https://evil.example/x")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath("")).toBeNull();
+    expect(sanitizeVirtualPreviewHomePath(null)).toBeNull();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -49,6 +49,9 @@ function developerSectionUrl(section) {
 test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.__virtPageErrors = pageErrors;
     await loginAsAdmin(page);
   });
 
@@ -127,7 +130,19 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-preview-hint"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-hint"]')).toBeVisible();
+
+      // Preview without a last build: in-panel empty/error (no 500 / no crash)
+      await page.locator('[data-testid="developer-site-virtual-preview"]').click();
+      const previewChrome = page.locator(
+        [
+          '[data-testid="developer-site-virtual-preview-error"]',
+          '[data-testid="developer-site-virtual-build-error"]',
+        ].join(", "),
+      );
+      await expect(previewChrome.first()).toBeVisible({ timeout: 20_000 });
 
       // Optional: click Build without save — expect client validation or API error chrome
       // (H2 QA rarely has a saved virtual root; do not require full build success)
@@ -145,5 +160,8 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     }
+
+    const jsErrors = page.__virtPageErrors || [];
+    expect(jsErrors, `uncaught page errors: ${jsErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Developer Sites → Virtual Site source panel (#2956 / #3020 / epic #2678).
+ * Developer Sites → Virtual Site source panel (#2956 / #3020 / #3300 / epic #2678).
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
  * with source-kind control (repository default), save chrome, and Build Virtual
  * Site chrome only when source kind is virtual (never for repository).
+ * Also intercepts build REST to prove link-problem detail lines render on HTTP 200.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -145,5 +146,141 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     }
+  });
+
+  test("build result lists linkProblems on HTTP 200", async ({ page }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      // Mocked catalog site has no GUID; ACL GET 404 is expected host noise, not a JS exception.
+      if (/Failed to load resource:.*404/.test(text)) {
+        return;
+      }
+      consoleErrors.push(text);
+    });
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual/build", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          siteName: "Help",
+          siteKey: "product-docs",
+          outputPath: "C:/tmp/virtual-sites/product-docs",
+          pagesWritten: 3,
+          linkProblemCount: 2,
+          hasLinkProblems: true,
+          linkProblems: [
+            "broken id:missing-page from 8.2/index.md",
+            "unresolved relative ./gone.md",
+          ],
+        }),
+      });
+    });
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/virtual/build")) {
+        await route.fallback();
+        return;
+      }
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sourceKind: "git-filesystem",
+          rootPath: "C:/docs",
+          configFile: "_config.yaml",
+          siteKey: "product-docs",
+          virtual: true,
+        }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const empty = page.locator('[data-testid="developer-site-empty"]');
+    if (await empty.isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — Virtual Site link-problem list requires a site row",
+      });
+      return;
+    }
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.locator('[data-testid="developer-site-virtual-build"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-result"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build-success"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-problems"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]'),
+    ).toHaveCount(2);
+    await page.locator('[data-testid="developer-site-virtual-build-link-toggle"]').click();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]').nth(0),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-site-virtual-build-link-line"]').nth(0),
+    ).toHaveText("broken id:missing-page from 8.2/index.md");
+    expect(consoleErrors).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -34,7 +34,32 @@ channels (static files, FTP, database, custom locations).
 For Git/filesystem Virtual Sites such as product documentation:
 
 - Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session.
-- Runtime virtual assemble paths (when configured on a Site) participate in normal Site-level publishing configuration where applicable.
+- **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
+  `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`).
+- **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
+  assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
+  publishing root). Staging `_meta` files are not copied.
+
+### Publish a Virtual Site to the Site filesystem target
+
+1. Sign in as **Admin**.
+2. Configure the Site as a Git-filesystem Virtual Site (see [Sites](id:admin-sites)).
+3. Set the Site **publishing filesystem root** (Site root) to a dedicated directory on the CMS
+   host. Do **not** point it at `virtual.rootPath` (the Markdown source tree).
+4. Confirm the source root exists on the host and that the publish directory is writable.
+5. Call `POST /services/sites/{nameOrId}/virtual/publish` (or run **Build Virtual Site** first if
+   you only want staging output).
+6. On success, the JSON result includes `publishPath`, `filesCopied`, `pagesWritten`, and any
+   link problems (`hasLinkProblems` can be true with HTTP 200).
+7. Spot-check `index.html` (and version folders such as `8.2/`) under the Site root.
+
+**Clear operator errors (HTTP 400, not a silent no-op):**
+
+- Site is not Virtual (`virtual.sourceKind` blank or `repository`)
+- Site filesystem publish root is not configured
+- Publish root is unsafe (`..` after normalize) or is a file rather than a directory
+- Publish root overlaps `virtual.rootPath` or the build staging tree
+- Caller is not Admin (403)
 
 See [Virtual Sites](id:developer-virtual-sites) and [Build product docs](id:developer-build-source#product-docs-build).
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -132,6 +132,25 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
    - **Error** — clear message when the Site is not virtual, the root is missing/invalid,
      or the caller lacks Admin (for example 400/403 from REST).
 
+### Preview the assembled Virtual Site
+
+After a successful **Build Virtual Site**, operators can open the assembled documentation
+home from the same Site detail panel (no CLI, no `file://` path).
+
+1. Stay on **Developer → Sites → Site detail** for the Virtual Site (Admin).
+2. Choose **Preview assembled site**.
+3. The CMS opens the last build’s home (typically `8.2/index.html`, or root `index.html`
+   when present) in a new tab. Navigation stays on the same-origin preview URL
+   (`GET /services/sites/{name}/virtual/preview/{path}`).
+4. If no build has been run yet (or the last output is missing), the panel shows a clear
+   empty state — **No assembled site to preview. Run Build Virtual Site first.** — and
+   does not return HTTP 500.
+
+The preview stream reads the last recorded `outputPath` from the build (default
+`{install}/tmp/virtual-sites/{siteKey}`). It is **Admin-only**, path-traversal safe, and
+does not invent a second assembler. Traditional **Repository** Sites do not show Preview
+chrome.
+
 Integrators can call the same operation over REST:
 `POST /sites/{nameOrId}/virtual/build` (optional JSON body `outputRoot`). See
 [Site configuration reference](id:reference-site-config) and

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -137,6 +137,20 @@ Integrators can call the same operation over REST:
 [Site configuration reference](id:reference-site-config) and
 [Virtual Sites (developer)](id:developer-virtual-sites).
 
+### Publish a Virtual Site to the Site filesystem target
+
+Build output under `{install}/tmp/virtual-sites/` is **staging**. To deliver a navigable static
+site to the Site's configured filesystem publish location:
+
+1. Set the Site **publishing filesystem root** (Site root / `IPSSite.root`) to a dedicated
+   directory on the CMS host (not the Markdown `virtual.rootPath`).
+2. As **Admin**, call `POST /sites/{nameOrId}/virtual/publish`.
+3. The server **builds then copies** HTML/assets to that Site root and returns `publishPath`
+   and `filesCopied`. Missing or unsafe Site root, overlap with the source tree, or a
+   non-virtual Site returns **400** with a readable message (not HTTP 500 / silent no-op).
+
+See [Publishing](id:admin-publishing) for the operator checklist.
+
 Offline scripts (`scripts/build-cms-docs.*`) remain available for developer workstations
 without a running CMS.
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -127,8 +127,12 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
 5. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).
-   - **Link problems** — reported in the result panel when internal links fail
-     (the build may still complete with HTTP 200).
+   - **Link problems** — a count appears when internal `id:` or relative links fail.
+     Expand **Show link problem details** to read the same lines written to
+     `link-report.txt` in the output directory. **Copy link problems** puts those
+     lines on the clipboard. The build still completes with HTTP 200
+     (`hasLinkProblems=true`); this is not a 500 and is not a failed save.
+     A clean build does **not** show a link-problem banner.
    - **Error** — clear message when the Site is not virtual, the root is missing/invalid,
      or the caller lacks Admin (for example 400/403 from REST).
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -109,6 +109,7 @@ Example create body:
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
 only empty-catalog case. See [Sites & content structure](id:admin-sites).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -109,6 +109,8 @@ Example create body:
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+| Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
+| Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
 only empty-catalog case. See [Sites & content structure](id:admin-sites).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -128,6 +128,12 @@ The body is optional. Without `outputRoot`, the server writes under
 `pagesWritten`, link problems, and the absolute `outputPath`. Traditional repository Sites and
 invalid/missing virtual configuration return **400**.
 
+A successful assemble with unresolved internal links still returns **HTTP 200** with
+`hasLinkProblems=true` and a `linkProblems` array (the same lines as `link-report.txt` under
+the output root). The Sites UI lists those lines in an expandable **Link problems** block so
+operators do not have to open the report file on the server. Do not treat that 200 as a
+server error.
+
 Operators can run the same operation from **Developer → Sites → Site detail → Build Virtual Site**
 (visible only when source kind is Virtual). Save Virtual Site source before building so the server
 uses the latest properties. See [Sites & content structure](id:admin-sites) and

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -133,6 +133,27 @@ Operators can run the same operation from **Developer → Sites → Site detail 
 uses the latest properties. See [Sites & content structure](id:admin-sites) and
 [Site configuration](id:reference-site-config).
 
+## CMS-integrated publish (Site filesystem target)
+
+Build writes a **staging** tree. To publish that tree to the Site's configured filesystem
+location (`IPSSite.root` / Site publishing root), an **Admin** calls:
+
+```http
+POST /sites/{nameOrId}/virtual/publish
+```
+
+The server:
+
+1. Validates the Site is a Git-filesystem Virtual Site.
+2. Selects the Site filesystem publish root (must be configured, safe after NIO normalize, and
+   distinct from `virtual.rootPath`).
+3. Runs the same build as `POST …/virtual/build`.
+4. Copies assembled HTML/assets (not `_meta`) to the Site root using portable `java.nio.file.Path`.
+
+The response includes `publishPath`, `buildOutputPath`, `pagesWritten`, `filesCopied`, and
+link-problem fields. Failures return **400/403/404** with an operator-readable message (never a
+silent no-op). See [Publishing](id:admin-publishing).
+
 ## What is not in Phase 1
 
 - CMS UI editing of Virtual items as normal content types

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -130,7 +130,12 @@ invalid/missing virtual configuration return **400**.
 
 Operators can run the same operation from **Developer → Sites → Site detail → Build Virtual Site**
 (visible only when source kind is Virtual). Save Virtual Site source before building so the server
-uses the latest properties. See [Sites & content structure](id:admin-sites) and
+uses the latest properties.
+
+After a successful build, **Preview assembled site** opens the last output home in a new tab
+(`GET /sites/{nameOrId}/virtual/preview` for status; `GET …/virtual/preview/{relPath}` for the
+assembled file stream). Missing output returns status `available=false` (HTTP 200) or file HTTP
+404 — not 500. See [Sites & content structure](id:admin-sites) and
 [Site configuration](id:reference-site-config).
 
 ## What is not in Phase 1

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -70,6 +70,7 @@ Integrators can read and write these keys via public Site REST:
 - `GET /sites/{nameOrId}/virtual`
 - `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
 - `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
+- `POST /sites/{nameOrId}/virtual/publish` (build then copy to Site filesystem root)
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable
@@ -94,6 +95,20 @@ the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
 Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+
+#### Publish Virtual Site (`POST …/virtual/publish`)
+
+Runs the same build, then copies the assembled tree to the Site **filesystem publish location**
+(`IPSSite.root`). Requires **Admin**. Staging `_meta` is not copied.
+
+| Status | When |
+|--------|------|
+| `200` | Published; response includes `publishPath`, `filesCopied`, `pagesWritten`, `hasLinkProblems` |
+| `400` | Not a Virtual Site, Site root missing/unsafe/not a directory, or overlap with `virtual.rootPath` / build output |
+| `403` | Caller is not Admin |
+| `404` | Site not found |
+
+Configure a dedicated Site root (not the Markdown source path). See [Publishing](id:admin-publishing).
 
 ## Related
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -93,7 +93,10 @@ unavailable). Link problems are reported in the JSON result (and in `link-report
 the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
-Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+Virtual (never for traditional repository Sites). When `hasLinkProblems` is true, the result
+panel shows the problem **count** and an expandable list of `linkProblems` (same text as
+`link-report.txt`). A clean build does not show that banner. See
+[Sites & content structure](id:admin-sites).
 
 ## Related
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -70,6 +70,8 @@ Integrators can read and write these keys via public Site REST:
 - `GET /sites/{nameOrId}/virtual`
 - `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
 - `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
+- `GET /sites/{nameOrId}/virtual/preview` (last-build preview status)
+- `GET /sites/{nameOrId}/virtual/preview/{relPath}` (assembled file stream)
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable
@@ -94,6 +96,17 @@ the output root) without failing the HTTP status when the build itself succeeds.
 
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
 Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
+
+#### Preview assembled Virtual Site (`GET …/virtual/preview`)
+
+Admin-only. Reports whether the last build output can be opened (`available`, `homePath`,
+`outputPath`). Missing or failed builds return **200** with `available=false` and a message
+(not 500). Traditional repository Sites return **400**.
+
+`GET …/virtual/preview/{relPath}` streams one file from that last output root (portable NIO
+resolution, no `..` after normalize). HTML root-relative `href`/`src` values are rewritten to
+the preview prefix so the assembled site is navigable in the browser. Missing files return
+**404**. The Developer UI **Preview assembled site** control uses these endpoints.
 
 ## Related
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -66,7 +66,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -610,7 +609,10 @@ public class SitesAdaptor implements ISiteAdaptor {
           safeOut.toString(),
           StandardCharsets.UTF_8); // codeql[java/path-injection]
     } catch (RuntimeException | IOException e) {
-      log.debug("Could not record last Virtual Site output path: {}", e.getMessage());
+      log.warn(
+          "Could not record last Virtual Site output path for site '{}': {}",
+          siteKey,
+          e.getMessage());
     }
   }
 
@@ -659,8 +661,11 @@ public class SitesAdaptor implements ISiteAdaptor {
           dirs.add(p);
         }
       }
-      dirs.sort(Comparator.comparing(p -> p.getFileName().toString()));
+      dirs.sort(SitesAdaptor::compareHomeCandidateDirectories);
       for (Path dir : dirs) {
+        if (isSkippedHomeDirectory(dir)) {
+          continue;
+        }
         Path idx = dir.resolve("index.html");
         if (Files.isRegularFile(idx)) {
           return toWirePath(root, idx);
@@ -670,6 +675,74 @@ public class SitesAdaptor implements ISiteAdaptor {
       return null;
     }
     return null;
+  }
+
+  /** Skip assembler sidecar dirs that are never a product-docs home. */
+  static boolean isSkippedHomeDirectory(Path dir) {
+    Path name = dir == null ? null : dir.getFileName();
+    return name != null && "_meta".equals(name.toString());
+  }
+
+  /**
+   * Version directories ({@code 8.2}, {@code 10.0}) newest-first; other names last,
+   * alphabetically. Avoids lexical {@code 10.0} before {@code 9.0}.
+   */
+  static int compareHomeCandidateDirectories(Path left, Path right) {
+    String a = fileNameOrEmpty(left);
+    String b = fileNameOrEmpty(right);
+    int[] va = parseDottedVersionParts(a);
+    int[] vb = parseDottedVersionParts(b);
+    if (va != null && vb != null) {
+      int n = Math.max(va.length, vb.length);
+      for (int i = 0; i < n; i++) {
+        int ai = i < va.length ? va[i] : 0;
+        int bi = i < vb.length ? vb[i] : 0;
+        int cmp = Integer.compare(bi, ai);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+      return 0;
+    }
+    if (va != null) {
+      return -1;
+    }
+    if (vb != null) {
+      return 1;
+    }
+    return a.compareTo(b);
+  }
+
+  static int[] parseDottedVersionParts(String name) {
+    if (name == null || name.isEmpty()) {
+      return null;
+    }
+    String[] bits = name.split("\\.", -1);
+    int[] parts = new int[bits.length];
+    for (int i = 0; i < bits.length; i++) {
+      String bit = bits[i];
+      if (bit.isEmpty()) {
+        return null;
+      }
+      for (int c = 0; c < bit.length(); c++) {
+        if (!Character.isDigit(bit.charAt(c))) {
+          return null;
+        }
+      }
+      try {
+        parts[i] = Integer.parseInt(bit);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return parts;
+  }
+
+  private static String fileNameOrEmpty(Path path) {
+    if (path == null || path.getFileName() == null) {
+      return "";
+    }
+    return path.getFileName().toString();
   }
 
   static Path resolvePreviewFile(Path outputRoot, String relativePath) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -26,6 +26,7 @@ import com.percussion.rest.sites.SiteList;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
 import com.percussion.rest.sites.VirtualSiteProperties;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.server.PSServer;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -38,7 +39,9 @@ import com.percussion.services.virtualsite.PSGitFilesystemVirtualSiteSource;
 import com.percussion.services.virtualsite.PSInMemoryVirtualParticipantService;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildService;
+import com.percussion.services.virtualsite.PSVirtualSiteFilesystemPublisher;
 import com.percussion.services.virtualsite.PSVirtualSiteHelper;
+import com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult;
 import com.percussion.services.virtualsite.VirtualSiteConfig;
 import com.percussion.services.virtualsite.VirtualSiteConfigLoader;
 import com.percussion.services.virtualsite.VirtualSiteException;
@@ -371,6 +374,69 @@ public class SitesAdaptor implements ISiteAdaptor {
     }
   }
 
+  @Override
+  public VirtualSitePublishResult publishVirtualSite(String nameOrId) {
+    requireAdmin();
+    IPSSite site = requireSite(nameOrId);
+
+    if (!PSVirtualSiteHelper.isVirtual(site)) {
+      throw new WebApplicationException(
+          "Site '"
+              + site.getName()
+              + "' is not a Virtual Site (virtual.sourceKind is blank or '"
+              + PSVirtualSiteHelper.SOURCE_KIND_REPOSITORY
+              + "'). Configure virtual.* properties before publishing.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    Path publishRoot;
+    try {
+      publishRoot = PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+    Path safePublishRoot = requireSafeOutputRoot(publishRoot);
+
+    VirtualSiteBuildResult built = buildVirtualSite(nameOrId, null);
+    Path buildOutput =
+        built.getOutputPath()
+            .filter(StringUtils::isNotBlank)
+            .map(Path::of)
+            .orElseThrow(
+                () ->
+                    new WebApplicationException(
+                        "Virtual Site build did not report an output path.",
+                        Response.Status.INTERNAL_SERVER_ERROR));
+
+    try {
+      PSVirtualSitePublishCopyResult copied =
+          PSVirtualSiteFilesystemPublisher.copyBuildToTarget(buildOutput, safePublishRoot);
+      return toWirePublishResult(site.getName(), PSVirtualSiteHelper.siteKey(site), built, copied);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (IOException e) {
+      log.error(
+          "Virtual Site publish I/O failed for '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(
+          "Virtual Site publish failed: " + e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Virtual Site publish failed for '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(
+          "Virtual Site publish failed: " + e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
   private PSVirtualSiteBuildResult runBuild(
       VirtualSiteConfig config, Path outputRoot, Path metaDir) throws Exception {
     if (buildRunner != null) {
@@ -443,11 +509,11 @@ public class SitesAdaptor implements ISiteAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to build Virtual Sites", Response.Status.FORBIDDEN);
+          "Admin role required to build or publish Virtual Sites", Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to build Virtual Sites", Response.Status.FORBIDDEN);
+          "Admin role required to build or publish Virtual Sites", Response.Status.FORBIDDEN);
     }
   }
 
@@ -545,6 +611,28 @@ public class SitesAdaptor implements ISiteAdaptor {
     dto.setHasLinkProblems(!problems.isEmpty());
     dto.setLinkProblems(truncate(problems, MAX_RESULT_LINES));
     dto.setWrittenFiles(truncate(built.writtenFiles(), MAX_RESULT_LINES));
+    return dto;
+  }
+
+  static VirtualSitePublishResult toWirePublishResult(
+      String siteName,
+      String siteKey,
+      VirtualSiteBuildResult built,
+      PSVirtualSitePublishCopyResult copied) {
+    VirtualSitePublishResult dto = new VirtualSitePublishResult();
+    dto.setSiteName(siteName);
+    dto.setSiteKey(siteKey);
+    if (copied != null && copied.publishRoot() != null) {
+      dto.setPublishPath(copied.publishRoot().toAbsolutePath().normalize().toString());
+    }
+    if (built != null) {
+      built.getOutputPath().ifPresent(dto::setBuildOutputPath);
+      dto.setPagesWritten(built.getPagesWritten());
+      dto.setLinkProblemCount(built.getLinkProblemCount());
+      dto.setHasLinkProblems(built.getHasLinkProblems());
+      dto.setLinkProblems(built.getLinkProblems());
+    }
+    dto.setFilesCopied(copied != null ? copied.filesCopied() : 0);
     return dto;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -25,6 +25,8 @@ import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.SiteList;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewFile;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
 import com.percussion.rest.sites.VirtualSiteProperties;
 import com.percussion.server.PSServer;
 import com.percussion.services.error.PSNotFoundException;
@@ -55,11 +57,15 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -80,6 +86,14 @@ public class SitesAdaptor implements ISiteAdaptor {
 
   /** Max link-problem / written-file lines returned on the wire (full report is on disk). */
   static final int MAX_RESULT_LINES = 200;
+
+  /** Sidecar under default output {@code _meta} pointing at the last successful build root. */
+  static final String LAST_OUTPUT_POINTER_FILE = "last-output-root.txt";
+
+  static final String MISSING_PREVIEW_MESSAGE =
+      "No assembled Virtual Site to preview. Run Build Virtual Site first.";
+
+  static final long MAX_PREVIEW_FILE_BYTES = 20L * 1024 * 1024;
 
   @Autowired private IPSPublishingWs publishingWs;
 
@@ -345,6 +359,7 @@ public class SitesAdaptor implements ISiteAdaptor {
 
       VirtualSiteConfig config = VirtualSiteConfigLoader.load(siteRoot, configFile, siteKey);
       PSVirtualSiteBuildResult built = runBuild(config, outputRoot, metaDir);
+      recordLastOutputRoot(siteKey, outputRoot);
       return toWireResult(site.getName(), siteKey, built);
     } catch (VirtualSiteException e) {
       throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
@@ -432,6 +447,258 @@ public class SitesAdaptor implements ISiteAdaptor {
         .ifPresent(v::setSiteKey);
     v.setVirtual(PSVirtualSiteHelper.isVirtual(site));
     return v;
+  }
+
+  @Override
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId) {
+    IPSSite site = requireVirtualAdminSite(nameOrId);
+    String siteKey = PSVirtualSiteHelper.siteKey(site);
+    Path outputRoot = resolveLastOutputRoot(siteKey);
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    if (outputRoot != null) {
+      status.setOutputPath(outputRoot.toAbsolutePath().normalize().toString());
+    }
+    String home = outputRoot == null ? null : findHomeRelativePath(outputRoot);
+    if (home == null) {
+      status.setAvailable(false);
+      status.setMessage(MISSING_PREVIEW_MESSAGE);
+      return status;
+    }
+    status.setAvailable(true);
+    status.setHomePath(home);
+    return status;
+  }
+
+  @Override
+  public VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath) {
+    IPSSite site = requireVirtualAdminSite(nameOrId);
+    String siteKey = PSVirtualSiteHelper.siteKey(site);
+    Path outputRoot = resolveLastOutputRoot(siteKey);
+    if (outputRoot == null || !Files.isDirectory(outputRoot)) {
+      throw new WebApplicationException(MISSING_PREVIEW_MESSAGE, Response.Status.NOT_FOUND);
+    }
+    String rel = blankToNull(relativePath);
+    if (rel == null) {
+      String home = findHomeRelativePath(outputRoot);
+      if (home == null) {
+        throw new WebApplicationException(MISSING_PREVIEW_MESSAGE, Response.Status.NOT_FOUND);
+      }
+      rel = home;
+    }
+    Path file = resolvePreviewFile(outputRoot, rel);
+    if (file == null) {
+      throw new WebApplicationException(
+          "Preview file not found: " + rel, Response.Status.NOT_FOUND);
+    }
+    try {
+      long size = Files.size(file); // codeql[java/path-injection]
+      if (size > MAX_PREVIEW_FILE_BYTES) {
+        throw new WebApplicationException(
+            "Preview file is too large to stream", Response.Status.BAD_REQUEST);
+      }
+      byte[] bytes = Files.readAllBytes(file); // codeql[java/path-injection]
+      return new VirtualSitePreviewFile(mediaTypeFor(file), toWirePath(outputRoot, file), bytes);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IOException e) {
+      throw new WebApplicationException(
+          "Could not read preview file", Response.Status.NOT_FOUND);
+    }
+  }
+
+  /**
+   * Admin + Virtual Site gate shared by preview status/file (missing output is handled by callers).
+   */
+  IPSSite requireVirtualAdminSite(String nameOrId) {
+    requireAdmin();
+    IPSSite site = requireSite(nameOrId);
+    if (!PSVirtualSiteHelper.isVirtual(site)) {
+      throw new WebApplicationException(
+          "Site '"
+              + site.getName()
+              + "' is not a Virtual Site (virtual.sourceKind is blank or '"
+              + PSVirtualSiteHelper.SOURCE_KIND_REPOSITORY
+              + "'). Configure virtual.* properties before previewing.",
+          Response.Status.BAD_REQUEST);
+    }
+    try {
+      PSVirtualSiteHelper.validate(site);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+    return site;
+  }
+
+  /**
+   * Persist the last successful build output root so preview can reuse {@code result.outputPath}
+   * (including custom {@code outputRoot}).
+   */
+  void recordLastOutputRoot(String siteKey, Path outputRoot) {
+    Path pointerDir =
+        defaultOutputRootResolver.apply(safePathSegment(siteKey)).resolve("_meta");
+    try {
+      Path safeOut = requireSafeOutputRoot(outputRoot.toAbsolutePath().normalize());
+      Files.createDirectories(pointerDir); // codeql[java/path-injection]
+      Files.writeString(
+          pointerDir.resolve(LAST_OUTPUT_POINTER_FILE),
+          safeOut.toString(),
+          StandardCharsets.UTF_8); // codeql[java/path-injection]
+    } catch (RuntimeException | IOException e) {
+      log.debug("Could not record last Virtual Site output path: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Last recorded output root when the pointer is a safe existing directory; otherwise the default
+   * output directory when it exists.
+   */
+  Path resolveLastOutputRoot(String siteKey) {
+    Path defaultRoot =
+        requireSafeOutputRoot(defaultOutputRootResolver.apply(safePathSegment(siteKey)));
+    Path pointer = defaultRoot.resolve("_meta").resolve(LAST_OUTPUT_POINTER_FILE);
+    if (Files.isRegularFile(pointer)) {
+      try {
+        String raw = Files.readString(pointer, StandardCharsets.UTF_8).trim(); // codeql[java/path-injection]
+        if (!raw.isEmpty()) {
+          Path candidate = Path.of(raw).toAbsolutePath().normalize();
+          if (PSVirtualSiteHelper.isSafeRootPath(candidate) && Files.isDirectory(candidate)) {
+            return candidate;
+          }
+        }
+      } catch (RuntimeException | IOException e) {
+        log.debug("Ignoring invalid last-output pointer: {}", e.getMessage());
+      }
+    }
+    if (Files.isDirectory(defaultRoot)) {
+      return defaultRoot;
+    }
+    return null;
+  }
+
+  static String findHomeRelativePath(Path outputRoot) {
+    if (outputRoot == null || !Files.isDirectory(outputRoot)) {
+      return null;
+    }
+    Path root = outputRoot.toAbsolutePath().normalize();
+    if (Files.isRegularFile(root.resolve("index.html"))) {
+      return "index.html";
+    }
+    if (Files.isRegularFile(root.resolve("8.2").resolve("index.html"))) {
+      return "8.2/index.html";
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+      List<Path> dirs = new ArrayList<>();
+      for (Path p : stream) {
+        if (Files.isDirectory(p)) {
+          dirs.add(p);
+        }
+      }
+      dirs.sort(Comparator.comparing(p -> p.getFileName().toString()));
+      for (Path dir : dirs) {
+        Path idx = dir.resolve("index.html");
+        if (Files.isRegularFile(idx)) {
+          return toWirePath(root, idx);
+        }
+      }
+    } catch (IOException e) {
+      return null;
+    }
+    return null;
+  }
+
+  static Path resolvePreviewFile(Path outputRoot, String relativePath) {
+    Path root = requireSafeOutputRoot(outputRoot.toAbsolutePath().normalize());
+    Path rel = requireSafeRelativePreviewPath(relativePath);
+    Path resolved = root.resolve(rel).normalize(); // codeql[java/path-injection]
+    if (!resolved.startsWith(root)) {
+      throw new WebApplicationException(
+          "Preview path is outside the build output", Response.Status.BAD_REQUEST);
+    }
+    if (Files.isDirectory(resolved)) {
+      Path index = resolved.resolve("index.html").normalize(); // codeql[java/path-injection]
+      if (!index.startsWith(root) || !Files.isRegularFile(index)) {
+        return null;
+      }
+      return index;
+    }
+    if (!Files.isRegularFile(resolved)) {
+      return null;
+    }
+    return resolved;
+  }
+
+  static Path requireSafeRelativePreviewPath(String relativePath) {
+    if (relativePath == null || relativePath.isBlank() || relativePath.indexOf('\0') >= 0) {
+      throw new WebApplicationException("Preview path is required", Response.Status.BAD_REQUEST);
+    }
+    String cleaned = relativePath.trim().replace('\\', '/');
+    while (cleaned.startsWith("/")) {
+      cleaned = cleaned.substring(1);
+    }
+    Path path;
+    try {
+      path = Path.of(cleaned).normalize();
+    } catch (InvalidPathException e) {
+      throw new WebApplicationException("Preview path is not valid", Response.Status.BAD_REQUEST);
+    }
+    if (path.isAbsolute()) {
+      throw new WebApplicationException(
+          "Preview path must be relative", Response.Status.BAD_REQUEST);
+    }
+    for (Path part : path) {
+      String name = part.toString();
+      if ("..".equals(name) || name.isEmpty()) {
+        throw new WebApplicationException(
+            "Preview path must not contain '..'", Response.Status.BAD_REQUEST);
+      }
+    }
+    return path;
+  }
+
+  static String toWirePath(Path outputRoot, Path file) {
+    Path root = outputRoot.toAbsolutePath().normalize();
+    Path resolved = file.toAbsolutePath().normalize();
+    Path rel = root.relativize(resolved);
+    return rel.toString().replace('\\', '/');
+  }
+
+  static String mediaTypeFor(Path file) {
+    String name = file.getFileName() != null ? file.getFileName().toString() : "";
+    String lower = name.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+      return "text/html; charset=UTF-8";
+    }
+    if (lower.endsWith(".css")) {
+      return "text/css; charset=UTF-8";
+    }
+    if (lower.endsWith(".js")) {
+      return "application/javascript; charset=UTF-8";
+    }
+    if (lower.endsWith(".json")) {
+      return "application/json; charset=UTF-8";
+    }
+    if (lower.endsWith(".svg")) {
+      return "image/svg+xml";
+    }
+    if (lower.endsWith(".png")) {
+      return "image/png";
+    }
+    if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+      return "image/jpeg";
+    }
+    if (lower.endsWith(".gif")) {
+      return "image/gif";
+    }
+    if (lower.endsWith(".woff2")) {
+      return "font/woff2";
+    }
+    if (lower.endsWith(".woff")) {
+      return "font/woff";
+    }
+    if (lower.endsWith(".txt")) {
+      return "text/plain; charset=UTF-8";
+    }
+    return "application/octet-stream";
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -32,6 +32,7 @@ import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
 import com.percussion.rest.sites.VirtualSiteProperties;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -367,6 +368,79 @@ class SitesAdaptorTest {
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(out.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(out.resolve("link-report.txt")));
+  }
+
+  @Test
+  void publishVirtualSite_rejectsRepositorySite() {
+    PSSite site = new PSSite();
+    site.setName("Corp");
+    site.setGUID(siteGuid);
+    site.setRoot(tempDir.resolve("pub").toString());
+    when(siteManager.findSite("Corp")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.publishVirtualSite("Corp"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("not a virtual"));
+  }
+
+  @Test
+  void publishVirtualSite_rejectsMissingSiteRoot() {
+    Path siteRoot = tempDir.resolve("src-no-root");
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toString());
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.publishVirtualSite("Help"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("not configured"));
+  }
+
+  @Test
+  void publishVirtualSite_forbiddenWhenNotAdmin() {
+    SitesAdaptor denied =
+        new SitesAdaptor(siteManager, () -> false, SitesAdaptor::defaultOutputRootForSiteKey, null);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.publishVirtualSite("Help"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void publishVirtualSite_buildsThenCopiesToSiteRoot() throws Exception {
+    Path siteRoot = createMinimalVirtualTree(tempDir.resolve("pub-src"));
+    Path staging = tempDir.resolve("pub-staging");
+    Path publishTo = tempDir.resolve("pub-target");
+
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    site.setRoot(publishTo.toString());
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "help-docs");
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    SitesAdaptor publishing =
+        new SitesAdaptor(siteManager, () -> true, key -> staging, null);
+
+    VirtualSitePublishResult result = publishing.publishVirtualSite("Help");
+    assertEquals("Help", result.getSiteName().orElse(null));
+    assertEquals("help-docs", result.getSiteKey().orElse(null));
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(result.getFilesCopied() >= 1);
+    assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
+    assertTrue(Files.isRegularFile(publishTo.resolve("8.2").resolve("index.html")));
+    assertTrue(Files.isRegularFile(staging.resolve("8.2").resolve("index.html")));
+    assertFalse(Files.exists(publishTo.resolve("_meta")));
+    assertTrue(result.getPublishPath().isPresent());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.when;
 import com.percussion.rest.sites.Site;
 import com.percussion.rest.sites.VirtualSiteBuildRequest;
 import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewFile;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
 import com.percussion.rest.sites.VirtualSiteProperties;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
@@ -412,6 +414,118 @@ class SitesAdaptorTest {
     VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
     req.setOutputRoot(out.toString());
     assertEquals(out, adaptor.resolveOutputRoot(req, "help").normalize());
+  }
+
+  @Test
+  void previewStatus_missingBuildIsUnavailableNot500() {
+    Path defaultOut = tempDir.resolve("preview-default-empty");
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+
+    VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.FALSE, status.getAvailable());
+    assertTrue(status.getMessage().orElse("").contains("No assembled"));
+  }
+
+  @Test
+  void previewStatus_findsVersionHomeAfterPointer() throws Exception {
+    Path defaultOut = tempDir.resolve("preview-default");
+    Path built = tempDir.resolve("preview-built");
+    Files.createDirectories(built.resolve("8.2"));
+    Files.writeString(built.resolve("8.2").resolve("index.html"), "<html>home</html>");
+
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+    previewing.recordLastOutputRoot("help-docs", built);
+
+    VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.TRUE, status.getAvailable());
+    assertEquals("8.2/index.html", status.getHomePath().orElse(null));
+  }
+
+  @Test
+  void previewFile_servesHtmlAndRejectsTraversal() throws Exception {
+    Path defaultOut = tempDir.resolve("preview-files");
+    Files.createDirectories(defaultOut.resolve("8.2"));
+    Files.writeString(
+        defaultOut.resolve("8.2").resolve("index.html"), "<html><a href=\"/8.2/x.html\">x</a>");
+
+    PSSite site = virtualHelpSite();
+    when(siteManager.findSite("Help")).thenReturn(site);
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+
+    VirtualSitePreviewFile file = previewing.previewVirtualSiteFile("Help", "8.2/index.html");
+    assertTrue(file.isHtml());
+    assertEquals("8.2/index.html", file.getRelativePath());
+    assertTrue(new String(file.getContent(), StandardCharsets.UTF_8).contains("href="));
+
+    WebApplicationException traversal =
+        assertThrows(
+            WebApplicationException.class,
+            () -> previewing.previewVirtualSiteFile("Help", "../secret.txt"));
+    assertEquals(400, traversal.getResponse().getStatus());
+
+    WebApplicationException missing =
+        assertThrows(
+            WebApplicationException.class,
+            () -> previewing.previewVirtualSiteFile("Help", "no-such.html"));
+    assertEquals(404, missing.getResponse().getStatus());
+  }
+
+  @Test
+  void preview_forbiddenWhenNotAdmin() {
+    SitesAdaptor denied =
+        new SitesAdaptor(siteManager, () -> false, SitesAdaptor::defaultOutputRootForSiteKey, null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.getVirtualSitePreviewStatus("Help"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void preview_rejectsRepositorySite() {
+    PSSite site = new PSSite();
+    site.setName("Corp");
+    site.setGUID(siteGuid);
+    when(siteManager.findSite("Corp")).thenReturn(site);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.getVirtualSitePreviewStatus("Corp"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void requireSafeRelativePreviewPath_rejectsAbsoluteAndDotDot() {
+    WebApplicationException dots =
+        assertThrows(
+            WebApplicationException.class,
+            () -> SitesAdaptor.requireSafeRelativePreviewPath("a/../../etc/passwd"));
+    assertEquals(400, dots.getResponse().getStatus());
+  }
+
+  @Test
+  void findHomeRelativePath_prefersRootThen82() throws Exception {
+    Path out = tempDir.resolve("homes");
+    Files.createDirectories(out.resolve("8.2"));
+    Files.writeString(out.resolve("8.2").resolve("index.html"), "v");
+    assertEquals("8.2/index.html", SitesAdaptor.findHomeRelativePath(out));
+    Files.writeString(out.resolve("index.html"), "root");
+    assertEquals("index.html", SitesAdaptor.findHomeRelativePath(out));
+  }
+
+  private PSSite virtualHelpSite() {
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, tempDir.resolve("virt-root").toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "help-docs");
+    return site;
   }
 
   private static Path createMinimalVirtualTree(Path siteRoot) throws Exception {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.apibridge;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -590,6 +591,29 @@ class SitesAdaptorTest {
     assertEquals("8.2/index.html", SitesAdaptor.findHomeRelativePath(out));
     Files.writeString(out.resolve("index.html"), "root");
     assertEquals("index.html", SitesAdaptor.findHomeRelativePath(out));
+  }
+
+  @Test
+  void findHomeRelativePath_picksHighestNumericVersionNotLexical() throws Exception {
+    Path out = tempDir.resolve("homes-versions");
+    Files.createDirectories(out.resolve("9.0"));
+    Files.createDirectories(out.resolve("10.0"));
+    Files.createDirectories(out.resolve("_meta"));
+    Files.writeString(out.resolve("9.0").resolve("index.html"), "nine");
+    Files.writeString(out.resolve("10.0").resolve("index.html"), "ten");
+    Files.writeString(out.resolve("_meta").resolve("index.html"), "meta");
+    assertEquals("10.0/index.html", SitesAdaptor.findHomeRelativePath(out));
+    assertTrue(SitesAdaptor.compareHomeCandidateDirectories(out.resolve("10.0"), out.resolve("9.0")) < 0);
+  }
+
+  @Test
+  void recordLastOutputRoot_doesNotThrowWhenPointerUnwritable() throws Exception {
+    Path defaultOut = tempDir.resolve("pointer-blocked");
+    Files.createDirectories(defaultOut);
+    Files.writeString(defaultOut.resolve("_meta"), "not-a-directory");
+    SitesAdaptor previewing =
+        new SitesAdaptor(siteManager, () -> true, key -> defaultOut, null);
+    assertDoesNotThrow(() -> previewing.recordLastOutputRoot("help-docs", defaultOut));
   }
 
   private PSSite virtualHelpSite() {

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -107,4 +107,28 @@ public interface ISiteAdaptor {
    *     path issues, 403 when not authorized, 404 when site not found
    */
   VirtualSiteBuildResult buildVirtualSite(String nameOrId, VirtualSiteBuildRequest request);
+
+  /**
+   * Reports whether the last Virtual Site static build can be previewed (assembled home exists).
+   *
+   * <p>Missing output is {@code available=false} with a message (not a 500). Requires Admin.
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @return status (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 when the site is not Virtual, 403 when not
+   *     authorized, 404 when site not found
+   */
+  VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId);
+
+  /**
+   * Streams one file from the last Virtual Site build output (path-traversal safe).
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @param relativePath path under the output root ({@code 8.2/index.html}); blank means assembled
+   *     home
+   * @return file bytes and media type (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 unsafe path / not virtual, 403 not Admin, 404
+   *     site or file missing
+   */
+  VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath);
 }

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -107,4 +107,20 @@ public interface ISiteAdaptor {
    *     path issues, 403 when not authorized, 404 when site not found
    */
   VirtualSiteBuildResult buildVirtualSite(String nameOrId, VirtualSiteBuildRequest request);
+
+  /**
+   * Builds a Virtual Site and copies the static output to the Site filesystem publish root ({@code
+   * IPSSite.getRoot()}).
+   *
+   * <p>Publish-includes-build: operators get a published docs tree at the configured Site
+   * publishing location, not only {@code tmp/virtual-sites}. Failures are operator-facing 4xx (not
+   * a silent no-op). Requires Admin.
+   *
+   * @param nameOrId site name or GUID string, not blank
+   * @return publish summary (never null)
+   * @throws jakarta.ws.rs.WebApplicationException 400 when the Site is not virtual, publish root is
+   *     missing/unsafe, or the source tree overlaps the target; 403 when not authorized; 404 when
+   *     site not found
+   */
+  VirtualSitePublishResult publishVirtualSite(String nameOrId);
 }

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -286,6 +286,54 @@ public class SitesResource {
     }
   }
 
+  /**
+   * Builds a Virtual Site and publishes the static output to the Site filesystem publish root.
+   *
+   * @param nameOrId site name or GUID
+   * @return pages written, files copied, and publish path
+   */
+  @POST
+  @Path("/{nameOrId}/virtual/publish")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Operation(
+      summary = "Publish Virtual Site to Site filesystem target",
+      description =
+          "Runs the Phase 1 Virtual Site static build (same as POST …/virtual/build) then copies"
+              + " assembled HTML/assets to the Site publishing filesystem location (IPSSite.root)."
+              + " Requires Admin. Traditional repository Sites, missing/unsafe Site root, or"
+              + " overlap with virtual.rootPath return 4xx with an operator-readable message"
+              + " (never a silent no-op).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Published (check hasLinkProblems / filesCopied)",
+            content = @Content(schema = @Schema(implementation = VirtualSitePublishResult.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Not virtual / missing Site root / unsafe path / overlap"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public VirtualSitePublishResult publishVirtualSite(@PathParam("nameOrId") String nameOrId) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      // JSON/XML DTO via Jackson/JAXB/CXF — not HTML body (see suppressions.md)
+      return requireAdaptor().publishVirtualSite(nameOrId); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to publish virtual site '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
   private Site resolveSite(String nameOrId) {
     ISiteAdaptor a = requireAdaptor();
     Site byName = a.findByName(nameOrId);

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -32,8 +32,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -58,6 +60,8 @@ public class SitesResource {
   static Logger log = LogManager.getLogger(IPSConstants.API_LOG);
 
   private final ISiteAdaptor adaptor;
+
+  @Context private UriInfo uriInfo;
 
   public SitesResource() {
     this.adaptor = null;
@@ -279,6 +283,106 @@ public class SitesResource {
       log.error(
           "Failed to build virtual site '{}' ({}): {}",
           nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Last-build preview availability (JSON). Missing assembled output is HTTP 200 with {@code
+   * available=false}.
+   *
+   * @param nameOrId site name or GUID
+   * @return preview status
+   */
+  @GET
+  @Path("/{nameOrId}/virtual/preview")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Operation(
+      summary = "Virtual Site preview status",
+      description =
+          "Reports whether the last Admin Virtual Site build can be opened from the product UI."
+              + " Uses the last build output path (default {install}/tmp/virtual-sites/{siteKey})."
+              + " Missing or failed builds return 200 with available=false (not 500). Requires"
+              + " Admin. Traditional repository Sites return 400.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Status (check available / homePath)",
+            content = @Content(schema = @Schema(implementation = VirtualSitePreviewStatus.class))),
+        @ApiResponse(responseCode = "400", description = "Not virtual / validation failure"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(
+      @PathParam("nameOrId") String nameOrId) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      // JSON/XML DTO via Jackson/JAXB/CXF — not HTML body (see suppressions.md)
+      return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to load virtual site preview status '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Streams one assembled file from the last Virtual Site build (navigable preview).
+   *
+   * @param nameOrId site name or GUID
+   * @param relPath path under the output root; blank uses assembled home
+   * @return file bytes
+   */
+  @GET
+  @Path("/{nameOrId}/virtual/preview/{relPath:.*}")
+  @Produces(MediaType.WILDCARD)
+  @Operation(
+      summary = "Preview Virtual Site file",
+      description =
+          "Streams a file from the last Virtual Site build output. Paths are resolved with portable"
+              + " NIO Path under the last output root (no '..' after normalize). HTML root-relative"
+              + " href/src/url() values are rewritten to this preview prefix so navigation works."
+              + " Requires Admin. Missing files return 404 (not 500).",
+      responses = {
+        @ApiResponse(responseCode = "200", description = "File bytes"),
+        @ApiResponse(responseCode = "400", description = "Not virtual / unsafe path"),
+        @ApiResponse(responseCode = "403", description = "Not authorized (Admin required)"),
+        @ApiResponse(responseCode = "404", description = "Site or file not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response previewVirtualSiteFile(
+      @PathParam("nameOrId") String nameOrId, @PathParam("relPath") String relPath) {
+    requireNonBlank(nameOrId, "nameOrId");
+    try {
+      VirtualSitePreviewFile file = requireAdaptor().previewVirtualSiteFile(nameOrId, relPath);
+      byte[] body = file.getContent();
+      if (file.isHtml()) {
+        String base = uriInfo != null ? uriInfo.getBaseUri().getPath() : "/services/";
+        String prefix = VirtualSitePreviewHtml.previewPrefix(base, nameOrId);
+        body = VirtualSitePreviewHtml.rewriteRootRelative(body, prefix);
+      }
+      return Response.ok(body, file.getMediaType())
+          .header("Cache-Control", "no-store")
+          .build(); // codeql[java/xss]
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to preview virtual site file '{}' path='{}' ({}): {}",
+          nameOrId,
+          relPath,
           e.getClass().getName(),
           e.getMessage(),
           e);

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewFile.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewFile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import java.util.Objects;
+
+/**
+ * Bytes of one assembled Virtual Site file for the Admin preview stream.
+ *
+ * <p>Not a public JSON entity — {@link SitesResource} maps this to an HTTP {@code Response}.
+ */
+public class VirtualSitePreviewFile {
+
+  private final String mediaType;
+  private final String relativePath;
+  private final byte[] content;
+
+  public VirtualSitePreviewFile(String mediaType, String relativePath, byte[] content) {
+    this.mediaType = mediaType != null && !mediaType.isBlank() ? mediaType : "application/octet-stream";
+    this.relativePath = relativePath != null ? relativePath : "";
+    this.content = content != null ? content : new byte[0];
+  }
+
+  public String getMediaType() {
+    return mediaType;
+  }
+
+  public String getRelativePath() {
+    return relativePath;
+  }
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public boolean isHtml() {
+    return mediaType.toLowerCase().startsWith("text/html");
+  }
+
+  @Override
+  public String toString() {
+    return "VirtualSitePreviewFile{mediaType="
+        + mediaType
+        + ", relativePath="
+        + relativePath
+        + ", bytes="
+        + content.length
+        + "}";
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mediaType, relativePath, content.length);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
@@ -27,9 +27,17 @@ import java.util.regex.Pattern;
  */
 public final class VirtualSitePreviewHtml {
 
+  /**
+   * Match standalone {@code href}/{@code src} attributes, not {@code data-href}, {@code data-src},
+   * or {@code xlink:href} (word-boundary {@code \\b} is true between {@code -} / {@code :} and the
+   * following letter).
+   */
   private static final Pattern ROOT_HREF_SRC =
-      Pattern.compile("(?i)(\\b(?:href|src)\\s*=\\s*[\"'])/(?!/)");
-  private static final Pattern ROOT_CSS_URL = Pattern.compile("(?i)(url\\(\\s*)/(?!/)");
+      Pattern.compile("(?i)(?<![\\w:-])((?:href|src)\\s*=\\s*[\"'])/(?!/)");
+
+  /** Unquoted {@code url(/path)} and quoted {@code url("/path")} / {@code url('/path')}. */
+  private static final Pattern ROOT_CSS_URL =
+      Pattern.compile("(?i)(url\\(\\s*(?:[\"'])?)/(?!/)");
 
   private VirtualSitePreviewHtml() {}
 

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewHtml.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites assembled Virtual Site HTML so root-relative {@code href}/{@code src}/{@code url()}
+ * values stay under the preview URL prefix (assembler emits site-root paths like {@code
+ * /8.2/index.html}).
+ */
+public final class VirtualSitePreviewHtml {
+
+  private static final Pattern ROOT_HREF_SRC =
+      Pattern.compile("(?i)(\\b(?:href|src)\\s*=\\s*[\"'])/(?!/)");
+  private static final Pattern ROOT_CSS_URL = Pattern.compile("(?i)(url\\(\\s*)/(?!/)");
+
+  private VirtualSitePreviewHtml() {}
+
+  /**
+   * Prefix must be an absolute URL path without a trailing slash (for example {@code
+   * /services/sites/Help/virtual/preview}).
+   *
+   * @param html assembled page bytes (UTF-8)
+   * @param previewPrefix URL path prefix for this site's preview stream
+   * @return rewritten HTML bytes
+   */
+  public static byte[] rewriteRootRelative(byte[] html, String previewPrefix) {
+    if (html == null || html.length == 0) {
+      return html == null ? new byte[0] : html;
+    }
+    String prefix = normalizePrefix(previewPrefix);
+    if (prefix.isEmpty()) {
+      return html;
+    }
+    String text = new String(html, StandardCharsets.UTF_8);
+    String withHref = ROOT_HREF_SRC.matcher(text).replaceAll("$1" + Matcher.quoteReplacement(prefix) + "/");
+    String withUrl = ROOT_CSS_URL.matcher(withHref).replaceAll("$1" + Matcher.quoteReplacement(prefix) + "/");
+    return withUrl.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Build the preview URL prefix from the JAX-RS application base path and site name.
+   *
+   * @param basePath {@link jakarta.ws.rs.core.UriInfo#getBaseUri()} path (may end with {@code /})
+   * @param siteNameOrId site name or GUID (decoded)
+   * @return prefix without trailing slash
+   */
+  public static String previewPrefix(String basePath, String siteNameOrId) {
+    String base = basePath == null ? "" : basePath.trim();
+    if (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    String name = siteNameOrId == null ? "" : siteNameOrId.trim();
+    String encoded = encodePathSegment(name);
+    return base + "/sites/" + encoded + "/virtual/preview";
+  }
+
+  static String normalizePrefix(String previewPrefix) {
+    if (previewPrefix == null) {
+      return "";
+    }
+    String p = previewPrefix.trim();
+    if (p.endsWith("/")) {
+      p = p.substring(0, p.length() - 1);
+    }
+    if (!p.startsWith("/") || p.contains("..") || p.indexOf('\0') >= 0) {
+      return "";
+    }
+    return p;
+  }
+
+  static String encodePathSegment(String raw) {
+    if (raw == null || raw.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder(raw.length() + 8);
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (isUnreservedPathChar(c)) {
+        sb.append(c);
+      } else if (c == ' ') {
+        sb.append("%20");
+      } else {
+        byte[] bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+        for (byte b : bytes) {
+          sb.append('%');
+          String hex = Integer.toHexString(b & 0xff).toUpperCase();
+          if (hex.length() == 1) {
+            sb.append('0');
+          }
+          sb.append(hex);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  private static boolean isUnreservedPathChar(char c) {
+    return (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || c == '-'
+        || c == '_'
+        || c == '.'
+        || c == '~';
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Optional;
+
+/**
+ * Whether a last Virtual Site static build can be previewed from the product UI ({@code GET
+ * /sites/{nameOrId}/virtual/preview}).
+ *
+ * <p>Missing or failed builds return HTTP 200 with {@code available=false} and a message — not 500.
+ */
+@XmlRootElement(name = "VirtualSitePreviewStatus")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(
+    name = "VirtualSitePreviewStatus",
+    description = "Last Virtual Site build preview availability and assembled home path")
+public class VirtualSitePreviewStatus {
+
+  @Schema(description = "True when an assembled index/home file exists under the last output root")
+  private Boolean available;
+
+  @Schema(
+      description = "Relative home path under the output root (forward slashes)",
+      example = "8.2/index.html")
+  private String homePath;
+
+  @Schema(
+      description = "Absolute filesystem path of the last build output root",
+      example = "C:/Rhythmyx/tmp/virtual-sites/product-docs")
+  private String outputPath;
+
+  @Schema(description = "Operator-facing reason when available is false")
+  private String message;
+
+  public VirtualSitePreviewStatus() {
+    // Default constructor for JAX-RS / Jackson
+  }
+
+  public Boolean getAvailable() {
+    return available;
+  }
+
+  public void setAvailable(Boolean available) {
+    this.available = available;
+  }
+
+  public Optional<String> getHomePath() {
+    return Optional.ofNullable(homePath);
+  }
+
+  public void setHomePath(String homePath) {
+    this.homePath = homePath;
+  }
+
+  public Optional<String> getOutputPath() {
+    return Optional.ofNullable(outputPath);
+  }
+
+  public void setOutputPath(String outputPath) {
+    this.outputPath = outputPath;
+  }
+
+  public Optional<String> getMessage() {
+    return Optional.ofNullable(message);
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outcome of {@code POST /sites/{nameOrId}/virtual/publish}: build-then-copy to the Site filesystem
+ * publish root ({@code IPSSite.root}).
+ */
+@XmlRootElement(name = "VirtualSitePublishResult")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(
+    name = "VirtualSitePublishResult",
+    description =
+        "Virtual Site publish summary: Site filesystem target, files copied, and build extras")
+public class VirtualSitePublishResult {
+
+  @Schema(description = "CMS Site name that was published", example = "Help")
+  private String siteName;
+
+  @Schema(description = "Participant registry site key used for the build", example = "product-docs")
+  private String siteKey;
+
+  @Schema(
+      description = "Absolute filesystem path of the Site publishing location (IPSSite.root)",
+      example = "C:/inetpub/wwwroot/help")
+  private String publishPath;
+
+  @Schema(
+      description = "Absolute filesystem path of the staging build output (tmp/virtual-sites)",
+      example = "C:/Rhythmyx/tmp/virtual-sites/product-docs")
+  private String buildOutputPath;
+
+  @Schema(description = "Number of Markdown pages assembled to HTML", example = "42")
+  private Integer pagesWritten;
+
+  @Schema(description = "Number of regular files copied to the Site publish root", example = "50")
+  private Integer filesCopied;
+
+  @Schema(description = "Number of unresolved internal id: / relative Markdown links", example = "0")
+  private Integer linkProblemCount;
+
+  @Schema(description = "True when one or more link problems were reported")
+  private Boolean hasLinkProblems;
+
+  @Schema(description = "Human-readable link problem lines from the build")
+  private List<String> linkProblems = new ArrayList<>();
+
+  public VirtualSitePublishResult() {
+    // Default constructor for JAX-RS / Jackson
+  }
+
+  public Optional<String> getSiteName() {
+    return Optional.ofNullable(siteName);
+  }
+
+  public void setSiteName(String siteName) {
+    this.siteName = siteName;
+  }
+
+  public Optional<String> getSiteKey() {
+    return Optional.ofNullable(siteKey);
+  }
+
+  public void setSiteKey(String siteKey) {
+    this.siteKey = siteKey;
+  }
+
+  public Optional<String> getPublishPath() {
+    return Optional.ofNullable(publishPath);
+  }
+
+  public void setPublishPath(String publishPath) {
+    this.publishPath = publishPath;
+  }
+
+  public Optional<String> getBuildOutputPath() {
+    return Optional.ofNullable(buildOutputPath);
+  }
+
+  public void setBuildOutputPath(String buildOutputPath) {
+    this.buildOutputPath = buildOutputPath;
+  }
+
+  public Integer getPagesWritten() {
+    return pagesWritten;
+  }
+
+  public void setPagesWritten(Integer pagesWritten) {
+    this.pagesWritten = pagesWritten;
+  }
+
+  public Integer getFilesCopied() {
+    return filesCopied;
+  }
+
+  public void setFilesCopied(Integer filesCopied) {
+    this.filesCopied = filesCopied;
+  }
+
+  public Integer getLinkProblemCount() {
+    return linkProblemCount;
+  }
+
+  public void setLinkProblemCount(Integer linkProblemCount) {
+    this.linkProblemCount = linkProblemCount;
+  }
+
+  public Boolean getHasLinkProblems() {
+    return hasLinkProblems;
+  }
+
+  public void setHasLinkProblems(Boolean hasLinkProblems) {
+    this.hasLinkProblems = hasLinkProblems;
+  }
+
+  public List<String> getLinkProblems() {
+    return linkProblems;
+  }
+
+  public void setLinkProblems(List<String> linkProblems) {
+    this.linkProblems = linkProblems != null ? new ArrayList<>(linkProblems) : new ArrayList<>();
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -195,6 +195,30 @@ public class SitesResourceTest {
     verify(adaptor, never()).buildVirtualSite(any(), any());
   }
 
+  @Test
+  public void publishVirtualSiteDelegates() {
+    VirtualSitePublishResult published = new VirtualSitePublishResult();
+    published.setSiteName("Help");
+    published.setPagesWritten(3);
+    published.setFilesCopied(5);
+    published.setPublishPath("C:/pub/help");
+    when(adaptor.publishVirtualSite("Help")).thenReturn(published);
+
+    VirtualSitePublishResult out = resource.publishVirtualSite("Help");
+    assertEquals(3, out.getPagesWritten().intValue());
+    assertEquals(5, out.getFilesCopied().intValue());
+    assertEquals("C:/pub/help", out.getPublishPath().orElse(null));
+    verify(adaptor).publishVirtualSite("Help");
+  }
+
+  @Test
+  public void publishVirtualSiteBlankName400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.publishVirtualSite(" "));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).publishVirtualSite(any());
+  }
+
   /**
    * CodeQL #1949: Jackson/JAXB JSON/XML DTO return must keep same-line {@code // codeql[java/xss]}
    * on the updateVirtual sink (not HTML body construction).
@@ -213,6 +237,9 @@ public class SitesResourceTest {
         text.contains(
             "return requireAdaptor().buildVirtualSite(nameOrId, request); // codeql[java/xss]"),
         "buildVirtualSite return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains("return requireAdaptor().publishVirtualSite(nameOrId); // codeql[java/xss]"),
+        "publishVirtualSite return sink must carry same-line codeql[java/xss]");
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -188,6 +189,51 @@ public class SitesResourceTest {
   }
 
   @Test
+  public void previewStatusDelegates() {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(true);
+    status.setHomePath("8.2/index.html");
+    when(adaptor.getVirtualSitePreviewStatus("Help")).thenReturn(status);
+
+    VirtualSitePreviewStatus out = resource.getVirtualSitePreviewStatus("Help");
+    assertEquals(Boolean.TRUE, out.getAvailable());
+    assertEquals("8.2/index.html", out.getHomePath().orElse(null));
+    verify(adaptor).getVirtualSitePreviewStatus("Help");
+  }
+
+  @Test
+  public void previewStatusBlankName400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.getVirtualSitePreviewStatus(" "));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).getVirtualSitePreviewStatus(any());
+  }
+
+  @Test
+  public void previewFileDelegatesAndRewritesHtml() {
+    byte[] html = "<a href=\"/8.2/index.html\">Home</a>".getBytes(StandardCharsets.UTF_8);
+    when(adaptor.previewVirtualSiteFile(eq("Help"), eq("8.2/index.html")))
+        .thenReturn(new VirtualSitePreviewFile("text/html; charset=UTF-8", "8.2/index.html", html));
+
+    Response out = resource.previewVirtualSiteFile("Help", "8.2/index.html");
+    assertEquals(200, out.getStatus());
+    byte[] body = (byte[]) out.getEntity();
+    String text = new String(body, StandardCharsets.UTF_8);
+    assertTrue(text.contains("/services/sites/Help/virtual/preview/8.2/index.html"), text);
+    verify(adaptor).previewVirtualSiteFile("Help", "8.2/index.html");
+  }
+
+  @Test
+  public void previewFileBlankName400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.previewVirtualSiteFile(" ", "index.html"));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).previewVirtualSiteFile(any(), any());
+  }
+
+  @Test
   public void buildVirtualSiteBlankName400() {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.buildVirtualSite(" ", null));
@@ -213,6 +259,13 @@ public class SitesResourceTest {
         text.contains(
             "return requireAdaptor().buildVirtualSite(nameOrId, request); // codeql[java/xss]"),
         "buildVirtualSite return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains(
+            "return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]"),
+        "getVirtualSitePreviewStatus return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains(".build(); // codeql[java/xss]"),
+        "previewVirtualSiteFile Response.ok sink must carry same-line codeql[java/xss]");
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -85,4 +85,16 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     }
     return result;
   }
+
+  @Override
+  public VirtualSitePublishResult publishVirtualSite(String nameOrId) {
+    VirtualSitePublishResult result = new VirtualSitePublishResult();
+    result.setSiteName(nameOrId);
+    result.setSiteKey(nameOrId);
+    result.setPagesWritten(0);
+    result.setFilesCopied(0);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+    return result;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -85,4 +85,18 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     }
     return result;
   }
+
+  @Override
+  public VirtualSitePreviewStatus getVirtualSitePreviewStatus(String nameOrId) {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(false);
+    status.setMessage("No assembled Virtual Site to preview.");
+    return status;
+  }
+
+  @Override
+  public VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath) {
+    throw new jakarta.ws.rs.WebApplicationException(
+        "No assembled Virtual Site to preview.", jakarta.ws.rs.core.Response.Status.NOT_FOUND);
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class VirtualSitePreviewHtmlTest {
+
+  @Test
+  public void rewriteRootRelativeHrefAndCssUrl() {
+    String html =
+        "<a href=\"/8.2/index.html\">Home</a>"
+            + "<img src='/assets/logo.png'/>"
+            + "<style>body{background:url(/assets/bg.png)}</style>"
+            + "<a href=\"//cdn.example/x\">ext</a>";
+    byte[] out =
+        VirtualSitePreviewHtml.rewriteRootRelative(
+            html.getBytes(StandardCharsets.UTF_8), "/services/sites/Help/virtual/preview");
+    String text = new String(out, StandardCharsets.UTF_8);
+    assertTrue(text.contains("href=\"/services/sites/Help/virtual/preview/8.2/index.html\""), text);
+    assertTrue(text.contains("src='/services/sites/Help/virtual/preview/assets/logo.png'"), text);
+    assertTrue(text.contains("url(/services/sites/Help/virtual/preview/assets/bg.png)"), text);
+    assertTrue(text.contains("href=\"//cdn.example/x\""), text);
+  }
+
+  @Test
+  public void rewriteRejectsUnsafePrefix() {
+    String html = "<a href=\"/8.2/index.html\">x</a>";
+    byte[] out =
+        VirtualSitePreviewHtml.rewriteRootRelative(
+            html.getBytes(StandardCharsets.UTF_8), "../evil");
+    assertEquals(html, new String(out, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void previewPrefixJoinsBaseAndEncodedName() {
+    assertEquals(
+        "/services/sites/Help/virtual/preview",
+        VirtualSitePreviewHtml.previewPrefix("/services/", "Help"));
+    assertEquals(
+        "/Rhythmyx/services/sites/Help%20Docs/virtual/preview",
+        VirtualSitePreviewHtml.previewPrefix("/Rhythmyx/services", "Help Docs"));
+    assertFalse(VirtualSitePreviewHtml.previewPrefix("/services/", "Help").endsWith("/"));
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/VirtualSitePreviewHtmlTest.java
@@ -33,7 +33,12 @@ public class VirtualSitePreviewHtmlTest {
         "<a href=\"/8.2/index.html\">Home</a>"
             + "<img src='/assets/logo.png'/>"
             + "<style>body{background:url(/assets/bg.png)}</style>"
-            + "<a href=\"//cdn.example/x\">ext</a>";
+            + "<style>div{background:url(\"/assets/quoted.png\")}</style>"
+            + "<style>span{background:url('/assets/single.png')}</style>"
+            + "<a href=\"//cdn.example/x\">ext</a>"
+            + "<a data-href=\"/8.2/x.html\">keep</a>"
+            + "<img data-src=\"/8.2/y.png\"/>"
+            + "<use xlink:href=\"/8.2/icon.svg#mark\"></use>";
     byte[] out =
         VirtualSitePreviewHtml.rewriteRootRelative(
             html.getBytes(StandardCharsets.UTF_8), "/services/sites/Help/virtual/preview");
@@ -41,7 +46,17 @@ public class VirtualSitePreviewHtmlTest {
     assertTrue(text.contains("href=\"/services/sites/Help/virtual/preview/8.2/index.html\""), text);
     assertTrue(text.contains("src='/services/sites/Help/virtual/preview/assets/logo.png'"), text);
     assertTrue(text.contains("url(/services/sites/Help/virtual/preview/assets/bg.png)"), text);
+    assertTrue(
+        text.contains("url(\"/services/sites/Help/virtual/preview/assets/quoted.png\")"), text);
+    assertTrue(
+        text.contains("url('/services/sites/Help/virtual/preview/assets/single.png')"), text);
     assertTrue(text.contains("href=\"//cdn.example/x\""), text);
+    assertTrue(text.contains("data-href=\"/8.2/x.html\""), text);
+    assertFalse(text.contains("data-href=\"/services/"), text);
+    assertTrue(text.contains("data-src=\"/8.2/y.png\""), text);
+    assertFalse(text.contains("data-src=\"/services/"), text);
+    assertTrue(text.contains("xlink:href=\"/8.2/icon.svg#mark\""), text);
+    assertFalse(text.contains("xlink:href=\"/services/"), text);
   }
 
   @Test

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.sitemgr.IPSSite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Selects the Site filesystem publish target and copies a Virtual Site build tree there.
+ *
+ * <p>The target is {@link IPSSite#getRoot()} (the Site publishing filesystem location), resolved
+ * with portable NIO {@link Path} I/O. Does not invent OS path separators.
+ */
+public final class PSVirtualSiteFilesystemPublisher {
+
+  /** Build-staging directory that is not copied to the published site. */
+  public static final String META_DIR_NAME = "_meta";
+
+  private PSVirtualSiteFilesystemPublisher() {}
+
+  /**
+   * Resolve the Site filesystem publish target from {@link IPSSite#getRoot()}.
+   *
+   * @param site CMS Site, not null
+   * @return normalized target path (not required to exist yet)
+   * @throws VirtualSiteException when root is blank, unsafe, or overlaps the Virtual source tree
+   */
+  public static Path selectFilesystemTarget(IPSSite site) throws VirtualSiteException {
+    if (site == null) {
+      throw new VirtualSiteException("Site is required to select a filesystem publish target.");
+    }
+    String raw = site.getRoot();
+    if (StringUtils.isBlank(raw)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is not configured. Set the Site publishing filesystem"
+              + " location (Site root) to a directory, then publish again.");
+    }
+    Path target;
+    try {
+      target = Path.of(raw.trim()).normalize();
+    } catch (InvalidPathException e) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is not a valid path: '" + raw.trim() + "'.", e);
+    }
+    if (!PSVirtualSiteHelper.isSafeRootPath(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root must be a non-empty path with no '..' segments after"
+              + " normalize. Rejected: '"
+              + raw.trim()
+              + "'.");
+    }
+    Optional<Path> source = PSVirtualSiteHelper.rootPath(site);
+    if (source.isPresent()) {
+      Path src = source.get().normalize();
+      if (sameOrNested(src, target)) {
+        throw new VirtualSiteException(
+            "Site filesystem publish root must be distinct from virtual.rootPath (publishing would"
+                + " overwrite or nest inside the Markdown source tree). Configure a dedicated"
+                + " publishing directory.");
+      }
+    }
+    return target;
+  }
+
+  /**
+   * Copy assembled static files from {@code buildOutput} into {@code target}.
+   *
+   * <p>Skips the {@code _meta} participant-registry directory. Overwrites existing files; does not
+   * delete stale files already under the target.
+   *
+   * @param buildOutput directory written by {@link PSVirtualSiteBuildService}
+   * @param target Site filesystem publish root
+   * @return copy summary
+   * @throws VirtualSiteException when inputs are missing, unsafe, or overlap
+   * @throws IOException on filesystem I/O failure
+   */
+  public static PSVirtualSitePublishCopyResult copyBuildToTarget(Path buildOutput, Path target)
+      throws VirtualSiteException, IOException {
+    if (buildOutput == null || !Files.isDirectory(buildOutput)) {
+      throw new VirtualSiteException(
+          "Virtual Site build output is missing or is not a directory: '" + buildOutput + "'.");
+    }
+    if (target == null || !PSVirtualSiteHelper.isSafeRootPath(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root is missing or unsafe: '" + target + "'.");
+    }
+    if (Files.exists(target) && !Files.isDirectory(target)) {
+      throw new VirtualSiteException(
+          "Site filesystem publish root exists and is not a directory: '" + target + "'.");
+    }
+
+    Path srcAbs = buildOutput.toAbsolutePath().normalize();
+    Path destAbs = target.toAbsolutePath().normalize();
+    if (sameOrNested(srcAbs, destAbs)) {
+      throw new VirtualSiteException(
+          "Build output and Site filesystem publish root overlap. Use a distinct publish directory"
+              + " (not the build staging tree).");
+    }
+
+    Files.createDirectories(destAbs); // codeql[java/path-injection]
+
+    int copied = 0;
+    try (Stream<Path> walk = Files.walk(srcAbs)) {
+      for (Path src : (Iterable<Path>) walk::iterator) {
+        Path rel = srcAbs.relativize(src);
+        if (isMetaTree(rel)) {
+          continue;
+        }
+        Path dest = destAbs.resolve(rel).normalize(); // codeql[java/path-injection]
+        if (!dest.startsWith(destAbs)) {
+          throw new VirtualSiteException(
+              "Refusing to write outside the Site filesystem publish root: '" + dest + "'.");
+        }
+        if (Files.isDirectory(src)) {
+          Files.createDirectories(dest); // codeql[java/path-injection]
+        } else if (Files.isRegularFile(src)) {
+          Path parent = dest.getParent();
+          if (parent != null) {
+            Files.createDirectories(parent); // codeql[java/path-injection]
+          }
+          Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING); // codeql[java/path-injection]
+          copied++;
+        }
+      }
+    }
+    return new PSVirtualSitePublishCopyResult(destAbs, copied);
+  }
+
+  static boolean isMetaTree(Path relative) {
+    if (relative == null || relative.getNameCount() < 1) {
+      return false;
+    }
+    Path first = relative.getName(0);
+    return first != null && META_DIR_NAME.equals(first.toString());
+  }
+
+  /**
+   * True when the two paths are equal after normalize, or either is a child of the other.
+   *
+   * <p>Does not call {@code toAbsolutePath()} so relative configs do not depend on process cwd.
+   */
+  static boolean sameOrNested(Path a, Path b) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Path left = a.normalize();
+    Path right = b.normalize();
+    if (left.equals(right)) {
+      return true;
+    }
+    try {
+      return left.startsWith(right) || right.startsWith(left);
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSitePublishCopyResult.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSitePublishCopyResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Outcome of copying a Virtual Site build tree to a Site filesystem publish target.
+ *
+ * @param publishRoot normalized absolute publish directory
+ * @param filesCopied number of regular files written (directories are created but not counted)
+ */
+public record PSVirtualSitePublishCopyResult(Path publishRoot, int filesCopied) {
+
+  public PSVirtualSitePublishCopyResult {
+    Objects.requireNonNull(publishRoot, "publishRoot");
+    if (filesCopied < 0) {
+      throw new IllegalArgumentException("filesCopied must be >= 0");
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.sitemgr.data.PSSite;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class PSVirtualSiteFilesystemPublisherTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void selectFilesystemTarget_requiresConfiguredRoot() {
+    PSSite site = virtualSite(tempDir.resolve("src"), null);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().toLowerCase().contains("not configured"));
+  }
+
+  @Test
+  void selectFilesystemTarget_rejectsUnsafeRoot() {
+    PSSite site = virtualSite(tempDir.resolve("src"), Path.of("a", "..", "..", "etc").toString());
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().contains(".."));
+  }
+
+  @Test
+  void selectFilesystemTarget_rejectsSameAsVirtualSource() {
+    Path src = tempDir.resolve("docs").normalize();
+    PSSite site = virtualSite(src, src.toString());
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
+    assertTrue(ex.getMessage().contains("virtual.rootPath"));
+  }
+
+  @Test
+  void selectFilesystemTarget_returnsNormalizedSiteRoot() throws Exception {
+    Path pub = tempDir.resolve("pub").resolve("site").normalize();
+    PSSite site = virtualSite(tempDir.resolve("src"), pub.toString());
+    Path selected = PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site);
+    assertEquals(pub, selected);
+  }
+
+  @Test
+  void copyBuildToTarget_copiesHtmlAndSkipsMeta() throws Exception {
+    Path build = tempDir.resolve("build");
+    Path pub = tempDir.resolve("published");
+    Path html = build.resolve("8.2").resolve("index.html");
+    Files.createDirectories(html.getParent());
+    Files.writeString(html, "<html>ok</html>", StandardCharsets.UTF_8);
+    Files.writeString(build.resolve("link-report.txt"), "clean", StandardCharsets.UTF_8);
+    Path meta = build.resolve("_meta").resolve("participants.jsonl");
+    Files.createDirectories(meta.getParent());
+    Files.writeString(meta, "{}", StandardCharsets.UTF_8);
+
+    PSVirtualSitePublishCopyResult result =
+        PSVirtualSiteFilesystemPublisher.copyBuildToTarget(build, pub);
+
+    assertEquals(2, result.filesCopied());
+    assertTrue(Files.isRegularFile(pub.resolve("8.2").resolve("index.html")));
+    assertEquals(
+        "<html>ok</html>",
+        Files.readString(pub.resolve("8.2").resolve("index.html"), StandardCharsets.UTF_8)
+            .replace("\r\n", "\n"));
+    assertTrue(Files.isRegularFile(pub.resolve("link-report.txt")));
+    assertFalse(Files.exists(pub.resolve("_meta")));
+    assertEquals(pub.toAbsolutePath().normalize(), result.publishRoot());
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsMissingBuildDir() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                PSVirtualSiteFilesystemPublisher.copyBuildToTarget(
+                    tempDir.resolve("missing-build"), tempDir.resolve("pub")));
+    assertTrue(ex.getMessage().toLowerCase().contains("build output"));
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsTargetThatIsAFile() throws Exception {
+    Path build = tempDir.resolve("b");
+    Files.createDirectories(build);
+    Files.writeString(build.resolve("index.html"), "x", StandardCharsets.UTF_8);
+    Path fileTarget = tempDir.resolve("not-a-dir");
+    Files.writeString(fileTarget, "nope", StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.copyBuildToTarget(build, fileTarget));
+    assertTrue(ex.getMessage().toLowerCase().contains("not a directory"));
+  }
+
+  @Test
+  void copyBuildToTarget_rejectsOverlappingTrees() throws Exception {
+    Path build = tempDir.resolve("overlap");
+    Files.createDirectories(build);
+    Files.writeString(build.resolve("index.html"), "x", StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                PSVirtualSiteFilesystemPublisher.copyBuildToTarget(
+                    build, build.resolve("nested-pub")));
+    assertTrue(ex.getMessage().toLowerCase().contains("overlap"));
+  }
+
+  @Test
+  void isMetaTree_onlyTopLevelMeta() {
+    assertTrue(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("_meta")));
+    assertTrue(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("_meta", "x.jsonl")));
+    assertFalse(PSVirtualSiteFilesystemPublisher.isMetaTree(Path.of("8.2", "index.html")));
+    assertFalse(PSVirtualSiteFilesystemPublisher.isMetaTree(null));
+  }
+
+  private static PSSite virtualSite(Path virtualRoot, String publishRoot) {
+    PSGuid ctx = new PSGuid(PSTypeEnum.CONTEXT, 1L);
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setRoot(publishRoot);
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_ROOT_PATH, virtualRoot.toString());
+    return site;
+  }
+}


### PR DESCRIPTION
## Summary

Overnight Virtual Site PRs thrash the same Developer Sites UI, public Sites REST adaptor, and product-docs pages. This cluster absorbs **#3309**, **#3310**, and **#3311** onto `main` with **union** semantics so operators do not merge three sequential conflicts on `SitesResource` / `ISiteAdaptor` / `VirtualSiteSourcePanel`.

**Thrash problem:** three owned PRs all extend the same Virtual Site surface (preview last build, list/copy `linkProblems`, publish assembled docs to Site filesystem root). Pairwise overlap includes `SitesAdaptor.java`, `SitesResource.java`, `ISiteAdaptor.java`, `VirtualSiteSourcePanel.tsx`, `virtualSiteBuild.ts`, `developer-site-virtual-source.spec.js`, and product-docs `sites.md` / `virtual-sites.md` / `site-config.md` / `rest.md`.

**Thrash files (shared by 2+ absorbed PRs):**

- `WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx`
- `WebUI/src/main/ts/developer/virtualSiteBuild.ts`
- `WebUI/src/main/ts/developer/messages.ts`
- `WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx`
- `WebUI/src/test/ts/developer/virtualSiteBuild.test.ts`
- `modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js`
- `projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java`
- `projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java`
- `rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java`
- `rest/src/main/java/com/percussion/rest/sites/SitesResource.java`
- `rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java`
- `rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java`
- `product-docs/8.2/admin/sites.md`
- `product-docs/8.2/developer/virtual-sites.md`
- `product-docs/8.2/developer/rest.md`
- `product-docs/8.2/reference/site-config.md`

Union notes:

- UI: keep **Preview** chrome (`onPreview` / preview status+file stream) **and** `linkProblems` details/copy.
- REST: keep `GET …/virtual/preview` + `GET …/virtual/preview/{relPath}` **and** `POST …/virtual/publish`.
- Docs: rest.md / site-config.md list preview **and** publish rows.
- `ISiteAdaptor` / `SitesTestAdaptor` implement all three methods (preview status, preview file, publish).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #3309 | `feat/issue-3299-virtual-site-preview` | yes | last-build preview status + file stream |
| yes | #3310 | `feat/issue-3300-virtual-site-link-problems` | yes | list/copy `linkProblems` in Sites UI |
| yes | #3311 | `feat/issue-3301-virtual-site-publish-target` | yes | publish assembled docs to Site filesystem root |

Do **not** merge the superseded PRs.

## modules_built

`rest`, `system`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`

## build_evidence

```
cd rest && ../mvnw.cmd clean install
  BUILD SUCCESS  2026-08-13T09:24:54-04:00
  Tests run: 349, Failures: 0, Errors: 0, Skipped: 0

cd system && ../mvnw.cmd clean install
  BUILD SUCCESS  2026-08-13T09:26:38-04:00
  Tests run: 2060, Failures: 0, Errors: 0, Skipped: 238

cd projects/sitemanage && ../../mvnw.cmd clean install
  BUILD SUCCESS  2026-08-13T09:27:45-04:00
  Tests run: 1102, Failures: 0, Errors: 0, Skipped: 125

cd WebUI && ../mvnw.cmd clean install
  BUILD SUCCESS  2026-08-13T09:29:17-04:00
  Surefire Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
  Vitest Test Files 305 passed (305); Tests 2208 passed (2208)

cd modules/perc-qa-automation && ../../mvnw.cmd clean install
  BUILD SUCCESS  2026-08-13T09:29:37-04:00
  Surefire: No tests to run.
```

C2 reverse-deps: grepped `implements ISiteAdaptor` — only `SitesAdaptor` (sitemanage, installed) and `SitesTestAdaptor` (rest tests, installed). No extra reverse-dep module.

## Operator

Grok: night-issue-prs (model grok-4.5)

- [x] Product documentation — union of Virtual Site preview, linkProblems, and publish target on `product-docs/8.2/` (sites, virtual-sites, rest, site-config, publishing)

> Co-Authored by Grok using grok-4.5 with agent night-issue-prs.
