### PR TITLE
fix(explorer): folder open stays in Explorer browse (no workflow -1) (#3330)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -94,7 +94,8 @@ import {
   type ReducedActionHandlers,
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
-import { EMPTY_SELECTION, type Selection } from "./selection";
+import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import { isWorkflowEligibleItem } from "./workflowEligibility";
 import { resolveFolderPathFromSelection } from "./folderPath";
 import { resolveSiteNameFromSelection } from "./sitePath";
 import {
@@ -283,14 +284,6 @@ function parseContentId(id: string | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/** True when the selection can receive workflow transitions (not a folder). */
-function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
-  if (!item) return false;
-  if (item.type === "folder") return false;
-  const id = item.id != null ? String(item.id).trim() : "";
-  return id.length > 0;
-}
-
 /**
  * Load the server action catalog for the current selection (#2849 / #2972).
  *
@@ -307,7 +300,8 @@ function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
 async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
-  const contentId = parseContentId(item?.id);
+  const contentId =
+    item && isWorkflowEligibleItem(item) ? parseContentId(item.id) : null;
   if (contentId != null) {
     try {
       const menus = await findAllowedContentTypeMenus([contentId]);
@@ -464,7 +458,7 @@ export function ContentExplorerShell({
     ...defaultReducedActionHandlers(),
     ...actionHandlers,
     onOpen: (item) => {
-      if (item.type === "folder" || (item.leaf === false && item.id == null)) {
+      if (isFolder(item)) {
         setSelection({ folderPath: item.path, item: null });
         return;
       }
@@ -814,7 +808,7 @@ export function ContentExplorerShell({
   const hasFolderContext = sourceFolderPathForCopy != null;
   const hasDependencyItem =
     selection.item != null &&
-    selection.item.type !== "folder" &&
+    !isFolder(selection.item) &&
     selection.item.id != null &&
     String(selection.item.id).trim().length > 0;
   const hasOpenSidePanel =
@@ -899,7 +893,7 @@ export function ContentExplorerShell({
   );
 
   const folderForActions: PSPathItem | null =
-    selection.item?.type === "folder"
+    selection.item && isFolder(selection.item)
       ? selection.item
       : selection.folderPath
         ? ({
@@ -918,7 +912,7 @@ export function ContentExplorerShell({
   useEffect(() => {
     let cancelled = false;
     async function resolve(): Promise<void> {
-      if (selection.item?.type === "folder" && selection.item.id) {
+      if (selection.item && isFolder(selection.item) && selection.item.id) {
         if (!cancelled) setSecurityFolderId(String(selection.item.id));
         return;
       }
@@ -1154,7 +1148,7 @@ export function ContentExplorerShell({
                 ? {
                     path: selection.folderPath,
                     accessLevel:
-                      selection.item?.type === "folder"
+                      selection.item && isFolder(selection.item)
                         ? selection.item.accessLevel
                         : "WRITE",
                   }

--- a/WebUI/src/main/ts/contentExplorer/openInEditor.ts
+++ b/WebUI/src/main/ts/contentExplorer/openInEditor.ts
@@ -22,10 +22,18 @@
  */
 
 import type { PSPathItem } from "../api/contentExplorer/types";
+import { isFolder } from "./selection";
 
 const EDITOR_BASE = "/cm/app/?view=editor";
 
+/**
+ * Open a content item in the product editor. Folders stay in Explorer
+ * browse — they are not workflowed pages (#3330).
+ */
 export function openInEditor(item: PSPathItem): void {
+  if (isFolder(item)) {
+    return;
+  }
   const path = (item.path ?? "").trim();
   const id = (item.id ?? "").trim();
   if (path) {

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -36,16 +36,26 @@ export const EMPTY_SELECTION: Selection = {
   item: null,
 };
 
+/**
+ * Server {@code IPSItemSummary} types that are folders (not workflowed items).
+ * Pathmanagement sends {@code Folder} / {@code FSFolder} (capital F), not
+ * the lowercase {@code folder} the SPA historically used (#3330 / #3329).
+ */
+const FOLDER_TYPE_KEYS = new Set(["folder", "fsfolder", "site"]);
+
 export function isFolder(item: PSPathItem | null): boolean {
   if (!item) return false;
-  // Site nodes from pathmanagement (TYPE_SITE = "site") are expandable
-  // containers under /Sites (#3001). Treat like folders when leaf is unset.
-  if (item.type === "folder" || item.type === "site") return true;
+  const type = (item.type ?? "").trim().toLowerCase();
+  if (FOLDER_TYPE_KEYS.has(type)) return true;
+  const category = (item.category ?? "").trim().toLowerCase();
+  if (category === "folder") return true;
+  // Server PSPathItem.setPath appends '/' only for folders. $System$ and
+  // similar under /Folders/ may omit type but still use a folder path (#3330).
+  const path = (item.path ?? "").trim();
+  if (path.endsWith("/")) return true;
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
-  // Fallback heuristic: folders lack an "id" with content semantics; they
-  // expose hasFolderChildren / hasItemChildren flags in PSPathItem.
-  return Boolean(item.hasFolderChildren) || item.category === "folder";
+  return Boolean(item.hasFolderChildren);
 }
 
 export function canRead(item: PSPathItem | null): boolean {

--- a/WebUI/src/main/ts/contentExplorer/workflowEligibility.ts
+++ b/WebUI/src/main/ts/contentExplorer/workflowEligibility.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * When Explorer may call itemmanagement workflow endpoints (#3330 / #3329).
+ *
+ * Folders (and objects with {@code workflowId == -1}) are not workflowed
+ * content. Loading transitions for them hits {@code getWorkflow(-1)} on
+ * the server.
+ */
+
+import type { PSPathItem } from "../api/contentExplorer/types";
+import { isFolder } from "./selection";
+
+function numericWorkflowId(item: PSPathItem): number | null {
+  const extras = item as PSPathItem & { workflowId?: string | number };
+  const raw =
+    extras.workflowId ??
+    item.displayProperties?.workflowId ??
+    item.displayProperties?.sys_workflowid ??
+    item.displayProperties?.sys_workflow;
+  if (raw == null || raw === "") return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** True when the item is a folder or its workflow id is the CMS "none" sentinel. */
+export function isNonWorkflowedItem(item: PSPathItem | null | undefined): boolean {
+  if (!item) return true;
+  if (isFolder(item)) return true;
+  const wf = numericWorkflowId(item);
+  return wf != null && wf <= 0;
+}
+
+/** True when the selection can receive workflow transitions. */
+export function isWorkflowEligibleItem(
+  item: PSPathItem | null | undefined,
+): boolean {
+  if (!item || isNonWorkflowedItem(item)) return false;
+  const id = item.id != null ? String(item.id).trim() : "";
+  return id.length > 0;
+}

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -571,6 +571,128 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("activating a pathmanagement Folder stays in Explorer browse (#3330)", async () => {
+    const onOpenItem = vi.fn();
+    const loadWorkflowMenuActions = vi.fn(async (item) => {
+      // Folders must not request transitions; default returns null (#3330).
+      if (item && String(item.type).toLowerCase() === "folder") {
+        return null;
+      }
+      return null;
+    });
+    const folderRow = {
+      id: "16777215-101-1",
+      name: "New-Folder",
+      path: "/Folders/New-Folder/",
+      type: "Folder",
+      leaf: true,
+      accessLevel: "WRITE" as const,
+    };
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        const listingFolders = url.includes("/Folders") && !url.includes("New-Folder");
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: listingFolders ? [folderRow] : [],
+              childrenCount: listingFolders ? 1 : 0,
+              startIndex: 1,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Folders"
+        onOpenItem={onOpenItem}
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        loadWorkflowMenuActions={loadWorkflowMenuActions}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-16777215-101-1")).toBeInTheDocument();
+    });
+    fireEvent.doubleClick(screen.getByTestId("detail-row-16777215-101-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell")).toBeInTheDocument();
+      expect(screen.getByTestId("detail-list")).toBeInTheDocument();
+    });
+    expect(onOpenItem).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("detail-row-16777215-101-1")).toBeNull();
+    for (const call of loadWorkflowMenuActions.mock.calls) {
+      const arg = call[0] as { type?: string } | null;
+      if (arg) {
+        expect(arg.type).not.toBe("Folder");
+      }
+    }
+  });
+
+  it("activating a page still opens the editor host (#3330)", async () => {
+    const onOpenItem = vi.fn();
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "55",
+                  name: "page-one",
+                  path: "/Sites/Demo/page-one",
+                  type: "page",
+                  leaf: true,
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 1,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        onOpenItem={onOpenItem}
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        loadWorkflowMenuActions={async () => null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-55")).toBeInTheDocument();
+    });
+    fireEvent.doubleClick(screen.getByTestId("detail-row-55"));
+    await waitFor(() => {
+      expect(onOpenItem).toHaveBeenCalled();
+    });
+    const opened = onOpenItem.mock.calls[0][0] as { id?: string; type?: string };
+    expect(opened.id).toBe("55");
+    expect(opened.type).toBe("page");
+  });
+
   it("chrome labels are EXPLORER_MSG / message() keys (i18n FR-026)", () => {
     // Product chrome must use perc.ui.explorer@ keys — not bare English.
     const chromeKeys = [

--- a/WebUI/src/test/ts/contentExplorer/openInEditor.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/openInEditor.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openInEditor } from "../../../main/ts/contentExplorer/openInEditor";
+
+describe("openInEditor (#3330)", () => {
+  const originalHref = window.location.href;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    try {
+      window.location.href = originalHref;
+    } catch {
+      // jsdom may freeze location; ignore
+    }
+  });
+
+  it("does not navigate to the editor for Folder path items", () => {
+    const hrefSpy = vi.fn();
+    vi.stubGlobal("location", { href: originalHref });
+    Object.defineProperty(window.location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: hrefSpy,
+    });
+    openInEditor({
+      id: "16777215-101-1",
+      name: "New-Folder",
+      path: "/Folders/New-Folder/",
+      type: "Folder",
+    });
+    expect(hrefSpy).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the editor for a page path", () => {
+    const hrefSpy = vi.fn();
+    Object.defineProperty(window.location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: hrefSpy,
+    });
+    openInEditor({
+      id: "55",
+      name: "Home",
+      path: "/Sites/Demo/Home",
+      type: "page",
+    });
+    expect(hrefSpy).toHaveBeenCalled();
+    const dest = String(hrefSpy.mock.calls[0][0]);
+    expect(dest).toContain("view=editor");
+    expect(dest).toContain(encodeURIComponent("/Sites/Demo/Home"));
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -45,6 +45,38 @@ describe("isFolder (#3001 site nodes)", () => {
     ).toBe(true);
   });
 
+  it("treats trailing-slash paths as folders when type is omitted (#3330 $System$)", () => {
+    expect(
+      isFolder({
+        id: "3",
+        name: "$System$",
+        path: "/Folders/$System$/",
+        leaf: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats pathmanagement Folder / FSFolder as folders even with id and leaf (#3330)", () => {
+    expect(
+      isFolder({
+        id: "16777215-101-1",
+        name: "New-Folder",
+        path: "/Folders/New-Folder/",
+        type: "Folder",
+        leaf: true,
+      }),
+    ).toBe(true);
+    expect(
+      isFolder({
+        id: "2",
+        name: "css",
+        path: "/Design/css/",
+        type: "FSFolder",
+        leaf: true,
+      }),
+    ).toBe(true);
+  });
+
   it("does not treat leaf pages as folders", () => {
     expect(
       isFolder({

--- a/WebUI/src/test/ts/contentExplorer/workflowEligibility.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/workflowEligibility.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import {
+  isNonWorkflowedItem,
+  isWorkflowEligibleItem,
+} from "../../../main/ts/contentExplorer/workflowEligibility";
+
+function item(partial: Partial<PSPathItem> & { name: string; path: string }): PSPathItem {
+  return partial;
+}
+
+describe("workflowEligibility (#3330)", () => {
+  it("rejects server Folder / FSFolder types even when they have a content id", () => {
+    const folder: PSPathItem = {
+      id: "16777215-101-703",
+      name: "New-Folder",
+      path: "/Folders/New-Folder/",
+      type: "Folder",
+      leaf: true,
+    };
+    expect(isNonWorkflowedItem(folder)).toBe(true);
+    expect(isWorkflowEligibleItem(folder)).toBe(false);
+
+    const fs: PSPathItem = {
+      id: "9",
+      name: "Design",
+      path: "/Design/",
+      type: "FSFolder",
+    };
+    expect(isWorkflowEligibleItem(fs)).toBe(false);
+  });
+
+  it("rejects workflowId -1 / 0 sentinels on otherwise item-shaped rows", () => {
+    expect(
+      isWorkflowEligibleItem({
+        id: "42",
+        name: "ghost",
+        path: "/Folders/ghost",
+        type: "percPage",
+        displayProperties: { sys_workflowid: -1 },
+      }),
+    ).toBe(false);
+    expect(
+      isNonWorkflowedItem({
+        id: "42",
+        name: "ghost",
+        path: "/Folders/ghost",
+        type: "percPage",
+        displayProperties: { workflowId: "0" },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a page with a real id and no invalid workflow sentinel", () => {
+    const page = item({
+      id: "33554432-101-1",
+      name: "Home",
+      path: "/Sites/Demo/Home",
+      type: "page",
+      leaf: true,
+    });
+    expect(isWorkflowEligibleItem(page)).toBe(true);
+    expect(isNonWorkflowedItem(page)).toBe(false);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3330-folder-open-explorer-browse.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3330-folder-open-explorer-browse.spec.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3330 / parent #3329 — folder open stays in Explorer browse.
+ *
+ * Opening a folder (tree or detail row) must list children in Content
+ * Explorer. It must not navigate to {@code view=editor} or call
+ * itemmanagement {@code getTransitions} / workflow load for {@code -1}.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3330-folder-open-explorer-browse.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+
+function isWorkflowLoadUrl(url) {
+  const u = String(url || "");
+  return (
+    u.includes("itemmanagement/workflow") ||
+    u.includes("getTransitions") ||
+    /workflow[/=]-1/.test(u)
+  );
+}
+
+test.describe("GH-3330 folder open stays in Explorer browse", () => {
+  test(
+    "opening Folders stays on Explorer and does not hit workflow -1",
+    { tag: ["@explorer", "@folder-browse", "@smoke"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const workflowHits = [];
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+      page.on("request", (req) => {
+        const url = req.url();
+        if (isWorkflowLoadUrl(url)) {
+          workflowHits.push(url);
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+
+      const foldersNode = page.locator(
+        '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
+      );
+      if ((await foldersNode.count()) === 0) {
+        test.info().annotations.push({
+          type: "note",
+          description: "No /Folders tree node on this fixture; chrome-only assert",
+        });
+        await expect(page).not.toHaveURL(/view=editor/);
+        return;
+      }
+      await foldersNode.first().click();
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+      await expect(page).not.toHaveURL(/view=editor/);
+
+      const childFolder = page
+        .locator('[data-testid^="detail-row-"]:not([aria-disabled="true"])')
+        .first();
+      if ((await childFolder.count()) > 0) {
+        await childFolder.dblclick();
+        await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+        await expect(page).not.toHaveURL(/view=editor/);
+      }
+
+      expect(
+        workflowHits,
+        "folder browse must not call itemmanagement workflow / getTransitions",
+      ).toEqual([]);
+      const unexpected = consoleErrors.filter(
+        (t) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            t,
+          ),
+      );
+      expect(unexpected, `console/page errors: ${unexpected.join(" | ")}`).toEqual(
+        [],
+      );
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/system/src/test/java/com/percussion/webservices/PSWebserviceUtilsGetWorkflowTest.java
+++ b/system/src/test/java/com/percussion/webservices/PSWebserviceUtilsGetWorkflowTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webservices;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guard: folder / sentinel workflow ids must not call {@code loadWorkflow}
+ * (GH-3330 — no 500 {@code Failed to load workflow with id '-1'}).
+ */
+public class PSWebserviceUtilsGetWorkflowTest {
+
+  @Test
+  public void sentinelIdsAreNotLoadable() {
+    assertFalse(PSWebserviceUtils.isLoadableWorkflowId(-1));
+    assertFalse(PSWebserviceUtils.isLoadableWorkflowId(0));
+    assertTrue(PSWebserviceUtils.isLoadableWorkflowId(1));
+    assertTrue(PSWebserviceUtils.isLoadableWorkflowId(6));
+  }
+
+  @Test
+  public void getWorkflowRejectsSentinelWithoutLocatorLoad() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> PSWebserviceUtils.getWorkflow(-1));
+    assertTrue(ex.getMessage().contains("-1"));
+    assertThrows(IllegalArgumentException.class, () -> PSWebserviceUtils.getWorkflow(0));
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/PSWebserviceUtils.java
+++ b/system/webservices/src/com/percussion/webservices/PSWebserviceUtils.java
@@ -1822,17 +1822,39 @@ public class PSWebserviceUtils
    }
 
    /**
+    * Folders and other non-workflowed CMS objects use {@code -1} (or {@code 0})
+    * as the workflow-id sentinel. Those ids are not loadable GUIDs.
+    *
+    * @param workflowId candidate workflow application id
+    * @return {@code true} when {@link #getWorkflow(int)} may attempt a load
+    */
+   public static boolean isLoadableWorkflowId(int workflowId)
+   {
+      return workflowId > 0;
+   }
+
+   /**
     * Loads the workflow with the specified workflow id.
     *
     * @param workflowId the workflow id.
     *
     * @return the specified workflow, never <code>null</code>.
     *
-    * @throws PSErrorException if failed to load the specified workflow.
+    * @throws IllegalArgumentException if {@code workflowId} is {@code <= 0}
+    *            (maps to HTTP 400 via {@code PSRuntimeExceptionMapper})
+    * @throws PSErrorException if failed to load a positive but missing workflow
     */
    public static PSWorkflow getWorkflow(int workflowId)
       throws PSErrorException
    {
+      if (!isLoadableWorkflowId(workflowId))
+      {
+         throw new IllegalArgumentException(
+               "Workflow id is not loadable: "
+                     + workflowId
+                     + " (folders and non-workflowed objects use -1)");
+      }
+
       IPSWorkflowService svc = PSWorkflowServiceLocator.getWorkflowService();
       IPSGuidManager gmgr = PSGuidManagerLocator.getGuidMgr();
       PSWorkflow wf = null;


### PR DESCRIPTION
## Summary

Opening a folder in Content Explorer (for example `/Folders/New-Folder/` or `/Folders/$System$/`) was treated as a workflowed content item. The SPA used lowercase `folder` only, while pathmanagement sends `Folder` / `FSFolder` (and some rows omit type but use a trailing-slash folder path). Double-click then navigated to `?view=editor&path=…` and the server tried `getWorkflow(-1)` → HTTP 500 `Failed to load workflow with id '-1'`.

This PR (parent tracker **#3329**, slice 1) keeps folder activate/open on the Explorer browse path, skips itemmanagement workflow loads for folders and `workflowId <= 0`, and makes `PSWebserviceUtils.getWorkflow` reject sentinel ids with `IllegalArgumentException` (HTTP 400 via `PSRuntimeExceptionMapper`) instead of a 500 after a GUID load failure.

Sibling slices remain out of scope: BootstrapContext `useContext` (#3331), editor icon 404s / stuck Editor chrome (#3332).

Fixes #3330  
Partial #3329 (slice 1 of 3)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. QA H2: `python docker/scripts/perc-devctl.py qa-up` (capture `TEST_CMS_URL` / admin password).
2. Log in as Admin → Explorer.
3. Open `/Folders` in the tree; confirm the shell stays on Explorer (URL has no `view=editor`).
4. Double-click a folder row (including `$System$` if listed). Confirm children list in Explorer; no Editor load.
5. Select a page/asset and confirm Open still goes to the editor.
6. Confirm `server.log` has no new `Unable to load workflow with id: -1` for folder browse.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing operator-step change): folder open still means browse the folder; no new admin/config/procedure.
- [x] **Unit / module tests** — Vitest folder vs item activate + eligibility; `PSWebserviceUtilsGetWorkflowTest`; standalone `mvnw clean install` on `WebUI` and `system`.
- [x] **WebUI + Playwright** — `tests/bugs/bug-3330-folder-open-explorer-browse.spec.js` + golden smoke.
- [x] **Build gates** — standalone clean install, tests included, no skipTests.
- [x] **Cross-platform** — **N/A** (no new filesystem path I/O).

## C3 evidence

- **modules_built:** `WebUI`, `system`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` → **BUILD SUCCESS** (Surefire Java `Tests run: 51, Failures: 0`; Vitest `Test Files 307 passed`, `Tests 2208 passed`)
  - `cd system; ../mvnw.cmd clean install` → **BUILD SUCCESS** (`Tests run: 2105, Failures: 0, Skipped: 241`; `PSWebserviceUtilsGetWorkflowTest` `Tests run: 2, Failures: 0`)
- **downstream_checked:** none — no existing public/protected signature made `final`/`sealed` or changed; added `isLoadableWorkflowId` only. Grep `extends PSWebserviceUtils` / anonymous `new PSWebserviceUtils() {` = 0 hits.

## C5 UI live proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CONTAINER=perc-matrix-cms-h2`)
- **deploy:** copied `WebUI/target/generated-webui/cm/modern/assets` into the cell; copied `perc-system-8.2.0-SNAPSHOT.jar` to `WEB-INF/lib` and `docker restart perc-matrix-cms-h2` (HTTP 200 on sitelist)
- **Playwright:**
  - `npm run test:surface -- --path tests/bugs/bug-3330-folder-open-explorer-browse.spec.js` → **1 passed**
  - `npm run test:golden` → **2 passed**
- **console-clean:** yes (resource 404/400 noise filtered per peer Explorer specs; no pageerror / workflow-load console errors on the passing run)
- **server.log-clean:** yes for the passing folder-browse window (no `Unable to load workflow with id: -1` after 14:55:30). One earlier `-1` ERROR at 14:54:49 was from the pre-trailing-slash `$System$` editor navigation during the same session; not reproduced on the passing spec.
- **qa-down:** removed `perc-matrix-cms-h2`

> Co-Authored by Grok Build using grok-4.5 with agent main.
