### PR TITLE
fix(webui): ContentExplorerShell BootstrapContext useContext crash (#3331)

### DIFF
--- a/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
+++ b/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
@@ -18,20 +18,40 @@
 import React, { createContext, useContext } from "react";
 import { DEFAULT_SPA_BOOTSTRAP, type SpaBootstrap } from "./types";
 
-const BootstrapContext = createContext<SpaBootstrap>(DEFAULT_SPA_BOOTSTRAP);
+/**
+ * {@code null} default so a missing provider is distinguishable from a real
+ * {@link DEFAULT_SPA_BOOTSTRAP} value. Callers that only need identity flags
+ * should use {@link useSpaBootstrap} (falls back). Explorer uses
+ * {@link useSpaBootstrapOptional} so a missing provider is an error state
+ * instead of a {@code useContext} crash (#3331 / parent #3329).
+ */
+const BootstrapContext = createContext<SpaBootstrap | null>(null);
 
 export function BootstrapProvider({
   value,
   children,
 }: {
   value: SpaBootstrap;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }): React.ReactElement {
   return (
     <BootstrapContext.Provider value={value}>{children}</BootstrapContext.Provider>
   );
 }
 
+/**
+ * Read SPA bootstrap without throwing when the provider is absent or React's
+ * dispatcher is unset (bridge remount / dual-React). Returns {@code null} in
+ * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}.
+ */
+export function useSpaBootstrapOptional(): SpaBootstrap | null {
+  try {
+    return useContext(BootstrapContext);
+  } catch {
+    return null;
+  }
+}
+
 export function useSpaBootstrap(): SpaBootstrap {
-  return useContext(BootstrapContext);
+  return useSpaBootstrapOptional() ?? DEFAULT_SPA_BOOTSTRAP;
 }

--- a/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
+++ b/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
@@ -40,15 +40,37 @@ export function BootstrapProvider({
 }
 
 /**
+ * True when {@code useContext} failed because React has no hook dispatcher
+ * (dual-React remount / hook called outside a component). Other errors must
+ * surface so real bugs are not swallowed.
+ */
+export function isBootstrapHookEnvironmentError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const msg = err.message;
+  return (
+    msg.includes("Invalid hook call") ||
+    /Cannot read propert(?:y|ies) of null \(reading ['"]useContext['"]\)/i.test(
+      msg,
+    )
+  );
+}
+
+/**
  * Read SPA bootstrap without throwing when the provider is absent or React's
  * dispatcher is unset (bridge remount / dual-React). Returns {@code null} in
- * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}.
+ * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}. Unexpected
+ * errors from {@code useContext} are rethrown.
  */
 export function useSpaBootstrapOptional(): SpaBootstrap | null {
   try {
     return useContext(BootstrapContext);
-  } catch {
-    return null;
+  } catch (err) {
+    if (isBootstrapHookEnvironmentError(err)) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
@@ -18,6 +18,11 @@
 import React, { lazy, useMemo } from "react";
 import { useLocation } from "react-router";
 import { normalizeExplorerPath } from "../deepLinks/allowlists";
+import {
+  BootstrapProvider,
+  useSpaBootstrapOptional,
+} from "../bootstrap/BootstrapContext";
+import { loadSpaBootstrap } from "../bootstrap/loadBootstrap";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";
 import styles from "./ExplorerRoute.module.css";
@@ -33,25 +38,29 @@ const ContentExplorerShellLazy = lazy(() =>
  */
 export function ExplorerRoute(): React.ReactElement {
   const location = useLocation();
+  const fromContext = useSpaBootstrapOptional();
+  const bootstrap = fromContext ?? loadSpaBootstrap();
   const initialPath = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return normalizeExplorerPath(params.get("path")) ?? "/";
   }, [location.search]);
 
   return (
-    <LazyRouteFrame
-      label="Content Explorer"
-      fallback={
-        <div
-          className={styles.loading}
-          data-testid="explorer-route-loading"
-          role="status"
-        >
-          Loading Content Explorer…
-        </div>
-      }
-    >
-      <ContentExplorerShellLazy initialPath={initialPath} />
-    </LazyRouteFrame>
+    <BootstrapProvider value={bootstrap}>
+      <LazyRouteFrame
+        label="Content Explorer"
+        fallback={
+          <div
+            className={styles.loading}
+            data-testid="explorer-route-loading"
+            role="status"
+          >
+            Loading Content Explorer…
+          </div>
+        }
+      >
+        <ContentExplorerShellLazy initialPath={initialPath} />
+      </LazyRouteFrame>
+    </BootstrapProvider>
   );
 }

--- a/WebUI/src/main/ts/bridge.ts
+++ b/WebUI/src/main/ts/bridge.ts
@@ -25,6 +25,8 @@
 
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { BootstrapProvider } from "./app/bootstrap/BootstrapContext";
+import { loadSpaBootstrap } from "./app/bootstrap/loadBootstrap";
 import { isRegisteredComponent, loadComponent } from "./registry";
 
 declare global {
@@ -87,7 +89,13 @@ export function mountReactComponent(
       }
       unmountRootOnly(elementId);
       const root = createRoot(el);
-      root.render(React.createElement(Component, props));
+      root.render(
+        React.createElement(
+          BootstrapProvider,
+          { value: loadSpaBootstrap() },
+          React.createElement(Component, props),
+        ),
+      );
       activeRoots.set(elementId, root);
     })
     .catch((err) => {

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -65,7 +65,8 @@ import type {
   ViewExecuteRequest,
   ViewExecuteResult,
 } from "../api/developer/types";
-import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
+import { useSpaBootstrapOptional } from "../app/bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "../app/bootstrap/types";
 import { message } from "../i18n/message";
 import {
   filterContextMenuActions,
@@ -367,7 +368,37 @@ async function defaultResolveFolderId(
   }
 }
 
-export function ContentExplorerShell({
+function ExplorerBootstrapUnavailable(): React.ReactElement {
+  return (
+    <div
+      data-testid="content-explorer-shell"
+      role="alert"
+      aria-live="assertive"
+      style={errorStateStyle}
+    >
+      <p data-testid="explorer-bootstrap-unavailable" style={{ margin: 0 }}>
+        {message(EXPLORER_MSG.BOOTSTRAP_UNAVAILABLE)}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Product Explorer entry. Reads bootstrap optionally so a missing
+ * {@code BootstrapProvider} (legacy bridge remount) is an error state, not a
+ * {@code useContext} throw (#3331).
+ */
+export function ContentExplorerShell(
+  props: ContentExplorerShellProps,
+): React.ReactElement {
+  const bootstrap = useSpaBootstrapOptional();
+  if (!bootstrap) {
+    return <ExplorerBootstrapUnavailable />;
+  }
+  return <ContentExplorerShellInner {...props} bootstrap={bootstrap} />;
+}
+
+function ContentExplorerShellInner({
   initialPath = "/",
   onOpenItem = openInEditor,
   actionHandlers,
@@ -384,8 +415,8 @@ export function ContentExplorerShell({
   executeSavedSearch,
   listViews = listViewsApi,
   executeView = executeViewApi,
-}: ContentExplorerShellProps): React.ReactElement {
-  const bootstrap = useSpaBootstrap();
+  bootstrap,
+}: ContentExplorerShellProps & { bootstrap: SpaBootstrap }): React.ReactElement {
   const currentUserIdentities = useMemo(() => {
     if (currentUserIdentitiesProp) {
       return [...currentUserIdentitiesProp];

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -64,6 +64,8 @@ export const EXPLORER_MSG = {
   PROMPT_NEW_FOLDER_NAME: "perc.ui.explorer@Enter new folder name",
   PROMPT_NEW_NAME: "perc.ui.explorer@Enter new name",
   ERROR_GENERIC: "perc.ui.explorer@Something went wrong",
+  BOOTSTRAP_UNAVAILABLE:
+    "perc.ui.explorer@Content Explorer could not start because the application session is not available. Reload the page or sign in again.",
 
   // US7 P-Adv / clipboard / wizards / dependency / relationships (FR-021–FR-029, SC-011)
   CLIPBOARD_TITLE: "perc.ui.explorer@Clipboard",

--- a/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
+++ b/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BootstrapProvider,
+  isBootstrapHookEnvironmentError,
   useSpaBootstrap,
   useSpaBootstrapOptional,
 } from "../../../../main/ts/app/bootstrap/BootstrapContext";
@@ -73,5 +74,27 @@ describe("BootstrapContext (#3331)", () => {
     );
     expect(screen.getByTestId("optional").textContent).toBe("Admin");
     expect(screen.getByTestId("required").textContent).toBe("Admin");
+  });
+
+  it("classifies only null-dispatcher / invalid-hook errors as environment", () => {
+    expect(
+      isBootstrapHookEnvironmentError(
+        new Error(
+          "Invalid hook call. Hooks can only be called inside of the body of a function component.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isBootstrapHookEnvironmentError(
+        new TypeError("Cannot read properties of null (reading 'useContext')"),
+      ),
+    ).toBe(true);
+    expect(
+      isBootstrapHookEnvironmentError(new Error("Cannot read property of null (reading 'useContext')")),
+    ).toBe(true);
+    expect(isBootstrapHookEnvironmentError(new Error("Maximum update depth exceeded"))).toBe(
+      false,
+    );
+    expect(isBootstrapHookEnvironmentError("not-an-error")).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
+++ b/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BootstrapProvider,
+  useSpaBootstrap,
+  useSpaBootstrapOptional,
+} from "../../../../main/ts/app/bootstrap/BootstrapContext";
+import {
+  DEFAULT_SPA_BOOTSTRAP,
+  type SpaBootstrap,
+} from "../../../../main/ts/app/bootstrap/types";
+
+const sample: SpaBootstrap = {
+  ...DEFAULT_SPA_BOOTSTRAP,
+  userName: "Admin",
+  isAdmin: true,
+  entry: "explorer",
+};
+
+function OptionalProbe(): React.ReactElement {
+  const value = useSpaBootstrapOptional();
+  return (
+    <div data-testid="optional">
+      {value == null ? "missing" : value.userName}
+    </div>
+  );
+}
+
+function RequiredProbe(): React.ReactElement {
+  const value = useSpaBootstrap();
+  return <div data-testid="required">{value.userName || "empty"}</div>;
+}
+
+describe("BootstrapContext (#3331)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("useSpaBootstrapOptional is null without a provider and does not throw", () => {
+    expect(() => render(<OptionalProbe />)).not.toThrow();
+    expect(screen.getByTestId("optional").textContent).toBe("missing");
+  });
+
+  it("useSpaBootstrap falls back to default identity without a provider", () => {
+    expect(() => render(<RequiredProbe />)).not.toThrow();
+    expect(screen.getByTestId("required").textContent).toBe("empty");
+  });
+
+  it("both hooks read the provider value", () => {
+    render(
+      <BootstrapProvider value={sample}>
+        <OptionalProbe />
+        <RequiredProbe />
+      </BootstrapProvider>,
+    );
+    expect(screen.getByTestId("optional").textContent).toBe("Admin");
+    expect(screen.getByTestId("required").textContent).toBe("Admin");
+  });
+});

--- a/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
+++ b/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
@@ -26,13 +26,19 @@ vi.mock("../../../../main/ts/registry", () => ({
     if (name !== "ContentExplorerShell") {
       throw new Error(`unexpected component: ${name}`);
     }
-    return function FakeExplorerShell(): React.ReactElement {
-      return <div data-testid="content-explorer-shell">explorer</div>;
+    return function StubExplorer({
+      initialPath,
+    }: {
+      initialPath?: string;
+    }): React.ReactElement {
+      return (
+        <div data-testid="content-explorer-shell">stub:{initialPath}</div>
+      );
     };
   },
 }));
 
-describe("ExplorerRoute loading chrome (#3332)", () => {
+describe("ExplorerRoute (#3331 / #3332)", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
@@ -50,5 +56,22 @@ describe("ExplorerRoute loading chrome (#3332)", () => {
       expect(screen.getByTestId("content-explorer-shell")).toBeTruthy();
     });
     expect(screen.queryByTestId("explorer-route-loading")).toBeNull();
+  });
+
+  it("renders the explorer shell without an outer BootstrapProvider", async () => {
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={["/explorer?path=/Folders"]}>
+          <Routes>
+            <Route path="/explorer" element={<ExplorerRoute />} />
+          </Routes>
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell").textContent).toBe(
+        "stub:/Folders",
+      );
+    });
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1772,3 +1772,23 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     );
   });
 });
+
+describe("ContentExplorerShell missing BootstrapProvider (#3331)", () => {
+  it("renders an error state without throwing useContext", async () => {
+    stubPathFetch();
+    expect(() =>
+      render(
+        <ContentExplorerShell
+          initialPath="/Folders"
+          loadDisplayFormats={async () => []}
+          loadMenuActions={async () => []}
+        />,
+      ),
+    ).not.toThrow();
+    const alert = screen.getByTestId("explorer-bootstrap-unavailable");
+    expect(alert).toBeInTheDocument();
+    expect(alert.textContent).toMatch(/application session is not available/i);
+    expect(screen.queryByTestId("explorer-nav")).toBeNull();
+    await renderA11yGate(screen.getByTestId("content-explorer-shell"));
+  });
+});

--- a/docs/ai-generated/code-reviews/3331-explorer-bootstrap-context-erlang.md
+++ b/docs/ai-generated/code-reviews/3331-explorer-bootstrap-context-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3331 ContentExplorerShell BootstrapContext
+
+**Date:** 2026-08-13  
+**Branch:** `fix/issue-3331-explorer-bootstrap-context`  
+**Scope:** uncommitted WebUI + perc-qa-automation + product-docs vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** pass — May commit/push: yes  
+**Memory patterns hit:** missing behavioral tests (covered); WebUI Playwright companion (covered); change-class closure for Explorer i18n/a11y (covered)
+
+## Summary
+
+Slice 2 of parent #3329. Explorer remount/bridge used `useSpaBootstrap` → `useContext` when React’s dispatcher or the provider was missing (`Cannot read properties of null (reading 'useContext')`). The change makes context optional, shows an i18n error state on the shell, and always wraps Explorer route + PercModernUI bridge mounts with `BootstrapProvider`.
+
+## Issues
+
+None (no bugs, no missing behavioral tests, no non-portable path I/O).
+
+## Companions
+
+| Kind | Status |
+|------|--------|
+| Vitest without provider (no throw + error chrome) | Yes |
+| Vitest with provider (existing shell suite) | Yes (module suite) |
+| ExplorerRoute wrap without outer provider | Yes |
+| Playwright folder open + no useContext console | Yes (`bug-3331-…spec.js`) |
+| `renderA11yGate` / Playwright a11y | Yes |
+| `EXPLORER_MSG` i18n | Yes |
+| product-docs | Yes (`admin/content-explorer.md`) |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Playwright uses `BASE_URL` from env.
+
+## Evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 309 files / 2214 tests; Surefire 51 tests
+- Playwright QA `TEST_CMS_URL=http://127.0.0.1:9993`: `bug-3331` 1 passed; `test:golden` 2 passed

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3331 / parent #3329 — ContentExplorerShell must not throw
+ * {@code useContext} on BootstrapContext when opening a folder.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+
+function isUseContextCrash(text) {
+  return /useContext|BootstrapContext|Cannot read properties of null/i.test(
+    String(text || ""),
+  );
+}
+
+test.describe("GH-3331 Explorer BootstrapContext useContext", () => {
+  test(
+    "opening a folder does not throw useContext on BootstrapContext",
+    { tag: ["@explorer", "@bootstrap", "@smoke"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-bootstrap-unavailable"]'),
+      ).toHaveCount(0);
+
+      const foldersNode = page.locator(
+        '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
+      );
+      if ((await foldersNode.count()) > 0) {
+        await foldersNode.first().click();
+      }
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+      await expect(
+        page.locator('[data-testid="explorer-bootstrap-unavailable"]'),
+      ).toHaveCount(0);
+
+      const childFolder = page
+        .locator('[data-testid^="detail-row-"]:not([aria-disabled="true"])')
+        .first();
+      if ((await childFolder.count()) > 0) {
+        await childFolder.dblclick();
+        await expect(
+          page.locator('[data-testid="content-explorer-shell"]'),
+        ).toBeVisible();
+      }
+
+      const useContextHits = consoleErrors.filter(isUseContextCrash);
+      expect(
+        useContextHits,
+        `useContext/BootstrapContext console errors: ${useContextHits.join(" | ")}`,
+      ).toEqual([]);
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -256,6 +256,14 @@ From the **View** menu you can also toggle:
   suitable item is selected
 - **Clipboard** — multi-select copy/cut staging when items are selected
 
+## If Content Explorer cannot start
+
+If the Explorer area shows a short error that the **application session is not
+available** instead of the tree and list, the page did not receive the usual
+authenticated SPA session. Reload the page, or sign out and sign in again, then
+open **Explorer** from the product navigation. Do not use a bookmarked editor
+URL that embeds Explorer without the SPA shell.
+
 ## Related
 
 - [Sites & content structure](id:admin-sites)


### PR DESCRIPTION
## Summary

Fixes Content Explorer remount/bridge crash `Cannot read properties of null (reading 'useContext')` at `useSpaBootstrap` / `BootstrapContext` (parent **#3329** slice 2).

- `useSpaBootstrapOptional()` never throws when the provider is missing or React's dispatcher is unset; `useSpaBootstrap()` still falls back to `DEFAULT_SPA_BOOTSTRAP`.
- `ContentExplorerShell` shows an i18n/508 error state (`explorer-bootstrap-unavailable`) instead of a white/stuck page when bootstrap is absent.
- `ExplorerRoute` and residual `PercModernUI` bridge mounts wrap children in `BootstrapProvider`.

**Parent:** #3329  
**Fixes #3331**  
**Partial #3329** (sibling slices #3330 / #3332 remain)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd WebUI` → `../mvnw.cmd clean install` (standalone).
2. Vitest: render `ContentExplorerShell` **without** `BootstrapProvider` — no throw; error chrome visible. With provider — existing explorer suite still green.
3. QA H2: `python docker/scripts/perc-devctl.py qa-up` (freeport `TEST_CMS_URL`).
4. Hot-copy `WebUI/target/generated-webui/cm/modern/assets` into the cell `…/Rhythmyx/cm/modern/assets`.
5. Playwright: `npm run test:surface -- --path tests/bugs/bug-3331-explorer-bootstrap-context.spec.js` — open a folder, no `useContext` console error.
6. Golden: `npm run test:golden`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` (If Content Explorer cannot start)
- [x] **Unit / module tests** — BootstrapContext + ExplorerRoute + shell-without-provider; modules green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3331-explorer-bootstrap-context.spec.js`
- [x] **Build gates** — standalone clean install; C2 API-shape reverse-deps N/A
- [x] **Cross-platform** — N/A (no filesystem path I/O)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-13T11:08:35-04:00). Surefire `Tests run: 51, Failures: 0`. Vitest `Test Files 309 passed`, `Tests 2214 passed`.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (placeholder jar; Playwright run separately).
- **downstream_checked:** none (no `final`/signature break; added optional hook + provider wrap only)

### C5 UI proof (H2 QA)

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CMS_HOST_PORT=9993`, container `perc-matrix-cms-h2`)
- Deploy: `docker cp` of `WebUI/target/generated-webui/cm/modern/assets` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`
- `npm run test:surface -- --path tests/bugs/bug-3331-explorer-bootstrap-context.spec.js` → **1 passed** (3.2s)
- `npm run test:golden` → **2 passed**
- **console-clean:** yes (spec asserts no `useContext` / `BootstrapContext` / null-read pageerror)
- **server.log-clean:** yes for this feature (no BootstrapContext / Explorer session errors in the test window; pre-existing `PSRuntimeExceptionMapper` null/path-traversal noise unrelated)

> Co-Authored by Grok Build using grok-4.5 with agent main.