### PR TITLE
fix(webui): editor icon 404s and stuck loading chrome (#3332)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -40,6 +40,10 @@ import java.util.Set;
  * tree's {@code spa.jsp} with an allowlisted {@code entry} (and section/tab when present). Real
  * JSPs, static assets, and non-SPA first segments pass through unchanged.
  *
+ * <p>Misplaced editor/chrome images under {@code /cm/app/images/**} or {@code
+ * /cm/pages/app/images/**} are remapped to {@code /cm/images/**} so those URLs return 200 instead
+ * of 404 (#3332).
+ *
  * <p>Server deep links and login return remain the query contract ({@code spa.jsp?entry=…}); this
  * filter only supports clean client path URLs after first paint.
  */
@@ -65,6 +69,8 @@ public class PSWebUiSpaFallbackFilter implements Filter {
 
   private static final String APP_PREFIX = "/cm/app";
   private static final String PAGES_PREFIX = "/cm/pages/app";
+  /** Canonical static image tree (not under the SPA mount). */
+  private static final String CANONICAL_IMAGES = "/cm/images";
 
   @Override
   public void init(FilterConfig filterConfig) {
@@ -90,6 +96,15 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     }
 
     String pathWithinContext = pathWithinContext(httpReq);
+    String imageRemap = buildStaticImageRemapPath(pathWithinContext);
+    if (imageRemap != null) {
+      RequestDispatcher remapDispatcher = request.getRequestDispatcher(imageRemap);
+      if (remapDispatcher != null) {
+        remapDispatcher.forward(request, response);
+        return;
+      }
+    }
+
     String forward = buildSpaForwardPath(pathWithinContext, httpReq.getQueryString());
     if (forward == null) {
       chain.doFilter(request, response);
@@ -126,6 +141,59 @@ public class PSWebUiSpaFallbackFilter implements Filter {
       return "/";
     }
     return uri;
+  }
+
+  /**
+   * Remap misplaced SPA-mount image URLs onto the real {@code /cm/images} tree.
+   *
+   * <p>Editor chrome historically requested {@code /cm/pages/app/images/icons/editor/*.png} (and
+   * {@code /cm/app/images/...}) after a dual-tree rewrite. Those paths 404 because assets live at
+   * {@code /cm/images/...}. Returning a forward path here serves the file without waiting on JSP
+   * callers to be updated.
+   *
+   * @return canonical {@code /cm/images/...} path, or {@code null} when this is not a remappable
+   *     image request
+   */
+  static String buildStaticImageRemapPath(String pathWithinContext) {
+    if (pathWithinContext == null || pathWithinContext.isEmpty()) {
+      return null;
+    }
+    String lower = pathWithinContext.toLowerCase(Locale.ROOT);
+    String misplacedPrefix;
+    if (lower.startsWith(PAGES_PREFIX + "/images/")) {
+      misplacedPrefix = PAGES_PREFIX + "/images";
+    } else if (lower.startsWith(APP_PREFIX + "/images/")) {
+      misplacedPrefix = APP_PREFIX + "/images";
+    } else {
+      return null;
+    }
+    if (!isRemappableImageExtension(lower)) {
+      return null;
+    }
+    String rest = pathWithinContext.substring(misplacedPrefix.length());
+    if (rest.isEmpty() || "/".equals(rest)) {
+      return null;
+    }
+    String[] segments = rest.split("/");
+    for (String seg : segments) {
+      if (seg.isEmpty()) {
+        continue;
+      }
+      if (isUnsafePathSegment(seg)) {
+        return null;
+      }
+    }
+    return CANONICAL_IMAGES + rest;
+  }
+
+  private static boolean isRemappableImageExtension(String lowerPath) {
+    return lowerPath.endsWith(".png")
+        || lowerPath.endsWith(".gif")
+        || lowerPath.endsWith(".jpg")
+        || lowerPath.endsWith(".jpeg")
+        || lowerPath.endsWith(".svg")
+        || lowerPath.endsWith(".ico")
+        || lowerPath.endsWith(".webp");
   }
 
   /**

--- a/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
@@ -42,7 +42,13 @@ export function ExplorerRoute(): React.ReactElement {
     <LazyRouteFrame
       label="Content Explorer"
       fallback={
-        <div className={styles.loading}>Loading Content Explorer…</div>
+        <div
+          className={styles.loading}
+          data-testid="explorer-route-loading"
+          role="status"
+        >
+          Loading Content Explorer…
+        </div>
       }
     >
       <ContentExplorerShellLazy initialPath={initialPath} />

--- a/WebUI/src/main/webapp/cm/app/includes/content_toolbar.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/content_toolbar.jsp
@@ -61,8 +61,8 @@
 <div id='perc_asset_library' class='perc-template-container perc-hidden' style="float:unset;">
     <div class="perc-orphan-assets-menu perc-orphan-assets-menu-left" style="z-index: 4330; float: left; margin-left: -27px; border-right: 1px solid rgb(210, 209, 205);"></div>
     <div class="perc-orphan-assets-menu perc-orphan-assets-menu-right">
-        <img src="/cm/pages/app/images/icons/editor/delete.png" class="perc-ui-menu-icon perc-ui-delete-asset" alt="Delete local content" title="Delete Asset" style="padding-right:4px; margin-top:-4px; float:right; cursor:pointer; padding-left: 1px;"></img>
-        <img src="/cm/pages/app/images/icons/editor/edit.png" class="perc-ui-menu-icon perc-ui-edit-asset" alt="Edit local content" title="Edit Asset" style="margin-top:-4px;float:right; cursor:pointer; padding-left: 1px;"></img>
+        <img src="/cm/images/icons/editor/delete.png" class="perc-ui-menu-icon perc-ui-delete-asset" alt="Delete local content" title="Delete Asset" style="padding-right:4px; margin-top:-4px; float:right; cursor:pointer; padding-left: 1px;" onerror="this.style.visibility='hidden'"></img>
+        <img src="/cm/images/icons/editor/edit.png" class="perc-ui-menu-icon perc-ui-edit-asset" alt="Edit local content" title="Edit Asset" style="margin-top:-4px;float:right; cursor:pointer; padding-left: 1px;" onerror="this.style.visibility='hidden'"></img>
     </div>
     <!-- Explore Orphan Assets Tray-->
     <div class='perc-orphan-assets-list'>

--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/PercViewReadyManager.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/PercViewReadyManager.js
@@ -19,6 +19,8 @@
   $.PercViewReadyManager = {
     wrappers: [],
     isInitialized: false,
+    /** Clear stuck editor/explorer overlay if components never report complete (#3332). */
+    READY_TIMEOUT_MS: 10000,
     init: function () {
       this.isInitialized = true;
     },
@@ -40,10 +42,27 @@
         .addClass("perc-ui-view-processing");
       this.wrappers.push(wrappertoset);
       wrappertoset.init();
+      this.scheduleReadyTimeout(wrappertoset);
       this.logMessage(
         "Added wrapper '" + wrappertoset.wrapperName + "' to manager",
       );
       return true;
+    },
+    scheduleReadyTimeout: function (wrapper) {
+      var self = this;
+      var timeoutMs = self.READY_TIMEOUT_MS || 10000;
+      window.setTimeout(function () {
+        if (!wrapper || wrapper.isWrapperComplete()) {
+          return;
+        }
+        var pending = wrapper.components || [];
+        for (var i = 0; i < pending.length; i++) {
+          var name = pending[i];
+          if ($.inArray(name, wrapper.processedComponents) === -1) {
+            wrapper.handleComponentProgress(name, "complete");
+          }
+        }
+      }, timeoutMs);
     },
     setProcessingFlag: function () {
       $("#perc-ui-view-indicator")

--- a/WebUI/src/main/webapp/cm/pages/app/includes/content_toolbar.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/content_toolbar.jsp
@@ -61,8 +61,8 @@
 <div id='perc_asset_library' class='perc-template-container perc-hidden' style="float:unset;">
     <div class="perc-orphan-assets-menu perc-orphan-assets-menu-left" style="z-index: 4330; float: left; margin-left: -27px; border-right: 1px solid rgb(210, 209, 205);"></div>
     <div class="perc-orphan-assets-menu perc-orphan-assets-menu-right">
-        <img src="/cm/pages/app/images/icons/editor/delete.png" class="perc-ui-menu-icon perc-ui-delete-asset" alt="Delete local content" title="Delete Asset" style="padding-right:4px; margin-top:-4px; float:right; cursor:pointer; padding-left: 1px;"></img>
-        <img src="/cm/pages/app/images/icons/editor/edit.png" class="perc-ui-menu-icon perc-ui-edit-asset" alt="Edit local content" title="Edit Asset" style="margin-top:-4px;float:right; cursor:pointer; padding-left: 1px;"></img>
+        <img src="/cm/images/icons/editor/delete.png" class="perc-ui-menu-icon perc-ui-delete-asset" alt="Delete local content" title="Delete Asset" style="padding-right:4px; margin-top:-4px; float:right; cursor:pointer; padding-left: 1px;" onerror="this.style.visibility='hidden'"></img>
+        <img src="/cm/images/icons/editor/edit.png" class="perc-ui-menu-icon perc-ui-edit-asset" alt="Edit local content" title="Edit Asset" style="margin-top:-4px;float:right; cursor:pointer; padding-left: 1px;" onerror="this.style.visibility='hidden'"></img>
     </div>
     <!-- Explore Orphan Assets Tray-->
     <div class='perc-orphan-assets-list'>

--- a/WebUI/src/main/webapp/cm/plugins/PercViewReadyManager.js
+++ b/WebUI/src/main/webapp/cm/plugins/PercViewReadyManager.js
@@ -19,6 +19,8 @@
   $.PercViewReadyManager = {
     wrappers: [],
     isInitialized: false,
+    /** Clear stuck editor/explorer overlay if components never report complete (#3332). */
+    READY_TIMEOUT_MS: 10000,
     init: function () {
       this.isInitialized = true;
     },
@@ -40,10 +42,27 @@
         .addClass("perc-ui-view-processing");
       this.wrappers.push(wrappertoset);
       wrappertoset.init();
+      this.scheduleReadyTimeout(wrappertoset);
       this.logMessage(
         "Added wrapper '" + wrappertoset.wrapperName + "' to manager",
       );
       return true;
+    },
+    scheduleReadyTimeout: function (wrapper) {
+      var self = this;
+      var timeoutMs = self.READY_TIMEOUT_MS || 10000;
+      window.setTimeout(function () {
+        if (!wrapper || wrapper.isWrapperComplete()) {
+          return;
+        }
+        var pending = wrapper.components || [];
+        for (var i = 0; i < pending.length; i++) {
+          var name = pending[i];
+          if ($.inArray(name, wrapper.processedComponents) === -1) {
+            wrapper.handleComponentProgress(name, "complete");
+          }
+        }
+      }, timeoutMs);
     },
     setProcessingFlag: function () {
       $("#perc-ui-view-indicator")

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -151,6 +151,39 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void remapsMisplacedSpaMountEditorIconsToCanonicalImages() {
+    assertEquals(
+        "/cm/images/icons/editor/delete.png",
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/pages/app/images/icons/editor/delete.png"));
+    assertEquals(
+        "/cm/images/icons/editor/edit.png",
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/pages/app/images/icons/editor/edit.png"));
+    assertEquals(
+        "/cm/images/icons/editor/delete.png",
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/app/images/icons/editor/delete.png"));
+  }
+
+  @Test
+  public void remapsSpaMountImagesRejectsTraversalAndNonImages() {
+    assertNull(
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/pages/app/images/../WEB-INF/web.xml"));
+    assertNull(
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/pages/app/images/icons/%2e%2e/secret.png"));
+    assertNull(
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath("/cm/pages/app/images/icons/editor/"));
+    assertNull(
+        PSWebUiSpaFallbackFilter.buildStaticImageRemapPath(
+            "/cm/pages/app/images/icons/editor/delete.js"));
+    assertNull(PSWebUiSpaFallbackFilter.buildStaticImageRemapPath("/cm/images/icons/editor/delete.png"));
+    assertNull(PSWebUiSpaFallbackFilter.buildStaticImageRemapPath("/cm/app/home"));
+  }
+
+  @Test
   public void dropsDuplicateEntryFromQuery() {
     String forward =
         PSWebUiSpaFallbackFilter.buildSpaForwardPath(

--- a/WebUI/src/test/ts/app/editorIconAssets.test.ts
+++ b/WebUI/src/test/ts/app/editorIconAssets.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Static-resource contract for editor toolbar icons (#3332 / parent #3329).
+ *
+ * The files live under {@code /cm/images/icons/editor}. Toolbar JSPs must
+ * request that canonical tree — not {@code /cm/pages/app/images/...} which
+ * 404s under the SPA mount.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const webappRoot = resolve(__dirname, "../../../main/webapp");
+
+const TOOLBAR_JSPS = [
+  "cm/app/includes/content_toolbar.jsp",
+  "cm/pages/app/includes/content_toolbar.jsp",
+] as const;
+
+const EDITOR_ICONS = [
+  "cm/images/icons/editor/delete.png",
+  "cm/images/icons/editor/edit.png",
+] as const;
+
+function read(rel: string): string {
+  return readFileSync(resolve(webappRoot, rel), "utf8").replace(/\r\n/g, "\n");
+}
+
+describe("editor toolbar icon assets (#3332)", () => {
+  it("ships delete.png and edit.png under /cm/images/icons/editor", () => {
+    for (const rel of EDITOR_ICONS) {
+      expect(existsSync(resolve(webappRoot, rel)), rel).toBe(true);
+    }
+  });
+
+  it("toolbar JSPs request canonical /cm/images paths, not SPA-mount images", () => {
+    for (const rel of TOOLBAR_JSPS) {
+      const text = read(rel);
+      expect(text, rel).toContain('src="/cm/images/icons/editor/delete.png"');
+      expect(text, rel).toContain('src="/cm/images/icons/editor/edit.png"');
+      expect(text, rel).not.toContain("/cm/pages/app/images/");
+      expect(text, rel).not.toContain("/cm/app/images/icons/editor/");
+      expect(text, rel).toContain("onerror=");
+    }
+  });
+});

--- a/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
+++ b/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExplorerRoute } from "../../../../main/ts/app/routes/ExplorerRoute";
+
+vi.mock("../../../../main/ts/registry", () => ({
+  loadComponent: async (name: string) => {
+    if (name !== "ContentExplorerShell") {
+      throw new Error(`unexpected component: ${name}`);
+    }
+    return function FakeExplorerShell(): React.ReactElement {
+      return <div data-testid="content-explorer-shell">explorer</div>;
+    };
+  },
+}));
+
+describe("ExplorerRoute loading chrome (#3332)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("replaces explorer-route-loading with the shell after lazy load", async () => {
+    render(
+      <MemoryRouter initialEntries={["/explorer"]}>
+        <Routes>
+          <Route path="/explorer" element={<ExplorerRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("explorer-route-loading")).toBeNull();
+  });
+});

--- a/docs/ai-generated/code-reviews/3332-editor-icon-404s-erlang.md
+++ b/docs/ai-generated/code-reviews/3332-editor-icon-404s-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — #3332 editor icon 404s / stuck loading chrome
+
+**Branch:** `fix/issue-3332-editor-icon-404s`  
+**Scope:** uncommitted WebUI + perc-qa-automation vs `HEAD` / `origin/main`  
+**Date:** 2026-08-13  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class companions (Vitest + Playwright for WebUI chrome); URL `/` paths are valid (not filesystem); dual-tree JSP lockstep; behavioral tests for remapper reject/accept
+
+## Summary
+
+Editor toolbar JSPs requested `/cm/pages/app/images/icons/editor/{delete,edit}.png`, which 404 because assets live at `/cm/images/icons/editor/`. The SPA fallback filter now remaps `/cm/{pages/}app/images/**` (safe image extensions only) onto `/cm/images/**`. Toolbar JSPs request the canonical URLs and hide on `onerror`. PercViewReadyManager clears a stuck processing overlay after 10s. Explorer route loading chrome has a testid so tests can assert it is not left up.
+
+## Issues
+
+None that block.
+
+## Cross-platform path checklist
+
+- Remap paths are **URL** paths (`/cm/images/...`) — `/` is correct.
+- Vitest uses `path.resolve` + `existsSync`; line endings normalized (`\r\n` → `\n`).
+- No filesystem separator concatenation. No Unix-only roots.
+
+## Companions
+
+- Java remapper + JUnit accept/reject (including traversal / non-image).
+- Dual-tree `content_toolbar.jsp` (`cm/app` + `cm/pages/app`).
+- Dual-tree `PercViewReadyManager.js` (`app/js/legacy` + `cm/plugins`).
+- Vitest static-resource contract + ExplorerRoute loading chrome.
+- Playwright surface spec `bug-3332-editor-icons.spec.js`.
+- Product-docs N/A (no new operator chrome; existing icons now load).

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3332-editor-icons.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3332-editor-icons.spec.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression: editor toolbar icon 404s leave chrome stuck loading (GH-3332 / parent #3329).
+ *
+ * Human QA reported:
+ *   GET /cm/pages/app/images/icons/editor/delete.png 404
+ *   GET /cm/pages/app/images/icons/editor/edit.png 404
+ *
+ * Those URLs must 200 (remap onto /cm/images/...) and Explorer/Editor chrome
+ * must finish loading.
+ *
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=... TEST_DB_TYPE=h2 \
+ *     npm run test:surface -- --path tests/bugs/bug-3332-editor-icons.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL, adminBasicAuthHeaders } = require("../helpers/auth");
+
+const ICON_NAMES = ["delete.png", "edit.png"];
+
+function explorerUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+}
+
+function editorUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/?view=editor&_=${Date.now()}`;
+}
+
+function canonicalIconUrl(name) {
+  return `${BASE_URL}/Rhythmyx/cm/images/icons/editor/${name}`;
+}
+
+test.describe("GH-3332 editor icons + chrome not stuck loading", () => {
+  test("REST: canonical editor icons are 200 PNG", async ({ request }) => {
+    test.setTimeout(30_000);
+    const headers = adminBasicAuthHeaders();
+    for (const name of ICON_NAMES) {
+      const url = canonicalIconUrl(name);
+      const res = await request.get(url, { headers });
+      expect(res.status(), `${url} must be 200 (not 404).`).toBe(200);
+      const ctype = (res.headers()["content-type"] || "").toLowerCase();
+      expect(
+        ctype,
+        `${url} content-type should be an image, got ${ctype}`,
+      ).toMatch(/image|octet-stream|png/);
+    }
+  });
+
+  test("UI: Explorer shell finishes loading without editor-icon 404s", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const pageErrors = [];
+    const icon404s = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.on("response", (res) => {
+      const url = res.url();
+      if (
+        res.status() === 404 &&
+        /\/images\/icons\/editor\/(delete|edit)\.png(?:\?|$)/i.test(url)
+      ) {
+        icon404s.push(url);
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(explorerUrl(), { waitUntil: "domcontentloaded" });
+
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('[data-testid="explorer-route-loading"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('[data-testid="explorer-tree"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    expect(icon404s, `editor icon 404s: ${icon404s.join(", ")}`).toEqual([]);
+    const unexpected = pageErrors.filter(
+      (t) =>
+        !/Failed to load resource/i.test(t) &&
+        !/ResizeObserver/i.test(t),
+    );
+    expect(unexpected, unexpected.join("\n")).toEqual([]);
+  });
+
+  test("UI: Editor view does not stay on loading overlay after icon chrome", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const icon404s = [];
+    page.on("response", (res) => {
+      const url = res.url();
+      if (
+        res.status() === 404 &&
+        /\/images\/icons\/editor\/(delete|edit)\.png(?:\?|$)/i.test(url)
+      ) {
+        icon404s.push(url);
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(editorUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("#perc-web-management")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator("#perc-pageEditor-tabs")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect
+      .poll(
+        async () => page.locator(".perc-ui-component-overlay").count(),
+        { timeout: 20_000 },
+      )
+      .toBe(0);
+    await expect(page.locator("#perc-ui-view-indicator")).toHaveClass(
+      /perc-ui-view-ready/,
+    );
+    expect(icon404s, `editor icon 404s: ${icon404s.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes editor toolbar icon 404s and stuck Editor/Explorer loading chrome (parent **#3329** slice 3).

Human QA reported:

```
GET /cm/pages/app/images/icons/editor/delete.png 404
GET /cm/pages/app/images/icons/editor/edit.png 404
```

Those paths were rewritten onto the SPA mount. The files live at `/cm/images/icons/editor/`.

- Dual-tree `content_toolbar.jsp` now requests `/cm/images/icons/editor/{delete,edit}.png` and hides the img on `onerror`.
- `PSWebUiSpaFallbackFilter` remaps `/cm/{pages/}app/images/**` (safe image extensions, traversal rejected) onto `/cm/images/**` so leftover callers still 200.
- `PercViewReadyManager` clears stuck processing overlays after 10s so chrome cannot spin forever if assets/components stall.
- Explorer route loading chrome has `data-testid="explorer-route-loading"` so tests can assert it is not left up.

**Parent:** #3329  
**Fixes #3332**  
**Partial #3329** (siblings #3330 / #3331)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd WebUI` → `../mvnw.cmd clean install` (standalone).
2. Vitest: `editorIconAssets.test.ts` (canonical PNG + JSP src); `ExplorerRoute.test.tsx` (loading chrome replaced).
3. JUnit: remapper accept/reject (including traversal / non-image).
4. QA H2: `python docker/scripts/perc-devctl.py qa-up` (freeport `TEST_CMS_URL`).
5. Deploy: copy filter class + JSPs + packed `perc_webmgt` + modern assets into the cell; restart Jetty **in-container** (do not `docker restart` — that restores the image tree).
6. Playwright: `npm run test:surface -- --path tests/bugs/bug-3332-editor-icons.spec.js`.
7. Golden: `npm run test:golden`.

## Checklist

- [x] **Product documentation** — **N/A** (not a new operator-facing chrome/procedure; existing toolbar icons now load)
- [x] **Unit / module tests** — remapper JUnit + Vitest static-resource/ExplorerRoute; modules green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3332-editor-icons.spec.js`
- [x] **Build gates** — standalone clean install; C2 API-shape reverse-deps N/A
- [x] **Cross-platform** — remap paths are URL `/` (not filesystem); Vitest uses `path.resolve` + CRLF normalize

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-13T11:23:00-04:00). Surefire `Tests run: 53, Failures: 0` (filter test `Tests run: 13`). Vitest `Test Files 307 passed`, `Tests 2203 passed`.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (placeholder jar; Playwright run separately).
- **downstream_checked:** none (added static remapper helpers + JSP/JS; no `final`/consumed signature break)

### C5 UI proof (H2 QA)

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CMS_HOST_PORT=9993`, container `perc-matrix-cms-h2`)
- Deploy: `docker cp` of remapper class, toolbar JSPs, packed `perc_webmgt*.js`, modern assets; in-container `StopJetty.sh` / `StartJetty.sh`
- `npm run test:surface -- --path tests/bugs/bug-3332-editor-icons.spec.js` → **3 passed** (13.5s)
- `npm run test:golden` → **2 passed**
- **console-clean:** yes (spec asserts no unexpected pageerror; no editor icon 404s)
- **server.log-clean:** yes for this feature (no icon/chrome errors). Pre-existing `PSRuntimeExceptionMapper` “validated object is null” noise unrelated (same as #3331)

> Co-Authored by Grok Build using grok-4.5 with agent main.
