### PR TITLE
fix(explorer): show sample site folders on expand (#3326)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -96,7 +96,10 @@ import {
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { EMPTY_SELECTION, type Selection } from "./selection";
 import { resolveFolderPathFromSelection } from "./folderPath";
-import { resolveSiteNameFromSelection } from "./sitePath";
+import {
+  resolveExplorerListPath,
+  resolveSiteNameFromSelection,
+} from "./sitePath";
 import {
   errorStateStyle,
   headerStyle,
@@ -571,7 +574,10 @@ export function ContentExplorerShell({
 
   const handleSelectFolder = useCallback(
     (path: string, folder: PSPathItem | null) => {
-      setSelection({ folderPath: path, item: null });
+      setSelection({
+        folderPath: resolveExplorerListPath(folder, path) ?? path,
+        item: null,
+      });
       // Reset multi-select when the folder changes: stale ids are not
       // present in the new list so the checkbox column would otherwise
       // show phantom selections until the next user click.
@@ -587,7 +593,10 @@ export function ContentExplorerShell({
 
   const handleActivate = useCallback(
     (path: string, folder: PSPathItem) => {
-      setSelection({ folderPath: path, item: null });
+      setSelection({
+        folderPath: resolveExplorerListPath(folder, path) ?? path,
+        item: null,
+      });
       setMultiSelectedIds(new Set<string>());
       setMultiSelectedItems(new Map<string, PSPathItem>());
       setContextMenu(null);

--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -373,7 +373,9 @@ export function DetailList({
   if (!folderPath) {
     return (
       <div style={listStyle} data-testid="detail-list">
-        <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
+        <div style={emptyStateStyle} data-testid="detail-list-empty">
+          {message(EXPLORER_MSG.LIST_EMPTY)}
+        </div>
       </div>
     );
   }
@@ -396,7 +398,9 @@ export function DetailList({
   if (!loading && children.length === 0) {
     return (
       <div style={listStyle} data-testid="detail-list">
-        <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
+        <div style={emptyStateStyle} data-testid="detail-list-empty">
+          {message(EXPLORER_MSG.LIST_EMPTY)}
+        </div>
       </div>
     );
   }

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -28,7 +28,8 @@ import { findChildren } from "../api/contentExplorer/pathApi";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
 import { message } from "../i18n/message";
-import { isStrictCmsPathDescendant } from "./folderPath";
+import { isSafeExplorerTreeChild } from "./folderPath";
+import { resolveExplorerListPath } from "./sitePath";
 import { isFolder } from "./selection";
 import {
   emptyStateStyle,
@@ -81,26 +82,30 @@ export function ExplorerTree({
     [initialPath]: EMPTY_STATE,
   }));
 
-  const ensureLoaded = useCallback(async (path: string) => {
-    setNodes((prev) => {
-      const cur = prev[path] ?? EMPTY_STATE;
-      if (cur.loaded || cur.loading) return prev;
-      return { ...prev, [path]: { ...cur, loading: true, error: null } };
-    });
-    try {
-      const children = await findChildren(path);
-      setNodes((prev) => ({
-        ...prev,
-        [path]: { loaded: true, loading: false, error: null, children },
-      }));
-    } catch (err) {
-      const msg = formatApiError(err, message(EXPLORER_MSG.TREE_LOAD_ERROR));
-      setNodes((prev) => ({
-        ...prev,
-        [path]: { loaded: true, loading: false, error: msg, children: [] },
-      }));
-    }
-  }, []);
+  const ensureLoaded = useCallback(
+    async (path: string, folder?: PSPathItem | null) => {
+      setNodes((prev) => {
+        const cur = prev[path] ?? EMPTY_STATE;
+        if (cur.loaded || cur.loading) return prev;
+        return { ...prev, [path]: { ...cur, loading: true, error: null } };
+      });
+      try {
+        const listPath = resolveExplorerListPath(folder, path) ?? path;
+        const children = await findChildren(listPath);
+        setNodes((prev) => ({
+          ...prev,
+          [path]: { loaded: true, loading: false, error: null, children },
+        }));
+      } catch (err) {
+        const msg = formatApiError(err, message(EXPLORER_MSG.TREE_LOAD_ERROR));
+        setNodes((prev) => ({
+          ...prev,
+          [path]: { loaded: true, loading: false, error: msg, children: [] },
+        }));
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     void ensureLoaded(initialPath);
@@ -110,7 +115,7 @@ export function ExplorerTree({
     (path: string, folder: PSPathItem) => {
       setExpanded((prev) => ({ ...prev, [path]: !prev[path] }));
       if (!nodes[path]?.loaded) {
-        void ensureLoaded(path);
+        void ensureLoaded(path, folder);
       }
       onActivate?.(path, folder);
     },
@@ -124,7 +129,10 @@ export function ExplorerTree({
     const path = folder.path;
     const isOpen = expanded[path] ?? false;
     const state = nodes[path] ?? EMPTY_STATE;
-    const selected = selectedPath === path;
+    const listPath = resolveExplorerListPath(folder, path);
+    const selected =
+      selectedPath === path ||
+      (listPath != null && selectedPath === listPath);
     const folderish = isFolder(folder);
 
     return (
@@ -179,9 +187,11 @@ export function ExplorerTree({
           isOpen &&
           state.children
             // Guard against self-path or ancestor cycles from a bad API payload
-            // (would recurse forever in render). Normalize //Sites vs /Sites and
-            // trailing slashes so site id children are not dropped (#3001).
-            .filter((child) => isStrictCmsPathDescendant(path, child.path))
+            // (would recurse forever in render). Accept name vs FOLDER_ROOT
+            // prefix mismatch on sample sites (#3001 / #3326).
+            .filter((child) =>
+              isSafeExplorerTreeChild(path, folder.folderPath, child.path),
+            )
             .map((child) => renderNode(child, depth + 1))}
       </div>
     );

--- a/WebUI/src/main/ts/contentExplorer/folderPath.ts
+++ b/WebUI/src/main/ts/contentExplorer/folderPath.ts
@@ -103,6 +103,54 @@ export function isStrictCmsPathDescendant(
 }
 
 /**
+ * Whether {@code childPath} is safe to render under a tree node.
+ *
+ * <p>Drops self/ancestor cycles. Accepts children whose finder path uses
+ * the site <em>name</em> while the node stores {@code folderPath} (or the
+ * reverse) so sample sites {@code Corporate_Investments} vs folder
+ * {@code CorporateInvestments} are not filtered to empty (#3326).</p>
+ */
+export function isSafeExplorerTreeChild(
+  parentPath: string | null | undefined,
+  parentFolderPath: string | null | undefined,
+  childPath: string | null | undefined,
+): boolean {
+  if (childPath == null || String(childPath).trim().length === 0) {
+    return false;
+  }
+  const childNorm = normalizeExplorerFolderPath(childPath);
+  const parentNorm = normalizeExplorerFolderPath(parentPath);
+  const folderNorm = normalizeExplorerFolderPath(parentFolderPath);
+  if (childNorm != null && parentNorm != null && childNorm === parentNorm) {
+    return false;
+  }
+  if (childNorm != null && folderNorm != null && childNorm === folderNorm) {
+    return false;
+  }
+  // Child that is an ancestor of the parent would recurse forever.
+  if (isStrictCmsPathDescendant(childPath, parentPath)) {
+    return false;
+  }
+  if (
+    parentFolderPath != null &&
+    isStrictCmsPathDescendant(childPath, parentFolderPath)
+  ) {
+    return false;
+  }
+  if (isStrictCmsPathDescendant(parentPath, childPath)) {
+    return true;
+  }
+  if (
+    parentFolderPath != null &&
+    isStrictCmsPathDescendant(parentFolderPath, childPath)
+  ) {
+    return true;
+  }
+  // Name vs folder-root prefix mismatch — still render (not a cycle).
+  return true;
+}
+
+/**
  * Resolve the source folder path for Subfolder Copy.
  *
  * <p>Prefer a selected folder row path; otherwise the active tree folder

--- a/WebUI/src/main/ts/contentExplorer/sitePath.ts
+++ b/WebUI/src/main/ts/contentExplorer/sitePath.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import type { PSPathItem } from "../api/contentExplorer/types";
+import { normalizeExplorerFolderPath } from "./folderPath";
+
 /**
  * CMS Explorer path helpers for site-scoped chrome (#2767 / parent #2400).
  *
@@ -61,4 +64,28 @@ export function resolveSiteNameFromSelection(
     resolveSiteNameFromExplorerPath(itemPath) ??
     resolveSiteNameFromExplorerPath(folderPath)
   );
+}
+
+/**
+ * Path used to list children of a site/folder PathItem.
+ *
+ * <p>Sample Rhythmyx sites use {@code SITENAME} {@code Corporate_Investments}
+ * but {@code FOLDER_ROOT} {@code //Sites/CorporateInvestments} (#3326).
+ * pathmanagement {@code PathItem.folderPath} is the repository folder;
+ * {@code PathItem.path} is the finder id (often the site name). Prefer
+ * {@code folderPath} so expand/list hits the seeded site folder.</p>
+ */
+export function resolveExplorerListPath(
+  item: Pick<PSPathItem, "path" | "folderPath"> | null | undefined,
+  fallback?: string | null,
+): string | null {
+  const fromFolder = normalizeExplorerFolderPath(item?.folderPath);
+  if (fromFolder != null) {
+    return fromFolder;
+  }
+  const fromPath = normalizeExplorerFolderPath(item?.path);
+  if (fromPath != null) {
+    return fromPath;
+  }
+  return normalizeExplorerFolderPath(fallback);
 }

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -197,6 +197,69 @@ describe("ExplorerTree", () => {
     expect(childCalls).toBe(1);
   });
 
+  it("lists site children using folderPath not sitename (#3326)", async () => {
+    const SITE_CHILD: PSPathItem = {
+      id: "Corporate_Investments",
+      path: "/Sites/Corporate_Investments/",
+      folderPath: "//Sites/CorporateInvestments",
+      name: "Corporate_Investments",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    const PAGES: PSPathItem = {
+      id: "pages-1",
+      path: "/Sites/CorporateInvestments/Pages",
+      name: "Pages",
+      type: "folder",
+      hasFolderChildren: false,
+    };
+    const requested: string[] = [];
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      requested.push(url);
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        return pathItemListResponse([SITE_CHILD]);
+      }
+      if (url.endsWith("/pathmanagement/path/folder/Sites/CorporateInvestments")) {
+        return pathItemListResponse([PAGES]);
+      }
+      return pathItemListResponse([]);
+    });
+    render(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath={null}
+        onSelectFolder={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/Corporate_Investments/"),
+      ).toBeInTheDocument(),
+    );
+    const node = screen.getByTestId("tree-node-/Sites/Corporate_Investments/");
+    const toggle = node.querySelector('[aria-hidden="true"]');
+    fireEvent.click(toggle!);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/CorporateInvestments/Pages"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      requested.some((u) =>
+        u.endsWith("/pathmanagement/path/folder/Sites/CorporateInvestments"),
+      ),
+    ).toBe(true);
+    expect(
+      requested.some((u) =>
+        u.endsWith(
+          "/pathmanagement/path/folder/Sites/Corporate_Investments",
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("fires onSelectFolder when a row is activated", async () => {
     mockFetch(async () => pathItemListResponse([ROOT_FOLDER]));
     let selected: string | null = null;

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  isSafeExplorerTreeChild,
   isStrictCmsPathDescendant,
   normalizeExplorerFolderPath,
   resolveFolderPathFromSelection,
@@ -74,6 +75,30 @@ describe("isStrictCmsPathDescendant (#3001)", () => {
   it("treats any non-root path as a child of root", () => {
     expect(isStrictCmsPathDescendant("/", "/Sites/")).toBe(true);
     expect(isStrictCmsPathDescendant("/", "/")).toBe(false);
+  });
+
+  it("accepts name vs FOLDER_ROOT children as safe tree kids (#3326)", () => {
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/CorporateInvestments/Pages",
+      ),
+    ).toBe(true);
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/Corporate_Investments/Pages",
+      ),
+    ).toBe(true);
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/Corporate_Investments/",
+      ),
+    ).toBe(false);
   });
 
   it("accepts classic Folders root and children under / (#3044)", () => {

--- a/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  resolveExplorerListPath,
   resolveSiteNameFromExplorerPath,
   resolveSiteNameFromSelection,
 } from "../../../main/ts/contentExplorer/sitePath";
@@ -75,5 +76,26 @@ describe("resolveSiteNameFromSelection (#2767)", () => {
     expect(
       resolveSiteNameFromSelection("/Sites/FolderSite/sub", "/Assets/x"),
     ).toBe("FolderSite");
+  });
+});
+
+describe("resolveExplorerListPath (#3326)", () => {
+  it("prefers folderPath over finder site-name path", () => {
+    expect(
+      resolveExplorerListPath({
+        path: "/Sites/Corporate_Investments/",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+    ).toBe("/Sites/CorporateInvestments");
+  });
+
+  it("falls back to path then explicit fallback", () => {
+    expect(
+      resolveExplorerListPath({ path: "/Sites/Demo/", folderPath: undefined }),
+    ).toBe("/Sites/Demo/");
+    expect(resolveExplorerListPath(null, "/Sites/Fallback")).toBe(
+      "/Sites/Fallback",
+    );
+    expect(resolveExplorerListPath(null, null)).toBeNull();
   });
 });

--- a/docs/ai-generated/code-reviews/3326-explorer-site-expand-erlang.md
+++ b/docs/ai-generated/code-reviews/3326-explorer-site-expand-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3326 Explorer sample-site expand
+
+**Scope:** uncommitted `fix/issue-3326-explorer-site-expand` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** empty list vs error envelope; site name vs folder root bind; installer seed companions
+
+## Summary
+
+Sample sites listed under Explorer `/Sites` but expand showed LIST_EMPTY because `installSampleSites` only created empty FOLDER_ROOT folders (350/351). Finder path uses `SITENAME` (`Corporate_Investments`) while repository folder is `//Sites/CorporateInvestments`.
+
+Fix: seed Pages/Files children under 350/351; bind tree/list loads to `PathItem.folderPath`; cycle-only tree filter so name vs folder-root children are not dropped.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Cross-platform path checklist
+
+- CMS finder paths use `/` (URL-style), not OS file separators.
+- New helpers normalize `\` / drive letters only for caller paste; no filesystem I/O.
+- Seed XML is installer data, not path concatenation.
+
+## Tests
+
+- Vitest: `resolveExplorerListPath`, `isSafeExplorerTreeChild`, ExplorerTree folderPath fetch
+- InstallSampleSitesWiringTest: 350/351 child relationships
+- Playwright surface: REST site children + UI expand (live C5 blocked — see PR)
+
+## C5
+
+`perc-devctl qa-up` used this worktree installer jar; sample sites echoed seeded, but Jetty context failed (`NoClassDefFoundError: PSVirtualSitePublishCopyResult` on `sitesAdaptor`). Unrelated SNAPSHOT mix; cell torn down.

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -180,6 +180,148 @@
 			<column name="LOCALE">en-us</column>
 			<column name="OBJECTTYPE">2</column>
 		</row>
+		<!-- Browseable children under sample site roots (#3326). Empty 350/351
+		     made Explorer expand show LIST_EMPTY after Sites listed. -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Pages</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Files</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Pages</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Files</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
 	</table>
 	<table name="CONTENTTYPES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4428,6 +4570,26 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="REVISIONID">1</column>
 			<column name="DESCRIPTION">Corporate Investments site root</column>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Enterprise Investments Pages</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Enterprise Investments Files</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Corporate Investments Pages</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Corporate Investments Files</column>
+		</row>
 	</table>
 	<table name="PSX_OBJECTACL" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4510,6 +4672,70 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="NAME">Admin</column>
 			<column name="PERMISSIONS">7</column>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92005</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92006</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92007</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92008</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92009</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92010</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92011</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92012</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
 	</table>
 	<table name="PSX_PROPERTIES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4548,6 +4774,38 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="CONTENTID">351</column>
 			<column name="REVISIONID">1</column>
 			<column name="SYSID">92002</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92003</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92004</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92005</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92006</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4593,6 +4851,39 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="OWNER_ID">2</column>
 			<column name="OWNER_REVISION">-1</column>
 			<column name="DEPENDENT_ID">351</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<!-- Sample site folder children (#3326) -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">352</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">350</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">352</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">353</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">350</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">353</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">354</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">351</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">354</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">355</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">351</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">355</column>
 			<column name="DEPENDENT_REVISION">-1</column>
 		</row>
 	</table>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
@@ -214,6 +214,24 @@ class InstallSampleSitesWiringTest {
     assertTrue(
         hasSiteChild,
         "PSX_OBJECTRELATIONSHIP must link Sites (owner 2) to sample site root folders 350/351");
+
+    Set<String> childDeps = new LinkedHashSet<>();
+    for (int i = 0; i < relRows.getLength(); i++) {
+      Element row = (Element) relRows.item(i);
+      String owner = columnValue(row, "OWNER_ID");
+      String dep = columnValue(row, "DEPENDENT_ID");
+      if (("350".equals(owner) || "351".equals(owner)) && dep != null && !dep.isBlank()) {
+        childDeps.add(owner + ":" + dep.trim());
+      }
+    }
+    assertTrue(
+        childDeps.contains("350:352") && childDeps.contains("350:353"),
+        "EnterpriseInvestments (350) must have Pages/Files children 352/353 (#3326); found "
+            + childDeps);
+    assertTrue(
+        childDeps.contains("351:354") && childDeps.contains("351:355"),
+        "CorporateInvestments (351) must have Pages/Files children 354/355 (#3326); found "
+            + childDeps);
   }
 
   @Test

--- a/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
@@ -20,7 +20,9 @@
  * <p>Coverage:</p>
  * <ul>
  *   <li>REST: {@code path/folder/Sites} is 200; non-empty when fixture has sites</li>
+ *   <li>REST: expanding a sample site (folderPath / sitename) lists children (#3326)</li>
  *   <li>UI: Sites tree expands to child site nodes when list is non-empty</li>
+ *   <li>UI: selecting a sample site shows folder children, not LIST_EMPTY (#3326)</li>
  *   <li>Create Site: Content menu always exposes Create Site; wizard details →
  *       template → confirm chrome; optional live submit when affordance present</li>
  * </ul>
@@ -56,6 +58,8 @@ const {
   TEST_IDS,
   explorerSpaUrl,
   sitesFolderUrl,
+  siteChildListPath,
+  folderChildrenUrl,
   openContentMenu,
   sitesTreeRootLocator,
   sitesTreeDescendantsLocator,
@@ -149,6 +153,43 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
   );
 
   test(
+    "REST: sample site folder children are non-empty (#3326)",
+    { tag: ["@explorer-sites-list-create", "@explorer", "@sites", "@smoke"] },
+    async ({ request }) => {
+      test.setTimeout(30_000);
+      const headers = adminBasicAuthHeaders();
+      const sitesRes = await request.get(SITES_URL, { headers });
+      expect(sitesRes.status()).toBe(200);
+      const body = await sitesRes.json();
+      const items = Array.isArray(body.PathItem)
+        ? body.PathItem
+        : Array.isArray(body)
+          ? body
+          : [];
+      const names = pathItemNames(body);
+      if (gateSitesListOrSoftSkip(names) === "soft-empty") {
+        return;
+      }
+      const sample =
+        items.find((it) =>
+          hasAnyExpectedSampleSite([
+            it && typeof it.name === "string" ? it.name : "",
+          ]),
+        ) || items[0];
+      expect(sample, "expected at least one site PathItem").toBeTruthy();
+      const listPath = siteChildListPath(sample);
+      const childUrl = folderChildrenUrl(BASE_URL, listPath);
+      const childRes = await request.get(childUrl, { headers });
+      expect(childRes.status(), `GET ${childUrl}`).toBe(200);
+      const childNames = pathItemNames(await childRes.json());
+      expect(
+        childNames.length,
+        `site children at ${childUrl}: ${JSON.stringify(childNames)}`,
+      ).toBeGreaterThan(0);
+    },
+  );
+
+  test(
     "UI: Content Explorer Sites expands to child site nodes when non-empty",
     { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
     async ({ page }) => {
@@ -195,6 +236,56 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
           `explorer tree missing sample sites; children=${JSON.stringify(childNames)}`,
         ).toBe(true);
       }
+    },
+  );
+
+  test(
+    "UI: expanding a sample site shows folder children not LIST_EMPTY (#3326)",
+    { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const probe = await page.request.get(SITES_URL, {
+        headers: adminBasicAuthHeaders(),
+      });
+      expect(probe.status()).toBe(200);
+      const restNames = pathItemNames(await probe.json());
+      if (gateSitesListOrSoftSkip(restNames) === "soft-empty") {
+        return;
+      }
+
+      const jsErrors = [];
+      page.on("pageerror", (err) => jsErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          jsErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(explorerSpaUrl(BASE_URL), { waitUntil: "networkidle" });
+
+      const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
+      await expect(tree).toBeVisible({ timeout: 20_000 });
+      const sitesRoot = sitesTreeRootLocator(page);
+      await expect(sitesRoot.first()).toBeVisible({ timeout: 20_000 });
+      await sitesRoot.first().click();
+
+      const descendants = sitesTreeDescendantsLocator(page);
+      await expect(descendants.first()).toBeVisible({ timeout: 20_000 });
+      await descendants.first().locator('[role="treeitem"]').first().click();
+
+      const detail = page.locator(`[data-testid="${TEST_IDS.detailList}"]`);
+      await expect(detail).toBeVisible({ timeout: 15_000 });
+      await expect(detail.locator('[data-testid="detail-list-empty"]')).toHaveCount(
+        0,
+        { timeout: 20_000 },
+      );
+      await expect(detail.locator('[data-testid^="detail-row-"]').first()).toBeVisible({
+        timeout: 20_000,
+      });
+      expect(jsErrors, `console/page errors: ${jsErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
@@ -73,6 +73,47 @@ function sitesFolderUrl(baseUrl) {
 }
 
 /**
+ * Encode a CMS finder path as a path/folder URL suffix (no leading slash).
+ * @param {string} cmsPath
+ * @returns {string}
+ */
+function encodeFolderListPath(cmsPath) {
+  return String(cmsPath || "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^[A-Za-z]:/, "")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((seg) => seg.length > 0)
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+/**
+ * Prefer PathItem.folderPath (FOLDER_ROOT) over finder name path (#3326).
+ * @param {{ path?: string, folderPath?: string } | null | undefined} item
+ * @returns {string}
+ */
+function siteChildListPath(item) {
+  const folder = item && item.folderPath ? String(item.folderPath).trim() : "";
+  if (folder.length > 0) {
+    return folder;
+  }
+  return item && item.path ? String(item.path) : "";
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} cmsPath
+ * @returns {string}
+ */
+function folderChildrenUrl(baseUrl, cmsPath) {
+  const suffix = encodeFolderListPath(cmsPath);
+  const root = pathFolderServiceUrl(baseUrl);
+  return suffix ? `${root}/${suffix}` : `${root}/`;
+}
+
+/**
  * Open Content menu dropdown.
  * @param {import('@playwright/test').Page} page
  */
@@ -173,6 +214,9 @@ module.exports = {
   explorerSpaUrl,
   pathFolderServiceUrl,
   sitesFolderUrl,
+  encodeFolderListPath,
+  siteChildListPath,
+  folderChildrenUrl,
   openContentMenu,
   sitesTreeRootLocator,
   sitesTreeDescendantsLocator,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -28,6 +28,9 @@ const {
   explorerSpaUrl,
   pathFolderServiceUrl,
   sitesFolderUrl,
+  encodeFolderListPath,
+  siteChildListPath,
+  folderChildrenUrl,
   siteChildNamesFromTreeTestIds,
   uniqueQaSiteName,
   createSiteMissingSkipReason,
@@ -65,6 +68,27 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(
       sitesFolderUrl("http://127.0.0.1:9992"),
       "http://127.0.0.1:9992/Rhythmyx/services/pathmanagement/path/folder/Sites",
+    );
+  });
+
+  it("prefers folderPath for site-child list URL (#3326)", () => {
+    assert.equal(
+      siteChildListPath({
+        path: "/Sites/Corporate_Investments/",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+      "//Sites/CorporateInvestments",
+    );
+    assert.equal(
+      encodeFolderListPath("//Sites/CorporateInvestments"),
+      "Sites/CorporateInvestments",
+    );
+    assert.equal(
+      folderChildrenUrl(
+        "http://127.0.0.1:9992",
+        "//Sites/CorporateInvestments",
+      ),
+      "http://127.0.0.1:9992/Rhythmyx/services/pathmanagement/path/folder/Sites/CorporateInvestments",
     );
   });
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -34,7 +34,7 @@ service (roles may hide Design/Recycling for some users):
 
 | Root | Maps to | Purpose |
 |------|---------|---------|
-| **Sites** | `//Sites` | Traditional site folders and pages |
+| **Sites** | `//Sites` | Traditional site folders and pages. Expand a site to list its folders (sample sites include **Pages** and **Files**) |
 | **Folders** | `//Folders` | Classic Rhythmyx folder tree (including `$System$` and other repository folders) |
 | **Assets** | `//Folders/$System$/Assets` | Shared asset library (CM1 convenience root) |
 | **Design** | Design file-system area | Templates, themes, web resources (Admin/Designer) |

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -27,8 +27,9 @@ Traditional Sites store pages and assets in the Percussion **content repository*
 2. Open **Content Explorer** (`spa.jsp?entry=explorer` or the **Explorer** product navigation entry).
 3. In the tree, expand **Sites**.
 4. Select a site folder to browse its pages and folders in the detail list.
+5. Expand a sample site (for example **Corporate_Investments** or **Enterprise_Investments**). The tree and detail list show that site's folders (such as **Pages** and **Files**), not an empty-folder message.
 
-After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Explorer features differ by site type after the site is listed and navigable. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
+After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). Site **names** may use underscores (`Corporate_Investments`) while the repository folder is `//Sites/CorporateInvestments` — Explorer binds expand/list to the site folder root. The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Explorer features differ by site type after the site is listed and navigable. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
 
 ### Create a traditional Site from Explorer
 


### PR DESCRIPTION
## Summary

Fixes Explorer **sample site expand** showing **No items in this folder** (`LIST_EMPTY`) while Corporate_Investments / Enterprise_Investments already list under Sites.

Root cause: `installSampleSites` created empty `FOLDER_ROOT` folders (contentids 350/351). Finder paths use `SITENAME` (`Corporate_Investments`) while the repository folder is `//Sites/CorporateInvestments`. Tree expand also dropped children when those prefixes differed.

This PR:

- Seeds **Pages** and **Files** folders under each sample site root (352–355).
- Binds Explorer tree/detail list loads to `PathItem.folderPath` when present.
- Keeps name-vs-folder-root children in the tree (cycle-only filter).
- Adds Vitest, installer wiring, and Playwright surface coverage; updates product browse steps.

Does **not** re-list RXSITES (#2989 / #3133).

Fixes #3326

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2204 passed; Surefire Tests run: 51, Failures: 0.
2. `cd modules/perc-distribution-tree` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 255, Failures: 0, Skipped: 5.
3. `cd modules/perc-qa-automation/frontend` then `npm run test:unit` — 245 pass (includes folderPath list URL helper).
4. After a **fresh** demo-sites install (`--demo-sites` / `qa-up`): `GET /Rhythmyx/services/pathmanagement/path/folder/Sites/<folderRoot>` is non-empty; Explorer expand of a sample site shows Pages/Files, not LIST_EMPTY.
5. Playwright: `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js` with `EXPECT_DEMO_SITES=1` when the image includes this seed.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/sites.md` and `content-explorer.md` browse steps (expand sample site shows folders)
- [x] **Unit / module tests** — Vitest + `InstallSampleSitesWiringTest` + Playwright helper/spec; standalone clean install green
- [x] **WebUI + Playwright** — `explorer-sites-list-create.spec.js` REST + UI expand cases
- [x] **Build gates** — WebUI and perc-distribution-tree standalone `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — CMS `/` finder paths only; helpers normalize `\` / drive letters for paste; no OS file I/O

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-distribution-tree`
- **build_evidence:**  
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Vitest Tests 2204 passed (305 files); Surefire Tests run: 51, Failures: 0  
  - `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 255, Failures: 0, Skipped: 5
- **downstream_checked:** none (no `final`/public Java API shape change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` used this worktree `perc-distribution-tree.jar`; install logged `Sample sites seeded`.
- Cell probe failed: Jetty `Failed startup of context` / `NoClassDefFoundError: com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult` on `sitesAdaptor` (SNAPSHOT mix, not this seed).
- Live Playwright **not** executed; cell `qa-down`. Human QA / retry C5 after a healthy H2 cell.
- console-clean=n/a (no live browser); server.log-clean=no (context CNFE, BUG: environmental SNAPSHOT)

## Erlang

Approve. Report: `docs/ai-generated/code-reviews/3326-explorer-site-expand-erlang.md`

> Co-Authored by Grok Build using grok-4.5 with agent main.
