### PR TITLE
fix(explorer): show folder icons in Folders detail list (#3328)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -22,6 +22,11 @@
  * 50 to bound render cost; the user paginates forward/back via the
  * controls below the list.</p>
  *
+ * <p>#3328: a dedicated type-icon column always precedes the display-format
+ * columns. Folders (including {@code $System$} and user folders) show a
+ * folder/open icon that activates browse. Multi-select checkboxes stay in
+ * their own column and do not replace the folder affordance.</p>
+ *
  * <p>FR-027 / T092b: when a `displayFormat` is supplied, the list honours
  * the column ordering + selection defined by the format. When absent
  * (default), the list falls back to Name + Type + Path. Supported column
@@ -207,10 +212,14 @@ export function columnHeaderLabel(
   }
 }
 import { message } from "../i18n/message";
-import { canRead } from "./selection";
+import { canRead, isFolder } from "./selection";
 import {
   emptyStateStyle,
   errorStateStyle,
+  folderIconButtonStyle,
+  iconTdCellStyle,
+  iconThCellStyle,
+  itemIconStyle,
   listStyle,
   rowStyle,
   tableStyle,
@@ -221,6 +230,32 @@ import {
 import { EXPLORER_MSG } from "./messages";
 
 const PAGE_SIZE = 50;
+
+function FolderClosedGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+      <path fill="currentColor" d="M1 4a1 1 0 0 1 1-1h4l1 1.5h7a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1z" />
+    </svg>
+  );
+}
+
+function FolderOpenGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+      <path fill="currentColor" opacity="0.7" d="M1 4a1 1 0 0 1 1-1h4l1 1.5h5.5a1 1 0 0 1 1 1V7H2.2z" />
+      <path fill="currentColor" d="M1 7h10.2a1 1 0 0 1 .95.7L14 14H2.5A1.5 1.5 0 0 1 1 12.5z" />
+    </svg>
+  );
+}
+
+function ItemGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <path fill="currentColor" d="M4 1.5h5.2L13 5.3V14.5H4z" />
+      <path fill="#fff" d="M9.2 1.7v3.6H12.8" />
+    </svg>
+  );
+}
 
 export interface DetailListProps {
   /** Folder path whose children to list. null disables the list. */
@@ -372,14 +407,22 @@ export function DetailList({
 
   if (!folderPath) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
       </div>
     );
   }
   if (error) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={errorStateStyle} role="alert">
           {message(EXPLORER_MSG.LIST_LOAD_ERROR)}: {error}
         </div>
@@ -388,21 +431,33 @@ export function DetailList({
   }
   if (loading && children.length === 0) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_LOADING)}</div>
       </div>
     );
   }
   if (!loading && children.length === 0) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
       </div>
     );
   }
 
   return (
-    <div style={listStyle} data-testid="detail-list">
+    <div
+      style={listStyle}
+      data-testid="detail-list"
+      data-folder-path={folderPath ?? ""}
+    >
       <table style={tableStyle}>
         <thead style={theadStyle}>
           <tr>
@@ -442,6 +497,11 @@ export function DetailList({
                 />
               </th>
             ) : null}
+            <th
+              style={iconThCellStyle}
+              data-testid="detail-col-header-icon"
+              aria-label={message(EXPLORER_MSG.ICON_COLUMN_LABEL)}
+            />
             {columnsToRender.map((c) => (
               <th
                 key={c}
@@ -459,10 +519,13 @@ export function DetailList({
             const idKey = item.id ?? item.path;
             const isChecked = multiSelectEnabled && multiSelected.has(idKey);
             const visible = canRead(item);
+            const folderish = isFolder(item);
+            const folderOpen = folderish && selected;
             return (
               <tr
                 key={idKey}
                 data-testid={`detail-row-${idKey}`}
+                data-row-kind={folderish ? "folder" : "item"}
                 data-selected={isChecked ? "true" : undefined}
                 style={rowStyle(selected)}
                 role="row"
@@ -497,6 +560,36 @@ export function DetailList({
                     />
                   </td>
                 ) : null}
+                <td style={iconTdCellStyle} data-testid={`detail-cell-icon-${idKey}`}>
+                  {folderish ? (
+                    <button
+                      type="button"
+                      style={folderIconButtonStyle}
+                      data-testid={`detail-folder-icon-${idKey}`}
+                      data-kind="folder"
+                      data-folder-state={folderOpen ? "open" : "closed"}
+                      aria-label={message(EXPLORER_MSG.OPEN_FOLDER_LABEL)}
+                      title={message(EXPLORER_MSG.OPEN_FOLDER_LABEL)}
+                      disabled={!visible}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (visible) onActivateItem?.(item);
+                      }}
+                    >
+                      {folderOpen ? <FolderOpenGlyph /> : <FolderClosedGlyph />}
+                    </button>
+                  ) : (
+                    <span
+                      style={itemIconStyle}
+                      data-testid={`detail-item-icon-${idKey}`}
+                      data-kind="item"
+                      aria-hidden="true"
+                      title={message(EXPLORER_MSG.ITEM_ICON_LABEL)}
+                    >
+                      <ItemGlyph />
+                    </span>
+                  )}
+                </td>
                 {columnsToRender.map((c) => (
                   <td
                     key={c}

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -243,6 +243,12 @@ export const EXPLORER_MSG = {
   // US7 P-Adv / multi-select + clipboard panel (FR-026, #2400 #2408).
   SELECT_COLUMN_HEADER: "perc.ui.explorer@Select",
   SELECT_ROW_LABEL: "perc.ui.explorer@Select item",
+  /** Type-icon column (#3328) — folder/open affordance, not a checkbox. */
+  ICON_COLUMN_LABEL: "perc.ui.explorer@Item type",
+  OPEN_FOLDER_LABEL: "perc.ui.explorer@Open folder",
+  FOLDER_ICON_CLOSED: "perc.ui.explorer@Folder",
+  FOLDER_ICON_OPEN: "perc.ui.explorer@Open folder",
+  ITEM_ICON_LABEL: "perc.ui.explorer@Item",
   SELECT_ALL_LABEL: "perc.ui.explorer@Select all items on this page",
   SELECT_ALL_CLEAR_LABEL: "perc.ui.explorer@Clear all items on this page",
   SELECTED_COUNT_SINGULAR: "perc.ui.explorer@1 item selected",

--- a/WebUI/src/main/ts/contentExplorer/styles.ts
+++ b/WebUI/src/main/ts/contentExplorer/styles.ts
@@ -204,6 +204,45 @@ export const tdCellStyle: CSSProperties = {
   maxWidth: 320,
 };
 
+/** Narrow type-icon column (#3328) — checkboxes stay in their own column. */
+export const iconThCellStyle: CSSProperties = {
+  ...thCellStyle,
+  width: 28,
+  padding: "6px 4px",
+};
+
+export const iconTdCellStyle: CSSProperties = {
+  ...tdCellStyle,
+  width: 28,
+  maxWidth: 36,
+  padding: "4px 6px",
+  textAlign: "center",
+  overflow: "visible",
+};
+
+export const folderIconButtonStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 22,
+  height: 22,
+  padding: 0,
+  border: "none",
+  background: "transparent",
+  color: "#c9922a",
+  cursor: "pointer",
+  borderRadius: 3,
+};
+
+export const itemIconStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 16,
+  height: 16,
+  color: "#5f6368",
+};
+
 export const emptyStateStyle: CSSProperties = {
   padding: "24px 16px",
   color: "#777",

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -432,6 +432,173 @@ describe("DetailList", () => {
     await renderA11yGate(container);
   });
 });
+
+const FOLDER_CHILDREN: PSPathItem[] = [
+  {
+    id: "sys-1",
+    path: "/Folders/$System$/",
+    name: "$System$",
+    accessLevel: "READ",
+    leaf: false,
+  },
+  {
+    id: "uf-1",
+    path: "/Folders/New-Folder/",
+    name: "New-Folder",
+    type: "Folder",
+    accessLevel: "WRITE",
+  },
+  {
+    id: "p-page",
+    path: "/Folders/Welcome",
+    name: "Welcome",
+    type: "page",
+    accessLevel: "WRITE",
+    leaf: true,
+  },
+];
+
+function mockFolderPage(children: PSPathItem[] = FOLDER_CHILDREN): void {
+  mockFetch(async () =>
+    new Response(
+      JSON.stringify({
+        PagedItemList: {
+          childrenInPage: children,
+          childrenCount: children.length,
+          startIndex: 0,
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+describe("DetailList folder row chrome (#3328)", () => {
+  it("shows folder icons for $System$ and user folders, not checkboxes in the icon column", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+        selectedItemIds={new Set<string>()}
+        onToggleSelectItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-row-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("detail-col-header-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("detail-col-header-select")).toBeInTheDocument();
+
+    const systemIcon = screen.getByTestId("detail-folder-icon-sys-1");
+    expect(systemIcon).toHaveAttribute("data-kind", "folder");
+    expect(systemIcon).toHaveAttribute("data-folder-state", "closed");
+    expect(screen.getByTestId("detail-row-sys-1")).toHaveAttribute(
+      "data-row-kind",
+      "folder",
+    );
+
+    const userIcon = screen.getByTestId("detail-folder-icon-uf-1");
+    expect(userIcon).toHaveAttribute("data-kind", "folder");
+    expect(userIcon).toHaveAttribute("data-folder-state", "closed");
+
+    expect(screen.getByTestId("detail-item-icon-p-page")).toHaveAttribute(
+      "data-kind",
+      "item",
+    );
+    expect(screen.queryByTestId("detail-folder-icon-p-page")).toBeNull();
+
+    expect(screen.getByTestId("detail-select-sys-1")).toBeInTheDocument();
+    expect(screen.getByTestId("detail-select-uf-1")).toBeInTheDocument();
+  });
+
+  it("uses the open folder icon when a folder row is selected", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId="sys-1"
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("detail-folder-icon-sys-1")).toHaveAttribute(
+      "data-folder-state",
+      "open",
+    );
+    expect(screen.getByTestId("detail-folder-icon-uf-1")).toHaveAttribute(
+      "data-folder-state",
+      "closed",
+    );
+  });
+
+  it("activates browse when the folder icon is clicked without toggling the checkbox", async () => {
+    mockFolderPage();
+    const activated: string[] = [];
+    const toggled: string[] = [];
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={(item) => {
+          activated.push(item.id ?? "");
+        }}
+        selectedItemIds={new Set<string>()}
+        onToggleSelectItem={(item) => {
+          toggled.push(item.id ?? "");
+        }}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-uf-1")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("detail-folder-icon-uf-1"));
+    expect(activated).toEqual(["uf-1"]);
+    expect(toggled).toEqual([]);
+  });
+
+  it("still renders folder icons when multi-select checkboxes are off", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("detail-col-header-select")).toBeNull();
+    expect(screen.getByTestId("detail-col-header-icon")).toBeInTheDocument();
+  });
+
+  it("passes the zero serious/critical axe-core gate (folder rows + checkboxes)", async () => {
+    mockFolderPage();
+    const { container } = render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId="sys-1"
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+        selectedItemIds={new Set<string>(["sys-1"])}
+        onToggleSelectItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    await renderA11yGate(container);
+  });
+});
+
 describe("T092b / FR-027: display-format column resolution", () => {
   const sample: PSPathItem = {
     id: "p-1",

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3328-folders-view-icons.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3328-folders-view-icons.spec.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3328 — Folders detail list shows folder icons, not checkboxes as the
+ * browse affordance.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3328-folders-view-icons.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+
+test.describe("GH-3328 Folders view folder icons", () => {
+  test(
+    "Folders children show folder icons beside checkboxes",
+    { tag: ["@explorer", "@folder-icons", "@smoke"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+
+      const foldersNode = page.locator(
+        '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
+      );
+      if ((await foldersNode.count()) === 0) {
+        test.info().annotations.push({
+          type: "note",
+          description: "No /Folders tree node on this fixture; chrome-only icon column",
+        });
+        await expect(
+          page.locator('[data-testid="detail-col-header-icon"]'),
+        ).toBeVisible();
+        return;
+      }
+
+      await foldersNode.first().click();
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+      await expect(
+        page.locator('[data-testid="detail-col-header-icon"]'),
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-testid="detail-col-header-select"]'),
+      ).toBeVisible();
+
+      const folderRows = page.locator('[data-testid^="detail-row-"][data-row-kind="folder"]');
+      const folderIcons = page.locator('[data-testid^="detail-folder-icon-"]');
+      if ((await folderRows.count()) === 0) {
+        test.info().annotations.push({
+          type: "note",
+          description: "Folders list empty on this fixture; icon header asserted",
+        });
+        return;
+      }
+
+      await expect(folderIcons.first()).toBeVisible();
+      await expect(folderIcons.first()).toHaveAttribute("data-kind", "folder");
+      await expect(folderIcons.first()).toHaveAttribute(
+        "data-folder-state",
+        /closed|open/,
+      );
+
+      const firstFolderRow = folderRows.first();
+      const rowCheckbox = firstFolderRow.locator('input[type="checkbox"]');
+      await expect(rowCheckbox).toBeVisible();
+      await expect(firstFolderRow.locator('[data-testid^="detail-folder-icon-"]')).toBeVisible();
+
+      const beforePath = await page
+        .locator('[data-testid="detail-list"]')
+        .getAttribute("data-folder-path")
+        .catch(() => null);
+      await firstFolderRow.locator('[data-testid^="detail-folder-icon-"]').click();
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+      await expect(page).not.toHaveURL(/view=editor/);
+      if (beforePath) {
+        await expect
+          .poll(async () =>
+            page.locator('[data-testid="detail-list"]').getAttribute("data-folder-path"),
+          )
+          .not.toBe(beforePath);
+      }
+
+      const unexpected = consoleErrors.filter(
+        (t) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            t,
+          ),
+      );
+      expect(unexpected, `console/page errors: ${unexpected.join(" | ")}`).toEqual(
+        [],
+      );
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -22,7 +22,7 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | **View tools** | Always-visible **Search**, **Folder Security**, and **Refresh** buttons under the reduced actions / Server actions rows (the same commands remain under **View**; Folder Security is one toolbar control, not a pair of identical buttons) |
 | **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
 | **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
-| **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
+| **Tree + detail list** | Folder navigation and list of children; folder/item type icons plus optional display-format columns |
 | **Views catalog** | System **Views** category under the left tree (My / Community / All / Other Content) |
 | **Views → My Content → Inbox** | Assignment list (not a top-level Explorer root — see below) |
 | **Context menu** | Right-click an item or folder row for the same catalog filtered for the popup surface |
@@ -44,6 +44,12 @@ service (roles may hide Design/Recycling for some users):
 Explorer. Use it when you need the full repository folder hierarchy rather than only the
 Assets or Sites shortcuts. Expanding **Folders** loads children from the server; folder
 visibility still respects folder ACLs.
+
+The detail list always shows a **type icon** in its own column (before Name / display-format
+columns). Repository folders — including **`$System$`** and user-created folders — use a
+folder icon (open when that row is the current selection). Click the folder icon, or
+double-click the row, to browse into the folder. Multi-select **checkboxes** remain in a
+separate column when you are selecting several items; they do not replace the folder icon.
 
 Below the folder roots, Explorer lists a **Views** system category. Expand **Views**
 to see the same four groups as Desktop Content Explorer:


### PR DESCRIPTION
## Summary

Content Explorer **Folders** detail rows showed a multi-select checkbox as the leading chrome, so `$System$` and user folders looked like a selectable list instead of a browsable folder tree.

This change adds a dedicated **type-icon column** (before Name / display-format columns). Folders render a folder/open icon that activates browse (`onActivateItem`). Multi-select checkboxes stay in their own column and no longer replace the folder affordance.

Fixes #3328

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2286 passed (311 files); Surefire Tests run: 51, Failures: 0.
2. Log in, open Explorer, select **Folders**. Confirm `$System$` (and any user folders) show a folder icon next to the checkbox, not a checkbox alone.
3. Click the folder icon — Explorer stays on the browse list and opens that folder (no editor / workflow `-1`).
4. Playwright (QA H2 Docker, `TEST_CMS_URL=http://127.0.0.1:9993`):
   - `npm run test:surface -- --path tests/bugs/bug-3328-folders-view-icons.spec.js` — 1 passed
   - `npm run test:golden` — 2 passed
   - console-clean=yes
   - server.log-clean=yes for this feature (pre-existing `PSRuntimeExceptionMapper` “validated object is null” noise during Explorer loads, not icon-column specific)

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (folder/item type icons + `$System$` browse)
- [x] **Unit / module tests** — `DetailList.test.tsx` folder-row chrome (`$System$`, user folder, checkbox coexistence, icon activate, a11y)
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3328-folders-view-icons.spec.js`
- [x] **Build gates** — standalone WebUI `mvnw clean install` (tests included)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (01:25); Vitest Tests 2286 passed (311 files); Surefire Tests run: 51, Failures: 0
- **downstream_checked:** none (no public Java API / `final` / signature change)

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`)
- Deploy: copied `WebUI/target/generated-webui/cm/modern/assets` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`; restarted Jetty only
- Playwright: surface 1 passed; golden 2 passed; console-clean=yes; server.log-clean=yes (feature)

> Co-Authored by Grok Build using grok-4.5 with agent main.
