### PR TITLE
fix(webui): dedupe Explorer All Content view leaves (#3325)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ViewResultsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ViewResultsPanel.tsx
@@ -131,7 +131,7 @@ function ViewRunBody(props: {
         role="status"
         aria-live="polite"
         data-testid="explorer-view-results-empty"
-        style={{ padding: 12, color: "#888" }}
+        style={{ padding: 12, color: "#444" }}
       >
         {message(EXPLORER_MSG.VIEWS_RUN_EMPTY)}
       </p>

--- a/WebUI/src/main/ts/contentExplorer/ViewsCatalogTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ViewsCatalogTree.tsx
@@ -16,7 +16,7 @@
  */
 
 /**
- * Product Explorer Views catalog tree (#3116).
+ * Product Explorer Views catalog tree (#3116 / #3325).
  *
  * <p>System category <strong>Views</strong> with My / Community / All /
  * Other groups from {@code GET /services/views} grouped by
@@ -49,7 +49,7 @@ import {
   isInboxView,
   type ViewParentCategory,
   viewKey,
-  viewLabel,
+  viewTreeLabel,
 } from "./viewCatalog";
 
 export interface ViewsCatalogTreeProps {
@@ -219,7 +219,7 @@ export function ViewsCatalogTree({
                     const inbox = isInboxView(def);
                     const label = inbox
                       ? message(EXPLORER_MSG.VIEWS_INBOX)
-                      : viewLabel(def);
+                      : viewTreeLabel(def, children);
                     return (
                       <div
                         key={key}

--- a/WebUI/src/main/ts/contentExplorer/viewCatalog.ts
+++ b/WebUI/src/main/ts/contentExplorer/viewCatalog.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * Pure grouping helpers for the Explorer Views catalog (#3116 / #3240).
+ * Pure grouping helpers for the Explorer Views catalog (#3116 / #3240 / #3325).
  *
  * <p>DCE {@code sys_category} / {@code PSSearch.ParentCategory} values
  * 1–4 map to My / Community / All / Other. Unknown categories fall into
@@ -24,6 +24,12 @@
  *
  * <p>Inbox is a system custom-URL view at {@code //Views//MyContent/Inbox},
  * never a free-floating Explorer root (#3118 slice 2 / #3240).</p>
+ *
+ * <p>#3325: {@link groupViewsByParentCategory} collapses catalog rows that
+ * are the same logical view (same name / guid / id). Distinct names and
+ * guids stay as separate leaves; unlabeled duplicates are omitted. Shared
+ * display labels (for example seven {@code All} rows) are disambiguated
+ * with the internal name when the keys differ.</p>
  */
 
 import type { ViewDef } from "../api/developer/types";
@@ -52,7 +58,8 @@ export function viewKey(def: ViewDef): string {
   return (
     def.name ||
     def.guid?.stringValue ||
-    (def.id != null ? String(def.id) : "")
+    def.guid?.untypedString ||
+    (def.id != null && Number(def.id) !== 0 ? String(def.id) : "")
   ).trim();
 }
 
@@ -60,13 +67,137 @@ export function viewLabel(def: ViewDef): string {
   return (def.label || def.name || viewKey(def) || "—").trim();
 }
 
-export function normalizeViewParentCategory(
-  raw: number | undefined | null,
-): ViewParentCategory {
-  if (raw === 1 || raw === 2 || raw === 3 || raw === 4) {
+/** Coerce JSON parentCategory (number or numeric string) to a finite int. */
+export function coerceViewParentCategory(
+  raw: unknown,
+): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
     return raw;
   }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+  return undefined;
+}
+
+export function normalizeViewParentCategory(
+  raw: number | string | undefined | null,
+): ViewParentCategory {
+  const n = coerceViewParentCategory(raw);
+  if (n === 1 || n === 2 || n === 3 || n === 4) {
+    return n;
+  }
   return 4;
+}
+
+/**
+ * Identity for catalog dedupe (#3325). Prefers internal name, then guid,
+ * then non-zero id. Empty when the row cannot be distinguished.
+ */
+export function viewCatalogIdentity(def: ViewDef): string {
+  const name = (def.name ?? "").trim().toLowerCase();
+  if (name) {
+    return `name:${name}`;
+  }
+  const guid = (
+    def.guid?.stringValue ||
+    def.guid?.untypedString ||
+    ""
+  )
+    .trim()
+    .toLowerCase();
+  if (guid) {
+    return `guid:${guid}`;
+  }
+  if (def.id != null && Number(def.id) !== 0) {
+    return `id:${String(def.id).trim()}`;
+  }
+  return "";
+}
+
+function unlabeledStamp(def: ViewDef): string {
+  const label = viewLabel(def).toLowerCase();
+  const cat = normalizeViewParentCategory(def.parentCategory);
+  return `unlabeled:${cat}:${label}`;
+}
+
+function preferRicherView(a: ViewDef, b: ViewDef): ViewDef {
+  const aScore =
+    (a.label ? 1 : 0) + (a.description ? 1 : 0) + (a.guid ? 1 : 0);
+  const bScore =
+    (b.label ? 1 : 0) + (b.description ? 1 : 0) + (b.guid ? 1 : 0);
+  return bScore > aScore ? b : a;
+}
+
+/**
+ * Collapse duplicate catalog rows that represent one logical view.
+ * Distinct {@link viewCatalogIdentity} values are kept. Rows with no
+ * name/guid/id are kept once per (category, label) and otherwise dropped.
+ */
+export function dedupeViewCatalog(
+  views: readonly ViewDef[] | null | undefined,
+): ViewDef[] {
+  if (!Array.isArray(views) || views.length === 0) {
+    return [];
+  }
+  const byIdentity = new Map<string, ViewDef>();
+  const unlabeledSeen = new Set<string>();
+  const order: string[] = [];
+  for (const def of views) {
+    if (def == null) {
+      continue;
+    }
+    const identity = viewCatalogIdentity(def);
+    if (!identity) {
+      const stamp = unlabeledStamp(def);
+      if (unlabeledSeen.has(stamp)) {
+        continue;
+      }
+      unlabeledSeen.add(stamp);
+      const key = `anon:${stamp}`;
+      byIdentity.set(key, def);
+      order.push(key);
+      continue;
+    }
+    const existing = byIdentity.get(identity);
+    if (existing == null) {
+      byIdentity.set(identity, def);
+      order.push(identity);
+    } else {
+      byIdentity.set(identity, preferRicherView(existing, def));
+    }
+  }
+  return order.map((k) => byIdentity.get(k)).filter((d): d is ViewDef => d != null);
+}
+
+/**
+ * Leaf label for the Views tree. When several distinct views in the same
+ * group share a display label, append the internal name (or guid) so
+ * operators can tell them apart (#3325).
+ */
+export function viewTreeLabel(def: ViewDef, group: readonly ViewDef[]): string {
+  const base = viewLabel(def);
+  if (!group || group.length < 2) {
+    return base;
+  }
+  const same = group.filter(
+    (d) => viewLabel(d).toLowerCase() === base.toLowerCase(),
+  );
+  if (same.length < 2) {
+    return base;
+  }
+  const name = (def.name ?? "").trim();
+  if (name && name.toLowerCase() !== base.toLowerCase()) {
+    return `${base} (${name})`;
+  }
+  const guid = (def.guid?.stringValue || def.guid?.untypedString || "").trim();
+  if (guid) {
+    return `${base} (${guid})`;
+  }
+  return base;
 }
 
 /** True when the view is a custom-URL design view (Inbox family / #3118). */
@@ -145,26 +276,33 @@ export function emptyViewCatalogGroups(): ViewCatalogGroups {
 
 /**
  * Group catalog rows by {@link ViewDef.parentCategory} (1–4).
- * Rows without a usable key are omitted. Each group is sorted by label.
+ * Duplicate logical views are collapsed (#3325). Rows without a usable
+ * key are omitted. Each group is sorted by tree label.
  */
 export function groupViewsByParentCategory(
   views: readonly ViewDef[] | null | undefined,
 ): ViewCatalogGroups {
   const groups = emptyViewCatalogGroups();
-  const list = ensureInboxInMyContent(views);
+  const list = ensureInboxInMyContent(dedupeViewCatalog(views));
   for (const def of list) {
     const key = viewKey(def);
     if (!key) {
       continue;
     }
-    const placed = isInboxView(def) ? { ...def, parentCategory: 1 } : def;
+    const cat = normalizeViewParentCategory(def.parentCategory);
+    const placed = isInboxView(def)
+      ? { ...def, parentCategory: 1 }
+      : { ...def, parentCategory: cat };
     groups[normalizeViewParentCategory(placed.parentCategory)].push(placed);
   }
   for (const cat of VIEW_PARENT_CATEGORIES) {
+    groups[cat] = dedupeViewCatalog(groups[cat]);
     groups[cat].sort((a, b) =>
-      viewLabel(a).localeCompare(viewLabel(b), undefined, {
-        sensitivity: "base",
-      }),
+      viewTreeLabel(a, groups[cat]).localeCompare(
+        viewTreeLabel(b, groups[cat]),
+        undefined,
+        { sensitivity: "base" },
+      ),
     );
   }
   return groups;

--- a/WebUI/src/test/ts/contentExplorer/ViewsCatalogTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ViewsCatalogTree.test.tsx
@@ -89,6 +89,25 @@ describe("ViewsCatalogTree (#3116)", () => {
     expect(listViews).toHaveBeenCalledTimes(2);
   });
 
+  it("renders one All leaf for seven catalog copies of View_All (#3325)", async () => {
+    const copies: ViewDef[] = Array.from({ length: 7 }, (_, i) => ({
+      name: "View_All",
+      label: "All",
+      parentCategory: 3,
+      id: i + 10,
+      standardView: true,
+    }));
+    render(<ViewsCatalogTree listViews={async () => copies} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-views-group-3")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-views-group-3-row"));
+    const leaves = screen.getAllByTestId("explorer-views-leaf-View_All");
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0].textContent).toContain("All");
+    expect(leaves[0].textContent).not.toMatch(/All.*All/);
+  });
+
   it("always shows an Inbox leaf under My Content when catalog is empty (#3240)", async () => {
     const { container } = render(
       <ViewsCatalogTree listViews={async () => []} />,

--- a/WebUI/src/test/ts/contentExplorer/viewCatalog.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/viewCatalog.test.ts
@@ -20,13 +20,16 @@ import type { ViewDef } from "../../../main/ts/api/developer/types";
 import {
   PATH_MY_CONTENT_INBOX,
   canExecuteView,
+  dedupeViewCatalog,
   ensureInboxInMyContent,
   groupViewsByParentCategory,
   isCustomUrlView,
   isInboxView,
   normalizeViewParentCategory,
+  viewCatalogIdentity,
   viewKey,
   viewLabel,
+  viewTreeLabel,
 } from "../../../main/ts/contentExplorer/viewCatalog";
 
 function v(
@@ -99,5 +102,72 @@ describe("viewCatalog grouping (#3116)", () => {
       { name: "Inbox", parentCategory: 4, customView: true },
     ]);
     expect(ensured[0].parentCategory).toBe(1);
+  });
+});
+
+describe("viewCatalog dedupe (#3325)", () => {
+  it("collapses seven All rows that share one name / logical view", () => {
+    const copies = Array.from({ length: 7 }, (_, i) =>
+      v({
+        name: "View_All",
+        label: "All",
+        parentCategory: 3,
+        id: i + 1,
+        standardView: true,
+      }),
+    );
+    const grouped = groupViewsByParentCategory(copies);
+    expect(grouped[3]).toHaveLength(1);
+    expect(grouped[3][0].name).toBe("View_All");
+    expect(viewTreeLabel(grouped[3][0], grouped[3])).toBe("All");
+    expect(dedupeViewCatalog(copies)).toHaveLength(1);
+  });
+
+  it("keeps distinct name/guid views and disambiguates shared All labels", () => {
+    const grouped = groupViewsByParentCategory([
+      v({
+        name: "View_All",
+        label: "All",
+        parentCategory: 3,
+        guid: { stringValue: "guid-all" },
+      }),
+      v({
+        name: "All_Sites",
+        label: "All",
+        parentCategory: 3,
+        guid: { stringValue: "guid-sites" },
+      }),
+    ]);
+    expect(grouped[3]).toHaveLength(2);
+    const labels = grouped[3].map((d) => viewTreeLabel(d, grouped[3])).sort();
+    expect(labels).toEqual(["All (All_Sites)", "All (View_All)"]);
+  });
+
+  it("drops unlabeled duplicates and ignores id 0 as an identity", () => {
+    const grouped = groupViewsByParentCategory([
+      { label: "All", parentCategory: 3, id: 0 },
+      { label: "All", parentCategory: 3, id: 0 },
+      { label: "All", parentCategory: 3 },
+    ]);
+    expect(grouped[3]).toHaveLength(0);
+    expect(viewCatalogIdentity({ label: "All", id: 0 })).toBe("");
+    expect(viewKey({ id: 0 })).toBe("");
+  });
+
+  it("coerces string parentCategory 3 into All Content", () => {
+    const grouped = groupViewsByParentCategory([
+      v({ name: "View_All", label: "All", parentCategory: "3" as unknown as number }),
+    ]);
+    expect(grouped[3].map((d) => d.name)).toEqual(["View_All"]);
+    expect(normalizeViewParentCategory("3")).toBe(3);
+    expect(normalizeViewParentCategory("x")).toBe(4);
+  });
+
+  it("does not collapse distinct keys that only share a blank-looking label after name fallback", () => {
+    const grouped = groupViewsByParentCategory([
+      v({ name: "Alpha", parentCategory: 3 }),
+      v({ name: "Beta", parentCategory: 3 }),
+    ]);
+    expect(grouped[3].map((d) => d.name)).toEqual(["Alpha", "Beta"]);
   });
 });

--- a/docs/ai-generated/code-reviews/3325-all-content-duplicate-views-erlang.md
+++ b/docs/ai-generated/code-reviews/3325-all-content-duplicate-views-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — #3325 All Content duplicate views
+
+**Branch:** `fix/issue-3325-all-content-duplicate-views`  
+**Date:** 2026-08-13  
+**Persona:** Erlang (independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A — no filesystem path I/O in the diff (TS grouping + product-docs + Playwright selectors).
+
+## Summary
+
+Explorer Views → All Content (parentCategory 3) could render the same logical view as seven identical **All** leaves when `GET /services/views` repeated `View_All` (or unlabeled rows). Grouping now dedupes by name/guid/id, drops unlabeled identity-less duplicates from the tree (no executable key), keeps distinct names/guids as separate leaves, and disambiguates shared display labels with the internal name.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests for new/changed non-trivial logic — covered (`viewCatalog.test.ts`, `ViewsCatalogTree.test.tsx`).
+- Incomplete change-class closure — Playwright companion + product-docs updated.
+
+## Issues
+
+None that block commit.
+
+## Tests
+
+- Vitest: seven `View_All` copies collapse to one leaf; distinct `View_All` / `All_Sites` stay two leaves with disambiguated labels; string `parentCategory` `"3"` buckets to All Content; `id: 0` is not an identity.
+- Playwright: `explorer-views.spec.js` expands group 3 and asserts at most one exact **All** leaf and unique leaf testids.
+
+## Product docs
+
+`product-docs/8.2/admin/content-explorer.md` All Content row documents unique-logical-view listing.

--- a/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
@@ -58,6 +58,9 @@ const {
   unwrapViewDefs,
   isCustomUrlView,
   isInboxView,
+  viewParentCategory,
+  viewDefKey,
+  viewDefLabel,
   pickRunnableStandardView,
   noViewsChromeSkipMessage,
   noRunnableViewSkipMessage,
@@ -281,6 +284,58 @@ test.describe("Explorer Views Playwright + a11y (#3117 / #3110)", () => {
     await expectNoSeriousA11yViolations(page, {
       scope: `[data-testid="${TEST_IDS.viewsTree}"], [data-testid="${TEST_IDS.results}"]`,
     });
+
+    expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+  });
+
+  test("All Content lists unique view leaves (no seven All dups) @explorer-views @views @3325", async ({
+    page,
+    request,
+  }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    const headers = adminBasicAuthHeaders();
+    let restAllLabels = [];
+    try {
+      const res = await request.get(viewsCatalogUrl(BASE_URL), {
+        headers: { ...headers, Accept: "application/json" },
+      });
+      if (res.ok()) {
+        const defs = unwrapViewDefs(await res.json().catch(() => null));
+        restAllLabels = defs
+          .filter((d) => viewParentCategory(d) === 3)
+          .map((d) => viewDefLabel(d) || viewDefKey(d));
+      }
+    } catch {
+      restAllLabels = [];
+    }
+
+    await page.goto(explorerEntryUrl(BASE_URL), { waitUntil: "networkidle" });
+    await expect(page.getByTestId(TEST_IDS.shell)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const hasChrome = await viewsChromeVisible(page);
+    if (!hasChrome) {
+      test.skip(true, noViewsChromeSkipMessage());
+      return;
+    }
+
+    await expandViewsGroup(page, 3);
+    const group = page.getByTestId(TEST_IDS.group(3));
+    const leafLabels = await group.locator('[role="treeitem"][data-testid^="explorer-views-leaf-"]').allTextContents();
+    const trimmed = leafLabels.map((s) => s.replace(/\s+/g, " ").trim()).filter(Boolean);
+    const allExact = trimmed.filter((s) => /^all$/i.test(s));
+    expect(
+      allExact.length,
+      `All Content should not list seven identical All leaves (ui=${JSON.stringify(trimmed)} rest=${JSON.stringify(restAllLabels)})`,
+    ).toBeLessThanOrEqual(1);
+
+    const keys = await group.locator('[data-testid^="explorer-views-leaf-"]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid")),
+    );
+    expect(new Set(keys).size, `duplicate leaf testids: ${keys.join(",")}`).toBe(
+      keys.length,
+    );
 
     expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
   });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -52,7 +52,7 @@ to see the same four groups as Desktop Content Explorer:
 |-------|------------------|
 | **My Content** | Views in parent category 1 (including system views such as Inbox) |
 | **Community Content** | Views in parent category 2 |
-| **All Content** | Views in parent category 3 |
+| **All Content** | Views in parent category 3. Each **logical** view appears once (same internal name or GUID is not listed repeatedly). Distinct views that share the display label **All** show the internal name in parentheses so you can tell them apart. |
 | **Other Content** | Views in parent category 4 (and any view without a known category) |
 
 Selecting a **group** only expands or collapses its children. Selecting a **standard**


### PR DESCRIPTION
## Summary

Explorer **Views → All Content** listed the same logical view as seven identical **All** leaves when `GET /services/views` repeated `View_All` (or unlabeled identity-less rows). Grouping now:

* Dedupes by internal name, then GUID, then non-zero id
* Drops unlabeled rows that cannot be executed
* Keeps distinct name/GUID views as separate leaves
* Disambiguates shared display labels with the internal name (for example `All (View_All)` vs `All (All_Sites)`)
* Coerces string `parentCategory` (`"3"`) into All Content

Empty view-result copy uses `#444` so axe color-contrast passes on the Views surface.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3325

## Test plan

1. Log in to Percussion CMS and open Explorer.
2. Expand **Views → All Content**.
3. Confirm there is at most one leaf labeled exactly **All** for the system `View_All` view.
4. Distinct views that share the label **All** should show the internal name in parentheses.
5. Select a standard view and confirm results (or empty) still load.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` All Content row
- [x] **Unit / module tests** — Vitest on `groupViewsByParentCategory` / tree; WebUI standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `tests/explorer-views.spec.js` (unique All Content leaves + existing Views surface)
- [x] **Build gates** — WebUI standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

* **modules_built:** `WebUI`
* **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Surefire Tests run: 53, Failures: 0; Vitest Test Files 313 / Tests 2290 passed)
* **downstream_checked:** none (no Java public/protected API or `final`/`sealed` type changes)

## C5 UI proof

* `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (host port **14607**, `TEST_CMS_URL=http://127.0.0.1:14607`)
* First `qa-up` health probe failed: Rhythmyx `ClassNotFoundException: PSVirtualSitePublishCopyResult` (pre-existing distribution/system SNAPSHOT mismatch). Cell kept; one-class shim jar copied into `WEB-INF/lib` (not committed); Jetty restarted; WebUI `cm/modern` hot-copied from this WebUI install.
* `npm run test:surface -- --path tests/explorer-views.spec.js` → **4 passed** (console-clean=yes)
* `npm run test:golden` → **2 passed**
* server.log-clean=yes for views/explorer (no view-related ERROR/FATAL). Unrelated `PSRuntimeExceptionMapper` “validated object is null” noise present.

> Co-Authored by Grok Build using grok-4.5 with agent main.
