### PR TITLE
cluster: absorb Explorer thrash (#3334 #3336 #3337 #3339)

### DIFF
--- a/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
+++ b/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
@@ -18,20 +18,40 @@
 import React, { createContext, useContext } from "react";
 import { DEFAULT_SPA_BOOTSTRAP, type SpaBootstrap } from "./types";
 
-const BootstrapContext = createContext<SpaBootstrap>(DEFAULT_SPA_BOOTSTRAP);
+/**
+ * {@code null} default so a missing provider is distinguishable from a real
+ * {@link DEFAULT_SPA_BOOTSTRAP} value. Callers that only need identity flags
+ * should use {@link useSpaBootstrap} (falls back). Explorer uses
+ * {@link useSpaBootstrapOptional} so a missing provider is an error state
+ * instead of a {@code useContext} crash (#3331 / parent #3329).
+ */
+const BootstrapContext = createContext<SpaBootstrap | null>(null);
 
 export function BootstrapProvider({
   value,
   children,
 }: {
   value: SpaBootstrap;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }): React.ReactElement {
   return (
     <BootstrapContext.Provider value={value}>{children}</BootstrapContext.Provider>
   );
 }
 
+/**
+ * Read SPA bootstrap without throwing when the provider is absent or React's
+ * dispatcher is unset (bridge remount / dual-React). Returns {@code null} in
+ * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}.
+ */
+export function useSpaBootstrapOptional(): SpaBootstrap | null {
+  try {
+    return useContext(BootstrapContext);
+  } catch {
+    return null;
+  }
+}
+
 export function useSpaBootstrap(): SpaBootstrap {
-  return useContext(BootstrapContext);
+  return useSpaBootstrapOptional() ?? DEFAULT_SPA_BOOTSTRAP;
 }

--- a/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
+++ b/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
@@ -40,15 +40,37 @@ export function BootstrapProvider({
 }
 
 /**
+ * True when {@code useContext} failed because React has no hook dispatcher
+ * (dual-React remount / hook called outside a component). Other errors must
+ * surface so real bugs are not swallowed.
+ */
+export function isBootstrapHookEnvironmentError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const msg = err.message;
+  return (
+    msg.includes("Invalid hook call") ||
+    /Cannot read propert(?:y|ies) of null \(reading ['"]useContext['"]\)/i.test(
+      msg,
+    )
+  );
+}
+
+/**
  * Read SPA bootstrap without throwing when the provider is absent or React's
  * dispatcher is unset (bridge remount / dual-React). Returns {@code null} in
- * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}.
+ * those cases — do not treat as {@link DEFAULT_SPA_BOOTSTRAP}. Unexpected
+ * errors from {@code useContext} are rethrown.
  */
 export function useSpaBootstrapOptional(): SpaBootstrap | null {
   try {
     return useContext(BootstrapContext);
-  } catch {
-    return null;
+  } catch (err) {
+    if (isBootstrapHookEnvironmentError(err)) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
@@ -18,6 +18,11 @@
 import React, { lazy, useMemo } from "react";
 import { useLocation } from "react-router";
 import { normalizeExplorerPath } from "../deepLinks/allowlists";
+import {
+  BootstrapProvider,
+  useSpaBootstrapOptional,
+} from "../bootstrap/BootstrapContext";
+import { loadSpaBootstrap } from "../bootstrap/loadBootstrap";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";
 import styles from "./ExplorerRoute.module.css";
@@ -33,25 +38,29 @@ const ContentExplorerShellLazy = lazy(() =>
  */
 export function ExplorerRoute(): React.ReactElement {
   const location = useLocation();
+  const fromContext = useSpaBootstrapOptional();
+  const bootstrap = fromContext ?? loadSpaBootstrap();
   const initialPath = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return normalizeExplorerPath(params.get("path")) ?? "/";
   }, [location.search]);
 
   return (
-    <LazyRouteFrame
-      label="Content Explorer"
-      fallback={
-        <div
-          className={styles.loading}
-          data-testid="explorer-route-loading"
-          role="status"
-        >
-          Loading Content Explorer…
-        </div>
-      }
-    >
-      <ContentExplorerShellLazy initialPath={initialPath} />
-    </LazyRouteFrame>
+    <BootstrapProvider value={bootstrap}>
+      <LazyRouteFrame
+        label="Content Explorer"
+        fallback={
+          <div
+            className={styles.loading}
+            data-testid="explorer-route-loading"
+            role="status"
+          >
+            Loading Content Explorer…
+          </div>
+        }
+      >
+        <ContentExplorerShellLazy initialPath={initialPath} />
+      </LazyRouteFrame>
+    </BootstrapProvider>
   );
 }

--- a/WebUI/src/main/ts/bridge.ts
+++ b/WebUI/src/main/ts/bridge.ts
@@ -25,6 +25,8 @@
 
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { BootstrapProvider } from "./app/bootstrap/BootstrapContext";
+import { loadSpaBootstrap } from "./app/bootstrap/loadBootstrap";
 import { isRegisteredComponent, loadComponent } from "./registry";
 
 declare global {
@@ -87,7 +89,13 @@ export function mountReactComponent(
       }
       unmountRootOnly(elementId);
       const root = createRoot(el);
-      root.render(React.createElement(Component, props));
+      root.render(
+        React.createElement(
+          BootstrapProvider,
+          { value: loadSpaBootstrap() },
+          React.createElement(Component, props),
+        ),
+      );
       activeRoots.set(elementId, root);
     })
     .catch((err) => {

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -65,7 +65,8 @@ import type {
   ViewExecuteRequest,
   ViewExecuteResult,
 } from "../api/developer/types";
-import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
+import { useSpaBootstrapOptional } from "../app/bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "../app/bootstrap/types";
 import { message } from "../i18n/message";
 import {
   filterContextMenuActions,
@@ -367,7 +368,37 @@ async function defaultResolveFolderId(
   }
 }
 
-export function ContentExplorerShell({
+function ExplorerBootstrapUnavailable(): React.ReactElement {
+  return (
+    <div
+      data-testid="content-explorer-shell"
+      role="alert"
+      aria-live="assertive"
+      style={errorStateStyle}
+    >
+      <p data-testid="explorer-bootstrap-unavailable" style={{ margin: 0 }}>
+        {message(EXPLORER_MSG.BOOTSTRAP_UNAVAILABLE)}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Product Explorer entry. Reads bootstrap optionally so a missing
+ * {@code BootstrapProvider} (legacy bridge remount) is an error state, not a
+ * {@code useContext} throw (#3331).
+ */
+export function ContentExplorerShell(
+  props: ContentExplorerShellProps,
+): React.ReactElement {
+  const bootstrap = useSpaBootstrapOptional();
+  if (!bootstrap) {
+    return <ExplorerBootstrapUnavailable />;
+  }
+  return <ContentExplorerShellInner {...props} bootstrap={bootstrap} />;
+}
+
+function ContentExplorerShellInner({
   initialPath = "/",
   onOpenItem = openInEditor,
   actionHandlers,
@@ -384,8 +415,8 @@ export function ContentExplorerShell({
   executeSavedSearch,
   listViews = listViewsApi,
   executeView = executeViewApi,
-}: ContentExplorerShellProps): React.ReactElement {
-  const bootstrap = useSpaBootstrap();
+  bootstrap,
+}: ContentExplorerShellProps & { bootstrap: SpaBootstrap }): React.ReactElement {
   const currentUserIdentities = useMemo(() => {
     if (currentUserIdentitiesProp) {
       return [...currentUserIdentitiesProp];

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -96,7 +96,10 @@ import {
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { EMPTY_SELECTION, type Selection } from "./selection";
 import { resolveFolderPathFromSelection } from "./folderPath";
-import { resolveSiteNameFromSelection } from "./sitePath";
+import {
+  resolveExplorerListPath,
+  resolveSiteNameFromSelection,
+} from "./sitePath";
 import {
   errorStateStyle,
   headerStyle,
@@ -571,7 +574,10 @@ export function ContentExplorerShell({
 
   const handleSelectFolder = useCallback(
     (path: string, folder: PSPathItem | null) => {
-      setSelection({ folderPath: path, item: null });
+      setSelection({
+        folderPath: resolveExplorerListPath(folder, path) ?? path,
+        item: null,
+      });
       // Reset multi-select when the folder changes: stale ids are not
       // present in the new list so the checkbox column would otherwise
       // show phantom selections until the next user click.
@@ -587,7 +593,10 @@ export function ContentExplorerShell({
 
   const handleActivate = useCallback(
     (path: string, folder: PSPathItem) => {
-      setSelection({ folderPath: path, item: null });
+      setSelection({
+        folderPath: resolveExplorerListPath(folder, path) ?? path,
+        item: null,
+      });
       setMultiSelectedIds(new Set<string>());
       setMultiSelectedItems(new Map<string, PSPathItem>());
       setContextMenu(null);

--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -373,7 +373,9 @@ export function DetailList({
   if (!folderPath) {
     return (
       <div style={listStyle} data-testid="detail-list">
-        <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
+        <div style={emptyStateStyle} data-testid="detail-list-empty">
+          {message(EXPLORER_MSG.LIST_EMPTY)}
+        </div>
       </div>
     );
   }
@@ -396,7 +398,9 @@ export function DetailList({
   if (!loading && children.length === 0) {
     return (
       <div style={listStyle} data-testid="detail-list">
-        <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
+        <div style={emptyStateStyle} data-testid="detail-list-empty">
+          {message(EXPLORER_MSG.LIST_EMPTY)}
+        </div>
       </div>
     );
   }

--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -22,6 +22,11 @@
  * 50 to bound render cost; the user paginates forward/back via the
  * controls below the list.</p>
  *
+ * <p>#3328: a dedicated type-icon column always precedes the display-format
+ * columns. Folders (including {@code $System$} and user folders) show a
+ * folder/open icon that activates browse. Multi-select checkboxes stay in
+ * their own column and do not replace the folder affordance.</p>
+ *
  * <p>FR-027 / T092b: when a `displayFormat` is supplied, the list honours
  * the column ordering + selection defined by the format. When absent
  * (default), the list falls back to Name + Type + Path. Supported column
@@ -207,10 +212,14 @@ export function columnHeaderLabel(
   }
 }
 import { message } from "../i18n/message";
-import { canRead } from "./selection";
+import { canRead, isFolder } from "./selection";
 import {
   emptyStateStyle,
   errorStateStyle,
+  folderIconButtonStyle,
+  iconTdCellStyle,
+  iconThCellStyle,
+  itemIconStyle,
   listStyle,
   rowStyle,
   tableStyle,
@@ -221,6 +230,32 @@ import {
 import { EXPLORER_MSG } from "./messages";
 
 const PAGE_SIZE = 50;
+
+function FolderClosedGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+      <path fill="currentColor" d="M1 4a1 1 0 0 1 1-1h4l1 1.5h7a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1z" />
+    </svg>
+  );
+}
+
+function FolderOpenGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+      <path fill="currentColor" opacity="0.7" d="M1 4a1 1 0 0 1 1-1h4l1 1.5h5.5a1 1 0 0 1 1 1V7H2.2z" />
+      <path fill="currentColor" d="M1 7h10.2a1 1 0 0 1 .95.7L14 14H2.5A1.5 1.5 0 0 1 1 12.5z" />
+    </svg>
+  );
+}
+
+function ItemGlyph(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <path fill="currentColor" d="M4 1.5h5.2L13 5.3V14.5H4z" />
+      <path fill="#fff" d="M9.2 1.7v3.6H12.8" />
+    </svg>
+  );
+}
 
 export interface DetailListProps {
   /** Folder path whose children to list. null disables the list. */
@@ -372,14 +407,22 @@ export function DetailList({
 
   if (!folderPath) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
       </div>
     );
   }
   if (error) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={errorStateStyle} role="alert">
           {message(EXPLORER_MSG.LIST_LOAD_ERROR)}: {error}
         </div>
@@ -388,21 +431,33 @@ export function DetailList({
   }
   if (loading && children.length === 0) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_LOADING)}</div>
       </div>
     );
   }
   if (!loading && children.length === 0) {
     return (
-      <div style={listStyle} data-testid="detail-list">
+      <div
+        style={listStyle}
+        data-testid="detail-list"
+        data-folder-path={folderPath ?? ""}
+      >
         <div style={emptyStateStyle}>{message(EXPLORER_MSG.LIST_EMPTY)}</div>
       </div>
     );
   }
 
   return (
-    <div style={listStyle} data-testid="detail-list">
+    <div
+      style={listStyle}
+      data-testid="detail-list"
+      data-folder-path={folderPath ?? ""}
+    >
       <table style={tableStyle}>
         <thead style={theadStyle}>
           <tr>
@@ -442,6 +497,11 @@ export function DetailList({
                 />
               </th>
             ) : null}
+            <th
+              style={iconThCellStyle}
+              data-testid="detail-col-header-icon"
+              aria-label={message(EXPLORER_MSG.ICON_COLUMN_LABEL)}
+            />
             {columnsToRender.map((c) => (
               <th
                 key={c}
@@ -459,10 +519,13 @@ export function DetailList({
             const idKey = item.id ?? item.path;
             const isChecked = multiSelectEnabled && multiSelected.has(idKey);
             const visible = canRead(item);
+            const folderish = isFolder(item);
+            const folderOpen = folderish && selected;
             return (
               <tr
                 key={idKey}
                 data-testid={`detail-row-${idKey}`}
+                data-row-kind={folderish ? "folder" : "item"}
                 data-selected={isChecked ? "true" : undefined}
                 style={rowStyle(selected)}
                 role="row"
@@ -497,6 +560,36 @@ export function DetailList({
                     />
                   </td>
                 ) : null}
+                <td style={iconTdCellStyle} data-testid={`detail-cell-icon-${idKey}`}>
+                  {folderish ? (
+                    <button
+                      type="button"
+                      style={folderIconButtonStyle}
+                      data-testid={`detail-folder-icon-${idKey}`}
+                      data-kind="folder"
+                      data-folder-state={folderOpen ? "open" : "closed"}
+                      aria-label={message(EXPLORER_MSG.OPEN_FOLDER_LABEL)}
+                      title={message(EXPLORER_MSG.OPEN_FOLDER_LABEL)}
+                      disabled={!visible}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (visible) onActivateItem?.(item);
+                      }}
+                    >
+                      {folderOpen ? <FolderOpenGlyph /> : <FolderClosedGlyph />}
+                    </button>
+                  ) : (
+                    <span
+                      style={itemIconStyle}
+                      data-testid={`detail-item-icon-${idKey}`}
+                      data-kind="item"
+                      aria-hidden="true"
+                      title={message(EXPLORER_MSG.ITEM_ICON_LABEL)}
+                    >
+                      <ItemGlyph />
+                    </span>
+                  )}
+                </td>
                 {columnsToRender.map((c) => (
                   <td
                     key={c}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -28,7 +28,8 @@ import { findChildren } from "../api/contentExplorer/pathApi";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
 import { message } from "../i18n/message";
-import { isStrictCmsPathDescendant } from "./folderPath";
+import { isSafeExplorerTreeChild } from "./folderPath";
+import { resolveExplorerListPath } from "./sitePath";
 import { isFolder } from "./selection";
 import {
   emptyStateStyle,
@@ -81,26 +82,30 @@ export function ExplorerTree({
     [initialPath]: EMPTY_STATE,
   }));
 
-  const ensureLoaded = useCallback(async (path: string) => {
-    setNodes((prev) => {
-      const cur = prev[path] ?? EMPTY_STATE;
-      if (cur.loaded || cur.loading) return prev;
-      return { ...prev, [path]: { ...cur, loading: true, error: null } };
-    });
-    try {
-      const children = await findChildren(path);
-      setNodes((prev) => ({
-        ...prev,
-        [path]: { loaded: true, loading: false, error: null, children },
-      }));
-    } catch (err) {
-      const msg = formatApiError(err, message(EXPLORER_MSG.TREE_LOAD_ERROR));
-      setNodes((prev) => ({
-        ...prev,
-        [path]: { loaded: true, loading: false, error: msg, children: [] },
-      }));
-    }
-  }, []);
+  const ensureLoaded = useCallback(
+    async (path: string, folder?: PSPathItem | null) => {
+      setNodes((prev) => {
+        const cur = prev[path] ?? EMPTY_STATE;
+        if (cur.loaded || cur.loading) return prev;
+        return { ...prev, [path]: { ...cur, loading: true, error: null } };
+      });
+      try {
+        const listPath = resolveExplorerListPath(folder, path) ?? path;
+        const children = await findChildren(listPath);
+        setNodes((prev) => ({
+          ...prev,
+          [path]: { loaded: true, loading: false, error: null, children },
+        }));
+      } catch (err) {
+        const msg = formatApiError(err, message(EXPLORER_MSG.TREE_LOAD_ERROR));
+        setNodes((prev) => ({
+          ...prev,
+          [path]: { loaded: true, loading: false, error: msg, children: [] },
+        }));
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     void ensureLoaded(initialPath);
@@ -110,7 +115,7 @@ export function ExplorerTree({
     (path: string, folder: PSPathItem) => {
       setExpanded((prev) => ({ ...prev, [path]: !prev[path] }));
       if (!nodes[path]?.loaded) {
-        void ensureLoaded(path);
+        void ensureLoaded(path, folder);
       }
       onActivate?.(path, folder);
     },
@@ -124,7 +129,10 @@ export function ExplorerTree({
     const path = folder.path;
     const isOpen = expanded[path] ?? false;
     const state = nodes[path] ?? EMPTY_STATE;
-    const selected = selectedPath === path;
+    const listPath = resolveExplorerListPath(folder, path);
+    const selected =
+      selectedPath === path ||
+      (listPath != null && selectedPath === listPath);
     const folderish = isFolder(folder);
 
     return (
@@ -179,9 +187,11 @@ export function ExplorerTree({
           isOpen &&
           state.children
             // Guard against self-path or ancestor cycles from a bad API payload
-            // (would recurse forever in render). Normalize //Sites vs /Sites and
-            // trailing slashes so site id children are not dropped (#3001).
-            .filter((child) => isStrictCmsPathDescendant(path, child.path))
+            // (would recurse forever in render). Accept name vs FOLDER_ROOT
+            // prefix mismatch on sample sites (#3001 / #3326).
+            .filter((child) =>
+              isSafeExplorerTreeChild(path, folder.folderPath, child.path),
+            )
             .map((child) => renderNode(child, depth + 1))}
       </div>
     );

--- a/WebUI/src/main/ts/contentExplorer/ViewResultsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ViewResultsPanel.tsx
@@ -131,7 +131,7 @@ function ViewRunBody(props: {
         role="status"
         aria-live="polite"
         data-testid="explorer-view-results-empty"
-        style={{ padding: 12, color: "#888" }}
+        style={{ padding: 12, color: "#444" }}
       >
         {message(EXPLORER_MSG.VIEWS_RUN_EMPTY)}
       </p>

--- a/WebUI/src/main/ts/contentExplorer/ViewsCatalogTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ViewsCatalogTree.tsx
@@ -16,7 +16,7 @@
  */
 
 /**
- * Product Explorer Views catalog tree (#3116).
+ * Product Explorer Views catalog tree (#3116 / #3325).
  *
  * <p>System category <strong>Views</strong> with My / Community / All /
  * Other groups from {@code GET /services/views} grouped by
@@ -49,7 +49,7 @@ import {
   isInboxView,
   type ViewParentCategory,
   viewKey,
-  viewLabel,
+  viewTreeLabel,
 } from "./viewCatalog";
 
 export interface ViewsCatalogTreeProps {
@@ -219,7 +219,7 @@ export function ViewsCatalogTree({
                     const inbox = isInboxView(def);
                     const label = inbox
                       ? message(EXPLORER_MSG.VIEWS_INBOX)
-                      : viewLabel(def);
+                      : viewTreeLabel(def, children);
                     return (
                       <div
                         key={key}

--- a/WebUI/src/main/ts/contentExplorer/folderPath.ts
+++ b/WebUI/src/main/ts/contentExplorer/folderPath.ts
@@ -103,6 +103,54 @@ export function isStrictCmsPathDescendant(
 }
 
 /**
+ * Whether {@code childPath} is safe to render under a tree node.
+ *
+ * <p>Drops self/ancestor cycles. Accepts children whose finder path uses
+ * the site <em>name</em> while the node stores {@code folderPath} (or the
+ * reverse) so sample sites {@code Corporate_Investments} vs folder
+ * {@code CorporateInvestments} are not filtered to empty (#3326).</p>
+ */
+export function isSafeExplorerTreeChild(
+  parentPath: string | null | undefined,
+  parentFolderPath: string | null | undefined,
+  childPath: string | null | undefined,
+): boolean {
+  if (childPath == null || String(childPath).trim().length === 0) {
+    return false;
+  }
+  const childNorm = normalizeExplorerFolderPath(childPath);
+  const parentNorm = normalizeExplorerFolderPath(parentPath);
+  const folderNorm = normalizeExplorerFolderPath(parentFolderPath);
+  if (childNorm != null && parentNorm != null && childNorm === parentNorm) {
+    return false;
+  }
+  if (childNorm != null && folderNorm != null && childNorm === folderNorm) {
+    return false;
+  }
+  // Child that is an ancestor of the parent would recurse forever.
+  if (isStrictCmsPathDescendant(childPath, parentPath)) {
+    return false;
+  }
+  if (
+    parentFolderPath != null &&
+    isStrictCmsPathDescendant(childPath, parentFolderPath)
+  ) {
+    return false;
+  }
+  if (isStrictCmsPathDescendant(parentPath, childPath)) {
+    return true;
+  }
+  if (
+    parentFolderPath != null &&
+    isStrictCmsPathDescendant(parentFolderPath, childPath)
+  ) {
+    return true;
+  }
+  // Name vs folder-root prefix mismatch — still render (not a cycle).
+  return true;
+}
+
+/**
  * Resolve the source folder path for Subfolder Copy.
  *
  * <p>Prefer a selected folder row path; otherwise the active tree folder

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -243,6 +243,12 @@ export const EXPLORER_MSG = {
   // US7 P-Adv / multi-select + clipboard panel (FR-026, #2400 #2408).
   SELECT_COLUMN_HEADER: "perc.ui.explorer@Select",
   SELECT_ROW_LABEL: "perc.ui.explorer@Select item",
+  /** Type-icon column (#3328) — folder/open affordance, not a checkbox. */
+  ICON_COLUMN_LABEL: "perc.ui.explorer@Item type",
+  OPEN_FOLDER_LABEL: "perc.ui.explorer@Open folder",
+  FOLDER_ICON_CLOSED: "perc.ui.explorer@Folder",
+  FOLDER_ICON_OPEN: "perc.ui.explorer@Open folder",
+  ITEM_ICON_LABEL: "perc.ui.explorer@Item",
   SELECT_ALL_LABEL: "perc.ui.explorer@Select all items on this page",
   SELECT_ALL_CLEAR_LABEL: "perc.ui.explorer@Clear all items on this page",
   SELECTED_COUNT_SINGULAR: "perc.ui.explorer@1 item selected",

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -64,6 +64,8 @@ export const EXPLORER_MSG = {
   PROMPT_NEW_FOLDER_NAME: "perc.ui.explorer@Enter new folder name",
   PROMPT_NEW_NAME: "perc.ui.explorer@Enter new name",
   ERROR_GENERIC: "perc.ui.explorer@Something went wrong",
+  BOOTSTRAP_UNAVAILABLE:
+    "perc.ui.explorer@Content Explorer could not start because the application session is not available. Reload the page or sign in again.",
 
   // US7 P-Adv / clipboard / wizards / dependency / relationships (FR-021–FR-029, SC-011)
   CLIPBOARD_TITLE: "perc.ui.explorer@Clipboard",

--- a/WebUI/src/main/ts/contentExplorer/sitePath.ts
+++ b/WebUI/src/main/ts/contentExplorer/sitePath.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import type { PSPathItem } from "../api/contentExplorer/types";
+import { normalizeExplorerFolderPath } from "./folderPath";
+
 /**
  * CMS Explorer path helpers for site-scoped chrome (#2767 / parent #2400).
  *
@@ -61,4 +64,28 @@ export function resolveSiteNameFromSelection(
     resolveSiteNameFromExplorerPath(itemPath) ??
     resolveSiteNameFromExplorerPath(folderPath)
   );
+}
+
+/**
+ * Path used to list children of a site/folder PathItem.
+ *
+ * <p>Sample Rhythmyx sites use {@code SITENAME} {@code Corporate_Investments}
+ * but {@code FOLDER_ROOT} {@code //Sites/CorporateInvestments} (#3326).
+ * pathmanagement {@code PathItem.folderPath} is the repository folder;
+ * {@code PathItem.path} is the finder id (often the site name). Prefer
+ * {@code folderPath} so expand/list hits the seeded site folder.</p>
+ */
+export function resolveExplorerListPath(
+  item: Pick<PSPathItem, "path" | "folderPath"> | null | undefined,
+  fallback?: string | null,
+): string | null {
+  const fromFolder = normalizeExplorerFolderPath(item?.folderPath);
+  if (fromFolder != null) {
+    return fromFolder;
+  }
+  const fromPath = normalizeExplorerFolderPath(item?.path);
+  if (fromPath != null) {
+    return fromPath;
+  }
+  return normalizeExplorerFolderPath(fallback);
 }

--- a/WebUI/src/main/ts/contentExplorer/styles.ts
+++ b/WebUI/src/main/ts/contentExplorer/styles.ts
@@ -204,6 +204,45 @@ export const tdCellStyle: CSSProperties = {
   maxWidth: 320,
 };
 
+/** Narrow type-icon column (#3328) — checkboxes stay in their own column. */
+export const iconThCellStyle: CSSProperties = {
+  ...thCellStyle,
+  width: 28,
+  padding: "6px 4px",
+};
+
+export const iconTdCellStyle: CSSProperties = {
+  ...tdCellStyle,
+  width: 28,
+  maxWidth: 36,
+  padding: "4px 6px",
+  textAlign: "center",
+  overflow: "visible",
+};
+
+export const folderIconButtonStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 22,
+  height: 22,
+  padding: 0,
+  border: "none",
+  background: "transparent",
+  color: "#c9922a",
+  cursor: "pointer",
+  borderRadius: 3,
+};
+
+export const itemIconStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 16,
+  height: 16,
+  color: "#5f6368",
+};
+
 export const emptyStateStyle: CSSProperties = {
   padding: "24px 16px",
   color: "#777",

--- a/WebUI/src/main/ts/contentExplorer/viewCatalog.ts
+++ b/WebUI/src/main/ts/contentExplorer/viewCatalog.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * Pure grouping helpers for the Explorer Views catalog (#3116 / #3240).
+ * Pure grouping helpers for the Explorer Views catalog (#3116 / #3240 / #3325).
  *
  * <p>DCE {@code sys_category} / {@code PSSearch.ParentCategory} values
  * 1–4 map to My / Community / All / Other. Unknown categories fall into
@@ -24,6 +24,12 @@
  *
  * <p>Inbox is a system custom-URL view at {@code //Views//MyContent/Inbox},
  * never a free-floating Explorer root (#3118 slice 2 / #3240).</p>
+ *
+ * <p>#3325: {@link groupViewsByParentCategory} collapses catalog rows that
+ * are the same logical view (same name / guid / id). Distinct names and
+ * guids stay as separate leaves; unlabeled duplicates are omitted. Shared
+ * display labels (for example seven {@code All} rows) are disambiguated
+ * with the internal name when the keys differ.</p>
  */
 
 import type { ViewDef } from "../api/developer/types";
@@ -52,7 +58,8 @@ export function viewKey(def: ViewDef): string {
   return (
     def.name ||
     def.guid?.stringValue ||
-    (def.id != null ? String(def.id) : "")
+    def.guid?.untypedString ||
+    (def.id != null && Number(def.id) !== 0 ? String(def.id) : "")
   ).trim();
 }
 
@@ -60,13 +67,137 @@ export function viewLabel(def: ViewDef): string {
   return (def.label || def.name || viewKey(def) || "—").trim();
 }
 
-export function normalizeViewParentCategory(
-  raw: number | undefined | null,
-): ViewParentCategory {
-  if (raw === 1 || raw === 2 || raw === 3 || raw === 4) {
+/** Coerce JSON parentCategory (number or numeric string) to a finite int. */
+export function coerceViewParentCategory(
+  raw: unknown,
+): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
     return raw;
   }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+  return undefined;
+}
+
+export function normalizeViewParentCategory(
+  raw: number | string | undefined | null,
+): ViewParentCategory {
+  const n = coerceViewParentCategory(raw);
+  if (n === 1 || n === 2 || n === 3 || n === 4) {
+    return n;
+  }
   return 4;
+}
+
+/**
+ * Identity for catalog dedupe (#3325). Prefers internal name, then guid,
+ * then non-zero id. Empty when the row cannot be distinguished.
+ */
+export function viewCatalogIdentity(def: ViewDef): string {
+  const name = (def.name ?? "").trim().toLowerCase();
+  if (name) {
+    return `name:${name}`;
+  }
+  const guid = (
+    def.guid?.stringValue ||
+    def.guid?.untypedString ||
+    ""
+  )
+    .trim()
+    .toLowerCase();
+  if (guid) {
+    return `guid:${guid}`;
+  }
+  if (def.id != null && Number(def.id) !== 0) {
+    return `id:${String(def.id).trim()}`;
+  }
+  return "";
+}
+
+function unlabeledStamp(def: ViewDef): string {
+  const label = viewLabel(def).toLowerCase();
+  const cat = normalizeViewParentCategory(def.parentCategory);
+  return `unlabeled:${cat}:${label}`;
+}
+
+function preferRicherView(a: ViewDef, b: ViewDef): ViewDef {
+  const aScore =
+    (a.label ? 1 : 0) + (a.description ? 1 : 0) + (a.guid ? 1 : 0);
+  const bScore =
+    (b.label ? 1 : 0) + (b.description ? 1 : 0) + (b.guid ? 1 : 0);
+  return bScore > aScore ? b : a;
+}
+
+/**
+ * Collapse duplicate catalog rows that represent one logical view.
+ * Distinct {@link viewCatalogIdentity} values are kept. Rows with no
+ * name/guid/id are kept once per (category, label) and otherwise dropped.
+ */
+export function dedupeViewCatalog(
+  views: readonly ViewDef[] | null | undefined,
+): ViewDef[] {
+  if (!Array.isArray(views) || views.length === 0) {
+    return [];
+  }
+  const byIdentity = new Map<string, ViewDef>();
+  const unlabeledSeen = new Set<string>();
+  const order: string[] = [];
+  for (const def of views) {
+    if (def == null) {
+      continue;
+    }
+    const identity = viewCatalogIdentity(def);
+    if (!identity) {
+      const stamp = unlabeledStamp(def);
+      if (unlabeledSeen.has(stamp)) {
+        continue;
+      }
+      unlabeledSeen.add(stamp);
+      const key = `anon:${stamp}`;
+      byIdentity.set(key, def);
+      order.push(key);
+      continue;
+    }
+    const existing = byIdentity.get(identity);
+    if (existing == null) {
+      byIdentity.set(identity, def);
+      order.push(identity);
+    } else {
+      byIdentity.set(identity, preferRicherView(existing, def));
+    }
+  }
+  return order.map((k) => byIdentity.get(k)).filter((d): d is ViewDef => d != null);
+}
+
+/**
+ * Leaf label for the Views tree. When several distinct views in the same
+ * group share a display label, append the internal name (or guid) so
+ * operators can tell them apart (#3325).
+ */
+export function viewTreeLabel(def: ViewDef, group: readonly ViewDef[]): string {
+  const base = viewLabel(def);
+  if (!group || group.length < 2) {
+    return base;
+  }
+  const same = group.filter(
+    (d) => viewLabel(d).toLowerCase() === base.toLowerCase(),
+  );
+  if (same.length < 2) {
+    return base;
+  }
+  const name = (def.name ?? "").trim();
+  if (name && name.toLowerCase() !== base.toLowerCase()) {
+    return `${base} (${name})`;
+  }
+  const guid = (def.guid?.stringValue || def.guid?.untypedString || "").trim();
+  if (guid) {
+    return `${base} (${guid})`;
+  }
+  return base;
 }
 
 /** True when the view is a custom-URL design view (Inbox family / #3118). */
@@ -145,26 +276,33 @@ export function emptyViewCatalogGroups(): ViewCatalogGroups {
 
 /**
  * Group catalog rows by {@link ViewDef.parentCategory} (1–4).
- * Rows without a usable key are omitted. Each group is sorted by label.
+ * Duplicate logical views are collapsed (#3325). Rows without a usable
+ * key are omitted. Each group is sorted by tree label.
  */
 export function groupViewsByParentCategory(
   views: readonly ViewDef[] | null | undefined,
 ): ViewCatalogGroups {
   const groups = emptyViewCatalogGroups();
-  const list = ensureInboxInMyContent(views);
+  const list = ensureInboxInMyContent(dedupeViewCatalog(views));
   for (const def of list) {
     const key = viewKey(def);
     if (!key) {
       continue;
     }
-    const placed = isInboxView(def) ? { ...def, parentCategory: 1 } : def;
+    const cat = normalizeViewParentCategory(def.parentCategory);
+    const placed = isInboxView(def)
+      ? { ...def, parentCategory: 1 }
+      : { ...def, parentCategory: cat };
     groups[normalizeViewParentCategory(placed.parentCategory)].push(placed);
   }
   for (const cat of VIEW_PARENT_CATEGORIES) {
+    groups[cat] = dedupeViewCatalog(groups[cat]);
     groups[cat].sort((a, b) =>
-      viewLabel(a).localeCompare(viewLabel(b), undefined, {
-        sensitivity: "base",
-      }),
+      viewTreeLabel(a, groups[cat]).localeCompare(
+        viewTreeLabel(b, groups[cat]),
+        undefined,
+        { sensitivity: "base" },
+      ),
     );
   }
   return groups;

--- a/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
+++ b/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BootstrapProvider,
+  isBootstrapHookEnvironmentError,
   useSpaBootstrap,
   useSpaBootstrapOptional,
 } from "../../../../main/ts/app/bootstrap/BootstrapContext";
@@ -73,5 +74,27 @@ describe("BootstrapContext (#3331)", () => {
     );
     expect(screen.getByTestId("optional").textContent).toBe("Admin");
     expect(screen.getByTestId("required").textContent).toBe("Admin");
+  });
+
+  it("classifies only null-dispatcher / invalid-hook errors as environment", () => {
+    expect(
+      isBootstrapHookEnvironmentError(
+        new Error(
+          "Invalid hook call. Hooks can only be called inside of the body of a function component.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isBootstrapHookEnvironmentError(
+        new TypeError("Cannot read properties of null (reading 'useContext')"),
+      ),
+    ).toBe(true);
+    expect(
+      isBootstrapHookEnvironmentError(new Error("Cannot read property of null (reading 'useContext')")),
+    ).toBe(true);
+    expect(isBootstrapHookEnvironmentError(new Error("Maximum update depth exceeded"))).toBe(
+      false,
+    );
+    expect(isBootstrapHookEnvironmentError("not-an-error")).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
+++ b/WebUI/src/test/ts/app/bootstrap/BootstrapContext.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BootstrapProvider,
+  useSpaBootstrap,
+  useSpaBootstrapOptional,
+} from "../../../../main/ts/app/bootstrap/BootstrapContext";
+import {
+  DEFAULT_SPA_BOOTSTRAP,
+  type SpaBootstrap,
+} from "../../../../main/ts/app/bootstrap/types";
+
+const sample: SpaBootstrap = {
+  ...DEFAULT_SPA_BOOTSTRAP,
+  userName: "Admin",
+  isAdmin: true,
+  entry: "explorer",
+};
+
+function OptionalProbe(): React.ReactElement {
+  const value = useSpaBootstrapOptional();
+  return (
+    <div data-testid="optional">
+      {value == null ? "missing" : value.userName}
+    </div>
+  );
+}
+
+function RequiredProbe(): React.ReactElement {
+  const value = useSpaBootstrap();
+  return <div data-testid="required">{value.userName || "empty"}</div>;
+}
+
+describe("BootstrapContext (#3331)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("useSpaBootstrapOptional is null without a provider and does not throw", () => {
+    expect(() => render(<OptionalProbe />)).not.toThrow();
+    expect(screen.getByTestId("optional").textContent).toBe("missing");
+  });
+
+  it("useSpaBootstrap falls back to default identity without a provider", () => {
+    expect(() => render(<RequiredProbe />)).not.toThrow();
+    expect(screen.getByTestId("required").textContent).toBe("empty");
+  });
+
+  it("both hooks read the provider value", () => {
+    render(
+      <BootstrapProvider value={sample}>
+        <OptionalProbe />
+        <RequiredProbe />
+      </BootstrapProvider>,
+    );
+    expect(screen.getByTestId("optional").textContent).toBe("Admin");
+    expect(screen.getByTestId("required").textContent).toBe("Admin");
+  });
+});

--- a/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
+++ b/WebUI/src/test/ts/app/routes/ExplorerRoute.test.tsx
@@ -26,13 +26,19 @@ vi.mock("../../../../main/ts/registry", () => ({
     if (name !== "ContentExplorerShell") {
       throw new Error(`unexpected component: ${name}`);
     }
-    return function FakeExplorerShell(): React.ReactElement {
-      return <div data-testid="content-explorer-shell">explorer</div>;
+    return function StubExplorer({
+      initialPath,
+    }: {
+      initialPath?: string;
+    }): React.ReactElement {
+      return (
+        <div data-testid="content-explorer-shell">stub:{initialPath}</div>
+      );
     };
   },
 }));
 
-describe("ExplorerRoute loading chrome (#3332)", () => {
+describe("ExplorerRoute (#3331 / #3332)", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
@@ -50,5 +56,22 @@ describe("ExplorerRoute loading chrome (#3332)", () => {
       expect(screen.getByTestId("content-explorer-shell")).toBeTruthy();
     });
     expect(screen.queryByTestId("explorer-route-loading")).toBeNull();
+  });
+
+  it("renders the explorer shell without an outer BootstrapProvider", async () => {
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={["/explorer?path=/Folders"]}>
+          <Routes>
+            <Route path="/explorer" element={<ExplorerRoute />} />
+          </Routes>
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell").textContent).toBe(
+        "stub:/Folders",
+      );
+    });
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1772,3 +1772,23 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     );
   });
 });
+
+describe("ContentExplorerShell missing BootstrapProvider (#3331)", () => {
+  it("renders an error state without throwing useContext", async () => {
+    stubPathFetch();
+    expect(() =>
+      render(
+        <ContentExplorerShell
+          initialPath="/Folders"
+          loadDisplayFormats={async () => []}
+          loadMenuActions={async () => []}
+        />,
+      ),
+    ).not.toThrow();
+    const alert = screen.getByTestId("explorer-bootstrap-unavailable");
+    expect(alert).toBeInTheDocument();
+    expect(alert.textContent).toMatch(/application session is not available/i);
+    expect(screen.queryByTestId("explorer-nav")).toBeNull();
+    await renderA11yGate(screen.getByTestId("content-explorer-shell"));
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -432,6 +432,173 @@ describe("DetailList", () => {
     await renderA11yGate(container);
   });
 });
+
+const FOLDER_CHILDREN: PSPathItem[] = [
+  {
+    id: "sys-1",
+    path: "/Folders/$System$/",
+    name: "$System$",
+    accessLevel: "READ",
+    leaf: false,
+  },
+  {
+    id: "uf-1",
+    path: "/Folders/New-Folder/",
+    name: "New-Folder",
+    type: "Folder",
+    accessLevel: "WRITE",
+  },
+  {
+    id: "p-page",
+    path: "/Folders/Welcome",
+    name: "Welcome",
+    type: "page",
+    accessLevel: "WRITE",
+    leaf: true,
+  },
+];
+
+function mockFolderPage(children: PSPathItem[] = FOLDER_CHILDREN): void {
+  mockFetch(async () =>
+    new Response(
+      JSON.stringify({
+        PagedItemList: {
+          childrenInPage: children,
+          childrenCount: children.length,
+          startIndex: 0,
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+describe("DetailList folder row chrome (#3328)", () => {
+  it("shows folder icons for $System$ and user folders, not checkboxes in the icon column", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+        selectedItemIds={new Set<string>()}
+        onToggleSelectItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-row-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("detail-col-header-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("detail-col-header-select")).toBeInTheDocument();
+
+    const systemIcon = screen.getByTestId("detail-folder-icon-sys-1");
+    expect(systemIcon).toHaveAttribute("data-kind", "folder");
+    expect(systemIcon).toHaveAttribute("data-folder-state", "closed");
+    expect(screen.getByTestId("detail-row-sys-1")).toHaveAttribute(
+      "data-row-kind",
+      "folder",
+    );
+
+    const userIcon = screen.getByTestId("detail-folder-icon-uf-1");
+    expect(userIcon).toHaveAttribute("data-kind", "folder");
+    expect(userIcon).toHaveAttribute("data-folder-state", "closed");
+
+    expect(screen.getByTestId("detail-item-icon-p-page")).toHaveAttribute(
+      "data-kind",
+      "item",
+    );
+    expect(screen.queryByTestId("detail-folder-icon-p-page")).toBeNull();
+
+    expect(screen.getByTestId("detail-select-sys-1")).toBeInTheDocument();
+    expect(screen.getByTestId("detail-select-uf-1")).toBeInTheDocument();
+  });
+
+  it("uses the open folder icon when a folder row is selected", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId="sys-1"
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("detail-folder-icon-sys-1")).toHaveAttribute(
+      "data-folder-state",
+      "open",
+    );
+    expect(screen.getByTestId("detail-folder-icon-uf-1")).toHaveAttribute(
+      "data-folder-state",
+      "closed",
+    );
+  });
+
+  it("activates browse when the folder icon is clicked without toggling the checkbox", async () => {
+    mockFolderPage();
+    const activated: string[] = [];
+    const toggled: string[] = [];
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={(item) => {
+          activated.push(item.id ?? "");
+        }}
+        selectedItemIds={new Set<string>()}
+        onToggleSelectItem={(item) => {
+          toggled.push(item.id ?? "");
+        }}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-uf-1")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("detail-folder-icon-uf-1"));
+    expect(activated).toEqual(["uf-1"]);
+    expect(toggled).toEqual([]);
+  });
+
+  it("still renders folder icons when multi-select checkboxes are off", async () => {
+    mockFolderPage();
+    render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("detail-col-header-select")).toBeNull();
+    expect(screen.getByTestId("detail-col-header-icon")).toBeInTheDocument();
+  });
+
+  it("passes the zero serious/critical axe-core gate (folder rows + checkboxes)", async () => {
+    mockFolderPage();
+    const { container } = render(
+      <DetailList
+        folderPath="/Folders"
+        selectedItemId="sys-1"
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+        selectedItemIds={new Set<string>(["sys-1"])}
+        onToggleSelectItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-folder-icon-sys-1")).toBeInTheDocument(),
+    );
+    await renderA11yGate(container);
+  });
+});
+
 describe("T092b / FR-027: display-format column resolution", () => {
   const sample: PSPathItem = {
     id: "p-1",

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -197,6 +197,69 @@ describe("ExplorerTree", () => {
     expect(childCalls).toBe(1);
   });
 
+  it("lists site children using folderPath not sitename (#3326)", async () => {
+    const SITE_CHILD: PSPathItem = {
+      id: "Corporate_Investments",
+      path: "/Sites/Corporate_Investments/",
+      folderPath: "//Sites/CorporateInvestments",
+      name: "Corporate_Investments",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    const PAGES: PSPathItem = {
+      id: "pages-1",
+      path: "/Sites/CorporateInvestments/Pages",
+      name: "Pages",
+      type: "folder",
+      hasFolderChildren: false,
+    };
+    const requested: string[] = [];
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      requested.push(url);
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        return pathItemListResponse([SITE_CHILD]);
+      }
+      if (url.endsWith("/pathmanagement/path/folder/Sites/CorporateInvestments")) {
+        return pathItemListResponse([PAGES]);
+      }
+      return pathItemListResponse([]);
+    });
+    render(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath={null}
+        onSelectFolder={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/Corporate_Investments/"),
+      ).toBeInTheDocument(),
+    );
+    const node = screen.getByTestId("tree-node-/Sites/Corporate_Investments/");
+    const toggle = node.querySelector('[aria-hidden="true"]');
+    fireEvent.click(toggle!);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/CorporateInvestments/Pages"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      requested.some((u) =>
+        u.endsWith("/pathmanagement/path/folder/Sites/CorporateInvestments"),
+      ),
+    ).toBe(true);
+    expect(
+      requested.some((u) =>
+        u.endsWith(
+          "/pathmanagement/path/folder/Sites/Corporate_Investments",
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("fires onSelectFolder when a row is activated", async () => {
     mockFetch(async () => pathItemListResponse([ROOT_FOLDER]));
     let selected: string | null = null;

--- a/WebUI/src/test/ts/contentExplorer/ViewsCatalogTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ViewsCatalogTree.test.tsx
@@ -89,6 +89,25 @@ describe("ViewsCatalogTree (#3116)", () => {
     expect(listViews).toHaveBeenCalledTimes(2);
   });
 
+  it("renders one All leaf for seven catalog copies of View_All (#3325)", async () => {
+    const copies: ViewDef[] = Array.from({ length: 7 }, (_, i) => ({
+      name: "View_All",
+      label: "All",
+      parentCategory: 3,
+      id: i + 10,
+      standardView: true,
+    }));
+    render(<ViewsCatalogTree listViews={async () => copies} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-views-group-3")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-views-group-3-row"));
+    const leaves = screen.getAllByTestId("explorer-views-leaf-View_All");
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0].textContent).toContain("All");
+    expect(leaves[0].textContent).not.toMatch(/All.*All/);
+  });
+
   it("always shows an Inbox leaf under My Content when catalog is empty (#3240)", async () => {
     const { container } = render(
       <ViewsCatalogTree listViews={async () => []} />,

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  isSafeExplorerTreeChild,
   isStrictCmsPathDescendant,
   normalizeExplorerFolderPath,
   resolveFolderPathFromSelection,
@@ -74,6 +75,30 @@ describe("isStrictCmsPathDescendant (#3001)", () => {
   it("treats any non-root path as a child of root", () => {
     expect(isStrictCmsPathDescendant("/", "/Sites/")).toBe(true);
     expect(isStrictCmsPathDescendant("/", "/")).toBe(false);
+  });
+
+  it("accepts name vs FOLDER_ROOT children as safe tree kids (#3326)", () => {
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/CorporateInvestments/Pages",
+      ),
+    ).toBe(true);
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/Corporate_Investments/Pages",
+      ),
+    ).toBe(true);
+    expect(
+      isSafeExplorerTreeChild(
+        "/Sites/Corporate_Investments/",
+        "//Sites/CorporateInvestments",
+        "/Sites/Corporate_Investments/",
+      ),
+    ).toBe(false);
   });
 
   it("accepts classic Folders root and children under / (#3044)", () => {

--- a/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  resolveExplorerListPath,
   resolveSiteNameFromExplorerPath,
   resolveSiteNameFromSelection,
 } from "../../../main/ts/contentExplorer/sitePath";
@@ -75,5 +76,26 @@ describe("resolveSiteNameFromSelection (#2767)", () => {
     expect(
       resolveSiteNameFromSelection("/Sites/FolderSite/sub", "/Assets/x"),
     ).toBe("FolderSite");
+  });
+});
+
+describe("resolveExplorerListPath (#3326)", () => {
+  it("prefers folderPath over finder site-name path", () => {
+    expect(
+      resolveExplorerListPath({
+        path: "/Sites/Corporate_Investments/",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+    ).toBe("/Sites/CorporateInvestments");
+  });
+
+  it("falls back to path then explicit fallback", () => {
+    expect(
+      resolveExplorerListPath({ path: "/Sites/Demo/", folderPath: undefined }),
+    ).toBe("/Sites/Demo/");
+    expect(resolveExplorerListPath(null, "/Sites/Fallback")).toBe(
+      "/Sites/Fallback",
+    );
+    expect(resolveExplorerListPath(null, null)).toBeNull();
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/viewCatalog.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/viewCatalog.test.ts
@@ -20,13 +20,16 @@ import type { ViewDef } from "../../../main/ts/api/developer/types";
 import {
   PATH_MY_CONTENT_INBOX,
   canExecuteView,
+  dedupeViewCatalog,
   ensureInboxInMyContent,
   groupViewsByParentCategory,
   isCustomUrlView,
   isInboxView,
   normalizeViewParentCategory,
+  viewCatalogIdentity,
   viewKey,
   viewLabel,
+  viewTreeLabel,
 } from "../../../main/ts/contentExplorer/viewCatalog";
 
 function v(
@@ -99,5 +102,72 @@ describe("viewCatalog grouping (#3116)", () => {
       { name: "Inbox", parentCategory: 4, customView: true },
     ]);
     expect(ensured[0].parentCategory).toBe(1);
+  });
+});
+
+describe("viewCatalog dedupe (#3325)", () => {
+  it("collapses seven All rows that share one name / logical view", () => {
+    const copies = Array.from({ length: 7 }, (_, i) =>
+      v({
+        name: "View_All",
+        label: "All",
+        parentCategory: 3,
+        id: i + 1,
+        standardView: true,
+      }),
+    );
+    const grouped = groupViewsByParentCategory(copies);
+    expect(grouped[3]).toHaveLength(1);
+    expect(grouped[3][0].name).toBe("View_All");
+    expect(viewTreeLabel(grouped[3][0], grouped[3])).toBe("All");
+    expect(dedupeViewCatalog(copies)).toHaveLength(1);
+  });
+
+  it("keeps distinct name/guid views and disambiguates shared All labels", () => {
+    const grouped = groupViewsByParentCategory([
+      v({
+        name: "View_All",
+        label: "All",
+        parentCategory: 3,
+        guid: { stringValue: "guid-all" },
+      }),
+      v({
+        name: "All_Sites",
+        label: "All",
+        parentCategory: 3,
+        guid: { stringValue: "guid-sites" },
+      }),
+    ]);
+    expect(grouped[3]).toHaveLength(2);
+    const labels = grouped[3].map((d) => viewTreeLabel(d, grouped[3])).sort();
+    expect(labels).toEqual(["All (All_Sites)", "All (View_All)"]);
+  });
+
+  it("drops unlabeled duplicates and ignores id 0 as an identity", () => {
+    const grouped = groupViewsByParentCategory([
+      { label: "All", parentCategory: 3, id: 0 },
+      { label: "All", parentCategory: 3, id: 0 },
+      { label: "All", parentCategory: 3 },
+    ]);
+    expect(grouped[3]).toHaveLength(0);
+    expect(viewCatalogIdentity({ label: "All", id: 0 })).toBe("");
+    expect(viewKey({ id: 0 })).toBe("");
+  });
+
+  it("coerces string parentCategory 3 into All Content", () => {
+    const grouped = groupViewsByParentCategory([
+      v({ name: "View_All", label: "All", parentCategory: "3" as unknown as number }),
+    ]);
+    expect(grouped[3].map((d) => d.name)).toEqual(["View_All"]);
+    expect(normalizeViewParentCategory("3")).toBe(3);
+    expect(normalizeViewParentCategory("x")).toBe(4);
+  });
+
+  it("does not collapse distinct keys that only share a blank-looking label after name fallback", () => {
+    const grouped = groupViewsByParentCategory([
+      v({ name: "Alpha", parentCategory: 3 }),
+      v({ name: "Beta", parentCategory: 3 }),
+    ]);
+    expect(grouped[3].map((d) => d.name)).toEqual(["Alpha", "Beta"]);
   });
 });

--- a/docs/ai-generated/code-reviews/3325-all-content-duplicate-views-erlang.md
+++ b/docs/ai-generated/code-reviews/3325-all-content-duplicate-views-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — #3325 All Content duplicate views
+
+**Branch:** `fix/issue-3325-all-content-duplicate-views`  
+**Date:** 2026-08-13  
+**Persona:** Erlang (independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A — no filesystem path I/O in the diff (TS grouping + product-docs + Playwright selectors).
+
+## Summary
+
+Explorer Views → All Content (parentCategory 3) could render the same logical view as seven identical **All** leaves when `GET /services/views` repeated `View_All` (or unlabeled rows). Grouping now dedupes by name/guid/id, drops unlabeled identity-less duplicates from the tree (no executable key), keeps distinct names/guids as separate leaves, and disambiguates shared display labels with the internal name.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests for new/changed non-trivial logic — covered (`viewCatalog.test.ts`, `ViewsCatalogTree.test.tsx`).
+- Incomplete change-class closure — Playwright companion + product-docs updated.
+
+## Issues
+
+None that block commit.
+
+## Tests
+
+- Vitest: seven `View_All` copies collapse to one leaf; distinct `View_All` / `All_Sites` stay two leaves with disambiguated labels; string `parentCategory` `"3"` buckets to All Content; `id: 0` is not an identity.
+- Playwright: `explorer-views.spec.js` expands group 3 and asserts at most one exact **All** leaf and unique leaf testids.
+
+## Product docs
+
+`product-docs/8.2/admin/content-explorer.md` All Content row documents unique-logical-view listing.

--- a/docs/ai-generated/code-reviews/3326-explorer-site-expand-erlang.md
+++ b/docs/ai-generated/code-reviews/3326-explorer-site-expand-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3326 Explorer sample-site expand
+
+**Scope:** uncommitted `fix/issue-3326-explorer-site-expand` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** empty list vs error envelope; site name vs folder root bind; installer seed companions
+
+## Summary
+
+Sample sites listed under Explorer `/Sites` but expand showed LIST_EMPTY because `installSampleSites` only created empty FOLDER_ROOT folders (350/351). Finder path uses `SITENAME` (`Corporate_Investments`) while repository folder is `//Sites/CorporateInvestments`.
+
+Fix: seed Pages/Files children under 350/351; bind tree/list loads to `PathItem.folderPath`; cycle-only tree filter so name vs folder-root children are not dropped.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Cross-platform path checklist
+
+- CMS finder paths use `/` (URL-style), not OS file separators.
+- New helpers normalize `\` / drive letters only for caller paste; no filesystem I/O.
+- Seed XML is installer data, not path concatenation.
+
+## Tests
+
+- Vitest: `resolveExplorerListPath`, `isSafeExplorerTreeChild`, ExplorerTree folderPath fetch
+- InstallSampleSitesWiringTest: 350/351 child relationships
+- Playwright surface: REST site children + UI expand (live C5 blocked — see PR)
+
+## C5
+
+`perc-devctl qa-up` used this worktree installer jar; sample sites echoed seeded, but Jetty context failed (`NoClassDefFoundError: PSVirtualSitePublishCopyResult` on `sitesAdaptor`). Unrelated SNAPSHOT mix; cell torn down.

--- a/docs/ai-generated/code-reviews/3331-explorer-bootstrap-context-erlang.md
+++ b/docs/ai-generated/code-reviews/3331-explorer-bootstrap-context-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3331 ContentExplorerShell BootstrapContext
+
+**Date:** 2026-08-13  
+**Branch:** `fix/issue-3331-explorer-bootstrap-context`  
+**Scope:** uncommitted WebUI + perc-qa-automation + product-docs vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** pass — May commit/push: yes  
+**Memory patterns hit:** missing behavioral tests (covered); WebUI Playwright companion (covered); change-class closure for Explorer i18n/a11y (covered)
+
+## Summary
+
+Slice 2 of parent #3329. Explorer remount/bridge used `useSpaBootstrap` → `useContext` when React’s dispatcher or the provider was missing (`Cannot read properties of null (reading 'useContext')`). The change makes context optional, shows an i18n error state on the shell, and always wraps Explorer route + PercModernUI bridge mounts with `BootstrapProvider`.
+
+## Issues
+
+None (no bugs, no missing behavioral tests, no non-portable path I/O).
+
+## Companions
+
+| Kind | Status |
+|------|--------|
+| Vitest without provider (no throw + error chrome) | Yes |
+| Vitest with provider (existing shell suite) | Yes (module suite) |
+| ExplorerRoute wrap without outer provider | Yes |
+| Playwright folder open + no useContext console | Yes (`bug-3331-…spec.js`) |
+| `renderA11yGate` / Playwright a11y | Yes |
+| `EXPLORER_MSG` i18n | Yes |
+| product-docs | Yes (`admin/content-explorer.md`) |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Playwright uses `BASE_URL` from env.
+
+## Evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 309 files / 2214 tests; Surefire 51 tests
+- Playwright QA `TEST_CMS_URL=http://127.0.0.1:9993`: `bug-3331` 1 passed; `test:golden` 2 passed

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -180,6 +180,148 @@
 			<column name="LOCALE">en-us</column>
 			<column name="OBJECTTYPE">2</column>
 		</row>
+		<!-- Browseable children under sample site roots (#3326). Empty 350/351
+		     made Explorer expand show LIST_EMPTY after Sites listed. -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Pages</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Files</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Pages</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="HIB_VER">0</column>
+			<column name="CONTENTSTATEID">1</column>
+			<column name="CONTENTCHECKOUTUSERNAME"/>
+			<column name="CONTENTLASTMODIFIER">admin1</column>
+			<column name="CONTENTLASTMODIFIEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="CONTENTTYPEID">101</column>
+			<column name="CONTENTCREATEDDATE">2007-04-08 15:08:22.0</column>
+			<column name="LASTTRANSITIONDATE"/>
+			<column name="NEXTAGINGDATE"/>
+			<column name="CONTENTCREATEDBY">admin1</column>
+			<column name="CONTENTSTARTDATE"/>
+			<column name="CONTENTEXPIRYDATE"/>
+			<column name="CONTENTAGINGTIME"/>
+			<column name="CONTENTPUBLISHDATE"/>
+			<column name="CONTENTPOSTDATE"/>
+			<column name="CONTENTPOSTDATETZ"/>
+			<column name="CONTENTPATHNAME"/>
+			<column name="CONTENTSUFFIX"/>
+			<column name="WORKFLOWAPPID">-1</column>
+			<column name="TITLE">Files</column>
+			<column name="CURRENTREVISION">1</column>
+			<column name="TIPREVISION">1</column>
+			<column name="EDITREVISION">1</column>
+			<column name="REVISIONLOCK"/>
+			<column name="CLONEDPARENT"/>
+			<column name="REMINDERDATE"/>
+			<column name="STATEENTEREDDATE"/>
+			<column name="NEXTAGINGTRANSITION"/>
+			<column name="REPEATEDAGINGTRANSSTARTDATE"/>
+			<column name="COMMUNITYID">-1</column>
+			<column name="LOCALE">en-us</column>
+			<column name="OBJECTTYPE">2</column>
+		</row>
 	</table>
 	<table name="CONTENTTYPES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4428,6 +4570,26 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="REVISIONID">1</column>
 			<column name="DESCRIPTION">Corporate Investments site root</column>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Enterprise Investments Pages</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Enterprise Investments Files</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Corporate Investments Pages</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="DESCRIPTION">Corporate Investments Files</column>
+		</row>
 	</table>
 	<table name="PSX_OBJECTACL" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4510,6 +4672,70 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="NAME">Admin</column>
 			<column name="PERMISSIONS">7</column>
 		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92005</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92006</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92007</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92008</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92009</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92010</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92011</column>
+			<column name="TYPE">2</column>
+			<column name="NAME">Everyone</column>
+			<column name="PERMISSIONS">1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92012</column>
+			<column name="TYPE">1</column>
+			<column name="NAME">Admin</column>
+			<column name="PERMISSIONS">7</column>
+		</row>
 	</table>
 	<table name="PSX_PROPERTIES" onCreateOnly="no">
 		<row action="r" onTableCreateOnly="no">
@@ -4548,6 +4774,38 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="CONTENTID">351</column>
 			<column name="REVISIONID">1</column>
 			<column name="SYSID">92002</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">352</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92003</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">353</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92004</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">354</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92005</column>
+			<column name="PROPERTYNAME">sys_displayformat</column>
+			<column name="PROPERTYVALUE">0</column>
+			<column name="DESCRIPTION"/>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="CONTENTID">355</column>
+			<column name="REVISIONID">1</column>
+			<column name="SYSID">92006</column>
 			<column name="PROPERTYNAME">sys_displayformat</column>
 			<column name="PROPERTYVALUE">0</column>
 			<column name="DESCRIPTION"/>
@@ -4593,6 +4851,39 @@ if (! empty($usage) and $usage == 'L') {
 			<column name="OWNER_ID">2</column>
 			<column name="OWNER_REVISION">-1</column>
 			<column name="DEPENDENT_ID">351</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<!-- Sample site folder children (#3326) -->
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">352</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">350</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">352</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">353</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">350</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">353</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">354</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">351</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">354</column>
+			<column name="DEPENDENT_REVISION">-1</column>
+		</row>
+		<row action="r" onTableCreateOnly="no">
+			<column name="RID">355</column>
+			<column name="CONFIG_ID">3</column>
+			<column name="OWNER_ID">351</column>
+			<column name="OWNER_REVISION">-1</column>
+			<column name="DEPENDENT_ID">355</column>
 			<column name="DEPENDENT_REVISION">-1</column>
 		</row>
 	</table>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallSampleSitesWiringTest.java
@@ -214,6 +214,24 @@ class InstallSampleSitesWiringTest {
     assertTrue(
         hasSiteChild,
         "PSX_OBJECTRELATIONSHIP must link Sites (owner 2) to sample site root folders 350/351");
+
+    Set<String> childDeps = new LinkedHashSet<>();
+    for (int i = 0; i < relRows.getLength(); i++) {
+      Element row = (Element) relRows.item(i);
+      String owner = columnValue(row, "OWNER_ID");
+      String dep = columnValue(row, "DEPENDENT_ID");
+      if (("350".equals(owner) || "351".equals(owner)) && dep != null && !dep.isBlank()) {
+        childDeps.add(owner + ":" + dep.trim());
+      }
+    }
+    assertTrue(
+        childDeps.contains("350:352") && childDeps.contains("350:353"),
+        "EnterpriseInvestments (350) must have Pages/Files children 352/353 (#3326); found "
+            + childDeps);
+    assertTrue(
+        childDeps.contains("351:354") && childDeps.contains("351:355"),
+        "CorporateInvestments (351) must have Pages/Files children 354/355 (#3326); found "
+            + childDeps);
   }
 
   @Test

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3328-folders-view-icons.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3328-folders-view-icons.spec.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3328 — Folders detail list shows folder icons, not checkboxes as the
+ * browse affordance.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3328-folders-view-icons.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+
+test.describe("GH-3328 Folders view folder icons", () => {
+  test(
+    "Folders children show folder icons beside checkboxes",
+    { tag: ["@explorer", "@folder-icons", "@smoke"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+
+      const foldersNode = page.locator(
+        '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
+      );
+      if ((await foldersNode.count()) === 0) {
+        test.info().annotations.push({
+          type: "note",
+          description: "No /Folders tree node on this fixture; chrome-only icon column",
+        });
+        await expect(
+          page.locator('[data-testid="detail-col-header-icon"]'),
+        ).toBeVisible();
+        return;
+      }
+
+      await foldersNode.first().click();
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+      await expect(
+        page.locator('[data-testid="detail-col-header-icon"]'),
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-testid="detail-col-header-select"]'),
+      ).toBeVisible();
+
+      const folderRows = page.locator('[data-testid^="detail-row-"][data-row-kind="folder"]');
+      const folderIcons = page.locator('[data-testid^="detail-folder-icon-"]');
+      if ((await folderRows.count()) === 0) {
+        test.info().annotations.push({
+          type: "note",
+          description: "Folders list empty on this fixture; icon header asserted",
+        });
+        return;
+      }
+
+      await expect(folderIcons.first()).toBeVisible();
+      await expect(folderIcons.first()).toHaveAttribute("data-kind", "folder");
+      await expect(folderIcons.first()).toHaveAttribute(
+        "data-folder-state",
+        /closed|open/,
+      );
+
+      const firstFolderRow = folderRows.first();
+      const rowCheckbox = firstFolderRow.locator('input[type="checkbox"]');
+      await expect(rowCheckbox).toBeVisible();
+      await expect(firstFolderRow.locator('[data-testid^="detail-folder-icon-"]')).toBeVisible();
+
+      const beforePath = await page
+        .locator('[data-testid="detail-list"]')
+        .getAttribute("data-folder-path")
+        .catch(() => null);
+      await firstFolderRow.locator('[data-testid^="detail-folder-icon-"]').click();
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+      await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+      await expect(page).not.toHaveURL(/view=editor/);
+      if (beforePath) {
+        await expect
+          .poll(async () =>
+            page.locator('[data-testid="detail-list"]').getAttribute("data-folder-path"),
+          )
+          .not.toBe(beforePath);
+      }
+
+      const unexpected = consoleErrors.filter(
+        (t) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            t,
+          ),
+      );
+      expect(unexpected, `console/page errors: ${unexpected.join(" | ")}`).toEqual(
+        [],
+      );
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3331 / parent #3329 — ContentExplorerShell must not throw
+ * {@code useContext} on BootstrapContext when opening a folder.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3331-explorer-bootstrap-context.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+
+function isUseContextCrash(text) {
+  return /useContext|BootstrapContext|Cannot read properties of null/i.test(
+    String(text || ""),
+  );
+}
+
+test.describe("GH-3331 Explorer BootstrapContext useContext", () => {
+  test(
+    "opening a folder does not throw useContext on BootstrapContext",
+    { tag: ["@explorer", "@bootstrap", "@smoke"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-bootstrap-unavailable"]'),
+      ).toHaveCount(0);
+
+      const foldersNode = page.locator(
+        '[data-testid="tree-node-/Folders/"], [data-testid="tree-node-/Folders"]',
+      );
+      if ((await foldersNode.count()) > 0) {
+        await foldersNode.first().click();
+      }
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible();
+      await expect(
+        page.locator('[data-testid="explorer-bootstrap-unavailable"]'),
+      ).toHaveCount(0);
+
+      const childFolder = page
+        .locator('[data-testid^="detail-row-"]:not([aria-disabled="true"])')
+        .first();
+      if ((await childFolder.count()) > 0) {
+        await childFolder.dblclick();
+        await expect(
+          page.locator('[data-testid="content-explorer-shell"]'),
+        ).toBeVisible();
+      }
+
+      const useContextHits = consoleErrors.filter(isUseContextCrash);
+      expect(
+        useContextHits,
+        `useContext/BootstrapContext console errors: ${useContextHits.join(" | ")}`,
+      ).toEqual([]);
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
@@ -20,7 +20,9 @@
  * <p>Coverage:</p>
  * <ul>
  *   <li>REST: {@code path/folder/Sites} is 200; non-empty when fixture has sites</li>
+ *   <li>REST: expanding a sample site (folderPath / sitename) lists children (#3326)</li>
  *   <li>UI: Sites tree expands to child site nodes when list is non-empty</li>
+ *   <li>UI: selecting a sample site shows folder children, not LIST_EMPTY (#3326)</li>
  *   <li>Create Site: Content menu always exposes Create Site; wizard details →
  *       template → confirm chrome; optional live submit when affordance present</li>
  * </ul>
@@ -56,6 +58,8 @@ const {
   TEST_IDS,
   explorerSpaUrl,
   sitesFolderUrl,
+  siteChildListPath,
+  folderChildrenUrl,
   openContentMenu,
   sitesTreeRootLocator,
   sitesTreeDescendantsLocator,
@@ -149,6 +153,43 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
   );
 
   test(
+    "REST: sample site folder children are non-empty (#3326)",
+    { tag: ["@explorer-sites-list-create", "@explorer", "@sites", "@smoke"] },
+    async ({ request }) => {
+      test.setTimeout(30_000);
+      const headers = adminBasicAuthHeaders();
+      const sitesRes = await request.get(SITES_URL, { headers });
+      expect(sitesRes.status()).toBe(200);
+      const body = await sitesRes.json();
+      const items = Array.isArray(body.PathItem)
+        ? body.PathItem
+        : Array.isArray(body)
+          ? body
+          : [];
+      const names = pathItemNames(body);
+      if (gateSitesListOrSoftSkip(names) === "soft-empty") {
+        return;
+      }
+      const sample =
+        items.find((it) =>
+          hasAnyExpectedSampleSite([
+            it && typeof it.name === "string" ? it.name : "",
+          ]),
+        ) || items[0];
+      expect(sample, "expected at least one site PathItem").toBeTruthy();
+      const listPath = siteChildListPath(sample);
+      const childUrl = folderChildrenUrl(BASE_URL, listPath);
+      const childRes = await request.get(childUrl, { headers });
+      expect(childRes.status(), `GET ${childUrl}`).toBe(200);
+      const childNames = pathItemNames(await childRes.json());
+      expect(
+        childNames.length,
+        `site children at ${childUrl}: ${JSON.stringify(childNames)}`,
+      ).toBeGreaterThan(0);
+    },
+  );
+
+  test(
     "UI: Content Explorer Sites expands to child site nodes when non-empty",
     { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
     async ({ page }) => {
@@ -195,6 +236,56 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
           `explorer tree missing sample sites; children=${JSON.stringify(childNames)}`,
         ).toBe(true);
       }
+    },
+  );
+
+  test(
+    "UI: expanding a sample site shows folder children not LIST_EMPTY (#3326)",
+    { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const probe = await page.request.get(SITES_URL, {
+        headers: adminBasicAuthHeaders(),
+      });
+      expect(probe.status()).toBe(200);
+      const restNames = pathItemNames(await probe.json());
+      if (gateSitesListOrSoftSkip(restNames) === "soft-empty") {
+        return;
+      }
+
+      const jsErrors = [];
+      page.on("pageerror", (err) => jsErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          jsErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(explorerSpaUrl(BASE_URL), { waitUntil: "networkidle" });
+
+      const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
+      await expect(tree).toBeVisible({ timeout: 20_000 });
+      const sitesRoot = sitesTreeRootLocator(page);
+      await expect(sitesRoot.first()).toBeVisible({ timeout: 20_000 });
+      await sitesRoot.first().click();
+
+      const descendants = sitesTreeDescendantsLocator(page);
+      await expect(descendants.first()).toBeVisible({ timeout: 20_000 });
+      await descendants.first().locator('[role="treeitem"]').first().click();
+
+      const detail = page.locator(`[data-testid="${TEST_IDS.detailList}"]`);
+      await expect(detail).toBeVisible({ timeout: 15_000 });
+      await expect(detail.locator('[data-testid="detail-list-empty"]')).toHaveCount(
+        0,
+        { timeout: 20_000 },
+      );
+      await expect(detail.locator('[data-testid^="detail-row-"]').first()).toBeVisible({
+        timeout: 20_000,
+      });
+      expect(jsErrors, `console/page errors: ${jsErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-views.spec.js
@@ -58,6 +58,9 @@ const {
   unwrapViewDefs,
   isCustomUrlView,
   isInboxView,
+  viewParentCategory,
+  viewDefKey,
+  viewDefLabel,
   pickRunnableStandardView,
   noViewsChromeSkipMessage,
   noRunnableViewSkipMessage,
@@ -281,6 +284,58 @@ test.describe("Explorer Views Playwright + a11y (#3117 / #3110)", () => {
     await expectNoSeriousA11yViolations(page, {
       scope: `[data-testid="${TEST_IDS.viewsTree}"], [data-testid="${TEST_IDS.results}"]`,
     });
+
+    expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+  });
+
+  test("All Content lists unique view leaves (no seven All dups) @explorer-views @views @3325", async ({
+    page,
+    request,
+  }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    const headers = adminBasicAuthHeaders();
+    let restAllLabels = [];
+    try {
+      const res = await request.get(viewsCatalogUrl(BASE_URL), {
+        headers: { ...headers, Accept: "application/json" },
+      });
+      if (res.ok()) {
+        const defs = unwrapViewDefs(await res.json().catch(() => null));
+        restAllLabels = defs
+          .filter((d) => viewParentCategory(d) === 3)
+          .map((d) => viewDefLabel(d) || viewDefKey(d));
+      }
+    } catch {
+      restAllLabels = [];
+    }
+
+    await page.goto(explorerEntryUrl(BASE_URL), { waitUntil: "networkidle" });
+    await expect(page.getByTestId(TEST_IDS.shell)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const hasChrome = await viewsChromeVisible(page);
+    if (!hasChrome) {
+      test.skip(true, noViewsChromeSkipMessage());
+      return;
+    }
+
+    await expandViewsGroup(page, 3);
+    const group = page.getByTestId(TEST_IDS.group(3));
+    const leafLabels = await group.locator('[role="treeitem"][data-testid^="explorer-views-leaf-"]').allTextContents();
+    const trimmed = leafLabels.map((s) => s.replace(/\s+/g, " ").trim()).filter(Boolean);
+    const allExact = trimmed.filter((s) => /^all$/i.test(s));
+    expect(
+      allExact.length,
+      `All Content should not list seven identical All leaves (ui=${JSON.stringify(trimmed)} rest=${JSON.stringify(restAllLabels)})`,
+    ).toBeLessThanOrEqual(1);
+
+    const keys = await group.locator('[data-testid^="explorer-views-leaf-"]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid")),
+    );
+    expect(new Set(keys).size, `duplicate leaf testids: ${keys.join(",")}`).toBe(
+      keys.length,
+    );
 
     expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
   });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
@@ -73,6 +73,47 @@ function sitesFolderUrl(baseUrl) {
 }
 
 /**
+ * Encode a CMS finder path as a path/folder URL suffix (no leading slash).
+ * @param {string} cmsPath
+ * @returns {string}
+ */
+function encodeFolderListPath(cmsPath) {
+  return String(cmsPath || "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^[A-Za-z]:/, "")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((seg) => seg.length > 0)
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+/**
+ * Prefer PathItem.folderPath (FOLDER_ROOT) over finder name path (#3326).
+ * @param {{ path?: string, folderPath?: string } | null | undefined} item
+ * @returns {string}
+ */
+function siteChildListPath(item) {
+  const folder = item && item.folderPath ? String(item.folderPath).trim() : "";
+  if (folder.length > 0) {
+    return folder;
+  }
+  return item && item.path ? String(item.path) : "";
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} cmsPath
+ * @returns {string}
+ */
+function folderChildrenUrl(baseUrl, cmsPath) {
+  const suffix = encodeFolderListPath(cmsPath);
+  const root = pathFolderServiceUrl(baseUrl);
+  return suffix ? `${root}/${suffix}` : `${root}/`;
+}
+
+/**
  * Open Content menu dropdown.
  * @param {import('@playwright/test').Page} page
  */
@@ -173,6 +214,9 @@ module.exports = {
   explorerSpaUrl,
   pathFolderServiceUrl,
   sitesFolderUrl,
+  encodeFolderListPath,
+  siteChildListPath,
+  folderChildrenUrl,
   openContentMenu,
   sitesTreeRootLocator,
   sitesTreeDescendantsLocator,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -28,6 +28,9 @@ const {
   explorerSpaUrl,
   pathFolderServiceUrl,
   sitesFolderUrl,
+  encodeFolderListPath,
+  siteChildListPath,
+  folderChildrenUrl,
   siteChildNamesFromTreeTestIds,
   uniqueQaSiteName,
   createSiteMissingSkipReason,
@@ -65,6 +68,27 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(
       sitesFolderUrl("http://127.0.0.1:9992"),
       "http://127.0.0.1:9992/Rhythmyx/services/pathmanagement/path/folder/Sites",
+    );
+  });
+
+  it("prefers folderPath for site-child list URL (#3326)", () => {
+    assert.equal(
+      siteChildListPath({
+        path: "/Sites/Corporate_Investments/",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+      "//Sites/CorporateInvestments",
+    );
+    assert.equal(
+      encodeFolderListPath("//Sites/CorporateInvestments"),
+      "Sites/CorporateInvestments",
+    );
+    assert.equal(
+      folderChildrenUrl(
+        "http://127.0.0.1:9992",
+        "//Sites/CorporateInvestments",
+      ),
+      "http://127.0.0.1:9992/Rhythmyx/services/pathmanagement/path/folder/Sites/CorporateInvestments",
     );
   });
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -34,7 +34,7 @@ service (roles may hide Design/Recycling for some users):
 
 | Root | Maps to | Purpose |
 |------|---------|---------|
-| **Sites** | `//Sites` | Traditional site folders and pages |
+| **Sites** | `//Sites` | Traditional site folders and pages. Expand a site to list its folders (sample sites include **Pages** and **Files**) |
 | **Folders** | `//Folders` | Classic Rhythmyx folder tree (including `$System$` and other repository folders) |
 | **Assets** | `//Folders/$System$/Assets` | Shared asset library (CM1 convenience root) |
 | **Design** | Design file-system area | Templates, themes, web resources (Admin/Designer) |

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -52,7 +52,7 @@ to see the same four groups as Desktop Content Explorer:
 |-------|------------------|
 | **My Content** | Views in parent category 1 (including system views such as Inbox) |
 | **Community Content** | Views in parent category 2 |
-| **All Content** | Views in parent category 3 |
+| **All Content** | Views in parent category 3. Each **logical** view appears once (same internal name or GUID is not listed repeatedly). Distinct views that share the display label **All** show the internal name in parentheses so you can tell them apart. |
 | **Other Content** | Views in parent category 4 (and any view without a known category) |
 
 Selecting a **group** only expands or collapses its children. Selecting a **standard**

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -22,7 +22,7 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | **View tools** | Always-visible **Search**, **Folder Security**, and **Refresh** buttons under the reduced actions / Server actions rows (the same commands remain under **View**; Folder Security is one toolbar control, not a pair of identical buttons) |
 | **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
 | **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
-| **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
+| **Tree + detail list** | Folder navigation and list of children; folder/item type icons plus optional display-format columns |
 | **Views catalog** | System **Views** category under the left tree (My / Community / All / Other Content) |
 | **Views → My Content → Inbox** | Assignment list (not a top-level Explorer root — see below) |
 | **Context menu** | Right-click an item or folder row for the same catalog filtered for the popup surface |
@@ -44,6 +44,12 @@ service (roles may hide Design/Recycling for some users):
 Explorer. Use it when you need the full repository folder hierarchy rather than only the
 Assets or Sites shortcuts. Expanding **Folders** loads children from the server; folder
 visibility still respects folder ACLs.
+
+The detail list always shows a **type icon** in its own column (before Name / display-format
+columns). Repository folders — including **`$System$`** and user-created folders — use a
+folder icon (open when that row is the current selection). Click the folder icon, or
+double-click the row, to browse into the folder. Multi-select **checkboxes** remain in a
+separate column when you are selecting several items; they do not replace the folder icon.
 
 Below the folder roots, Explorer lists a **Views** system category. Expand **Views**
 to see the same four groups as Desktop Content Explorer:

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -256,6 +256,14 @@ From the **View** menu you can also toggle:
   suitable item is selected
 - **Clipboard** — multi-select copy/cut staging when items are selected
 
+## If Content Explorer cannot start
+
+If the Explorer area shows a short error that the **application session is not
+available** instead of the tree and list, the page did not receive the usual
+authenticated SPA session. Reload the page, or sign out and sign in again, then
+open **Explorer** from the product navigation. Do not use a bookmarked editor
+URL that embeds Explorer without the SPA shell.
+
 ## Related
 
 - [Sites & content structure](id:admin-sites)

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -27,8 +27,9 @@ Traditional Sites store pages and assets in the Percussion **content repository*
 2. Open **Content Explorer** (`spa.jsp?entry=explorer` or the **Explorer** product navigation entry).
 3. In the tree, expand **Sites**.
 4. Select a site folder to browse its pages and folders in the detail list.
+5. Expand a sample site (for example **Corporate_Investments** or **Enterprise_Investments**). The tree and detail list show that site's folders (such as **Pages** and **Files**), not an empty-folder message.
 
-After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Explorer features differ by site type after the site is listed and navigable. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
+After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). Site **names** may use underscores (`Corporate_Investments`) while the repository folder is `//Sites/CorporateInvestments` — Explorer binds expand/list to the site folder root. The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Explorer features differ by site type after the site is listed and navigable. Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data.
 
 ### Create a traditional Site from Explorer
 


### PR DESCRIPTION
## Summary

Overnight same-file thrash on the Explorer surface: four owned PRs all edited `product-docs/8.2/admin/content-explorer.md`, and subsets also overlapped `ContentExplorerShell.tsx`, `DetailList.tsx`, and `messages.ts`. Sequential merge to `main` would keep rewriting that doc and those components.

This cluster absorbs **#3334, #3336, #3337, #3339** (oldest first) onto `origin/main`. Union on the one conflict (`DetailList.tsx` empty states): keep both `data-folder-path` (#3336) and `data-testid="detail-list-empty"`.

**Out of cluster (not same-file thrash at ≥3):** #3316 / #3322 (Design SPA; only two MERGEABLE PRs).

## Thrash files

- `product-docs/8.2/admin/content-explorer.md` (#3334 #3336 #3337 #3339)
- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx` (#3334 #3336)
- `WebUI/src/main/ts/contentExplorer/DetailList.tsx` (#3336 #3337)
- `WebUI/src/main/ts/contentExplorer/messages.ts` (#3334 #3337)

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #3334 | `fix/issue-3331-explorer-bootstrap-usecontext` | yes | BootstrapContext / ExplorerRoute / bridge wrap |
| yes | #3336 | `fix/issue-3326-explorer-site-expand` | yes | folderPath expand + sample site Pages/Files seed |
| yes | #3337 | `fix/issue-3328-folders-view-icons` | yes | folder icon column; union empty-state attrs |
| yes | #3339 | `fix/issue-3325-all-content-duplicate-views` | yes | All Content view leaf dedupe |

Tip: `b7ba7cec93`

## modules_built

`WebUI,modules/perc-qa-automation,modules/perc-distribution-tree`

## build_evidence

- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** 2026-08-13T13:00:57-04:00. Surefire Tests run: 53, Failures: 0. Vitest Test Files 314 passed, Tests 2305 passed.
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** 2026-08-13T12:59:31-04:00. Surefire: No tests to run (frontend Playwright lives outside Surefire).
- `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` → **BUILD SUCCESS** 2026-08-13T13:04:40-04:00 (after WebUI SNAPSHOT installed). Tests run: 255, Failures: 0, Skipped: 5.

No new compiler/surefire failures on the changed modules. First dist-tree attempt raced a parallel WebUI `clean` (missing unpacked `jquery.cookie.js`); sequential retry after WebUI install was green.

No final/sealed/public API shape change requiring reverse-dep installs.

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok 1.0 using grok-4.5 with agent night-issue-prs.
