### PR TITLE
fix(sites): stop sitesAdaptor CNFE on PSVirtualSitePublishCopyResult (#3342)

### DIFF
--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercSystemVirtualSiteClassPackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercSystemVirtualSiteClassPackagingTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GH-3342: H2 qa-up died because {@code sitesAdaptor} could not load {@code
+ * PSVirtualSitePublishCopyResult}. That type lives in perc-system and must be present on the same
+ * runtime classpath as sitemanage (WebUI WAR {@code WEB-INF/lib}).
+ */
+class PercSystemVirtualSiteClassPackagingTest {
+
+  private static final String COPY_RESULT_FQN =
+      "com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult";
+
+  private static final String COPY_RESULT_ENTRY =
+      "com/percussion/services/virtualsite/PSVirtualSitePublishCopyResult.class";
+
+  @Test
+  @DisplayName("provided perc-system on dist-tree classpath contains the copy-result record")
+  void percSystemOnClasspathContainsCopyResult() throws Exception {
+    Class<?> type = Class.forName(COPY_RESULT_FQN);
+    assertTrue(type.isRecord(), COPY_RESULT_FQN + " must be a record in perc-system");
+    URL location = type.getProtectionDomain().getCodeSource().getLocation();
+    assertNotNull(location, "perc-system code source");
+    Path artifact = Paths.get(location.toURI());
+    if (Files.isRegularFile(artifact) && artifact.getFileName().toString().endsWith(".jar")) {
+      assertTrue(
+          jarContains(artifact, COPY_RESULT_ENTRY),
+          "perc-system jar must contain " + COPY_RESULT_ENTRY + ": " + artifact);
+    } else {
+      assertTrue(
+          Files.isRegularFile(artifact.resolve(COPY_RESULT_ENTRY)),
+          "perc-system classes dir must contain " + COPY_RESULT_ENTRY + ": " + artifact);
+    }
+  }
+
+  @Test
+  @DisplayName("WebUI WAR perc-system (when packaged) includes the copy-result class")
+  void webUiWarPercSystemContainsCopyResultWhenPresent() throws Exception {
+    Path war = findWebUiWar();
+    if (war == null) {
+      return;
+    }
+    boolean foundPercSystem = false;
+    try (JarFile warFile = new JarFile(war.toFile())) {
+      Enumeration<JarEntry> entries = warFile.entries();
+      while (entries.hasMoreElements()) {
+        JarEntry entry = entries.nextElement();
+        String name = entry.getName().replace('\\', '/');
+        if (!name.startsWith("WEB-INF/lib/") || !name.contains("perc-system") || !name.endsWith(".jar")) {
+          continue;
+        }
+        foundPercSystem = true;
+        Path tmp = Files.createTempFile("perc-system-from-war-", ".jar");
+        try (var in = warFile.getInputStream(entry)) {
+          Files.copy(in, tmp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        try {
+          assertTrue(
+              jarContains(tmp, COPY_RESULT_ENTRY),
+              "WEB-INF/lib perc-system inside " + war + " must contain " + COPY_RESULT_ENTRY);
+        } finally {
+          Files.deleteIfExists(tmp);
+        }
+      }
+    }
+    assertTrue(foundPercSystem, "WebUI WAR must package perc-system under WEB-INF/lib: " + war);
+  }
+
+  private static boolean jarContains(Path jar, String entryName) throws IOException {
+    try (JarFile jf = new JarFile(jar.toFile())) {
+      return jf.getEntry(entryName) != null;
+    }
+  }
+
+  private static Path findWebUiWar() throws IOException {
+    Path cwd = Paths.get("").toAbsolutePath().normalize();
+    Path[] dirs =
+        new Path[] {
+          cwd.resolve("WebUI").resolve("target"),
+          cwd.resolve("..").resolve("..").resolve("WebUI").resolve("target"),
+        };
+    for (Path dir : dirs) {
+      if (dir == null || !Files.isDirectory(dir)) {
+        continue;
+      }
+      try (var stream = Files.list(dir)) {
+        Path war =
+            stream
+                .filter(p -> p.getFileName().toString().endsWith(".war"))
+                .filter(p -> p.getFileName().toString().contains("perc-web-ui"))
+                .findFirst()
+                .orElse(null);
+        if (war != null) {
+          return war;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -43,7 +43,6 @@ import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildService;
 import com.percussion.services.virtualsite.PSVirtualSiteFilesystemPublisher;
 import com.percussion.services.virtualsite.PSVirtualSiteHelper;
-import com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult;
 import com.percussion.services.virtualsite.VirtualSiteConfig;
 import com.percussion.services.virtualsite.VirtualSiteConfigLoader;
 import com.percussion.services.virtualsite.VirtualSiteException;
@@ -423,9 +422,17 @@ public class SitesAdaptor implements ISiteAdaptor {
                         Response.Status.INTERNAL_SERVER_ERROR));
 
     try {
-      PSVirtualSitePublishCopyResult copied =
-          PSVirtualSiteFilesystemPublisher.copyBuildToTarget(buildOutput, safePublishRoot);
-      return toWirePublishResult(site.getName(), PSVirtualSiteHelper.siteKey(site), built, copied);
+      // Do not mention PSVirtualSitePublishCopyResult here: Spring lookup-method
+      // resolution loads every declared parameter type while creating sitesAdaptor.
+      int filesCopied =
+          PSVirtualSiteFilesystemPublisher.copyBuildFileCountToTarget(
+              buildOutput, safePublishRoot);
+      return toWirePublishResult(
+          site.getName(),
+          PSVirtualSiteHelper.siteKey(site),
+          built,
+          safePublishRoot,
+          filesCopied);
     } catch (VirtualSiteException e) {
       throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
     } catch (IOException e) {
@@ -958,12 +965,13 @@ public class SitesAdaptor implements ISiteAdaptor {
       String siteName,
       String siteKey,
       VirtualSiteBuildResult built,
-      PSVirtualSitePublishCopyResult copied) {
+      Path publishRoot,
+      int filesCopied) {
     VirtualSitePublishResult dto = new VirtualSitePublishResult();
     dto.setSiteName(siteName);
     dto.setSiteKey(siteKey);
-    if (copied != null && copied.publishRoot() != null) {
-      dto.setPublishPath(copied.publishRoot().toAbsolutePath().normalize().toString());
+    if (publishRoot != null) {
+      dto.setPublishPath(publishRoot.toAbsolutePath().normalize().toString());
     }
     if (built != null) {
       built.getOutputPath().ifPresent(dto::setBuildOutputPath);
@@ -972,7 +980,7 @@ public class SitesAdaptor implements ISiteAdaptor {
       dto.setHasLinkProblems(built.getHasLinkProblems());
       dto.setLinkProblems(built.getLinkProblems());
     }
-    dto.setFilesCopied(copied != null ? copied.filesCopied() : 0);
+    dto.setFilesCopied(Math.max(filesCopied, 0));
     return dto;
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorSpringClasspathContractTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorSpringClasspathContractTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GH-3342: Spring fails creating {@code sitesAdaptor} when a declared method mentions {@code
+ * PSVirtualSitePublishCopyResult} and that type is missing from the Rhythmyx/H2 classloader.
+ *
+ * <p>sitesAdaptor must load using only rest wire types / JDK types in its method descriptors.
+ * perc-system must still ship the record for publisher internals.
+ */
+@Tag("UnitTest")
+class SitesAdaptorSpringClasspathContractTest {
+
+  private static final String COPY_RESULT_FQN =
+      "com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult";
+
+  private static final String COPY_RESULT_SIMPLE = "PSVirtualSitePublishCopyResult";
+
+  @Test
+  @DisplayName("sitesAdaptor method descriptors do not mention the perc-system copy record")
+  void sitesAdaptorMethodsDoNotReferenceCopyResult() {
+    for (Method method : SitesAdaptor.class.getDeclaredMethods()) {
+      assertFalse(
+          COPY_RESULT_FQN.equals(method.getReturnType().getName()),
+          () -> "return type of " + method + " must not be " + COPY_RESULT_SIMPLE);
+      for (Class<?> param : method.getParameterTypes()) {
+        assertFalse(
+            COPY_RESULT_FQN.equals(param.getName()),
+            () -> "parameter of " + method + " must not be " + COPY_RESULT_SIMPLE);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("SitesAdaptor class file constant pool does not name the copy record")
+  void sitesAdaptorClassFileDoesNotNameCopyResult() throws Exception {
+    try (InputStream in = SitesAdaptor.class.getResourceAsStream("SitesAdaptor.class")) {
+      assertNotNull(in, "SitesAdaptor.class resource");
+      String latin1 = new String(in.readAllBytes(), StandardCharsets.ISO_8859_1);
+      assertFalse(
+          latin1.contains(COPY_RESULT_SIMPLE),
+          "SitesAdaptor bytecode must not mention "
+              + COPY_RESULT_SIMPLE
+              + " (Spring lookup-method resolution / class load)");
+    }
+  }
+
+  @Test
+  @DisplayName("perc-system record is loadable on the sitemanage test classpath")
+  void percSystemCopyResultIsOnSitemanageClasspath() throws Exception {
+    Class<?> type = Class.forName(COPY_RESULT_FQN);
+    assertTrue(type.isRecord(), COPY_RESULT_FQN + " must be the perc-system record");
+    assertNotNull(type.getProtectionDomain());
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -447,6 +447,30 @@ class SitesAdaptorTest {
   }
 
   @Test
+  void toWirePublishResult_mapsRestDtoWithoutSystemCopyRecord() {
+    VirtualSiteBuildResult built = new VirtualSiteBuildResult();
+    built.setOutputPath(tempDir.resolve("staging").toString());
+    built.setPagesWritten(3);
+    built.setLinkProblemCount(1);
+    built.setHasLinkProblems(true);
+    built.setLinkProblems(List.of("missing id:foo"));
+
+    Path publishRoot = tempDir.resolve("published-root");
+    VirtualSitePublishResult dto =
+        SitesAdaptor.toWirePublishResult("Help", "help-docs", built, publishRoot, 7);
+
+    assertEquals("Help", dto.getSiteName().orElse(null));
+    assertEquals("help-docs", dto.getSiteKey().orElse(null));
+    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath().orElse(null));
+    assertEquals(built.getOutputPath().orElse(null), dto.getBuildOutputPath().orElse(null));
+    assertEquals(3, dto.getPagesWritten().intValue());
+    assertEquals(7, dto.getFilesCopied().intValue());
+    assertEquals(1, dto.getLinkProblemCount().intValue());
+    assertTrue(Boolean.TRUE.equals(dto.getHasLinkProblems()));
+    assertEquals(List.of("missing id:foo"), dto.getLinkProblems());
+  }
+
+  @Test
   void safePathSegment_stripsSeparators() {
     assertEquals("a_b_c", SitesAdaptor.safePathSegment("a/b\\c"));
     assertEquals("default", SitesAdaptor.safePathSegment(".."));

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
@@ -147,6 +147,23 @@ public final class PSVirtualSiteFilesystemPublisher {
     return new PSVirtualSitePublishCopyResult(destAbs, copied);
   }
 
+  /**
+   * Copy assembled static files and return only the file count.
+   *
+   * <p>Callers that must not mention {@link PSVirtualSitePublishCopyResult} in method signatures
+   * (Spring lookup-method resolution / {@code sitesAdaptor} bean load) should use this entry.
+   *
+   * @param buildOutput directory written by {@link PSVirtualSiteBuildService}
+   * @param target Site filesystem publish root
+   * @return number of regular files written
+   * @throws VirtualSiteException when inputs are missing, unsafe, or overlap
+   * @throws IOException on filesystem I/O failure
+   */
+  public static int copyBuildFileCountToTarget(Path buildOutput, Path target)
+      throws VirtualSiteException, IOException {
+    return copyBuildToTarget(buildOutput, target).filesCopied();
+  }
+
   static boolean isMetaTree(Path relative) {
     if (relative == null || relative.getNameCount() < 1) {
       return false;

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
@@ -102,6 +102,24 @@ class PSVirtualSiteFilesystemPublisherTest {
   }
 
   @Test
+  void copyBuildFileCountToTarget_matchesCopyResultCount() throws Exception {
+    Path build = tempDir.resolve("build-count");
+    Path pub = tempDir.resolve("published-count");
+    Path html = build.resolve("page.html");
+    Files.createDirectories(build);
+    Files.writeString(html, "n", StandardCharsets.UTF_8);
+    Path meta = build.resolve("_meta").resolve("skip.json");
+    Files.createDirectories(meta.getParent());
+    Files.writeString(meta, "{}", StandardCharsets.UTF_8);
+
+    int count = PSVirtualSiteFilesystemPublisher.copyBuildFileCountToTarget(build, pub);
+
+    assertEquals(1, count);
+    assertTrue(Files.isRegularFile(pub.resolve("page.html")));
+    assertFalse(Files.exists(pub.resolve("_meta")));
+  }
+
+  @Test
   void copyBuildToTarget_rejectsMissingBuildDir() {
     VirtualSiteException ex =
         assertThrows(


### PR DESCRIPTION
## Summary

H2 `qa-up` died creating Spring bean `sitesAdaptor` / `restSitesResource` with `ClassNotFoundException: com.percussion.services.virtualsite.PSVirtualSitePublishCopyResult`. Spring lookup-method resolution loads every **declared** method parameter type on `SitesAdaptor`. The adaptor imported the perc-system record, so a stale WebUI WAR perc-system (or classloader split) failed context startup before Playwright could run.

This change:

- Stops `SitesAdaptor` from mentioning the perc-system record (bytecode + method descriptors). Publish maps to the rest wire `VirtualSitePublishResult` via `Path` + file count.
- Adds `PSVirtualSiteFilesystemPublisher.copyBuildFileCountToTarget` so the adaptor never loads the record at bean creation.
- Adds a Spring classpath contract test and a dist-tree packaging test that the WebUI WAR `WEB-INF/lib/perc-system-*.jar` contains the class.

Fixes #3342
Parent: #3342

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Standalone `mvnw clean install` on `system`, then `projects/sitemanage`, then `modules/perc-distribution-tree` (after packaging WebUI so the WAR carries current perc-system).
2. `python docker/scripts/perc-devctl.py qa-up --skip-image-build --timeout-seconds 900` → `RESULT:OK`; qa-health HTTP 302 on `TEST_CMS_URL`.
3. `npm run test:surface` on golden/login/editor/explorer-views (pass). `explorer-sites-list-create` UI expand/wizard still fails on **main** without cluster PR #3341 (not this CNFE).
4. Confirm no `Failed startup of context` / `PSVirtualSitePublishCopyResult` in the H2 cell log.
5. Always `python docker/scripts/perc-devctl.py qa-down`.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): classpath / Spring bean-load fix; Virtual Site publish contract unchanged
- [x] **Unit / module tests** — SitesAdaptor mapping + Spring contract; publisher file-count helper; WAR perc-system class packaging
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change). C5 still run: qa-up OK; see evidence below
- [x] **Build gates** — standalone clean install on changed modules (no skipTests)
- [x] **Cross-platform** — NIO `Path` / zip `/` entries only

## C3 evidence

- **modules_built:** system, projects/sitemanage, modules/perc-distribution-tree
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2089, Failures: 0, Errors: 0, Skipped: 238
  - `cd rest && ../mvnw.cmd clean install` (matching SNAPSHOT for sitemanage compile only) → BUILD SUCCESS
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1115, Failures: 0, Errors: 0, Skipped: 125
  - `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 257, Failures: 0, Errors: 0, Skipped: 5
- **downstream_checked:** grep `extends SitesAdaptor` / `new SitesAdaptor() {` (none). `copyBuildToTarget` signature unchanged; `copyBuildFileCountToTarget` is additive. sitemanage standalone install covers the adaptor consumer.

## C5 UI proof (cell start + smoke; no WebUI source change)

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build --timeout-seconds 900` → **RESULT:OK**
- `TEST_CMS_URL=http://127.0.0.1:9993` (from qa-up stdout; not hardcoded)
- qa-health: HTTP **302**
- Deploy: rebuilt perc-system + sitemanage, packaged WebUI WAR, perc-distribution-tree.jar bind-mounted by qa-up
- Playwright (`modules/perc-qa-automation/frontend`, TEST_DB_TYPE=h2):
  - golden-unattended-smoke: pass
  - login.spec.js: pass
  - bug-3330, bug-3332: pass
  - explorer-views: pass (1 soft-skip)
  - explorer-sites-list-create: 2 pass, 3 fail (Sites expand / wizard chrome — cluster #3341 / #3326; not this CNFE)
  - bug-3328 / bug-3331 specs are not on `main` (cluster tip only)
- console-clean=yes on passed surfaces
- server.log-clean=yes (no `PSVirtualSitePublishCopyResult` / `Failed startup of context`)
- `python docker/scripts/perc-devctl.py qa-down` → RESULT:OK

> Co-Authored by Grok Build using grok-4.5 with agent main.