### PR TITLE
fix(qa): #3340 Admin has no Administration sibling (unified tabs)

### DIFF
--- a/WebUI/README.md
+++ b/WebUI/README.md
@@ -142,16 +142,16 @@ The legacy Miller-column Finder is hard-cut in 8.2:
 | Vitest (component + a11y gate) | `WebUI/src/test/ts/{contentExplorer,contentBrowser}/` | `cd WebUI/src/main/frontend && npx vitest run`       |
 | Playwright (E2E + a11y gate)   | `modules/perc-qa-automation/frontend/tests/`          | `cd modules/perc-qa-automation/frontend && npm test` |
 
-## Modern Unified Workflow & Admin UI (feature 993)
+## Modern Unified Workflow & Admin UI (feature 993 / #3088 / #3201)
 
-Modern React replacement for the legacy Workflow, Role, User, Category, and Admin UI screens. Integrated within `WorkflowAdminShell` and `AdminShell`.
+Modern React replacement for the legacy Workflow, Role, User, Category, and Admin UI screens. **One product shell:** `AdminShell` titled **Admin tools**. Workflow, roles, users, and categories are in-shell tabs — there is no separate Administration sibling (`admin-sibling-workflow-link`, #3340). `WorkflowAdminShell` is a redirect stub into `/admin/:tab`.
 
 ### Entry points (SPA — PR-5/PR-8)
 
 |      Page      |               URL               |                                       Component(s)                                        |
 |----------------|---------------------------------|-------------------------------------------------------------------------------------------|
-| Workflow Admin | `cm/app/spa.jsp?entry=workflow` | `WorkflowAdminShell` (Workflow definitions, assignment, roles, users, categories)         |
-| Admin          | `cm/app/spa.jsp?entry=admin`    | `AdminShell` (Scheduled Tasks, Task Logs, Task Notifications, System Consistency Checker) |
+| Admin tools    | `cm/app/spa.jsp?entry=admin`    | `AdminShell` (tasks, logs, notifications, tools, workflow, roles, users, categories)      |
+| Legacy workflow entry | `cm/app/spa.jsp?entry=workflow` | Redirects into `AdminShell` workflow tab (`/admin/workflow`)                         |
 
 Former product hosts `adminWorkflowModern.jsp` / `adminModern.jsp` were removed in PR-8.
 
@@ -159,14 +159,14 @@ Former product hosts `adminWorkflowModern.jsp` / `adminModern.jsp` were removed 
 
 |          Component          |      Mount path      |                                       Role                                       |
 |-----------------------------|----------------------|----------------------------------------------------------------------------------|
-| `WorkflowAdminShell`        | SPA `entry=workflow` | Top-level workflow navigation (Workflows, Site Assign, Roles, Users, Categories) |
-| `WorkflowsSection`          | inside Shell         | Workflow list, creation, editing, state & transition management                  |
-| `WorkflowAssignmentSection` | inside Shell         | Site-to-workflow mapping, contentType & publishing default template rules        |
-| `RolesSection`              | inside Shell         | Role list, creation, member management with dual list picker                     |
-| `UsersSection`              | inside Shell         | User list, user creation, role & group assignment                                |
-| `CategoriesSection`         | inside Shell         | Category tree explorer, node creation, lock management                           |
+| `AdminShell`                | SPA `entry=admin`    | Unified Admin tools (tasks, logs, notifications, tools + workflow/roles/users/categories) |
+| `WorkflowAdminShell`        | redirect only        | Legacy name; `Navigate` to `/admin/:tab` (#3088)                                 |
+| `WorkflowsSection`          | Admin tab            | Workflow list, creation, editing, state & transition management                  |
+| `WorkflowAssignmentSection` | inside Workflow tab  | Site-to-workflow mapping, contentType & publishing default template rules        |
+| `RolesSection`              | Admin tab            | Role list, creation, member management with dual list picker                     |
+| `UsersSection`              | Admin tab            | User list, user creation, role & group assignment                                |
+| `CategoriesSection`         | Admin tab            | Category tree explorer, node creation, lock management                           |
 | `InContextTransitionButton` | standalone / editor  | Action button for executing item workflow state transitions                      |
-| `AdminShell`                | SPA `entry=admin`    | System administration shell (Tasks, Logs, Notifications, System Tools)           |
 | `TasksSection`              | inside AdminShell    | Scheduled task list, schedule builder, trigger actions                           |
 | `TaskLogsSection`           | inside AdminShell    | Task execution logs, status filter, detail viewer                                |
 | `TaskNotifications`         | inside AdminShell    | Email notification template manager                                              |

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -71,7 +71,7 @@ function renderShell(ui: React.ReactElement) {
 }
 
 describe("AdminShell", () => {
-  it("renders unified Admin title without sibling Workflow link (#3088)", () => {
+  it("renders unified Admin title without sibling Workflow link (#3088 / #3340)", () => {
     renderShell(<AdminShell />);
     expect(screen.getByTestId("perc-admin-shell")).toBeDefined();
     expect(screen.getByTestId("mock-tasks-section")).toBeDefined();
@@ -79,9 +79,11 @@ describe("AdminShell", () => {
     expect(screen.getByTestId("perc-admin-shell-title").textContent).toMatch(
       /Admin tools/i,
     );
-    // Sibling cross-links removed when Workflow admin folded into Admin (#3088)
+    // Sibling chrome is not product (#3088 / #3340). Do not restore
+    // Administration / Admin tools cross-links.
     expect(screen.queryByTestId("admin-sibling-workflow-link")).toBeNull();
     expect(screen.queryByTestId("admin-sibling-tools-link")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Administration" })).toBeNull();
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
@@ -7,7 +7,8 @@
  * Workflow / Roles / Users / Categories must unwrap before .map so the
  * Admin shell loads without RouteErrorBoundary.
  *
- * #3088: Workflow admin lives under unified AdminShell (not sibling Workflow shell).
+ * #3088 / #3340: Workflow admin lives under unified AdminShell
+ * (not a sibling Administration shell / admin-sibling-workflow-link).
  *
  * Tags: @workflow-admin @administration @smoke @bug-2959 @bug-3202
  *

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3340-admin-no-sibling.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3340-admin-no-sibling.spec.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3340 — Admin tools must NOT restore a right-side Administration sibling.
+ *
+ * QA filed #3340 against an older test plan that expected:
+ *   - admin-sibling-workflow-link on Admin tools
+ *   - a separate Administration shell (workflow / users / roles / categories)
+ *   - reverse Admin tools sibling from that shell
+ *
+ * 8.2 product (#3088 / #3201) is a single Admin tools shell. Workflow,
+ * users, roles, and categories are in-shell tabs. Product docs:
+ *   product-docs/8.2/admin/index.md
+ * Companion: tests/top-nav-restructure.spec.js
+ *
+ * Surface filter:
+ *   npm run test:surface -- --path tests/bugs/bug-3340-admin-no-sibling.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+function adminEntry() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=admin&_=${Date.now()}`;
+}
+
+test.describe("GH-3340 no Administration sibling on Admin tools", () => {
+  test(
+    "Admin tools has in-shell tabs, not admin-sibling-workflow-link",
+    {
+      tag: ["@admin", "@workflow-admin", "@bug-3340", "@smoke"],
+    },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      const consoleErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(adminEntry(), { waitUntil: "domcontentloaded" });
+
+      const shell = page.getByTestId("perc-admin-shell");
+      await expect(shell).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId("perc-admin-shell-title")).toContainText(
+        /Admin tools/i,
+      );
+
+      // #3340 expected result (old plan) is NOT product: no sibling chrome
+      await expect(page.getByTestId("admin-sibling-workflow-link")).toHaveCount(
+        0,
+      );
+      await expect(page.getByTestId("admin-sibling-tools-link")).toHaveCount(0);
+      await expect(page.getByTestId("perc-workflow-admin-shell")).toHaveCount(0);
+      await expect(
+        shell.getByRole("link", { name: "Administration", exact: true }),
+      ).toHaveCount(0);
+
+      await expect(page.getByTestId("tab-workflow")).toBeVisible();
+      await expect(page.getByTestId("tab-users")).toBeVisible();
+      await expect(page.getByTestId("tab-roles")).toBeVisible();
+      await expect(page.getByTestId("tab-categories")).toBeVisible();
+      await expect(page.getByTestId("tab-tools")).toBeVisible();
+
+      await page.getByTestId("tab-workflow").click();
+      await expect(page.getByTestId("perc-workflow-section")).toBeVisible({
+        timeout: 30_000,
+      });
+      // Still one shell — no reverse sibling to a second Administration page
+      await expect(page.getByTestId("perc-admin-shell")).toBeVisible();
+      await expect(page.getByTestId("admin-sibling-tools-link")).toHaveCount(0);
+      await expect(page.getByTestId("route-error")).toHaveCount(0);
+
+      const unexpected = [...pageErrors, ...consoleErrors].filter(
+        (t) =>
+          !/favicon|404|net::ERR|Failed to load resource/i.test(t) &&
+          !/Download the React DevTools/i.test(t),
+      );
+      expect(unexpected, `JS console errors: ${unexpected.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -20,7 +20,8 @@
  * - Explorer immediately after Home
  * - Single consolidated Admin labeled "Admin" (not "Administration")
  * - Admin lands on working Admin tools shell (/admin); workflow/roles/users/
- *   categories are in-shell tabs (sibling chrome removed in #3088)
+ *   categories are in-shell tabs (sibling chrome removed in #3088).
+ *   #3340 is not a revert: do not restore admin-sibling-workflow-link.
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -104,7 +105,7 @@ test.describe("Top nav restructure (#2702 / #3201)", () => {
     );
     await expect(page.getByTestId("tab-tools")).toBeVisible();
     await expect(page.getByTestId("tab-tasks")).toBeVisible();
-    // No sibling cross-links; workflow is an Admin tab (#3088)
+    // No sibling cross-links; workflow is an Admin tab (#3088 / #3340)
     await expect(page.getByTestId("admin-sibling-workflow-link")).toHaveCount(0);
     await expect(page.getByTestId("admin-sibling-tools-link")).toHaveCount(0);
     await expect(page.getByTestId("tab-workflow")).toBeVisible();


### PR DESCRIPTION
## Summary

Treat [#3340](https://github.com/intersoftdatalabs-in/percussioncms/issues/3340) as **spec/test alignment**, not an IA revert.

8.2 already ships a **single Admin tools** shell (`AdminShell`) with in-shell tabs (`tab-workflow`, users, roles, categories). Product docs (`product-docs/8.2/admin/index.md`) and `tests/top-nav-restructure.spec.js` already forbid `admin-sibling-workflow-link` after #3088 / #3201. This PR does **not** restore a separate Administration sibling shell.

- New Playwright regression `tests/bugs/bug-3340-admin-no-sibling.spec.js` (QA repro steps → current product).
- Vitest `AdminShell.test.tsx` cites #3340 (no Administration sibling link).
- Comments on `top-nav-restructure` / `bug-2959` so they stay consistent.
- `WebUI/README.md` no longer describes two product shells.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3340

## Test plan

1. Log in as Admin; click **Admin** in the SPA top nav.
2. Confirm **Admin tools** shell title and tabs (Workflow / Users / Roles / Categories / Tools).
3. Confirm there is **no** right-side Administration sibling (`admin-sibling-workflow-link` count 0).
4. Click **Workflow** tab — stay on `perc-admin-shell`; no `perc-workflow-admin-shell`.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): product-docs/8.2/admin/index.md already documents a single Admin tools shell and forbids sibling chrome. No operator-facing behavior change.
- [x] **Unit / module tests** — Vitest AdminShell + Playwright #3340 / top-nav / #2959
- [x] **WebUI + Playwright** — new/updated specs; live QA H2 surface run
- [x] **Build gates** — standalone clean install on WebUI and perc-qa-automation
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Surefire: 15+13+7+7+11 Java tests; Vitest: 313 files / 2284 tests passed)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **downstream_checked:** none (C2 N/A — no `final`/signature/API shape change)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` (H2; no UI hot-deploy — tests-only)
- `npm run test:surface -- --path tests/bugs/bug-3340-admin-no-sibling.spec.js` → **1 passed**
- `npm run test:surface -- --path tests/top-nav-restructure.spec.js` → **1 passed**
- `npm run test:surface -- --path tests/bugs/bug-2959-admin-workflow-section.spec.js` → **3 passed**
- console-clean=yes (spec pageerror/console listeners; unexpected empty)
- server.log-clean=yes (no ERROR/FATAL in `/opt/Percussion/jetty/base/logs/server.log` tail during run)
- `python docker/scripts/perc-devctl.py qa-down`

> Co-Authored by Grok Build using grok-4.5 with agent main.
