### PR TITLE
fix(sitemanage): My Profile change password returns 2xx after persist (#3338)

### DIFF
--- a/docs/ai-generated/code-reviews/3338-profile-changepw-500-erlang.md
+++ b/docs/ai-generated/code-reviews/3338-profile-changepw-500-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — issue #3338 profile change-password HTTP 500
+
+**Date:** 2026-08-13  
+**Branch:** `fix/issue-3338-profile-change-password-500`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A (no path/file I/O)
+
+## Summary
+
+My Profile → Security → Change Password persisted the new hash then returned HTTP 500. `PSUserService.changePassword` could return a null JAX-RS entity (CXF writers 500), cloned the request body after persist (`BeanUtils.cloneBean`), and historically risked a post-write `getCurrentUser()`/`find()` reload. The fix validates first, rejects DIRECTORY with 400, loads the session user once before `USERLOGIN` save, always returns a non-null password-cleared `PSUser`, and does not re-fetch after persist.
+
+## Memory patterns hit
+
+- Behavioral unit tests for new/changed logic (success persist + validation + persist failure)
+- Secrets must not appear in logs/responses (password cleared; JSON assertion rejects plaintext/hash)
+- False green / success-then-exception after a committed write
+- Incomplete change-class: no new rest adaptor surface; CM1 `PUT /user/user/changepw` only; WebUI already shows success on 2xx (no screen change)
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Playwright success+restore already exists in `modules/perc-qa-automation/frontend/tests/profile-password.spec.js`. This PR does not change WebUI; C5 live QA cell not required for the Java-only fix.
+- Test passwords are dummy literals, not production secrets; they must not be logged.
+
+## Tests
+
+- `PSUserChangePasswordTest` — 6 tests, 0 failures
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1189, Failures: 0, Errors: 0

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -59,8 +59,12 @@ Authenticated users open **My profile** from the header user menu (or deep link
 
 Password rules enforced by the server (complexity / history filters when configured)
 still apply. Client-side checks require a non-empty password of at least six characters
-and a matching confirmation before submit. Success and failure messages are announced
-to assistive technology via a live region.
+and a matching confirmation before submit. After a **successful** change the Security
+section shows a success confirmation (not an error); the current session stays signed
+in, and the new password is required at the next sign-in. Failed validation (too short,
+mismatch, or a server-side rule) stays an error and does not change the stored
+password. Success and failure messages are announced to assistive technology via a
+live region.
 
 ## My profile — Preferences (default landing)
 

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -797,15 +797,7 @@ public class PSUserService implements IPSUserService {
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public PSUser changePassword(PSUser user) throws PSDataServiceException {
-    log.debug("changing password for user {}", user);
-
-    // the result
-    PSUser rvalue = null;
-
-    PSUserProviderType provider = fromProvider(user.getName());
-    user.setProviderType(provider);
-
-    // parameter validation
+    // Validate before any lookup so a null body is 400, not NPE 500.
     PSParameterValidationUtils.validateParameters("changePassword")
         .rejectIfNull("user", user)
         .throwIfInvalid();
@@ -816,8 +808,24 @@ public class PSUserService implements IPSUserService {
         .rejectIfBlank("name", user.getName())
         .throwIfInvalid();
 
-    // can only change password of self
     String userName = user.getName();
+    log.debug("changing password for user {}", userName);
+
+    PSUserProviderType provider = fromProvider(userName);
+    user.setProviderType(provider);
+    if (provider != PSUserProviderType.INTERNAL) {
+      PSParameterValidationUtils.validateParameters("changePassword")
+          .rejectField(
+              "password",
+              "Password can only be changed for internal users",
+              userName)
+          .throwIfInvalid();
+    }
+
+    // Load the session user once *before* the credential write. Reloading
+    // getCurrentUser()/find() after USERLOGIN is updated can fail (session
+    // subject refresh) and would map to HTTP 500 even though the password
+    // already persisted — issue #3338.
     PSCurrentUser currentUser = getCurrentUser();
     if (currentUser == null || !userName.equalsIgnoreCase(currentUser.getName())) {
       String emsg = "Can only change the password of the current user";
@@ -827,33 +835,47 @@ public class PSUserService implements IPSUserService {
           .throwIfInvalid();
     }
 
-    // only update if there is a password supplied
-    // and its an internal user.
-    if (provider == PSUserProviderType.INTERNAL && isNotBlank(user.getPassword())) {
-      PSUserLogin login = new PSUserLogin();
-      login.setUserid(user.getName());
-      String cryptPW =
-          (passwordFilter == null)
-              ? user.getPassword()
-              : passwordFilter.encrypt(user.getPassword());
-      login.setPassword(cryptPW);
+    PSUserLogin login = new PSUserLogin();
+    login.setUserid(userName);
+    String cryptPW =
+        (passwordFilter == null)
+            ? user.getPassword()
+            : passwordFilter.encrypt(user.getPassword());
+    login.setPassword(cryptPW);
+    userLoginDao.save(login);
 
-      // save changes
-      userLoginDao.save(login);
-
-      try {
-        rvalue = user.clone();
-      } catch (CloneNotSupportedException e) {
-        throw new PSDataServiceException(e);
-      }
-      rvalue.setRoles(currentUser.getRoles());
-      rvalue.setProviderType(provider);
-      rvalue.setPassword(null);
+    try {
+      PSSystemAuditLogger.userUpdate(
+          currentServletRequest(), AuditOutcome.SUCCESS, userName, "changepw");
+    } catch (Exception e) {
+      log.error(PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
 
+    // Never return null (CXF JSON/XML writers 500 on a null entity). Build a
+    // fresh DTO from the pre-loaded session user — do not clone the request
+    // body (BeanUtils.cloneBean) and do not re-fetch after persist.
+    PSUser rvalue = passwordChangeResult(currentUser);
     // XSS residual (Jackson/JAXB/CXF or documented pass-through): JSON/XML DTO via Jackson/JAXB;
     // not HTML body (alert #755)
     return rvalue; // codeql[java/xss]
+  }
+
+  /**
+   * Wire DTO for a successful self-service password change. Password is always
+   * cleared. Roles/email come from the user loaded before persist.
+   */
+  private static PSUser passwordChangeResult(PSCurrentUser currentUser) {
+    PSUser rvalue = new PSUser();
+    rvalue.setName(currentUser.getName());
+    rvalue.setEmail(currentUser.getEmail() == null ? "" : currentUser.getEmail());
+    rvalue.setProviderType(PSUserProviderType.INTERNAL);
+    rvalue.setPassword(null);
+    List<String> roles = currentUser.getRoles();
+    if (roles != null) {
+      rvalue.setRoles(new ArrayList<>(roles));
+    }
+    return rvalue;
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserChangePasswordTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserChangePasswordTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.user.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.metadata.service.IPSMetadataService;
+import com.percussion.security.IPSPasswordFilter;
+import com.percussion.services.security.IPSBackEndRoleMgr;
+import com.percussion.services.security.IPSRoleMgr;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.share.dao.IPSGenericDao;
+import com.percussion.share.dao.PSSerializerUtils;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.sitemanage.dao.IPSUserLoginDao;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.data.PSUser;
+import com.percussion.user.data.PSUserLogin;
+import com.percussion.user.data.PSUserProviderType;
+import com.percussion.utils.service.IPSUtilityService;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.security.IPSSecurityWs;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for self-service {@link PSUserService#changePassword(PSUser)} (issue #3338).
+ *
+ * <p>Successful persist must return a non-null {@link PSUser} (HTTP 2xx via JAX-RS) and must not
+ * reload the current user after {@code USERLOGIN} is updated. Validation failures stay
+ * {@link PSValidationException} (mapped 400), not 500.
+ */
+@DisplayName("Self-service changePassword (#3338)")
+class PSUserChangePasswordTest {
+
+  private IPSUserLoginDao userLoginDao;
+  private IPSPasswordFilter passwordFilter;
+  private PSUserService userService;
+
+  @BeforeEach
+  void setUp() {
+    userLoginDao = mock(IPSUserLoginDao.class);
+    passwordFilter = mock(IPSPasswordFilter.class);
+    userService =
+        spy(
+            new PSUserService(
+                userLoginDao,
+                passwordFilter,
+                mock(IPSBackEndRoleMgr.class),
+                mock(IPSRoleMgr.class),
+                /* notificationService */ null,
+                mock(IPSWorkflowService.class),
+                mock(IPSSecurityWs.class),
+                mock(IPSContentWs.class),
+                mock(IPSIdMapper.class),
+                mock(IPSUtilityService.class),
+                mock(IPSMetadataService.class)));
+  }
+
+  @Test
+  @DisplayName("INTERNAL self change persists hash and returns non-null user without password")
+  void internalSelfChangeReturnsUserAndDoesNotRefetch() throws Exception {
+    PSCurrentUser current = internalCurrent("Admin", "admin@example.com");
+    doReturn(current).when(userService).getCurrentUser();
+    when(userLoginDao.find("Admin")).thenReturn(login("Admin"));
+    when(passwordFilter.encrypt("new-secret")).thenReturn("hashed-secret");
+    when(userLoginDao.save(any(PSUserLogin.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    PSUser request = requestUser("Admin", "new-secret");
+    PSUser result = userService.changePassword(request);
+
+    assertNotNull(result, "null entity becomes HTTP 500 from CXF JSON/XML writers");
+    assertEquals("Admin", result.getName());
+    assertNull(result.getPassword());
+    assertEquals(PSUserProviderType.INTERNAL, result.getProviderType());
+    assertEquals(List.of("Admin"), result.getRoles());
+    assertEquals("admin@example.com", result.getEmail());
+
+    ArgumentCaptor<PSUserLogin> saved = ArgumentCaptor.forClass(PSUserLogin.class);
+    verify(userLoginDao).save(saved.capture());
+    assertEquals("Admin", saved.getValue().getUserid());
+    assertEquals("hashed-secret", saved.getValue().getPassword());
+
+    InOrder order = Mockito.inOrder(userService, userLoginDao);
+    order.verify(userService).getCurrentUser();
+    order.verify(userLoginDao).save(any(PSUserLogin.class));
+    verify(userService, times(1)).getCurrentUser();
+    verify(userService, never()).find(anyString());
+
+    String json = PSSerializerUtils.getJsonFromObject(result);
+    assertTrue(json.contains("Admin"), json);
+    assertFalse(json.contains("new-secret"), "response must not echo the new password");
+    assertFalse(json.contains("hashed-secret"), "response must not include the stored hash");
+  }
+
+  @Test
+  @DisplayName("blank password is validation, not persist")
+  void blankPasswordRejected() throws Exception {
+    assertThrows(
+        PSValidationException.class,
+        () -> userService.changePassword(requestUser("Admin", "  ")));
+    verify(userLoginDao, never()).save(any(PSUserLogin.class));
+  }
+
+  @Test
+  @DisplayName("null user is validation, not NPE")
+  void nullUserRejected() throws Exception {
+    assertThrows(PSValidationException.class, () -> userService.changePassword(null));
+    verify(userLoginDao, never()).save(any(PSUserLogin.class));
+  }
+
+  @Test
+  @DisplayName("cannot change another user's password")
+  void rejectsOtherUser() throws Exception {
+    PSCurrentUser current = internalCurrent("Admin", "admin@example.com");
+    doReturn(current).when(userService).getCurrentUser();
+    when(userLoginDao.find("editor1")).thenReturn(login("editor1"));
+
+    assertThrows(
+        PSValidationException.class,
+        () -> userService.changePassword(requestUser("editor1", "new-secret")));
+    verify(userLoginDao, never()).save(any(PSUserLogin.class));
+  }
+
+  @Test
+  @DisplayName("DIRECTORY provider is validation, not null 500")
+  void rejectsDirectoryUser() throws Exception {
+    when(userLoginDao.find("ldap.user")).thenReturn(null);
+
+    assertThrows(
+        PSValidationException.class,
+        () -> userService.changePassword(requestUser("ldap.user", "new-secret")));
+    verify(userLoginDao, never()).save(any(PSUserLogin.class));
+    verify(userService, never()).getCurrentUser();
+  }
+
+  @Test
+  @DisplayName("persist exception still surfaces (no silent success)")
+  void persistFailurePropagates() throws Exception {
+    PSCurrentUser current = internalCurrent("Admin", "admin@example.com");
+    doReturn(current).when(userService).getCurrentUser();
+    when(userLoginDao.find("Admin")).thenReturn(login("Admin"));
+    when(passwordFilter.encrypt(anyString())).thenReturn("hashed");
+    when(userLoginDao.save(any(PSUserLogin.class)))
+        .thenThrow(new IPSGenericDao.SaveException("db write failed"));
+
+    assertThrows(
+        IPSGenericDao.SaveException.class,
+        () -> userService.changePassword(requestUser("Admin", "new-secret")));
+  }
+
+  private static PSUser requestUser(String name, String password) {
+    PSUser user = new PSUser();
+    user.setName(name);
+    user.setPassword(password);
+    user.setEmail("admin@example.com");
+    user.setRoles(List.of("Admin"));
+    return user;
+  }
+
+  private static PSCurrentUser internalCurrent(String name, String email) {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName(name);
+    user.setEmail(email);
+    user.setProviderType(PSUserProviderType.INTERNAL);
+    user.setRoles(List.of("Admin"));
+    return user;
+  }
+
+  private static PSUserLogin login(String userId) {
+    PSUserLogin login = new PSUserLogin();
+    login.setUserid(userId);
+    login.setPassword("old-hash");
+    return login;
+  }
+}


### PR DESCRIPTION
## Summary

My Profile → Security → Change Password persisted the new password but the UI showed HTTP 500 because `PUT /user/user/changepw` could return a **null JAX-RS entity** (CXF JSON/XML writers map that to 500) or fail while building the response after `USERLOGIN` was already saved (request-body `clone()` / session user reload).

This keeps the INTERNAL-only persist path. Validation failures (blank, not self, directory user) stay `PSValidationException` (HTTP 400). On success the method always returns a non-null `PSUser` with the password cleared, built from the session user loaded **before** the credential write. The existing React Security section treats any 2xx as success and shows `perc-profile-security-success`.

Fixes #3338

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Unit: `PSUserChangePasswordTest` (success persist, no post-save `getCurrentUser`/`find`, validation, persist failure).
2. Standalone: `cd projects/sitemanage` → `../../mvnw.cmd clean install`.
3. Manual / later Human QA: sign in as local Admin → My Profile → Security → change password (valid 6+ chars) → expect success live region (`perc-profile-security-success`), not HTTP 500 → sign out/in with new password → restore original password the same way → restore must also show success.
4. Confirm a too-short or mismatch password still shows field errors and does not persist.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (success confirmation vs error after change)
- [x] **Unit / module tests** — `PSUserChangePasswordTest`; sitemanage standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; existing `profile-password.spec.js` already covers success+restore)
- [x] **Build gates** — standalone `projects/sitemanage` clean install, no skipTests
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (51.9s). Tests run: 1189, Failures: 0, Errors: 0, Skipped: 125. `PSUserChangePasswordTest`: Tests run: 6, Failures: 0.
- **downstream_checked:** none (no `final`/`sealed` type change; `changePassword` signature unchanged)

### C5 UI proof

N/A — Java/sitemanage + product-docs only. WebUI already maps 2xx to `perc-profile-security-success`. Live Playwright optional after #3342 QA cell if desired.

> Co-Authored by Grok Build using grok-4.5 with agent main.
