### PR TITLE
fix(explorer): Inbox execute ViewExecuteRequest / startIndex JAXB (#3323)

### DIFF
--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1658,6 +1658,68 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("Inbox default executeView POSTs ViewExecuteRequest envelope (#3323)", async () => {
+    const executeBodies: string[] = [];
+    mockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [],
+              childrenCount: 0,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (/\/views\/[^/]+\/execute/i.test(url) && String(init?.method) === "POST") {
+        executeBodies.push(String(init?.body ?? ""));
+        return new Response(
+          JSON.stringify({
+            children: [],
+            totalCount: 0,
+            startIndex: 1,
+            viewName: "Inbox",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        listViews={async () => [
+          { name: "Inbox", label: "Inbox", parentCategory: 1, customView: true },
+        ]}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-views-leaf-Inbox")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-views-leaf-Inbox"));
+    await waitFor(() => {
+      expect(executeBodies.length).toBeGreaterThan(0);
+    });
+    const parsed = JSON.parse(executeBodies[0] ?? "{}");
+    expect(parsed.ViewExecuteRequest).toEqual({
+      startIndex: 1,
+      maxResults: 50,
+    });
+    expect(parsed.startIndex).toBeUndefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-view-results-empty")).toBeInTheDocument();
+    });
+  });
+
   it("running Inbox POSTs view execute and shows results (#3240)", async () => {
     stubPathFetch();
     const listViews = vi.fn(async () => [

--- a/WebUI/src/test/ts/contentExplorer/viewsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/viewsApi.test.ts
@@ -137,6 +137,23 @@ describe("executeView", () => {
     expect(result.viewName).toBe("View_All");
   });
 
+  it("POSTs Inbox paging overrides under ViewExecuteRequest (#3323)", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ children: [], totalCount: 0, startIndex: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await executeView("Inbox", { startIndex: 1, maxResults: 50 });
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe(
+      `${PATHS.VIEWS}/${encodeURIComponent("Inbox")}/execute`,
+    );
+    const body = JSON.parse(String(init?.body));
+    expect(body.ViewExecuteRequest).toEqual({ startIndex: 1, maxResults: 50 });
+    expect(body.startIndex).toBeUndefined();
+  });
+
   it("POSTs an empty ViewExecuteRequest envelope when overrides are omitted", async () => {
     const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
       new Response(JSON.stringify({ children: [], totalCount: 0, startIndex: 1 }), {

--- a/modules/perc-qa-automation/frontend/tests/explorer-inbox.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-inbox.spec.js
@@ -53,6 +53,7 @@ const {
   findInboxView,
   inboxLeafSelector,
   inboxResultsSelector,
+  isViewExecuteJaxbError,
   missingInboxSkipMessage,
   noAssignmentsSkipMessage,
 } = require("./helpers/explorer-inbox");
@@ -179,6 +180,14 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
       return;
     }
 
+    const executeBodies = [];
+    page.on("request", (req) => {
+      if (req.method() !== "POST") return;
+      const reqUrl = req.url();
+      if (!/\/services\/views\/[^/]+\/execute(?:\?|$)/i.test(reqUrl)) return;
+      executeBodies.push(req.postData() || "");
+    });
+
     await inboxLeaf.first().click();
 
     const results = page.locator(inboxResultsSelector());
@@ -205,8 +214,27 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
       await expect(loading).toBeHidden({ timeout: 30_000 });
     }
 
+    if (executeBodies.length > 0) {
+      for (const raw of executeBodies) {
+        const parsed = JSON.parse(raw);
+        expect(
+          parsed.ViewExecuteRequest,
+          "JAXB root ViewExecuteRequest required (#3323)",
+        ).toBeTruthy();
+        expect(
+          parsed.startIndex,
+          "bare startIndex must not be the JSON root",
+        ).toBeUndefined();
+      }
+    }
+
     const err = page.locator(`[data-testid="${TEST_IDS.resultsError}"]`);
     if (await err.isVisible().catch(() => false)) {
+      const errText = (await err.textContent().catch(() => "")) || "";
+      expect(
+        isViewExecuteJaxbError(errText),
+        `Inbox must not fail JAXB startIndex / ViewExecuteRequest (#3323): ${errText}`,
+      ).toBe(false);
       expect(pageErrors, "uncaught pageerror on Inbox execute error").toEqual(
         [],
       );

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-inbox.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-inbox.js
@@ -218,6 +218,23 @@ function missingInboxSkipMessage(detail = {}) {
  * @param {{ restStatus?: number }} [detail]
  * @returns {string}
  */
+/**
+ * True when Inbox execute failed on the JAXB / ViewExecuteRequest envelope
+ * (#3323). That is a product defect — do not soft-skip.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+function isViewExecuteJaxbError(text) {
+  const raw = String(text ?? "");
+  if (!raw.trim()) {
+    return false;
+  }
+  const jaxb = /JAXBException|unexpected element/i.test(raw);
+  const envelope = /startIndex/i.test(raw) && /ViewExecuteRequest/i.test(raw);
+  return jaxb || envelope;
+}
+
 function noAssignmentsSkipMessage(detail = {}) {
   const parts = [
     "Inbox surface present but H2 fixture has no assignment rows.",
@@ -242,6 +259,7 @@ module.exports = {
   findInboxView,
   inboxLeafSelector,
   inboxResultsSelector,
+  isViewExecuteJaxbError,
   missingInboxSkipMessage,
   noAssignmentsSkipMessage,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-inbox.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-inbox.test.js
@@ -39,6 +39,7 @@ const {
   findInboxView,
   inboxLeafSelector,
   inboxResultsSelector,
+  isViewExecuteJaxbError,
   missingInboxSkipMessage,
   noAssignmentsSkipMessage,
 } = require("../helpers/explorer-inbox");
@@ -138,6 +139,21 @@ describe("explorer-inbox helpers (#3241)", () => {
     assert.match(results, /explorer-view-results-loading/);
     assert.match(results, /explorer-view-results-error/);
     assert.doesNotMatch(results, /data-testid="explorer-view-results"/);
+  });
+
+  it("isViewExecuteJaxbError matches Inbox 400 envelope failures (#3323)", () => {
+    assert.equal(isViewExecuteJaxbError(""), false);
+    assert.equal(isViewExecuteJaxbError("timeout"), false);
+    assert.equal(
+      isViewExecuteJaxbError(
+        'JAXBException occurred: unexpected element (uri:"", local:"startIndex"). Expected elements are <{}ViewExecuteRequest>.',
+      ),
+      true,
+    );
+    assert.equal(
+      isViewExecuteJaxbError("Failed to run view: unexpected element startIndex / ViewExecuteRequest"),
+      true,
+    );
   });
 
   it("skip messages mention leaf vs empty assignments", () => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -63,8 +63,10 @@ folder in the tree), matching the Search panel result actions.
 **Inbox** is always listed under **Views → My Content** (the Desktop Content Explorer
 path `//Views//MyContent/Inbox`, not a separate Explorer root). Selecting **Inbox**
 runs it with the same view execute service as standard views
-(`POST /services/views/{idOrName}/execute`) and shows assignment rows, or an empty
-state when you have no Inbox items.
+(`POST /services/views/{idOrName}/execute`, body wrapped as `ViewExecuteRequest`)
+and shows assignment rows, or an empty state when you have no Inbox items. A
+Retry button appears only for a real execute failure — not for a request-envelope
+mismatch.
 
 Other **custom URL** views (for example Outbox or Recent) stay listed so you can see
 them in the catalog, but they cannot be executed from this Explorer release. Those

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -217,10 +217,11 @@ with the execute call below.
 
 ### Execute request / response
 
-The execute body must use the Jackson / JAXB root name `ViewExecuteRequest`. A
-bare `{ "startIndex": 1, "maxResults": 50 }` object is rejected (`unexpected
-element startIndex`). An empty body is allowed when you need design defaults
-only; if you send JSON, wrap the fields:
+The preferred execute body uses the Jackson / JAXB root name `ViewExecuteRequest`.
+Explorer Inbox and other clients should send that envelope. The server also
+accepts a flat `{ "startIndex": 1, "maxResults": 50 }` object (same fields) so
+Inbox execute is not rejected as `unexpected element startIndex`. An empty body
+is allowed when you need design defaults only. Recommended JSON:
 
 ```json
 {

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -122,6 +122,8 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="validationExceptionMapper" />
             <ref bean="constraintsViolatedExceptionMapper" />
             <ref bean="runtimeExceptionMapper" />
+            <!-- Inbox #3323: bind flat startIndex before jackson UNWRAP_ROOT_VALUE -->
+            <ref bean="viewExecuteRequestJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -53,6 +53,9 @@ class CatalogRestJaxrsRegistrationTest {
     "restContentExplorerFoldersResource",
   };
 
+  /** Inbox execute #3323 — must precede jacksonProvider on rest-jax-rs. */
+  private static final String VIEW_EXECUTE_JSON_READER = "viewExecuteRequestJsonReader";
+
   @Test
   void restJaxRsServiceBeansIncludeDeveloperCatalogResources() throws Exception {
     Path root = resolveRepoRoot();
@@ -75,6 +78,38 @@ class CatalogRestJaxrsRegistrationTest {
           restBlock.contains("bean=\"" + bean + "\""),
           "rest-jax-rs serviceBeans must ref " + bean + " (missing → CXF 404 for catalog REST)");
     }
+  }
+
+  @Test
+  void restJaxRsProvidersIncludeViewExecuteRequestJsonReaderBeforeJackson() throws Exception {
+    Path root = resolveRepoRoot();
+    Path beans =
+        root.resolve(
+            "projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/"
+                + "rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml");
+    assertTrue(Files.isRegularFile(beans), "missing sitemanage-beans.xml at " + beans);
+
+    String xml = Files.readString(beans, StandardCharsets.UTF_8);
+    int restServer = xml.indexOf("id=\"rest-jax-rs\"");
+    assertTrue(restServer >= 0, "rest-jax-rs server must exist in sitemanage-beans.xml");
+    int end = xml.indexOf("</jaxrs:server>", restServer);
+    assertTrue(end > restServer, "rest-jax-rs server block must close");
+    String restBlock = xml.substring(restServer, end);
+    int providers = restBlock.indexOf("<jaxrs:providers>");
+    int providersEnd = restBlock.indexOf("</jaxrs:providers>");
+    assertTrue(providers >= 0 && providersEnd > providers, "rest-jax-rs providers block");
+    String providerBlock = restBlock.substring(providers, providersEnd);
+    int reader = providerBlock.indexOf("bean=\"" + VIEW_EXECUTE_JSON_READER + "\"");
+    int jackson = providerBlock.indexOf("bean=\"jacksonProvider\"");
+    assertTrue(
+        reader >= 0,
+        "rest-jax-rs providers must ref "
+            + VIEW_EXECUTE_JSON_READER
+            + " (missing → Inbox flat startIndex 400)");
+    assertTrue(jackson >= 0, "rest-jax-rs providers must still ref jacksonProvider");
+    assertTrue(
+        reader < jackson,
+        VIEW_EXECUTE_JSON_READER + " must be listed before jacksonProvider");
   }
 
   private static Path resolveRepoRoot() {

--- a/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequest.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequest.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.views;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
@@ -30,6 +31,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * and Searches stay distinct public contracts.
  */
 @XmlRootElement(name = "ViewExecuteRequest")
+@JsonRootName("ViewExecuteRequest")
 @Schema(description = "Optional overrides when executing a CX design view by id or name")
 public class ViewExecuteRequest {
 

--- a/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequestJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewExecuteRequestJsonReader.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for {@link ViewExecuteRequest} that accepts both the JAXB / Jackson
+ * root envelope and a flat paging object.
+ *
+ * <p>CXF {@code UNWRAP_ROOT_VALUE} / JAXB rejects a bare {@code startIndex} field
+ * ({@code unexpected element startIndex}, expected {@code ViewExecuteRequest}).
+ * Explorer Inbox (#3323) historically POSTed that flat shape. This reader binds
+ * either:
+ *
+ * <ul>
+ *   <li>{@code {"ViewExecuteRequest":{"startIndex":1,"maxResults":50}}} (preferred)
+ *   <li>{@code {"startIndex":1,"maxResults":50}} (Inbox / QA residual)
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of
+ * {@code jacksonProvider} so it wins over UNWRAP_ROOT_VALUE.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("viewExecuteRequestJsonReader")
+public class ViewExecuteRequestJsonReader implements MessageBodyReader<ViewExecuteRequest> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so a flat startIndex object is readable. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type != null && ViewExecuteRequest.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public ViewExecuteRequest readFrom(
+      Class<ViewExecuteRequest> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new ViewExecuteRequest();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new ViewExecuteRequest();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind execute JSON. Empty / whitespace is an empty request (design defaults).
+   *
+   * @param json request body; may be null
+   * @return non-null request
+   */
+  public static ViewExecuteRequest parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new ViewExecuteRequest();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid execute request", 400);
+    }
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new ViewExecuteRequest();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("Invalid execute request", 400);
+    }
+    JsonNode nested = firstObject(root, "ViewExecuteRequest", "viewExecuteRequest");
+    JsonNode fields = nested != null ? nested : root;
+    ViewExecuteRequest out = new ViewExecuteRequest();
+    out.setFolderPath(textField(fields, "folderPath"));
+    out.setStartIndex(intField(fields, "startIndex"));
+    out.setMaxResults(intField(fields, "maxResults"));
+    out.setSortColumn(textField(fields, "sortColumn"));
+    out.setSortOrder(textField(fields, "sortOrder"));
+    return out;
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  private static String textField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || !n.isString()) {
+      return null;
+    }
+    String v = n.asString();
+    return v != null && !v.isBlank() ? v : null;
+  }
+
+  private static Integer intField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || !n.isNumber()) {
+      return null;
+    }
+    return n.intValue();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/ViewExecuteResult.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewExecuteResult.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.views;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.List;
  * not share a catalog identity on the wire.
  */
 @XmlRootElement(name = "ViewExecuteResult")
+@JsonRootName("ViewExecuteResult")
 @Schema(description = "Paged Explorer-ready results from executing a CX design view")
 public class ViewExecuteResult {
 

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -121,7 +121,8 @@ public class ViewResource {
               + " format, max results, and case sensitivity. Custom URL views in the Inbox family"
               + " (sys_cxViews/inbox, outbox, recent, session, checkedoutbyme,"
               + " duplicatefolderpaths) invoke the classic app resource and return Explorer rows."
-              + " Optional body may override folder scope (standard views), paging, and sort."
+              + " Optional body may override folder scope (standard views), paging, and sort"
+              + " as a ViewExecuteRequest envelope or a flat startIndex/maxResults object."
               + " Unsupported custom URLs return 400.",
       responses = {
         @ApiResponse(

--- a/rest/src/test/java/com/percussion/rest/views/ViewExecuteRequestJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewExecuteRequestJsonReaderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class ViewExecuteRequestJsonReaderTest {
+
+  private final ViewExecuteRequestJsonReader reader = new ViewExecuteRequestJsonReader();
+
+  @Test
+  public void parseAcceptsWrappedEnvelope() {
+    ViewExecuteRequest out =
+        ViewExecuteRequestJsonReader.parse(
+            "{\"ViewExecuteRequest\":{\"folderPath\":\"/Sites/Foo\","
+                + "\"startIndex\":1,\"maxResults\":50,\"sortColumn\":\"title\","
+                + "\"sortOrder\":\"desc\"}}");
+    assertEquals("/Sites/Foo", out.getFolderPath());
+    assertEquals(1, out.getStartIndex());
+    assertEquals(50, out.getMaxResults());
+    assertEquals("title", out.getSortColumn());
+    assertEquals("desc", out.getSortOrder());
+  }
+
+  @Test
+  public void parseAcceptsFlatStartIndexBody() {
+    ViewExecuteRequest out =
+        ViewExecuteRequestJsonReader.parse("{\"startIndex\":1,\"maxResults\":50}");
+    assertEquals(1, out.getStartIndex());
+    assertEquals(50, out.getMaxResults());
+    assertNull(out.getFolderPath());
+  }
+
+  @Test
+  public void parseAcceptsCamelCaseRootAlias() {
+    ViewExecuteRequest out =
+        ViewExecuteRequestJsonReader.parse(
+            "{\"viewExecuteRequest\":{\"startIndex\":2,\"maxResults\":10}}");
+    assertEquals(2, out.getStartIndex());
+    assertEquals(10, out.getMaxResults());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyRequest() {
+    ViewExecuteRequest empty = ViewExecuteRequestJsonReader.parse("  ");
+    assertNull(empty.getStartIndex());
+    assertNull(ViewExecuteRequestJsonReader.parse(null).getMaxResults());
+  }
+
+  @Test
+  public void parseRejectsNonObject() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> ViewExecuteRequestJsonReader.parse("[1,2]"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void parseRejectsInvalidJson() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> ViewExecuteRequestJsonReader.parse("{"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void readFromReadsUtf8Stream() throws Exception {
+    assertTrue(reader.isReadable(ViewExecuteRequest.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    byte[] raw = "{\"startIndex\":3}".getBytes(StandardCharsets.UTF_8);
+    ViewExecuteRequest out =
+        reader.readFrom(
+            ViewExecuteRequest.class,
+            ViewExecuteRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(raw));
+    assertEquals(3, out.getStartIndex());
+  }
+
+  @Test
+  public void readFromEmptyStreamIsEmptyRequest() throws Exception {
+    ViewExecuteRequest out =
+        reader.readFrom(
+            ViewExecuteRequest.class,
+            ViewExecuteRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(new byte[0]));
+    assertNull(out.getStartIndex());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/views/ViewExecuteRequestSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewExecuteRequestSerialDeserialTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.views;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link ViewExecuteRequest} under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE.
+ *
+ * <p>SPA execute (#3318) sends {@code {"ViewExecuteRequest":{…}}}. Inbox (#3323) must not 400
+ * when a client still posts a flat {@code startIndex} — that path is {@link
+ * ViewExecuteRequestJsonReader}, not this mapper.
+ */
+@Tag("UnitTest")
+public class ViewExecuteRequestSerialDeserialTest {
+
+  private final ObjectMapper mapper =
+      new JacksonContextResolver().getContext(ViewExecuteRequest.class);
+
+  @Test
+  public void serializesUnderViewExecuteRequestRoot() {
+    ViewExecuteRequest req = new ViewExecuteRequest();
+    req.setStartIndex(1);
+    req.setMaxResults(50);
+    String json = mapper.writeValueAsString(req);
+    assertTrue(json.contains("\"ViewExecuteRequest\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"startIndex\""), json);
+  }
+
+  @Test
+  public void deserializesWrappedBody() {
+    String json = "{\"ViewExecuteRequest\":{\"startIndex\":4,\"maxResults\":25}}";
+    ViewExecuteRequest req = mapper.readValue(json, ViewExecuteRequest.class);
+    assertEquals(4, req.getStartIndex());
+    assertEquals(25, req.getMaxResults());
+  }
+}


### PR DESCRIPTION
## Summary

Content Explorer **Views → My Content → Inbox** POSTed `POST /services/views/Inbox/execute` with a paging object whose first field is `startIndex`. CXF JAXB / Jackson `UNWRAP_ROOT_VALUE` expected the `@XmlRootElement` root `ViewExecuteRequest`, which produced HTTP 400:

`JAXBException occurred: unexpected element (uri:"", local:"startIndex"). Expected elements are <{}ViewExecuteRequest>.`

#3320 already wrapped the SPA `executeView` body. This PR hardens the **server** so Inbox still succeeds if a client posts the flat QA payload, keeps the SPA wrap, and stops Playwright from soft-skipping the JAXB residual.

- New `ViewExecuteRequestJsonReader` binds both `{ "ViewExecuteRequest": { … } }` and `{ "startIndex", "maxResults" }`.
- Registered on `rest-jax-rs` **before** `jacksonProvider`.
- `@JsonRootName` on `ViewExecuteRequest` / `ViewExecuteResult`.
- Vitest: Inbox default `executeView` POST envelope; viewsApi Inbox paging wrap.
- `explorer-inbox.spec.js` fails on JAXB `startIndex` / `ViewExecuteRequest` (does not skip).
- Product docs: execute envelope + Inbox leaf.

Does **not** mark DCE gap-matrix Present.

Parent tracker: #3118 (I1 Inbox) / reality-check #3102. Related #3318 / #3320 (V1 wrap).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3323
Partial #3118
Related #3102

## Test plan

1. Vitest: Inbox shell uses default `executeView` and POSTs `{ ViewExecuteRequest: { startIndex, maxResults } }` (`WebUI` standalone clean install).
2. Rest: `ViewExecuteRequestJsonReaderTest` (wrapped + flat) + serial/deserial wrap (`rest` standalone clean install).
3. Sitemanage: `CatalogRestJaxrsRegistrationTest` asserts provider ref before jacksonProvider.
4. Node: `node --test tests/unit/explorer-inbox.test.js` (`isViewExecuteJaxbError`).
5. H2 QA (when #3342 is green): `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL` from stdout → hot-copy WebUI modern assets + rest/sitemanage jars if needed → `npm run test:surface -- --path tests/explorer-inbox.spec.js` and `explorer-views-catalog.spec.js`. **This run skipped qa-up because #3342 is still OPEN.**
6. Click Explorer → Views → My Content → Inbox: results or empty state, not JAXB Retry.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (flat body accepted) and `product-docs/8.2/admin/content-explorer.md` (Inbox execute envelope)
- [x] **Unit / module tests** — reader + serial/deserial; Vitest payload; Playwright helper; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `explorer-inbox.spec.js` asserts wrap and fails on JAXB (does not skip)
- [x] **Build gates** — standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O; XML path resolve uses `Path`)

## C3 evidence

- **modules_built:** `rest`, `WebUI`, `projects/sitemanage`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest && ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire `Tests run: 362, Failures: 0, Errors: 0, Skipped: 0` (includes `ViewExecuteRequestJsonReaderTest` 8, `ViewExecuteRequestSerialDeserialTest` 2)
  - `cd WebUI && ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire `Tests run: 53, Failures: 0`
  - `cd projects/sitemanage && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire `Tests run: 1112, Failures: 0, Errors: 0, Skipped: 125`; `CatalogRestJaxrsRegistrationTest` 2 passed
  - `cd modules/perc-qa-automation && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
  - `node --test tests/unit/explorer-inbox.test.js tests/unit/explorer-views.test.js` → **22 passed**
  - `scripts\ci-smoke-product-docs.bat` → **OK**
- **downstream_checked:** grepped monorepo for `extends ViewExecuteRequest` and `new ViewExecuteRequest() {` — none. Standalone `projects/sitemanage` clean install after rest install (uses `ViewExecuteRequest`; provider XML + registration test).

## C5 UI proof

- **Skipped qa-up:** issue #3342 (`Playwright: qa-up H2 cell start`) is still **OPEN**, not green. Overnight policy: qa-up only if #3342 is green; always qa-down.
- Playwright specs updated for surface `tests/explorer-inbox.spec.js` (JAXB fail-not-skip + wrap assert). Live H2 proof remains for a later cycle when the QA cell starts.

> Co-Authored by Grok Build using grok-4.5 with agent main.
