### PR TITLE
[8.2] utils: drop XmlSer blanket suppress and scoped cast residuals

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3172-utils-javac-residuals-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3172-utils-javac-residuals-erlang.md
@@ -1,0 +1,44 @@
+# Erlang review — issue #3172 utils javac residual batch
+
+- **Branch:** `fix/issue-3172-utils-javac-residuals`
+- **Scope:** uncommitted + vs `origin/main` in `modules/utils` (plus this report)
+- **Date:** 2026-08-13
+- **Reviewer persona:** Erlang (independent of implementer)
+- **Memory patterns hit:** missing behavioral tests; incomplete change-class closure (not applicable — no Spring/UI/adaptor surface); non-portable paths (none)
+
+## Summary
+
+Safe utils main-source suppression batch after #3015. Does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map APIs. Changes:
+
+1. `PSXmlSerializationHelper` — drop class-level `@SuppressWarnings({"rawtypes","unchecked"})`; parameterize leftover raw `Class` as `Class<?>` (erasure-identical).
+2. `PSCollection(String)` — assign `Class.forName` to existing `Class<?>` field instead of an unchecked `Class<? extends E>` ctor cast.
+3. `PSItemIterator` — collapse two method-scoped unchecked casts into one private `asItem` helper (no new blanket suppress).
+
+`PSCopier` nested-map `(V)` and `PSConcurrentList.restoreList` remain inherent deserialization/recursion residuals. `ConfigurationContextAbstract` already has no suppressions after batch 8.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- **Bugs:** none found
+- **Behavioral tests:** present for className ctor, `readFromXML(String, Class<?>)`, and multi-map non-Collection rejection
+- **Cross-platform paths:** N/A (no filesystem path I/O in this diff)
+- **May commit/push:** yes
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- `Class` → `Class<?>` is a public static signature widening; bytecode erasure is unchanged. No `extends PSXmlSerializationHelper` / anonymous subclass sites.
+- Multi-map detection still uses `!(m_map instanceof HashMap)` (pre-existing). New test uses `TreeMap` because `LinkedHashMap` is a `HashMap`.
+- Remaining `PSWorkflowUtilsBase` raw public API stays out of this PR by source-compat policy (issue body).
+
+## Test evidence
+
+- `cd modules/utils && ../../mvnw.cmd clean install`
+- `BUILD SUCCESS`
+- `Tests run: 387, Failures: 0, Errors: 0, Skipped: 9`

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -64,7 +64,6 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * @author dougrand
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXmlSerializationHelper {
   /** Static for logging */
   private static final Logger log = LogManager.getLogger(PSXmlSerializationHelper.class);
@@ -251,7 +250,7 @@ public class PSXmlSerializationHelper {
    * @throws IOException
    * @throws SAXException
    */
-  public static synchronized Object readFromXML(String xmlString, Class clazz)
+  public static synchronized Object readFromXML(String xmlString, Class<?> clazz)
       throws IOException, SAXException {
     if (StringUtils.isBlank(xmlString)) {
       throw new IllegalArgumentException("xmlString may not be null or empty");
@@ -265,7 +264,7 @@ public class PSXmlSerializationHelper {
    * @param xmlString never blank
    * @param clazz target type, may be {@code null} (resolved from root via type map)
    */
-  private static Object readFromXMLJackson(String xmlString, Class clazz)
+  private static Object readFromXMLJackson(String xmlString, Class<?> clazz)
       throws IOException, SAXException {
     Class<?> target = clazz;
     String parseXml = rewriteLegacyNullRoot(xmlString, target);

--- a/modules/utils/src/main/java/com/percussion/util/PSCollection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSCollection.java
@@ -53,9 +53,9 @@ public class PSCollection<E> extends PSConcurrentList<E> {
    * @param className the name of the class which this collection's members must be or extend
    * @exception ClassNotFoundException if the specified class cannot be found
    */
-  @SuppressWarnings("unchecked")
   public PSCollection(String className) throws ClassNotFoundException {
-    this((Class<? extends E>) Class.forName(className));
+    super();
+    m_memberClass = Class.forName(className);
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/utils/jsr170/PSItemIterator.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jsr170/PSItemIterator.java
@@ -84,9 +84,7 @@ public abstract class PSItemIterator<M> {
     // declaration; the cast to M is safe per the iteration contract documented on m_map.
     List<M> values = new ArrayList<>();
     for (Object v : m_map.values()) {
-      @SuppressWarnings("unchecked")
-      M m = (M) v;
-      values.add(m);
+      values.add(asItem(v));
     }
     if (m_filter != null) {
       FilterIterator<M> fi = new FilterIterator<>(values.iterator(), m_filter);
@@ -102,10 +100,8 @@ public abstract class PSItemIterator<M> {
       Collection<? extends M> collection;
       if (value instanceof Collection<?>) {
         // Per the iteration contract, the collection's elements are M. The unchecked cast is
-        // documented on the field declaration; this site is the single rewrap that needs it.
-        @SuppressWarnings("unchecked")
-        Collection<? extends M> typed = (Collection<? extends M>) value;
-        collection = typed;
+        // isolated in {@link #asItem(Object)} (same residual as simple-map values).
+        collection = asItem(value);
       } else if (value == null) {
         collection = null;
       } else {
@@ -116,6 +112,19 @@ public abstract class PSItemIterator<M> {
       multi.put(e.getKey(), collection);
     }
     return multi;
+  }
+
+  /**
+   * Reinterpret a {@code Map<?, ?>} value (or multi-map {@code Collection}) as {@code T}. The
+   * iterator contract documents that simple-map values are {@code M} and multi-map values are
+   * {@code Collection<? extends M>}; this is the single unchecked residual for that contract.
+   *
+   * @param value map payload, may be {@code null}
+   * @return {@code value} as {@code T}
+   */
+  @SuppressWarnings("unchecked")
+  private static <T> T asItem(Object value) {
+    return (T) value;
   }
 
   // Type and ParameterizedType imports removed; no longer used.

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
@@ -304,6 +304,22 @@ class PSXmlSerializationHelperTest {
   }
 
   @Test
+  void readFromXmlAcceptsExplicitClassWildcard() throws Exception {
+    PSJacksonXmlSerializationHelperTest.SampleKeyword original = jacksonPilotKeyword();
+    String xml = PSXmlSerializationHelper.writeToXml(original);
+    Class<?> type = PSJacksonXmlSerializationHelperTest.SampleKeyword.class;
+    Object restored = PSXmlSerializationHelper.readFromXML(xml, type);
+    assertNotNull(restored);
+    assertTrue(restored instanceof PSJacksonXmlSerializationHelperTest.SampleKeyword);
+    PSJacksonXmlSerializationHelperTest.SampleKeyword keyword =
+        (PSJacksonXmlSerializationHelperTest.SampleKeyword) restored;
+    assertEquals(original.getLabel(), keyword.getLabel());
+    assertEquals(original.getValue(), keyword.getValue());
+    assertEquals(1, keyword.getChoices().size());
+    assertEquals("ACT", keyword.getChoices().get(0).getLabel());
+  }
+
+  @Test
   void addTypeRegistersOnJacksonHelper() {
     class LocalMarker {
       // marker type for registry only

--- a/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSCollectionTypedTest.java
@@ -48,6 +48,17 @@ public class PSCollectionTypedTest {
 
   @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
+  public void classNameCtorLoadsMemberClassWithoutUncheckedCast() throws ClassNotFoundException {
+    PSCollection<String> coll = new PSCollection<>(String.class.getName());
+    assertEquals(String.class, coll.getMemberClassType());
+    assertTrue(coll.add("ok"));
+    PSCollection raw = coll;
+    assertThrows(ClassCastException.class, () -> raw.add(Integer.valueOf(1)));
+    assertThrows(ClassNotFoundException.class, () -> new PSCollection("no.such.Type" + System.nanoTime()));
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void addAllRejectsWrongElementType() {
     PSCollection<String> coll = new PSCollection<>(String.class);
     coll.add("ok");

--- a/modules/utils/src/test/java/com/percussion/utils/PSItemIteratorTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/PSItemIteratorTest.java
@@ -17,6 +17,7 @@
 package com.percussion.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.utils.jsr170.PSItemIterator;
@@ -262,5 +263,18 @@ public class PSItemIteratorTest {
     assertTrue(result.contains("aa"));
     assertTrue(result.contains("ab"));
     assertTrue(result.contains("ac"));
+  }
+
+  /**
+   * Non-{@link HashMap} sources are treated as multi-maps. A value that is not a {@link
+   * java.util.Collection} must fail fast rather than being silently treated as a single item.
+   */
+  @Test
+  public void multiMapRejectsNonCollectionValues() {
+    Map<String, Object> notAMulti = new java.util.TreeMap<>();
+    notAMulti.put("aa", new TestItem("aa"));
+    ClassCastException thrown =
+        assertThrows(ClassCastException.class, () -> new TestItemIterator(notAMulti, null));
+    assertTrue(thrown.getMessage().contains("Collection"), thrown.getMessage());
   }
 }


### PR DESCRIPTION
## Summary

Second implementable residual after utils batch 8 (#3015 / PR #3173) and the merged CRTP slice (PR #3277). This PR removes more **main-source** suppressions without touching `PSWorkflowUtilsBase` public raw `List`/`Map` APIs (source-compat; still needs an explicit policy).

- **`PSXmlSerializationHelper`:** drop class-level `@SuppressWarnings({"rawtypes","unchecked"})`. Parameterize leftover raw `Class` as `Class<?>` on `readFromXML` / Jackson path (erasure-identical).
- **`PSCollection(String)`:** assign `Class.forName` to the existing `Class<?>` field instead of an unchecked `Class<? extends E>` constructor cast.
- **`PSItemIterator`:** collapse two method-scoped unchecked `Map<?,?>` casts into one private `asItem` helper (no new blanket suppress).

**Not in this PR (policy / inherent):**

- `PSWorkflowUtilsBase` public raw `List`/`Map` APIs.
- `PSCopier` nested `Map`-as-`V` unchecked (generic recursion).
- `PSConcurrentList.restoreList` generic deserialization cast.

Parent tracker: #2200. Module parent: #2016. Prior slice: #3277.

Fixes #3172

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd modules/utils && ..\..\mvnw.cmd clean install` (Windows) or `../../mvnw clean install` (Unix).
2. Confirm new tests: `PSXmlSerializationHelperTest.readFromXmlAcceptsExplicitClassWildcard`, `PSCollectionTypedTest.classNameCtorLoadsMemberClassWithoutUncheckedCast`, `PSItemIteratorTest.multiMapRejectsNonCollectionValues`.
3. No UI / Playwright — internal generics only.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal javac/generics tech-debt; no operator/admin/API behavior change
- [x] **Unit / module tests** — behavioral tests for Class<?> read, className ctor, multi-map reject; standalone `modules/utils` `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install (no skipTests); C2 greps for `extends PSXmlSerializationHelper` / anonymous subclass
- [x] **Cross-platform** — N/A (no path/file I/O in this change)

## C3 evidence

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **387**, Failures: **0**, Errors: **0**, Skipped: **9**
- **downstream_checked:** C2 applied (`Class` → `Class<?>` public static param; same erasure). Grep monorepo `extends PSXmlSerializationHelper` and `new PSXmlSerializationHelper` → no subclasses. No `final`/`sealed`. Downstream standalone not required.

## C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build using grok-4.5 with agent main.
