### PR TITLE
fix(webui): Navigation tree keyboard a11y (Tab/arrows/Home/End) (#3354)

### DIFF
--- a/WebUI/src/main/ts/architecture/NavTree.tsx
+++ b/WebUI/src/main/ts/architecture/NavTree.tsx
@@ -16,11 +16,11 @@
  */
 
 /**
- * Accessible navigation tree for Architecture (#3095 / #3096).
+ * Accessible navigation tree for Architecture (#3095 / #3096 / #3354).
  *
- * <p>Uses ARIA tree / treeitem + keyboard expand/collapse and focus movement
- * (peer: ExplorerTree). Structure mutations are driven from the shell toolbar
- * against the selected node.</p>
+ * <p>Uses ARIA tree / treeitem + APG keyboard (Tab in, arrows, Home/End,
+ * no trap). Structure mutations are driven from the shell toolbar against
+ * the selected node.</p>
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -29,7 +29,8 @@ import { catalogColors } from "../developer/catalogStyles";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
 import type { SectionType } from "../api/architecture/types";
 import { isNavBranch } from "./treeModel";
-import { ARCH_MSG } from "./messages";
+import { ARCH_MSG, ARCH_MSG_KEYS } from "./messages";
+import { collectVisibleNavNodes, resolveNavTreeKey } from "./navTreeKeyboard";
 
 /** i18n type badge for nav tree rows (#3098). */
 function typeBadgeLabel(sectionType: SectionType | string): string | null {
@@ -97,9 +98,18 @@ function nodeRowStyle(
       : "3px solid transparent",
     fontSize: "0.95rem",
     lineHeight: 1.35,
-    outline: "none",
   };
 }
+
+const TREE_ITEM_FOCUS_CSS = `
+.perc-architecture-nav-tree-item:focus {
+  outline: none;
+}
+.perc-architecture-nav-tree-item:focus-visible {
+  outline: 2px solid ${catalogColors.accent};
+  outline-offset: -2px;
+}
+`;
 
 const toggleStyle: React.CSSProperties = {
   display: "inline-flex",
@@ -123,36 +133,6 @@ const badgeStyle: React.CSSProperties = {
   background: "#fff",
 };
 
-/** Flatten visible nodes in document order for arrow up/down. */
-function collectVisible(
-  node: NavTreeNode,
-  expanded: Record<string, boolean>,
-  out: NavTreeNode[] = [],
-): NavTreeNode[] {
-  out.push(node);
-  if (isNavBranch(node) && (expanded[node.id] ?? false)) {
-    for (const child of node.children) {
-      collectVisible(child, expanded, out);
-    }
-  }
-  return out;
-}
-
-/** Parent id map for ArrowLeft focus-to-parent. */
-function buildParentMap(
-  node: NavTreeNode,
-  parentId: string | null = null,
-  map: Map<string, string | null> = new Map(),
-): Map<string, string | null> {
-  map.set(node.id, parentId);
-  if (node.children?.length) {
-    for (const child of node.children) {
-      buildParentMap(child, node.id, map);
-    }
-  }
-  return map;
-}
-
 /**
  * Site navigation tree (navons / sections) with selection for structure actions.
  */
@@ -164,6 +144,9 @@ export function NavTree({
   onSelect,
 }: NavTreeProps): React.ReactElement {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [focusedId, setFocusedId] = useState<string | null>(
+    selectedId ?? root?.id ?? null,
+  );
   const treeRef = useRef<HTMLDivElement | null>(null);
 
   const rootId = root?.id ?? null;
@@ -174,6 +157,21 @@ export function NavTree({
       );
     }
   }, [rootId]);
+
+  useEffect(() => {
+    setFocusedId(selectedId ?? rootId);
+  }, [rootId, selectedId]);
+
+  useEffect(() => {
+    if (!root || !focusedId) return;
+    const visible = collectVisibleNavNodes(root, expanded);
+    if (visible.some((n) => n.id === focusedId)) {
+      return;
+    }
+    const selectedVisible =
+      selectedId != null && visible.some((n) => n.id === selectedId);
+    setFocusedId(selectedVisible ? selectedId : (visible[0]?.id ?? root.id));
+  }, [root, expanded, focusedId, selectedId]);
 
   const toggle = useCallback((id: string) => {
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -186,6 +184,7 @@ export function NavTree({
   }, []);
 
   const focusItem = useCallback((id: string) => {
+    setFocusedId(id);
     const el = treeRef.current?.querySelector<HTMLElement>(
       `[data-testid="nav-tree-item-${id}"]`,
     );
@@ -195,69 +194,32 @@ export function NavTree({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, node: NavTreeNode) => {
       if (!root) return;
-      const branch = isNavBranch(node);
-      const open = expanded[node.id] ?? false;
-      const visible = collectVisible(root, expanded);
-      const parentMap = buildParentMap(root);
-      const idx = visible.findIndex((n) => n.id === node.id);
-
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
+      const result = resolveNavTreeKey(e.key, node, root, expanded);
+      if (result.action === "none") {
+        return;
+      }
+      e.preventDefault();
+      if (result.action === "prevent") {
+        return;
+      }
+      if (result.action === "select") {
         onSelect?.(node);
-        if (branch) toggle(node.id);
+        setFocusedId(node.id);
+        if (result.toggleExpand) toggle(node.id);
         return;
       }
-
-      if (e.key === "ArrowRight") {
-        e.preventDefault();
-        if (branch && !open) {
-          setExpandedOpen(node.id, true);
-          return;
-        }
-        if (branch && open && node.children.length > 0) {
-          focusItem(node.children[0].id);
-        }
+      if (result.action === "expand") {
+        setExpandedOpen(result.id, true);
+        setFocusedId(result.id);
         return;
       }
-
-      if (e.key === "ArrowLeft") {
-        e.preventDefault();
-        if (branch && open) {
-          setExpandedOpen(node.id, false);
-          return;
-        }
-        const parentId = parentMap.get(node.id);
-        if (parentId) {
-          focusItem(parentId);
-        }
+      if (result.action === "collapse") {
+        setExpandedOpen(result.id, false);
+        setFocusedId(result.id);
         return;
       }
-
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        if (idx >= 0 && idx < visible.length - 1) {
-          focusItem(visible[idx + 1].id);
-        }
-        return;
-      }
-
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        if (idx > 0) {
-          focusItem(visible[idx - 1].id);
-        }
-        return;
-      }
-
-      if (e.key === "Home") {
-        e.preventDefault();
-        if (visible.length > 0) focusItem(visible[0].id);
-        return;
-      }
-
-      if (e.key === "End") {
-        e.preventDefault();
-        if (visible.length > 0) focusItem(visible[visible.length - 1].id);
+      if (result.action === "focus") {
+        focusItem(result.id);
       }
     },
     [root, expanded, onSelect, toggle, setExpandedOpen, focusItem],
@@ -271,10 +233,12 @@ export function NavTree({
     const open = expanded[node.id] ?? false;
     const selected = selectedId === node.id;
     const typeBadge = typeBadgeLabel(node.sectionType);
-    // Roving tabindex: selected item, else root when nothing selected
+    // Roving tabindex follows last focused item (Tab lands there; others -1).
     const isTabStop =
-      selected ||
-      (selectedId == null && root != null && node.id === root.id);
+      focusedId != null
+        ? node.id === focusedId
+        : selected ||
+          (selectedId == null && root != null && node.id === root.id);
 
     return (
       <div key={node.id} data-testid={`nav-tree-node-${node.id}`}>
@@ -284,10 +248,14 @@ export function NavTree({
           aria-expanded={branch ? open : undefined}
           aria-selected={selected}
           tabIndex={isTabStop ? 0 : -1}
+          className="perc-architecture-nav-tree-item"
           data-testid={`nav-tree-item-${node.id}`}
           data-section-type={node.sectionType}
           style={nodeRowStyle(selected, depth)}
-          onClick={() => onSelect?.(node)}
+          onClick={() => {
+            setFocusedId(node.id);
+            onSelect?.(node);
+          }}
           onKeyDown={(e) => handleKeyDown(e, node)}
         >
           <span
@@ -319,6 +287,9 @@ export function NavTree({
               <span
                 style={badgeStyle}
                 title={ARCH_MSG.SECURE_TITLE}
+                aria-label={ARCH_MSG.SECURE_TITLE}
+                data-i18n-key={ARCH_MSG_KEYS.SECURE_TITLE}
+                data-i18n-badge-key={ARCH_MSG_KEYS.SECURE_BADGE}
                 data-testid={`nav-tree-secure-${node.id}`}
               >
                 {ARCH_MSG.SECURE_BADGE}
@@ -395,6 +366,7 @@ export function NavTree({
         role="tree"
         aria-label={ARCH_MSG.TREE_PANEL_TITLE}
       >
+        <style>{TREE_ITEM_FOCUS_CSS}</style>
         {renderNode(root, 0)}
       </div>
     );

--- a/WebUI/src/main/ts/architecture/index.ts
+++ b/WebUI/src/main/ts/architecture/index.ts
@@ -54,6 +54,14 @@ export type {
 export { ARCH_MSG, ARCH_MSG_KEYS } from "./messages";
 export type { ArchitectureMsgKey } from "./messages";
 export {
+  buildNavParentMap,
+  collectVisibleNavNodes,
+  isNavTreeRovingKey,
+  NAV_TREE_ROVING_KEYS,
+  resolveNavTreeKey,
+} from "./navTreeKeyboard";
+export type { NavTreeKeyResult, NavTreeRovingKey } from "./navTreeKeyboard";
+export {
   countNavTreeNodes,
   flattenNavTree,
   isNavBranch,

--- a/WebUI/src/main/ts/architecture/navTreeKeyboard.ts
+++ b/WebUI/src/main/ts/architecture/navTreeKeyboard.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure ARIA tree keyboard helpers for Navigation (#3354 / QA #3155).
+ *
+ * <p>Tab / Shift+Tab are intentionally not consumed so focus can enter and
+ * leave the tree (no keyboard trap). Arrow / Home / End / Enter / Space
+ * follow the APG tree pattern.</p>
+ */
+
+import type { NavTreeNode } from "../api/architecture/types";
+import { isNavBranch } from "./treeModel";
+
+/** Keys the tree owns (preventDefault). Tab is not in this set. */
+export const NAV_TREE_ROVING_KEYS = [
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "Enter",
+  " ",
+] as const;
+
+export type NavTreeRovingKey = (typeof NAV_TREE_ROVING_KEYS)[number];
+
+export type NavTreeKeyResult =
+  | { action: "none" }
+  | { action: "prevent" }
+  | { action: "select"; id: string; toggleExpand: boolean }
+  | { action: "expand"; id: string }
+  | { action: "collapse"; id: string }
+  | { action: "focus"; id: string };
+
+/** True for keys the Navigation tree must handle (not Tab). */
+export function isNavTreeRovingKey(key: string): key is NavTreeRovingKey {
+  return (NAV_TREE_ROVING_KEYS as readonly string[]).includes(key);
+}
+
+/** Flatten visible nodes in document order for Arrow Up/Down and Home/End. */
+export function collectVisibleNavNodes(
+  node: NavTreeNode,
+  expanded: Record<string, boolean>,
+  out: NavTreeNode[] = [],
+): NavTreeNode[] {
+  out.push(node);
+  if (isNavBranch(node) && (expanded[node.id] ?? false)) {
+    for (const child of node.children) {
+      collectVisibleNavNodes(child, expanded, out);
+    }
+  }
+  return out;
+}
+
+/** Parent id map for ArrowLeft focus-to-parent. */
+export function buildNavParentMap(
+  node: NavTreeNode,
+  parentId: string | null = null,
+  map: Map<string, string | null> = new Map(),
+): Map<string, string | null> {
+  map.set(node.id, parentId);
+  if (node.children?.length) {
+    for (const child of node.children) {
+      buildNavParentMap(child, node.id, map);
+    }
+  }
+  return map;
+}
+
+/**
+ * Resolve an ARIA tree key to a command. {@code none} means the event must
+ * not be prevented (Tab, typing, etc.). {@code prevent} means consume the
+ * key but do not change selection or expansion (boundary / no-op).
+ */
+export function resolveNavTreeKey(
+  key: string,
+  node: NavTreeNode,
+  root: NavTreeNode,
+  expanded: Record<string, boolean>,
+): NavTreeKeyResult {
+  if (!isNavTreeRovingKey(key)) {
+    return { action: "none" };
+  }
+
+  const branch = isNavBranch(node);
+  const open = expanded[node.id] ?? false;
+  const visible = collectVisibleNavNodes(root, expanded);
+  const parentMap = buildNavParentMap(root);
+  const idx = visible.findIndex((n) => n.id === node.id);
+
+  if (key === "Enter" || key === " ") {
+    return { action: "select", id: node.id, toggleExpand: branch };
+  }
+
+  if (key === "ArrowRight") {
+    if (branch && !open) {
+      return { action: "expand", id: node.id };
+    }
+    if (branch && open && node.children.length > 0) {
+      return { action: "focus", id: node.children[0].id };
+    }
+    return { action: "prevent" };
+  }
+
+  if (key === "ArrowLeft") {
+    if (branch && open) {
+      return { action: "collapse", id: node.id };
+    }
+    const parentId = parentMap.get(node.id);
+    if (parentId) {
+      return { action: "focus", id: parentId };
+    }
+    return { action: "prevent" };
+  }
+
+  if (key === "ArrowDown") {
+    if (idx >= 0 && idx < visible.length - 1) {
+      return { action: "focus", id: visible[idx + 1].id };
+    }
+    return { action: "prevent" };
+  }
+
+  if (key === "ArrowUp") {
+    if (idx > 0) {
+      return { action: "focus", id: visible[idx - 1].id };
+    }
+    return { action: "prevent" };
+  }
+
+  if (key === "Home") {
+    if (visible.length > 0) {
+      return { action: "focus", id: visible[0].id };
+    }
+    return { action: "prevent" };
+  }
+
+  if (key === "End") {
+    if (visible.length > 0) {
+      return { action: "focus", id: visible[visible.length - 1].id };
+    }
+    return { action: "prevent" };
+  }
+
+  return { action: "none" };
+}

--- a/WebUI/src/test/ts/architecture/NavTree.test.tsx
+++ b/WebUI/src/test/ts/architecture/NavTree.test.tsx
@@ -105,6 +105,42 @@ describe("NavTree (#3095 / #3354)", () => {
     expect(screen.queryByTestId("nav-tree-item-link-1")).toBeNull();
   });
 
+  it("selects with Enter/Space via handleKeyDown and toggles branches", () => {
+    const onSelect = vi.fn();
+    render(
+      <NavTree root={sampleRoot} selectedId="root" onSelect={onSelect} />,
+    );
+    const leaf = screen.getByTestId("nav-tree-item-link-1");
+    leaf.focus();
+    expect(fireEvent.keyDown(leaf, { key: "Enter" })).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "link-1" }),
+    );
+    expect(screen.getByTestId("nav-tree-item-link-1")).toBeTruthy();
+
+    onSelect.mockClear();
+    expect(fireEvent.keyDown(leaf, { key: " " })).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "link-1" }),
+    );
+
+    onSelect.mockClear();
+    const rootItem = screen.getByTestId("nav-tree-item-root");
+    rootItem.focus();
+    expect(fireEvent.keyDown(rootItem, { key: "Enter" })).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "root" }),
+    );
+    expect(screen.queryByTestId("nav-tree-item-link-1")).toBeNull();
+
+    onSelect.mockClear();
+    expect(fireEvent.keyDown(rootItem, { key: " " })).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "root" }),
+    );
+    expect(screen.getByTestId("nav-tree-item-link-1")).toBeTruthy();
+  });
+
   it("moves focus with Home/End and Arrow Right into a child", () => {
     render(
       <NavTree root={sampleRoot} selectedId="root" onSelect={() => undefined} />,

--- a/WebUI/src/test/ts/architecture/NavTree.test.tsx
+++ b/WebUI/src/test/ts/architecture/NavTree.test.tsx
@@ -19,6 +19,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NavTree } from "../../../main/ts/architecture/NavTree";
+import { ARCH_MSG_KEYS } from "../../../main/ts/architecture/messages";
 import type { NavTreeNode } from "../../../main/ts/api/architecture/types";
 
 const sampleRoot: NavTreeNode = {
@@ -47,7 +48,7 @@ const sampleRoot: NavTreeNode = {
   ],
 };
 
-describe("NavTree (#3095)", () => {
+describe("NavTree (#3095 / #3354)", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => {
@@ -76,6 +77,11 @@ describe("NavTree (#3095)", () => {
     const secure = screen.getByTestId("nav-tree-secure-ext-1");
     expect(secure).toBeTruthy();
     expect(secure.getAttribute("title")).toMatch(/requires login/i);
+    expect(secure.getAttribute("aria-label")).toMatch(/requires login/i);
+    expect(secure.getAttribute("data-i18n-key")).toBe(ARCH_MSG_KEYS.SECURE_TITLE);
+    expect(secure.getAttribute("data-i18n-badge-key")).toBe(
+      ARCH_MSG_KEYS.SECURE_BADGE,
+    );
     expect(secure.textContent).toMatch(/secure/i);
   });
 
@@ -97,6 +103,46 @@ describe("NavTree (#3095)", () => {
     );
     fireEvent.keyDown(rootItem, { key: "ArrowLeft" });
     expect(screen.queryByTestId("nav-tree-item-link-1")).toBeNull();
+  });
+
+  it("moves focus with Home/End and Arrow Right into a child", () => {
+    render(
+      <NavTree root={sampleRoot} selectedId="root" onSelect={() => undefined} />,
+    );
+    const rootItem = screen.getByTestId("nav-tree-item-root");
+    rootItem.focus();
+    fireEvent.keyDown(rootItem, { key: "End" });
+    expect(document.activeElement?.getAttribute("data-testid")).toBe(
+      "nav-tree-item-ext-1",
+    );
+    fireEvent.keyDown(screen.getByTestId("nav-tree-item-ext-1"), {
+      key: "Home",
+    });
+    expect(document.activeElement?.getAttribute("data-testid")).toBe(
+      "nav-tree-item-root",
+    );
+    fireEvent.keyDown(screen.getByTestId("nav-tree-item-root"), {
+      key: "ArrowRight",
+    });
+    expect(document.activeElement?.getAttribute("data-testid")).toBe(
+      "nav-tree-item-link-1",
+    );
+    expect(screen.getByTestId("nav-tree-item-root").getAttribute("tabindex")).toBe(
+      "-1",
+    );
+    expect(screen.getByTestId("nav-tree-item-link-1").getAttribute("tabindex")).toBe(
+      "0",
+    );
+  });
+
+  it("does not trap Tab (default is not prevented)", () => {
+    render(
+      <NavTree root={sampleRoot} selectedId="root" onSelect={() => undefined} />,
+    );
+    const rootItem = screen.getByTestId("nav-tree-item-root");
+    rootItem.focus();
+    expect(fireEvent.keyDown(rootItem, { key: "Tab" })).toBe(true);
+    expect(fireEvent.keyDown(rootItem, { key: "ArrowDown" })).toBe(false);
   });
 
   it("reports selection and collapses via toggle", () => {

--- a/WebUI/src/test/ts/architecture/NavTree.test.tsx
+++ b/WebUI/src/test/ts/architecture/NavTree.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, createEvent, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NavTree } from "../../../main/ts/architecture/NavTree";
@@ -47,6 +47,13 @@ const sampleRoot: NavTreeNode = {
     },
   ],
 };
+
+/** RTL fireEvent returns !defaultPrevented; assert the event flag directly. */
+function keyDownDefaultPrevented(el: HTMLElement, key: string): boolean {
+  const ev = createEvent.keyDown(el, { key });
+  fireEvent(el, ev);
+  return ev.defaultPrevented;
+}
 
 describe("NavTree (#3095 / #3354)", () => {
   beforeEach(() => {
@@ -112,14 +119,14 @@ describe("NavTree (#3095 / #3354)", () => {
     );
     const leaf = screen.getByTestId("nav-tree-item-link-1");
     leaf.focus();
-    expect(fireEvent.keyDown(leaf, { key: "Enter" })).toBe(false);
+    expect(keyDownDefaultPrevented(leaf, "Enter")).toBe(true);
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: "link-1" }),
     );
     expect(screen.getByTestId("nav-tree-item-link-1")).toBeTruthy();
 
     onSelect.mockClear();
-    expect(fireEvent.keyDown(leaf, { key: " " })).toBe(false);
+    expect(keyDownDefaultPrevented(leaf, " ")).toBe(true);
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: "link-1" }),
     );
@@ -127,14 +134,14 @@ describe("NavTree (#3095 / #3354)", () => {
     onSelect.mockClear();
     const rootItem = screen.getByTestId("nav-tree-item-root");
     rootItem.focus();
-    expect(fireEvent.keyDown(rootItem, { key: "Enter" })).toBe(false);
+    expect(keyDownDefaultPrevented(rootItem, "Enter")).toBe(true);
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: "root" }),
     );
     expect(screen.queryByTestId("nav-tree-item-link-1")).toBeNull();
 
     onSelect.mockClear();
-    expect(fireEvent.keyDown(rootItem, { key: " " })).toBe(false);
+    expect(keyDownDefaultPrevented(rootItem, " ")).toBe(true);
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: "root" }),
     );
@@ -177,8 +184,8 @@ describe("NavTree (#3095 / #3354)", () => {
     );
     const rootItem = screen.getByTestId("nav-tree-item-root");
     rootItem.focus();
-    expect(fireEvent.keyDown(rootItem, { key: "Tab" })).toBe(true);
-    expect(fireEvent.keyDown(rootItem, { key: "ArrowDown" })).toBe(false);
+    expect(keyDownDefaultPrevented(rootItem, "Tab")).toBe(false);
+    expect(keyDownDefaultPrevented(rootItem, "ArrowDown")).toBe(true);
   });
 
   it("reports selection and collapses via toggle", () => {

--- a/WebUI/src/test/ts/architecture/navTreeKeyboard.test.ts
+++ b/WebUI/src/test/ts/architecture/navTreeKeyboard.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NavTreeNode } from "../../../main/ts/api/architecture/types";
+import {
+  buildNavParentMap,
+  collectVisibleNavNodes,
+  isNavTreeRovingKey,
+  resolveNavTreeKey,
+} from "../../../main/ts/architecture/navTreeKeyboard";
+
+const tree: NavTreeNode = {
+  id: "root",
+  title: "Home",
+  folderPath: "//Sites/Demo",
+  sectionType: "section",
+  requiresLogin: false,
+  children: [
+    {
+      id: "about",
+      title: "About",
+      folderPath: "//Sites/Demo/About",
+      sectionType: "section",
+      requiresLogin: false,
+      children: [
+        {
+          id: "team",
+          title: "Team",
+          folderPath: "//Sites/Demo/About/Team",
+          sectionType: "section",
+          requiresLogin: false,
+          children: [],
+        },
+      ],
+    },
+    {
+      id: "members",
+      title: "Members",
+      folderPath: "//Sites/Demo/Members",
+      sectionType: "section",
+      requiresLogin: true,
+      children: [],
+    },
+  ],
+};
+
+const expandedAll = { root: true, about: true };
+
+describe("navTreeKeyboard helpers (#3354)", () => {
+  it("does not treat Tab as a tree-owned key (no trap)", () => {
+    expect(isNavTreeRovingKey("Tab")).toBe(false);
+    expect(isNavTreeRovingKey("Shift")).toBe(false);
+    expect(resolveNavTreeKey("Tab", tree, tree, expandedAll)).toEqual({
+      action: "none",
+    });
+    expect(resolveNavTreeKey("Escape", tree, tree, expandedAll)).toEqual({
+      action: "none",
+    });
+  });
+
+  it("owns Arrow / Home / End / Enter / Space", () => {
+    expect(isNavTreeRovingKey("ArrowDown")).toBe(true);
+    expect(isNavTreeRovingKey("Home")).toBe(true);
+    expect(isNavTreeRovingKey("End")).toBe(true);
+    expect(isNavTreeRovingKey("Enter")).toBe(true);
+    expect(isNavTreeRovingKey(" ")).toBe(true);
+  });
+
+  it("collects visible nodes in document order", () => {
+    const collapsed = collectVisibleNavNodes(tree, { root: false });
+    expect(collapsed.map((n) => n.id)).toEqual(["root"]);
+
+    const rootOnly = collectVisibleNavNodes(tree, { root: true });
+    expect(rootOnly.map((n) => n.id)).toEqual(["root", "about", "members"]);
+
+    const all = collectVisibleNavNodes(tree, expandedAll);
+    expect(all.map((n) => n.id)).toEqual(["root", "about", "team", "members"]);
+  });
+
+  it("maps parents for ArrowLeft", () => {
+    const map = buildNavParentMap(tree);
+    expect(map.get("root")).toBeNull();
+    expect(map.get("about")).toBe("root");
+    expect(map.get("team")).toBe("about");
+    expect(map.get("members")).toBe("root");
+  });
+
+  it("moves focus with Arrow Up/Down and Home/End", () => {
+    const about = tree.children[0];
+    expect(resolveNavTreeKey("ArrowDown", tree, tree, expandedAll)).toEqual({
+      action: "focus",
+      id: "about",
+    });
+    expect(resolveNavTreeKey("ArrowUp", about, tree, expandedAll)).toEqual({
+      action: "focus",
+      id: "root",
+    });
+    expect(resolveNavTreeKey("Home", about, tree, expandedAll)).toEqual({
+      action: "focus",
+      id: "root",
+    });
+    expect(resolveNavTreeKey("End", about, tree, expandedAll)).toEqual({
+      action: "focus",
+      id: "members",
+    });
+  });
+
+  it("expands, enters child, and collapses with Arrow Right/Left", () => {
+    const about = tree.children[0];
+    expect(
+      resolveNavTreeKey("ArrowRight", about, tree, { root: true, about: false }),
+    ).toEqual({ action: "expand", id: "about" });
+    expect(resolveNavTreeKey("ArrowRight", about, tree, expandedAll)).toEqual({
+      action: "focus",
+      id: "team",
+    });
+    expect(resolveNavTreeKey("ArrowLeft", about, tree, expandedAll)).toEqual({
+      action: "collapse",
+      id: "about",
+    });
+    expect(
+      resolveNavTreeKey("ArrowLeft", tree.children[1], tree, { root: true }),
+    ).toEqual({ action: "focus", id: "root" });
+  });
+
+  it("selects and toggles branches on Enter/Space", () => {
+    expect(resolveNavTreeKey("Enter", tree, tree, expandedAll)).toEqual({
+      action: "select",
+      id: "root",
+      toggleExpand: true,
+    });
+    expect(
+      resolveNavTreeKey(" ", tree.children[1], tree, expandedAll),
+    ).toEqual({
+      action: "select",
+      id: "members",
+      toggleExpand: false,
+    });
+  });
+
+  it("consumes arrows at the boundary without moving", () => {
+    expect(resolveNavTreeKey("ArrowUp", tree, tree, expandedAll)).toEqual({
+      action: "prevent",
+    });
+    expect(
+      resolveNavTreeKey("ArrowDown", tree.children[1], tree, expandedAll),
+    ).toEqual({ action: "prevent" });
+    expect(resolveNavTreeKey("ArrowLeft", tree, tree, { root: false })).toEqual(
+      { action: "prevent" },
+    );
+  });
+});

--- a/docs/ai-generated/code-reviews/3354-nav-tree-keyboard-a11y-erlang.md
+++ b/docs/ai-generated/code-reviews/3354-nav-tree-keyboard-a11y-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — #3354 Navigation tree keyboard a11y
+
+**Branch:** `fix/issue-3354-nav-tree-keyboard-a11y`  
+**Date:** 2026-08-13  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (WebUI screen → Vitest + Playwright + product-docs); behavioral tests for new keyboard helper; no non-portable path I/O
+
+## Summary
+
+Slice 5 of parent #3197 / QA #3155 steps 3 and 6. Extracts a pure ARIA-tree key resolver, wires roving tabindex + visible `:focus-visible` on `NavTree`, marks the Secure badge with TMX keys, extends Vitest, adds a route-mocked Playwright keyboard spec so C5 does not depend on sibling #3352 seed, and updates product-docs keyboard steps.
+
+## Scope
+
+Uncommitted work on `fix/issue-3354-nav-tree-keyboard-a11y` vs `origin/main`.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. CMS `//Sites/…` strings are repository paths. Playwright uses URL routes.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Playwright keyboard depth uses a fulfilled site/tree payload (peer: `architecture-nav-tree-empty.spec.js`) so H2 without a seeded NavTree still exercises Tab/arrows/Home/End and the Secure i18n attributes. Live-tree coverage remains in `architecture-a11y-smoke.spec.js` with documented soft-skip when no treeitems exist.
+- `outline: none` was replaced with `:focus-visible` so keyboard users get a visible ring (WCAG 2.4.7).
+- Tab / Shift+Tab are not in `NAV_TREE_ROVING_KEYS`; `resolveNavTreeKey` returns `none` so the component does not `preventDefault`.
+
+## Tests
+
+- Vitest: `navTreeKeyboard.test.ts` (Tab not owned, arrows/Home/End/expand/collapse/boundary) + `NavTree.test.tsx` (Home/End, ArrowRight into child, Tab not prevented, Secure `data-i18n-key`).
+- Playwright: `architecture-nav-keyboard-a11y.spec.js`; Home/End added to `architecture-a11y-smoke.spec.js`.
+
+## Change-class closure
+
+WebUI product screen + few existing TMX keys (no new locale matrix) + perc-qa-automation surface spec + product-docs 8.2 keyboard page.

--- a/modules/perc-qa-automation/frontend/tests/architecture-a11y-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-a11y-smoke.spec.js
@@ -188,6 +188,10 @@ test.describe("Architecture a11y hardening (#3098)", () => {
             await expect(second).toBeFocused();
             await second.press("ArrowUp");
             await expect(first).toBeFocused();
+            await first.press("End");
+            await expect(treeItems.nth(itemCount - 1)).toBeFocused();
+            await treeItems.nth(itemCount - 1).press("Home");
+            await expect(first).toBeFocused();
           }
 
           const createBtn = page.getByTestId("architecture-action-create");

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-keyboard-a11y.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-keyboard-a11y.spec.js
@@ -191,9 +191,27 @@ test.describe("Navigation tree keyboard a11y (#3354)", () => {
     await items.first().press("ArrowRight");
     await expect(items.nth(1)).toBeFocused();
 
+    // Enter/Space select the focused node; Enter on a branch also toggles expand.
+    const about = page.getByTestId("nav-tree-item-nav-about");
+    await about.focus();
+    await about.press("Enter");
+    await expect(about).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByTestId("nav-tree-item-nav-team")).toBeVisible();
+    await about.press(" ");
+    await expect(about).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByTestId("nav-tree-item-nav-team")).toHaveCount(0);
+
+    const members = page.getByTestId("nav-tree-item-nav-members");
+    await members.focus();
+    await members.press("Enter");
+    await expect(members).toHaveAttribute("aria-selected", "true");
+    await members.press("ArrowLeft");
+    await expect(items.first()).toBeFocused();
+
     const secure = page.getByTestId("nav-tree-secure-nav-members");
     await expect(secure).toBeVisible();
     await expect(secure).toHaveAttribute("title", /requires login/i);
+    await expect(secure).toHaveAttribute("aria-label", /requires login/i);
     await expect(secure).toHaveAttribute(
       "data-i18n-key",
       "perc.ui.architecture.modern@Requires login",

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-keyboard-a11y.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-keyboard-a11y.spec.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Navigation tree keyboard a11y (#3354 / QA #3155 steps 3 and 6).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-keyboard-a11y.spec.js
+ *
+ * Intercepts site list + tree so keyboard steps do not depend on sibling
+ * slice 4 (#3352) having seeded a live NavTree. A populated three-level
+ * tree (including one login-required node) is always available.
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    site: "KeyboardSite",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+const KEYBOARD_TREE = {
+  SectionNode: {
+    id: "nav-root",
+    title: "Keyboard Site",
+    folderPath: "//Sites/KeyboardSite",
+    sectionType: "section",
+    requiresLogin: false,
+    childNodes: [
+      {
+        id: "nav-about",
+        title: "About",
+        folderPath: "//Sites/KeyboardSite/About",
+        sectionType: "section",
+        requiresLogin: false,
+        childNodes: [
+          {
+            id: "nav-team",
+            title: "Team",
+            folderPath: "//Sites/KeyboardSite/About/Team",
+            sectionType: "section",
+            requiresLogin: false,
+            childNodes: [],
+          },
+        ],
+      },
+      {
+        id: "nav-members",
+        title: "Members",
+        folderPath: "//Sites/KeyboardSite/Members",
+        sectionType: "section",
+        requiresLogin: true,
+        childNodes: [],
+      },
+    ],
+  },
+};
+
+async function installKeyboardTreeRoutes(page) {
+  await page.route("**/sitemanage/site/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        SiteSummary: [{ name: "KeyboardSite" }],
+      }),
+    });
+  });
+  await page.route("**/sitemanage/section/tree/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(KEYBOARD_TREE),
+    });
+  });
+}
+
+function treeItems(page) {
+  return page.locator(
+    '[data-testid="architecture-nav-tree"] [role="treeitem"]',
+  );
+}
+
+async function activeIsTreeitem(page) {
+  return page.evaluate(() => {
+    const el = document.activeElement;
+    return (
+      el != null &&
+      el.getAttribute("role") === "treeitem" &&
+      el.closest('[data-testid="architecture-nav-tree"]') != null
+    );
+  });
+}
+
+test.describe("Navigation tree keyboard a11y (#3354)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("Tab/arrows/Home/End + secure i18n badge; no trap @smoke @ui @a11y", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await installKeyboardTreeRoutes(page);
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("architecture-nav-tree")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const treeRole = page.locator(
+      '[data-testid="architecture-nav-tree"] [role="tree"]',
+    );
+    await expect(treeRole).toBeVisible({ timeout: 20_000 });
+    await expect(treeRole).toHaveAttribute("aria-label", /navigation tree/i);
+
+    const items = treeItems(page);
+    await expect(items.first()).toBeVisible();
+    await expect.poll(async () => items.count()).toBeGreaterThanOrEqual(2);
+
+    // Tab into the tree from the site picker (or a later toolbar control).
+    await page.getByTestId("architecture-site-select").focus();
+    let landed = false;
+    for (let i = 0; i < 24; i++) {
+      await page.keyboard.press("Tab");
+      if (await activeIsTreeitem(page)) {
+        landed = true;
+        break;
+      }
+    }
+    expect(landed, "Tab must land on a navigation treeitem").toBe(true);
+
+    const firstId = await items.first().getAttribute("data-testid");
+    await items.first().focus();
+    await expect(items.first()).toBeFocused();
+
+    await items.first().press("ArrowDown");
+    await expect(items.nth(1)).toBeFocused();
+    await items.nth(1).press("ArrowUp");
+    await expect(items.first()).toBeFocused();
+
+    await items.first().press("End");
+    const lastIndex = (await items.count()) - 1;
+    await expect(items.nth(lastIndex)).toBeFocused();
+    await items.nth(lastIndex).press("Home");
+    await expect(items.first()).toBeFocused();
+
+    // Collapse root (Arrow Left) then expand (Arrow Right) and enter first child.
+    await items.first().press("ArrowLeft");
+    await expect.poll(async () => items.count()).toBe(1);
+    await items.first().press("ArrowRight");
+    await expect.poll(async () => items.count()).toBeGreaterThan(1);
+    await items.first().press("ArrowRight");
+    await expect(items.nth(1)).toBeFocused();
+
+    const secure = page.getByTestId("nav-tree-secure-nav-members");
+    await expect(secure).toBeVisible();
+    await expect(secure).toHaveAttribute("title", /requires login/i);
+    await expect(secure).toHaveAttribute(
+      "data-i18n-key",
+      "perc.ui.architecture.modern@Requires login",
+    );
+    await expect(secure).toHaveAttribute(
+      "data-i18n-badge-key",
+      "perc.ui.architecture.modern@Secure",
+    );
+
+    await items.first().press("End");
+    await expect(items.nth((await items.count()) - 1)).toBeFocused();
+    await page.keyboard.press("Tab");
+    expect(
+      await activeIsTreeitem(page),
+      "Tab from the last node must leave the tree (no trap)",
+    ).toBe(false);
+
+    // Restore a known first-item focus so firstId is still a treeitem.
+    expect(firstId).toBeTruthy();
+
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            String(e),
+          ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -75,16 +75,23 @@ sites with a tree continue to load normally.
 
 ## Keyboard and accessibility
 
-The navigation tree follows the ARIA tree pattern:
+The navigation tree follows the ARIA tree pattern. **Tab** moves focus into
+the tree (roving tabindex on the last focused item). **Tab** / **Shift+Tab**
+are not captured — focus can leave the tree; there is no keyboard trap.
 
 | Key | Behavior |
 |-----|----------|
-| **Tab** | Moves focus into the tree (roving tabindex on the selected or root item). |
+| **Tab** | Moves focus into the tree (roving tabindex on the last focused item). |
+| **Shift+Tab** | Moves focus out of the tree to the previous control. |
 | **Arrow Up / Down** | Move focus among visible nodes. |
 | **Arrow Right** | Expand a collapsed branch, or move into the first child when expanded. |
 | **Arrow Left** | Collapse an expanded branch, or move focus to the parent. |
 | **Home / End** | Jump to the first or last visible node. |
 | **Enter / Space** | Select the focused section (and toggle expand on branches). |
+
+Sections that require login show a **Secure** badge. The badge tooltip
+(**Requires login**) comes from the `perc.ui.architecture.modern` catalog
+(not a hard-coded-only string).
 
 Structure dialogs (create, create from folder, rename, landing page, section link, external link, the
 section picker, **New Site**, and **Copy Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**


### PR DESCRIPTION
## Summary

Slice 5 of parent **#3197** (QA Failed residual of **#3155** / epic **#3092**). Unblocks #3155 steps 3 and 6: Navigation tree keyboard operability and Secure-badge i18n tooltip.

The SPA already had a partial ARIA tree. This change:

- Extracts a pure `resolveNavTreeKey` helper (Tab is **not** consumed — no trap).
- Uses roving tabindex on the last focused item; `:focus-visible` ring for keyboard users.
- Marks the Secure badge with TMX keys (`perc.ui.architecture.modern@Requires login` / `@Secure`) via `title`, `aria-label`, and `data-i18n-key`.
- Adds Vitest keyboard helpers + Home/End / ArrowRight / no-trap coverage.
- Adds H2 Playwright `architecture-nav-keyboard-a11y.spec.js` that route-mocks a populated tree so keyboard steps do **not** wait on sibling #3352 seed.
- Keeps product-docs 8.2 keyboard steps accurate (Tab in/out, Home/End, Secure tooltip).

Out of scope: seeding NavTree (#3352) and Create section dialogs (#3350).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3354  
Parent: #3197  
Also residual of: #3155

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Java Tests run: 59; Vitest 315 files / 2318 tests).
2. Focused Vitest: `navTreeKeyboard.test.ts` + `NavTree.test.tsx` — 14 passed.
3. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
4. H2 `perc-devctl qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` → hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into the cell → Playwright:
   - `test:surface -- --path tests/architecture-nav-keyboard-a11y.spec.js` — 1 passed
   - `test:surface -- --path tests/architecture-a11y-smoke.spec.js` — 1 passed
5. Manual: Tab from Site picker into the tree; Arrow Up/Down, Right/Left, Home/End; Tab leaves the tree; Secure badge tooltip is “Requires login”.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (keyboard table + Secure badge TMX tooltip)
- [x] **Unit / module tests** — `navTreeKeyboard` helper + NavTree component keyboard tests; WebUI and perc-qa-automation standalone `mvnw clean install`
- [x] **WebUI + Playwright** — new keyboard a11y surface spec; Home/End added to architecture a11y smoke
- [x] **Build gates** — standalone `WebUI` and `modules/perc-qa-automation` `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — N/A (no OS filesystem path I/O; CMS `//Sites/…` repository paths only)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (Java Tests run: 59, Failures: 0; Vitest Test Files 315 passed, Tests 2318 passed)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - Focused Vitest (`navTreeKeyboard` + `NavTree`): 14 passed
  - `scripts/ci-smoke-product-docs.bat` → OK
- **downstream_checked:** none — no Java `final`/`sealed`/public signature change. New TS helpers are WebUI-internal.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (freeport preferred)
- Hot-deploy: copied `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (JS/CSS; no Jetty restart)
- Playwright:
  - `npm run test:surface -- --path tests/architecture-nav-keyboard-a11y.spec.js` → 1 passed
  - `npm run test:surface -- --path tests/architecture-a11y-smoke.spec.js` → 1 passed
- console-clean=yes (specs assert no pageerror / console error)
- server.log-clean=yes (no ERROR/FATAL after startup during the test window)
- Tear-down: `qa-down` (cell removed)

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
