### PR TITLE
fix(webui): Navigation create-section dialogs once NavTree exists (#3350)

### DIFF
--- a/WebUI/src/main/ts/architecture/StructureActionBar.tsx
+++ b/WebUI/src/main/ts/architecture/StructureActionBar.tsx
@@ -22,6 +22,7 @@
 import React from "react";
 import { catalogColors } from "../developer/catalogStyles";
 import { ARCH_MSG } from "./messages";
+import { captureDialogOpener } from "./useDialogEscape";
 
 export interface StructureActionBarProps {
   busy: boolean;
@@ -117,7 +118,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-create"
         disabled={!createEnabled}
-        onClick={onCreate}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onCreate();
+        }}
         style={buttonStyle(createEnabled)}
       >
         {ARCH_MSG.ACTION_CREATE}
@@ -126,7 +130,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-create-from-folder"
         disabled={!createFromFolderEnabled}
-        onClick={onCreateFromFolder}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onCreateFromFolder();
+        }}
         style={buttonStyle(createFromFolderEnabled)}
       >
         {ARCH_MSG.ACTION_CREATE_FROM_FOLDER}
@@ -135,7 +142,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-create-section-link"
         disabled={!sectionLinkEnabled}
-        onClick={onCreateSectionLink}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onCreateSectionLink();
+        }}
         style={buttonStyle(sectionLinkEnabled)}
       >
         {ARCH_MSG.ACTION_CREATE_SECTION_LINK}
@@ -144,7 +154,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-create-external-link"
         disabled={!externalLinkEnabled}
-        onClick={onCreateExternalLink}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onCreateExternalLink();
+        }}
         style={buttonStyle(externalLinkEnabled)}
       >
         {ARCH_MSG.ACTION_CREATE_EXTERNAL_LINK}
@@ -153,7 +166,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-landing"
         disabled={!landingEnabled}
-        onClick={onLanding}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onLanding();
+        }}
         style={buttonStyle(landingEnabled)}
       >
         {ARCH_MSG.ACTION_LANDING}
@@ -162,7 +178,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-edit-link"
         disabled={!editLinkEnabled}
-        onClick={onEditLink}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onEditLink();
+        }}
         style={buttonStyle(editLinkEnabled)}
       >
         {ARCH_MSG.ACTION_EDIT_LINK}
@@ -171,7 +190,10 @@ export function StructureActionBar({
         type="button"
         data-testid="architecture-action-rename"
         disabled={!renameEnabled}
-        onClick={onRename}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onRename();
+        }}
         style={buttonStyle(renameEnabled)}
       >
         {ARCH_MSG.ACTION_RENAME}

--- a/WebUI/src/main/ts/architecture/useDialogEscape.ts
+++ b/WebUI/src/main/ts/architecture/useDialogEscape.ts
@@ -15,7 +15,29 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+/** Last structure-toolbar control that opened a dialog (#3350). */
+let pendingOpener: HTMLElement | null = null;
+
+/**
+ * Record the control that opened a structure dialog so focus can return
+ * after Escape / cancel. Prefer the clicked button over
+ * {@code document.activeElement} (jsdom click does not move focus).
+ */
+export function captureDialogOpener(el: EventTarget | null): void {
+  pendingOpener = el instanceof HTMLElement ? el : null;
+}
+
+function takePendingOpener(): HTMLElement | null {
+  const fromClick = pendingOpener;
+  pendingOpener = null;
+  if (fromClick) {
+    return fromClick;
+  }
+  const ae = document.activeElement;
+  return ae instanceof HTMLElement ? ae : null;
+}
 
 /**
  * Close Architecture dialogs on Escape when open and not busy (#3098 a11y).
@@ -23,6 +45,9 @@ import { useEffect, useRef } from "react";
  *
  * <p>{@code onCancel} is held in a ref so inline arrow call-sites do not
  * teardown/re-register the window keydown listener every parent render.</p>
+ *
+ * <p>#3350: capture the opener (toolbar click or current focus) on the first
+ * open render and restore focus when the dialog closes.</p>
  */
 export function useDialogEscape(
   open: boolean,
@@ -31,6 +56,28 @@ export function useDialogEscape(
 ): void {
   const onCancelRef = useRef(onCancel);
   onCancelRef.current = onCancel;
+
+  const openerRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
+
+  if (open && !wasOpenRef.current) {
+    openerRef.current = takePendingOpener();
+  }
+  wasOpenRef.current = open;
+
+  useLayoutEffect(() => {
+    if (open) {
+      return;
+    }
+    const el = openerRef.current;
+    if (!el) {
+      return;
+    }
+    openerRef.current = null;
+    if (typeof el.focus === "function" && document.contains(el)) {
+      el.focus();
+    }
+  }, [open]);
 
   useEffect(() => {
     if (!open) {

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -166,6 +166,66 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
   });
 
+  it("keeps create disabled when the site has no NavTree (#3350)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "BareSite" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(null);
+
+    render(<ArchitectureShell embedded initialSite="BareSite" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-nav-tree-empty")).toBeTruthy();
+    });
+    expect(
+      (screen.getByTestId("architecture-action-create") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (
+        screen.getByTestId(
+          "architecture-action-create-external-link",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      (
+        screen.getByTestId(
+          "architecture-action-create-section-link",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("enables create when a regular section is selected (#3350)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+      { id: "tpl-1", name: "Base" },
+    ]);
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    const createBtn = screen.getByTestId(
+      "architecture-action-create",
+    ) as HTMLButtonElement;
+    expect(createBtn.disabled).toBe(false);
+    fireEvent.click(createBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-create-dialog")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("architecture-create-dialog").querySelector(
+        '[role="dialog"]',
+      ),
+    ).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-create-dialog")).toBeNull();
+    });
+    expect(document.activeElement).toBe(createBtn);
+  });
+
   it("enables create under root and opens create dialog", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);

--- a/WebUI/src/test/ts/architecture/CreateSectionDialog.test.tsx
+++ b/WebUI/src/test/ts/architecture/CreateSectionDialog.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateSectionDialog } from "../../../main/ts/architecture/CreateSectionDialog";
+import * as homeApi from "../../../main/ts/api/home/homeApi";
+
+describe("CreateSectionDialog (#3350 / #3155)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+      { id: "tpl-1", name: "Base" },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a modal dialog and Escape closes when not busy", async () => {
+    const onCancel = vi.fn();
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={onCancel}
+        onSubmit={() => undefined}
+      />,
+    );
+    const panel = await screen.findByRole("dialog");
+    expect(panel.getAttribute("aria-modal")).toBe("true");
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("architecture-create-template-select"),
+      ).toBeTruthy();
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape while busy", async () => {
+    const onCancel = vi.fn();
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy
+        onCancel={onCancel}
+        onSubmit={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("restores focus to the opener after Escape (#3350)", async () => {
+    const onCancel = vi.fn();
+    const opener = document.createElement("button");
+    opener.type = "button";
+    opener.setAttribute("data-testid", "create-opener");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { rerender } = render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={onCancel}
+        onSubmit={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    rerender(
+      <CreateSectionDialog
+        open={false}
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={onCancel}
+        onSubmit={() => undefined}
+      />,
+    );
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+});

--- a/WebUI/src/test/ts/architecture/useDialogEscape.test.tsx
+++ b/WebUI/src/test/ts/architecture/useDialogEscape.test.tsx
@@ -18,7 +18,10 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useDialogEscape } from "../../../main/ts/architecture/useDialogEscape";
+import {
+  captureDialogOpener,
+  useDialogEscape,
+} from "../../../main/ts/architecture/useDialogEscape";
 
 function Harness({
   open,
@@ -55,6 +58,51 @@ describe("useDialogEscape (#3098)", () => {
     rerender(<Harness open={false} busy={false} onCancel={onCancel} />);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("restores focus to the captured toolbar button (#3350)", () => {
+    const onCancel = vi.fn();
+    const opener = document.createElement("button");
+    opener.type = "button";
+    document.body.appendChild(opener);
+    captureDialogOpener(opener);
+
+    const steal = document.createElement("input");
+    document.body.appendChild(steal);
+    steal.focus();
+
+    const { rerender } = render(
+      <Harness open busy={false} onCancel={onCancel} />,
+    );
+    rerender(<Harness open={false} busy={false} onCancel={onCancel} />);
+    expect(document.activeElement).toBe(opener);
+
+    steal.remove();
+    opener.remove();
+  });
+
+  it("restores focus to the opener when the dialog closes (#3350)", () => {
+    const onCancel = vi.fn();
+    const opener = document.createElement("button");
+    opener.type = "button";
+    opener.setAttribute("data-testid", "escape-opener");
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const { rerender } = render(
+      <Harness open busy={false} onCancel={onCancel} />,
+    );
+    const steal = document.createElement("input");
+    document.body.appendChild(steal);
+    steal.focus();
+    expect(document.activeElement).toBe(steal);
+
+    rerender(<Harness open={false} busy={false} onCancel={onCancel} />);
+    expect(document.activeElement).toBe(opener);
+
+    steal.remove();
+    opener.remove();
   });
 
   it("removes keydown listener when open goes false or unmounts", () => {

--- a/modules/perc-qa-automation/frontend/tests/architecture-a11y-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-a11y-smoke.spec.js
@@ -192,21 +192,16 @@ test.describe("Architecture a11y hardening (#3098)", () => {
 
           const createBtn = page.getByTestId("architecture-action-create");
           await expect(createBtn).toBeVisible();
-          if (await createBtn.isEnabled().catch(() => false)) {
-            await createBtn.click();
-            const dialog = page.getByTestId("architecture-create-dialog");
-            await expect(dialog).toBeVisible({ timeout: 10_000 });
-            const dialogPanel = dialog.locator('[role="dialog"]');
-            await expect(dialogPanel).toHaveAttribute("aria-modal", "true");
-            await page.keyboard.press("Escape");
-            await expect(dialog).toHaveCount(0);
-          } else {
-            test.info().annotations.push({
-              type: "note",
-              description:
-                "Create disabled — skipped Escape dialog close (parent blocked)",
-            });
-          }
+          // #3350: treeitems mean a NavTree exists — Create section must be enabled
+          await expect(createBtn).toBeEnabled();
+          await createBtn.click();
+          const dialog = page.getByTestId("architecture-create-dialog");
+          await expect(dialog).toBeVisible({ timeout: 10_000 });
+          const dialogPanel = dialog.locator('[role="dialog"]');
+          await expect(dialogPanel).toHaveAttribute("aria-modal", "true");
+          await page.keyboard.press("Escape");
+          await expect(dialog).toHaveCount(0);
+          await expect(createBtn).toBeFocused();
         }
       } else {
         test.info().annotations.push({

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
@@ -124,17 +124,83 @@ test.describe("Architecture nav structure mutations (#3096)", () => {
           page.getByTestId("architecture-readonly-note"),
         ).toHaveCount(0);
 
-        // Create dialog open/close (no forced save against live site)
+        // #3350 / #3155: when a NavTree is present, Create section is enabled
+        // (root or selected regular section). Dialog is modal; Escape closes
+        // and returns focus to the opener. No forced save against the live site.
+        const treeItems = page.locator(
+          '[data-testid="architecture-nav-tree"] [role="treeitem"]',
+        );
+        const itemCount = await treeItems.count();
         const createBtn = page.getByTestId("architecture-action-create");
-        if (await createBtn.isEnabled().catch(() => false)) {
+        const extBtn = page.getByTestId(
+          "architecture-action-create-external-link",
+        );
+        const linkBtn = page.getByTestId(
+          "architecture-action-create-section-link",
+        );
+        if (itemCount > 0) {
+          await treeItems.first().click();
+          await expect(createBtn).toBeEnabled();
+          await expect(extBtn).toBeEnabled();
+          await expect(linkBtn).toBeEnabled();
+          await createBtn.click();
+          const createDialog = page.getByTestId("architecture-create-dialog");
+          await expect(createDialog).toBeVisible({ timeout: 10_000 });
+          await expect(createDialog.locator('[role="dialog"]')).toHaveAttribute(
+            "aria-modal",
+            "true",
+          );
+          await page.keyboard.press("Escape");
+          await expect(createDialog).toHaveCount(0);
+          await expect(createBtn).toBeFocused();
+
+          await extBtn.click();
+          const extDialog = page.getByTestId(
+            "architecture-external-link-dialog",
+          );
+          await expect(extDialog).toBeVisible({ timeout: 10_000 });
+          await expect(extDialog).toHaveAttribute("role", "dialog");
+          await page.keyboard.press("Escape");
+          await expect(extDialog).toHaveCount(0);
+          await expect(extBtn).toBeFocused();
+
+          await linkBtn.click();
+          const linkDialog = page.getByTestId(
+            "architecture-section-link-dialog",
+          );
+          await expect(linkDialog).toBeVisible({ timeout: 10_000 });
+          await expect(linkDialog).toHaveAttribute("role", "dialog");
+          await page.keyboard.press("Escape");
+          await expect(linkDialog).toHaveCount(0);
+          await expect(linkBtn).toBeFocused();
+
+          const renameBtn = page.getByTestId("architecture-action-rename");
+          await expect(renameBtn).toBeEnabled();
+          await renameBtn.click();
+          const renameDialog = page.getByTestId("architecture-rename-dialog");
+          await expect(renameDialog).toBeVisible({ timeout: 10_000 });
+          await expect(renameDialog.locator('[role="dialog"]')).toHaveAttribute(
+            "aria-modal",
+            "true",
+          );
+          await page.keyboard.press("Escape");
+          await expect(renameDialog).toHaveCount(0);
+          await expect(renameBtn).toBeFocused();
+        } else if (await createBtn.isEnabled().catch(() => false)) {
           await createBtn.click();
           await expect(
             page.getByTestId("architecture-create-dialog"),
           ).toBeVisible({ timeout: 10_000 });
-          await page.getByTestId("architecture-create-cancel").click();
+          await page.keyboard.press("Escape");
           await expect(
             page.getByTestId("architecture-create-dialog"),
           ).toHaveCount(0);
+        } else {
+          test.info().annotations.push({
+            type: "note",
+            description:
+              "No treeitems — Create stays disabled (empty NavTree). Dialog Escape covered by Vitest + cells with #3352 seed.",
+          });
         }
       }
     }

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -104,8 +104,12 @@ The navigation tree follows the ARIA tree pattern:
 
 Structure dialogs (create, create from folder, rename, landing page, section link, external link, the
 section picker, **New Site**, and **Copy Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
-closes the open dialog when a mutation is not in progress. Closing **New Site** or
-**Copy Site** returns keyboard focus to the matching toolbar button. Primary
+closes the open dialog when a mutation is not in progress. Closing a structure
+dialog, **New Site**, or **Copy Site** returns keyboard focus to the control that
+opened it. **Create section**, **Create section from folder**, **Create section
+link**, and **Create external link** are enabled when the selected site has a
+navigation tree and a regular section (or the tree root) can be the parent —
+including when the root is used because nothing is selected yet. Primary
 structure actions live in a toolbar with an accessible name (**Structure actions**).
 
 Chrome strings (shell, tree states, actions, dialogs, validation) use the


### PR DESCRIPTION
## Summary

Slice 6 of parent **#3197** (QA residual **#3155** / epic **#3092**). Does **not** seed a second NavTree; uses existing rff/perc alias recognition (#3357) and sample-site seed (#3352).

When a site has a NavTree, **Create section** and peer structure actions stay enabled for a selected regular section or the tree root. Structure dialogs remain `role="dialog"` / `aria-modal`. **Escape** closes when a mutation is not in progress, and focus returns to the toolbar control that opened the dialog.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3350. Parent tracker: #3197. Related QA: #3155.

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest 2320, Surefire 59, 0 failures).
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. QA H2: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:51442`.
4. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`.
5. `npm run test:surface -- --path tests/architecture-nav-mutations-smoke.spec.js` — 1 passed.
6. `npm run test:surface -- --path tests/architecture-a11y-smoke.spec.js` — 1 passed.
7. Sign in as Admin; open **Navigation**. Select a regular section on a site that has a NavTree. **Create section** is enabled; dialog is modal; Escape closes and returns focus to the button. Repeat for Create external link, Create section link, Rename.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (create enablement + focus return on structure dialogs)
- [x] **Unit / module tests** — Vitest: empty-tree create disabled; selected regular section enables create; dialog `role=dialog`; Escape; opener focus restore
- [x] **WebUI + Playwright** — `architecture-nav-mutations-smoke.spec.js` and `architecture-a11y-smoke.spec.js` require Create enabled when treeitems exist; Escape + focus return
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- `modules_built=WebUI,modules/perc-qa-automation`
- `build_evidence=cd WebUI && ../mvnw.cmd clean install → BUILD SUCCESS; Vitest Tests 2320 passed; Surefire 59 tests 0 fail. cd modules/perc-qa-automation && ../../mvnw.cmd clean install → BUILD SUCCESS (No tests to run / npm ci).`
- `downstream_checked=none` (no Java public API / final / signature change)

### C5 UI proof

- `qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:51442` (`QA_CONTAINER=perc-matrix-cms-h2`)
- Hot-deploy: copied generated `cm/modern/assets` into the cell (no Jetty restart required for JS)
- Playwright: `npm run test:surface -- --path tests/architecture-nav-mutations-smoke.spec.js` → 1 passed; `…/architecture-a11y-smoke.spec.js` → 1 passed
- `console-clean=yes` (pageerror/console error listeners; favicon/network noise filtered)
- `server.log-clean=yes` (no ERROR/FATAL in `/opt/Percussion/jetty/base/logs/server.log` for the test window)
- Note: cached `percussion-matrix-cell:local` (2d) predates merged #3352 seed; this cell’s sample-site `GET …/section/tree` was still empty, so the live dialog branch is gated on treeitems. Enablement + Escape + focus are covered by Vitest; cells with #3352/#3357 exercise the live dialog path.

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
