### PR TITLE
fix(sites): VirtualSiteProperties JAXB PUT envelope (#3365)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -197,6 +197,26 @@ export function parseVirtualSiteProperties(payload: unknown): VirtualSitePropert
   };
 }
 
+/**
+ * PUT body for {@code /services/sites/{nameOrId}/virtual}.
+ *
+ * <p>Production CXF Jackson uses WRAP/UNWRAP_ROOT_VALUE and JAXB expects root
+ * {@code VirtualSiteProperties}. A flat {@code {sourceKind,...}} body is treated
+ * as unexpected element {@code sourceKind} (QA #3030 / #3365).
+ */
+export function toVirtualSitePropertiesEnvelope(
+  props: VirtualSiteProperties,
+): { VirtualSiteProperties: Record<string, string | null> } {
+  return {
+    VirtualSiteProperties: {
+      sourceKind: props.sourceKind ?? null,
+      rootPath: props.rootPath ?? null,
+      configFile: props.configFile ?? null,
+      siteKey: props.siteKey ?? null,
+    },
+  };
+}
+
 /** GET /services/sites/{nameOrId}/virtual */
 export async function getVirtualSiteProperties(
   nameOrId: string,
@@ -212,7 +232,10 @@ export async function updateVirtualSiteProperties(
   props: VirtualSiteProperties,
 ): Promise<VirtualSiteProperties> {
   const key = encodeURIComponent(nameOrId.trim());
-  const payload = await put<unknown>(`${PATHS.SITES}/${key}/virtual`, props);
+  const payload = await put<unknown>(
+    `${PATHS.SITES}/${key}/virtual`,
+    toVirtualSitePropertiesEnvelope(props),
+  );
   return parseVirtualSiteProperties(payload);
 }
 

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -209,8 +209,17 @@ export function VirtualSiteSourcePanel({
     try {
       const body = formToVirtualProps(form);
       const saved = await updateVirtualSiteProperties(siteName, body);
-      setForm(virtualPropsToForm(saved));
-      setIsVirtual(saved.virtual === true || isVirtualSourceKind(saved.sourceKind));
+      // GET-roundtrip so virtual=true / sourceKind persist without a full page reload (#3365).
+      let confirmed = saved;
+      try {
+        confirmed = await getVirtualSiteProperties(siteName);
+      } catch {
+        // Persist already succeeded; keep PUT result.
+      }
+      setForm(virtualPropsToForm(confirmed));
+      setIsVirtual(
+        confirmed.virtual === true || isVirtualSourceKind(confirmed.sourceKind),
+      );
       setSavedNotice(DEV_MSG.SITE_VIRT_SAVED);
     } catch (e: unknown) {
       setFormError(panelErrMsg(e, DEV_MSG.SITE_VIRT_SAVE_ERROR));

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -11,6 +11,7 @@ import {
   parseVirtualSiteBuildResult,
   parseVirtualSitePreviewStatus,
   parseVirtualSiteProperties,
+  toVirtualSitePropertiesEnvelope,
   updateVirtualSiteProperties,
   virtualSitePreviewContentHref,
 } from "../../../../main/ts/api/developer/sitesApi";
@@ -70,11 +71,30 @@ describe("sitesApi virtual properties", () => {
     expect(out.virtual).toBe(false);
   });
 
-  it("updateVirtualSiteProperties PUTs body", async () => {
+  it("toVirtualSitePropertiesEnvelope wraps VirtualSiteProperties root", () => {
+    expect(
+      toVirtualSitePropertiesEnvelope({
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        virtual: true,
+      }),
+    ).toEqual({
+      VirtualSiteProperties: {
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        configFile: null,
+        siteKey: null,
+      },
+    });
+  });
+
+  it("updateVirtualSiteProperties PUTs VirtualSiteProperties envelope", async () => {
     put.mockResolvedValue({
-      sourceKind: "git-filesystem",
-      rootPath: "C:/docs",
-      virtual: true,
+      VirtualSiteProperties: {
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        virtual: true,
+      },
     });
     const out = await updateVirtualSiteProperties("Help", {
       sourceKind: "git-filesystem",
@@ -82,9 +102,17 @@ describe("sitesApi virtual properties", () => {
     });
     expect(put).toHaveBeenCalledWith(
       expect.stringMatching(/\/sites\/Help\/virtual$/),
-      expect.objectContaining({ sourceKind: "git-filesystem", rootPath: "C:/docs" }),
+      {
+        VirtualSiteProperties: {
+          sourceKind: "git-filesystem",
+          rootPath: "C:/docs",
+          configFile: null,
+          siteKey: null,
+        },
+      },
     );
     expect(out.rootPath).toBe("C:/docs");
+    expect(out.virtual).toBe(true);
   });
 
   it("parseVirtualSiteBuildResult handles plain and wrapped payloads", () => {

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -106,7 +106,15 @@ describe("VirtualSiteSourcePanel", () => {
   });
 
   it("saves git-filesystem configuration after client validation", async () => {
-    getVirtual.mockResolvedValue({ sourceKind: null, virtual: false });
+    getVirtual
+      .mockResolvedValueOnce({ sourceKind: null, virtual: false })
+      .mockResolvedValueOnce({
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        configFile: null,
+        siteKey: null,
+        virtual: true,
+      });
     updateVirtual.mockResolvedValue({
       sourceKind: "git-filesystem",
       rootPath: "C:/docs",
@@ -148,17 +156,28 @@ describe("VirtualSiteSourcePanel", () => {
       configFile: null,
       siteKey: null,
     });
+    expect(getVirtual).toHaveBeenCalledTimes(2);
     expect(
       (screen.getByTestId("developer-site-virtual-root-path") as HTMLInputElement).value,
     ).toBe("C:/docs");
+    expect(screen.getByTestId("developer-site-virtual-build-section")).toBeTruthy();
+    expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
+      DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
+    );
   });
 
   it("saves repository mode to clear virtual configuration", async () => {
-    getVirtual.mockResolvedValue({
-      sourceKind: "git-filesystem",
-      rootPath: "C:/docs",
-      virtual: true,
-    });
+    getVirtual
+      .mockResolvedValueOnce({
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        virtual: true,
+      })
+      .mockResolvedValueOnce({
+        sourceKind: null,
+        rootPath: null,
+        virtual: false,
+      });
     updateVirtual.mockResolvedValue({
       sourceKind: null,
       rootPath: null,
@@ -181,6 +200,8 @@ describe("VirtualSiteSourcePanel", () => {
       configFile: null,
       siteKey: null,
     });
+    expect(getVirtual).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
   });
 
   it("surfaces save API errors", async () => {

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -301,4 +301,136 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     ).toHaveText("broken id:missing-page from 8.2/index.md");
     expect(consoleErrors).toEqual([]);
   });
+
+  test("save PUTs VirtualSiteProperties envelope and GET-roundtrip shows Build chrome (#3365)", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    let virtualState = {
+      sourceKind: "repository",
+      rootPath: null,
+      configFile: null,
+      siteKey: null,
+      virtual: false,
+    };
+    /** @type {unknown} */
+    let lastPutBody = null;
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (/\/virtual\//.test(url)) {
+        await route.fallback();
+        return;
+      }
+      const method = route.request().method();
+      if (method === "PUT") {
+        lastPutBody = route.request().postDataJSON();
+        const envelope =
+          lastPutBody &&
+          typeof lastPutBody === "object" &&
+          lastPutBody.VirtualSiteProperties
+            ? lastPutBody.VirtualSiteProperties
+            : lastPutBody;
+        virtualState = {
+          sourceKind: envelope.sourceKind || "repository",
+          rootPath: envelope.rootPath || null,
+          configFile: envelope.configFile || null,
+          siteKey: envelope.siteKey || null,
+          virtual: envelope.sourceKind === "git-filesystem",
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ VirtualSiteProperties: virtualState }),
+        });
+        return;
+      }
+      if (method !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ VirtualSiteProperties: virtualState }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — Virtual Site save envelope test requires a site row",
+      });
+      return;
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(
+      0,
+    );
+
+    await page.locator('[data-testid="developer-site-virtual-source-kind"]').selectOption(
+      "git-filesystem",
+    );
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill("C:/docs/product-docs");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    expect(lastPutBody).toBeTruthy();
+    expect(lastPutBody).toHaveProperty("VirtualSiteProperties");
+    expect(lastPutBody.VirtualSiteProperties.sourceKind).toBe("git-filesystem");
+    expect(lastPutBody.VirtualSiteProperties.rootPath).toBe("C:/docs/product-docs");
+    expect(lastPutBody).not.toHaveProperty("sourceKind");
+
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -104,7 +104,10 @@ failures show **Could not load sites** rather than the empty state.
    - **Config file** (optional) — simple file name under the root (default `_config.yaml`
      when unset). No path separators.
    - **Site key** (optional) — participant registry key; defaults to the Site name when blank.
-5. Choose **Save Virtual Site source**. Reload the Site detail to confirm values persisted.
+5. Choose **Save Virtual Site source**. The SPA sends the Jackson/JAXB envelope
+   `{ "VirtualSiteProperties": { "sourceKind": "git-filesystem", "rootPath": "…", … } }`
+   (not a bare `sourceKind` object). After a successful save the panel reloads
+   properties from GET so **Build Virtual Site** appears without a full page reload.
 6. To return a Virtual Site to traditional repository mode, set source kind back to
    **Repository (traditional)** and save (clears `virtual.*` properties).
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -107,7 +107,7 @@ Example create body:
 |-----------|------|--------|
 | List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array. Each entry includes a plain string `name` when the Site has one. |
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
-| Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag |
+| Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag. PUT JSON is `{ "VirtualSiteProperties": { "sourceKind", "rootPath", "configFile", "siteKey" } }` (Jackson/JAXB root wrap). A flat `{ "sourceKind": … }` body returns **400** unexpected element `sourceKind`. |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
 | Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -138,6 +138,24 @@ Operators can run the same operation from **Developer → Sites → Site detail 
 (visible only when source kind is Virtual). Save Virtual Site source before building so the server
 uses the latest properties.
 
+`PUT /sites/{nameOrId}/virtual` requires the wire root name **`VirtualSiteProperties`**:
+
+```json
+{
+  "VirtualSiteProperties": {
+    "sourceKind": "git-filesystem",
+    "rootPath": "C:/workspaces/product-docs",
+    "configFile": "_config.yaml",
+    "siteKey": "product-docs"
+  }
+}
+```
+
+A bare `{ "sourceKind": "git-filesystem", … }` body is rejected (**400**, JAXB unexpected
+element `sourceKind`). GET returns the same envelope (or a plain object the SPA unwraps).
+After save, the Developer Sites panel GET-roundtrips so `virtual=true` and Build chrome appear
+without reloading the page.
+
 After a successful build, **Preview assembled site** opens the last output home in a new tab
 (`GET /sites/{nameOrId}/virtual/preview` for status; `GET …/virtual/preview/{relPath}` for the
 assembled file stream). Missing output returns status `available=false` (HTTP 200) or file HTTP

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -78,11 +78,28 @@ or NIO/`Path` APIs.
 Integrators can read and write these keys via public Site REST:
 
 - `GET /sites/{nameOrId}/virtual`
-- `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
+- `PUT /sites/{nameOrId}/virtual` (JSON body **must** use the `VirtualSiteProperties` root wrap — not a bare `sourceKind` object)
 - `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
 - `GET /sites/{nameOrId}/virtual/preview` (last-build preview status)
 - `GET /sites/{nameOrId}/virtual/preview/{relPath}` (assembled file stream)
 - `POST /sites/{nameOrId}/virtual/publish` (build then copy to Site filesystem root)
+
+PUT JSON (Jackson/JAXB) must wrap fields under the DTO root name:
+
+```json
+{
+  "VirtualSiteProperties": {
+    "sourceKind": "git-filesystem",
+    "rootPath": "C:/workspaces/product-docs",
+    "configFile": "_config.yaml",
+    "siteKey": "product-docs"
+  }
+}
+```
+
+A flat `{ "sourceKind": "git-filesystem", … }` body is **400** (`unexpected element sourceKind`).
+GET uses the same envelope. The Developer Sites **Save Virtual Site source** action sends this
+wrap and then GET-roundtrips so Build chrome appears without a full reload.
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -243,10 +243,10 @@ public class SitesAdaptor implements ISiteAdaptor {
       }
 
       IPSGuid contextId = resolvePropertyContext(psSite);
-      String sourceKind = blankToNull(props.getSourceKind().orElse(null));
-      String rootPath = blankToNull(props.getRootPath().orElse(null));
-      String configFile = blankToNull(props.getConfigFile().orElse(null));
-      String siteKey = blankToNull(props.getSiteKey().orElse(null));
+      String sourceKind = blankToNull(props.getSourceKind());
+      String rootPath = blankToNull(props.getRootPath());
+      String configFile = blankToNull(props.getConfigFile());
+      String siteKey = blankToNull(props.getSiteKey());
 
       // Clear virtual config when sourceKind is blank or explicit repository.
       if (sourceKind == null

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -92,10 +92,10 @@ class SitesAdaptorTest {
     put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "product-docs");
 
     VirtualSiteProperties v = SitesAdaptor.readVirtual(site);
-    assertEquals("git-filesystem", v.getSourceKind().orElse(null));
-    assertEquals("C:/docs/product-docs", v.getRootPath().orElse(null));
-    assertEquals("custom.yaml", v.getConfigFile().orElse(null));
-    assertEquals("product-docs", v.getSiteKey().orElse(null));
+    assertEquals("git-filesystem", v.getSourceKind());
+    assertEquals("C:/docs/product-docs", v.getRootPath());
+    assertEquals("custom.yaml", v.getConfigFile());
+    assertEquals("product-docs", v.getSiteKey());
     assertTrue(Boolean.TRUE.equals(v.getVirtual()));
   }
 
@@ -105,7 +105,7 @@ class SitesAdaptorTest {
     site.setName("Corp");
     VirtualSiteProperties v = SitesAdaptor.readVirtual(site);
     assertFalse(Boolean.TRUE.equals(v.getVirtual()));
-    assertTrue(v.getSourceKind().isEmpty());
+    assertTrue(v.getSourceKind() == null || v.getSourceKind().isBlank());
   }
 
   @Test
@@ -185,8 +185,8 @@ class SitesAdaptorTest {
 
     VirtualSiteProperties out = adaptor.updateVirtualSiteProperties("Help", body);
     assertTrue(Boolean.TRUE.equals(out.getVirtual()));
-    assertEquals("git-filesystem", out.getSourceKind().orElse(null));
-    assertEquals("C:/docs/product-docs", out.getRootPath().orElse(null));
+    assertEquals("git-filesystem", out.getSourceKind());
+    assertEquals("C:/docs/product-docs", out.getRootPath());
 
     ArgumentCaptor<PSSite> saved = ArgumentCaptor.forClass(PSSite.class);
     verify(siteManager).saveSite(saved.capture());

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteProperties.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteProperties.java
@@ -17,9 +17,9 @@
 package com.percussion.rest.sites;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Wire DTO for Virtual Site property bag keys stored on a CMS Site.
@@ -35,8 +35,15 @@ import java.util.Optional;
  *
  * <p>Blank / missing {@code sourceKind} (or value {@code repository}) means a traditional repository
  * Site. Phase 1 virtual adapter: {@code git-filesystem}.
+ *
+ * <p>Wire getters return plain {@code String} (not {@code Optional}) so JAXB/Jettison and Jackson
+ * {@code WRAP_ROOT_VALUE} emit/accept child elements {@code sourceKind}, {@code rootPath},
+ * {@code configFile}, and {@code siteKey} under root {@code VirtualSiteProperties}. Optional
+ * getters historically produced JAXB {@code unexpected element sourceKind} on PUT (#3365 / QA
+ * #3030).
  */
 @XmlRootElement(name = "VirtualSiteProperties")
+@JsonRootName("VirtualSiteProperties")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(
     name = "VirtualSiteProperties",
@@ -80,32 +87,32 @@ public class VirtualSiteProperties {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSourceKind() {
-    return Optional.ofNullable(sourceKind);
+  public String getSourceKind() {
+    return sourceKind;
   }
 
   public void setSourceKind(String sourceKind) {
     this.sourceKind = sourceKind;
   }
 
-  public Optional<String> getRootPath() {
-    return Optional.ofNullable(rootPath);
+  public String getRootPath() {
+    return rootPath;
   }
 
   public void setRootPath(String rootPath) {
     this.rootPath = rootPath;
   }
 
-  public Optional<String> getConfigFile() {
-    return Optional.ofNullable(configFile);
+  public String getConfigFile() {
+    return configFile;
   }
 
   public void setConfigFile(String configFile) {
     this.configFile = configFile;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -96,7 +96,7 @@ public class SitesResourceTest {
     Site out = resource.getSite("Help");
     assertEquals("Help", out.getName());
     assertTrue(out.getVirtual() != null);
-    assertEquals("git-filesystem", out.getVirtual().getSourceKind().orElse(null));
+    assertEquals("git-filesystem", out.getVirtual().getSourceKind());
     verify(adaptor).findByName("Help");
     verify(adaptor, never()).findByGuid(any());
   }
@@ -130,7 +130,7 @@ public class SitesResourceTest {
     when(adaptor.getVirtualSiteProperties("Help")).thenReturn(v);
 
     VirtualSiteProperties out = resource.getVirtualProperties("Help");
-    assertEquals("git-filesystem", out.getSourceKind().orElse(null));
+    assertEquals("git-filesystem", out.getSourceKind());
     verify(adaptor).getVirtualSiteProperties("Help");
   }
 

--- a/rest/src/test/java/com/percussion/rest/sites/VirtualSitePropertiesSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/VirtualSitePropertiesSerialDeserialTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.sites;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.rest.JacksonContextResolver;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.UnmarshalException;
+import jakarta.xml.bind.Unmarshaller;
+import java.io.StringReader;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * PUT/GET {@code /services/sites/{id}/virtual} wire shape (#3365 / QA #3030).
+ *
+ * <p>Production JSON uses {@link JacksonContextResolver} WRAP/UNWRAP_ROOT_VALUE so the envelope
+ * must be {@code VirtualSiteProperties}, not a bare {@code sourceKind}. JAXB child elements must be
+ * plain strings — Optional getters historically produced {@code unexpected element sourceKind}.
+ */
+@Tag("UnitTest")
+public class VirtualSitePropertiesSerialDeserialTest {
+
+  private static VirtualSiteProperties sample() {
+    VirtualSiteProperties props = new VirtualSiteProperties();
+    props.setSourceKind("git-filesystem");
+    props.setRootPath("C:/docs/product-docs");
+    props.setConfigFile("_config.yaml");
+    props.setSiteKey("product-docs");
+    props.setVirtual(true);
+    return props;
+  }
+
+  private static JsonMapper wrapRootMapper() {
+    return JsonMapper.builder()
+        .enable(SerializationFeature.WRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+        .build();
+  }
+
+  @Test
+  public void jacksonWrapsRootAndPlainStringFields() throws JacksonException {
+    var mapper = wrapRootMapper();
+    String json = mapper.writeValueAsString(sample());
+    assertTrue(json.contains("\"VirtualSiteProperties\""), "expected root wrap, got: " + json);
+    assertTrue(json.contains("\"sourceKind\""), json);
+    assertTrue(json.contains("\"git-filesystem\""), json);
+    assertTrue(json.contains("\"rootPath\""), json);
+    assertFalse(
+        json.contains("\"empty\"") && json.contains("\"present\""),
+        "sourceKind must be a plain string, not an Optional bean: " + json);
+
+    VirtualSiteProperties roundTrip = mapper.readValue(json, VirtualSiteProperties.class);
+    assertEquals("git-filesystem", roundTrip.getSourceKind());
+    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+    assertEquals("_config.yaml", roundTrip.getConfigFile());
+    assertEquals("product-docs", roundTrip.getSiteKey());
+    assertEquals(Boolean.TRUE, roundTrip.getVirtual());
+  }
+
+  @Test
+  public void productionMapperRoundTripsEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(VirtualSiteProperties.class);
+    String json = mapper.writeValueAsString(sample());
+    assertTrue(json.contains("\"VirtualSiteProperties\""), json);
+    assertTrue(json.contains("\"sourceKind\""), json);
+    assertTrue(json.contains("\"git-filesystem\""), json);
+    assertFalse(
+        json.contains("\"empty\"") && !json.contains("\"sourceKind\":\"git-filesystem\""),
+        "sourceKind must be a plain string: " + json);
+
+    VirtualSiteProperties roundTrip = mapper.readValue(json, VirtualSiteProperties.class);
+    assertEquals("git-filesystem", roundTrip.getSourceKind());
+    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+  }
+
+  @Test
+  public void productionMapperRejectsBareSourceKindRoot() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(VirtualSiteProperties.class);
+    String flat =
+        "{\"sourceKind\":\"git-filesystem\",\"rootPath\":\"C:/docs\",\"virtual\":true}";
+    try {
+      VirtualSiteProperties result = mapper.readValue(flat, VirtualSiteProperties.class);
+      assertTrue(
+          result == null
+              || result.getSourceKind() == null
+              || result.getSourceKind().isBlank(),
+          "flat sourceKind root must not bind under UNWRAP_ROOT_VALUE; got sourceKind="
+              + (result == null ? "null" : result.getSourceKind()));
+    } catch (Exception expected) {
+      assertTrue(
+          expected.getMessage() != null
+              && (expected.getMessage().contains("VirtualSiteProperties")
+                  || expected.getMessage().contains("Root name")
+                  || expected.getMessage().contains("sourceKind")),
+          "unexpected failure: " + expected);
+    }
+  }
+
+  @Test
+  public void jaxbMarshalsRootAndStringChildren() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(VirtualSiteProperties.class);
+    Marshaller marshaller = ctx.createMarshaller();
+    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
+    var writer = new StringWriter();
+    try {
+      marshaller.marshal(sample(), writer);
+    } catch (Exception e) {
+      fail("JAXB must marshal VirtualSiteProperties (#3365); got: " + e.getMessage(), e);
+    }
+    String xml = writer.toString();
+    assertTrue(xml.contains("VirtualSiteProperties"), xml);
+    assertTrue(xml.contains("sourceKind"), xml);
+    assertTrue(xml.contains("git-filesystem"), xml);
+    assertTrue(xml.contains("rootPath"), xml);
+    assertFalse(xml.contains("<empty>"), "must not marshal Optional beans: " + xml);
+
+    Unmarshaller unmarshaller = ctx.createUnmarshaller();
+    VirtualSiteProperties roundTrip =
+        (VirtualSiteProperties) unmarshaller.unmarshal(new StringReader(xml));
+    assertEquals("git-filesystem", roundTrip.getSourceKind());
+    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+    assertEquals("_config.yaml", roundTrip.getConfigFile());
+    assertEquals("product-docs", roundTrip.getSiteKey());
+  }
+
+  @Test
+  public void jaxbRejectsBareSourceKindRoot() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(VirtualSiteProperties.class);
+    Unmarshaller unmarshaller = ctx.createUnmarshaller();
+    String bare = "<sourceKind>git-filesystem</sourceKind>";
+    try {
+      Object result = unmarshaller.unmarshal(new StringReader(bare));
+      fail(
+          "bare sourceKind root must not unmarshal as VirtualSiteProperties (#3365); got: "
+              + result);
+    } catch (UnmarshalException expected) {
+      // CXF/JAXB production path: unexpected element sourceKind
+    } catch (AssertionError expected) {
+      // GlassFish JAXB + Saxon XML parser can fail as AssertionError on unexpected root
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Unblocks human QA #3030 steps 5–7 (parent epic #2678, residual of #3020 / REST #3018).

`PUT /services/sites/{nameOrId}/virtual` rejected the Developer Sites save body with JAXB **unexpected element `sourceKind`; expected `VirtualSiteProperties`**. Two wire mismatches caused that:

1. The SPA sent a **flat** `{ sourceKind, rootPath, … }` JSON object. Production CXF Jackson uses `WRAP_ROOT_VALUE` / `UNWRAP_ROOT_VALUE`, and JAXB/Jettison expect root **`VirtualSiteProperties`**.
2. `VirtualSiteProperties` getters returned `Optional<String>`, so JAXB did not treat children as `sourceKind` string elements.

This change:

- Uses **plain `String` getters** on the wire DTO (`@JsonRootName("VirtualSiteProperties")`), matching `Site` (#3198).
- Sends `{ VirtualSiteProperties: { sourceKind, rootPath, configFile, siteKey } }` from WebUI.
- **GET-roundtrips** after a successful save so `virtual=true` and **Build Virtual Site** appear without a full page reload.

Partial #3365. Parent #2678. Related QA #3030.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `mvnw clean install` on `rest`, `projects/sitemanage` (after matching `system` SNAPSHOT), and `WebUI`.
2. Unit: `VirtualSitePropertiesSerialDeserialTest` (Jackson wrap + JAXB string children); Vitest envelope + GET-after-save; `SitesAdaptorTest` String getters.
3. H2 QA: `perc-devctl qa-up` → hot-copy `WebUI/target/generated-webui/cm/modern` → `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` (3 passed).
4. Manual (later Human QA / #3030): Developer → Sites → detail → Git filesystem + root path → Save Virtual Site source → expect 200 (not 400) and Build chrome without reload.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `developer/rest.md`, `developer/virtual-sites.md`, `reference/site-config.md` (wire root name + `git-filesystem` save)
- [x] **Unit / module tests** — JAXB/Jackson envelope, WebUI PUT body + GET-roundtrip, adaptor getters
- [x] **WebUI + Playwright** — `developer-site-virtual-source.spec.js` save-path envelope + Build chrome
- [x] **Build gates** — standalone clean install on changed modules (no skipTests); C2 reverse-dep `projects/sitemanage` after getter signature change
- [x] **Cross-platform** — N/A for new filesystem I/O (wire JSON/XML only; existing path rules unchanged)

### C3 evidence

- **modules_built:** `rest`, `WebUI`, `projects/sitemanage` (C2; local `system` SNAPSHOT reinstall first so `PSNavNameAliases` resolved)
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 367, Failures: 0 (`VirtualSitePropertiesSerialDeserialTest` 5)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Surefire 59 Java tests, Failures: 0); Vitest virtual: 23 passed
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (`SitesAdaptorTest` Tests run: 36, Failures: 0)
- **downstream_checked:** grepped `extends VirtualSiteProperties` / `new VirtualSiteProperties() {` (none). Reverse-dep `projects/sitemanage` standalone clean install green after `String` getter change.

### C5 UI proof (H2 Docker QA)

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **3 passed** (including #3365 save envelope)
- console-clean=yes (pageerror listeners)
- server.log-clean=yes (no ERROR/FATAL in `jetty/base/logs/server.log` for the test window)

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
