### PR TITLE
feat(webui): Developer Sites Publish Virtual Site chrome (#3366)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -12,6 +12,7 @@ import type {
   VirtualSiteBuildResult,
   VirtualSitePreviewStatus,
   VirtualSiteProperties,
+  VirtualSitePublishResult,
 } from "./types";
 
 /** Honest design gaps for Developer SY-04 site browse (not full site design). */
@@ -317,6 +318,44 @@ export async function getVirtualSitePreviewStatus(
  * Browser URL for the assembled preview file stream (same-origin cookies).
  * {@code homePath} must be a relative path such as {@code 8.2/index.html}.
  */
+/**
+ * Normalize Virtual Site publish result (Jackson root wrap or plain DTO).
+ */
+export function parseVirtualSitePublishResult(payload: unknown): VirtualSitePublishResult {
+  if (payload == null || typeof payload !== "object") {
+    return {};
+  }
+  const obj = payload as Record<string, unknown>;
+  const root =
+    (obj.VirtualSitePublishResult as Record<string, unknown> | undefined) ??
+    (obj.virtualSitePublishResult as Record<string, unknown> | undefined) ??
+    obj;
+  return {
+    siteName: asNullableString(root.siteName),
+    siteKey: asNullableString(root.siteKey),
+    publishPath: asNullableString(root.publishPath),
+    buildOutputPath: asNullableString(root.buildOutputPath),
+    pagesWritten: asNullableNumber(root.pagesWritten),
+    filesCopied: asNullableNumber(root.filesCopied),
+    linkProblemCount: asNullableNumber(root.linkProblemCount),
+    hasLinkProblems:
+      typeof root.hasLinkProblems === "boolean" ? root.hasLinkProblems : undefined,
+    linkProblems: asStringArray(root.linkProblems),
+  };
+}
+
+/**
+ * POST /services/sites/{nameOrId}/virtual/publish
+ *
+ * <p>Admin-only. Builds the saved Virtual Site then copies assembled files to
+ * the Site filesystem publish root. Traditional repository Sites return 4xx.
+ */
+export async function publishVirtualSite(nameOrId: string): Promise<VirtualSitePublishResult> {
+  const key = encodeURIComponent(nameOrId.trim());
+  const payload = await post<unknown>(`${PATHS.SITES}/${key}/virtual/publish`, {});
+  return parseVirtualSitePublishResult(payload);
+}
+
 export function virtualSitePreviewContentHref(nameOrId: string, homePath: string): string {
   const key = encodeURIComponent(nameOrId.trim());
   const rel = homePath

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -772,3 +772,23 @@ export interface VirtualSitePreviewStatus {
   message?: string | null;
 }
 
+/**
+ * Outcome of {@code POST /services/sites/{nameOrId}/virtual/publish}:
+ * build-then-copy to the Site filesystem publish root.
+ *
+ * <p>HTTP 200 may still report link problems via {@code hasLinkProblems}.
+ */
+export interface VirtualSitePublishResult {
+  siteName?: string | null;
+  siteKey?: string | null;
+  /** Absolute filesystem path of the Site publishing location. */
+  publishPath?: string | null;
+  /** Absolute filesystem path of the staging build output. */
+  buildOutputPath?: string | null;
+  pagesWritten?: number | null;
+  filesCopied?: number | null;
+  linkProblemCount?: number | null;
+  hasLinkProblems?: boolean | null;
+  linkProblems?: string[] | null;
+}
+

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -20,10 +20,14 @@ import {
   buildVirtualSite,
   getVirtualSitePreviewStatus,
   getVirtualSiteProperties,
+  publishVirtualSite,
   updateVirtualSiteProperties,
   virtualSitePreviewContentHref,
 } from "../api/developer/sitesApi";
-import type { VirtualSiteBuildResult } from "../api/developer/types";
+import type {
+  VirtualSiteBuildResult,
+  VirtualSitePublishResult,
+} from "../api/developer/types";
 import {
   catalogColors,
   errorAlert,
@@ -35,8 +39,10 @@ import { DEV_MSG } from "./messages";
 import { copyTextToClipboard } from "./templateSourceViewer";
 import {
   formatVirtualSiteBuildSummary,
+  formatVirtualSitePublishSummary,
   sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
+  shouldShowVirtualPublishChrome,
 } from "./virtualSiteBuild";
 import {
   SOURCE_KIND_GIT_FILESYSTEM,
@@ -133,7 +139,8 @@ function validationMessage(
 /**
  * Site detail section: view/edit Virtual Site source fields via public Site REST
  * ({@code GET|PUT /services/sites/{name}/virtual}) and trigger a CMS-integrated
- * build ({@code POST …/virtual/build}) when source kind is Virtual.
+ * build ({@code POST …/virtual/build}) or publish ({@code POST …/virtual/publish})
+ * when source kind is Virtual.
  */
 export function VirtualSiteSourcePanel({
   siteName,
@@ -144,6 +151,7 @@ export function VirtualSiteSourcePanel({
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [building, setBuilding] = useState(false);
+  const [publishing, setPublishing] = useState(false);
   /** Load-time failure (hides form; retry reloads). */
   const [loadError, setLoadError] = useState<string | null>(null);
   /** Save / client validation failure (keeps form mounted). */
@@ -152,6 +160,10 @@ export function VirtualSiteSourcePanel({
   const [isVirtual, setIsVirtual] = useState(false);
   const [buildError, setBuildError] = useState<string | null>(null);
   const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [publishResult, setPublishResult] = useState<VirtualSitePublishResult | null>(
+    null,
+  );
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [previewBusy, setPreviewBusy] = useState(false);
   const [linkCopyNotice, setLinkCopyNotice] = useState<string | null>(null);
@@ -169,6 +181,8 @@ export function VirtualSiteSourcePanel({
     setSavedNotice(null);
     setBuildError(null);
     setBuildResult(null);
+    setPublishError(null);
+    setPublishResult(null);
     setPreviewError(null);
     setLinkCopyNotice(null);
     getVirtualSiteProperties(siteName)
@@ -253,6 +267,30 @@ export function VirtualSiteSourcePanel({
     }
   }
 
+  async function onPublish(): Promise<void> {
+    // Publish uses *saved* server properties — validate form only as a soft gate.
+    const clientErr = validateVirtualSiteForm(form);
+    if (clientErr) {
+      setPublishError(validationMessage(clientErr));
+      setPublishResult(null);
+      return;
+    }
+    setPublishing(true);
+    setPublishError(null);
+    setPublishResult(null);
+    setBuildError(null);
+    setPreviewError(null);
+    setFormError(null);
+    try {
+      const result = await publishVirtualSite(siteName);
+      setPublishResult(result);
+    } catch (e: unknown) {
+      setPublishError(panelErrMsg(e, DEV_MSG.SITE_VIRT_PUBLISH_ERROR));
+    } finally {
+      setPublishing(false);
+    }
+  }
+
   async function onPreview(): Promise<void> {
     setPreviewBusy(true);
     setPreviewError(null);
@@ -287,10 +325,14 @@ export function VirtualSiteSourcePanel({
   }
 
   const virtualMode = isVirtualSourceKind(form.sourceKind);
-  /** Build chrome only for virtual source kinds (never for repository). */
+  /** Build/publish chrome only for virtual source kinds (never for repository). */
   const showBuildChrome = shouldShowVirtualBuildChrome(form.sourceKind);
-  const busy = saving || building;
+  const showPublishChrome = shouldShowVirtualPublishChrome(form.sourceKind);
+  const busy = saving || building || publishing;
   const buildSummary = buildResult ? formatVirtualSiteBuildSummary(buildResult) : null;
+  const publishSummary = publishResult
+    ? formatVirtualSitePublishSummary(publishResult)
+    : null;
 
   return (
     <section
@@ -463,6 +505,17 @@ export function VirtualSiteSourcePanel({
                 >
                   {DEV_MSG.SITE_VIRT_PREVIEW}
                 </button>
+                {showPublishChrome ? (
+                  <button
+                    type="button"
+                    data-testid="developer-site-virtual-publish"
+                    style={busy ? disabledSecondaryButton : secondaryButton}
+                    disabled={busy}
+                    onClick={() => void onPublish()}
+                  >
+                    {publishing ? DEV_MSG.SITE_VIRT_PUBLISHING : DEV_MSG.SITE_VIRT_PUBLISH}
+                  </button>
+                ) : null}
               </div>
               <p
                 style={{ ...mutedHintText, margin: "8px 0 0" }}
@@ -470,6 +523,22 @@ export function VirtualSiteSourcePanel({
               >
                 {DEV_MSG.SITE_VIRT_PREVIEW_HINT}
               </p>
+              {showPublishChrome ? (
+                <>
+                  <p
+                    style={{ ...mutedHintText, margin: "8px 0 0" }}
+                    data-testid="developer-site-virtual-publish-hint"
+                  >
+                    {DEV_MSG.SITE_VIRT_PUBLISH_HINT}
+                  </p>
+                  <p
+                    style={{ ...mutedHintText, margin: "8px 0 0" }}
+                    data-testid="developer-site-virtual-publish-save-first"
+                  >
+                    {DEV_MSG.SITE_VIRT_PUBLISH_SAVE_FIRST}
+                  </p>
+                </>
+              ) : null}
 
               {building ? (
                 <div data-testid="developer-site-virtual-build-busy" style={{ ...mutedText, marginTop: "10px" }}>
@@ -587,6 +656,44 @@ export function VirtualSiteSourcePanel({
                           </ul>
                         </details>
                       ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {showPublishChrome && publishing ? (
+                <div data-testid="developer-site-virtual-publish-busy" style={{ ...mutedText, marginTop: "10px" }}>
+                  {DEV_MSG.SITE_VIRT_PUBLISHING}
+                </div>
+              ) : null}
+
+              {showPublishChrome && publishError ? (
+                <div
+                  role="alert"
+                  data-testid="developer-site-virtual-publish-error"
+                  style={{ ...errorAlert, marginTop: "10px" }}
+                >
+                  {publishError}
+                </div>
+              ) : null}
+
+              {showPublishChrome && publishResult && publishSummary ? (
+                <div data-testid="developer-site-virtual-publish-result" style={buildResultBox}>
+                  <div data-testid="developer-site-virtual-publish-success" style={successNotice}>
+                    {DEV_MSG.SITE_VIRT_PUBLISH_SUCCESS}
+                  </div>
+                  <div style={{ marginTop: "6px" }}>
+                    <span>{DEV_MSG.SITE_VIRT_PUBLISH_FILES}: </span>
+                    <span data-testid="developer-site-virtual-publish-files" style={buildResultMono}>
+                      {publishSummary.filesLine}
+                    </span>
+                  </div>
+                  {publishSummary.destLine ? (
+                    <div style={{ marginTop: "4px" }}>
+                      <span>{DEV_MSG.SITE_VIRT_PUBLISH_DEST}: </span>
+                      <span data-testid="developer-site-virtual-publish-dest" style={buildResultMono}>
+                        {publishSummary.destLine}
+                      </span>
                     </div>
                   ) : null}
                 </div>

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -787,6 +787,16 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_PREVIEW_MISSING:
     "perc.ui.developer@No assembled site to preview. Run Build Virtual Site first.",
   SITE_VIRT_PREVIEW_ERROR: "perc.ui.developer@Could not open Virtual Site preview.",
+  SITE_VIRT_PUBLISH: "perc.ui.developer@Publish Virtual Site",
+  SITE_VIRT_PUBLISHING: "perc.ui.developer@Publishing Virtual Site...",
+  SITE_VIRT_PUBLISH_HINT:
+    "perc.ui.developer@Builds this Virtual Site using saved source properties, then copies assembled files to the Site filesystem publish location. Requires Admin. Traditional repository Sites do not show this control.",
+  SITE_VIRT_PUBLISH_SAVE_FIRST:
+    "perc.ui.developer@Save Virtual Site source before publishing so the server uses the latest properties. The Site publishing filesystem root must be configured.",
+  SITE_VIRT_PUBLISH_ERROR: "perc.ui.developer@Could not publish Virtual Site.",
+  SITE_VIRT_PUBLISH_SUCCESS: "perc.ui.developer@Virtual Site published.",
+  SITE_VIRT_PUBLISH_FILES: "perc.ui.developer@Files copied",
+  SITE_VIRT_PUBLISH_DEST: "perc.ui.developer@Destination path",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
-import type { VirtualSiteBuildResult } from "../api/developer/types";
+import type {
+  VirtualSiteBuildResult,
+  VirtualSitePublishResult,
+} from "../api/developer/types";
 
 /**
  * True when the Build Virtual Site control should be shown.
@@ -26,6 +29,16 @@ export function shouldShowVirtualBuildChrome(
 ): boolean {
   const v = (sourceKind ?? "").trim().toLowerCase();
   return v.length > 0 && v !== "repository";
+}
+
+/**
+ * True when the Publish Virtual Site control should be shown.
+ * Repository / blank source kinds must not display publish chrome.
+ */
+export function shouldShowVirtualPublishChrome(
+  sourceKind: string | null | undefined,
+): boolean {
+  return shouldShowVirtualBuildChrome(sourceKind);
 }
 
 /**
@@ -90,6 +103,50 @@ export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
     outputLine: output,
     linkLine,
     hasLinkProblems,
+    linkProblems,
+  };
+}
+
+/**
+ * Operator-facing success summary from a publish result DTO.
+ * Highlights files copied and the Site filesystem destination path.
+ */
+export function formatVirtualSitePublishSummary(result: VirtualSitePublishResult): {
+  filesLine: string;
+  destLine: string | null;
+  pagesLine: string;
+  hasLinkProblems: boolean;
+  linkLine: string | null;
+  linkProblems: string[];
+} {
+  const files =
+    typeof result.filesCopied === "number" && Number.isFinite(result.filesCopied)
+      ? result.filesCopied
+      : 0;
+  const pages =
+    typeof result.pagesWritten === "number" && Number.isFinite(result.pagesWritten)
+      ? result.pagesWritten
+      : 0;
+  const dest =
+    typeof result.publishPath === "string" && result.publishPath.trim()
+      ? result.publishPath.trim()
+      : null;
+
+  const linkProblems = normalizeVirtualSiteLinkProblems(result);
+  const linkCount =
+    typeof result.linkProblemCount === "number" && Number.isFinite(result.linkProblemCount)
+      ? result.linkProblemCount
+      : 0;
+  const hasLinkProblems =
+    result.hasLinkProblems === true || linkCount > 0 || linkProblems.length > 0;
+  const resolvedCount = linkCount > 0 ? linkCount : linkProblems.length;
+
+  return {
+    filesLine: String(files),
+    destLine: dest,
+    pagesLine: String(pages),
+    hasLinkProblems,
+    linkLine: hasLinkProblems ? String(resolvedCount) : null,
     linkProblems,
   };
 }

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -11,6 +11,8 @@ import {
   parseVirtualSiteBuildResult,
   parseVirtualSitePreviewStatus,
   parseVirtualSiteProperties,
+  parseVirtualSitePublishResult,
+  publishVirtualSite,
   toVirtualSitePropertiesEnvelope,
   updateVirtualSiteProperties,
   virtualSitePreviewContentHref,
@@ -209,5 +211,57 @@ describe("sitesApi virtual properties", () => {
     const href = virtualSitePreviewContentHref("Help Docs", "8.2/index.html");
     expect(href).toMatch(/\/sites\/Help%20Docs\/virtual\/preview\/8.2\/index.html$/);
     expect(virtualSitePreviewContentHref("Help", "../secret")).not.toContain("..");
+  });
+
+  it("parseVirtualSitePublishResult handles plain and wrapped payloads", () => {
+    expect(
+      parseVirtualSitePublishResult({
+        siteName: "Help",
+        filesCopied: 12,
+        publishPath: "C:/inetpub/wwwroot/help",
+        hasLinkProblems: false,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        siteName: "Help",
+        filesCopied: 12,
+        publishPath: "C:/inetpub/wwwroot/help",
+        hasLinkProblems: false,
+      }),
+    );
+    expect(
+      parseVirtualSitePublishResult({
+        VirtualSitePublishResult: {
+          publishPath: "C:/sites/help",
+          filesCopied: 4,
+          pagesWritten: 3,
+          buildOutputPath: "C:/tmp/virtual-sites/help",
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        publishPath: "C:/sites/help",
+        filesCopied: 4,
+        pagesWritten: 3,
+        buildOutputPath: "C:/tmp/virtual-sites/help",
+      }),
+    );
+    expect(parseVirtualSitePublishResult(null)).toEqual({});
+  });
+
+  it("publishVirtualSite POSTs /virtual/publish and parses result", async () => {
+    post.mockResolvedValue({
+      siteName: "Help",
+      publishPath: "C:/sites/help",
+      filesCopied: 9,
+      pagesWritten: 7,
+    });
+    const out = await publishVirtualSite("Help Docs");
+    expect(post).toHaveBeenCalledWith(
+      expect.stringMatching(/\/sites\/Help%20Docs\/virtual\/publish$/),
+      {},
+    );
+    expect(out.filesCopied).toBe(9);
+    expect(out.publishPath).toContain("sites/help");
   });
 });

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   getVirtualSiteProperties: vi.fn(),
   updateVirtualSiteProperties: vi.fn(),
   buildVirtualSite: vi.fn(),
+  publishVirtualSite: vi.fn(),
   getVirtualSitePreviewStatus: vi.fn(),
   virtualSitePreviewContentHref: vi.fn(
     (name: string, home: string) => `/services/sites/${encodeURIComponent(name)}/virtual/preview/${home}`,
@@ -25,6 +26,7 @@ vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
 const getVirtual = sitesApi.getVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const updateVirtual = sitesApi.updateVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const buildVirtual = sitesApi.buildVirtualSite as ReturnType<typeof vi.fn>;
+const publishVirtual = sitesApi.publishVirtualSite as ReturnType<typeof vi.fn>;
 const previewStatus = sitesApi.getVirtualSitePreviewStatus as ReturnType<typeof vi.fn>;
 
 describe("VirtualSiteSourcePanel", () => {
@@ -35,6 +37,7 @@ describe("VirtualSiteSourcePanel", () => {
     getVirtual.mockReset();
     updateVirtual.mockReset();
     buildVirtual.mockReset();
+    publishVirtual.mockReset();
     previewStatus.mockReset();
   });
 
@@ -55,10 +58,11 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-source-kind")).toBeTruthy();
     // Root path hidden until virtual selected
     expect(screen.queryByTestId("developer-site-virtual-root-path")).toBeNull();
-    // Repository sites must not show Build chrome
+    // Repository sites must not show Build or Publish chrome
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
     expect(getVirtual).toHaveBeenCalledWith("Corporate");
   });
 
@@ -363,6 +367,7 @@ describe("VirtualSiteSourcePanel", () => {
       expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     });
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
   });
 
   it("client-validates before build when root is empty", async () => {
@@ -431,5 +436,83 @@ describe("VirtualSiteSourcePanel", () => {
       );
     });
     expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("shows Publish chrome for virtual sites and success dest path", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    publishVirtual.mockResolvedValue({
+      siteName: "Help",
+      publishPath: "C:/inetpub/wwwroot/help",
+      filesCopied: 18,
+      pagesWritten: 12,
+      hasLinkProblems: false,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-publish"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish-result")).toBeTruthy();
+    });
+    expect(publishVirtual).toHaveBeenCalledWith("Help");
+    expect(screen.getByTestId("developer-site-virtual-publish-success").textContent).toContain(
+      DEV_MSG.SITE_VIRT_PUBLISH_SUCCESS,
+    );
+    expect(screen.getByTestId("developer-site-virtual-publish-files").textContent).toBe("18");
+    expect(screen.getByTestId("developer-site-virtual-publish-dest").textContent).toContain(
+      "inetpub",
+    );
+  });
+
+  it("surfaces publish API errors", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    publishVirtual.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "Site is not configured as a Virtual Site" },
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-publish"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-publish-error").textContent).toContain(
+      DEV_MSG.SITE_VIRT_PUBLISH_ERROR,
+    );
+    expect(screen.getByTestId("developer-site-virtual-publish-error").textContent).toContain(
+      "not configured",
+    );
+    expect(screen.queryByTestId("developer-site-virtual-publish-result")).toBeNull();
+  });
+
+  it("client-validates before publish when root is empty", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-publish"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish-error").textContent).toContain(
+        DEV_MSG.SITE_VIRT_ERR_ROOT_REQUIRED,
+      );
+    });
+    expect(publishVirtual).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -5,9 +5,11 @@
 import { describe, expect, it } from "vitest";
 import {
   formatVirtualSiteBuildSummary,
+  formatVirtualSitePublishSummary,
   normalizeVirtualSiteLinkProblems,
   sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
+  shouldShowVirtualPublishChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
 describe("virtualSiteBuild helpers", () => {
@@ -18,6 +20,32 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualBuildChrome("Repository")).toBe(false);
     expect(shouldShowVirtualBuildChrome("git-filesystem")).toBe(true);
     expect(shouldShowVirtualBuildChrome("  git-filesystem  ")).toBe(true);
+  });
+
+  it("shouldShowVirtualPublishChrome only for virtual source kinds", () => {
+    expect(shouldShowVirtualPublishChrome(null)).toBe(false);
+    expect(shouldShowVirtualPublishChrome("")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("repository")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("Repository")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("git-filesystem")).toBe(true);
+  });
+
+  it("formatVirtualSitePublishSummary reports files copied and dest path", () => {
+    const ok = formatVirtualSitePublishSummary({
+      filesCopied: 15,
+      publishPath: " C:/inetpub/help ",
+      pagesWritten: 8,
+      hasLinkProblems: false,
+    });
+    expect(ok.filesLine).toBe("15");
+    expect(ok.destLine).toBe("C:/inetpub/help");
+    expect(ok.pagesLine).toBe("8");
+    expect(ok.hasLinkProblems).toBe(false);
+
+    const missing = formatVirtualSitePublishSummary({});
+    expect(missing.filesLine).toBe("0");
+    expect(missing.destLine).toBeNull();
+    expect(missing.pagesLine).toBe("0");
   });
 
   it("formatVirtualSiteBuildSummary reports pages, output, and link problems", () => {

--- a/docs/ai-generated/code-reviews/issue-3366-virtual-site-publish-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3366-virtual-site-publish-chrome-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #3366 Developer Sites Publish Virtual Site chrome
+
+**Branch:** `feat/issue-3366-virtual-site-publish-chrome`  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Date:** 2026-08-14  
+**Recommendation:** approve
+
+## Change class
+
+WebUI product chrome on Developer → Sites Virtual panel: Publish control calling existing `POST /services/sites/{nameOrId}/virtual/publish`. Companions: `sitesApi` helper + DTO parse, Vitest (API + helpers + panel), H2 Playwright surface spec, `product-docs/8.2` operator steps.
+
+## Gate checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs | None found |
+| Behavioral tests | Vitest covers hide-for-repository, success dest/files, API error, client validation; Playwright live + mocked success |
+| Change-class closure | WebUI + perc-qa-automation spec + product-docs 8.2 |
+| Portable paths | Display-only dest strings from REST; no host filesystem join |
+| Java API shape / `final` | N/A — TypeScript client only; does not reimplement `SitesAdaptor.publishVirtualSite` |
+| Agent rule files | None |
+
+## Notes (non-blocking)
+
+- Publish reuses the Build chrome visibility predicate (`shouldShowVirtualPublishChrome` → `shouldShowVirtualBuildChrome`).
+- Live H2 publish success is not required; panel posts to REST and surfaces 4xx when source is unsaved / Site root missing (sibling #3365).
+- Pre-existing QA install `PSX_OBJECTACL` PK ERROR during `qa-up` is unrelated to this surface (install-time folder ACL).

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -18,9 +18,10 @@
  * Developer Sites → Virtual Site source panel (#2956 / #3020 / #3300 / epic #2678).
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
- * with source-kind control (repository default), save chrome, and Build Virtual
- * Site chrome only when source kind is virtual (never for repository).
- * Also intercepts build REST to prove link-problem detail lines render on HTTP 200.
+ * with source-kind control (repository default), save chrome, and Build / Publish
+ * Virtual Site chrome only when source kind is virtual (never for repository).
+ * Also intercepts build REST to prove link-problem detail lines render on HTTP 200
+ * and publish REST to prove dest path + files copied on HTTP 200.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -124,9 +125,10 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         await expect(
           page.locator('[data-testid="developer-site-virtual-build-section"]'),
         ).toHaveCount(0);
+        await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
       }
 
-      // Switch to git-filesystem reveals root path + Build control
+      // Switch to git-filesystem reveals root path + Build / Publish controls
       await kind.selectOption("git-filesystem");
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
@@ -134,6 +136,8 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-preview-hint"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-hint"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-publish-hint"]')).toBeVisible();
 
       // Preview without a last build: in-panel empty/error (no 500 / no crash)
       await page.locator('[data-testid="developer-site-virtual-preview"]').click();
@@ -157,9 +161,22 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       );
       await expect(buildChrome.first()).toBeVisible({ timeout: 20_000 });
 
+      // Publish without a saved virtual source / Site root: error or success chrome
+      // (H2 QA rarely has a saved virtual source; do not require live publish success)
+      await page.locator('[data-testid="developer-site-virtual-publish"]').click();
+      const publishChrome = page.locator(
+        [
+          '[data-testid="developer-site-virtual-publish-error"]',
+          '[data-testid="developer-site-virtual-publish-result"]',
+          '[data-testid="developer-site-virtual-publish-busy"]',
+        ].join(", "),
+      );
+      await expect(publishChrome.first()).toBeVisible({ timeout: 20_000 });
+
       // Restore repository to avoid leaving QA site dirty when save is not exercised
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
     }
 
     const jsErrors = page.__virtPageErrors || [];
@@ -299,6 +316,132 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(
       page.locator('[data-testid="developer-site-virtual-build-link-line"]').nth(0),
     ).toHaveText("broken id:missing-page from 8.2/index.md");
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("publish result shows files copied and dest path on HTTP 200", async ({ page }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      if (/Failed to load resource:.*404/.test(text)) {
+        return;
+      }
+      consoleErrors.push(text);
+    });
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual/publish", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          siteName: "Help",
+          siteKey: "product-docs",
+          publishPath: "C:/inetpub/wwwroot/help",
+          buildOutputPath: "C:/tmp/virtual-sites/product-docs",
+          pagesWritten: 5,
+          filesCopied: 11,
+          linkProblemCount: 0,
+          hasLinkProblems: false,
+        }),
+      });
+    });
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/virtual/publish") || url.includes("/virtual/build")) {
+        await route.fallback();
+        return;
+      }
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sourceKind: "git-filesystem",
+          rootPath: "C:/docs",
+          configFile: "_config.yaml",
+          siteKey: "product-docs",
+          virtual: true,
+        }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const empty = page.locator('[data-testid="developer-site-empty"]');
+    if (await empty.isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — Virtual Site publish result requires a site row",
+      });
+      return;
+    }
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.locator('[data-testid="developer-site-virtual-publish"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-result"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-success"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-files"]')).toHaveText(
+      "11",
+    );
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-dest"]')).toContainText(
+      "inetpub",
+    );
     expect(consoleErrors).toEqual([]);
   });
 

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -47,9 +47,11 @@ For Git/filesystem Virtual Sites such as product documentation:
 3. Set the Site **publishing filesystem root** (Site root) to a dedicated directory on the CMS
    host. Do **not** point it at `virtual.rootPath` (the Markdown source tree).
 4. Confirm the source root exists on the host and that the publish directory is writable.
-5. Call `POST /services/sites/{nameOrId}/virtual/publish` (or run **Build Virtual Site** first if
-   you only want staging output).
-6. On success, the JSON result includes `publishPath`, `filesCopied`, `pagesWritten`, and any
+5. From **Developer → Sites → Site detail**, choose **Publish Virtual Site** (visible only
+   when source kind is Virtual). The panel reports files copied and the destination path,
+   or a clear error. Integrators can call `POST /services/sites/{nameOrId}/virtual/publish`
+   instead. Run **Build Virtual Site** first if you only want staging output.
+6. On success, the result includes `publishPath`, `filesCopied`, `pagesWritten`, and any
    link problems (`hasLinkProblems` can be true with HTTP 200).
 7. Spot-check `index.html` (and version folders such as `8.2/`) under the Site root.
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -171,8 +171,14 @@ site to the Site's configured filesystem publish location:
 
 1. Set the Site **publishing filesystem root** (Site root / `IPSSite.root`) to a dedicated
    directory on the CMS host (not the Markdown `virtual.rootPath`).
-2. As **Admin**, call `POST /sites/{nameOrId}/virtual/publish`.
-3. The server **builds then copies** HTML/assets to that Site root and returns `publishPath`
+2. As **Admin**, open **Developer → Sites → Site detail** for the Virtual Site.
+3. Confirm **Source kind** is **Git filesystem** and **Save Virtual Site source** if you
+   changed properties. Traditional **Repository** Sites never show Publish chrome.
+4. Choose **Publish Virtual Site**. The panel shows a busy state, then success with
+   **files copied** and the **destination path**, or a clear error (not Admin, still a
+   repository Site on the server, missing or unsafe Site root).
+5. Integrators can call the same operation over REST: `POST /sites/{nameOrId}/virtual/publish`.
+   The server **builds then copies** HTML/assets to that Site root and returns `publishPath`
    and `filesCopied`. Missing or unsafe Site root, overlap with the source tree, or a
    non-virtual Site returns **400** with a readable message (not HTTP 500 / silent no-op).
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -111,7 +111,7 @@ Example create body:
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
 | Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
-| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root |
+| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root. Same action as **Developer → Sites → Publish Virtual Site** |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
 only empty-catalog case. See [Sites & content structure](id:admin-sites).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -165,7 +165,9 @@ assembled file stream). Missing output returns status `available=false` (HTTP 20
 ## CMS-integrated publish (Site filesystem target)
 
 Build writes a **staging** tree. To publish that tree to the Site's configured filesystem
-location (`IPSSite.root` / Site publishing root), an **Admin** calls:
+location (`IPSSite.root` / Site publishing root), an **Admin** uses
+**Developer → Sites → Site detail → Publish Virtual Site** (visible only when source kind
+is Virtual; hidden for repository Sites) or calls:
 
 ```http
 POST /sites/{nameOrId}/virtual/publish

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -151,7 +151,9 @@ Runs the same build, then copies the assembled tree to the Site **filesystem pub
 | `403` | Caller is not Admin |
 | `404` | Site not found |
 
-Configure a dedicated Site root (not the Markdown source path). See [Publishing](id:admin-publishing).
+Configure a dedicated Site root (not the Markdown source path). Operators can run the same
+action from **Developer → Sites → Site detail → Publish Virtual Site** (Admin; hidden for
+repository Sites). See [Publishing](id:admin-publishing).
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds **Publish Virtual Site** chrome on **Developer → Sites → Site detail** (Admin). The control is shown only when source kind is Virtual (`git-filesystem`) and is **hidden for repository Sites**. It calls the existing `POST /services/sites/{nameOrId}/virtual/publish` (does **not** re-implement `SitesAdaptor.publishVirtualSite`).

Busy, success (files copied + destination path), and clear error states (not Admin, still repository on the server, missing Site root, client validation) follow the existing Build chrome pattern.

Parent tracker: #2678  
Fixes #3366

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2320; Surefire 59 / 0 failures.
2. Open Developer → Sites → a traditional Site: **Publish Virtual Site** is absent.
3. Switch source kind to Git filesystem: Publish control + hints appear.
4. Click Publish with empty root: in-panel validation error; no REST call.
5. Click Publish with saved virtual source / missing Site root: in-panel API error (H2 default path).
6. Playwright (H2 QA): `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — 3 passed.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `admin/publishing.md`, `developer/virtual-sites.md`, `developer/rest.md`, `reference/site-config.md`
- [x] **Unit / module tests** — Vitest API/helper/panel + WebUI standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js`
- [x] **Build gates** — WebUI standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no host filesystem I/O; dest path is REST display text)

## C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-14). Vitest: Tests 2320 passed (314 files). Surefire Java: Tests run 59, Failures 0.
- **downstream_checked:** none (no Java public/protected API or `final`/`sealed` change)

## C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up` (matrix cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`). Matrix step reported install-time `PSX_OBJECTACL` PK ERROR (pre-existing, not this feature); HTTP probe `/Rhythmyx/rest/mimetypes` = 200.
- **deploy:** `docker cp` `WebUI/target/generated-webui/cm/modern/assets/.` → container `.../cm/modern/assets/`
- **Playwright:** `TEST_CMS_URL=http://127.0.0.1:9993 TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **3 passed** (5.7s). Specs include pageerror listeners.
- **console-clean:** yes
- **server.log-clean:** yes for the feature window (only pre-existing install-time folder ACL ERROR at 13:20:27)
- **qa-down:** removed cell after the run

## Erlang

Pre-commit review: `docs/ai-generated/code-reviews/issue-3366-virtual-site-publish-chrome-erlang.md` — approve.

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
