### PR TITLE
fix(security): CodeQL #1980 java/tainted-numeric-cast in ChunkedInputStream

### DIFF
--- a/system/src/main/java/com/percussion/HTTPClient/ChunkedInputStream.java
+++ b/system/src/main/java/com/percussion/HTTPClient/ChunkedInputStream.java
@@ -62,7 +62,7 @@ class ChunkedInputStream extends FilterInputStream {
 
     if (chunk_len > 0) // it's data
     {
-      if (len > chunk_len) len = (int) chunk_len;
+      len = Codecs.clampToChunkLength(len, chunk_len);
       int rcvd = in.read(buf, off, len);
       if (rcvd == -1) throw new EOFException("Premature EOF encountered");
 
@@ -86,18 +86,37 @@ class ChunkedInputStream extends FilterInputStream {
     }
   }
 
-  public synchronized long skip(long num) throws IOException {
-    byte[] tmp = new byte[(int) num];
-    int got = read(tmp, 0, (int) num);
+  /** Bounded skip buffer so a huge {@code num} cannot allocate a user-sized array. */
+  private static final int SKIP_BUFFER_SIZE = 8192;
 
-    if (got > 0) return (long) got;
-    else return 0L;
+  public synchronized long skip(long num) throws IOException {
+    if (num <= 0L) {
+      return 0L;
+    }
+    int bufSize = (int) Math.min(num, SKIP_BUFFER_SIZE);
+    byte[] tmp = new byte[bufSize];
+    long remaining = num;
+    long skipped = 0L;
+    while (remaining > 0L) {
+      int toRead = (int) Math.min(remaining, tmp.length);
+      int got = read(tmp, 0, toRead);
+      if (got <= 0) {
+        break;
+      }
+      skipped += got;
+      remaining -= got;
+    }
+    return skipped;
   }
 
   public synchronized int available() throws IOException {
-    if (eof) return 0;
+    if (eof) {
+      return 0;
+    }
 
-    if (chunk_len != -1) return (int) chunk_len + in.available();
-    else return in.available();
+    if (chunk_len != -1) {
+      return Codecs.saturateAvailable(chunk_len, in.available());
+    }
+    return in.available();
   }
 }

--- a/system/src/main/java/com/percussion/HTTPClient/Codecs.java
+++ b/system/src/main/java/com/percussion/HTTPClient/Codecs.java
@@ -1634,10 +1634,61 @@ public class Codecs {
     // parse chunk length
 
     try {
-      return Long.parseLong(new String(hex_len, 0, off, "8859_1").trim(), 16);
+      long clen = Long.parseLong(new String(hex_len, 0, off, "8859_1").trim(), 16);
+      if (clen < 0L || clen > Integer.MAX_VALUE) {
+        throw new ParseException(
+            "Can't deal with chunk lengths greater "
+                + "Integer.MAX_VALUE: "
+                + clen
+                + " > "
+                + Integer.MAX_VALUE);
+      }
+      return clen;
     } catch (NumberFormatException nfe) {
       throw new ParseException(
           "Didn't find valid chunk length: " + new String(hex_len, 0, off, "8859_1"));
     }
+  }
+
+  /**
+   * Clamp a requested read length to the remaining HTTP chunk size without narrowing a
+   * user-controlled {@code long} that may exceed {@link Integer#MAX_VALUE}.
+   *
+   * @param requested the caller {@code read} length ({@code int})
+   * @param remainingChunk remaining bytes in the current chunk
+   * @return a non-negative length no larger than {@code requested}
+   */
+  static int clampToChunkLength(int requested, long remainingChunk) {
+    if (requested <= 0 || remainingChunk <= 0L) {
+      return 0;
+    }
+    if (remainingChunk >= requested) {
+      return requested;
+    }
+    return (int) remainingChunk;
+  }
+
+  /**
+   * Saturating conversion of remaining HTTP chunk bytes plus the underlying stream's {@link
+   * InputStream#available()} estimate. User-controlled chunk sizes must not truncate to a negative
+   * or wrapping {@code int}.
+   *
+   * @param remainingChunk remaining bytes in the current chunk, or a negative sentinel
+   * @param underlyingAvailable {@code in.available()} estimate (treated as {@code 0} if negative)
+   * @return a non-negative {@code int} no larger than {@link Integer#MAX_VALUE}
+   */
+  static int saturateAvailable(long remainingChunk, int underlyingAvailable) {
+    int extra = Math.max(0, underlyingAvailable);
+    if (remainingChunk < 0L) {
+      return extra;
+    }
+    if (remainingChunk > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    }
+    int remaining = (int) remainingChunk;
+    if (remaining > Integer.MAX_VALUE - extra) {
+      return Integer.MAX_VALUE;
+    }
+    return remaining + extra;
   }
 }

--- a/system/src/main/java/com/percussion/HTTPClient/StreamDemultiplexor.java
+++ b/system/src/main/java/com/percussion/HTTPClient/StreamDemultiplexor.java
@@ -240,7 +240,7 @@ class StreamDemultiplexor implements GlobalConstants {
 
             if (chunk_len > 0) // it's data
             {
-              if (len > chunk_len) len = (int) chunk_len;
+              len = Codecs.clampToChunkLength(len, chunk_len);
               rcvd = Stream.read(b, off, len);
               if (rcvd == -1) throw new EOFException("Premature EOF encountered");
               chunk_len -= rcvd;

--- a/system/src/test/java/com/percussion/HTTPClient/ChunkedInputStreamNumericCastTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/ChunkedInputStreamNumericCastTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for CodeQL {@code java/tainted-numeric-cast} #1980: HTTP chunk sizes are
+ * user-controlled longs and must not be narrowed to {@code int} without a range guard (CWE-197 /
+ * CWE-681).
+ */
+class ChunkedInputStreamNumericCastTest {
+
+  @Test
+  void saturateAvailableCapsAtIntegerMaxWhenChunkExceedsInt() {
+    assertEquals(Integer.MAX_VALUE, Codecs.saturateAvailable(Integer.MAX_VALUE + 1L, 0));
+    assertEquals(Integer.MAX_VALUE, Codecs.saturateAvailable(Long.MAX_VALUE, 10));
+  }
+
+  @Test
+  void saturateAvailableDoesNotWrapWhenSumExceedsInt() {
+    assertEquals(
+        Integer.MAX_VALUE, Codecs.saturateAvailable(Integer.MAX_VALUE - 5L, 20));
+    assertEquals(42, Codecs.saturateAvailable(10L, 32));
+    assertEquals(7, Codecs.saturateAvailable(-1L, 7));
+    assertEquals(0, Codecs.saturateAvailable(0L, 0));
+  }
+
+  @Test
+  void clampToChunkLengthNeverNarrowsOversizedChunk() {
+    assertEquals(1024, Codecs.clampToChunkLength(1024, Integer.MAX_VALUE + 100L));
+    assertEquals(5, Codecs.clampToChunkLength(1024, 5L));
+    assertEquals(0, Codecs.clampToChunkLength(1024, 0L));
+    assertEquals(0, Codecs.clampToChunkLength(0, 50L));
+  }
+
+  @Test
+  void getChunkLengthRejectsValuesLargerThanIntegerMax() {
+    // 0x80000000 = 2147483648 > Integer.MAX_VALUE
+    byte[] header = "80000000\r\n".getBytes(StandardCharsets.US_ASCII);
+    assertThrows(
+        ParseException.class, () -> Codecs.getChunkLength(new ByteArrayInputStream(header)));
+  }
+
+  @Test
+  void getChunkLengthAcceptsIntegerMax() throws Exception {
+    byte[] header = "7FFFFFFF\r\n".getBytes(StandardCharsets.US_ASCII);
+    assertEquals(Integer.MAX_VALUE, Codecs.getChunkLength(new ByteArrayInputStream(header)));
+  }
+
+  @Test
+  void availableAfterSmallChunkDoesNotTruncate() throws Exception {
+    // chunk of 5 bytes "hello"
+    byte[] wire = "5\r\nhello\r\n0\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    ChunkedInputStream in = new ChunkedInputStream(new ByteArrayInputStream(wire));
+    assertEquals('h', in.read());
+    int avail = in.available();
+    assertTrue(avail >= 4, "remaining chunk bytes should be visible, got " + avail);
+  }
+
+  @Test
+  void availableWithHugeReflectedChunkLenDoesNotReturnNegative() throws Exception {
+    ByteArrayInputStream raw = new ByteArrayInputStream(new byte[8]);
+    ChunkedInputStream in = new ChunkedInputStream(raw);
+    Field f = ChunkedInputStream.class.getDeclaredField("chunk_len");
+    f.setAccessible(true);
+    f.setLong(in, Integer.MAX_VALUE + 12345L);
+    int avail = in.available();
+    assertTrue(avail >= 0, "truncated cast must not go negative, got " + avail);
+    assertEquals(Integer.MAX_VALUE, avail);
+  }
+
+  @Test
+  void skipHugeCountDoesNotAllocateUserSizedBuffer() throws IOException {
+    byte[] wire = "5\r\nhello\r\n0\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    ChunkedInputStream in = new ChunkedInputStream(new ByteArrayInputStream(wire));
+    long skipped = in.skip(Integer.MAX_VALUE + 100L);
+    assertEquals(5L, skipped);
+    assertEquals(-1, in.read());
+  }
+
+  @Test
+  void skipZeroAndNegativeReturnZero() throws IOException {
+    byte[] wire = "5\r\nhello\r\n0\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    ChunkedInputStream in = new ChunkedInputStream(new ByteArrayInputStream(wire));
+    assertEquals(0L, in.skip(0L));
+    assertEquals(0L, in.skip(-3L));
+    assertEquals('h', in.read());
+  }
+}


### PR DESCRIPTION
## Summary

Closes the CodeQL **critical** `java/tainted-numeric-cast` sink on HTTP chunked transfer decoding so a user-controlled chunk size cannot truncate to a negative or wrapping `int`.

**Parent audit issue:** #2470
**code-scanning alert #1980:** https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/1980
**Rule:** `java/tainted-numeric-cast` (CWE-197 / CWE-681)
**Disposition:** ladder step 1 — runtime fix + tests (no dismiss-only; no default CodeQL setup change)

## What changed

- `Codecs.getChunkLength` rejects hex chunk lengths outside `[0, Integer.MAX_VALUE]` (same policy as `chunkedDecode`).
- `Codecs.saturateAvailable` range-checks before any `long`→`int` conversion and saturates at `Integer.MAX_VALUE`.
- `Codecs.clampToChunkLength` never narrows an oversized remaining chunk; used from `ChunkedInputStream` and `StreamDemultiplexor`.
- `ChunkedInputStream.available()` uses `saturateAvailable` (alert line 100).
- `ChunkedInputStream.skip(long)` uses an 8KiB buffer instead of `new byte[(int) num]`.

## Tests

- `ChunkedInputStreamNumericCastTest` (9 tests): saturate/clamp guards, parse reject of `0x80000000`, `available()` never negative, huge `skip` does not allocate a user-sized array.

## Pre-PR verification

```bat
cd system
..\mvnw.cmd clean install
```

- **BUILD SUCCESS** (`perc-system`)
- Tests run: **2159**, Failures: **0**, Errors: **0**, Skipped: 241
- No new warnings attributable to this change (baseline javadoc/dependency-analyze warnings unchanged)

## Product documentation

- [x] N/A — internal HTTP client numeric-cast hardening; no operator/admin/user-facing surface

## Checklist

- [x] Runtime fix + `./mvnw` tests green
- [ ] Model pack updated (not needed — range guard is the sanitizer)
- [x] No sink-line suppression (cast removed from the alert line)
- [x] Default setup still `not-configured`
- [x] Do not merge from night agent

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs-security.
