### PR TITLE
fix(virtualsite): rebuild always reads current filesystem (#3367)

### DIFF
--- a/docs/ai-generated/code-reviews/3367-virtual-site-rebuild-current-fs-erlang.md
+++ b/docs/ai-generated/code-reviews/3367-virtual-site-rebuild-current-fs-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — #3367 Virtual Site rebuild reads current filesystem
+
+**Branch:** `fix/issue-3367-virtual-site-rebuild-current-fs`  
+**Date:** 2026-08-14  
+**Reviewer:** Erlang (pre-commit, independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for changed logic; portable `Path`/`Files` (no Unix-only roots); product-docs companion for operator-facing rebuild note; no incomplete rest/sitemanage adaptor cache (none present)
+
+## Summary
+
+Git-filesystem Virtual Site discover/load already `Files.readString`s on every call; SitesAdaptor constructs a new `PSVirtualSiteBuildService` per build. This change makes the no-stale-parse-cache contract explicit (SPI + source + build Javadoc), proves same-JVM edit→rebuild emits new HTML, and documents that operators rebuild after `git pull`/local edit without a CMS restart.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Test I/O uses `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`
+- [x] No Unix-only `/tmp` or Windows-only `C:\` hardcodes
+- [x] No raw OS `toString()` path equality assertions
+- [x] Line-ending sensitive checks use `contains` tokens, not whole-file `\n` equality
+
+## Issues
+
+None (hard-gate).
+
+## Nits
+
+- SPI Javadoc is slightly longer than surrounding Phase-1 comments; acceptable as a contract lock.
+
+## Build
+
+Standalone `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**.  
+`PSVirtualSiteBuildServiceTest`: Tests run: 8, Failures: 0.  
+Module Surefire: Tests run: 2099, Failures: 0, Errors: 0, Skipped: 238.

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -35,7 +35,9 @@ For Git/filesystem Virtual Sites such as product documentation:
 
 - Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session.
 - **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
-  `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`).
+  `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`). Each build re-reads the
+  current Git/filesystem tree. After `git pull` or a local Markdown edit, run Build (or Publish)
+  again — no CMS restart.
 - **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
   assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
   publishing root). Staging `_meta` files are not copied.

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -128,7 +128,10 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
    that exists on the CMS host. If you just edited properties, choose **Save Virtual Site source**
    first — the build uses the **saved** server properties, not unsaved form fields.
 4. Choose **Build Virtual Site**.
-5. Wait for the busy indicator, then review:
+5. After a `git pull` or a local Markdown/frontmatter edit on the host, choose **Build Virtual
+   Site** again. The build re-reads the current filesystem — **do not restart the CMS** just to
+   pick up those edits. There is no file watcher; the next explicit build is the refresh.
+6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).
    - **Link problems** — a count appears when internal `id:` or relative links fail.

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -62,6 +62,7 @@ HTML path in the **virtual participant registry** (`IPSVirtualParticipantService
 | **Process-scoped (default)** | Registrations live in memory until the process exits, or until `clear(siteKey)` / `clearAll()` is called (SPI reset API). Unit tests and one-shot builds use this mode when no store directory is supplied. |
 | **Path-backed (optional)** | Construct the registry with a portable `java.nio.file.Path` base (CLI uses `outputRoot/_meta`). Existing `participants-<siteKey>.jsonl` files are loaded on construct; `flush(siteKey)` rewrites that site’s file. Survives JVM restart when the same Path base is reused. |
 | **Full rebuild** | A complete site build **clears** that site key, then upserts every discovered page, then flushes. A second build therefore does not keep pages removed from the source tree, and does not lose current ids. |
+| **Current filesystem** | Each build reloads `_config.yaml` and re-reads every Markdown/frontmatter file from disk. The CMS process does **not** keep a parsed-page cache across builds. After `git pull` or a local edit under `virtual.rootPath`, run **Build Virtual Site** (or the offline docs script) again — **no JVM / CMS restart** is required. File watchers are not used; the next explicit build is the refresh. |
 
 Operators can treat the JSONL under the build meta directory as a diagnostic dump of stable ids after
 an offline docs build. The registry is **not** a substitute for Git as the system of record.
@@ -155,6 +156,17 @@ A bare `{ "sourceKind": "git-filesystem", … }` body is rejected (**400**, JAXB
 element `sourceKind`). GET returns the same envelope (or a plain object the SPA unwraps).
 After save, the Developer Sites panel GET-roundtrips so `virtual=true` and Build chrome appear
 without reloading the page.
+
+### Rebuild after git pull or a local edit (no CMS restart)
+
+The Git/filesystem adapter always sees the **current** tree on the CMS host:
+
+1. Update Markdown or frontmatter under `virtual.rootPath` (`git pull`, copy, or an editor).
+2. Run **Build Virtual Site** again (UI, `POST …/virtual/build`, or `scripts/build-cms-docs.*`).
+3. Preview or publish the new output.
+
+You do **not** restart the CMS JVM for those file changes to appear. A restart is only needed
+when you change server code, Site properties that were never saved, or the process itself.
 
 After a successful build, **Preview assembled site** opens the last output home in a new tab
 (`GET /sites/{nameOrId}/virtual/preview` for status; `GET …/virtual/preview/{relPath}` for the

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -122,11 +122,12 @@ Optional body field `outputRoot` overrides the default output directory
 unavailable). Link problems are reported in the JSON result (and in `link-report.txt` under
 the output root) without failing the HTTP status when the build itself succeeds.
 
-The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
-Virtual (never for traditional repository Sites). When `hasLinkProblems` is true, the result
-panel shows the problem **count** and an expandable list of `linkProblems` (same text as
-`link-report.txt`). A clean build does not show that banner. See
-[Sites & content structure](id:admin-sites).
+Each build re-reads current Markdown/frontmatter from `virtual.rootPath` (no CMS restart after
+`git pull` or a local edit). The Developer Sites UI exposes this operation as **Build Virtual
+Site** when source kind is Virtual (never for traditional repository Sites). When
+`hasLinkProblems` is true, the result panel shows the problem **count** and an expandable list
+of `linkProblems` (same text as `link-report.txt`). A clean build does not show that banner.
+See [Sites & content structure](id:admin-sites).
 
 #### Preview assembled Virtual Site (`GET …/virtual/preview`)
 

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -22,6 +22,12 @@ import java.util.List;
 /**
  * SPI for Virtual Site content sources. Phase 1: {@link PSGitFilesystemVirtualSiteSource}.
  * Future adapters (SQL, API, …) implement this interface.
+ *
+ * <p>Filesystem implementations must read <em>current</em> file contents on every {@link
+ * #discover} and {@link #load}. Process-lifetime parse caches that skip a file because its path
+ * or mtime looks unchanged are not allowed — a second build in the same JVM (after {@code git
+ * pull} or a local Markdown/frontmatter edit) must see the new bytes. File watchers are not
+ * required; the next explicit build is the refresh.
  */
 public interface IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSGitFilesystemVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSGitFilesystemVirtualSiteSource.java
@@ -33,6 +33,9 @@ import java.util.stream.Stream;
 /**
  * Phase 1 Virtual Site source: local filesystem tree (Git checkout). Discovers {@code *.md} under
  * each configured version path.
+ *
+ * <p>Stateless: {@link #discover} and {@link #load} always {@link Files#readString} the current
+ * file. No path/mtime parse cache is kept on the instance or in statics.
  */
 public class PSGitFilesystemVirtualSiteSource implements IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -63,6 +63,11 @@ public class PSVirtualSiteBuildService {
   /**
    * Build a Virtual Site from a filesystem root into {@code outputRoot}.
    *
+   * <p>Every invocation reloads {@code _config.yaml}, re-discovers and re-loads Markdown from the
+   * current tree, then overwrites emitted HTML. The same service instance does not reuse parsed
+   * pages from a previous build — operators do not need a JVM restart after {@code git pull} or a
+   * local edit.
+   *
    * @param siteRoot source tree (contains {@code _config.yaml})
    * @param outputRoot destination for HTML + assets
    * @param siteKey participant key

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -18,6 +18,7 @@ package com.percussion.services.virtualsite;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,87 @@ class PSVirtualSiteBuildServiceTest {
     String report = Files.readString(linkReport, StandardCharsets.UTF_8);
     assertTrue(report.contains("OK"), report);
     assertTrue(result.writtenFiles().contains("link-report.txt"), result.writtenFiles()::toString);
+  }
+
+  @Test
+  void secondBuildAfterMarkdownEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path siteRoot = tempDir.resolve("live-site");
+    Path versionDir = siteRoot.resolve("8.2");
+    Files.createDirectories(versionDir);
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Files.writeString(
+        siteRoot.resolve("_config.yaml"),
+        """
+        site:
+          title: Live Docs
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${pageTitle}</h1>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Path indexMd = versionDir.resolve("index.md");
+    Files.writeString(
+        indexMd,
+        """
+        ---
+        id: live-home
+        title: First Title
+        ---
+
+        First body unique-token-AAA.
+        """,
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("live-out");
+    PSInMemoryVirtualParticipantService participants =
+        new PSInMemoryVirtualParticipantService(tempDir.resolve("live-meta"));
+    PSGitFilesystemVirtualSiteSource source = new PSGitFilesystemVirtualSiteSource();
+    PSVirtualSiteBuildService service = new PSVirtualSiteBuildService(source, participants);
+
+    PSVirtualSiteBuildResult first = service.build(siteRoot, out, "live");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        indexMd,
+        """
+        ---
+        id: live-home
+        title: Second Title
+        ---
+
+        Second body unique-token-BBB.
+        """,
+        StandardCharsets.UTF_8);
+
+    VirtualSiteConfig config =
+        VirtualSiteConfigLoader.load(siteRoot, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, "live");
+    var refs = source.discover(config);
+    assertEquals(1, refs.size());
+    VirtualItem loaded = source.load(config, refs.get(0));
+    assertEquals("Second Title", loaded.frontmatter().title());
+    assertTrue(loaded.markdownBody().contains("unique-token-BBB"), loaded.markdownBody());
+
+    PSVirtualSiteBuildResult second = service.build(siteRoot, out, "live");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent: #2678 (Virtual Sites & Git-backed documentation). Slice #3367.

A Virtual Site **Build** already walked the Git/filesystem tree with `Files.readString`, but there was no same-JVM proof that a second build after an operator edit could not reuse a parsed/output cache. This change:

- Locks the SPI/`PSGitFilesystemVirtualSiteSource`/`PSVirtualSiteBuildService` contract: every discover/load/build re-reads current Markdown, frontmatter, and `_config.yaml`. No path/mtime parse cache. No file watchers.
- Adds a portable `@TempDir` unit test: build, edit a `.md` (title + body), build again on the **same** service instance, assert HTML and source load changed.
- Documents the operator path: after `git pull` or a local edit, run Build again — **no CMS JVM restart**.

`SitesAdaptor` already constructs a new `PSVirtualSiteBuildService` per REST build; rest/sitemanage were not changed.

Fixes #3367

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system` → `../mvnw.cmd clean install` (standalone; tests included).
2. Confirm `PSVirtualSiteBuildServiceTest.secondBuildAfterMarkdownEditEmitsUpdatedHtmlWithoutRestart` passes.
3. Review product-docs notes: `developer/virtual-sites.md`, `admin/sites.md`, `admin/publishing.md`, `reference/site-config.md`.
4. No WebUI/Playwright (backend + operator docs only).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/` operator notes (rebuild after git pull / local edit; no JVM restart)
- [x] **Unit / module tests** — `PSVirtualSiteBuildServiceTest` (8 tests, 0 failures); `system` standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone `cd system` → repo-root `mvnw.cmd clean install` (no skipTests); C2 N/A (no `final`/signature/API shape change)
- [x] **Cross-platform** — test uses `@TempDir` + `Path` / `Files` only

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system` then `..\mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-14T10:19:17-04:00). Surefire: Tests run: 2099, Failures: 0, Errors: 0, Skipped: 238. `PSVirtualSiteBuildServiceTest`: Tests run: 8, Failures: 0.
- **downstream_checked:** none (C2 did not apply — Javadoc/test/docs only; no public/protected signature or `final`/`sealed` type change)

## C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
