### PR TITLE
feat(nav): section properties editor for Navigation (#3353)

### DIFF
--- a/WebUI/src/main/ts/api/architecture/index.ts
+++ b/WebUI/src/main/ts/api/architecture/index.ts
@@ -67,7 +67,10 @@ export {
   sectionTypeLabel,
 } from "./mapSectionTree";
 export {
+  applySectionPropertiesForm,
   applyTitleToProperties,
+  canEditSectionProperties,
+  canToggleRequiresLogin,
   buildCreateExternalLinkBody,
   buildCreateSectionFromFolderBody,
   buildCreateSectionLinkPath,
@@ -98,10 +101,13 @@ export {
   splitCmsPagePath,
   validateExternalUrl,
   validateLandingPageName,
+  validateCssClassNames,
   validateSectionFolderName,
+  validateSectionPropertiesForm,
   validateSectionTitle,
   validateSourceFolderPath,
 } from "./sectionMutations";
+export type { SectionPropertiesFormValues } from "./sectionMutations";
 export type {
   CreateExternalLinkFields,
   CreateSectionFromFolderFields,

--- a/WebUI/src/main/ts/api/architecture/sectionMutations.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionMutations.ts
@@ -363,6 +363,113 @@ export function canReplaceLandingPage(node: NavTreeNode | null): boolean {
 }
 
 /**
+ * Regular section (including site root) may open the section-properties editor.
+ * Section links, external links, and blogs use other editors.
+ */
+export function canEditSectionProperties(node: NavTreeNode | null): boolean {
+  return canReplaceLandingPage(node);
+}
+
+/** Form fields for the section-properties dialog (CM1 configure parity). */
+export interface SectionPropertiesFormValues {
+  title: string;
+  folderName: string;
+  target: string;
+  cssClassNames: string;
+  requiresLogin: boolean;
+  allowAccessTo: string;
+}
+
+/**
+ * Login checkbox is editable only on a secure site when no ancestor already
+ * requires login (CM1 {@code perc_editSectionDialog} rule).
+ */
+export function canToggleRequiresLogin(
+  props: Pick<
+    SiteSectionPropertiesWire,
+    "secureSite" | "secureAncestor"
+  > | null,
+): boolean {
+  if (!props) return false;
+  return Boolean(props.secureSite) && !props.secureAncestor;
+}
+
+/** CSS class tokens: letters, digits, hyphen, underscore, spaces. Max 255. */
+const CSS_CLASS_NAMES_RE = /^[A-Za-z0-9_\- ]*$/;
+
+/**
+ * Validate nav-widget CSS class names (legacy edit-section dialog).
+ */
+export function validateCssClassNames(value: string): string | null {
+  const t = value.replace(/ +/g, " ").trim();
+  if (t.length > 255) {
+    return message(
+      "perc.ui.architecture.modern@CSS classes are too long (max 255 characters)",
+    );
+  }
+  if (t && !CSS_CLASS_NAMES_RE.test(t)) {
+    return message(
+      "perc.ui.architecture.modern@CSS classes may only contain letters, numbers, dash, underscore, and spaces",
+    );
+  }
+  return null;
+}
+
+/**
+ * Validate the section-properties form before POST.
+ * Returns the first error or {@code null} when valid.
+ */
+export function validateSectionPropertiesForm(
+  form: SectionPropertiesFormValues,
+  options?: { folderNameLocked?: boolean },
+): string | null {
+  const titleErr = validateSectionTitle(form.title);
+  if (titleErr) return titleErr;
+  if (!options?.folderNameLocked) {
+    const folderErr = validateSectionFolderName(form.folderName);
+    if (folderErr) return folderErr;
+  }
+  return validateCssClassNames(form.cssClassNames);
+}
+
+/**
+ * Merge operator-edited form fields onto loaded properties.
+ * Preserves {@code folderPermission} and security flags. Root folder name
+ * is not rewritten (site folder). Login/groups follow CM1 enablement.
+ */
+export function applySectionPropertiesForm(
+  props: SiteSectionPropertiesWire,
+  form: SectionPropertiesFormValues,
+): SiteSectionPropertiesWire {
+  const folderNameLocked = Boolean(props.siteRootSection);
+  const folderName = folderNameLocked
+    ? props.folderName
+    : form.folderName.trim();
+  const loginEditable = canToggleRequiresLogin(props);
+  const requiresLogin = loginEditable
+    ? Boolean(form.requiresLogin)
+    : Boolean(props.requiresLogin);
+  let allowAccessTo: string | null;
+  if (!requiresLogin) {
+    allowAccessTo = "";
+  } else if (loginEditable) {
+    allowAccessTo = form.allowAccessTo.trim();
+  } else {
+    allowAccessTo = props.allowAccessTo != null ? String(props.allowAccessTo) : "";
+  }
+  const css = form.cssClassNames.replace(/ +/g, " ").trim();
+  return {
+    ...props,
+    title: form.title.trim(),
+    folderName,
+    target: form.target?.trim() || "_self",
+    cssClassNames: css.length > 0 ? css : "",
+    requiresLogin,
+    allowAccessTo,
+  };
+}
+
+/**
  * Regular non-root navon may be converted to a plain folder.
  * Root, blogs, section links, and external links are blocked (matches docs).
  */

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -43,10 +43,12 @@ import {
 import {
   applyTitleToProperties,
   buildSiblingReorderMove,
+  applySectionPropertiesForm,
   canConvertSectionToFolder,
   canCreateChildUnder,
   canDeleteNavNode,
   canEditLinkNode,
+  canEditSectionProperties,
   canMoveNavNodeDown,
   canMoveNavNodeUp,
   canReplaceLandingPage,
@@ -56,7 +58,11 @@ import {
   isSectionLinkType,
   resolveCreateParentFolderPath,
 } from "../api/architecture/sectionMutations";
-import type { NavTreeNode } from "../api/architecture/types";
+import type { SectionPropertiesFormValues } from "../api/architecture/sectionMutations";
+import type {
+  NavTreeNode,
+  SiteSectionPropertiesWire,
+} from "../api/architecture/types";
 import {
   copyManagedSite,
   deleteManagedSite,
@@ -76,6 +82,7 @@ import { ExternalLinkDialog } from "./ExternalLinkDialog";
 import { NavTree } from "./NavTree";
 import { RenameSectionDialog } from "./RenameSectionDialog";
 import { ReplaceLandingPageDialog } from "./ReplaceLandingPageDialog";
+import { SectionPropertiesDialog } from "./SectionPropertiesDialog";
 import { SectionLinkDialog } from "./SectionLinkDialog";
 import { SitePicker } from "./SitePicker";
 import { StructureActionBar } from "./StructureActionBar";
@@ -159,6 +166,13 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   const [createOpen, setCreateOpen] = useState(false);
   const [createFromFolderOpen, setCreateFromFolderOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
+  const [propertiesOpen, setPropertiesOpen] = useState(false);
+  const [propertiesLoading, setPropertiesLoading] = useState(false);
+  const [propertiesLoadError, setPropertiesLoadError] = useState<string | null>(
+    null,
+  );
+  const [propertiesInitial, setPropertiesInitial] =
+    useState<SiteSectionPropertiesWire | null>(null);
   const [landingOpen, setLandingOpen] = useState(false);
   const [sectionLinkOpen, setSectionLinkOpen] = useState(false);
   const [sectionLinkMode, setSectionLinkMode] = useState<"create" | "edit">(
@@ -453,6 +467,8 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     String(selectedNode.sectionType || "section").toLowerCase() ===
       "section" &&
     !mutationBusy;
+  const canProperties =
+    canEditSectionProperties(selectedNode) && !mutationBusy;
   const canMoveUp =
     !!selectedNodeId &&
     canMoveNavNodeUp(treeRoot, selectedNodeId) &&
@@ -518,6 +534,60 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
       });
     },
     [selectedNode, runMutation],
+  );
+
+  const propertiesLoadGen = useRef(0);
+
+  const openProperties = useCallback(() => {
+    if (!selectedNode || !canEditSectionProperties(selectedNode)) {
+      setMutationError(ARCH_MSG.MUTATION_ERROR);
+      return;
+    }
+    setMutationError(null);
+    setPropertiesLoadError(null);
+    setPropertiesInitial(null);
+    setPropertiesOpen(true);
+    setPropertiesLoading(true);
+    const nodeId = selectedNode.id;
+    const gen = ++propertiesLoadGen.current;
+    void (async () => {
+      try {
+        const props = await loadSectionProperties(nodeId);
+        if (gen !== propertiesLoadGen.current) return;
+        setPropertiesInitial(props);
+        setPropertiesLoading(false);
+      } catch (err) {
+        if (gen !== propertiesLoadGen.current) return;
+        if (isSessionRedirectError(err)) return;
+        setPropertiesLoading(false);
+        setPropertiesLoadError(
+          formatApiError(err, ARCH_MSG.PROPERTIES_LOAD_ERROR),
+        );
+      }
+    })();
+  }, [selectedNode]);
+
+  const closeProperties = useCallback(() => {
+    if (mutationBusy) return;
+    propertiesLoadGen.current += 1;
+    setPropertiesOpen(false);
+    setPropertiesLoading(false);
+    setPropertiesLoadError(null);
+    setPropertiesInitial(null);
+  }, [mutationBusy]);
+
+  const onPropertiesSubmit = useCallback(
+    (form: SectionPropertiesFormValues) => {
+      if (!selectedNode || !propertiesInitial) return;
+      void runMutation(async () => {
+        const next = applySectionPropertiesForm(propertiesInitial, form);
+        await updateSiteSection(next);
+        setPropertiesOpen(false);
+        setPropertiesInitial(null);
+        setPropertiesLoadError(null);
+      });
+    },
+    [selectedNode, propertiesInitial, runMutation],
   );
 
   const onMove = useCallback(
@@ -1262,6 +1332,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             canLanding={canLanding}
             canEditLink={canEditLink}
             canRename={canRename}
+            canProperties={canProperties}
             canMoveUp={canMoveUp}
             canMoveDown={canMoveDown}
             canDelete={canDelete}
@@ -1314,6 +1385,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
               setMutationError(null);
               setRenameOpen(true);
             }}
+            onProperties={openProperties}
             onMoveUp={() => onMove("up")}
             onMoveDown={() => onMove("down")}
             onDelete={onDelete}
@@ -1408,6 +1480,15 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
           if (!mutationBusy) setRenameOpen(false);
         }}
         onSubmit={onRenameSubmit}
+      />
+      <SectionPropertiesDialog
+        open={propertiesOpen}
+        busy={mutationBusy}
+        loading={propertiesLoading}
+        loadError={propertiesLoadError}
+        initial={propertiesInitial}
+        onCancel={closeProperties}
+        onSubmit={onPropertiesSubmit}
       />
       <ReplaceLandingPageDialog
         open={landingOpen}

--- a/WebUI/src/main/ts/architecture/SectionPropertiesDialog.tsx
+++ b/WebUI/src/main/ts/architecture/SectionPropertiesDialog.tsx
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Section properties dialog (CM1 perc_editSectionDialog parity) for Navigation.
+ * Parent loads GET /section/properties and posts POST /section/update.
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  canToggleRequiresLogin,
+  validateSectionPropertiesForm,
+} from "../api/architecture/sectionMutations";
+import type { SectionPropertiesFormValues } from "../api/architecture/sectionMutations";
+import type { SiteSectionPropertiesWire } from "../api/architecture/types";
+import { catalogColors } from "../developer/catalogStyles";
+import { ARCH_MSG } from "./messages";
+import { useDialogEscape } from "./useDialogEscape";
+
+export interface SectionPropertiesDialogProps {
+  open: boolean;
+  busy: boolean;
+  loading: boolean;
+  loadError: string | null;
+  initial: SiteSectionPropertiesWire | null;
+  onCancel: () => void;
+  onSubmit: (values: SectionPropertiesFormValues) => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  border: `1px solid ${catalogColors.headerBorder}`,
+  maxWidth: 480,
+  width: "100%",
+  padding: "1.25rem 1.5rem",
+  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+  maxHeight: "90vh",
+  overflowY: "auto",
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  marginTop: 4,
+  marginBottom: 12,
+  padding: "0.4rem 0.5rem",
+  fontSize: "0.95rem",
+  boxSizing: "border-box",
+};
+
+const emptyForm: SectionPropertiesFormValues = {
+  title: "",
+  folderName: "",
+  target: "_self",
+  cssClassNames: "",
+  requiresLogin: false,
+  allowAccessTo: "",
+};
+
+function formFromInitial(
+  initial: SiteSectionPropertiesWire | null,
+): SectionPropertiesFormValues {
+  if (!initial) {
+    return { ...emptyForm };
+  }
+  return {
+    title: initial.title ?? "",
+    folderName: initial.folderName ?? "",
+    target: initial.target ? String(initial.target) : "_self",
+    cssClassNames: initial.cssClassNames != null ? String(initial.cssClassNames) : "",
+    requiresLogin: Boolean(initial.requiresLogin),
+    allowAccessTo:
+      initial.allowAccessTo != null ? String(initial.allowAccessTo) : "",
+  };
+}
+
+export function SectionPropertiesDialog({
+  open,
+  busy,
+  loading,
+  loadError,
+  initial,
+  onCancel,
+  onSubmit,
+}: SectionPropertiesDialogProps): React.ReactElement | null {
+  const [form, setForm] = useState<SectionPropertiesFormValues>(emptyForm);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useDialogEscape(open, busy, onCancel);
+
+  const seedKey = open
+    ? `${initial?.id ?? ""}|${initial?.title ?? ""}|${initial?.folderName ?? ""}`
+    : "";
+  useEffect(() => {
+    if (!open) return;
+    setForm(formFromInitial(initial));
+    setLocalError(null);
+    // seedKey collapses open + loaded identity so late GET still applies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, seedKey]);
+
+  if (!open) {
+    return null;
+  }
+
+  const folderLocked = Boolean(initial?.siteRootSection);
+  const loginEditable = canToggleRequiresLogin(initial);
+  const groupsEnabled = loginEditable && form.requiresLogin && !busy && !loading;
+  const formDisabled = busy || loading || !initial || !!loadError;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    if (!initial || loadError) {
+      return;
+    }
+    const err = validateSectionPropertiesForm(form, {
+      folderNameLocked: folderLocked,
+    });
+    if (err) {
+      setLocalError(err);
+      return;
+    }
+    onSubmit({
+      title: form.title.trim(),
+      folderName: folderLocked ? initial.folderName : form.folderName.trim(),
+      target: form.target || "_self",
+      cssClassNames: form.cssClassNames.replace(/ +/g, " ").trim(),
+      requiresLogin: form.requiresLogin,
+      allowAccessTo: form.requiresLogin ? form.allowAccessTo.trim() : "",
+    });
+  };
+
+  const update = <K extends keyof SectionPropertiesFormValues>(
+    key: K,
+    value: SectionPropertiesFormValues[K],
+  ) => {
+    setLocalError(null);
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="architecture-properties-dialog"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="architecture-properties-title"
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="architecture-properties-title"
+          style={{ marginTop: 0, marginBottom: 8, fontSize: "1.1rem" }}
+        >
+          {ARCH_MSG.PROPERTIES_DIALOG_TITLE}
+        </h2>
+        <p
+          style={{
+            margin: "0 0 12px",
+            color: catalogColors.muted,
+            fontSize: "0.85rem",
+          }}
+        >
+          {ARCH_MSG.PROPERTIES_HINT}
+        </p>
+        {loading ? (
+          <p
+            data-testid="architecture-properties-loading"
+            aria-live="polite"
+            style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_LOADING}
+          </p>
+        ) : null}
+        {loadError ? (
+          <p
+            role="alert"
+            data-testid="architecture-properties-load-error"
+            style={{ color: catalogColors.error, fontSize: "0.9rem" }}
+          >
+            {loadError}
+          </p>
+        ) : null}
+        <form onSubmit={handleSubmit}>
+          <label
+            htmlFor="architecture-properties-title-input"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_TITLE_LABEL}
+            <input
+              id="architecture-properties-title-input"
+              data-testid="architecture-properties-title"
+              value={form.title}
+              onChange={(e) => update("title", e.target.value)}
+              required
+              disabled={formDisabled}
+              autoFocus={!loading}
+              maxLength={512}
+              style={fieldStyle}
+            />
+          </label>
+          <label
+            htmlFor="architecture-properties-folder"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_FOLDER_LABEL}
+            <input
+              id="architecture-properties-folder"
+              data-testid="architecture-properties-folder"
+              value={form.folderName}
+              onChange={(e) => update("folderName", e.target.value)}
+              required={!folderLocked}
+              disabled={formDisabled || folderLocked}
+              maxLength={100}
+              style={fieldStyle}
+            />
+          </label>
+          {folderLocked ? (
+            <p
+              data-testid="architecture-properties-folder-locked"
+              style={{
+                margin: "-8px 0 12px",
+                color: catalogColors.muted,
+                fontSize: "0.8rem",
+              }}
+            >
+              {ARCH_MSG.PROPERTIES_FOLDER_ROOT_HINT}
+            </p>
+          ) : null}
+          <label
+            htmlFor="architecture-properties-target"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_TARGET_LABEL}
+            <select
+              id="architecture-properties-target"
+              data-testid="architecture-properties-target"
+              value={form.target}
+              onChange={(e) => update("target", e.target.value)}
+              disabled={formDisabled}
+              style={fieldStyle}
+            >
+              <option value="_self">{ARCH_MSG.EXTERNAL_LINK_TARGET_SELF}</option>
+              <option value="_blank">
+                {ARCH_MSG.EXTERNAL_LINK_TARGET_BLANK}
+              </option>
+              <option value="_top">{ARCH_MSG.EXTERNAL_LINK_TARGET_TOP}</option>
+              <option value="_parent">
+                {ARCH_MSG.EXTERNAL_LINK_TARGET_PARENT}
+              </option>
+            </select>
+          </label>
+          <label
+            htmlFor="architecture-properties-css"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_CSS_LABEL}
+            <input
+              id="architecture-properties-css"
+              data-testid="architecture-properties-css"
+              value={form.cssClassNames}
+              onChange={(e) => update("cssClassNames", e.target.value)}
+              disabled={formDisabled}
+              maxLength={255}
+              style={fieldStyle}
+            />
+          </label>
+          <label
+            htmlFor="architecture-properties-login"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: "0.9rem",
+              marginBottom: 8,
+            }}
+          >
+            <input
+              id="architecture-properties-login"
+              data-testid="architecture-properties-login"
+              type="checkbox"
+              checked={form.requiresLogin}
+              disabled={formDisabled || !loginEditable}
+              onChange={(e) => update("requiresLogin", e.target.checked)}
+            />
+            {ARCH_MSG.PROPERTIES_LOGIN_LABEL}
+          </label>
+          {!loginEditable && initial ? (
+            <p
+              data-testid="architecture-properties-login-locked"
+              style={{
+                margin: "0 0 8px",
+                color: catalogColors.muted,
+                fontSize: "0.8rem",
+              }}
+            >
+              {ARCH_MSG.PROPERTIES_LOGIN_LOCKED}
+            </p>
+          ) : null}
+          <label
+            htmlFor="architecture-properties-groups"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.PROPERTIES_GROUPS_LABEL}
+            <input
+              id="architecture-properties-groups"
+              data-testid="architecture-properties-groups"
+              value={form.allowAccessTo}
+              onChange={(e) => update("allowAccessTo", e.target.value)}
+              disabled={!groupsEnabled}
+              style={fieldStyle}
+            />
+          </label>
+          <p
+            style={{
+              margin: "-8px 0 12px",
+              color: catalogColors.muted,
+              fontSize: "0.8rem",
+            }}
+          >
+            {ARCH_MSG.PROPERTIES_GROUPS_HINT}
+          </p>
+          {localError ? (
+            <p
+              role="alert"
+              data-testid="architecture-properties-error"
+              style={{ color: catalogColors.error, fontSize: "0.9rem" }}
+            >
+              {localError}
+            </p>
+          ) : null}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 8,
+              marginTop: 8,
+            }}
+          >
+            <button
+              type="button"
+              data-testid="architecture-properties-cancel"
+              onClick={onCancel}
+              disabled={busy}
+              style={{
+                padding: "0.4rem 0.85rem",
+                border: `1px solid ${catalogColors.softBorder}`,
+                borderRadius: 4,
+                background: "#fff",
+                cursor: busy ? "not-allowed" : "pointer",
+              }}
+            >
+              {ARCH_MSG.PROPERTIES_CANCEL}
+            </button>
+            <button
+              type="submit"
+              data-testid="architecture-properties-submit"
+              disabled={formDisabled}
+              style={{
+                padding: "0.4rem 0.85rem",
+                border: `1px solid ${catalogColors.accent}`,
+                borderRadius: 4,
+                background: catalogColors.accent,
+                color: "#fff",
+                cursor: formDisabled ? "not-allowed" : "pointer",
+              }}
+            >
+              {busy ? ARCH_MSG.ACTION_BUSY : ARCH_MSG.PROPERTIES_SUBMIT}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default SectionPropertiesDialog;

--- a/WebUI/src/main/ts/architecture/StructureActionBar.tsx
+++ b/WebUI/src/main/ts/architecture/StructureActionBar.tsx
@@ -33,6 +33,7 @@ export interface StructureActionBarProps {
   canLanding: boolean;
   canEditLink: boolean;
   canRename: boolean;
+  canProperties: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
   canDelete: boolean;
@@ -44,6 +45,7 @@ export interface StructureActionBarProps {
   onLanding: () => void;
   onEditLink: () => void;
   onRename: () => void;
+  onProperties: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
   onDelete: () => void;
@@ -79,6 +81,7 @@ export function StructureActionBar({
   canLanding,
   canEditLink,
   canRename,
+  canProperties,
   canMoveUp,
   canMoveDown,
   canDelete,
@@ -90,6 +93,7 @@ export function StructureActionBar({
   onLanding,
   onEditLink,
   onRename,
+  onProperties,
   onMoveUp,
   onMoveDown,
   onDelete,
@@ -102,6 +106,7 @@ export function StructureActionBar({
   const landingEnabled = canLanding && !busy;
   const editLinkEnabled = canEditLink && !busy;
   const renameEnabled = canRename && !busy;
+  const propertiesEnabled = canProperties && !busy;
   const upEnabled = canMoveUp && !busy;
   const downEnabled = canMoveDown && !busy;
   const deleteEnabled = canDelete && !busy;
@@ -175,6 +180,15 @@ export function StructureActionBar({
         style={buttonStyle(renameEnabled)}
       >
         {ARCH_MSG.ACTION_RENAME}
+      </button>
+      <button
+        type="button"
+        data-testid="architecture-action-properties"
+        disabled={!propertiesEnabled}
+        onClick={onProperties}
+        style={buttonStyle(propertiesEnabled)}
+      >
+        {ARCH_MSG.ACTION_PROPERTIES}
       </button>
       <button
         type="button"

--- a/WebUI/src/main/ts/architecture/index.ts
+++ b/WebUI/src/main/ts/architecture/index.ts
@@ -29,6 +29,8 @@ export { CreateSectionFromFolderDialog } from "./CreateSectionFromFolderDialog";
 export type { CreateSectionFromFolderDialogProps } from "./CreateSectionFromFolderDialog";
 export { RenameSectionDialog } from "./RenameSectionDialog";
 export type { RenameSectionDialogProps } from "./RenameSectionDialog";
+export { SectionPropertiesDialog } from "./SectionPropertiesDialog";
+export type { SectionPropertiesDialogProps } from "./SectionPropertiesDialog";
 export { ReplaceLandingPageDialog } from "./ReplaceLandingPageDialog";
 export type { ReplaceLandingPageDialogProps } from "./ReplaceLandingPageDialog";
 export { SectionLinkDialog } from "./SectionLinkDialog";

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -46,7 +46,7 @@ const KEYS = {
     "perc.ui.architecture.modern@A site can exist without a NavTree. Add a navigation tree at the site root in Explorer, then refresh, or choose another site.",
   TREE_PANEL_TITLE: "perc.ui.architecture.modern@Navigation tree",
   TREE_STRUCTURE_NOTE:
-    "perc.ui.architecture.modern@Select a section, then use structure actions: create, convert to folder, create from folder, rename, move, delete, landing page, or link editors.",
+    "perc.ui.architecture.modern@Select a section, then use structure actions: create, convert to folder, create from folder, rename, properties, move, delete, landing page, or link editors.",
   REFRESH: "perc.ui.architecture.modern@Refresh",
   ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
   NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
@@ -89,6 +89,7 @@ const KEYS = {
   ACTION_LANDING: "perc.ui.architecture.modern@Landing page",
   ACTION_EDIT_LINK: "perc.ui.architecture.modern@Edit link",
   ACTION_RENAME: "perc.ui.architecture.modern@Rename",
+  ACTION_PROPERTIES: "perc.ui.architecture.modern@Properties",
   ACTION_MOVE_UP: "perc.ui.architecture.modern@Move up",
   ACTION_MOVE_DOWN: "perc.ui.architecture.modern@Move down",
   ACTION_DELETE: "perc.ui.architecture.modern@Delete",
@@ -110,6 +111,32 @@ const KEYS = {
   RENAME_TITLE_LABEL: "perc.ui.architecture.modern@Title",
   RENAME_SUBMIT: "perc.ui.architecture.modern@Save",
   RENAME_CANCEL: "perc.ui.architecture.modern@Cancel",
+  PROPERTIES_DIALOG_TITLE:
+    "perc.ui.architecture.modern@Section properties",
+  PROPERTIES_HINT:
+    "perc.ui.architecture.modern@Edit the selected section title, folder name, target window, CSS classes, and login settings.",
+  PROPERTIES_TITLE_LABEL: "perc.ui.architecture.modern@Title",
+  PROPERTIES_FOLDER_LABEL: "perc.ui.architecture.modern@Folder name",
+  PROPERTIES_FOLDER_ROOT_HINT:
+    "perc.ui.architecture.modern@The site root folder name cannot be changed here.",
+  PROPERTIES_TARGET_LABEL: "perc.ui.architecture.modern@Target window",
+  PROPERTIES_CSS_LABEL: "perc.ui.architecture.modern@CSS classes",
+  PROPERTIES_LOGIN_LABEL: "perc.ui.architecture.modern@Requires login",
+  PROPERTIES_GROUPS_LABEL:
+    "perc.ui.architecture.modern@Allow access to (group names)",
+  PROPERTIES_GROUPS_HINT:
+    "perc.ui.architecture.modern@Use a comma to separate each group name.",
+  PROPERTIES_LOGIN_LOCKED:
+    "perc.ui.architecture.modern@Login is inherited from an ancestor section or the site is not secure.",
+  PROPERTIES_LOADING: "perc.ui.architecture.modern@Loading section properties…",
+  PROPERTIES_LOAD_ERROR:
+    "perc.ui.architecture.modern@Could not load section properties.",
+  PROPERTIES_SUBMIT: "perc.ui.architecture.modern@Save",
+  PROPERTIES_CANCEL: "perc.ui.architecture.modern@Cancel",
+  VALIDATION_CSS_TOO_LONG:
+    "perc.ui.architecture.modern@CSS classes are too long (max 255 characters)",
+  VALIDATION_CSS_CHARS:
+    "perc.ui.architecture.modern@CSS classes may only contain letters, numbers, dash, underscore, and spaces",
   DELETE_CONFIRM:
     "perc.ui.architecture.modern@Delete section \"{0}\"? This cannot be undone.",
   DELETE_ROOT_BLOCKED:
@@ -288,6 +315,7 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   ACTION_LANDING: message(KEYS.ACTION_LANDING),
   ACTION_EDIT_LINK: message(KEYS.ACTION_EDIT_LINK),
   ACTION_RENAME: message(KEYS.ACTION_RENAME),
+  ACTION_PROPERTIES: message(KEYS.ACTION_PROPERTIES),
   ACTION_MOVE_UP: message(KEYS.ACTION_MOVE_UP),
   ACTION_MOVE_DOWN: message(KEYS.ACTION_MOVE_DOWN),
   ACTION_DELETE: message(KEYS.ACTION_DELETE),
@@ -307,6 +335,23 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   RENAME_TITLE_LABEL: message(KEYS.RENAME_TITLE_LABEL),
   RENAME_SUBMIT: message(KEYS.RENAME_SUBMIT),
   RENAME_CANCEL: message(KEYS.RENAME_CANCEL),
+  PROPERTIES_DIALOG_TITLE: message(KEYS.PROPERTIES_DIALOG_TITLE),
+  PROPERTIES_HINT: message(KEYS.PROPERTIES_HINT),
+  PROPERTIES_TITLE_LABEL: message(KEYS.PROPERTIES_TITLE_LABEL),
+  PROPERTIES_FOLDER_LABEL: message(KEYS.PROPERTIES_FOLDER_LABEL),
+  PROPERTIES_FOLDER_ROOT_HINT: message(KEYS.PROPERTIES_FOLDER_ROOT_HINT),
+  PROPERTIES_TARGET_LABEL: message(KEYS.PROPERTIES_TARGET_LABEL),
+  PROPERTIES_CSS_LABEL: message(KEYS.PROPERTIES_CSS_LABEL),
+  PROPERTIES_LOGIN_LABEL: message(KEYS.PROPERTIES_LOGIN_LABEL),
+  PROPERTIES_GROUPS_LABEL: message(KEYS.PROPERTIES_GROUPS_LABEL),
+  PROPERTIES_GROUPS_HINT: message(KEYS.PROPERTIES_GROUPS_HINT),
+  PROPERTIES_LOGIN_LOCKED: message(KEYS.PROPERTIES_LOGIN_LOCKED),
+  PROPERTIES_LOADING: message(KEYS.PROPERTIES_LOADING),
+  PROPERTIES_LOAD_ERROR: message(KEYS.PROPERTIES_LOAD_ERROR),
+  PROPERTIES_SUBMIT: message(KEYS.PROPERTIES_SUBMIT),
+  PROPERTIES_CANCEL: message(KEYS.PROPERTIES_CANCEL),
+  VALIDATION_CSS_TOO_LONG: message(KEYS.VALIDATION_CSS_TOO_LONG),
+  VALIDATION_CSS_CHARS: message(KEYS.VALIDATION_CSS_CHARS),
   DELETE_CONFIRM: message(KEYS.DELETE_CONFIRM),
   DELETE_ROOT_BLOCKED: message(KEYS.DELETE_ROOT_BLOCKED),
   CREATE_PARENT_BLOCKED: message(KEYS.CREATE_PARENT_BLOCKED),

--- a/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  applySectionPropertiesForm,
   applyTitleToProperties,
   buildCreateSectionFromFolderBody,
   buildCreateSiteSectionBody,
@@ -208,6 +209,69 @@ describe("sectionMutations (#3096)", () => {
     );
     expect(props.title).toBe("New Title");
     expect(props.folderName).toBe("old");
+  });
+
+  it("applies section properties form without dropping folder ACL", () => {
+    const next = applySectionPropertiesForm(
+      {
+        id: "g1",
+        title: "Old",
+        folderName: "old",
+        target: "_self",
+        cssClassNames: "",
+        requiresLogin: false,
+        allowAccessTo: "",
+        secureSite: true,
+        secureAncestor: false,
+        siteRootSection: false,
+        folderPermission: { accessLevel: "WRITE", writePrincipals: ["a"] },
+      },
+      {
+        title: " About ",
+        folderName: " about ",
+        target: "_blank",
+        cssClassNames: "  nav-about   featured  ",
+        requiresLogin: true,
+        allowAccessTo: " Editors ",
+      },
+    );
+    expect(next.title).toBe("About");
+    expect(next.folderName).toBe("about");
+    expect(next.target).toBe("_blank");
+    expect(next.cssClassNames).toBe("nav-about featured");
+    expect(next.requiresLogin).toBe(true);
+    expect(next.allowAccessTo).toBe("Editors");
+    expect(next.folderPermission).toEqual({
+      accessLevel: "WRITE",
+      writePrincipals: ["a"],
+    });
+  });
+
+  it("does not rewrite root folder name or inherited login", () => {
+    const next = applySectionPropertiesForm(
+      {
+        id: "root",
+        title: "Home",
+        folderName: "Demo",
+        siteRootSection: true,
+        secureSite: true,
+        secureAncestor: true,
+        requiresLogin: true,
+        allowAccessTo: "Members",
+      },
+      {
+        title: "Home Page",
+        folderName: "hacked",
+        target: "_self",
+        cssClassNames: "",
+        requiresLogin: false,
+        allowAccessTo: "x",
+      },
+    );
+    expect(next.folderName).toBe("Demo");
+    expect(next.requiresLogin).toBe(true);
+    expect(next.allowAccessTo).toBe("Members");
+    expect(next.title).toBe("Home Page");
   });
 
   it("parses properties payload and detects section links", () => {

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -1024,4 +1024,94 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     expect(replaceSpy).not.toHaveBeenCalled();
   });
+
+  it("properties is disabled until a regular section is selected (#3353)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    expect(
+      (
+        screen.getByTestId(
+          "architecture-action-properties",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByTestId(
+            "architecture-action-properties",
+          ) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+  });
+
+  it("loads properties, saves update, and cancel does not POST (#3353)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    const loadProps = vi.spyOn(sectionApi, "loadSectionProperties").mockResolvedValue({
+      id: "c1",
+      title: "About",
+      folderName: "About",
+      target: "_self",
+      cssClassNames: "",
+      requiresLogin: false,
+      allowAccessTo: "",
+      secureSite: false,
+      siteRootSection: false,
+      folderPermission: { accessLevel: "WRITE" },
+    });
+    const updateSpy = vi
+      .spyOn(sectionApi, "updateSiteSection")
+      .mockResolvedValue({});
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    fireEvent.click(screen.getByTestId("architecture-action-properties"));
+    await waitFor(() => {
+      expect(loadProps).toHaveBeenCalledWith("c1");
+      expect(screen.getByTestId("architecture-properties-title")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-cancel"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-properties-dialog")).toBeNull();
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("architecture-action-properties"));
+    await waitFor(() => {
+      const input = screen.getByTestId(
+        "architecture-properties-title",
+      ) as HTMLInputElement;
+      expect(input.value).toBe("About");
+      expect(input.disabled).toBe(false);
+    });
+    fireEvent.change(screen.getByTestId("architecture-properties-title"), {
+      target: { value: "About Us" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-properties-target"), {
+      target: { value: "_blank" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-submit"));
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "c1",
+          title: "About Us",
+          folderName: "About",
+          target: "_blank",
+          folderPermission: { accessLevel: "WRITE" },
+        }),
+      );
+    });
+  });
 });

--- a/WebUI/src/test/ts/architecture/SectionPropertiesDialog.test.tsx
+++ b/WebUI/src/test/ts/architecture/SectionPropertiesDialog.test.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SectionPropertiesDialog } from "../../../main/ts/architecture/SectionPropertiesDialog";
+import type { SiteSectionPropertiesWire } from "../../../main/ts/api/architecture/types";
+
+const loaded: SiteSectionPropertiesWire = {
+  id: "g1",
+  title: "About",
+  folderName: "About",
+  target: "_self",
+  cssClassNames: "nav-about",
+  requiresLogin: false,
+  allowAccessTo: "",
+  secureSite: true,
+  secureAncestor: false,
+  siteRootSection: false,
+  folderPermission: { accessLevel: "WRITE" },
+};
+
+describe("SectionPropertiesDialog (#3353)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <SectionPropertiesDialog
+        open={false}
+        busy={false}
+        loading={false}
+        loadError={null}
+        initial={loaded}
+        onCancel={() => undefined}
+        onSubmit={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId("architecture-properties-dialog")).toBeNull();
+  });
+
+  it("validates empty title before save", () => {
+    const onSubmit = vi.fn();
+    render(
+      <SectionPropertiesDialog
+        open
+        busy={false}
+        loading={false}
+        loadError={null}
+        initial={loaded}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("architecture-properties-title"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-submit"));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByTestId("architecture-properties-error")).toBeTruthy();
+  });
+
+  it("saves edited fields", () => {
+    const onSubmit = vi.fn();
+    render(
+      <SectionPropertiesDialog
+        open
+        busy={false}
+        loading={false}
+        loadError={null}
+        initial={loaded}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("architecture-properties-title"), {
+      target: { value: "About Us" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-properties-folder"), {
+      target: { value: "about-us" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-properties-target"), {
+      target: { value: "_blank" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-properties-css"), {
+      target: { value: "nav-about featured" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-login"));
+    fireEvent.change(screen.getByTestId("architecture-properties-groups"), {
+      target: { value: "Editors,Admins" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-submit"));
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "About Us",
+      folderName: "about-us",
+      target: "_blank",
+      cssClassNames: "nav-about featured",
+      requiresLogin: true,
+      allowAccessTo: "Editors,Admins",
+    });
+  });
+
+  it("cancel does not submit", () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <SectionPropertiesDialog
+        open
+        busy={false}
+        loading={false}
+        loadError={null}
+        initial={loaded}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("architecture-properties-title"), {
+      target: { value: "Changed" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-cancel"));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("locks folder name on site root and login when not secure", () => {
+    const onSubmit = vi.fn();
+    const root: SiteSectionPropertiesWire = {
+      ...loaded,
+      siteRootSection: true,
+      secureSite: false,
+      folderName: "Demo",
+    };
+    render(
+      <SectionPropertiesDialog
+        open
+        busy={false}
+        loading={false}
+        loadError={null}
+        initial={root}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    expect(
+      (screen.getByTestId("architecture-properties-folder") as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      screen.getByTestId("architecture-properties-folder-locked"),
+    ).toBeTruthy();
+    expect(
+      (screen.getByTestId("architecture-properties-login") as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.change(screen.getByTestId("architecture-properties-title"), {
+      target: { value: "Home" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-properties-submit"));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Home",
+        folderName: "Demo",
+      }),
+    );
+  });
+});

--- a/docs/ai-generated/code-reviews/3353-section-properties-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/3353-section-properties-editor-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #3353 section properties editor
+
+**Branch:** `feat/issue-3353-section-properties-editor`  
+**Scope:** uncommitted Navigation SPA section-properties dialog vs `origin/main`  
+**Date:** 2026-08-14  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** reuse existing REST envelopes; cancel must not mutate; validation errors must not become 500; companion tests + product-docs + Playwright for WebUI screens.
+
+## Summary
+
+Adds a CM1-parity **Section properties** dialog on Navigation for regular (and root) sections: title, folder name, target window, CSS classes, login/groups. Load uses `GET /section/properties/{id}`; save uses `POST /section/update` with the existing `SiteSectionProperties` envelope. Folder ACL is passed through. Root folder name and inherited login stay locked. Vitest covers form validation/save/cancel and shell enablement/load/save/cancel. Playwright surface spec asserts cancel does not POST. Product-docs 8.2 Navigation page updated.
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path I/O, installers, or OS path assertions.
+
+## Issues
+
+None blocking.
+
+### Notes (not gates)
+
+- Folder ACL write-principals list is not edited in this dialog (out of issue field list; documented as later).
+- HTML `required` plus client validators keep empty title/folder from posting.
+- Load generation increment on cancel avoids stale GET applying after close.
+
+## Tests
+
+- `WebUI/src/test/ts/architecture/SectionPropertiesDialog.test.tsx`
+- `WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx` (#3353 cases)
+- `WebUI/src/test/ts/api/architecture/sectionMutations.test.ts` (`applySectionPropertiesForm`)
+- `modules/perc-qa-automation/frontend/tests/architecture-nav-section-properties.spec.js`
+
+Standalone `WebUI` `mvnw clean install`: **BUILD SUCCESS**, Tests run: 2334, Failures: 0.

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-section-properties.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-section-properties.spec.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture section properties dialog (#3353 / parent #3092).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-section-properties.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Cancel must not POST /section/update and must not 500 / pageerror.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Architecture section properties (#3353)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("properties dialog loads and cancel does not error @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    const updatePosts = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        /\/section\/update(?:\?|$)/.test(req.url())
+      ) {
+        updatePosts.push(req.url());
+      }
+    });
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const sitesEmpty = page.getByTestId("architecture-sites-empty");
+    const sitesError = page.getByTestId("architecture-sites-error");
+    const treePanel = page.getByTestId("architecture-tree-panel");
+
+    await expect
+      .poll(
+        async () => {
+          if (await sitesEmpty.isVisible().catch(() => false)) return "empty";
+          if (await sitesError.isVisible().catch(() => false)) return "error";
+          if (await treePanel.isVisible().catch(() => false)) return "tree";
+          return "wait";
+        },
+        { timeout: 45_000 },
+      )
+      .not.toBe("wait");
+
+    if (await treePanel.isVisible().catch(() => false)) {
+      await expect(
+        page.getByTestId("architecture-action-properties"),
+      ).toBeVisible();
+
+      const siteSelect = page.getByTestId("architecture-site-select");
+      const optionValues = await siteSelect
+        .locator("option")
+        .evaluateAll((els) =>
+          els
+            .map((el) => el.getAttribute("value") || el.value || "")
+            .filter((v) => v && v !== ""),
+        );
+      for (const site of optionValues) {
+        await siteSelect.selectOption(site);
+        const firstSection = page
+          .locator("[data-testid^='nav-tree-item-']")
+          .first();
+        const hasTree = await firstSection
+          .waitFor({ state: "visible", timeout: 15_000 })
+          .then(() => true)
+          .catch(() => false);
+        if (!hasTree) {
+          continue;
+        }
+        await firstSection.click();
+        const propsBtn = page.getByTestId("architecture-action-properties");
+        if (await propsBtn.isEnabled().catch(() => false)) {
+          await propsBtn.click();
+          await expect(
+            page.getByTestId("architecture-properties-dialog"),
+          ).toBeVisible({ timeout: 15_000 });
+          await expect(
+            page.getByTestId("architecture-properties-title"),
+          ).toBeVisible({ timeout: 10_000 });
+          await page.getByTestId("architecture-properties-cancel").click();
+          await expect(
+            page.getByTestId("architecture-properties-dialog"),
+          ).toHaveCount(0);
+        }
+        break;
+      }
+    }
+
+    expect(updatePosts).toEqual([]);
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          !/favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+            e,
+          ),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -109,7 +109,7 @@ Sections that require login show a **Secure** badge. The badge tooltip
 (**Requires login**) comes from the `perc.ui.architecture.modern` catalog
 (not a hard-coded-only string).
 
-Structure dialogs (create, create from folder, rename, landing page, section link, external link, the
+Structure dialogs (create, create from folder, rename, **section properties**, landing page, section link, external link, the
 section picker, **New Site**, and **Copy Site**) are modal (`role="dialog"`, `aria-modal`). **Escape**
 closes the open dialog when a mutation is not in progress. Closing **New Site** or
 **Copy Site** returns keyboard focus to the matching toolbar button. Primary
@@ -132,13 +132,32 @@ With a site selected, use the structure action bar above the tree:
 | **Landing page** | Opens the product **page picker** (Content Browser, pages only) so you can assign a different landing page to the selected regular section. Confirming a page calls `POST /section/replaceLandingPage` and **refreshes the tree** while keeping the section selected. The assigned page name is shown on the selected section. **Cancel** or an empty pick does not call the server and does not produce an error 500 — the dialog shows “No page selected” until a page is chosen. Folders and assets cannot be assigned. |
 | **Edit link** | Edits the selected section link (new target) or external link (text, URL, target window). |
 | **Rename** | Renames the selected regular section (updates section title / landing link title). |
+| **Properties** | Opens **Section properties** for the selected regular section (including the site root). Edit **title**, **folder name** (not on the site root), **target window**, **CSS classes**, and **Requires login** / **Allow access to** group names when the site is secure. **Save** posts `GET /section/properties/{id}` then `POST /section/update` (`SiteSectionProperties`). **Cancel** or **Escape** closes without posting. Validation errors (empty title, invalid folder name, invalid CSS class tokens) stay in the dialog — they do not produce an HTTP 500. |
 | **Move up / Move down** | Reorders the selected section among its siblings under the same parent. |
 | **Convert to folder** | After confirmation, removes the selected regular (non-root) section and its sub-sections from Navigation. The folder and its pages stay in the site. |
 | **Delete** | Deletes the selected non-root section after confirmation. Section links use the section-link delete path. |
 
-Server errors from create, convert, create-from-folder, rename, move, delete, landing-page, or link mutations are
+Server errors from create, convert, create-from-folder, rename, properties, move, delete, landing-page, or link mutations are
 shown in the panel (no silent failure). The tree reloads after a successful mutation
 and keeps the previously selected section when it still exists.
+
+### Edit section properties
+
+1. Select a **regular section** (or the site root) in the Navigation tree. Section
+   links, external links, and blogs use other editors — **Properties** stays disabled.
+2. Choose **Properties**. The dialog loads the current values from
+   `GET /sitemanage/section/properties/{id}`.
+3. Change **Title** (required), **Folder name** (URL segment; locked on the site
+   root), **Target window** (same / new / top / parent), and **CSS classes**
+   (optional nav-widget class tokens).
+4. When the site is **secure** and no ancestor already requires login, check
+   **Requires login** and optionally list group names (comma-separated) in
+   **Allow access to**. Otherwise login is inherited or unavailable and those
+   fields stay read-only.
+5. Choose **Save**. The shell posts `POST /sitemanage/section/update` and
+   refreshes the tree. Folder ACL (`folderPermission`) from the load is sent
+   back unchanged.
+6. **Cancel** or **Escape** closes the dialog without posting.
 
 ### Replace a section landing page
 
@@ -160,7 +179,7 @@ regular (non-root) sections — not blogs, section links, or external links.
 
 ### Still later
 
-Full section security / ACL preferences, blog type editor, and
+Folder ACL user-list editing (write principals), blog type editor, and
 retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 
 ## Current status (migration)
@@ -175,6 +194,7 @@ retirement of the legacy `siteArchitecture.jsp` host ship in follow-on slices.
 | Delete Site (confirm + picker refresh) | **Available** |
 | Site navigation tree browse (navons / sections) | **Available** |
 | Structure editing (create / rename / reorder / delete) | **Available** |
+| Section properties (title / folder / target / CSS / login) | **Available** |
 | Convert section to folder / create section from folder | **Available** |
 | Landing page / section-link / external-link parity | **Available** |
 | Landing page picker + replace (`replaceLandingPage`) | **Available** |


### PR DESCRIPTION
## Summary

Adds a **Section properties** dialog on Navigation (parent epic #3092, slice K / #3353) so operators can edit a selected regular or root navon: title, folder name, target window, CSS classes, and login-required / groups (CM1 configure-dialog parity).

Reuses existing `GET /sitemanage/section/properties/{id}` and `POST /sitemanage/section/update` (`SiteSectionProperties`). No new mutation REST. **Cancel** / **Escape** do not POST. Validation errors stay in the dialog (empty title, invalid folder name / CSS tokens) and do not become HTTP 500. Root folder name is locked; login is editable only on a secure site without a secure ancestor. Folder ACL from GET is passed through unchanged.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3353  
Parent: #3092

## Test plan

1. Standalone `cd WebUI && ../mvnw clean install` — BUILD SUCCESS, Tests run: 2334, Failures: 0.
2. Standalone `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS (placeholder jar; Playwright is npm).
3. Vitest: dialog validation/save/cancel; shell Properties disabled until a regular section is selected; load + save + cancel does not POST.
4. H2 QA (`perc-devctl qa-up --skip-image-build`): `TEST_CMS_URL=http://127.0.0.1:48521`; hot-copied `WebUI/target/generated-webui/cm/modern` into `perc-matrix-cms-h2`.
5. Playwright: `npm run test:surface -- --path tests/architecture-nav-section-properties.spec.js` — 1 passed; cancel did not POST `/section/update`; console-clean=yes; server.log-clean=yes (no ERROR/FATAL).
6. Manual: Navigation → select section → Properties → change title/CSS → Save → refresh tree; cancel after edits does not persist.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (Properties action + Edit section properties steps)
- [x] **Unit / module tests** — Vitest dialog + shell + `applySectionPropertiesForm`; WebUI + perc-qa-automation standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/architecture-nav-section-properties.spec.js`
- [x] **Build gates** — standalone clean install; no public Java API / `final` / signature change
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** WebUI, modules/perc-qa-automation
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-14T10:35:17); Tests run: 2334, Failures: 0. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-14T10:43:28); No tests to run (Maven).
- **downstream_checked:** none (no public Java type/`final`/signature change; C2 did not apply)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:48521` (`QA_CONTAINER=perc-matrix-cms-h2`)
- **deploy:** copied `WebUI/target/generated-webui/cm/modern` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- **Playwright:** `npm run test:surface -- --path tests/architecture-nav-section-properties.spec.js` — 1 passed (31.5s)
- **console-clean:** yes
- **server.log-clean:** yes

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
