### PR TITLE
fix(explorer): keep MENU cascade nested on ActionToolbar (#3379)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
@@ -179,7 +179,9 @@ export async function findAllowedTemplateMenus(
  * <p>Children under {@link ActionMenu.children} are unwrapped recursively
  * and sorted by {@code sortRank}. Nested parents remain nested so
  * {@code ActionToolbar} can render MENU dropdowns (#2730) rather than a
- * flat button dump. The mapper is pure (no side effects, no fetch).</p>
+ * flat button dump. Flat catalogs that still carry {@code parentId}
+ * (or that dump already-nested children as extra roots) are reconstructed
+ * here (#3379). The mapper is pure (no side effects, no fetch).</p>
  *
  * <p>Wire-shape note: Jackson typically serializes an {@code ActionMenuList}
  * field as a JSON <em>array</em>. Root list responses still wrap under
@@ -188,15 +190,37 @@ export async function findAllowedTemplateMenus(
 export function mapActionMenusToMenuActions(
   menus: ActionMenu[],
 ): MenuAction[] {
-  return (menus ?? [])
+  const reconstructed = nestActionMenusByParentId(menus ?? []);
+  const mapped = reconstructed
     .slice()
-    .sort((a, b) => a.sortRank - b.sortRank)
+    .sort((a, b) => (a.sortRank ?? 0) - (b.sortRank ?? 0))
     .map(mapSingleActionMenu);
+  return collapseFlattenedMenuActionRoots(mapped);
+}
+
+/**
+ * Normalize a single ActionMenu node. Jackson WRAP_ROOT_VALUE can emit
+ * {@code { ActionMenu: { name, ... } }} for a nested child.
+ */
+export function normalizeActionMenuNode(raw: unknown): ActionMenu | null {
+  if (raw == null || typeof raw !== "object") {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.name === "string") {
+    return raw as ActionMenu;
+  }
+  const inner = obj.ActionMenu ?? obj.actionMenu;
+  if (inner && typeof inner === "object" && !Array.isArray(inner)) {
+    return normalizeActionMenuNode(inner);
+  }
+  return null;
 }
 
 /**
  * Unwrap nested children whether Jackson emitted a raw array or an
- * {@code ActionMenuList} / {@code ActionMenu} envelope object.
+ * {@code ActionMenuList} / {@code ActionMenu} envelope object. A single
+ * child object (JAXB/Jettison) is accepted as a one-element list.
  */
 export function unwrapActionMenuChildren(
   children: ActionMenu["children"] | unknown,
@@ -205,18 +229,107 @@ export function unwrapActionMenuChildren(
     return [];
   }
   if (Array.isArray(children)) {
-    return children as ActionMenu[];
+    return children
+      .map((c) => normalizeActionMenuNode(c))
+      .filter((c): c is ActionMenu => c != null);
   }
   if (typeof children === "object") {
     const env = children as Record<string, unknown>;
-    if (Array.isArray(env.ActionMenuList)) {
-      return env.ActionMenuList as ActionMenu[];
+    const listed = env.ActionMenuList ?? env.ActionMenu ?? env.actionMenuList ?? env.actionMenu;
+    if (Array.isArray(listed)) {
+      return listed
+        .map((c) => normalizeActionMenuNode(c))
+        .filter((c): c is ActionMenu => c != null);
     }
-    if (Array.isArray(env.ActionMenu)) {
-      return env.ActionMenu as ActionMenu[];
-    }
+    const single = normalizeActionMenuNode(listed) ?? normalizeActionMenuNode(children);
+    return single ? [single] : [];
   }
   return [];
+}
+
+/**
+ * Rebuild a cascade from a flat {@link ActionMenu} list using
+ * {@code parentId} (RXMENUACTIONRELATION on the wire). Pure.
+ *
+ * <p>Parents that already have {@code children[]} keep those children and
+ * also accept additional siblings that point at the same parent. Items
+ * attached as children are omitted from the returned root list.</p>
+ */
+export function nestActionMenusByParentId(menus: ActionMenu[]): ActionMenu[] {
+  if (menus.length === 0) {
+    return menus;
+  }
+  const hasParent = menus.some(
+    (m) => m.parentId != null && m.parentId !== 0 && m.parentId !== m.id,
+  );
+  if (!hasParent) {
+    return menus;
+  }
+  const byId = new Map<number, ActionMenu>();
+  for (const menu of menus) {
+    if (menu == null || menu.id == null) {
+      continue;
+    }
+    if (byId.has(menu.id)) {
+      continue;
+    }
+    byId.set(menu.id, {
+      ...menu,
+      children: unwrapActionMenuChildren(menu.children),
+    });
+  }
+  const childIds = new Set<number>();
+  for (const menu of menus) {
+    if (menu == null || menu.id == null) {
+      continue;
+    }
+    const parentId = menu.parentId;
+    if (parentId == null || parentId === 0 || parentId === menu.id) {
+      continue;
+    }
+    const parent = byId.get(parentId);
+    const child = byId.get(menu.id);
+    if (!parent || !child) {
+      continue;
+    }
+    const kids = unwrapActionMenuChildren(parent.children);
+    if (!kids.some((k) => k.id === child.id || k.name === child.name)) {
+      parent.children = [...kids, child];
+    }
+    childIds.add(menu.id);
+  }
+  return menus
+    .filter((m) => m != null && (m.id == null || !childIds.has(m.id)))
+    .map((m) => (m.id != null ? (byId.get(m.id) ?? m) : m));
+}
+
+/**
+ * Drop root actions that already appear as descendants of another root.
+ * Prevents a tree+flat Jackson dump from rendering children as extra
+ * toolbar buttons while the parent dropdown is closed (#3379).
+ */
+export function collapseFlattenedMenuActionRoots(
+  actions: MenuAction[],
+): MenuAction[] {
+  if (actions.length === 0) {
+    return actions;
+  }
+  const descendantNames = new Set<string>();
+  const walk = (list?: MenuAction[]): void => {
+    for (const action of list ?? []) {
+      if (action?.name) {
+        descendantNames.add(action.name);
+      }
+      walk(action.children);
+    }
+  };
+  for (const root of actions) {
+    walk(root.children);
+  }
+  if (descendantNames.size === 0) {
+    return actions;
+  }
+  return actions.filter((a) => a != null && !descendantNames.has(a.name));
 }
 
 function mapSingleActionMenu(menu: ActionMenu): MenuAction {
@@ -233,6 +346,12 @@ function mapSingleActionMenu(menu: ActionMenu): MenuAction {
     menuType: menu.menuType,
     parameters: menu.parameters,
   };
+  if (menu.id != null) {
+    result.id = menu.id;
+  }
+  if (menu.parentId != null && menu.parentId !== 0) {
+    result.parentId = menu.parentId;
+  }
   if (childActions.length > 0) {
     result.children = childActions;
   }

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -469,6 +469,11 @@ export interface ActionMenu {
   /** Marker for client-handled vs server-handled actions. */
   handler?: string;
   /**
+   * Parent {@link ActionMenu.id} from {@code RXMENUACTIONRELATION} when the
+   * wire is a flat catalog (#3379). {@code 0} / omitted means a root.
+   */
+  parentId?: number;
+  /**
    * Cascading children. Wire may be a raw array (Jackson ArrayList field)
    * or an {@link ActionMenuListEnvelope} object.
    */
@@ -503,6 +508,10 @@ export interface MenuAction {
   handler?: string;
   sortRank: number;
   menuType: ActionMenuType;
+  /** Server action id (used to nest flat catalogs via {@code parentId}). */
+  id?: number;
+  /** Parent server action id when the catalog arrived flat (#3379). */
+  parentId?: number;
   parameters?: ActionMenuParameter[];
   /** Empty unless the parent has cascading children. */
   children?: MenuAction[];

--- a/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
@@ -28,8 +28,8 @@
  *
  * <p>Toolbar refreshes when the {@link ActionToolbarProps.actions} prop
  * changes (e.g. on selection change the parent fetches the allowed
- * actions via {@code findAllowedContentTypeMenus} + workflow transitions
- * and re-renders this component).</p>
+ * actions via {@code GET /actions/find} (plus merged type menus) and
+ * workflow transitions and re-renders this component).</p>
  */
 
 import React, { useEffect, useId, useRef, useState } from "react";

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -35,10 +35,9 @@ import React, {
 } from "react";
 import { formatApiError } from "../api/client";
 import {
-  findActions,
-  findAllowedContentTypeMenus,
-  mapActionMenusToMenuActions,
-} from "../api/contentExplorer/actionMenuApi";
+  loadExplorerMenuCatalog,
+  parseExplorerContentId,
+} from "./menuCatalogLoad";
 import {
   listDisplayFormats,
   normalizeDisplayFormatColumns,
@@ -282,46 +281,20 @@ const serverActionsLabelStyle: React.CSSProperties = {
   minWidth: 96,
 };
 
-function parseContentId(id: string | undefined): number | null {
-  if (!id) return null;
-  const n = Number(id);
-  return Number.isFinite(n) ? n : null;
-}
-
 /**
- * Load the server action catalog for the current selection (#2849 / #2972).
+ * Load the server action catalog for the current selection (#2849 / #2972 / #3379).
  *
- * <p>When a content item is selected, prefer per-content-type menus from
- * {@code POST /actions/find/types}. Failures or empty type menus fall back to
- * the full cascading tree from {@code GET /actions/find} (no
- * {@code item=true} filter) so toolbar dropdown parents ({@code MENU}) remain
- * available — {@code item=true} would keep only flat {@code MENUITEM} roots
- * and drop nested chrome. Folder-only selection always uses {@code find}.</p>
- *
- * <p>Desktop-only / surface enablement is applied by the shell after load
- * via {@link filterToolbarActions} / {@link filterContextMenuActions}.</p>
+ * <p>Always uses the cascading {@code GET /actions/find} tree. Per-content-type
+ * menus from {@code POST /actions/find/types} are merged under existing MENU
+ * parents — they never replace the cascade (that replacement dumped children
+ * as top-level toolbar buttons). Desktop-only / surface enablement is applied
+ * by the shell after load via {@link filterToolbarActions} /
+ * {@link filterContextMenuActions}.</p>
  */
 async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
-  const contentId =
-    item && isWorkflowEligibleItem(item) ? parseContentId(item.id) : null;
-  if (contentId != null) {
-    try {
-      const menus = await findAllowedContentTypeMenus([contentId]);
-      if (menus.length > 0) {
-        return mapActionMenusToMenuActions(menus);
-      }
-    } catch (err: unknown) {
-      // Non-fatal: fall through to the full catalog so the toolbar is not wiped.
-      console.warn(
-        "[ContentExplorerShell] content-type menus load failed; falling back to findActions",
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-  }
-  const menus = await findActions({});
-  return mapActionMenusToMenuActions(menus);
+  return loadExplorerMenuCatalog(item);
 }
 
 /**
@@ -1229,7 +1202,7 @@ function ContentExplorerShellInner({
       {showTranslations &&
         selection.item &&
         selection.item.type !== "folder" &&
-        parseContentId(selection.item.id) != null && (
+        parseExplorerContentId(selection.item.id) != null && (
           <section
             id="explorer-translations-panel"
             style={sidePanelStyle}
@@ -1253,7 +1226,7 @@ function ContentExplorerShellInner({
         !(
           selection.item &&
           selection.item.type !== "folder" &&
-          parseContentId(selection.item.id) != null
+          parseExplorerContentId(selection.item.id) != null
         ) && (
           <div
             id="explorer-translations-panel"
@@ -1359,7 +1332,7 @@ function ContentExplorerShellInner({
       {showRelationships &&
         selection.item &&
         selection.item.type !== "folder" &&
-        parseContentId(selection.item.id) != null && (
+        parseExplorerContentId(selection.item.id) != null && (
           <section
             id="explorer-relationships-panel"
             style={sidePanelStyle}
@@ -1379,7 +1352,7 @@ function ContentExplorerShellInner({
         !(
           selection.item &&
           selection.item.type !== "folder" &&
-          parseContentId(selection.item.id) != null
+          parseExplorerContentId(selection.item.id) != null
         ) && (
           <div
             id="explorer-relationships-panel"

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer toolbar catalog load (#3379 / parent #2730).
+ *
+ * <p>Always starts from {@code GET /actions/find} so MENU parents stay
+ * nested. {@code POST /actions/find/types} is a flat content-type list
+ * and must never replace the cascade (that dump is what human QA saw on
+ * #2783). Extra type menus are merged under an existing New/Content MENU
+ * or dropped — they are not appended as top-level toolbar buttons.</p>
+ */
+
+import {
+  findActions,
+  findAllowedContentTypeMenus,
+  mapActionMenusToMenuActions,
+} from "../api/contentExplorer/actionMenuApi";
+import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
+import { isWorkflowEligibleItem } from "./workflowEligibility";
+
+export function parseExplorerContentId(
+  id: string | number | undefined,
+): number | null {
+  if (id == null || id === "") {
+    return null;
+  }
+  const n = Number(id);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isCascadeParent(action: MenuAction): boolean {
+  const type = (action.menuType ?? "").toUpperCase();
+  return type === "MENU" || type === "CONTEXTMENU" || type === "DYNAMICMENU";
+}
+
+function collectActionNames(actions: MenuAction[], into: Set<string>): void {
+  for (const action of actions) {
+    if (action?.name) {
+      into.add(action.name);
+    }
+    if (action.children?.length) {
+      collectActionNames(action.children, into);
+    }
+  }
+}
+
+function findNewItemHost(tree: MenuAction[]): MenuAction | null {
+  const preferred = ["new", "newitem", "new_item", "contenttypes", "content"];
+  const stack = [...tree];
+  let fallback: MenuAction | null = null;
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (isCascadeParent(node)) {
+      const key = node.name.replace(/[\s_-]/g, "").toLowerCase();
+      if (preferred.includes(key) || /new/i.test(node.label ?? node.name)) {
+        return node;
+      }
+      if (fallback == null) {
+        fallback = node;
+      }
+    }
+    if (node.children?.length) {
+      stack.push(...node.children);
+    }
+  }
+  return fallback;
+}
+
+function cloneAction(action: MenuAction): MenuAction {
+  return {
+    ...action,
+    children: action.children?.map(cloneAction),
+  };
+}
+
+/**
+ * Merge per-content-type menus into the cascading {@code find()} tree
+ * without flattening. Pure: does not mutate inputs.
+ */
+export function mergeContentTypeMenusIntoCatalog(
+  tree: MenuAction[],
+  typeMenus: MenuAction[],
+): MenuAction[] {
+  if (typeMenus.length === 0) {
+    return tree.slice();
+  }
+  const out = tree.map(cloneAction);
+  const known = new Set<string>();
+  collectActionNames(out, known);
+
+  const extraParents: MenuAction[] = [];
+  const extraLeaves: MenuAction[] = [];
+  for (const menu of typeMenus) {
+    if (!menu?.name || known.has(menu.name)) {
+      continue;
+    }
+    const copy = cloneAction(menu);
+    if ((copy.children?.length ?? 0) > 0 || isCascadeParent(copy)) {
+      extraParents.push(copy);
+    } else {
+      extraLeaves.push(copy);
+    }
+  }
+
+  if (extraLeaves.length > 0) {
+    const host = findNewItemHost(out) ?? extraParents.find(isCascadeParent);
+    if (host) {
+      host.children = [...(host.children ?? []), ...extraLeaves];
+    }
+    // Else drop leftover leaves — do not dump them as top-level buttons.
+  }
+
+  return extraParents.length > 0 ? [...out, ...extraParents] : out;
+}
+
+/**
+ * Product default for Explorer toolbar / context-menu catalog load.
+ *
+ * <p>Always uses {@code GET /actions/find} for MENU cascade. When a
+ * workflow-eligible item is selected, type menus are merged under existing
+ * parents — they never replace the tree.</p>
+ */
+export async function loadExplorerMenuCatalog(
+  item: PSPathItem | null,
+): Promise<MenuAction[]> {
+  const menus = await findActions({});
+  const tree = mapActionMenusToMenuActions(menus);
+  const contentId =
+    item && isWorkflowEligibleItem(item)
+      ? parseExplorerContentId(item.id)
+      : null;
+  if (contentId == null) {
+    return tree;
+  }
+  try {
+    const typeMenus = mapActionMenusToMenuActions(
+      await findAllowedContentTypeMenus([contentId]),
+    );
+    return mergeContentTypeMenusIntoCatalog(tree, typeMenus);
+  } catch (err: unknown) {
+    console.warn(
+      "[ContentExplorerShell] content-type menus load failed; keeping find() cascade",
+      err instanceof Error ? err.message : String(err),
+    );
+    return tree;
+  }
+}

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -59,15 +59,33 @@ function collectActionNames(actions: MenuAction[], into: Set<string>): void {
   }
 }
 
+/**
+ * Normalized {@code name} keys that host leftover content-type MENUITEMs.
+ * Underscores/spaces/hyphens are stripped before compare, so {@code new_item}
+ * matches {@code newitem}. Include common synonyms (create) for localized or
+ * custom New/Create menus.
+ */
+export const NEW_ITEM_HOST_PREFERRED_KEYS: readonly string[] = [
+  "new",
+  "newitem",
+  "contenttypes",
+  "content",
+  "create",
+];
+
+const NEW_ITEM_HOST_LABEL = /new|create/i;
+
 function findNewItemHost(tree: MenuAction[]): MenuAction | null {
-  const preferred = ["new", "newitem", "new_item", "contenttypes", "content"];
   const stack = [...tree];
   let fallback: MenuAction | null = null;
   while (stack.length > 0) {
     const node = stack.shift()!;
     if (isCascadeParent(node)) {
       const key = node.name.replace(/[\s_-]/g, "").toLowerCase();
-      if (preferred.includes(key) || /new/i.test(node.label ?? node.name)) {
+      if (
+        NEW_ITEM_HOST_PREFERRED_KEYS.includes(key) ||
+        NEW_ITEM_HOST_LABEL.test(node.label ?? node.name)
+      ) {
         return node;
       }
       if (fallback == null) {

--- a/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
@@ -183,6 +183,24 @@ describe("filterEnabledMenuActions", () => {
     );
   });
 
+  it("keeps MENU children nested rather than hoisting them to the toolbar (#3379)", () => {
+    const actions: MenuAction[] = [
+      {
+        name: "file",
+        label: "File",
+        sortRank: 1,
+        menuType: "MENU",
+        children: [
+          leaf({ name: "open", url: "/Rhythmyx/ok" }),
+          leaf({ name: "saveAs", url: "/Rhythmyx/saveas" }),
+        ],
+      },
+    ];
+    const filtered = filterToolbarActions(actions, BASE);
+    expect(filtered.map((a) => a.name)).toEqual(["file"]);
+    expect(filtered[0]?.children?.map((c) => c.name)).toEqual(["open", "saveAs"]);
+  });
+
   it("does not mutate the input tree", () => {
     const child = leaf({ name: "child", url: "javascript:x" });
     const parent: MenuAction = {

--- a/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
@@ -17,10 +17,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActionMenu } from "../../../main/ts/api/contentExplorer/types";
 import {
+  collapseFlattenedMenuActionRoots,
   findActions,
   findAllowedContentTypeMenus,
   findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
+  nestActionMenusByParentId,
   unwrapActionMenuChildren,
   unwrapActionMenuListPayload,
 } from "../../../main/ts/api/contentExplorer/actionMenuApi";
@@ -124,9 +126,95 @@ describe("mapActionMenusToMenuActions", () => {
       description: "Open the item in the editor",
       sortRank: 0,
       menuType: "MENUITEM",
+      id: 1,
       parameters: undefined,
       children: undefined,
     });
+  });
+
+  it("nests flat MENUITEM siblings using parentId (#3379)", () => {
+    const menus: ActionMenu[] = [
+      makeMenu({ id: 8, name: "file", menuType: "MENU", sortRank: 0 }),
+      makeMenu({
+        id: 2,
+        name: "open",
+        parentId: 8,
+        menuType: "MENUITEM",
+        sortRank: 1,
+      }),
+      makeMenu({
+        id: 17,
+        name: "saveAs",
+        parentId: 8,
+        menuType: "MENUITEM",
+        sortRank: 2,
+      }),
+    ];
+    const actions = mapActionMenusToMenuActions(menus);
+    expect(actions.map((a) => a.name)).toEqual(["file"]);
+    expect(actions[0]?.children?.map((c) => c.name)).toEqual(["open", "saveAs"]);
+  });
+
+  it("does not dump nested children that also appear as extra roots (#3379)", () => {
+    const nestedKids = [
+      makeMenu({ id: 2, name: "open", sortRank: 1 }),
+      makeMenu({ id: 17, name: "saveAs", sortRank: 2 }),
+    ];
+    const menus: ActionMenu[] = [
+      makeMenu({
+        id: 8,
+        name: "file",
+        menuType: "MENU",
+        sortRank: 0,
+        children: nestedKids,
+      }),
+      ...nestedKids,
+    ];
+    const actions = mapActionMenusToMenuActions(menus);
+    expect(actions.map((a) => a.name)).toEqual(["file"]);
+    expect(actions[0]?.children?.map((c) => c.name)).toEqual(["open", "saveAs"]);
+  });
+
+  it("unwrapActionMenuChildren accepts a single child object", () => {
+    expect(
+      unwrapActionMenuChildren({
+        ActionMenu: makeMenu({ name: "only" }),
+      }).map((m) => m.name),
+    ).toEqual(["only"]);
+  });
+
+  it("nestActionMenusByParentId is a no-op without parentId", () => {
+    const menus = [makeMenu({ name: "open" }), makeMenu({ name: "edit", id: 2 })];
+    expect(nestActionMenusByParentId(menus).map((m) => m.name)).toEqual([
+      "open",
+      "edit",
+    ]);
+  });
+
+  it("collapseFlattenedMenuActionRoots drops descendant names from roots", () => {
+    const file = {
+      name: "file",
+      label: "File",
+      sortRank: 0,
+      menuType: "MENU" as const,
+      children: [
+        {
+          name: "open",
+          label: "Open",
+          sortRank: 1,
+          menuType: "MENUITEM" as const,
+        },
+      ],
+    };
+    const open = {
+      name: "open",
+      label: "Open",
+      sortRank: 1,
+      menuType: "MENUITEM" as const,
+    };
+    expect(
+      collapseFlattenedMenuActionRoots([file, open]).map((a) => a.name),
+    ).toEqual(["file"]);
   });
 
   it("omits the children key when there are none", () => {

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -19,6 +19,7 @@ import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
 import {
   loadExplorerMenuCatalog,
   mergeContentTypeMenusIntoCatalog,
+  NEW_ITEM_HOST_PREFERRED_KEYS,
   parseExplorerContentId,
 } from "../../../main/ts/contentExplorer/menuCatalogLoad";
 
@@ -99,6 +100,41 @@ describe("mergeContentTypeMenusIntoCatalog", () => {
     const merged = mergeContentTypeMenusIntoCatalog(tree, []);
     expect(merged).toEqual(tree);
     expect(merged).not.toBe(tree);
+  });
+
+  it("nests leftover type leaves under a Create MENU host", () => {
+    expect(NEW_ITEM_HOST_PREFERRED_KEYS).toContain("create");
+    const tree: MenuAction[] = [
+      action({
+        name: "create",
+        label: "Create",
+        menuType: "MENU",
+        children: [action({ name: "folder" })],
+      }),
+    ];
+    const merged = mergeContentTypeMenusIntoCatalog(tree, [
+      action({ name: "new-page" }),
+    ]);
+    expect(merged.map((a) => a.name)).toEqual(["create"]);
+    expect(merged[0]?.children?.map((c) => c.name)).toEqual([
+      "folder",
+      "new-page",
+    ]);
+  });
+
+  it("treats a Create label as a New-item host", () => {
+    const tree: MenuAction[] = [
+      action({
+        name: "items",
+        label: "Create items",
+        menuType: "MENU",
+        children: [action({ name: "folder" })],
+      }),
+    ];
+    const merged = mergeContentTypeMenusIntoCatalog(tree, [
+      action({ name: "new-page" }),
+    ]);
+    expect(merged[0]?.children?.map((c) => c.name)).toContain("new-page");
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
+import {
+  loadExplorerMenuCatalog,
+  mergeContentTypeMenusIntoCatalog,
+  parseExplorerContentId,
+} from "../../../main/ts/contentExplorer/menuCatalogLoad";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function action(
+  partial: Partial<MenuAction> & Pick<MenuAction, "name">,
+): MenuAction {
+  return {
+    label: partial.label ?? partial.name,
+    sortRank: partial.sortRank ?? 0,
+    menuType: partial.menuType ?? "MENUITEM",
+    ...partial,
+  };
+}
+
+describe("parseExplorerContentId", () => {
+  it("parses finite numeric ids and rejects junk", () => {
+    expect(parseExplorerContentId("42")).toBe(42);
+    expect(parseExplorerContentId(7)).toBe(7);
+    expect(parseExplorerContentId(undefined)).toBeNull();
+    expect(parseExplorerContentId("")).toBeNull();
+    expect(parseExplorerContentId("nope")).toBeNull();
+  });
+});
+
+describe("mergeContentTypeMenusIntoCatalog", () => {
+  it("does not replace the cascade tree with a flat type-menu dump (#3379)", () => {
+    const tree: MenuAction[] = [
+      action({
+        name: "file",
+        label: "File",
+        menuType: "MENU",
+        children: [action({ name: "open" }), action({ name: "saveAs" })],
+      }),
+      action({ name: "preview" }),
+    ];
+    const typeMenus: MenuAction[] = [
+      action({ name: "new-page", label: "Page" }),
+      action({ name: "new-file", label: "File item" }),
+    ];
+    const merged = mergeContentTypeMenusIntoCatalog(tree, typeMenus);
+    expect(merged.map((a) => a.name)).toEqual(["file", "preview"]);
+    expect(merged[0]?.children?.map((c) => c.name)).toEqual([
+      "open",
+      "saveAs",
+      "new-page",
+      "new-file",
+    ]);
+    expect(merged.some((a) => a.name === "new-page")).toBe(false);
+  });
+
+  it("does not mutate the input tree", () => {
+    const tree: MenuAction[] = [
+      action({
+        name: "new",
+        menuType: "MENU",
+        children: [action({ name: "new-folder" })],
+      }),
+    ];
+    const snapshot = tree[0].children?.length;
+    mergeContentTypeMenusIntoCatalog(tree, [action({ name: "new-page" })]);
+    expect(tree[0].children?.length).toBe(snapshot);
+  });
+
+  it("drops leftover type leaves when there is no MENU host", () => {
+    const tree: MenuAction[] = [action({ name: "preview" })];
+    const merged = mergeContentTypeMenusIntoCatalog(tree, [
+      action({ name: "new-page" }),
+    ]);
+    expect(merged.map((a) => a.name)).toEqual(["preview"]);
+  });
+
+  it("returns a copy when type menus are empty", () => {
+    const tree: MenuAction[] = [action({ name: "open" })];
+    const merged = mergeContentTypeMenusIntoCatalog(tree, []);
+    expect(merged).toEqual(tree);
+    expect(merged).not.toBe(tree);
+  });
+});
+
+describe("loadExplorerMenuCatalog", () => {
+  it("always loads find() and keeps MENU children when types are also returned", async () => {
+    const findPayload = {
+      ActionMenu: [
+        {
+          id: 8,
+          name: "file",
+          label: "File",
+          sortRank: 0,
+          menuType: "MENU",
+          children: [
+            { id: 2, name: "open", sortRank: 1, menuType: "MENUITEM" },
+          ],
+        },
+      ],
+    };
+    const typesPayload = {
+      ActionMenuList: [
+        { id: 90, name: "new-page", sortRank: 0, menuType: "MENUITEM" },
+      ],
+    };
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(findPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(typesPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const actions = await loadExplorerMenuCatalog({
+      id: "101",
+      name: "Home",
+      type: "percPage",
+      path: "/Sites/Demo/Home",
+      folderPath: "/Sites/Demo",
+      displayProperties: { workflowId: "5" },
+    } as never);
+
+    expect(actions.map((a) => a.name)).toEqual(["file"]);
+    expect(actions[0]?.children?.map((c) => c.name)).toContain("open");
+    expect(actions[0]?.children?.map((c) => c.name)).toContain("new-page");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses only find() for folder-only selection", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ActionMenu: [
+            { id: 1, name: "new-folder", sortRank: 0, menuType: "MENUITEM" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const actions = await loadExplorerMenuCatalog({
+      id: "1",
+      name: "Sites",
+      type: "Folder",
+      path: "/Sites",
+      folderPath: "/Sites",
+    } as never);
+    expect(actions.map((a) => a.name)).toEqual(["new-folder"]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
@@ -36,6 +36,7 @@ const {
   TEST_IDS,
   explorerSpaUrl,
 } = require("./helpers/explorer-menu-bar");
+const { collectMenuParents } = require("./helpers/explorer-action-toolbar-catalog");
 
 test.describe("modern React Content Explorer — nested ActionToolbar menus (#2730)", () => {
   test.beforeEach(async ({ page }) => {
@@ -85,24 +86,85 @@ test.describe("modern React Content Explorer — nested ActionToolbar menus (#27
   );
 
   test(
-    "MENU parents with children open nested dropdowns (soft when no nested menus)",
+    "MENU parents with children open nested dropdowns (do not skip when catalog has MENU parents)",
     { tag: ["@explorer-action-toolbar", "@explorer"] },
     async ({ page }) => {
       await expect(
         page.locator(`[data-testid="${TEST_IDS.actionToolbar}"]`),
       ).toBeVisible({ timeout: 15_000 });
 
+      const catalog = await page.evaluate(async () => {
+        const paths = [
+          "/Rhythmyx/services/actions/find",
+          "/services/actions/find",
+        ];
+        for (const url of paths) {
+          try {
+            const res = await fetch(url, { credentials: "same-origin" });
+            if (!res.ok) continue;
+            return { url, payload: await res.json() };
+          } catch {
+            // try next path
+          }
+        }
+        return { url: null, payload: null };
+      });
+
+      const menuParents = collectMenuParents(catalog.payload);
+      test.info().annotations.push({
+        type: "note",
+        description: `find() ${catalog.url || "unreached"} MENU parents=${menuParents.length}`,
+      });
+
       const parents = page.locator(
         `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid^="action-toolbar-item-"][aria-haspopup="menu"]`,
       );
+
+      if (menuParents.length > 0) {
+        // Live catalog has cascading MENU parents — must render dropdowns
+        // (#3379). Do not soft-skip.
+        await expect
+          .poll(async () => parents.count(), { timeout: 15_000 })
+          .toBeGreaterThan(0);
+
+        const parent = parents.first();
+        const parentTestId = await parent.getAttribute("data-testid");
+        const menuName = String(parentTestId || "").replace(
+          /^action-toolbar-item-/,
+          "",
+        );
+
+        // Closed: children must not appear as extra top-level toolbar buttons.
+        const closedTopLevel = page.locator(
+          `[data-testid="${TEST_IDS.actionToolbar}"] > button[data-testid^="action-toolbar-item-"], [data-testid="${TEST_IDS.actionToolbar}"] > div > button[data-testid^="action-toolbar-item-"]`,
+        );
+        const closedNames = await closedTopLevel.evaluateAll((els) =>
+          els.map((el) => el.getAttribute("data-testid") || ""),
+        );
+        for (const childName of menuParents[0].childNames) {
+          expect(
+            closedNames.includes(`action-toolbar-item-${childName}`),
+            `closed toolbar dumped child "${childName}" as a top-level button`,
+          ).toBe(false);
+        }
+
+        await parent.click();
+        await expect(
+          page.locator(`[data-testid="action-toolbar-menu-${menuName}"]`),
+        ).toBeVisible({ timeout: 5_000 });
+        const items = page.locator(
+          `[data-testid="action-toolbar-menu-${menuName}"] [role="menuitem"]`,
+        );
+        await expect(items.first()).toBeVisible();
+        return;
+      }
+
       const parentCount = await parents.count();
       if (parentCount === 0) {
-        // Live CMS may still return only leaf MENUITEMs for the current
-        // selection; nested dropdown chrome is covered by WebUI Vitest.
         test.info().annotations.push({
           type: "note",
           description:
-            "No aria-haspopup=menu parents on live CMS; nested chrome covered by Vitest ActionToolbar tests.",
+            "Live catalog has no MENU parents; nested chrome covered by WebUI Vitest.",
         });
         return;
       }
@@ -117,12 +179,13 @@ test.describe("modern React Content Explorer — nested ActionToolbar menus (#27
       await expect(
         page.locator(`[data-testid="action-toolbar-menu-${menuName}"]`),
       ).toBeVisible({ timeout: 5_000 });
-
-      // While open, at least one menuitem is present under the dropdown.
-      const items = page.locator(
-        `[data-testid="action-toolbar-menu-${menuName}"] [role="menuitem"]`,
-      );
-      await expect(items.first()).toBeVisible();
+      await expect(
+        page
+          .locator(
+            `[data-testid="action-toolbar-menu-${menuName}"] [role="menuitem"]`,
+          )
+          .first(),
+      ).toBeVisible();
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
@@ -134,18 +134,21 @@ test.describe("modern React Content Explorer — nested ActionToolbar menus (#27
           "",
         );
 
-        // Closed: children must not appear as extra top-level toolbar buttons.
+        // Closed: children of every MENU parent must not appear as extra
+        // top-level toolbar buttons (#3379).
         const closedTopLevel = page.locator(
           `[data-testid="${TEST_IDS.actionToolbar}"] > button[data-testid^="action-toolbar-item-"], [data-testid="${TEST_IDS.actionToolbar}"] > div > button[data-testid^="action-toolbar-item-"]`,
         );
         const closedNames = await closedTopLevel.evaluateAll((els) =>
           els.map((el) => el.getAttribute("data-testid") || ""),
         );
-        for (const childName of menuParents[0].childNames) {
-          expect(
-            closedNames.includes(`action-toolbar-item-${childName}`),
-            `closed toolbar dumped child "${childName}" as a top-level button`,
-          ).toBe(false);
+        for (const parentMenu of menuParents) {
+          for (const childName of parentMenu.childNames) {
+            expect(
+              closedNames.includes(`action-toolbar-item-${childName}`),
+              `closed toolbar dumped child "${childName}" of "${parentMenu.name}" as a top-level button`,
+            ).toBe(false);
+          }
         }
 
         await parent.click();

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-action-toolbar-catalog.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-action-toolbar-catalog.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure helpers for #3379 Explorer action-toolbar Playwright: unwrap
+ * GET /actions/find and detect MENU parents with children.
+ */
+
+"use strict";
+
+/**
+ * @param {unknown} payload
+ * @returns {any[]}
+ */
+function unwrapFindPayload(payload) {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload === "object") {
+    const raw =
+      payload.ActionMenu ??
+      payload.ActionMenuList ??
+      payload.actionMenu ??
+      payload.actionMenuList;
+    if (Array.isArray(raw)) return raw;
+    if (raw && typeof raw === "object") return [raw];
+  }
+  return [];
+}
+
+/**
+ * @param {unknown} children
+ * @returns {any[]}
+ */
+function unwrapChildren(children) {
+  if (children == null) return [];
+  if (Array.isArray(children)) return children;
+  if (typeof children === "object") {
+    const raw =
+      children.ActionMenuList ??
+      children.ActionMenu ??
+      children.actionMenuList ??
+      children.actionMenu;
+    if (Array.isArray(raw)) return raw;
+    if (raw && typeof raw === "object" && raw.name) return [raw];
+  }
+  return [];
+}
+
+/**
+ * @param {unknown} payload
+ * @returns {{ name: string, childNames: string[] }[]}
+ */
+function collectMenuParents(payload) {
+  const roots = unwrapFindPayload(payload);
+  const byId = new Map();
+  for (const menu of roots) {
+    if (menu && menu.id != null) {
+      byId.set(menu.id, menu);
+    }
+  }
+  const childrenOf = new Map();
+  function addChild(parentName, childName) {
+    if (!parentName || !childName) return;
+    const list = childrenOf.get(parentName) || [];
+    list.push(childName);
+    childrenOf.set(parentName, list);
+  }
+  for (const menu of roots) {
+    if (!menu || !menu.name) continue;
+    for (const child of unwrapChildren(menu.children)) {
+      addChild(menu.name, child.name);
+    }
+    if (menu.parentId && byId.has(menu.parentId)) {
+      addChild(byId.get(menu.parentId).name, menu.name);
+    }
+  }
+  const parents = [];
+  for (const menu of roots) {
+    if (!menu || !menu.name) continue;
+    const type = String(menu.menuType || "").toUpperCase();
+    const kids = childrenOf.get(menu.name) || [];
+    if (
+      kids.length > 0 &&
+      (type === "MENU" || type === "CONTEXTMENU" || type === "DYNAMICMENU")
+    ) {
+      parents.push({ name: menu.name, childNames: kids });
+    }
+  }
+  return parents;
+}
+
+module.exports = {
+  unwrapFindPayload,
+  unwrapChildren,
+  collectMenuParents,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
@@ -23,6 +23,10 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { TEST_IDS } = require("../helpers/explorer-menu-bar");
+const {
+  collectMenuParents,
+  unwrapFindPayload,
+} = require("../helpers/explorer-action-toolbar-catalog");
 
 describe("explorer-action-toolbar-menus helpers (#2730)", () => {
   it("exports action toolbar + server-actions region test ids", () => {
@@ -36,5 +40,31 @@ describe("explorer-action-toolbar-menus helpers (#2730)", () => {
       TEST_IDS.serverActionsError,
       "explorer-server-actions-error",
     );
+  });
+
+  it("collectMenuParents finds nested MENU children and parentId links (#3379)", () => {
+    const fromChildren = collectMenuParents({
+      ActionMenu: [
+        {
+          id: 8,
+          name: "file",
+          menuType: "MENU",
+          children: [{ name: "open" }, { name: "saveAs" }],
+        },
+      ],
+    });
+    assert.equal(fromChildren.length, 1);
+    assert.equal(fromChildren[0].name, "file");
+    assert.deepEqual(fromChildren[0].childNames, ["open", "saveAs"]);
+
+    const fromParentId = collectMenuParents({
+      ActionMenu: [
+        { id: 8, name: "file", menuType: "MENU" },
+        { id: 2, name: "open", menuType: "MENUITEM", parentId: 8 },
+      ],
+    });
+    assert.equal(fromParentId.length, 1);
+    assert.deepEqual(fromParentId[0].childNames, ["open"]);
+    assert.deepEqual(unwrapFindPayload(null), []);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
@@ -67,4 +67,29 @@ describe("explorer-action-toolbar-menus helpers (#2730)", () => {
     assert.deepEqual(fromParentId[0].childNames, ["open"]);
     assert.deepEqual(unwrapFindPayload(null), []);
   });
+
+  it("collectMenuParents returns every MENU parent so closed-toolbar checks cover all cascades", () => {
+    const parents = collectMenuParents({
+      ActionMenu: [
+        {
+          id: 8,
+          name: "file",
+          menuType: "MENU",
+          children: [{ name: "open" }],
+        },
+        {
+          id: 9,
+          name: "view",
+          menuType: "MENU",
+          children: [{ name: "preview" }],
+        },
+      ],
+    });
+    assert.equal(parents.length, 2);
+    assert.deepEqual(
+      parents.map((p) => p.name),
+      ["file", "view"],
+    );
+    assert.deepEqual(parents[1].childNames, ["preview"]);
+  });
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -216,15 +216,19 @@ catalog region apart from the Content / View / Help menu bar and the display-for
 
 Menus and toolbar buttons come from the server action catalog used by Content Explorer:
 
-- When you select a content item, the shell loads allowed menus for that content type and
-  falls back to the full action catalog when type menus are empty or unavailable.
-- When only a folder is active, the shell loads the cascading action tree for the Explorer UI.
+- Cascading **MENU** parents render as **one toolbar control** with a dropdown (`▾`). Open
+  the parent to choose a child command. Child items are **not** shown as extra top-level
+  buttons while the menu is closed.
+- When you select a content item, the shell keeps that cascading tree and may add
+  content-type **New** commands under an existing menu. It does not replace the tree with
+  a flat list of every allowed command.
+- When only a folder is active, the shell loads the same cascading action tree.
 - **Desktop-only** actions (for example custom application protocols that only DCE can run)
   are **hidden** in the web shell so operators are not offered controls that cannot succeed
   in the browser.
 - Actions of type **context menu** appear on right-click, not as permanent toolbar buttons.
 - Workflow transition triggers (when available for the selected item) appear as a labeled
-  group on the toolbar and in the context menu.
+  **one-click button group** on the toolbar and in the context menu (not a dropdown).
 - If the catalog cannot be loaded, the **Server actions** region stays visible with a short
   error message (and an empty-action placeholder) rather than disappearing from the page.
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -773,9 +773,17 @@ public class ApiUtils {
     // Preserve cascading children for nested Explorer toolbar dropdowns (#2730).
     // Without this, structured menus (content-type submenus / RXMENUACTIONRELATION
     // trees) lose hierarchy and ActionToolbar dumps every leaf as a flat button.
+    // Stamp parentId on each child so the SPA can reconstruct if a serializer
+    // flattens the tree (#3379).
     List<PSActionMenu> childMenus = pa.getChildren();
     if (childMenus != null && !childMenus.isEmpty()) {
-      ret.setChildren(new ActionMenuList(convertPSActionMenuList(childMenus)));
+      ActionMenuList converted = new ActionMenuList(convertPSActionMenuList(childMenus));
+      for (ActionMenu child : converted) {
+        if (child != null && child.getParentId() == 0) {
+          child.setParentId(ret.getId());
+        }
+      }
+      ret.setChildren(converted);
     }
 
     ArrayList<ActionMenuProperty> props = new ArrayList<>();

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
@@ -62,6 +62,8 @@ public class ApiUtilsActionMenuConvertTest {
     assertEquals("open", converted.getChildren().get(0).getName());
     assertEquals("edit", converted.getChildren().get(1).getName());
     assertEquals("Open", converted.getChildren().get(0).getLabel());
+    assertEquals(1, converted.getChildren().get(0).getParentId());
+    assertEquals(1, converted.getChildren().get(1).getParentId());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
@@ -82,6 +82,17 @@ public class ActionMenu {
               + " handled by client is handled by server.")
   private String handler;
 
+  /**
+   * Parent action id from {@code RXMENUACTIONRELATION}. {@code 0} when this menu is a
+   * catalog root. Lets clients reconstruct a cascade if a serializer flattens children
+   * (#3379).
+   */
+  @Schema(
+      description =
+          "Parent action id when this menu is a child in RXMENUACTIONRELATION. 0 if this"
+              + " menu is a catalog root.")
+  private int parentId;
+
   /** Child actions when this action is a menu. */
   @Schema(
       description =
@@ -281,6 +292,24 @@ public class ActionMenu {
   }
 
   /**
+   * Returns the parent action id, or {@code 0} when this menu is a catalog root.
+   *
+   * @return parent action id
+   */
+  public int getParentId() {
+    return parentId;
+  }
+
+  /**
+   * Sets the parent action id from {@code RXMENUACTIONRELATION}.
+   *
+   * @param parentId parent action id, or {@code 0} for a root
+   */
+  public void setParentId(int parentId) {
+    this.parentId = parentId;
+  }
+
+  /**
    * Returns the child actions of this menu.
    *
    * @return the children, may be {@code null}
@@ -379,6 +408,7 @@ public class ActionMenu {
     var that = (ActionMenu) o;
     return id == that.id
         && sortRank == that.sortRank
+        && parentId == that.parentId
         && Objects.equals(guid, that.guid)
         && Objects.equals(name, that.name)
         && Objects.equals(label, that.label)
@@ -397,7 +427,17 @@ public class ActionMenu {
   public int hashCode() {
     int result =
         Objects.hash(
-            id, guid, name, label, description, url, sortRank, menuType, handler, children);
+            id,
+            guid,
+            name,
+            label,
+            description,
+            url,
+            sortRank,
+            menuType,
+            handler,
+            parentId,
+            children);
     result = 31 * result + Arrays.hashCode(parameters);
     result = 31 * result + Arrays.hashCode(visibilityContexts);
     result = 31 * result + Arrays.hashCode(uiContexts);
@@ -432,6 +472,8 @@ public class ActionMenu {
         + ", handler='"
         + handler
         + '\''
+        + ", parentId="
+        + parentId
         + ", children="
         + children
         + ", parameters="

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.actions;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -32,8 +33,15 @@ import java.util.Objects;
  * subclass as a bean ({@code {"empty":false}}) when it is nested as {@code
  * ActionMenu.children}. A bean-shaped children field would drop the cascade and the
  * Explorer toolbar would dump MENUITEMs as flat buttons (#3379 / #2730).
+ *
+ * <p>{@link JsonRootName} matches {@link com.percussion.rest.sites.SiteList} so
+ * {@code JacksonContextResolver} WRAP_ROOT_VALUE emits {@code {"ActionMenuList":
+ * [...]}} for top-level {@code /actions/find/types} and {@code
+ * /actions/find/templates/{id}}. Nested {@code children} stay a JSON array
+ * because WRAP_ROOT_VALUE only wraps the document root.
  */
 @XmlRootElement(name = "ActionMenuList")
+@JsonRootName("ActionMenuList")
 @ArraySchema(schema = @Schema(implementation = ActionMenu.class))
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 public class ActionMenuList extends ArrayList<ActionMenu> {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -24,9 +25,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
-/** List of ActionMenu objects. */
+/**
+ * List of ActionMenu objects.
+ *
+ * <p>{@link JsonFormat.Shape#ARRAY} keeps Jackson from treating this {@code ArrayList}
+ * subclass as a bean ({@code {"empty":false}}) when it is nested as {@code
+ * ActionMenu.children}. A bean-shaped children field would drop the cascade and the
+ * Explorer toolbar would dump MENUITEMs as flat buttons (#3379 / #2730).
+ */
 @XmlRootElement(name = "ActionMenuList")
 @ArraySchema(schema = @Schema(implementation = ActionMenu.class))
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 public class ActionMenuList extends ArrayList<ActionMenu> {
   /** Safe to serialize. */
   private static final long serialVersionUID = 1L;

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuEqualsTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuEqualsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Equality contract for {@link ActionMenu} after {@code parentId} joined
+ * {@code equals}/{@code hashCode} (#3379 review).
+ */
+@Tag("UnitTest")
+public class ActionMenuEqualsTest {
+
+  private static ActionMenu sample(int parentId) {
+    ActionMenu menu = new ActionMenu();
+    menu.setId(2);
+    menu.setName("open");
+    menu.setLabel("Open");
+    menu.setDescription("Open item");
+    menu.setUrl("/open");
+    menu.setMenuType("MENUITEM");
+    menu.setHandler("CLIENT");
+    menu.setSortRank(1);
+    menu.setParentId(parentId);
+    return menu;
+  }
+
+  @Test
+  public void parentIdParticipatesInEqualsAndHashCode() {
+    ActionMenu sameParentA = sample(8);
+    ActionMenu sameParentB = sample(8);
+    ActionMenu otherParent = sample(9);
+
+    assertEquals(sameParentA, sameParentB);
+    assertEquals(sameParentA.hashCode(), sameParentB.hashCode());
+    assertNotEquals(sameParentA, otherParent);
+    assertNotEquals(sameParentA.hashCode(), otherParent.hashCode());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuJacksonNestingTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuJacksonNestingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Wire shape for nested {@link ActionMenu} children under the production
+ * WRAP_ROOT_VALUE mapper (#3379). ActionMenuList must serialize as a JSON
+ * array, not an ArrayList bean ({@code {"empty":false}}).
+ */
+@Tag("UnitTest")
+public class ActionMenuJacksonNestingTest {
+
+  private static JsonMapper wrapRootMapper() {
+    return JsonMapper.builder()
+        .enable(SerializationFeature.WRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+        .build();
+  }
+
+  private static ActionMenu sampleTree() {
+    ActionMenu child = new ActionMenu();
+    child.setId(2);
+    child.setName("open");
+    child.setLabel("Open");
+    child.setMenuType("MENUITEM");
+    child.setSortRank(1);
+    child.setParentId(8);
+
+    ActionMenu parent = new ActionMenu();
+    parent.setId(8);
+    parent.setName("file");
+    parent.setLabel("File");
+    parent.setMenuType("MENU");
+    parent.setSortRank(0);
+    parent.setChildren(new ActionMenuList(List.of(child)));
+    return parent;
+  }
+
+  @Test
+  public void childrenSerializeAsJsonArrayNotEmptyBean() throws JacksonException {
+    String json = wrapRootMapper().writeValueAsString(sampleTree());
+    assertTrue(json.contains("\"ActionMenu\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"open\""), json);
+    assertTrue(json.contains("\"file\""), json);
+    assertFalse(
+        json.contains("\"empty\""),
+        "ActionMenuList must not serialize as an ArrayList bean: " + json);
+
+    JsonNode root = JsonMapper.builder().build().readTree(json);
+    JsonNode menu = root.has("ActionMenu") ? root.get("ActionMenu") : root;
+    JsonNode children = menu.get("children");
+    assertTrue(children != null && children.isArray(), "children should be a JSON array: " + json);
+    assertEquals(1, children.size());
+    assertEquals("open", children.get(0).get("name").asString());
+    assertEquals(8, children.get(0).get("parentId").asInt());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuListSerialDeserialTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Top-level {@link ActionMenuList} wire shape under the production CXF mapper
+ * (#3379 review). Mirrors {@code SiteListSerialDeserialTest}.
+ */
+@Tag("UnitTest")
+public class ActionMenuListSerialDeserialTest {
+
+  private static ActionMenu sampleMenu() {
+    ActionMenu menu = new ActionMenu();
+    menu.setId(2);
+    menu.setName("open");
+    menu.setLabel("Open");
+    menu.setMenuType("MENUITEM");
+    menu.setSortRank(1);
+    menu.setParentId(8);
+    return menu;
+  }
+
+  @Test
+  public void productionMapperWrapsTopLevelActionMenuList() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ActionMenuList.class);
+    ActionMenuList list = new ActionMenuList();
+    list.add(sampleMenu());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"ActionMenuList\""), "expected WRAP_ROOT_VALUE ActionMenuList: " + json);
+    assertTrue(json.contains("\"open\""), json);
+    assertFalse(
+        json.contains("\"empty\""),
+        "ActionMenuList must not serialize as an ArrayList bean: " + json);
+
+    JsonNode root = JsonMapper.builder().build().readTree(json);
+    assertTrue(root.has("ActionMenuList"), "root wrapper missing: " + json);
+    JsonNode items = root.get("ActionMenuList");
+    assertTrue(items.isArray(), "ActionMenuList value must be a JSON array: " + json);
+    assertEquals(1, items.size());
+    assertEquals("open", items.get(0).get("name").asString());
+    assertEquals(8, items.get(0).get("parentId").asInt());
+
+    ActionMenuList roundTrip = mapper.readValue(json, ActionMenuList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("open", roundTrip.get(0).getName());
+    assertEquals(8, roundTrip.get(0).getParentId());
+  }
+
+  @Test
+  public void productionMapperSerializesEmptyActionMenuListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ActionMenuList.class);
+    String json = mapper.writeValueAsString(new ActionMenuList());
+    assertTrue(json.contains("ActionMenuList") || json.contains("["), json);
+    ActionMenuList roundTrip = mapper.readValue(json, ActionMenuList.class);
+    assertTrue(roundTrip.isEmpty());
+  }
+
+  @Test
+  public void productionMapperKeepsNestedChildrenAsArray() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ActionMenu.class);
+    ActionMenu parent = new ActionMenu();
+    parent.setId(8);
+    parent.setName("file");
+    parent.setLabel("File");
+    parent.setMenuType("MENU");
+    parent.setChildren(new ActionMenuList(java.util.List.of(sampleMenu())));
+
+    String json = mapper.writeValueAsString(parent);
+    JsonNode root = JsonMapper.builder().build().readTree(json);
+    JsonNode menu = root.has("ActionMenu") ? root.get("ActionMenu") : root;
+    JsonNode children = menu.get("children");
+    assertTrue(children != null && children.isArray(), "nested children must stay a JSON array: " + json);
+    assertEquals("open", children.get(0).get("name").asString());
+  }
+}

--- a/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
+++ b/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
@@ -306,27 +306,7 @@ public class PSCmsObjectMgr
             return new ArrayList<>();
         }
 
-        List<int[]> pairs = new ArrayList<>();
-        Session session = getSession();
-        try {
-            List<Object[]> rows =
-                    session.createNativeQuery(ACTION_MENU_RELATION_SQL, Object[].class).getResultList();
-            if (rows != null) {
-                for (Object[] row : rows) {
-                    if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
-                        continue;
-                    }
-                    pairs.add(
-                            new int[] {
-                                ((Number) row[0]).intValue(), ((Number) row[1]).intValue()
-                            });
-                }
-            }
-        } catch (Exception e) {
-            logger.warn(
-                    "An error occurred while loading action menu relations; returning flat roots: {}",
-                    PSExceptionUtils.getMessageForLog(e));
-        }
+        List<int[]> pairs = loadActionMenuRelationPairs();
         return com.percussion.services.menus.PSActionMenuTreeAssembler.assemble(all, pairs);
     }
 
@@ -348,6 +328,75 @@ public class PSCmsObjectMgr
                     + ACTION_MENU_RELATION_CHILD_COL
                     + " from "
                     + ACTION_MENU_RELATION_TABLE;
+
+    /**
+     * Loads {@code RXMENUACTIONRELATION} edges as {@code [parentId, childId]} pairs.
+     *
+     * <p>Uses typed {@code addScalar} rather than {@code createNativeQuery(sql,
+     * Object[].class)} so H2/Hibernate 6 does not treat {@code Object[]} as an entity
+     * (that failure was swallowed and produced a flat toolbar dump — #3379).
+     */
+    @SuppressWarnings("unchecked")
+    List<int[]> loadActionMenuRelationPairs() {
+        List<int[]> pairs = new ArrayList<>();
+        Session session = getSession();
+        try {
+            List<Object[]> rows =
+                    session
+                            .createNativeQuery(ACTION_MENU_RELATION_SQL)
+                            .addScalar(
+                                    ACTION_MENU_RELATION_PARENT_COL,
+                                    org.hibernate.type.StandardBasicTypes.INTEGER)
+                            .addScalar(
+                                    ACTION_MENU_RELATION_CHILD_COL,
+                                    org.hibernate.type.StandardBasicTypes.INTEGER)
+                            .getResultList();
+            if (rows != null) {
+                for (Object row : rows) {
+                    int[] pair = toActionMenuRelationPair(row);
+                    if (pair != null) {
+                        pairs.add(pair);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn(
+                    "An error occurred while loading action menu relations; returning flat roots: {}",
+                    PSExceptionUtils.getMessageForLog(e));
+        }
+        return pairs;
+    }
+
+    /**
+     * Normalizes one native-query row to {@code [parentId, childId]}. Package-visible
+     * for unit tests. Accepts {@code Object[]} or a two-element {@link List}.
+     */
+    static int[] toActionMenuRelationPair(Object row) {
+        if (row == null) {
+            return null;
+        }
+        Object parent;
+        Object child;
+        if (row instanceof Object[] arr) {
+            if (arr.length < 2) {
+                return null;
+            }
+            parent = arr[0];
+            child = arr[1];
+        } else if (row instanceof List<?> list) {
+            if (list.size() < 2) {
+                return null;
+            }
+            parent = list.get(0);
+            child = list.get(1);
+        } else {
+            return null;
+        }
+        if (!(parent instanceof Number) || !(child instanceof Number)) {
+            return null;
+        }
+        return new int[] {((Number) parent).intValue(), ((Number) child).intValue()};
+    }
 
     /**
      * Builds the HQL for {@link #findLocales(String, String)}. Package-visible for unit tests.

--- a/system/src/test/java/com/percussion/services/legacy/impl/PSServicesLegacyTypedTest.java
+++ b/system/src/test/java/com/percussion/services/legacy/impl/PSServicesLegacyTypedTest.java
@@ -98,4 +98,21 @@ class PSServicesLegacyTypedTest {
         "select ACTIONID, CHILDACTIONID from RXMENUACTIONRELATION",
         PSCmsObjectMgr.ACTION_MENU_RELATION_SQL);
   }
+
+  @Test
+  @DisplayName("action menu relation row normalizes Object[] and List pairs (#3379)")
+  void actionMenuRelationPairFromNativeRow() {
+    int[] fromArray = PSCmsObjectMgr.toActionMenuRelationPair(new Object[] {8, 17});
+    assertEquals(8, fromArray[0]);
+    assertEquals(17, fromArray[1]);
+    int[] fromList =
+        PSCmsObjectMgr.toActionMenuRelationPair(java.util.Arrays.asList(104, 118));
+    assertEquals(104, fromList[0]);
+    assertEquals(118, fromList[1]);
+    org.junit.jupiter.api.Assertions.assertNull(PSCmsObjectMgr.toActionMenuRelationPair(null));
+    org.junit.jupiter.api.Assertions.assertNull(
+        PSCmsObjectMgr.toActionMenuRelationPair(new Object[] {1}));
+    org.junit.jupiter.api.Assertions.assertNull(
+        PSCmsObjectMgr.toActionMenuRelationPair(new Object[] {"8", 17}));
+  }
 }


### PR DESCRIPTION
## Summary

Explorer **Server actions** still dumped cascading MENU children as top-level toolbar buttons after #2730 / PR #2782 (human FAIL on QA #2783).

This residual keeps the cascade nested:

1. **Always load `GET /actions/find`** for the toolbar tree. `POST /actions/find/types` is merged under an existing New/Content MENU (or dropped). It no longer *replaces* the cascade with a flat content-type dump.
2. **Client reconstructs** a tree from `parentId` and drops roots that already appear as descendants (tree + flattened-sibling wire).
3. **Wire:** `ActionMenuList` serializes as a JSON array (`@JsonFormat(ARRAY)`), not an ArrayList bean (`{"empty":false}`). Children get `parentId` from `RXMENUACTIONRELATION`.
4. **Assembler query:** `RXMENUACTIONRELATION` is loaded with typed `addScalar` so Hibernate 6/H2 does not treat `Object[]` as an entity and silently return a flat list.
5. Workflow stays a labeled one-click group (#2732).

Parent implement: #2730. Failed QA: #2783. Residual: #3379.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3379
Partial #2783
Parent #2730

## Test plan

1. `perc-devctl qa-up` (H2). Log in as Admin.
2. Open Explorer (`spa.jsp?entry=explorer`).
3. Confirm **Server actions** MENU parents are one `aria-haspopup=menu` control with `▾`.
4. Closed menu: children are **not** extra top-level toolbar buttons.
5. Open a parent: children are `role=menuitem` inside `action-toolbar-menu-*`.
6. Select a content item: cascade remains (type menus may nest under New/Content). Workflow group still one-click buttons.
7. `npm run test:surface -- --path tests/explorer-action-toolbar-menus.spec.js` from `modules/perc-qa-automation/frontend`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (Server actions dropdown vs flat dump; Workflow one-click group)
- [x] **Unit / module tests** — mapper nest/collapse, catalog merge, Jackson children array, relation pair parse, Playwright helper
- [x] **WebUI + Playwright** — `explorer-action-toolbar-menus.spec.js` **does not soft-skip** when live `find()` has MENU parents; golden smoke passed
- [x] **Build gates** — standalone `mvnw clean install` on each changed module (no skipTests)
- [x] **Cross-platform** — no new filesystem path construction

### C3 evidence

- **modules_built:** rest, system, projects/sitemanage, WebUI
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 368, Failures: 0
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2099, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1135, Failures: 0
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS, Vitest Tests 2338 passed, Java surefire Tests run: 59, Failures: 0
- **downstream_checked:** C2 additive only (`parentId` + `JsonFormat` on `ActionMenuList`; `getChildren()` still `ActionMenuList`). Grep: no `extends ActionMenu` / anonymous `ActionMenu` subclasses. Built reverse-dep `projects/sitemanage` against new rest DTO.

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Deploy: copied `WebUI/target/generated-webui/cm/modern/assets` + `rest` / `sitemanage` / `perc-system` SNAPSHOT jars into the cell; Jetty restart; login 200
- Playwright:
  - `npm run test:surface -- --path tests/explorer-action-toolbar-menus.spec.js` → **2 passed**
  - `npm run test:golden` → **2 passed**
- console-clean=yes (surface + golden green after full asset copy)
- server.log-clean=yes (no action/menu/explorer ERROR/FATAL in `/opt/Percussion/jetty/base/logs/server.log`)
- `python docker/scripts/perc-devctl.py qa-down`

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
