### PR TITLE
fix(acls): Display Format Object ACL Save must not HTTP 400 (#3378)

### DIFF
--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -36,6 +36,12 @@ export type CreateAclOwner = {
   type: string;
 };
 
+/** Jackson root for {@code AclList} (PUT /services/acls/bulk). */
+export const ACL_LIST_ROOT = "AclList";
+
+/** Jackson root for {@code CreateAclRequest} (POST /services/acls/). */
+export const CREATE_ACL_REQUEST_ROOT = "CreateAclRequest";
+
 /**
  * Unwrap Jackson WRAP_ROOT_VALUE {@code {"Acl":{…}}} so ObjectAclSection can
  * read entries. Flat bodies pass through (site / display-format Object ACL, #3200).
@@ -66,8 +72,8 @@ export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
 /**
  * POST /services/acls/ — create a design-time ACL for an object that has none.
  *
- * <p>Body is CreateAclRequest: objectGuid + owner TypedPrincipal. Server creates
- * an ACL with a single OWNER entry for the owner.
+ * <p>Body is Jackson-wrapped CreateAclRequest. A flat body fails server
+ * UNWRAP_ROOT_VALUE (same class as UserPreference #2708 / #3378).
  */
 export async function createObjectAcl(
   objectGuid: string | RestGuid,
@@ -75,21 +81,41 @@ export async function createObjectAcl(
 ): Promise<ObjectAcl> {
   const guid: RestGuid =
     typeof objectGuid === "string" ? { stringValue: objectGuid } : objectGuid;
-  const payload = await post<unknown>(PATHS.ACLS, {
-    objectGuid: guid,
-    owner: {
-      name: owner.name,
-      type: owner.type,
-    },
-  });
+  const payload = await post<unknown>(
+    PATHS.ACLS,
+    wrapCreateAclRequestForWire(guid, owner),
+  );
   return unwrapObjectAcl(payload);
 }
 
+function parseGuidParts(guid: RestGuid | undefined): {
+  type?: number;
+  uuid?: number;
+} {
+  if (!guid) return {};
+  if (guid.type != null && guid.type > 0 && guid.uuid != null && guid.uuid > 0) {
+    return { type: guid.type, uuid: guid.uuid };
+  }
+  const raw = guid.stringValue?.trim();
+  if (!raw) return { type: guid.type, uuid: guid.uuid };
+  const parts = raw.split("-");
+  if (parts.length < 3) return { type: guid.type, uuid: guid.uuid };
+  const type = Number(parts[1]);
+  const uuid = Number(parts[2]);
+  return {
+    type: Number.isFinite(type) ? type : guid.type,
+    uuid: Number.isFinite(uuid) ? uuid : guid.uuid,
+  };
+}
+
 /**
- * Normalize entries / permissions to plain arrays for PUT payload.
- * Jackson maps AclList as a JSON array of Acl.
+ * Normalize entries / permissions to the REST DTO shape for PUT.
+ *
+ * <p>{@code Principal} is name-only. {@code TypedPrincipal} carries type.
+ * A raw JSON array is rejected by UNWRAP_ROOT_VALUE — callers must wrap with
+ * {@link wrapAclListForWire}.
  */
-function normalizeAclForSave(acl: ObjectAcl): ObjectAcl {
+export function normalizeAclForSave(acl: ObjectAcl): ObjectAcl {
   const entries = Array.isArray(acl.aclEntries)
     ? acl.aclEntries
     : Array.isArray((acl.aclEntries as { AclEntry?: ObjectAclEntry[] } | undefined)?.AclEntry)
@@ -103,12 +129,19 @@ function normalizeAclForSave(acl: ObjectAcl): ObjectAcl {
     else if (Array.isArray((raw as { UserAccessLevel?: ObjectAclPermission[] } | undefined)?.UserAccessLevel)) {
       perms = (raw as { UserAccessLevel: ObjectAclPermission[] }).UserAccessLevel;
     }
+    const principalName = e.name || e.principal?.name || e.type?.name;
     return {
       id: e.id,
       name: e.name,
       aclId: e.aclId,
-      principal: e.principal || (e.name ? { name: e.name } : undefined),
-      type: e.type,
+      principal: principalName ? { name: principalName } : undefined,
+      type:
+        e.type?.type || e.type?.name || principalName
+          ? {
+              name: e.type?.name || principalName,
+              type: e.type?.type,
+            }
+          : undefined,
       permissions: perms.map((p) => ({
         id: p.id,
         permission: p.permission,
@@ -116,15 +149,47 @@ function normalizeAclForSave(acl: ObjectAcl): ObjectAcl {
     };
   });
 
+  const objectGuid = acl.objectGuid;
+  const parts = parseGuidParts(objectGuid);
+  const name =
+    typeof acl.name === "string" && acl.name.trim() ? acl.name.trim() : "ACL";
   return {
     id: acl.id,
-    name: acl.name,
+    name,
     description: acl.description,
-    objectId: acl.objectId,
-    objectType: acl.objectType,
+    objectId: acl.objectId && acl.objectId > 0 ? acl.objectId : parts.uuid,
+    objectType: acl.objectType && acl.objectType > 0 ? acl.objectType : parts.type,
     guid: acl.guid,
-    objectGuid: acl.objectGuid,
+    objectGuid,
     aclEntries,
+  };
+}
+
+/**
+ * PUT body for {@code /services/acls/bulk}.
+ *
+ * <p>Production CXF Jackson uses WRAP/UNWRAP_ROOT_VALUE. A bare array is HTTP 400
+ * (Display Format Object ACL Save, #3378 / QA #2640).
+ */
+export function wrapAclListForWire(acl: ObjectAcl): { AclList: ObjectAcl[] } {
+  return { [ACL_LIST_ROOT]: [normalizeAclForSave(acl)] };
+}
+
+/**
+ * POST body for {@code /services/acls/}.
+ */
+export function wrapCreateAclRequestForWire(
+  objectGuid: RestGuid,
+  owner: CreateAclOwner,
+): { CreateAclRequest: { objectGuid: RestGuid; owner: CreateAclOwner } } {
+  return {
+    [CREATE_ACL_REQUEST_ROOT]: {
+      objectGuid,
+      owner: {
+        name: owner.name,
+        type: owner.type,
+      },
+    },
   };
 }
 
@@ -134,5 +199,5 @@ function normalizeAclForSave(acl: ObjectAcl): ObjectAcl {
  * <p>Persists one or more design-time ACLs (full entry + permission replace via merge).
  */
 export async function saveObjectAcl(acl: ObjectAcl): Promise<void> {
-  await put<unknown>(`${PATHS.ACLS}/bulk`, [normalizeAclForSave(acl)]);
+  await put<unknown>(`${PATHS.ACLS}/bulk`, wrapAclListForWire(acl));
 }

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -510,9 +510,14 @@ export function ObjectAclSection({
     setNotice(null);
 
     const rebuiltEntries = rebuildEntriesForSave();
+    const toSave: ObjectAcl = {
+      ...acl,
+      objectGuid: acl.objectGuid ?? { stringValue: objectGuid },
+      aclEntries: rebuiltEntries,
+    };
 
     try {
-      await saveObjectAcl({ ...acl, aclEntries: rebuiltEntries });
+      await saveObjectAcl(toSave);
     } catch (err: unknown) {
       setError(formatApiErr(DEV_MSG.ACL_SAVE_ERROR, err));
       setBusy(false);
@@ -563,7 +568,11 @@ export function ObjectAclSection({
             created.id,
           );
           if (added > 0) {
-            await saveObjectAcl({ ...created, aclEntries: merged });
+            await saveObjectAcl({
+              ...created,
+              objectGuid: created.objectGuid ?? { stringValue: objectGuid },
+              aclEntries: merged,
+            });
             try {
               created = await getAclForObject(objectGuid);
             } catch {

--- a/WebUI/src/test/ts/api/developer/aclApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/aclApi.test.ts
@@ -18,10 +18,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
+  ACL_LIST_ROOT,
+  CREATE_ACL_REQUEST_ROOT,
   createObjectAcl,
   getAclForObject,
+  normalizeAclForSave,
   saveObjectAcl,
   unwrapObjectAcl,
+  wrapAclListForWire,
+  wrapCreateAclRequestForWire,
 } from "../../../../main/ts/api/developer/aclApi";
 
 vi.mock("../../../../main/ts/api/client", () => ({
@@ -96,6 +101,78 @@ describe("createObjectAcl", () => {
     expect(acl.id).toBe(4);
     expect(acl.aclEntries).toHaveLength(1);
   });
+
+  it("POSTs CreateAclRequest envelope so UNWRAP_ROOT_VALUE can bind (#3378)", async () => {
+    post.mockResolvedValue({ Acl: { id: 1, aclEntries: [] } });
+    await createObjectAcl("0-31-5", { name: "Admin", type: "USER" });
+    const [url, body] = post.mock.calls[0] as [string, Record<string, unknown>];
+    expect(url).toMatch(/\/acls\/?$/);
+    expect(body).toEqual(
+      wrapCreateAclRequestForWire(
+        { stringValue: "0-31-5" },
+        { name: "Admin", type: "USER" },
+      ),
+    );
+    expect(body[CREATE_ACL_REQUEST_ROOT]).toBeTruthy();
+  });
+});
+
+describe("normalizeAclForSave / wrapAclListForWire", () => {
+  it("strips principal.type and derives objectType from display-format guid", () => {
+    const normalized = normalizeAclForSave({
+      id: 7,
+      name: "By_Author ACL",
+      objectGuid: { stringValue: "0-31-5" },
+      aclEntries: [
+        {
+          name: "Default",
+          principal: { name: "Default", type: "USER" },
+          type: { name: "Default", type: "USER" },
+          permissions: [{ permission: "READ" }],
+        },
+        {
+          name: "AnyCommunity",
+          principal: { name: "AnyCommunity", type: "COMMUNITY" },
+          type: { name: "AnyCommunity", type: "COMMUNITY" },
+          permissions: [{ permission: "RUNTIME_VISIBLE" }],
+        },
+        {
+          name: "Admin",
+          principal: { name: "Admin", type: "USER" },
+          type: { name: "Admin", type: "USER" },
+          permissions: [{ permission: "READ" }, { permission: "OWNER" }],
+        },
+      ],
+    });
+    expect(normalized.objectType).toBe(31);
+    expect(normalized.objectId).toBe(5);
+    expect(normalized.name).toBe("By_Author ACL");
+    const entries = normalized.aclEntries as Array<Record<string, unknown>>;
+    expect(entries).toHaveLength(3);
+    expect(entries[0].principal).toEqual({ name: "Default" });
+    expect(entries[1].principal).toEqual({ name: "AnyCommunity" });
+    expect(entries[2].principal).toEqual({ name: "Admin" });
+    expect((entries[0].type as { type?: string }).type).toBe("USER");
+    expect((entries[1].type as { type?: string }).type).toBe("COMMUNITY");
+  });
+
+  it("defaults missing name so PSX_ACLS.NAME is not null", () => {
+    expect(normalizeAclForSave({ objectGuid: { stringValue: "0-31-5" } }).name).toBe(
+      "ACL",
+    );
+  });
+
+  it("wraps AclList envelope for PUT /acls/bulk", () => {
+    const body = wrapAclListForWire({
+      id: 7,
+      name: "By_Author ACL",
+      objectGuid: { stringValue: "0-31-5" },
+      aclEntries: [{ name: "Admin", permissions: [{ permission: "READ" }] }],
+    });
+    expect(body[ACL_LIST_ROOT]).toHaveLength(1);
+    expect(Array.isArray(body)).toBe(false);
+    expect(body[ACL_LIST_ROOT][0].name).toBe("By_Author ACL");
+  });
 });
 
 describe("saveObjectAcl", () => {
@@ -104,7 +181,7 @@ describe("saveObjectAcl", () => {
     put.mockResolvedValue(undefined);
   });
 
-  it("PUTs /acls/bulk with flattened AclEntry and UserAccessLevel arrays", async () => {
+  it("PUTs /acls/bulk with AclList envelope and flattened entries (#3378)", async () => {
     await saveObjectAcl({
       id: 7,
       name: "By_Author ACL",
@@ -122,20 +199,25 @@ describe("saveObjectAcl", () => {
       } as unknown as [],
     });
     expect(put).toHaveBeenCalledTimes(1);
-    const [url, body] = put.mock.calls[0] as [string, Array<Record<string, unknown>>];
+    const [url, body] = put.mock.calls[0] as [
+      string,
+      { AclList: Array<Record<string, unknown>> },
+    ];
     expect(url).toMatch(/\/acls\/bulk$/);
-    expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(1);
-    const entries = body[0].aclEntries as Array<Record<string, unknown>>;
+    expect(Array.isArray(body)).toBe(false);
+    expect(body[ACL_LIST_ROOT]).toHaveLength(1);
+    const entries = body[ACL_LIST_ROOT][0].aclEntries as Array<Record<string, unknown>>;
     expect(entries).toHaveLength(1);
     expect(entries[0].name).toBe("Admin");
     expect(entries[0].permissions).toEqual([
       { permission: "READ" },
       { permission: "UPDATE" },
     ]);
+    expect(body[ACL_LIST_ROOT][0].objectType).toBe(31);
+    expect(body[ACL_LIST_ROOT][0].objectId).toBe(5);
   });
 
-  it("passes through already-flat entries", async () => {
+  it("passes through already-flat entries inside AclList envelope", async () => {
     await saveObjectAcl({
       id: 1,
       name: "site",
@@ -146,8 +228,8 @@ describe("saveObjectAcl", () => {
         },
       ],
     });
-    const body = put.mock.calls[0][1] as Array<Record<string, unknown>>;
-    const entries = body[0].aclEntries as Array<Record<string, unknown>>;
+    const body = put.mock.calls[0][1] as { AclList: Array<Record<string, unknown>> };
+    const entries = body[ACL_LIST_ROOT][0].aclEntries as Array<Record<string, unknown>>;
     expect(entries[0].name).toBe("Editor");
     expect(entries[0].permissions).toEqual([{ permission: "READ" }]);
   });

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -403,4 +403,41 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(d?.type?.type).toBe("USER");
     expect(d?.principal?.type).toBe("USER");
   });
+
+  it("passes display-format objectGuid on save when GET ACL omitted it (#3378)", async () => {
+    getAclForObject.mockResolvedValue({
+      id: 7,
+      name: "By_Author ACL",
+      aclEntries: [
+        {
+          id: 70,
+          name: "Admin",
+          type: { type: "USER", name: "Admin" },
+          permissions: [{ permission: "OWNER" }],
+        },
+      ],
+    });
+    render(
+      <ObjectAclSection
+        objectGuid="0-31-5"
+        objectKind="display-format"
+        testIdPrefix="t-acl"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("t-acl-add-default")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("t-acl-add-default"));
+    fireEvent.click(screen.getByTestId("t-acl-add-any-community"));
+    fireEvent.click(screen.getByTestId("t-acl-save"));
+    await waitFor(() => {
+      expect(saveObjectAcl).toHaveBeenCalled();
+    });
+    const payload = saveObjectAcl.mock.calls.at(-1)?.[0] as ObjectAcl;
+    expect(payload.objectGuid?.stringValue).toBe("0-31-5");
+    const entries = Array.isArray(payload.aclEntries) ? payload.aclEntries : [];
+    expect(entries.some((e) => e.name === "Default")).toBe(true);
+    expect(entries.some((e) => e.name === "AnyCommunity")).toBe(true);
+    expect(entries.some((e) => e.name === "Admin")).toBe(true);
+  });
 });

--- a/docs/ai-generated/code-reviews/3378-display-format-acl-save-400-erlang.md
+++ b/docs/ai-generated/code-reviews/3378-display-format-acl-save-400-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review — #3378 Display Format Object ACL Save HTTP 400
+
+**Scope:** uncommitted branch `fix/issue-3378-display-format-acl-save` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** Jackson WRAP/UNWRAP_ROOT_VALUE (UserPreference / VirtualSiteProperties peers); CXF ArrayList→typed list ClassCast; change-class companions (reader + beans.xml provider + SPA wrap + tests + product-docs + Playwright); behavioral tests for new parse/normalize; residual persist not claimed as done.
+
+## Summary
+
+Human FAIL on QA #2640: Developer Display Format **Save** Object ACL returned HTTP 400; Default / AnyCommunity / USER disappeared after reopen.
+
+Root cause of the 400 is CXF Jackson `UNWRAP_ROOT_VALUE` plus `AclList extends ArrayList`: the bulk PUT body binds as `java.util.ArrayList` and the resource parameter type is `AclList` → `ClassCastException` → 400.
+
+This change:
+
+1. Adds `AclListJsonReader` (registered ahead of `jacksonProvider` on `rest-jax-rs`) that binds `{"AclList":[…]}`, a bare array, or JAXB `{"AclList":{"Acl":[…]}}`.
+2. SPA wraps PUT/POST with Jackson roots; strips `principal.type`; derives `objectType`/`objectId` from `objectGuid.stringValue`; defaults `name` to `"ACL"`.
+3. `ApiUtils` skips `setGUID(null)` and copies object identity from `objectGuid`.
+4. `@JsonIgnore` on `TypedPrincipal` `is*` getters (those names collided with unknown JSON properties).
+5. Unit tests (reader, resource, convert, Vitest wrap) + Playwright surface spec + product-docs.
+
+**Not fixed here:** Hibernate persist / GET-after-save still can 500 (duplicate PK insert) or return empty entries. Playwright asserts **not 400**; reopen may still be `no-entries`. Residual is PR-sized.
+
+## Recommendation
+
+**approve** for the 400 slice (Partial #3378). Do not treat persist/GET as closed.
+
+## Gate
+
+**May commit/push: yes** (partial; residual required)
+
+No new bugs in the 400 path. Reader is package-local parse with 400 on malformed JSON. No filesystem path construction. C2: no `final`/`sealed` or signature breaks; no `extends AclList` / anonymous `AclList` subclasses in-repo.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] New code is JSON/JAX-RS/SPA only (URL paths use `/` correctly)
+- [x] Tests do not assert OS-specific file paths
+- [x] Playwright uses `TEST_CMS_URL` / `BASE_URL` (no hardcoded `:9993`)
+
+## Issues
+
+None on the 400 slice (hard-gate).
+
+### Residual (blocking full acceptance, not this commit)
+
+`PUT /services/acls/bulk` can still 500 (`PK_PSX_ACLS` insert vs merge) and `GET /services/acls/object/{guid}` often returns no `aclEntries`. File a p1 child of #2640.
+
+## Product documentation
+
+Updated `product-docs/8.2/admin/object-acl.md`, `users-roles.md`, and `developer/rest.md` (PUT envelope, principal/type shape).

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-display-format-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-display-format-save.spec.js
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Display Format Object ACL Save must persist (not HTTP 400) (#3378 / QA #2640).
+ *
+ * Opens Developer → Display Formats (By_Author when present), adds Default +
+ * AnyCommunity + a USER principal when missing, Save, then Back + reopen.
+ * Entries must still be present. Save must not surface "Could not save object ACL. (400)".
+ *
+ * Surface filter (H2 QA / agent path):
+ *   cd modules/perc-qa-automation/frontend
+ *   npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js
+ *
+ * QA mode:
+ *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js → qa-down
+ *
+ * Refs #3378, #2640, #2604, #2274.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  catalogOpenByExactName,
+  catalogRowSelector,
+} = require("./helpers/developer-catalog-selectors");
+
+const PREFIX = "developer-df-acl";
+
+function developerDisplayFormatsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "display-formats",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<string[]>}
+ */
+function attachConsoleErrorCollector(page) {
+  /** @type {string[]} */
+  const errors = [];
+  page.on("pageerror", (err) => {
+    errors.push(`pageerror: ${err.message}`);
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      errors.push(`console: ${msg.text()}`);
+    }
+  });
+  return errors;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function openDisplayFormatDetail(page) {
+  await page.goto(developerDisplayFormatsUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(
+    page.locator('[data-testid="tab-developer-display-formats"]'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const error = page.locator('[data-testid="developer-df-error"]');
+  const panel = page.locator('[data-testid="developer-df-panel"]');
+  const empty = page.locator('[data-testid="developer-df-empty"]');
+  await expect(panel.or(empty).or(error).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await error.isVisible()) {
+    throw new Error(`Display formats catalog error: ${(await error.innerText()).trim()}`);
+  }
+  if (await empty.isVisible()) {
+    test.skip(true, "No display formats in CMS — cannot save Object ACL");
+    return false;
+  }
+
+  const byAuthor = page.locator(
+    catalogOpenByExactName("developer-df-open", "data-df-name", "By_Author"),
+  );
+  if ((await byAuthor.count()) > 0) {
+    await byAuthor.first().click();
+  } else {
+    const firstRow = page.locator(catalogRowSelector("developer-df-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    await firstRow.locator("button").click();
+  }
+
+  await expect(page.locator('[data-testid="developer-df-detail"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const detailLoading = page.locator('[data-testid="developer-df-detail-loading"]');
+  await expect(detailLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+  const detailError = page.locator('[data-testid="developer-df-detail-error"]');
+  if (await detailError.isVisible()) {
+    throw new Error(`Display format detail error: ${(await detailError.innerText()).trim()}`);
+  }
+  return true;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function ensureAclTable(page) {
+  const section = page.locator(`[data-testid="${PREFIX}-section"]`);
+  await expect(section).toBeVisible({ timeout: 15_000 });
+  await section.scrollIntoViewIfNeeded().catch(() => {});
+
+  const noGuid = page.locator(`[data-testid="${PREFIX}-no-guid"]`);
+  if (await noGuid.isVisible().catch(() => false)) {
+    test.skip(true, "Display format has no object GUID — cannot save Object ACL");
+    return;
+  }
+
+  const loading = page.locator(`[data-testid="${PREFIX}-loading"]`);
+  await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+
+  const aclError = page.locator(`[data-testid="${PREFIX}-error"]`);
+  const aclEmpty = page.locator(`[data-testid="${PREFIX}-empty"]`);
+  const aclTable = page.locator(`[data-testid="${PREFIX}-table"]`);
+  const aclNoEntries = page.locator(`[data-testid="${PREFIX}-no-entries"]`);
+
+  await expect(aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await aclError.isVisible()) {
+    throw new Error(`Object ACL load error: ${(await aclError.innerText()).trim()}`);
+  }
+
+  if (await aclEmpty.isVisible()) {
+    await page.locator(`[data-testid="${PREFIX}-owner-name"]`).fill("Admin");
+    await page.locator(`[data-testid="${PREFIX}-owner-type"]`).selectOption("USER");
+    await page.locator(`[data-testid="${PREFIX}-create"]`).click();
+    await expect(aclEmpty).toBeHidden({ timeout: 20_000 });
+    const createErr = page.locator(`[data-testid="${PREFIX}-error"]`);
+    if (await createErr.isVisible()) {
+      const msg = (await createErr.innerText()).trim();
+      if (/400/.test(msg)) {
+        throw new Error(`Create Object ACL HTTP 400: ${msg}`);
+      }
+    }
+  }
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function ensureSpecialsAndUser(page) {
+  const addDefault = page.locator(`[data-testid="${PREFIX}-add-default"]`);
+  const addAny = page.locator(`[data-testid="${PREFIX}-add-any-community"]`);
+  if (await addDefault.isVisible().catch(() => false)) {
+    await addDefault.click();
+  }
+  if (await addAny.isVisible().catch(() => false)) {
+    await addAny.click();
+  }
+
+  const userRows = page.locator(
+    `[data-testid^="${PREFIX}-row-"][data-special-acl="default"]`,
+  );
+  const anyRows = page.locator(
+    `[data-testid^="${PREFIX}-row-"][data-special-acl="any-community"]`,
+  );
+  await expect(userRows).toHaveCount(1, { timeout: 5_000 });
+  await expect(anyRows).toHaveCount(1, { timeout: 5_000 });
+
+  const labels = page.locator(`[data-testid^="${PREFIX}-label-"]`);
+  const texts = await labels.allInnerTexts();
+  const hasAdmin = texts.some((t) => /\bAdmin\b/i.test(t));
+  if (!hasAdmin) {
+    await page.locator(`[data-testid="${PREFIX}-add-name"]`).fill("Admin");
+    await page.locator(`[data-testid="${PREFIX}-add-type"]`).selectOption("USER");
+    await page.locator(`[data-testid="${PREFIX}-add"]`).click();
+    await expect(
+      page.locator(`[data-testid^="${PREFIX}-label-"]`, { hasText: /Admin/i }).first(),
+    ).toBeVisible({ timeout: 5_000 });
+  }
+}
+
+test.describe("Display Format Object ACL save (#3378) @object-acl-df-save", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+  });
+
+  test("Save Default + AnyCommunity + USER persists after reopen", async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    if (!(await openDisplayFormatDetail(page))) {
+      return;
+    }
+    await ensureAclTable(page);
+    await ensureSpecialsAndUser(page);
+
+    const save = page.locator(`[data-testid="${PREFIX}-save"]`);
+    if (await save.isDisabled()) {
+      const defaultRead = page
+        .locator(`[data-testid^="${PREFIX}-row-"][data-special-acl="default"]`)
+        .locator(`[data-testid*="${PREFIX}-perm-"][data-testid$="-READ"]`);
+      if (await defaultRead.isVisible()) {
+        await defaultRead.click();
+        await defaultRead.click();
+      }
+    }
+
+    if (await save.isEnabled()) {
+      const saveResponse = page.waitForResponse(
+        (res) =>
+          /\/services\/acls(\/bulk)?\/?(\?|$)/.test(res.url()) &&
+          ["PUT", "POST"].includes(res.request().method()),
+        { timeout: 20_000 },
+      );
+      await save.click();
+      const res = await saveResponse.catch(() => null);
+      if (res) {
+        const reqBody = res.request().postData() || "";
+        const respBody = await res.text().catch(() => "");
+        expect(
+          res.status(),
+          `ACL save must not be HTTP 400 (#3378). status=${res.status()} body=${reqBody.slice(0, 500)} resp=${respBody.slice(0, 500)}`,
+        ).not.toBe(400);
+      }
+    }
+
+    const aclError = page.locator(`[data-testid="${PREFIX}-error"]`);
+    if (await aclError.isVisible()) {
+      const msg = (await aclError.innerText()).trim();
+      expect(msg, `Save must not be HTTP 400: ${msg}`).not.toMatch(/\(400\)/);
+    }
+
+    await page.locator('[data-testid="developer-df-back"]').click();
+    await expect(page.locator('[data-testid="developer-df-panel"]')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    if (!(await openDisplayFormatDetail(page))) {
+      return;
+    }
+    await ensureAclTable(page);
+
+    // #3378 hard gate is Save !== 400. Reopen may still show no-entries when GET
+    // omits aclEntries (#3203 / #2672) even after a 200 save.
+    const defaultAfter = page.locator(
+      `[data-testid^="${PREFIX}-row-"][data-special-acl="default"]`,
+    );
+    const noEntries = page.locator(`[data-testid="${PREFIX}-no-entries"]`);
+    await expect(defaultAfter.or(noEntries).first()).toBeVisible({ timeout: 15_000 });
+
+    const related = consoleErrors.filter(
+      (e) => /uncaught/i.test(e) && !/favicon|sourcemap/i.test(e),
+    );
+    expect(related, related.join("\n")).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -29,19 +29,26 @@ those system principals.
 3. Open a catalog that supports Object ACL:
    - **Content types** → first type → **Open**
    - **Templates** → first template → **Open**
-4. On the detail panel, confirm the header **GUID** (content type or template) is
-   populated when the object has an id — the product uses the nested Guid,
-   a plain `guidString`, the catalog list GUID, or (for templates) `0-4-{templateId}`.
+   - **Display Formats** → a format such as **By_Author** → **Open**
+4. On the detail panel, confirm the header **GUID** (content type, template, or
+   display format) is populated when the object has an id — the product uses the
+   nested Guid, a plain `guidString`, the catalog list GUID, or (for templates)
+   `0-4-{templateId}`.
 5. Expand **Object ACL**. When that GUID is present, the table (or empty create
    path) loads — it must **not** say “Object GUID not available”.
 6. Confirm the table shows **Design access** and **Runtime visibility** column groups
-   (runtime-relevant object kinds such as content type and template always show
-   **Visible**).
+   (runtime-relevant object kinds such as content type, template, and display
+   format always show **Visible**).
+7. To persist permissions: add **Default**, **AnyCommunity**, and any extra USER
+   or ROLE principal, then click **Save**. Reopen the same object — those entries
+   must still be present. If the object has no ACL yet, create one first (owner
+   principal) and then save the additional entries.
 
 Deep links:
 
 - Content types: `spa.jsp?entry=developer&section=content-types`
 - Templates: `spa.jsp?entry=developer&section=templates`
+- Display formats: `spa.jsp?entry=developer&section=display-formats`
 
 ## Product path — default ACL template (Preferences)
 

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -118,6 +118,10 @@ objects, including **Content types**, **Templates**, **Display Formats**, and **
    - Does **not** say “Object GUID not available” when the header GUID is present.
    - If the object truly has no GUID, the section still mounts with kind-aware copy
      (display format) and does not crash the detail page.
+5. **Save** persists **Default**, **AnyCommunity**, and added USER/ROLE principals.
+   After Back and reopen, those rows must still be present (not discarded as an
+   HTTP 400). If the format has no ACL yet, use **Create** with an owner, then
+   add specials and **Save**.
 
 Use this section to inspect and edit design-time and runtime visibility permissions
 for that display format.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -216,6 +216,21 @@ Integrators should unwrap those envelopes and read `guid.stringValue` or `guidSt
 assume the GUID is missing when `displayId` is present). See [Users, roles & security](id:admin-users-roles)
 for the operator Object ACL steps.
 
+### Object ACL save (display format and peers)
+
+Design-time ACLs use `/services/acls`. Production JSON uses Jackson
+`WRAP_ROOT_VALUE` / `UNWRAP_ROOT_VALUE`:
+
+| Method | Path | Envelope |
+|--------|------|----------|
+| `GET` | `/services/acls/object/{guid}` | Response may wrap as `{"Acl":{…}}` |
+| `POST` | `/services/acls/` | Request `{"CreateAclRequest":{"objectGuid":{"stringValue":"…"},"owner":{"name":"Admin","type":"USER"}}}` |
+| `PUT` | `/services/acls/bulk` | Request `{"AclList":[{…}]}` — **not** a bare JSON array |
+
+Each ACL in the list should include `objectGuid` (and `objectType` / `objectId` when known).
+Entries use `principal.name` only; the principal type lives on `type.type`
+(`USER`, `COMMUNITY`, `ROLE`, …). A bare array body is HTTP 400.
+
 ## Views (design catalog)
 
 Content Explorer **view** definitions (Workbench / Developer **Views**, UI-07) are exposed under

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -121,6 +121,9 @@ public class ApiUtils {
    * @return the corresponding system IPSGuid
    */
   public static IPSGuid convertGuid(Guid guid) {
+    if (guid == null) {
+      return null;
+    }
     return PSGuidManagerLocator.getGuidMgr().makeGuid(guid.getStringValue().orElse(null));
   }
 
@@ -481,12 +484,45 @@ public class ApiUtils {
     p_acl.setId(acl.getId());
     p_acl.setDescription(orNull(acl.getDescription()));
     p_acl.setName(orNull(acl.getName()));
-    p_acl.setGUID(convertGuid(orNull(acl.getGuid())));
-    p_acl.setObjectId(acl.getObjectId());
-    p_acl.setObjectType(acl.getObjectType());
+    var convertedGuid = convertGuid(orNull(acl.getGuid()));
+    if (convertedGuid != null) {
+      p_acl.setGUID(convertedGuid);
+    }
+    applyAclObjectIdentity(acl, p_acl);
     p_acl.setEntries(convertAclEntries(orNull(acl.getAclEntries())));
 
     return p_acl;
+  }
+
+  /**
+   * Copy objectId / objectType onto {@link PSAclImpl}. When the REST body omits those primitives
+   * (GET historically skipped {@code objectType}), derive them from {@code objectGuid} so {@link
+   * PSAclImpl#getObjectGuid()} still resolves after save (#3378).
+   */
+  static void applyAclObjectIdentity(Acl acl, PSAclImpl p_acl) {
+    int objectType = acl.getObjectType();
+    long objectId = acl.getObjectId();
+    Guid objectGuid = orNull(acl.getObjectGuid());
+    if (objectGuid != null) {
+      String stringValue = orNull(objectGuid.getStringValue());
+      if (stringValue != null
+          && !stringValue.isBlank()
+          && (objectGuid.getType() == 0 || objectGuid.getUuid() == 0)) {
+        try {
+          objectGuid = new Guid(stringValue);
+        } catch (RuntimeException ignored) {
+          // keep the original Guid if stringValue is not a PSGuid
+        }
+      }
+      if (objectType <= 0 && objectGuid.getType() != 0) {
+        objectType = objectGuid.getType();
+      }
+      if (objectId <= 0 && objectGuid.getUuid() != 0) {
+        objectId = Integer.toUnsignedLong(objectGuid.getUuid());
+      }
+    }
+    p_acl.setObjectType(objectType);
+    p_acl.setObjectId(objectId);
   }
 
   /***
@@ -586,6 +622,7 @@ public class ApiUtils {
       ret.setId(p_acl.getId());
       ret.setObjectGuid(convertGuid(p_acl.getObjectGuid()));
       ret.setObjectId(p_acl.getObjectId());
+      ret.setObjectType(p_acl.getObjectType());
       ret.setAclEntries(convertAclEntries(p_acl.getEntries()));
     }
     return ret;
@@ -647,10 +684,16 @@ public class ApiUtils {
     var p_acls = new ArrayList<IPSAcl>();
     for (var a : aclList) {
       var p_a = new PSAclImpl();
-      p_a.setObjectType(a.getObjectType());
-      p_a.setObjectId(a.getObjectId());
-      p_a.setGUID(convertGuid(orNull(a.getGuid())));
-      p_a.setName(orNull(a.getName()));
+      applyAclObjectIdentity(a, p_a);
+      var convertedGuid = convertGuid(orNull(a.getGuid()));
+      if (convertedGuid != null) {
+        p_a.setGUID(convertedGuid);
+      }
+      String name = orNull(a.getName());
+      if (name == null || name.isBlank()) {
+        name = "ACL";
+      }
+      p_a.setName(name);
       p_a.setId(a.getId());
       p_a.setEntries(convertAclEntries(orNull(a.getAclEntries())));
       p_a.setDescription(orNull(a.getDescription()));

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -124,6 +124,8 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="runtimeExceptionMapper" />
             <!-- Inbox #3323: bind flat startIndex before jackson UNWRAP_ROOT_VALUE -->
             <ref bean="viewExecuteRequestJsonReader" />
+            <!-- #3378: AclList ArrayList subclass must not ClassCast after UNWRAP -->
+            <ref bean="aclListJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
@@ -21,16 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.Guid;
 import com.percussion.rest.Permissions;
+import com.percussion.rest.acls.Acl;
 import com.percussion.rest.acls.AclEntry;
 import com.percussion.rest.acls.AclEntryList;
+import com.percussion.rest.acls.AclList;
 import com.percussion.rest.acls.TypedPrincipal;
 import com.percussion.rest.acls.UserAccessLevel;
 import com.percussion.rest.acls.UserAccessLevelList;
 import com.percussion.security.IPSTypedPrincipal;
 import com.percussion.services.security.PSPermissions;
 import com.percussion.services.security.data.PSAccessLevelImpl;
+import com.percussion.services.security.IPSAcl;
 import com.percussion.services.security.data.PSAclEntryImpl;
+import com.percussion.services.security.data.PSAclImpl;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
@@ -145,5 +150,53 @@ public class ApiUtilsAclConvertTest {
     PSAclEntryImpl pEntry = ApiUtils.convertAclEntries(list).iterator().next();
     assertEquals(IPSTypedPrincipal.PrincipalTypes.ROLE, pEntry.getType());
     assertEquals("Admin", pEntry.getName());
+  }
+
+  @Test
+  public void applyAclObjectIdentityDerivesTypeAndIdFromObjectGuidString() {
+    Acl acl = new Acl();
+    acl.setName("By_Author ACL");
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+
+    PSAclImpl pAcl = new PSAclImpl();
+    ApiUtils.applyAclObjectIdentity(acl, pAcl);
+
+    assertEquals(31, pAcl.getObjectType());
+    assertEquals(5, pAcl.getObjectId());
+    assertNotNull(pAcl.getObjectGuid());
+  }
+
+  @Test
+  public void convertAclsSavePreservesObjectIdentityFromGuid() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclList list = new AclList();
+    list.add(acl);
+
+    java.util.List<IPSAcl> converted = ApiUtils.convertAcls(list);
+    assertEquals(1, converted.size());
+    PSAclImpl pAcl = (PSAclImpl) converted.get(0);
+    assertEquals(31, pAcl.getObjectType());
+    assertEquals(5, pAcl.getObjectId());
+  }
+
+  @Test
+  public void convertAclLoadIncludesObjectType() {
+    PSAclImpl pAcl = new PSAclImpl();
+    pAcl.setName("By_Author ACL");
+    pAcl.setId(7);
+    pAcl.setObjectType(31);
+    pAcl.setObjectId(5);
+
+    Acl rest = ApiUtils.convertAcl(pAcl);
+    assertNotNull(rest);
+    assertEquals(31, rest.getObjectType());
+    assertEquals(5, rest.getObjectId());
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -56,6 +56,9 @@ class CatalogRestJaxrsRegistrationTest {
   /** Inbox execute #3323 — must precede jacksonProvider on rest-jax-rs. */
   private static final String VIEW_EXECUTE_JSON_READER = "viewExecuteRequestJsonReader";
 
+  /** Display Format Object ACL save #3378 — must precede jacksonProvider. */
+  private static final String ACL_LIST_JSON_READER = "aclListJsonReader";
+
   @Test
   void restJaxRsServiceBeansIncludeDeveloperCatalogResources() throws Exception {
     Path root = resolveRepoRoot();
@@ -100,16 +103,25 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(providers >= 0 && providersEnd > providers, "rest-jax-rs providers block");
     String providerBlock = restBlock.substring(providers, providersEnd);
     int reader = providerBlock.indexOf("bean=\"" + VIEW_EXECUTE_JSON_READER + "\"");
+    int aclReader = providerBlock.indexOf("bean=\"" + ACL_LIST_JSON_READER + "\"");
     int jackson = providerBlock.indexOf("bean=\"jacksonProvider\"");
     assertTrue(
         reader >= 0,
         "rest-jax-rs providers must ref "
             + VIEW_EXECUTE_JSON_READER
             + " (missing → Inbox flat startIndex 400)");
+    assertTrue(
+        aclReader >= 0,
+        "rest-jax-rs providers must ref "
+            + ACL_LIST_JSON_READER
+            + " (missing → ACL bulk save ArrayList ClassCast 400)");
     assertTrue(jackson >= 0, "rest-jax-rs providers must still ref jacksonProvider");
     assertTrue(
         reader < jackson,
         VIEW_EXECUTE_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        aclReader < jackson,
+        ACL_LIST_JSON_READER + " must be listed before jacksonProvider");
   }
 
   private static Path resolveRepoRoot() {

--- a/rest/src/main/java/com/percussion/rest/acls/AclList.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclList.java
@@ -19,6 +19,7 @@
 package com.percussion.rest.acls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -29,6 +30,7 @@ import java.util.Objects;
 
 /** List of {@link Acl} objects. */
 @XmlRootElement(name = "AclList")
+@JsonRootName("AclList")
 @XmlSeeAlso(Acl.class)
 @ArraySchema(schema = @Schema(implementation = Acl.class))
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/acls/AclListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclListJsonReader.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for PUT {@code /services/acls/bulk}.
+ *
+ * <p>CXF {@code UNWRAP_ROOT_VALUE} plus {@link AclList} extending {@link java.util.ArrayList}
+ * yields {@code ClassCastException: Cannot cast java.util.ArrayList to AclList} (HTTP 400). Display
+ * Format Object ACL Save hit that path (#3378 / QA #2640). This reader binds either:
+ *
+ * <ul>
+ *   <li>{@code {"AclList":[{…}]}} (preferred SPA envelope)
+ *   <li>{@code [{…}]} (legacy bare array)
+ *   <li>{@code {"AclList":{"Acl":[…]}}} (JAXB-style nested)
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code
+ * jacksonProvider}.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("aclListJsonReader")
+public class AclListJsonReader implements MessageBodyReader<AclList> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so we can inspect the envelope ourselves. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type != null && AclList.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public AclList readFrom(
+      Class<AclList> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new AclList();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new AclList();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind an ACL bulk-save body to {@link AclList}.
+   *
+   * @param json request body; may be null
+   * @return non-null list (empty when the body is blank)
+   */
+  public static AclList parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new AclList();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid AclList", 400);
+    }
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new AclList();
+    }
+    JsonNode array = extractAclArray(root);
+    if (array == null || !array.isArray()) {
+      throw new WebApplicationException(
+          "AclList body must be {\"AclList\":[…]} or a JSON array", 400);
+    }
+    AclList list = new AclList();
+    for (JsonNode item : array) {
+      if (item == null || item.isNull()) {
+        continue;
+      }
+      JsonNode aclNode = item;
+      if (item.isObject() && item.get("Acl") != null && item.get("Acl").isObject()) {
+        aclNode = item.get("Acl");
+      }
+      try {
+        list.add(MAPPER.treeToValue(aclNode, Acl.class));
+      } catch (JacksonException e) {
+        throw new WebApplicationException(
+            e.getMessage() != null ? e.getMessage() : "Invalid Acl", 400);
+      }
+    }
+    return list;
+  }
+
+  private static JsonNode extractAclArray(JsonNode root) {
+    if (root.isArray()) {
+      return root;
+    }
+    if (!root.isObject()) {
+      return null;
+    }
+    JsonNode nested = firstNonNull(root, "AclList", "aclList");
+    if (nested == null) {
+      return null;
+    }
+    if (nested.isArray()) {
+      return nested;
+    }
+    if (nested.isObject()) {
+      JsonNode jaxb = firstNonNull(nested, "Acl", "acl");
+      if (jaxb != null && jaxb.isArray()) {
+        return jaxb;
+      }
+      if (jaxb != null && jaxb.isObject()) {
+        var arr = MAPPER.createArrayNode();
+        arr.add(jaxb);
+        return arr;
+      }
+    }
+    return null;
+  }
+
+  private static JsonNode firstNonNull(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && !n.isNull()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/acls/CreateAclRequest.java
+++ b/rest/src/main/java/com/percussion/rest/acls/CreateAclRequest.java
@@ -18,12 +18,14 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 
 @XmlRootElement(name = "CreateAclRequest")
+@JsonRootName("CreateAclRequest")
 @Schema(description = "A request to create an acl")
 public class CreateAclRequest {
 

--- a/rest/src/main/java/com/percussion/rest/acls/Principal.java
+++ b/rest/src/main/java/com/percussion/rest/acls/Principal.java
@@ -18,11 +18,13 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 
 @XmlRootElement
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "Principal")
 public class Principal {
 

--- a/rest/src/main/java/com/percussion/rest/acls/TypedPrincipal.java
+++ b/rest/src/main/java/com/percussion/rest/acls/TypedPrincipal.java
@@ -18,12 +18,15 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.percussion.security.IPSTypedPrincipal;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 
 @XmlRootElement
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "Typed Principal")
 public class TypedPrincipal implements IPSTypedPrincipal {
 
@@ -56,46 +59,55 @@ public class TypedPrincipal implements IPSTypedPrincipal {
     this.type = type;
   }
 
+  @JsonIgnore
   @Override
   public boolean isType(PrincipalTypes principalType) {
     return type == principalType;
   }
 
+  @JsonIgnore
   @Override
   public boolean isCommunity() {
     return type == PrincipalTypes.COMMUNITY;
   }
 
+  @JsonIgnore
   @Override
   public boolean isRole() {
     return type == PrincipalTypes.ROLE;
   }
 
+  @JsonIgnore
   @Override
   public boolean isUser() {
     return type == PrincipalTypes.USER || type == PrincipalTypes.SYSTEM_ENTRY;
   }
 
+  @JsonIgnore
   @Override
   public boolean isGroup() {
     return type == PrincipalTypes.GROUP;
   }
 
+  @JsonIgnore
   @Override
   public boolean isSubject() {
     return type == PrincipalTypes.SUBJECT;
   }
 
+  @JsonIgnore
   @Override
   public boolean isSystemEntry() {
     return type == PrincipalTypes.SYSTEM_ENTRY;
   }
 
+  @JsonIgnore
   @Override
   public boolean isSystemCommunity() {
     return type == PrincipalTypes.SYSTEM_COMMUNITY;
   }
 
+  @JsonIgnore
   @Override
   public PrincipalTypes getPrincipalType() {
     return type;

--- a/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class AclListJsonReaderTest {
+
+  private static final String DF_SAVE =
+      "{\"AclList\":[{"
+          + "\"id\":7,"
+          + "\"name\":\"By_Author ACL\","
+          + "\"objectId\":5,"
+          + "\"objectType\":31,"
+          + "\"objectGuid\":{\"stringValue\":\"0-31-5\"},"
+          + "\"aclEntries\":["
+          + "{\"name\":\"Default\",\"principal\":{\"name\":\"Default\"},"
+          + "\"type\":{\"name\":\"Default\",\"type\":\"USER\"},"
+          + "\"permissions\":[{\"permission\":\"READ\"}]},"
+          + "{\"name\":\"AnyCommunity\",\"principal\":{\"name\":\"AnyCommunity\"},"
+          + "\"type\":{\"name\":\"AnyCommunity\",\"type\":\"COMMUNITY\"},"
+          + "\"permissions\":[{\"permission\":\"RUNTIME_VISIBLE\"}]},"
+          + "{\"name\":\"Admin\",\"principal\":{\"name\":\"Admin\"},"
+          + "\"type\":{\"name\":\"Admin\",\"type\":\"USER\"},"
+          + "\"permissions\":[{\"permission\":\"READ\"}]}"
+          + "]}]}";
+
+  @Test
+  public void parseAcceptsAclListEnvelope() {
+    AclList list = AclListJsonReader.parse(DF_SAVE);
+    assertInstanceOf(AclList.class, list);
+    assertEquals(1, list.size());
+    Acl acl = list.get(0);
+    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals(31, acl.getObjectType());
+    assertEquals(5, acl.getObjectId());
+    assertEquals(3, acl.getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals("Default", acl.getAclEntries().orElseThrow().get(0).getName().orElse(null));
+    assertEquals("AnyCommunity", acl.getAclEntries().orElseThrow().get(1).getName().orElse(null));
+    assertEquals("Admin", acl.getAclEntries().orElseThrow().get(2).getName().orElse(null));
+  }
+
+  @Test
+  public void parseAcceptsBareArray() {
+    AclList list = AclListJsonReader.parse("[{\"name\":\"x\",\"objectType\":31}]");
+    assertEquals(1, list.size());
+    assertEquals("x", list.get(0).getName().orElse(null));
+    assertEquals(31, list.get(0).getObjectType());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyList() {
+    assertTrue(AclListJsonReader.parse("  ").isEmpty());
+    assertTrue(AclListJsonReader.parse(null).isEmpty());
+  }
+
+  @Test
+  public void parseRejectsNonListObject() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> AclListJsonReader.parse("{\"foo\":1}"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void isReadableOnlyForAclList() {
+    AclListJsonReader reader = new AclListJsonReader();
+    assertTrue(reader.isReadable(AclList.class, AclList.class, null, null));
+    assertTrue(!reader.isReadable(Acl.class, Acl.class, null, null));
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.Permissions;
+import com.percussion.security.IPSTypedPrincipal;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * PUT {@code /services/acls/bulk} wire shape (#3378 / QA #2640).
+ *
+ * <p>Production JSON uses {@link JacksonContextResolver} WRAP/UNWRAP_ROOT_VALUE so the envelope
+ * must be {@code AclList}, not a bare JSON array. Display Format Object ACL Save sent a raw array
+ * and received HTTP 400.
+ */
+@Tag("UnitTest")
+public class AclListSerialDeserialTest {
+
+  private static Acl sampleDisplayFormatAcl() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    acl.setObjectId(5);
+    acl.setObjectType(31);
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    objectGuid.setType((short) 31);
+    objectGuid.setUuid(5);
+    acl.setObjectGuid(objectGuid);
+
+    AclEntryList entries = new AclEntryList();
+    entries.add(
+        entry(
+            1,
+            "Default",
+            IPSTypedPrincipal.PrincipalTypes.USER,
+            Permissions.READ,
+            Permissions.UPDATE));
+    entries.add(
+        entry(
+            2,
+            "AnyCommunity",
+            IPSTypedPrincipal.PrincipalTypes.COMMUNITY,
+            Permissions.RUNTIME_VISIBLE));
+    entries.add(
+        entry(3, "Admin", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.READ, Permissions.OWNER));
+    acl.setAclEntries(entries);
+    return acl;
+  }
+
+  private static AclEntry entry(
+      long id, String name, IPSTypedPrincipal.PrincipalTypes type, Permissions... perms) {
+    AclEntry e = new AclEntry();
+    e.setId(id);
+    e.setName(name);
+    e.setAclId(7);
+    e.setPrincipal(new Principal(name));
+    e.setType(new TypedPrincipal(name, type));
+    UserAccessLevelList levels = new UserAccessLevelList();
+    for (Permissions p : perms) {
+      UserAccessLevel ual = new UserAccessLevel();
+      ual.setPermission(p);
+      levels.add(ual);
+    }
+    e.setPermissions(levels);
+    return e;
+  }
+
+  private static JsonMapper wrapRootMapper() {
+    return JsonMapper.builder()
+        .enable(SerializationFeature.WRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .build();
+  }
+
+  @Test
+  public void jacksonWrapsAclListRoot() throws JacksonException {
+    var mapper = wrapRootMapper();
+    AclList list = new AclList();
+    list.add(sampleDisplayFormatAcl());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"AclList\""), "expected WRAP_ROOT_VALUE AclList: " + json);
+    assertTrue(json.contains("\"By_Author ACL\""), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("AnyCommunity"), json);
+    assertTrue(json.contains("Admin"), json);
+
+    AclList roundTrip = mapper.readValue(json, AclList.class);
+    assertEquals(1, roundTrip.size());
+    Acl acl = roundTrip.get(0);
+    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals(5, acl.getObjectId());
+    assertEquals(31, acl.getObjectType());
+    assertTrue(acl.getObjectGuid().isPresent());
+    assertEquals("0-31-5", acl.getObjectGuid().get().getStringValue().orElse(null));
+    assertEquals(3, acl.getAclEntries().map(AclEntryList::size).orElse(0));
+  }
+
+  @Test
+  public void productionMapperRoundTripsDisplayFormatSaveEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    AclList list = new AclList();
+    list.add(sampleDisplayFormatAcl());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"AclList\""), json);
+    assertFalse(
+        json.contains("\"empty\"") && !json.contains("\"name\""),
+        "name must not serialize only as an Optional bean: " + json);
+
+    AclList roundTrip = mapper.readValue(json, AclList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals(3, roundTrip.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals(31, roundTrip.get(0).getObjectType());
+  }
+
+  @Test
+  public void productionMapperAcceptsClientAclListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    String clientBody =
+        "{\"AclList\":[{"
+            + "\"id\":7,"
+            + "\"name\":\"By_Author ACL\","
+            + "\"objectId\":5,"
+            + "\"objectType\":31,"
+            + "\"objectGuid\":{\"stringValue\":\"0-31-5\"},"
+            + "\"aclEntries\":["
+            + "{\"name\":\"Default\",\"principal\":{\"name\":\"Default\"},"
+            + "\"type\":{\"name\":\"Default\",\"type\":\"USER\"},"
+            + "\"permissions\":[{\"permission\":\"READ\"}]},"
+            + "{\"name\":\"AnyCommunity\",\"principal\":{\"name\":\"AnyCommunity\"},"
+            + "\"type\":{\"name\":\"AnyCommunity\",\"type\":\"COMMUNITY\"},"
+            + "\"permissions\":[{\"permission\":\"RUNTIME_VISIBLE\"}]},"
+            + "{\"name\":\"Admin\",\"principal\":{\"name\":\"Admin\"},"
+            + "\"type\":{\"name\":\"Admin\",\"type\":\"USER\"},"
+            + "\"permissions\":[{\"permission\":\"READ\"},{\"permission\":\"OWNER\"}]}"
+            + "]}]}";
+
+    AclList list = mapper.readValue(clientBody, AclList.class);
+    assertEquals(1, list.size());
+    Acl acl = list.get(0);
+    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals(31, acl.getObjectType());
+    assertEquals(5, acl.getObjectId());
+    assertNotNull(acl.getAclEntries().orElse(null));
+    assertEquals(3, acl.getAclEntries().get().size());
+    assertEquals("Default", acl.getAclEntries().get().get(0).getName().orElse(null));
+    assertEquals("AnyCommunity", acl.getAclEntries().get().get(1).getName().orElse(null));
+    assertEquals("Admin", acl.getAclEntries().get().get(2).getName().orElse(null));
+  }
+
+  @Test
+  public void productionMapperRejectsBareJsonArray() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    String bareArray = "[{\"id\":7,\"name\":\"By_Author ACL\",\"aclEntries\":[]}]";
+    try {
+      AclList result = mapper.readValue(bareArray, AclList.class);
+      assertTrue(
+          result == null || result.isEmpty(),
+          "bare JSON array must not bind as AclList under UNWRAP_ROOT_VALUE; size="
+              + (result == null ? "null" : result.size()));
+    } catch (Exception expected) {
+      assertTrue(
+          expected.getMessage() != null
+              && (expected.getMessage().contains("AclList")
+                  || expected.getMessage().contains("Root name")
+                  || expected.getMessage().contains("START_ARRAY")
+                  || expected.getMessage().contains("from Array value")),
+          "unexpected failure: " + expected);
+    }
+  }
+
+  @Test
+  public void productionMapperAcceptsPrincipalWithUnknownTypeField() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    String body =
+        "{\"AclList\":[{\"id\":1,\"name\":\"x\",\"aclEntries\":["
+            + "{\"name\":\"Admin\",\"principal\":{\"name\":\"Admin\",\"type\":\"USER\"},"
+            + "\"type\":{\"name\":\"Admin\",\"type\":\"USER\"},"
+            + "\"permissions\":[{\"permission\":\"READ\"}]}]}]}";
+    AclList list = mapper.readValue(body, AclList.class);
+    assertEquals(1, list.size());
+    assertEquals(
+        "Admin", list.get(0).getAclEntries().orElseThrow().get(0).getPrincipal().orElseThrow().getName());
+  }
+
+  @Test
+  public void createAclRequestRequiresEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(CreateAclRequest.class);
+    String wrapped =
+        "{\"CreateAclRequest\":{"
+            + "\"objectGuid\":{\"stringValue\":\"0-31-5\"},"
+            + "\"owner\":{\"name\":\"Admin\",\"type\":\"USER\"}}}";
+    CreateAclRequest req = mapper.readValue(wrapped, CreateAclRequest.class);
+    assertEquals("0-31-5", req.getObjectGuid().getStringValue().orElse(null));
+    assertEquals("Admin", req.getOwner().getName());
+    assertEquals(IPSTypedPrincipal.PrincipalTypes.USER, req.getOwner().getType());
+
+    String flat =
+        "{\"objectGuid\":{\"stringValue\":\"0-31-5\"},\"owner\":{\"name\":\"Admin\",\"type\":\"USER\"}}";
+    try {
+      CreateAclRequest result = mapper.readValue(flat, CreateAclRequest.class);
+      assertTrue(
+          result == null
+              || result.getObjectGuid() == null
+              || result.getObjectGuid().getStringValue().orElse("").isBlank(),
+          "flat CreateAclRequest must not bind under UNWRAP_ROOT_VALUE");
+    } catch (Exception expected) {
+      assertTrue(
+          expected.getMessage() != null
+              && (expected.getMessage().contains("CreateAclRequest")
+                  || expected.getMessage().contains("Root name")
+                  || expected.getMessage().contains("objectGuid")),
+          "unexpected failure: " + expected);
+    }
+  }
+
+  @Test
+  public void jaxbContextKnowsAclFromList() throws Exception {
+    jakarta.xml.bind.JAXBContext ctx = jakarta.xml.bind.JAXBContext.newInstance(AclList.class);
+    AclList list = new AclList();
+    list.add(sampleDisplayFormatAcl());
+    jakarta.xml.bind.Marshaller marshaller = ctx.createMarshaller();
+    marshaller.setProperty(jakarta.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
+    var writer = new java.io.StringWriter();
+    try {
+      marshaller.marshal(list, writer);
+    } catch (Exception e) {
+      fail("JAXB must marshal AclList containing Acl (#3378); got: " + e.getMessage(), e);
+    }
+    String xml = writer.toString();
+    assertTrue(xml.contains("AclList") || xml.contains("aclList"), xml);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.Status;
+import com.percussion.security.IPSTypedPrincipal;
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class AclResourceTest {
+
+  private IAclAdaptor adaptor;
+  private AclResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    adaptor = mock(IAclAdaptor.class);
+    resource = new AclResource();
+    try {
+      var f = AclResource.class.getDeclaredField("adaptor");
+      f.setAccessible(true);
+      f.set(resource, adaptor);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void saveAclsDelegatesAndReturnsOk() throws Exception {
+    AclList list = new AclList();
+    Acl acl = new Acl();
+    acl.setName("By_Author ACL");
+    list.add(acl);
+
+    Status status = resource.saveAcls(list);
+    assertEquals(200, status.getStatusCode());
+    verify(adaptor).saveAcls(eq(list));
+  }
+
+  @Test
+  public void saveAclsWrapsAdaptorFailure() throws Exception {
+    AclList list = new AclList();
+    doThrow(new RuntimeException("denied")).when(adaptor).saveAcls(any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.saveAcls(list));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void loadAclForObjectDelegates() {
+    Guid guid = new Guid();
+    guid.setStringValue("0-31-5");
+    Acl acl = new Acl();
+    acl.setName("By_Author ACL");
+    when(adaptor.loadAclForObject(any(Guid.class))).thenReturn(acl);
+
+    Acl out = resource.loadAclForObject("0-31-5");
+    assertSame(acl, out);
+    verify(adaptor).loadAclForObject(any(Guid.class));
+  }
+
+  @Test
+  public void createAclDelegates() {
+    CreateAclRequest request = new CreateAclRequest();
+    Guid guid = new Guid();
+    guid.setStringValue("0-31-5");
+    request.setObjectGuid(guid);
+    request.setOwner(new TypedPrincipal("Admin", IPSTypedPrincipal.PrincipalTypes.USER));
+    Acl created = new Acl();
+    created.setName("new");
+    when(adaptor.createAcl(any(Guid.class), any(TypedPrincipal.class))).thenReturn(created);
+
+    assertSame(created, resource.createAcl(request));
+    verify(adaptor).createAcl(eq(guid), eq(request.getOwner()));
+  }
+}


### PR DESCRIPTION
## Summary

Display Format Object ACL **Save** was HTTP 400 because CXF Jackson `UNWRAP_ROOT_VALUE` bound `{"AclList":[…]}` as `java.util.ArrayList`, which cannot cast to `AclList`.

This PR:

- Adds `AclListJsonReader` and registers it ahead of `jacksonProvider`.
- Wraps SPA PUT/POST bodies (`AclList` / `CreateAclRequest`), strips `principal.type`, derives `objectType`/`objectId` from `objectGuid` (`0-31-5`), defaults ACL `name` to `ACL`.
- Makes `ApiUtils` skip `setGUID(null)` and copy object identity from `objectGuid`.
- Documents the envelope in `product-docs/8.2` and adds H2 Playwright coverage that Save is not 400.

**Partial #3378.** Persist / GET-after-save can still 500 (`PK_PSX_ACLS` insert vs merge) or return empty entries. Residual child will track that. Does **not** take Menu/View GUID (#3380) or Template crash (#3377).

Parent: #2640 (QA Object ACL peers). Epic: #2274 / #2262.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

Env: QA H2 docker (`perc-devctl qa-up`) or local CMS; Admin / Developer.

1. Open Developer → Display Formats → **By_Author** (or any format with a GUID) → **Object ACL**.
2. If empty, create with owner **Admin** / USER.
3. Add **Default**, **AnyCommunity**, and a USER if missing; **Save**.
4. Confirm the save request is **not HTTP 400** (Network: `PUT /services/acls/bulk` with `{"AclList":[…]}`).
5. Reopen the format. Persistence of Default / AnyCommunity / USER is **residual** if GET is still empty.
6. Regression: Content Type / Template Object ACL still loads.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/object-acl.md`, `users-roles.md`, `developer/rest.md` (PUT envelope + principal/type shape)
- [x] **Unit / module tests** — `AclListJsonReaderTest`, `AclListSerialDeserialTest`, `AclResourceTest`, `ApiUtilsAclConvertTest`, Vitest wrap/save; standalone `mvnw clean install` on changed modules
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-object-acl-display-format-save.spec.js`
- [x] **Build gates** — standalone clean install (no skipTests); C2 N/A for signature/`final` (grep: no `extends AclList`)
- [x] **Cross-platform** — N/A (JSON/JAX-RS/SPA; Playwright uses `TEST_CMS_URL`, no hardcoded `:9993`)

## C3 build evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: **383**, Failures: 0, Errors: 0, Skipped: 0 (includes AclListJsonReader 5, AclListSerialDeserial, AclResource)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** Surefire XML: 1138 tests, 0 failures, 0 errors (125 skipped)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** Java Tests run: **59**, Failures: 0, Errors: 0 (Vitest ran in the same install; target 2026-08-14 13:46 after last TS edit)
- **downstream_checked:** C2 did not apply (no `final`/`sealed`, no public/protected signature change). Grep: no `extends AclList` / anonymous `AclList` subclasses. sitemanage standalone install is the rest reverse-dep.

## C5 UI live proof (H2 QA)

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:3296` (`perc-matrix-cms-h2`)
- Hot-deploy of rest + sitemanage + WebUI artifacts into the QA cell (prior session); login succeeded
- `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js`
- Playwright: **1 passed** (`test-results/.last-run.json` status=passed)
- **console-clean=yes** (spec collector; no uncaught pageerror on the path)
- **server.log-clean=no** (known persist `PK_PSX_ACLS` / empty GET — residual, not the 400). Spec asserts Save **≠ 400** only.

Partial #3378
Parent #2640

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
