### PR TITLE
fix(acl): merge Display Format ACL on PUT; GET-after-save returns Default/AnyCommunity/USER

### DIFF
--- a/docs/ai-generated/code-reviews/3384-display-format-acl-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/3384-display-format-acl-persist-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3384 Display Format Object ACL persist/GET
+
+**Date:** 2026-08-14  
+**Branch:** `fix/issue-3384-display-format-acl-persist`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+PUT `/services/acls/bulk` converted a new `PSAclImpl` and `session.merge` inserted a
+duplicate `PK_PSX_ACLS` (or swallowed the error and GET reopened empty). This change
+loads the existing ACL by objectGuid/SYSID, merges entries onto that identity
+(preserving version and object type/id), and rethrows persist failures as
+`ACL_SAVE_ERROR` instead of returning 200 after a silent Hibernate error.
+
+## Scope
+
+Uncommitted work vs `origin/main` on `fix/issue-3384-display-format-acl-persist`.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — **addressed** (merge-vs-insert + GET-after-save shape)
+- Empty catch / swallowed exceptions — **addressed** (`internalPersist` now throws)
+- Incomplete change-class closure — Playwright spec tightened; product-docs updated
+- Cross-platform path checklist — N/A (no new filesystem I/O)
+
+## Issues
+
+None that block commit.
+
+## Notes (not blocking)
+
+- `PSAclImpl.merge` still copies `m_version` from the incoming object; the helper
+  restores version when incoming version is null. Callers must use the helper, not
+  raw `merge`, for REST save.
+- Adaptor GET path still uses `ApiUtils.convertGuid(Guid)` (GuidManager). Tests
+  that would hit Spring locator were kept off that path; GET shape is covered by
+  `ApiUtils.convertAcl(PSAclImpl)`.
+- GET JSON used JAXB/Jettison on Optional getters and omitted `aclEntries`/`name`.
+  Field-access `@XmlElement`/`@JsonProperty` on `Acl`/`AclEntry` is required for
+  GET-after-save. Live H2: PUT 200 then GET includes Default/AnyCommunity/Admin.
+  Playwright surface spec passed.
+
+## Tests
+
+- `PSAclPersistMergerTest` — 4 tests
+- `AclAdaptorSaveMergeTest` — merge identity + insert-when-absent
+- `ApiUtilsAclConvertTest` — GET-after-save Default/AnyCommunity/Admin + identity
+- `AclResourceTest` — GET entries contract
+- Playwright reopen now requires those three rows (no `no-entries` accept)
+
+## Cross-platform path checklist
+
+N/A — no new `File`/`Path` construction.

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-display-format-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-display-format-save.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Display Format Object ACL Save must persist (not HTTP 400) (#3378 / QA #2640).
+ * Display Format Object ACL Save must persist (#3384 / #3378 / QA #2640).
  *
  * Opens Developer → Display Formats (By_Author when present), adds Default +
  * AnyCommunity + a USER principal when missing, Save, then Back + reopen.
- * Entries must still be present. Save must not surface "Could not save object ACL. (400)".
+ * Reopen must show those three rows (not an empty no-entries table). Save must
+ * be HTTP 200 (not 400 / 500).
  *
  * Surface filter (H2 QA / agent path):
  *   cd modules/perc-qa-automation/frontend
@@ -28,7 +29,7 @@
  * QA mode:
  *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js → qa-down
  *
- * Refs #3378, #2640, #2604, #2274.
+ * Refs #3384, #3378, #2640, #2604, #2274.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -196,7 +197,7 @@ async function ensureSpecialsAndUser(page) {
   }
 }
 
-test.describe("Display Format Object ACL save (#3378) @object-acl-df-save", () => {
+test.describe("Display Format Object ACL save (#3384) @object-acl-df-save", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(120_000);
     await loginAsAdmin(page);
@@ -235,15 +236,15 @@ test.describe("Display Format Object ACL save (#3378) @object-acl-df-save", () =
         const respBody = await res.text().catch(() => "");
         expect(
           res.status(),
-          `ACL save must not be HTTP 400 (#3378). status=${res.status()} body=${reqBody.slice(0, 500)} resp=${respBody.slice(0, 500)}`,
-        ).not.toBe(400);
+          `ACL save must be HTTP 200 (#3384). status=${res.status()} body=${reqBody.slice(0, 500)} resp=${respBody.slice(0, 500)}`,
+        ).toBe(200);
       }
     }
 
     const aclError = page.locator(`[data-testid="${PREFIX}-error"]`);
     if (await aclError.isVisible()) {
       const msg = (await aclError.innerText()).trim();
-      expect(msg, `Save must not be HTTP 400: ${msg}`).not.toMatch(/\(400\)/);
+      expect(msg, `Save must succeed: ${msg}`).not.toMatch(/\((400|500)\)/);
     }
 
     await page.locator('[data-testid="developer-df-back"]').click();
@@ -256,13 +257,22 @@ test.describe("Display Format Object ACL save (#3378) @object-acl-df-save", () =
     }
     await ensureAclTable(page);
 
-    // #3378 hard gate is Save !== 400. Reopen may still show no-entries when GET
-    // omits aclEntries (#3203 / #2672) even after a 200 save.
+    // #3384: reopen must show Default + AnyCommunity + USER (not empty GET).
     const defaultAfter = page.locator(
       `[data-testid^="${PREFIX}-row-"][data-special-acl="default"]`,
     );
+    const anyAfter = page.locator(
+      `[data-testid^="${PREFIX}-row-"][data-special-acl="any-community"]`,
+    );
     const noEntries = page.locator(`[data-testid="${PREFIX}-no-entries"]`);
-    await expect(defaultAfter.or(noEntries).first()).toBeVisible({ timeout: 15_000 });
+    await expect(noEntries).toHaveCount(0);
+    await expect(defaultAfter).toHaveCount(1, { timeout: 15_000 });
+    await expect(anyAfter).toHaveCount(1, { timeout: 15_000 });
+    const labelsAfter = await page.locator(`[data-testid^="${PREFIX}-label-"]`).allInnerTexts();
+    expect(
+      labelsAfter.some((t) => /\bAdmin\b/i.test(t)),
+      `reopen must include USER Admin; labels=${labelsAfter.join(",")}`,
+    ).toBeTruthy();
 
     const related = consoleErrors.filter(
       (e) => /uncaught/i.test(e) && !/favicon|sourcemap/i.test(e),

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -43,8 +43,10 @@ those system principals.
    format always show **Visible**).
 7. To persist permissions: add **Default**, **AnyCommunity**, and any extra USER
    or ROLE principal, then click **Save**. Reopen the same object — those entries
-   must still be present. If the object has no ACL yet, create one first (owner
-   principal) and then save the additional entries.
+   must still be present (Default, AnyCommunity, and the USER you added). The
+   product updates the existing object ACL; it does not create a second empty
+   ACL. If the object has no ACL yet, create one first (owner principal) and then
+   save the additional entries.
 
 Deep links:
 

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -119,10 +119,11 @@ objects, including **Content types**, **Templates**, **Display Formats**, **Site
    - Does **not** say “Object GUID not available” when the header GUID is present.
    - If the object truly has no GUID, the section still mounts with kind-aware copy
      (display format) and does not crash the detail page.
-5. **Save** persists **Default**, **AnyCommunity**, and added USER/ROLE principals.
-   After Back and reopen, those rows must still be present (not discarded as an
-   HTTP 400). If the format has no ACL yet, use **Create** with an owner, then
-   add specials and **Save**.
+5. **Save** persists **Default**, **AnyCommunity**, and added USER/ROLE principals
+   onto the existing object ACL (the server updates that row; it does not insert
+   a second empty ACL). After Back and reopen, those three rows must still be
+   present (not HTTP 400/500 and not an empty table). If the format has no ACL
+   yet, use **Create** with an owner, then add specials and **Save**.
 
 Use this section to inspect and edit design-time and runtime visibility permissions
 for that display format.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -227,7 +227,11 @@ Design-time ACLs use `/services/acls`. Production JSON uses Jackson
 | `POST` | `/services/acls/` | Request `{"CreateAclRequest":{"objectGuid":{"stringValue":"…"},"owner":{"name":"Admin","type":"USER"}}}` |
 | `PUT` | `/services/acls/bulk` | Request `{"AclList":[{…}]}` — **not** a bare JSON array |
 
-Each ACL in the list should include `objectGuid` (and `objectType` / `objectId` when known).
+Each ACL in the list should include `objectGuid` (and `objectType` / `objectId` when known),
+plus the ACL `id` / `guid` when the object already has an ACL. The server **merges** that
+payload onto the existing `PSX_ACLS` row (same SYSID / object identity) instead of inserting
+a duplicate. After HTTP 200, `GET /services/acls/object/{guid}` returns `aclEntries`
+including **Default**, **AnyCommunity**, and any USER you saved (for example Admin).
 Entries use `principal.name` only; the principal type lives on `type.type`
 (`USER`, `COMMUNITY`, `ROLE`, …). A bare array body is HTTP 400.
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AclAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AclAdaptor.java
@@ -29,11 +29,13 @@ import com.percussion.security.PSSecurityException;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.security.IPSAcl;
 import com.percussion.services.security.IPSAclService;
+import com.percussion.services.security.PSAclPersistMerger;
 import com.percussion.services.security.PSServiceSecurityException;
 import com.percussion.services.security.data.PSAclImpl;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import jakarta.ws.rs.NotFoundException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -144,7 +146,64 @@ public class AclAdaptor implements IAclAdaptor {
 
   @Override
   public void saveAcls(AclList aclList) throws PSServiceSecurityException {
-    aclService.saveAcls(ApiUtils.convertAcls(aclList));
+    if (aclList == null) {
+      aclService.saveAcls(null);
+      return;
+    }
+    List<IPSAcl> toSave = new ArrayList<>();
+    for (Acl restAcl : aclList) {
+      if (restAcl == null) {
+        continue;
+      }
+      PSAclImpl incoming = ApiUtils.convertAcl(restAcl);
+      IPSAcl existing = loadExistingAclForSave(incoming);
+      if (existing instanceof PSAclImpl persistent && persistent.getId() != 0) {
+        toSave.add(PSAclPersistMerger.mergeOntoExisting(persistent, incoming));
+      } else {
+        toSave.add(incoming);
+      }
+    }
+    aclService.saveAcls(toSave);
+  }
+
+  /**
+   * Load the persisted ACL for this object or ACL SYSID so save merges entries
+   * onto that identity (#3384).
+   */
+  private IPSAcl loadExistingAclForSave(PSAclImpl incoming) {
+    if (incoming == null) {
+      return null;
+    }
+    IPSGuid objectGuid = incoming.getObjectGuid();
+    if (objectGuid != null) {
+      try {
+        IPSAcl byObject = aclService.loadAclForObjectModifiable(objectGuid);
+        if (byObject != null) {
+          return byObject;
+        }
+      } catch (PSServiceSecurityException e) {
+        log.debug("No existing ACL for objectGuid {}", objectGuid, e);
+      }
+    }
+    if (incoming.getId() != 0) {
+      try {
+        IPSGuid aclGuid = incoming.getGUID();
+        if (aclGuid != null) {
+          List<IPSAcl> loaded = aclService.loadAclsModifiable(List.of(aclGuid));
+          if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+            return loaded.get(0);
+          }
+        }
+      } catch (PSServiceSecurityException e) {
+        log.debug("No existing ACL for id {}", incoming.getId(), e);
+      }
+    }
+    return null;
+  }
+
+  /** Package-visible for unit tests. */
+  void setAclService(IPSAclService aclService) {
+    this.aclService = aclService;
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -483,7 +483,11 @@ public class ApiUtils {
 
     p_acl.setId(acl.getId());
     p_acl.setDescription(orNull(acl.getDescription()));
-    p_acl.setName(orNull(acl.getName()));
+    String name = orNull(acl.getName());
+    if (name == null || name.isBlank()) {
+      name = "ACL";
+    }
+    p_acl.setName(name);
     var convertedGuid = convertGuid(orNull(acl.getGuid()));
     if (convertedGuid != null) {
       p_acl.setGUID(convertedGuid);
@@ -682,22 +686,13 @@ public class ApiUtils {
 
   public static List<IPSAcl> convertAcls(AclList aclList) {
     var p_acls = new ArrayList<IPSAcl>();
+    if (aclList == null) {
+      return p_acls;
+    }
     for (var a : aclList) {
-      var p_a = new PSAclImpl();
-      applyAclObjectIdentity(a, p_a);
-      var convertedGuid = convertGuid(orNull(a.getGuid()));
-      if (convertedGuid != null) {
-        p_a.setGUID(convertedGuid);
+      if (a != null) {
+        p_acls.add(convertAcl(a));
       }
-      String name = orNull(a.getName());
-      if (name == null || name.isBlank()) {
-        name = "ACL";
-      }
-      p_a.setName(name);
-      p_a.setId(a.getId());
-      p_a.setEntries(convertAclEntries(orNull(a.getAclEntries())));
-      p_a.setDescription(orNull(a.getDescription()));
-      p_acls.add(p_a);
     }
     return p_acls;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AclAdaptorSaveMergeTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AclAdaptorSaveMergeTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.Permissions;
+import com.percussion.rest.acls.Acl;
+import com.percussion.rest.acls.AclEntry;
+import com.percussion.rest.acls.AclEntryList;
+import com.percussion.rest.acls.AclList;
+import com.percussion.rest.acls.TypedPrincipal;
+import com.percussion.rest.acls.UserAccessLevel;
+import com.percussion.rest.acls.UserAccessLevelList;
+import com.percussion.security.IPSTypedPrincipal;
+import com.percussion.services.security.IPSAcl;
+import com.percussion.services.security.IPSAclService;
+import com.percussion.services.security.PSPermissions;
+import com.percussion.services.security.PSTypedPrincipal;
+import com.percussion.services.security.data.PSAccessLevelImpl;
+import com.percussion.services.security.data.PSAclEntryImpl;
+import com.percussion.services.security.data.PSAclImpl;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link AclAdaptor#saveAcls} must merge onto the existing {@link PSAclImpl} identity
+ * (objectGuid / SYSID) so Hibernate does not insert a duplicate {@code PK_PSX_ACLS} (#3384).
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class AclAdaptorSaveMergeTest {
+
+  @Mock private IPSAclService aclService;
+
+  private AclAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    adaptor = new AclAdaptor();
+    adaptor.setAclService(aclService);
+  }
+
+  @Test
+  void saveMergesEntriesOntoExistingIdentity() throws Exception {
+    PSAclImpl existing = new PSAclImpl();
+    existing.setId(7);
+    existing.setVersion(2);
+    existing.setName("By_Author ACL");
+    existing.setObjectType(31);
+    existing.setObjectId(5);
+    PSAclEntryImpl owner =
+        new PSAclEntryImpl(new PSTypedPrincipal("Admin", IPSTypedPrincipal.PrincipalTypes.USER));
+    owner.addPermission(new PSAccessLevelImpl(owner, PSPermissions.OWNER));
+    existing.addEntry(owner);
+
+    when(aclService.loadAclForObjectModifiable(any())).thenReturn(existing);
+
+    adaptor.saveAcls(displayFormatSaveList());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSAcl>> captor = ArgumentCaptor.forClass(List.class);
+    verify(aclService).saveAcls(captor.capture());
+    verify(aclService, never()).loadAclsModifiable(anyList());
+
+    List<IPSAcl> saved = captor.getValue();
+    assertEquals(1, saved.size());
+    assertSame(existing, saved.get(0), "must persist the loaded identity, not a new PSAclImpl");
+    PSAclImpl persisted = (PSAclImpl) saved.get(0);
+    assertEquals(7, persisted.getId());
+    assertEquals(Integer.valueOf(2), persisted.getVersion());
+    assertEquals(31, persisted.getObjectType());
+    assertEquals(5, persisted.getObjectId());
+    Set<String> names =
+        persisted.getEntries().stream()
+            .map(e -> ((PSAclEntryImpl) e).getName())
+            .collect(Collectors.toSet());
+    assertEquals(Set.of("Default", "AnyCommunity", "Admin"), names);
+  }
+
+  @Test
+  void saveInsertsWhenNoExistingAcl() throws Exception {
+    when(aclService.loadAclForObjectModifiable(any())).thenReturn(null);
+    when(aclService.loadAclsModifiable(anyList())).thenReturn(List.of());
+
+    adaptor.saveAcls(displayFormatSaveList());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSAcl>> captor = ArgumentCaptor.forClass(List.class);
+    verify(aclService).saveAcls(captor.capture());
+    PSAclImpl inserted = (PSAclImpl) captor.getValue().get(0);
+    assertEquals(7, inserted.getId());
+    assertEquals(31, inserted.getObjectType());
+    assertEquals(5, inserted.getObjectId());
+    assertTrue(inserted.getEntries().stream().anyMatch(e -> "Default".equals(e.getName())));
+  }
+
+  private static AclList displayFormatSaveList() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclEntryList entries = new AclEntryList();
+    entries.add(restEntry("Default", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.READ));
+    entries.add(
+        restEntry(
+            "AnyCommunity", IPSTypedPrincipal.PrincipalTypes.COMMUNITY, Permissions.RUNTIME_VISIBLE));
+    entries.add(restEntry("Admin", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.OWNER));
+    acl.setAclEntries(entries);
+    AclList list = new AclList();
+    list.add(acl);
+    return list;
+  }
+
+  private static AclEntry restEntry(
+      String name, IPSTypedPrincipal.PrincipalTypes type, Permissions perm) {
+    AclEntry entry = new AclEntry();
+    entry.setName(name);
+    entry.setType(new TypedPrincipal(name, type));
+    UserAccessLevelList levels = new UserAccessLevelList();
+    UserAccessLevel level = new UserAccessLevel();
+    level.setPermission(perm);
+    levels.add(level);
+    entry.setPermissions(levels);
+    return entry;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
@@ -32,6 +32,7 @@ import com.percussion.rest.acls.UserAccessLevel;
 import com.percussion.rest.acls.UserAccessLevelList;
 import com.percussion.security.IPSTypedPrincipal;
 import com.percussion.services.security.PSPermissions;
+import com.percussion.services.security.PSTypedPrincipal;
 import com.percussion.services.security.data.PSAccessLevelImpl;
 import com.percussion.services.security.IPSAcl;
 import com.percussion.services.security.data.PSAclEntryImpl;
@@ -198,5 +199,88 @@ public class ApiUtilsAclConvertTest {
     assertNotNull(rest);
     assertEquals(31, rest.getObjectType());
     assertEquals(5, rest.getObjectId());
+  }
+
+  @Test
+  public void convertAclLoadIncludesDefaultAnyCommunityAndUser() {
+    PSAclImpl pAcl = new PSAclImpl();
+    pAcl.setId(7);
+    pAcl.setName("By_Author ACL");
+    pAcl.setObjectType(31);
+    pAcl.setObjectId(5);
+    addEntry(pAcl, "Default", IPSTypedPrincipal.PrincipalTypes.USER, PSPermissions.READ);
+    addEntry(
+        pAcl, "AnyCommunity", IPSTypedPrincipal.PrincipalTypes.COMMUNITY, PSPermissions.RUNTIME_VISIBLE);
+    addEntry(pAcl, "Admin", IPSTypedPrincipal.PrincipalTypes.USER, PSPermissions.OWNER);
+
+    Acl rest = ApiUtils.convertAcl(pAcl);
+    assertNotNull(rest.getAclEntries().orElse(null));
+    assertEquals(3, rest.getAclEntries().get().size());
+    var names =
+        rest.getAclEntries().get().stream()
+            .map(e -> e.getName().orElse(""))
+            .collect(Collectors.toSet());
+    assertTrue(names.contains("Default"));
+    assertTrue(names.contains("AnyCommunity"));
+    assertTrue(names.contains("Admin"));
+    assertEquals(31, rest.getObjectType());
+    assertEquals(5, rest.getObjectId());
+    assertNotNull(rest.getObjectGuid().orElse(null));
+  }
+
+  @Test
+  public void convertAclsSaveKeepsAclIdGuidAndEntries() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclEntryList entries = new AclEntryList();
+    entries.add(restEntry("Default", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.READ));
+    entries.add(
+        restEntry(
+            "AnyCommunity",
+            IPSTypedPrincipal.PrincipalTypes.COMMUNITY,
+            Permissions.RUNTIME_VISIBLE));
+    entries.add(restEntry("Admin", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.OWNER));
+    acl.setAclEntries(entries);
+    AclList list = new AclList();
+    list.add(acl);
+
+    java.util.List<IPSAcl> converted = ApiUtils.convertAcls(list);
+    PSAclImpl pAcl = (PSAclImpl) converted.get(0);
+    assertEquals(7, pAcl.getId());
+    assertEquals(31, pAcl.getObjectType());
+    assertEquals(5, pAcl.getObjectId());
+    assertNotNull(pAcl.getGUID());
+    var names =
+        pAcl.getEntries().stream()
+            .map(e -> ((PSAclEntryImpl) e).getName())
+            .collect(Collectors.toSet());
+    assertEquals(java.util.Set.of("Default", "AnyCommunity", "Admin"), names);
+  }
+
+  private static void addEntry(
+      PSAclImpl acl,
+      String name,
+      IPSTypedPrincipal.PrincipalTypes type,
+      PSPermissions permission) {
+    PSAclEntryImpl entry = new PSAclEntryImpl(new PSTypedPrincipal(name, type));
+    entry.addPermission(new PSAccessLevelImpl(entry, permission));
+    acl.addEntry(entry);
+  }
+
+  private static AclEntry restEntry(
+      String name, IPSTypedPrincipal.PrincipalTypes type, Permissions perm) {
+    AclEntry entry = new AclEntry();
+    entry.setName(name);
+    entry.setType(new TypedPrincipal(name, type));
+    UserAccessLevelList levels = new UserAccessLevelList();
+    UserAccessLevel level = new UserAccessLevel();
+    level.setPermission(perm);
+    levels.add(level);
+    entry.setPermissions(levels);
+    return entry;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/acls/Acl.java
+++ b/rest/src/main/java/com/percussion/rest/acls/Acl.java
@@ -17,14 +17,20 @@
 
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 import java.util.Optional;
 
 /** REST representation of an access control list. */
 @XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
 @Schema(description = "Acl")
 public class Acl {
 
@@ -32,25 +38,25 @@ public class Acl {
   private long id;
 
   /** Optional GUID identifying the ACL. */
-  private Guid guid;
+  @XmlElement @JsonProperty private Guid guid;
 
   /** Human-readable name of the ACL. */
-  private String name;
+  @XmlElement @JsonProperty private String name;
 
   /** Identifier of the secured object. */
   private long objectId;
 
   /** Free-form description of the ACL. */
-  private String description;
+  @XmlElement @JsonProperty private String description;
 
   /** Entries that make up the ACL. */
-  private AclEntryList aclEntries;
+  @XmlElement @JsonProperty private AclEntryList aclEntries;
 
   /** Type identifier of the secured object. */
   private int objectType;
 
   /** Optional GUID of the secured object. */
-  private Guid objectGuid; // fixed typo
+  @XmlElement @JsonProperty private Guid objectGuid;
 
   /** No-op constructor. */
   public Acl() {}
@@ -109,6 +115,7 @@ public class Acl {
    *
    * @return the GUID, may be empty
    */
+  @JsonIgnore
   public Optional<Guid> getGuid() {
     return Optional.ofNullable(guid);
   }
@@ -127,6 +134,7 @@ public class Acl {
    *
    * @return the name, may be empty
    */
+  @JsonIgnore
   public Optional<String> getName() {
     return Optional.ofNullable(name);
   }
@@ -163,6 +171,7 @@ public class Acl {
    *
    * @return the description, may be empty
    */
+  @JsonIgnore
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);
   }
@@ -181,6 +190,7 @@ public class Acl {
    *
    * @return the entries, may be empty
    */
+  @JsonIgnore
   public Optional<AclEntryList> getAclEntries() {
     return Optional.ofNullable(aclEntries);
   }
@@ -217,6 +227,7 @@ public class Acl {
    *
    * @return the object GUID, may be empty
    */
+  @JsonIgnore
   public Optional<Guid> getObjectGuid() {
     return Optional.ofNullable(objectGuid);
   }

--- a/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
@@ -18,13 +18,19 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 import java.util.Optional;
 
 /** REST representation of an ACL entry. */
 @XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
 @Schema(description = "AclEntry")
 public class AclEntry {
 
@@ -32,16 +38,16 @@ public class AclEntry {
   private long id;
 
   /** Human-readable name of the entry. */
-  private String name;
+  @XmlElement @JsonProperty private String name;
 
   /** Principal associated with the entry, may be {@code null}. */
-  private Principal principal;
+  @XmlElement @JsonProperty private Principal principal;
 
   /** Typed principal classification. */
-  private TypedPrincipal type;
+  @XmlElement @JsonProperty private TypedPrincipal type;
 
   /** Permission set granted by this entry. */
-  private UserAccessLevelList permissions;
+  @XmlElement @JsonProperty private UserAccessLevelList permissions;
 
   /** Identifier of the owning ACL. */
   private long aclId;
@@ -115,6 +121,7 @@ public class AclEntry {
    *
    * @return the name, may be empty
    */
+  @JsonIgnore
   public Optional<String> getName() {
     return Optional.ofNullable(name);
   }
@@ -133,6 +140,7 @@ public class AclEntry {
    *
    * @return the principal, may be empty
    */
+  @JsonIgnore
   public Optional<Principal> getPrincipal() {
     return Optional.ofNullable(principal);
   }
@@ -151,6 +159,7 @@ public class AclEntry {
    *
    * @return the type, may be empty
    */
+  @JsonIgnore
   public Optional<TypedPrincipal> getType() {
     return Optional.ofNullable(type);
   }
@@ -169,6 +178,7 @@ public class AclEntry {
    *
    * @return the permissions, may be empty
    */
+  @JsonIgnore
   public Optional<UserAccessLevelList> getPermissions() {
     return Optional.ofNullable(permissions);
   }

--- a/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
@@ -19,6 +19,7 @@ package com.percussion.rest.acls;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.rest.Guid;
+import com.percussion.rest.JacksonContextResolver;
 import com.percussion.rest.Status;
 import com.percussion.security.IPSTypedPrincipal;
 import jakarta.ws.rs.WebApplicationException;
@@ -86,6 +88,63 @@ public class AclResourceTest {
     Acl out = resource.loadAclForObject("0-31-5");
     assertSame(acl, out);
     verify(adaptor).loadAclForObject(any(Guid.class));
+  }
+
+  @Test
+  public void jacksonWritesAclEntriesOnGetShape() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    acl.setObjectType(31);
+    acl.setObjectId(5);
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclEntryList entries = new AclEntryList();
+    entries.add(namedEntry("Default"));
+    entries.add(namedEntry("AnyCommunity"));
+    entries.add(namedEntry("Admin"));
+    acl.setAclEntries(entries);
+
+    String json = new JacksonContextResolver().getContext(Acl.class).writeValueAsString(acl);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("AnyCommunity"), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("By_Author ACL"), json);
+    assertTrue(json.contains("aclEntries") || json.contains("AclEntries"), json);
+  }
+
+  @Test
+  public void loadAclForObjectReturnsDefaultAnyCommunityAndUserAfterSave() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    acl.setObjectType(31);
+    acl.setObjectId(5);
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclEntryList entries = new AclEntryList();
+    entries.add(namedEntry("Default"));
+    entries.add(namedEntry("AnyCommunity"));
+    entries.add(namedEntry("Admin"));
+    acl.setAclEntries(entries);
+    when(adaptor.loadAclForObject(any(Guid.class))).thenReturn(acl);
+
+    Acl out = resource.loadAclForObject("0-31-5");
+    assertEquals(3, out.getAclEntries().orElseThrow().size());
+    assertEquals("Default", out.getAclEntries().get().get(0).getName().orElse(null));
+    assertEquals("AnyCommunity", out.getAclEntries().get().get(1).getName().orElse(null));
+    assertEquals("Admin", out.getAclEntries().get().get(2).getName().orElse(null));
+    assertEquals(31, out.getObjectType());
+    assertEquals(5, out.getObjectId());
+  }
+
+  private static AclEntry namedEntry(String name) {
+    AclEntry entry = new AclEntry();
+    entry.setName(name);
+    entry.setType(new TypedPrincipal(name, IPSTypedPrincipal.PrincipalTypes.USER));
+    return entry;
   }
 
   @Test

--- a/system/services/src/com/percussion/services/security/PSAclPersistMerger.java
+++ b/system/services/src/com/percussion/services/security/PSAclPersistMerger.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.security;
+
+import com.percussion.services.security.data.PSAclImpl;
+import com.percussion.utils.guid.IPSGuid;
+
+/**
+ * Merge a converted REST/wire ACL onto an existing Hibernate identity so save
+ * updates {@code PSX_ACLS} instead of inserting a duplicate {@code PK_PSX_ACLS}
+ * (#3384).
+ */
+public final class PSAclPersistMerger {
+
+  private PSAclPersistMerger() {}
+
+  /**
+   * Copy incoming name/description/entries onto {@code existing} while keeping
+   * the persisted SYSID, version, and object identity when the wire object
+   * omitted them.
+   *
+   * @param existing loaded ACL with a real SYSID, or {@code null} when this is
+   *     a first insert
+   * @param incoming converted payload, not {@code null} when {@code existing} is
+   *     {@code null}
+   * @return the instance Hibernate should merge/persist
+   */
+  public static PSAclImpl mergeOntoExisting(PSAclImpl existing, PSAclImpl incoming) {
+    if (existing == null) {
+      return incoming;
+    }
+    if (incoming == null || existing == incoming) {
+      return existing;
+    }
+    Integer version = existing.getVersion();
+    long id = existing.getId();
+    IPSGuid guid = existing.getGUID();
+    long objectId = existing.getObjectId();
+    int objectType = existing.getObjectType();
+    existing.merge(incoming);
+    if (incoming.getVersion() == null && version != null) {
+      existing.setVersion(version);
+    }
+    if (existing.getId() == 0 && id != 0) {
+      existing.setId(id);
+    }
+    if (guid != null && (existing.getGUID() == null || existing.getGUID().longValue() == 0)) {
+      existing.setGUID(guid);
+    }
+    if (incoming.getObjectId() <= 0 && objectId > 0) {
+      existing.setObjectId(objectId);
+    }
+    if (incoming.getObjectType() <= 0 && objectType > 0) {
+      existing.setObjectType(objectType);
+    }
+    return existing;
+  }
+}

--- a/system/services/src/com/percussion/services/security/impl/PSAclService.java
+++ b/system/services/src/com/percussion/services/security/impl/PSAclService.java
@@ -32,6 +32,7 @@ import com.percussion.services.security.IPSAcl;
 import com.percussion.services.security.IPSAclEntry;
 import com.percussion.services.security.IPSAclService;
 import com.percussion.services.security.IPSSecurityErrors;
+import com.percussion.services.security.PSAclPersistMerger;
 import com.percussion.services.security.PSPermissions;
 import com.percussion.services.security.PSServiceSecurityException;
 import com.percussion.services.security.PSTypedPrincipal;
@@ -348,7 +349,9 @@ public class PSAclService implements IPSAclService
             Root<PSAclImpl> critRoot = criteria.from(PSAclImpl.class);
 
             if (guid != null)
-               criteria.where(builder.equal(critRoot.get("objectId"), (long) guid.getUUID()));
+               criteria.where(
+                   builder.equal(critRoot.get("objectId"), (long) guid.getUUID()),
+                   builder.equal(critRoot.get("objectType"), guid.getType()));
 
             List<PSAclImpl> results =  entityManager.createQuery(criteria).getResultList();
             if(results != null && !results.isEmpty()) {
@@ -664,6 +667,9 @@ public class PSAclService implements IPSAclService
          if(iacl != null) {
             try {
                ms_logger.debug("Saving ACL: {}" , iacl);
+               if (iacl instanceof PSAclImpl src) {
+                  iacl = PSAclPersistMerger.mergeOntoExisting(findExistingPersistIdentity(src), src);
+               }
               iacl = (IPSAcl) getSession().merge(iacl);
                updatedList.add(iacl);
                 ms_logger.debug("Save complete.");
@@ -673,13 +679,64 @@ public class PSAclService implements IPSAclService
                } catch (Exception e) {
                   ms_logger.error("Error persisting Acl: {} " , iacl.getId());
                }
+               throw new PSServiceSecurityException(
+                  IPSSecurityErrors.ACL_SAVE_ERROR, ex, iacl.getId(), ex.getLocalizedMessage());
             }
          }
       }
 
       getSession().flush();
+      for (IPSAcl saved : updatedList) {
+         evictAclSecondLevelCache(saved);
+      }
 
       return updatedList;
+   }
+
+   /** Stale L2/collection cache would make GET after save look empty (#3384). */
+   private void evictAclSecondLevelCache(IPSAcl acl) {
+      if (acl == null) {
+         return;
+      }
+      try {
+         var cache = getSession().getSessionFactory().getCache();
+         if (cache != null) {
+            cache.evictEntityData(PSAclImpl.class, acl.getId());
+            cache.evictCollectionData(PSAclImpl.class.getName() + ".entries", acl.getId());
+         }
+      } catch (RuntimeException e) {
+         ms_logger.debug("ACL L2 cache evict skipped for id {}", acl.getId(), e);
+      }
+   }
+
+   /**
+    * Load the persisted {@link PSAclImpl} for this SYSID or object GUID so
+    * Hibernate updates that row instead of inserting a duplicate {@code PK_PSX_ACLS}.
+    */
+   private PSAclImpl findExistingPersistIdentity(PSAclImpl src)
+   {
+      if (src == null)
+      {
+         return null;
+      }
+      if (src.getId() != 0)
+      {
+         PSAclImpl byId = getSession().get(PSAclImpl.class, src.getId());
+         if (byId != null)
+         {
+            return byId;
+         }
+      }
+      IPSGuid objectGuid = src.getObjectGuid();
+      if (objectGuid != null)
+      {
+         IPSAcl byObject = loadAclForObjectModifiable(objectGuid);
+         if (byObject instanceof PSAclImpl impl)
+         {
+            return impl;
+         }
+      }
+      return null;
    }
 
    @Override

--- a/system/src/test/java/com/percussion/services/security/PSAclPersistMergerTest.java
+++ b/system/src/test/java/com/percussion/services/security/PSAclPersistMergerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
+import com.percussion.services.security.data.PSAccessLevelImpl;
+import com.percussion.services.security.data.PSAclEntryImpl;
+import com.percussion.services.security.data.PSAclImpl;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Merge-vs-insert identity for Display Format Object ACL save (#3384).
+ *
+ * <p>Hibernate {@code session.merge} on a new {@link PSAclImpl} that reuses an existing SYSID
+ * inserts a duplicate {@code PK_PSX_ACLS}. The persist path must copy entries onto the loaded
+ * identity and keep version / object identity.
+ */
+@Tag("UnitTest")
+class PSAclPersistMergerTest {
+
+  @Test
+  void nullExistingReturnsIncomingForInsert() {
+    PSAclImpl incoming = newAcl(0, null, 31, 5);
+    addEntry(incoming, "Admin", PrincipalTypes.USER, PSPermissions.OWNER);
+
+    assertSame(incoming, PSAclPersistMerger.mergeOntoExisting(null, incoming));
+  }
+
+  @Test
+  void sameInstanceIsUnchanged() {
+    PSAclImpl existing = newAcl(42, 3, 31, 5);
+    assertSame(existing, PSAclPersistMerger.mergeOntoExisting(existing, existing));
+  }
+
+  @Test
+  void mergeKeepsExistingSysidAndVersion() {
+    PSAclImpl existing = newAcl(42, 3, 31, 5);
+    addEntry(existing, "Admin", PrincipalTypes.USER, PSPermissions.OWNER);
+
+    PSAclImpl incoming = newAcl(42, null, 31, 5);
+    addEntry(incoming, "Default", PrincipalTypes.USER, PSPermissions.READ);
+    addEntry(incoming, "AnyCommunity", PrincipalTypes.COMMUNITY, PSPermissions.RUNTIME_VISIBLE);
+    addEntry(incoming, "Admin", PrincipalTypes.USER, PSPermissions.OWNER);
+
+    PSAclImpl merged = PSAclPersistMerger.mergeOntoExisting(existing, incoming);
+
+    assertSame(existing, merged, "must reuse Hibernate identity — not a new insert");
+    assertNotSame(incoming, merged);
+    assertEquals(42, merged.getId());
+    assertEquals(Integer.valueOf(3), merged.getVersion());
+    assertEquals(31, merged.getObjectType());
+    assertEquals(5, merged.getObjectId());
+    assertEquals(
+        Set.of("Default", "AnyCommunity", "Admin"),
+        merged.getEntries().stream().map(e -> ((PSAclEntryImpl) e).getName()).collect(Collectors.toSet()));
+  }
+
+  @Test
+  void mergeDoesNotWipeObjectIdentityWhenIncomingOmitsIt() {
+    PSAclImpl existing = newAcl(7, 1, 31, 5);
+    addEntry(existing, "Admin", PrincipalTypes.USER, PSPermissions.OWNER);
+
+    PSAclImpl incoming = newAcl(7, null, 0, 0);
+    addEntry(incoming, "Default", PrincipalTypes.USER, PSPermissions.READ);
+    addEntry(incoming, "AnyCommunity", PrincipalTypes.COMMUNITY, PSPermissions.RUNTIME_VISIBLE);
+    addEntry(incoming, "Admin", PrincipalTypes.USER, PSPermissions.OWNER);
+
+    PSAclImpl merged = PSAclPersistMerger.mergeOntoExisting(existing, incoming);
+    assertEquals(31, merged.getObjectType());
+    assertEquals(5, merged.getObjectId());
+    assertTrue(merged.getObjectGuid().toString().contains("31"));
+  }
+
+  private static PSAclImpl newAcl(long id, Integer version, int objectType, long objectId) {
+    PSAclImpl acl = new PSAclImpl();
+    if (id != 0) {
+      acl.setId(id);
+    }
+    acl.setVersion(version);
+    acl.setName("By_Author ACL");
+    acl.setObjectType(objectType);
+    if (objectId > 0) {
+      acl.setObjectId(objectId);
+    }
+    return acl;
+  }
+
+  private static void addEntry(
+      PSAclImpl acl, String name, PrincipalTypes type, PSPermissions permission) {
+    PSAclEntryImpl entry = new PSAclEntryImpl(new PSTypedPrincipal(name, type));
+    entry.addPermission(new PSAccessLevelImpl(entry, permission));
+    acl.addEntry(entry);
+  }
+}


### PR DESCRIPTION
## Summary

Display Format Object ACL Save after #3378/#3386 was HTTP 200 (or 500 `PK_PSX_ACLS`) but reopen showed an empty table. `AclAdaptor.saveAcls` / `ApiUtils.convertAcls` always built a **new** `PSAclImpl`; Hibernate then inserted a duplicate `PSX_ACLS` row or updated identity without a GET-visible entry list.

This PR:

1. Loads the existing ACL by `objectGuid` / SYSID and **merges** entries onto that identity (`PSAclPersistMerger`), preserving version and object type/id.
2. `PSAclService.internalPersist` does the same lookup in-session, filters load-by-object on `objectType` as well as `objectId`, evicts L2/collection cache after flush, and **rethrows** persist failures (`ACL_SAVE_ERROR`) instead of swallowing them into a false 200.
3. GET `/services/acls/object/{guid}` now serializes `name`, `objectGuid`, and `aclEntries` (JAXB field access + `@JsonProperty`). Optional getters had been dropped by the live JAX-RS writer, so reopen looked empty even when rows were in the DB.
4. Playwright `developer-object-acl-display-format-save.spec.js` requires Default + AnyCommunity + Admin after reopen (no longer accepts `no-entries`).

Fixes #3384  
Parent: #2640 (QA Object ACL peer mounts)  
Slice of: #3378 / cluster #3386

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `mvnw clean install`: `system`, `rest`, `projects/sitemanage` (see C3).
2. H2 QA: `perc-devctl qa-up` → hot-deploy `perc-system`, `rest`, `sitemanage` + `sitemanage-beans.xml` (aclListJsonReader) → `qa-health`.
3. PUT `/services/acls/bulk` with AclList envelope (Default + AnyCommunity + Admin) on Display Format `0-31-5` → 200.
4. GET `/services/acls/object/0-31-5` includes those three `aclEntries` plus `name` / `objectGuid`.
5. Playwright: `npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js` (1 passed).
6. Confirm no `PK_PSX_ACLS` ERROR in `server.log` on the save window.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md`, `product-docs/8.2/admin/object-acl.md`, `product-docs/8.2/admin/users-roles.md` (PUT merges existing ACL; GET-after-save returns Default / AnyCommunity / USER)
- [x] **Unit / module tests** — `PSAclPersistMergerTest` (4), `AclAdaptorSaveMergeTest` (2), `ApiUtilsAclConvertTest` (+GET shape), `AclResourceTest` GET/serialize; module clean installs green
- [x] **WebUI + Playwright** — tightened `developer-object-acl-display-format-save.spec.js`; H2 surface 1 passed
- [x] **Build gates** — standalone clean install on each changed Maven module (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

## C3 evidence

- **modules_built:** `system`, `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (`PSAclPersistMergerTest` Tests run: 4, Failures: 0)
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 390, Failures: 0; `AclResourceTest` 6)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (`AclAdaptorSaveMergeTest` Tests run: 2; `ApiUtilsAclConvertTest` Tests run: 10)
- **downstream_checked:** no public method/ctor made final/sealed or signature-changed; `sitemanage` standalone clean install is the reverse-dep of system ACL persist; rest suite green after Acl DTO field-access change

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy (after qa-up, after jar/XML deploy + Jetty Stop/Start inside cell)
- Deploy: `docker cp` `perc-system-8.2.0-SNAPSHOT.jar`, `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar` → `WEB-INF/lib`; also copied `sitemanage-beans.xml` (`aclListJsonReader`); Jetty restart via `StopJetty.sh` / `StartJetty.sh` (not `docker restart`)
- `npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js` — **1 passed**
- console-clean=yes (spec collector; no uncaught pageerror)
- server.log-clean=yes (no `PK_PSX_ACLS` / persist ERROR on the save window)

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.