### PR TITLE
fix(webui): empty Object ACL Runtime columns + isolate Template load (#3377)

### DIFF
--- a/WebUI/src/main/ts/developer/DeveloperSectionErrorBoundary.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperSectionErrorBoundary.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { DEV_MSG } from "./messages";
+
+export interface DeveloperSectionErrorBoundaryProps {
+  /** Tab or panel label interpolated into SECTION_LOAD_FAILED ({0}). */
+  label: string;
+  children: React.ReactNode;
+  /** Override the in-panel error test id (default developer-section-error). */
+  testId?: string;
+}
+
+interface DeveloperSectionErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Isolates a single Developer tab or detail panel. A Template (or other
+ * section) render/load throw must not replace the whole Developer route with
+ * RouteErrorBoundary ("Unable to load Developer") — #3377 / peer of
+ * AdminSectionErrorBoundary (#3195).
+ */
+export class DeveloperSectionErrorBoundary extends React.Component<
+  DeveloperSectionErrorBoundaryProps,
+  DeveloperSectionErrorBoundaryState
+> {
+  state: DeveloperSectionErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(
+    error: Error,
+  ): DeveloperSectionErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error(
+      `[PercModernUI] Developer section failed (${this.props.label})`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      const testId = this.props.testId ?? "developer-section-error";
+      return (
+        <div data-testid={testId} role="alert">
+          <p>
+            {DEV_MSG.SECTION_LOAD_FAILED.replace("{0}", this.props.label)}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -45,6 +45,7 @@ import { TemplatesPanel } from "./TemplatesPanel";
 import { ViewsPanel } from "./ViewsPanel";
 import { WorkflowsPanel } from "./WorkflowsPanel";
 import { catalogColors } from "./catalogStyles";
+import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 
 
 export type { DeveloperSection };
@@ -164,51 +165,56 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
         aria-labelledby={`tab-developer-${active}`}
         data-testid={`panel-developer-${active}`}
       >
-        {active === "content-types" ? (
-          <ContentTypesPanel />
-        ) : active === "templates" ? (
-          <TemplatesPanel />
-        ) : active === "slots" ? (
-          <SlotsPanel />
-        ) : active === "keywords" ? (
-          <KeywordsPanel />
-        ) : active === "locales" ? (
-          <LocalesPanel />
-        ) : active === "shared-fields" ? (
-          <SharedFieldsPanel />
-        ) : active === "system-def" ? (
-          <SystemDefPanel />
-        ) : active === "item-filters" ? (
-          <ItemFiltersPanel />
-        ) : active === "display-formats" ? (
-          <DisplayFormatsPanel />
-        ) : active === "action-menus" ? (
-          <ActionMenusPanel />
-        ) : active === "searches" ? (
-          <SearchesPanel />
-        ) : active === "views" ? (
-          <ViewsPanel />
-        ) : active === "extensions" ? (
-          <ExtensionsPanel />
-        ) : active === "relationship-types" ? (
-          <RelationshipTypesPanel />
-        ) : active === "workflows" ? (
-          <WorkflowsPanel />
-        ) : active === "server-configs" ? (
-          <ServerConfigsPanel />
-        ) : active === "ce-controls" ? (
-          <ControlsPanel />
-        ) : active === "sites" ? (
-          <SitesPanel />
-        ) : active === "communities" ? (
-          <CommunitiesPanel />
-        ) : active === "community-visibility" ? (
-          <CommunityVisibilityNavigatorPanel />
-        ) : active === "pipelines" ? (
-          <PipelinesPanel />
-        ) : (
-          <DeveloperPreferencesPanel />
-        )}
+        <DeveloperSectionErrorBoundary
+          key={active}
+          label={SECTION_LABEL[active]}
+        >
+          {active === "content-types" ? (
+            <ContentTypesPanel />
+          ) : active === "templates" ? (
+            <TemplatesPanel />
+          ) : active === "slots" ? (
+            <SlotsPanel />
+          ) : active === "keywords" ? (
+            <KeywordsPanel />
+          ) : active === "locales" ? (
+            <LocalesPanel />
+          ) : active === "shared-fields" ? (
+            <SharedFieldsPanel />
+          ) : active === "system-def" ? (
+            <SystemDefPanel />
+          ) : active === "item-filters" ? (
+            <ItemFiltersPanel />
+          ) : active === "display-formats" ? (
+            <DisplayFormatsPanel />
+          ) : active === "action-menus" ? (
+            <ActionMenusPanel />
+          ) : active === "searches" ? (
+            <SearchesPanel />
+          ) : active === "views" ? (
+            <ViewsPanel />
+          ) : active === "extensions" ? (
+            <ExtensionsPanel />
+          ) : active === "relationship-types" ? (
+            <RelationshipTypesPanel />
+          ) : active === "workflows" ? (
+            <WorkflowsPanel />
+          ) : active === "server-configs" ? (
+            <ServerConfigsPanel />
+          ) : active === "ce-controls" ? (
+            <ControlsPanel />
+          ) : active === "sites" ? (
+            <SitesPanel />
+          ) : active === "communities" ? (
+            <CommunitiesPanel />
+          ) : active === "community-visibility" ? (
+            <CommunityVisibilityNavigatorPanel />
+          ) : active === "pipelines" ? (
+            <PipelinesPanel />
+          ) : (
+            <DeveloperPreferencesPanel />
+          )}
+        </DeveloperSectionErrorBoundary>
       </div>
     </div>
   );

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -633,6 +633,7 @@ export function ObjectAclSection({
       data-testid={`${testIdPrefix}-section`}
       data-acl-object-kind={objectKind ?? "unknown"}
       data-acl-has-guid="true"
+      data-acl-show-runtime={showRuntimeColumns ? "true" : "false"}
     >
       <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.ACL_TITLE}</h3>
       <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.ACL_HINT}</p>
@@ -746,32 +747,50 @@ export function ObjectAclSection({
             <p style={{ color: catalogColors.empty }} data-testid={`${testIdPrefix}-no-entries`}>
               {DEV_MSG.ACL_NO_ENTRIES}
             </p>
-          ) : (
-            <div style={{ overflowX: "auto", marginTop: "8px" }}>
-              <table
-                data-testid={`${testIdPrefix}-table`}
-                data-acl-show-runtime={showRuntimeColumns ? "true" : "false"}
-                data-acl-object-kind={objectKind ?? "unknown"}
-                style={{
-                  width: "100%",
-                  borderCollapse: "collapse",
-                  fontSize: "0.9rem",
-                }}
-              >
-                <thead>
-                  {/* Layer group headers — Design access | Runtime visibility (CD-19) */}
-                  <tr
-                    style={tableHeaderRow}
-                    data-testid={`${testIdPrefix}-layer-headers`}
+          ) : null}
+          {/* Always render Design + Runtime headers — even with zero draft rows
+              (#3377). Runtime-relevant kinds must not wait for a first entry. */}
+          <div style={{ overflowX: "auto", marginTop: "8px" }}>
+            <table
+              data-testid={`${testIdPrefix}-table`}
+              data-acl-show-runtime={showRuntimeColumns ? "true" : "false"}
+              data-acl-object-kind={objectKind ?? "unknown"}
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                fontSize: "0.9rem",
+              }}
+            >
+              <thead>
+                {/* Layer group headers — Design access | Runtime visibility (CD-19) */}
+                <tr
+                  style={tableHeaderRow}
+                  data-testid={`${testIdPrefix}-layer-headers`}
+                >
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_ENTRY}
+                  </th>
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_TYPE}
+                  </th>
+                  <th
+                    colSpan={designPerms.length}
+                    style={{
+                      padding: "6px 8px",
+                      textAlign: "center",
+                      fontSize: "0.8rem",
+                      borderBottom: `1px solid ${catalogColors.softBorder}`,
+                      background: "rgba(0,0,0,0.02)",
+                    }}
+                    title={DEV_MSG.ACL_LAYER_DESIGN_HINT}
+                    data-testid={`${testIdPrefix}-layer-design`}
+                    data-acl-layer={"design" satisfies AclPermissionLayer}
                   >
-                    <th style={{ padding: "8px" }} rowSpan={2}>
-                      {DEV_MSG.ACL_COL_ENTRY}
-                    </th>
-                    <th style={{ padding: "8px" }} rowSpan={2}>
-                      {DEV_MSG.ACL_COL_TYPE}
-                    </th>
+                    {DEV_MSG.ACL_LAYER_DESIGN}
+                  </th>
+                  {showRuntimeColumns ? (
                     <th
-                      colSpan={designPerms.length}
+                      colSpan={runtimePerms.length}
                       style={{
                         padding: "6px 8px",
                         textAlign: "center",
@@ -779,57 +798,41 @@ export function ObjectAclSection({
                         borderBottom: `1px solid ${catalogColors.softBorder}`,
                         background: "rgba(0,0,0,0.02)",
                       }}
-                      title={DEV_MSG.ACL_LAYER_DESIGN_HINT}
-                      data-testid={`${testIdPrefix}-layer-design`}
-                      data-acl-layer={"design" satisfies AclPermissionLayer}
+                      title={DEV_MSG.ACL_LAYER_RUNTIME_HINT}
+                      data-testid={`${testIdPrefix}-layer-runtime`}
+                      data-acl-layer={"runtime" satisfies AclPermissionLayer}
                     >
-                      {DEV_MSG.ACL_LAYER_DESIGN}
+                      {DEV_MSG.ACL_LAYER_RUNTIME}
                     </th>
-                    {showRuntimeColumns ? (
-                      <th
-                        colSpan={runtimePerms.length}
-                        style={{
-                          padding: "6px 8px",
-                          textAlign: "center",
-                          fontSize: "0.8rem",
-                          borderBottom: `1px solid ${catalogColors.softBorder}`,
-                          background: "rgba(0,0,0,0.02)",
-                        }}
-                        title={DEV_MSG.ACL_LAYER_RUNTIME_HINT}
-                        data-testid={`${testIdPrefix}-layer-runtime`}
-                        data-acl-layer={"runtime" satisfies AclPermissionLayer}
-                      >
-                        {DEV_MSG.ACL_LAYER_RUNTIME}
-                      </th>
-                    ) : null}
-                    <th style={{ padding: "8px" }} rowSpan={2}>
-                      {DEV_MSG.ACL_COL_ACTIONS}
+                  ) : null}
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_ACTIONS}
+                  </th>
+                </tr>
+                <tr
+                  style={tableHeaderRow}
+                  data-testid={`${testIdPrefix}-perm-headers`}
+                >
+                  {visiblePermissions.map((p) => (
+                    <th
+                      key={p}
+                      style={{
+                        padding: "8px",
+                        textAlign: "center",
+                        fontSize: "0.8rem",
+                        fontWeight: 500,
+                      }}
+                      data-testid={`${testIdPrefix}-perm-header-${p}`}
+                      data-acl-permission={p}
+                      title={p}
+                    >
+                      {permissionColumnLabel(p)}
                     </th>
-                  </tr>
-                  <tr
-                    style={tableHeaderRow}
-                    data-testid={`${testIdPrefix}-perm-headers`}
-                  >
-                    {visiblePermissions.map((p) => (
-                      <th
-                        key={p}
-                        style={{
-                          padding: "8px",
-                          textAlign: "center",
-                          fontSize: "0.8rem",
-                          fontWeight: 500,
-                        }}
-                        data-testid={`${testIdPrefix}-perm-header-${p}`}
-                        data-acl-permission={p}
-                        title={p}
-                      >
-                        {permissionColumnLabel(p)}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {draftEntries.map((e) => {
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {draftEntries.map((e) => {
                     const key = e.clientKey;
                     const chosen = selected[key] ?? new Set<string>();
                     const label = entryLabel(e);
@@ -906,7 +909,6 @@ export function ObjectAclSection({
                 </tbody>
               </table>
             </div>
-          )}
 
           {missingSpecials.length > 0 ? (
             <div

--- a/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
@@ -315,7 +315,7 @@ export function TemplateDetailPanel({
     detail != null &&
     (label !== (detail.label || "") ||
       description !== (detail.description || "") ||
-      source !== (detail.templateSource || "") ||
+      source !== asSourceText(detail.templateSource) ||
       !bindingsEqual(bindings, initialBindings) ||
       !slotsEqual(slotKeys, initialSlotKeys));
 

--- a/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
@@ -93,8 +93,38 @@ const inputStyle: React.CSSProperties = {
   boxSizing: "border-box",
 };
 
-function cloneBindings(list: TemplateBindingSummary[] | undefined): TemplateBindingSummary[] {
-  return (list || []).map((b) => ({
+function asBindingList(raw: unknown): TemplateBindingSummary[] {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === "object") {
+    const env = raw as { Binding?: unknown; TemplateBinding?: unknown };
+    const nested = env.Binding ?? env.TemplateBinding;
+    if (Array.isArray(nested)) return nested as TemplateBindingSummary[];
+    if (nested && typeof nested === "object") {
+      return [nested as TemplateBindingSummary];
+    }
+  }
+  return [];
+}
+
+function asSlotList(raw: unknown): TemplateSlotSummary[] {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === "object") {
+    const env = raw as { Slot?: unknown; TemplateSlot?: unknown };
+    const nested = env.Slot ?? env.TemplateSlot;
+    if (Array.isArray(nested)) return nested as TemplateSlotSummary[];
+    if (nested && typeof nested === "object") {
+      return [nested as TemplateSlotSummary];
+    }
+  }
+  return [];
+}
+
+function asSourceText(raw: unknown): string {
+  return typeof raw === "string" ? raw : raw == null ? "" : String(raw);
+}
+
+function cloneBindings(list: unknown): TemplateBindingSummary[] {
+  return asBindingList(list).map((b) => ({
     executionOrder: b.executionOrder,
     variable: b.variable || "",
     expression: b.expression || "",
@@ -245,21 +275,26 @@ export function TemplateDetailPanel({
     Promise.all([getTemplateDetail(idOrName), listSlots().catch(() => [] as SlotSummary[])])
       .then(([d, slots]) => {
         if (cancelled) return;
-        setDetail(d);
-        setLabel(d.label || "");
-        setDescription(d.description || "");
-        setSource(d.templateSource || "");
-        setBindings(cloneBindings(d.bindings));
-        setExpandedExprRows(new Set());
-        setSlotKeys(
-          new Set(
-            (d.slots || [])
-              .map((s) => slotKey(s))
-              .filter((k) => k.length > 0),
-          ),
-        );
-        setAllSlots(slots);
-        setLoading(false);
+        try {
+          const sourceText = asSourceText(d?.templateSource);
+          const slotRows = asSlotList(d?.slots);
+          setDetail(d);
+          setLabel(d?.label || "");
+          setDescription(d?.description || "");
+          setSource(sourceText);
+          setBindings(cloneBindings(d?.bindings));
+          setExpandedExprRows(new Set());
+          setSlotKeys(
+            new Set(slotRows.map((s) => slotKey(s)).filter((k) => k.length > 0)),
+          );
+          setAllSlots(Array.isArray(slots) ? slots : []);
+          setLoading(false);
+        } catch (applyErr: unknown) {
+          // Missing / envelope fields must stay in-panel — never unmount Developer.
+          setError(panelErrMsg(applyErr, DEV_MSG.TPL_DETAIL_ERROR));
+          setDetail(null);
+          setLoading(false);
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -273,7 +308,7 @@ export function TemplateDetailPanel({
 
   const initialBindings = cloneBindings(detail?.bindings);
   const initialSlotKeys = new Set(
-    (detail?.slots || []).map((s) => slotKey(s)).filter((k) => k.length > 0),
+    asSlotList(detail?.slots).map((s) => slotKey(s)).filter((k) => k.length > 0),
   );
 
   const dirty =
@@ -376,11 +411,11 @@ export function TemplateDetailPanel({
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
-      setSource(saved.templateSource || "");
+      setSource(asSourceText(saved.templateSource));
       setBindings(cloneBindings(saved.bindings));
       setSlotKeys(
         new Set(
-          (saved.slots || [])
+          asSlotList(saved.slots)
             .map((s) => slotKey(s))
             .filter((x) => x.length > 0),
         ),
@@ -396,7 +431,7 @@ export function TemplateDetailPanel({
   const slotsForTable =
     allSlots.length > 0
       ? allSlots
-      : (detail?.slots || []).map((s) => ({
+      : asSlotList(detail?.slots).map((s) => ({
           name: s.name,
           label: s.label,
           guid: s.guid,
@@ -828,11 +863,11 @@ export function TemplateDetailPanel({
             testIdPrefix="developer-tpl-acl"
           />
 
-          {(detail.designGaps || []).length > 0 ? (
+          {Array.isArray(detail.designGaps) && detail.designGaps.length > 0 ? (
             <section data-testid="developer-tpl-gaps">
               <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.TPL_GAPS}</h3>
               <ul style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
-                {(detail.designGaps || []).map((g, i) => (
+                {detail.designGaps.map((g, i) => (
                   <li key={designGapKey(g, i)} data-gap-code={designGapCode(g)}>
                     {formatDesignGap(g)}
                   </li>

--- a/WebUI/src/main/ts/developer/TemplatesPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplatesPanel.tsx
@@ -23,6 +23,7 @@ import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
 import { monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 import { TemplateDetailPanel } from "./TemplateDetailPanel";
 
 /** Open-key for detail route; null when the row is not selectable. */
@@ -80,11 +81,16 @@ export function TemplatesPanel(): React.ReactElement {
 
   if (selected) {
     return (
-      <TemplateDetailPanel
-        idOrName={selected.idOrName}
-        catalogGuid={selected.catalogGuid}
-        onBack={() => setSelected(null)}
-      />
+      <DeveloperSectionErrorBoundary
+        label={DEV_MSG.TAB_TEMPLATES}
+        testId="developer-tpl-panel-error"
+      >
+        <TemplateDetailPanel
+          idOrName={selected.idOrName}
+          catalogGuid={selected.catalogGuid}
+          onBack={() => setSelected(null)}
+        />
+      </DeveloperSectionErrorBoundary>
     );
   }
 

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -26,6 +26,11 @@ import { message } from "../i18n/message";
 export const DEV_MSG_KEYS = {
   TITLE: "perc.ui.developer@Developer",
   SHELL_LOADING: "perc.ui.developer@Loading Developer...",
+  /**
+   * Isolated tab/detail failure (#3377 / peer Admin #3195). Arg {0} is the section label.
+   */
+  SECTION_LOAD_FAILED:
+    "perc.ui.developer@Unable to load {0}. Other Developer tabs remain available.",
   INTRO: "perc.ui.developer@Design-time tools for content types, assembly, and related CMS objects. Replaces the classic Workbench / Design surfaces.",
   SESSION_REDIRECT: "perc.ui.developer@Session expired - redirecting to login...",
   ACL_TITLE: "perc.ui.developer@Object ACL",

--- a/WebUI/src/test/ts/developer/DeveloperSectionErrorBoundary.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperSectionErrorBoundary.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DeveloperSectionErrorBoundary } from "../../../main/ts/developer/DeveloperSectionErrorBoundary";
+
+function Bomb(): React.ReactElement {
+  throw new Error("workflowName is not defined");
+}
+
+describe("DeveloperSectionErrorBoundary", () => {
+  it("isolates a child TypeError so Developer chrome stays mounted (#3377)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(
+      <div>
+        <div data-testid="perc-developer-shell">Developer chrome</div>
+        <DeveloperSectionErrorBoundary label="Templates">
+          <Bomb />
+        </DeveloperSectionErrorBoundary>
+      </div>,
+    );
+    expect(screen.getByTestId("perc-developer-shell")).toBeDefined();
+    expect(screen.getByTestId("developer-section-error")).toBeDefined();
+    expect(screen.getByTestId("developer-section-error").textContent).toMatch(
+      /Templates/i,
+    );
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    spy.mockRestore();
+  });
+
+  it("renders children when they do not throw", () => {
+    render(
+      <DeveloperSectionErrorBoundary label="Templates">
+        <div data-testid="ok-child">ok</div>
+      </DeveloperSectionErrorBoundary>,
+    );
+    expect(screen.getByTestId("ok-child")).toBeDefined();
+    expect(screen.queryByTestId("developer-section-error")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/developer/DeveloperShell.templateIsolation.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.templateIsolation.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DeveloperShell } from "../../../main/ts/developer/DeveloperShell";
+
+vi.mock("../../../main/ts/developer/ContentTypesPanel", () => ({
+  ContentTypesPanel: () => (
+    <div data-testid="developer-ct-panel">Content types</div>
+  ),
+}));
+
+vi.mock("../../../main/ts/developer/TemplatesPanel", () => ({
+  TemplatesPanel: () => {
+    throw new Error("workflowName is not defined");
+  },
+}));
+
+describe("DeveloperShell Template isolation (#3377)", () => {
+  it("keeps Developer shell when TemplatesPanel throws (no RouteErrorBoundary)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(<DeveloperShell initialSection="templates" embedded />);
+
+    expect(screen.getByTestId("perc-developer-shell")).toBeDefined();
+    expect(screen.getByTestId("developer-section-error")).toBeDefined();
+    expect(screen.getByTestId("developer-section-error").textContent).toMatch(
+      /Templates/i,
+    );
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    expect(screen.queryByText(/Unable to load Developer/i)).toBeNull();
+
+    fireEvent.click(screen.getByTestId("tab-developer-content-types"));
+    expect(screen.getByTestId("developer-ct-panel")).toBeDefined();
+    spy.mockRestore();
+  });
+});

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -246,6 +246,79 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(rt.checked).toBe(false);
   });
 
+  it("shows Runtime Visible column on empty ACL for runtime-relevant kinds (#3377)", async () => {
+    getAclForObject.mockResolvedValue({
+      id: 4,
+      name: "empty-acl",
+      guid: { stringValue: "0-2-301" },
+      aclEntries: [],
+    });
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="content-type"
+        testIdPrefix="t-acl"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("t-acl-table")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("t-acl-no-entries").textContent).toMatch(
+      /No ACL entries yet/i,
+    );
+    expect(screen.getByTestId("t-acl-section").getAttribute("data-acl-show-runtime")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("t-acl-table").getAttribute("data-acl-show-runtime")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("t-acl-layer-design")).toBeTruthy();
+    expect(screen.getByTestId("t-acl-layer-runtime").textContent).toMatch(
+      /Runtime visibility/i,
+    );
+    expect(screen.getByTestId("t-acl-perm-header-RUNTIME_VISIBLE").textContent).toMatch(
+      /Visible/i,
+    );
+    expect(screen.getByTestId("t-acl-perm-header-READ")).toBeTruthy();
+    expect(screen.queryAllByTestId(/^t-acl-row-/)).toHaveLength(0);
+  });
+
+  it("shows empty-table Runtime headers for template and display-format (#3377)", async () => {
+    getAclForObject.mockResolvedValue({
+      id: 5,
+      name: "empty-acl",
+      aclEntries: [],
+    });
+    const { unmount } = render(
+      <ObjectAclSection
+        objectGuid="0-4-12"
+        objectKind="template"
+        testIdPrefix="tpl-acl"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("tpl-acl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("tpl-acl-layer-runtime")).toBeTruthy();
+    expect(screen.getByTestId("tpl-acl-perm-header-RUNTIME_VISIBLE")).toBeTruthy();
+    unmount();
+
+    render(
+      <ObjectAclSection
+        objectGuid="0-31-5"
+        objectKind="display-format"
+        testIdPrefix="df-acl"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("df-acl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("df-acl-layer-runtime")).toBeTruthy();
+    expect(screen.getByTestId("df-acl-perm-header-RUNTIME_VISIBLE")).toBeTruthy();
+  });
+
   it("hides Runtime visibility columns for non-runtime-relevant object kinds", async () => {
     getAclForObject.mockResolvedValue(aclWithDefaultOnly);
     render(

--- a/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
@@ -362,5 +362,30 @@ describe("TemplateDetailPanel", () => {
     expect(screen.getByTestId("developer-tpl-slots-table")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-source-edit")).toBeTruthy();
     expect(screen.queryByTestId("developer-tpl-detail-error")).toBeNull();
+    // Dirty check must compare asSourceText(templateSource), not raw envelope
+    // (object !== string would incorrectly enable Save).
+    expect((screen.getByTestId("developer-tpl-save") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("does not mark dirty when templateSource is a non-string envelope (#3389 review)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      name: "perc.page",
+      label: "Page",
+      description: "",
+      templateSource: { TemplateSource: "<html/>" },
+      bindings: [],
+      slots: [],
+    } as never);
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-save")).toBeTruthy();
+    });
+    const save = screen.getByTestId("developer-tpl-save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    const sourceEdit = screen.getByTestId("developer-tpl-source-edit") as HTMLTextAreaElement;
+    fireEvent.change(sourceEdit, { target: { value: "<html>edited</html>" } });
+    expect(save.disabled).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
@@ -325,4 +325,42 @@ describe("TemplateDetailPanel", () => {
       DEV_MSG.TPL_DETAIL_ERROR,
     );
   });
+
+  it("keeps load errors inside the detail panel (#3377)", async () => {
+    getTemplateDetailMock.mockRejectedValue(new Error("missing field"));
+    render(
+      <div>
+        <div data-testid="developer-chrome">Developer chrome</div>
+        <TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />
+      </div>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-chrome")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-detail")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-back")).toBeTruthy();
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    expect(screen.queryByText(/Unable to load Developer/i)).toBeNull();
+  });
+
+  it("unwraps envelope bindings/slots and stringifies source without crashing (#3377)", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      name: "perc.page",
+      label: "Page",
+      templateSource: { wrapped: true },
+      bindings: {
+        TemplateBinding: [{ executionOrder: 1, variable: "$x", expression: "1" }],
+      },
+      slots: { Slot: [{ name: "target", label: "Target" }] },
+    } as never);
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-bindings-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-slots-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-source-edit")).toBeTruthy();
+    expect(screen.queryByTestId("developer-tpl-detail-error")).toBeNull();
+  });
 });

--- a/WebUI/src/test/ts/developer/TemplatesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplatesPanel.test.tsx
@@ -9,10 +9,19 @@ import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
 import { TemplatesPanel } from "../../../main/ts/developer/TemplatesPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { TemplateDetailPanel } from "../../../main/ts/developer/TemplateDetailPanel";
 
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn(),
 }));
+
+vi.mock("../../../main/ts/developer/TemplateDetailPanel", () => ({
+  TemplateDetailPanel: vi.fn(),
+}));
+
+const TemplateDetailPanelMock = TemplateDetailPanel as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
 
@@ -22,6 +31,17 @@ describe("TemplatesPanel", () => {
       message: (key: string) => key,
     };
     listTemplates.mockReset();
+    TemplateDetailPanelMock.mockReset();
+    TemplateDetailPanelMock.mockImplementation(
+      (props: { idOrName: string; onBack: () => void }) => (
+        <div data-testid="developer-tpl-detail">
+          <button type="button" data-testid="developer-tpl-back" onClick={props.onBack}>
+            back
+          </button>
+          {props.idOrName}
+        </div>
+      ),
+    );
   });
 
   it("lists templates on success", async () => {
@@ -95,5 +115,37 @@ describe("TemplatesPanel", () => {
       expect(screen.getByTestId("developer-tpl-error")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-tpl-error").textContent).toBe(DEV_MSG.TPL_ERROR);
+  });
+
+  it("keeps a TemplateDetailPanel render throw inside the panel (#3377)", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 42,
+        templateName: "perc.page",
+        templateLabel: "Page",
+      },
+    ]);
+    TemplateDetailPanelMock.mockImplementation(() => {
+      throw new Error("Cannot read properties of undefined (reading 'workflowName')");
+    });
+    render(
+      <div>
+        <div data-testid="developer-chrome">Developer chrome</div>
+        <TemplatesPanel />
+      </div>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-table")).toBeTruthy();
+    });
+    const openBtn = screen.getByRole("button", { name: /Open Page/i });
+    openBtn.click();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-panel-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-chrome")).toBeTruthy();
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    expect(screen.queryByText(/Unable to load Developer/i)).toBeNull();
+    spy.mockRestore();
   });
 });

--- a/docs/ai-generated/code-reviews/3377-empty-acl-runtime-template-shell-erlang.md
+++ b/docs/ai-generated/code-reviews/3377-empty-acl-runtime-template-shell-erlang.md
@@ -1,0 +1,25 @@
+# Erlang review — #3377 empty ACL runtime columns + Template shell isolation
+
+**Branch:** `fix/issue-3377-empty-acl-runtime-template-shell`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** isolate SPA section throws (Admin #3195 peer); empty-state tables must keep headers; product-docs companion for operator ACL chrome.
+
+## Summary
+
+Object ACL skipped the permission table when `draftEntries.length === 0`, so Runtime headers only appeared after a draft row. Template (or missing-field) render throws replaced the whole Developer route via `RouteErrorBoundary` ("Unable to load Developer").
+
+This change always renders Design + Runtime headers for a loaded ACL (runtime columns still gated by `shouldShowRuntimeAccessColumns(kind)` without requiring `forceShow` from existing bits), isolates Template/Developer sections with an error boundary peer of Admin, and hardens Template detail apply against envelope/missing fields.
+
+## Cross-platform path checklist
+
+Not applicable — no new filesystem path construction. Playwright URLs use `/` (URL paths). Docker copy in C5 uses container POSIX paths only.
+
+## Issues
+
+None (bug-class). Behavioral tests cover empty ACL Runtime Visible, Template load error remaining in-panel, and Developer shell surviving a TemplatesPanel throw.
+
+## Suggestion (non-blocking)
+
+`DeveloperSectionErrorBoundary` wraps every Developer tab. That is slightly broader than the Template-only acceptance line; it matches Admin isolation and is the right change-class companion for "do not crash Developer."

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
@@ -107,11 +107,16 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
 
     const aclError = page.locator('[data-testid="developer-ct-acl-error"]');
     const aclEmpty = page.locator('[data-testid="developer-ct-acl-empty"]');
+    const aclNoEntries = page.locator(
+      '[data-testid="developer-ct-acl-no-entries"]',
+    );
     const aclTable = page.locator('[data-testid="developer-ct-acl-table"]');
     const aclLoading = page.locator('[data-testid="developer-ct-acl-loading"]');
 
     await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-    await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+    await expect(
+      aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+    ).toBeVisible({
       timeout: 30_000,
     });
 
@@ -162,6 +167,13 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
     await expect(
       page.locator('[data-testid="developer-ct-acl-perm-header-RUNTIME_VISIBLE"]'),
     ).toContainText(/Visible/i);
+
+    // #3377: empty ACL still shows Design + Runtime headers; checkboxes exist
+    // only after a principal row. Do not require a draft entry for this spec.
+    if (await aclNoEntries.isVisible().catch(() => false)) {
+      await expect(aclNoEntries).toContainText(/No ACL entries yet/i);
+      return;
+    }
 
     // Checkbox-only locators: prefix also matches perm-header-<PERM> <th> cells;
     // scope to input so .first() is never the header (see ObjectAclSection.tsx).
@@ -236,13 +248,18 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
 
     const aclError = page.locator('[data-testid="developer-tpl-acl-error"]');
     const aclEmpty = page.locator('[data-testid="developer-tpl-acl-empty"]');
+    const aclNoEntries = page.locator(
+      '[data-testid="developer-tpl-acl-no-entries"]',
+    );
     const aclTable = page.locator('[data-testid="developer-tpl-acl-table"]');
     const aclLoading = page.locator(
       '[data-testid="developer-tpl-acl-loading"]',
     );
 
     await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
-    await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+    await expect(
+      aclTable.or(aclEmpty).or(aclError).or(aclNoEntries).first(),
+    ).toBeVisible({
       timeout: 30_000,
     });
 

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -206,10 +206,27 @@ async function assertLayeredObjectAcl(page, prefix, objectKind) {
   if (await aclNoEntries.isVisible()) {
     // ACL document exists but has no principals yet — still readable/editable
     // (add specials / add entry). Live By_Author often serializes without
-    // aclEntries (#3203 / #2672).
+    // aclEntries (#3203 / #2672). #3377: Design + Runtime headers stay visible
+    // before any draft row exists (do not require forceShow from existing bits).
     await expect(aclSection).toHaveAttribute("data-acl-object-kind", objectKind);
     await expect(aclSection).toHaveAttribute("data-acl-has-guid", "true");
     await expect(aclNoEntries).toContainText(/No ACL entries yet/i);
+    await expect(aclTable).toBeVisible();
+    await expect(aclTable).toHaveAttribute(
+      "data-acl-show-runtime",
+      expectRuntime ? "true" : "false",
+    );
+    await expect(
+      page.locator(`[data-testid="${prefix}-layer-design"]`),
+    ).toBeVisible();
+    if (expectRuntime) {
+      await expect(
+        page.locator(`[data-testid="${prefix}-layer-runtime"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${prefix}-perm-header-RUNTIME_VISIBLE"]`),
+      ).toContainText(/Visible/i);
+    }
     return "no-entries";
   }
 
@@ -358,6 +375,107 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       ).toContain(mode);
     } else {
       expect(["table", "no-guid", "empty", "no-entries"]).toContain(mode);
+    }
+  });
+
+  test("opening Content Type then Template does not crash Developer shell (#3377)", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto(developerSectionUrl("content-types"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-content-types"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+
+    const ctOpened = await openFirstCatalogDetail(page, {
+      rowBase: "developer-ct-row",
+      panel: "developer-ct-panel",
+      empty: "developer-ct-empty",
+      error: "developer-ct-error",
+      detail: "developer-ct-detail",
+      detailLoading: "developer-ct-detail-loading",
+      detailError: "developer-ct-detail-error",
+      catalogLabel: "content types",
+    });
+    if (!ctOpened) return;
+
+    await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+    await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="tab-developer-templates"]').click();
+    await expect(
+      page.locator('[data-testid="panel-developer-templates"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+    await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+    await expect(page.getByText(/Unable to load Developer/i)).toHaveCount(0);
+
+    const tplError = page.locator('[data-testid="developer-tpl-error"]');
+    const tplPanel = page.locator('[data-testid="developer-tpl-panel"]');
+    const tplEmpty = page.locator('[data-testid="developer-tpl-empty"]');
+    const tplSectionError = page.locator('[data-testid="developer-section-error"]');
+    await expect(
+      tplPanel.or(tplEmpty).or(tplError).or(tplSectionError).first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    if (await tplError.isVisible()) {
+      const msg = (await tplError.innerText()).trim();
+      throw new Error(`templates catalog error after CT: ${msg}`);
+    }
+    if (await tplEmpty.isVisible()) {
+      // Catalog empty is valid; shell must still be intact.
+      await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+      expect(pageErrors, `pageerror after CT→Templates: ${pageErrors.join("; ")}`).toEqual(
+        [],
+      );
+      return;
+    }
+    if (await tplSectionError.isVisible()) {
+      // Isolated in-panel error is acceptable; the Developer shell must remain.
+      await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+      await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+      return;
+    }
+
+    const firstRow = page.locator(catalogRowSelector("developer-tpl-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    const openBtn = firstRow.locator("button");
+    await expect(openBtn).toBeVisible({ timeout: 5_000 });
+    await openBtn.click();
+
+    await expect(page.locator('[data-testid="developer-tpl-detail"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    const detailLoading = page.locator(
+      '[data-testid="developer-tpl-detail-loading"]',
+    );
+    await expect(detailLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+
+    await expect(page.locator('[data-testid="perc-developer-shell"]')).toBeVisible();
+    await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+    await expect(page.getByText(/Unable to load Developer/i)).toHaveCount(0);
+    expect(pageErrors, `pageerror after CT→Template: ${pageErrors.join("; ")}`).toEqual(
+      [],
+    );
+
+    const tplAclTable = page.locator('[data-testid="developer-tpl-acl-table"]');
+    const tplAclNoEntries = page.locator(
+      '[data-testid="developer-tpl-acl-no-entries"]',
+    );
+    if (
+      (await tplAclNoEntries.isVisible().catch(() => false)) ||
+      (await tplAclTable.isVisible().catch(() => false))
+    ) {
+      await expect(tplAclTable).toBeVisible();
+      await expect(tplAclTable).toHaveAttribute("data-acl-show-runtime", "true");
+      await expect(
+        page.locator('[data-testid="developer-tpl-acl-perm-header-RUNTIME_VISIBLE"]'),
+      ).toContainText(/Visible/i);
     }
   });
 

--- a/product-docs/8.2/admin/object-acl.md
+++ b/product-docs/8.2/admin/object-acl.md
@@ -40,7 +40,9 @@ those system principals.
    path) loads — it must **not** say “Object GUID not available”.
 6. Confirm the table shows **Design access** and **Runtime visibility** column groups
    (runtime-relevant object kinds such as content type, template, and display
-   format always show **Visible**).
+   format always show **Visible**). Those layer headers stay visible even when
+   the ACL has **no entries yet** (no draft row required) — only the body is empty
+   until you add a principal.
 7. To persist permissions: add **Default**, **AnyCommunity**, and any extra USER
    or ROLE principal, then click **Save**. Reopen the same object — those entries
    must still be present. If the object has no ACL yet, create one first (owner

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -103,6 +103,9 @@ objects, including **Content types**, **Templates**, **Display Formats**, **Site
    present).
 4. **Object ACL** below the detail form:
    - Shows the ACL table when entries exist (Design access and Runtime visibility).
+   - When an ACL document exists but has **no principals yet**, the table headers
+     (including **Runtime visibility → Visible** for content types and templates)
+     still appear; add a principal below the empty body.
    - Shows an empty create path when the object has no ACL yet.
    - Does **not** say “Object GUID not available” when the header GUID is present.
 


### PR DESCRIPTION
## Summary

Slice of parent #2640 (Object ACL QA residuals). Empty Object ACL tables skipped the permission grid, so **Runtime visibility** headers only appeared after a draft row. Opening a Template after a Content Type could throw and replace the whole Developer route with `Unable to load Developer`.

This PR:

- Always renders the Design + Runtime header table when an ACL document is loaded, even with zero entries. Runtime columns still follow `shouldShowRuntimeAccessColumns(kind)` (no `forceShow` required from existing bits).
- Isolates Developer tabs (and Template detail) with `DeveloperSectionErrorBoundary` so a Template load or missing field stays in-panel.
- Hardens Template detail apply against Jackson envelopes / non-string source.

Does **not** redo CT/Template GUID bind (#3319). Sibling persist work stays on #3384.

Fixes #3377  
Parent: #2640

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. QA H2: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (`TEST_CMS_URL=http://127.0.0.1:9993`).
2. Developer → Content types → open first type → Object ACL with no principals still shows **Design access** and **Runtime visibility → Visible**.
3. Switch to Templates (or open a template after a content type). Developer chrome stays; no `Unable to load Developer`.
4. Empty Template ACL still shows Runtime Visible column.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/object-acl.md` and `users-roles.md` (empty ACL table still shows runtime columns)
- [x] **Unit / module tests** — Vitest empty ACL + Template isolation; `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS (Tests 2404)
- [x] **WebUI + Playwright** — `developer-object-acl-product-path.spec.js` (incl. CT→Template #3377) and `developer-object-acl-design-runtime.spec.js`
- [x] **Build gates** — standalone WebUI clean install; no API `final`/signature change
- [x] **Cross-platform** — N/A (no filesystem path I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2404, Failures: 0 (Vitest 323 files). Pre-existing javadoc/dependency-analyze warnings unchanged.
- **downstream_checked:** none (no public Java type made `final`/`sealed`; no method/ctor signature change)

### C5 UI proof

- `perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`; `qa-health` again RESULT:OK
- `npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js` → 10 passed (includes #3377 CT→Template)
- `npm run test:surface -- --path tests/developer-object-acl-design-runtime.spec.js` → 2 passed
- console-clean=yes (pageerror empty on #3377 path)
- server.log-clean=yes (test window AUTH INFO only; no feature ERROR/FATAL)

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
