### PR TITLE
fix(rest): bind PUT /acls/bulk as AclList not ArrayList (#3391)

### DIFF
--- a/docs/ai-generated/code-reviews/3391-acl-bulk-arraylist-cast-erlang.md
+++ b/docs/ai-generated/code-reviews/3391-acl-bulk-arraylist-cast-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — #3391 PUT /services/acls/bulk ArrayList→AclList ClassCast
+
+**Scope:** uncommitted branch `fix/issue-3391-acl-bulk-arraylist-cast` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** CXF ArrayList→typed list ClassCast; Jackson WRAP/UNWRAP_ROOT_VALUE; change-class companions (reader + deserializer + CXF pipeline test + product-docs); dual-ship beans.xml vs rest jar; behavioral tests for new deserialize path.
+
+## Summary
+
+Cycle Verify residual of #3387 / #3378: Playwright Display Format Object ACL Save still got HTTP 400 `ClassCastException: Cannot cast java.util.ArrayList to com.percussion.rest.acls.AclList`. `AclListJsonReader` exists and is listed ahead of `jacksonProvider`, but the live CXF pipeline still selected Jackson. `JacksonJsonProvider` constructs a collection `JavaType` whose impl is raw `ArrayList`; CXF then casts to `AclList`.
+
+This change:
+
+1. Adds `AclListDeserializer` (`@JsonDeserialize(using=…)`) so Jackson itself instantiates `AclList` (hot-deploy of `rest` jar is enough even if filesystem `sitemanage-beans.xml` is stale).
+2. Hardens `AclListJsonReader` media-type matching (`application/json`, `text/json`, `+json`, charset).
+3. Binds PUT `/acls/bulk` as `String` then `AclListJsonReader.parse` so CXF Jettison cannot reject a bare array (`JSONObject` ParseError) and Jackson cannot ClassCast.
+4. `ApiUtils.convertGuid` builds `PSGuid` from `type`/`uuid`/`hostId` when `stringValue` is blank (`raw may not be blank`).
+5. Adds CXF/JAX-RS pipeline tests: `JavaType` read, `JacksonJsonProvider.readFrom`, `ServerProviderFactory` selection, in-process PUT envelope + bare array.
+6. Keeps persist/GET-after-save coverage from #3387.
+7. Updates `product-docs/8.2/developer/rest.md`.
+
+H2 QA Playwright `developer-object-acl-display-format-save.spec.js` passed (1) after hot-deploy.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No new bugs. Deserializer delegates to `AclListJsonReader.parseNode`. No filesystem path construction. C2: `AclList` not made `final`/`sealed`; no signature change; no `extends AclList` / anonymous subclasses. Standalone `mvnw clean install`: rest Tests run: 396, Failures: 0; sitemanage BUILD SUCCESS.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] New code is JSON/JAX-RS only (URL paths use `/` correctly)
+- [x] Tests do not assert OS-specific file paths
+- [x] Playwright spec already uses `TEST_CMS_URL` / `BASE_URL` (no hardcoded `:9993`)
+
+## Issues
+
+None (hard-gate).
+
+## Product documentation
+
+Updated `product-docs/8.2/developer/rest.md` (server binds `{"AclList":[…]}` as `AclList`, not raw `ArrayList`).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -227,6 +227,13 @@ Design-time ACLs use `/services/acls`. Production JSON uses Jackson
 | `POST` | `/services/acls/` | Request `{"CreateAclRequest":{"objectGuid":{"stringValue":"…"},"owner":{"name":"Admin","type":"USER"}}}` |
 | `PUT` | `/services/acls/bulk` | Request `{"AclList":[{…}]}` — **not** a bare JSON array |
 
+The server binds that `{"AclList":[…]}` envelope (or a bare JSON array) to an
+`AclList` instance (not a raw `java.util.ArrayList`). A JAX-RS reader, a Jackson
+deserializer, and a string-body bind all accept the SPA save shape so Display Format
+Object ACL Save is HTTP 200, not `ClassCastException: Cannot cast java.util.ArrayList
+to AclList`. Nested `guid` / `objectGuid` objects may omit `stringValue` when
+`type` and `uuid` are present.
+
 Each ACL in the list should include `objectGuid` (and `objectType` / `objectId` when known),
 plus the ACL `id` / `guid` when the object already has an ACL. The server **merges** that
 payload onto the existing `PSX_ACLS` row (same SYSID / object identity) instead of inserting

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -124,7 +124,19 @@ public class ApiUtils {
     if (guid == null) {
       return null;
     }
-    return PSGuidManagerLocator.getGuidMgr().makeGuid(guid.getStringValue().orElse(null));
+    String raw = guid.getStringValue().orElse(null);
+    if (raw != null && !raw.isBlank()) {
+      return PSGuidManagerLocator.getGuidMgr().makeGuid(raw);
+    }
+    // SPA GET often serializes hostId/type/uuid without stringValue. makeGuid(null)
+    // throws "raw may not be blank" (#3391 persist after AclList bind).
+    if (guid.getType() != 0 && guid.getUuid() != 0) {
+      PSTypeEnum type = PSTypeEnum.valueOf(guid.getType());
+      if (type != null) {
+        return new PSGuid(guid.getHostId(), type, guid.getUuid());
+      }
+    }
+    return null;
   }
 
   /**

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -124,7 +124,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="runtimeExceptionMapper" />
             <!-- Inbox #3323: bind flat startIndex before jackson UNWRAP_ROOT_VALUE -->
             <ref bean="viewExecuteRequestJsonReader" />
-            <!-- #3378: AclList ArrayList subclass must not ClassCast after UNWRAP -->
+            <!-- #3378 / #3391: AclList ArrayList subclass must not ClassCast after UNWRAP.
+                 Rest jar also has AclListDeserializer so a stale filesystem beans.xml
+                 (hot-deploy jars only) still binds {"AclList":[…]} as AclList. -->
             <ref bean="aclListJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
@@ -170,6 +170,35 @@ public class ApiUtilsAclConvertTest {
   }
 
   @Test
+  public void convertAclAcceptsGuidWithoutStringValue() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("x5");
+    acl.setObjectType(31);
+    acl.setObjectId(5);
+    Guid guid = new Guid();
+    guid.setHostId(6622135);
+    guid.setLongValue(7281114506216867000L);
+    guid.setType((short) 17);
+    guid.setUuid(1418);
+    acl.setGuid(guid);
+    Guid objectGuid = new Guid();
+    objectGuid.setHostId(0);
+    objectGuid.setLongValue(5);
+    objectGuid.setType((short) 31);
+    objectGuid.setUuid(5);
+    acl.setObjectGuid(objectGuid);
+
+    PSAclImpl converted = ApiUtils.convertAcl(acl);
+    assertEquals("x5", converted.getName());
+    assertEquals(31, converted.getObjectType());
+    assertEquals(5, converted.getObjectId());
+    assertNotNull(converted.getGUID());
+    assertEquals(17, converted.getGUID().getType());
+    assertEquals(1418, converted.getGUID().getUUID());
+  }
+
+  @Test
   public void convertAclsSavePreservesObjectIdentityFromGuid() {
     Acl acl = new Acl();
     acl.setId(7);

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -63,6 +63,16 @@
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-local</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
             <version>${cxf.version}</version>
         </dependency>

--- a/rest/src/main/java/com/percussion/rest/acls/AclList.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclList.java
@@ -27,6 +27,7 @@ import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /** List of {@link Acl} objects. */
 @XmlRootElement(name = "AclList")
@@ -34,6 +35,7 @@ import java.util.Objects;
 @XmlSeeAlso(Acl.class)
 @ArraySchema(schema = @Schema(implementation = Acl.class))
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = AclListDeserializer.class)
 public class AclList extends ArrayList<Acl> {
   /** Safe to serialize. */
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/rest/acls/AclListDeserializer.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclListDeserializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+
+/**
+ * Forces PUT {@code /services/acls/bulk} to instantiate {@link AclList}, not a raw {@link
+ * java.util.ArrayList}.
+ *
+ * <p>CXF {@code JacksonJsonProvider} builds a collection {@code JavaType} whose default impl is
+ * {@code ArrayList}. {@code UNWRAP_ROOT_VALUE} then returns that list and CXF casts it to {@link
+ * AclList} — {@code ClassCastException} HTTP 400 (#3391 / #3378). {@link AclListJsonReader} is the
+ * preferred JAX-RS reader, but the live pipeline may still select Jackson; this deserializer is the
+ * Jackson-side barrier.
+ */
+public class AclListDeserializer extends ValueDeserializer<AclList> {
+
+  @Override
+  public AclList deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+    if (p == null) {
+      return new AclList();
+    }
+    JsonToken token = p.currentToken();
+    if (token == null) {
+      token = p.nextToken();
+    }
+    if (token == null || token == JsonToken.VALUE_NULL) {
+      return new AclList();
+    }
+    JsonNode node = ctxt != null ? ctxt.readTree(p) : p.readValueAsTree();
+    return AclListJsonReader.parseNode(node);
+  }
+
+  @Override
+  public AclList getNullValue(DeserializationContext ctxt) {
+    return new AclList();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/acls/AclListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclListJsonReader.java
@@ -51,7 +51,7 @@ import tools.jackson.databind.json.JsonMapper;
  * jacksonProvider}.
  */
 @Provider
-@Consumes(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
 @Priority(Priorities.USER - 100)
 @PSSiteManageBean("aclListJsonReader")
 public class AclListJsonReader implements MessageBodyReader<AclList> {
@@ -62,7 +62,22 @@ public class AclListJsonReader implements MessageBodyReader<AclList> {
   @Override
   public boolean isReadable(
       Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-    return type != null && AclList.class.isAssignableFrom(type);
+    if (type == null || !AclList.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
   }
 
   @Override
@@ -101,6 +116,16 @@ public class AclListJsonReader implements MessageBodyReader<AclList> {
       throw new WebApplicationException(
           e.getMessage() != null ? e.getMessage() : "Invalid AclList", 400);
     }
+    return parseNode(root);
+  }
+
+  /**
+   * Bind a parsed JSON tree to {@link AclList}.
+   *
+   * @param root parsed body; may be null
+   * @return non-null list (empty when the node is null/missing)
+   */
+  public static AclList parseNode(JsonNode root) {
     if (root == null || root.isNull() || root.isMissingNode()) {
       return new AclList();
     }

--- a/rest/src/main/java/com/percussion/rest/acls/AclResource.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclResource.java
@@ -210,16 +210,30 @@ public class AclResource {
   }
 
   /**
-   * Persists the supplied ACL list.
+   * Persists the supplied ACL list JSON.
    *
-   * @param aclList the ACL list to save
+   * <p>The body is parsed by {@link AclListJsonReader} so CXF Jackson/Jettison cannot bind a raw
+   * {@code ArrayList} (HTTP 400 ClassCast, #3391) or reject a bare JSON array (org.json
+   * ParseError). Accepts {@code {"AclList":[…]}} and {@code [{…}]}.
+   *
+   * @param json the ACL list JSON to save
    * @return the save status
    */
   @PUT
   @Path("/bulk")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public Status saveAcls(AclList aclList) {
+  public Status saveAcls(String json) {
+    return persistAcls(AclListJsonReader.parse(json));
+  }
+
+  /**
+   * Persists an already-bound ACL list (unit tests and {@link #saveAcls(String)}).
+   *
+   * @param aclList the ACL list to save
+   * @return the save status
+   */
+  Status persistAcls(AclList aclList) {
     var ret = new Status(200, "OK");
     try {
       adaptor.saveAcls(aclList);

--- a/rest/src/test/java/com/percussion/rest/MainTest.java
+++ b/rest/src/test/java/com/percussion/rest/MainTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.acls.AclListJsonReader;
 import com.percussion.rest.errors.RestExceptionMapper;
 import com.percussion.rest.errors.WebApplicationExceptionMapper;
 import com.percussion.utils.testing.PSTestNetUtils;
@@ -156,7 +157,12 @@ public class MainTest {
       factory.setExtensionMappings(extensionMap);
       factory.setBus(ctx.getBean(SpringBus.class));
       factory.setProviders(
-          Arrays.asList(exceptionMapper, waeMapper, jacksonProvider, contextResolver));
+          Arrays.asList(
+              exceptionMapper,
+              waeMapper,
+              new AclListJsonReader(),
+              jacksonProvider,
+              contextResolver));
       factory.setResourceProviders(resourceProviders);
       factory.setAddress(endpoint);
       try {

--- a/rest/src/test/java/com/percussion/rest/acls/AclListCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListCxfUnmarshallTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.acls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.errors.WebApplicationExceptionMapper;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
+
+/**
+ * CXF / JAX-RS pipeline for PUT {@code /acls/bulk} (#3391).
+ *
+ * <p>{@link AclListJsonReaderTest} only covers {@link AclListJsonReader#parse(String)}. The live
+ * 400 was {@code ClassCastException: Cannot cast java.util.ArrayList to AclList} after CXF selected
+ * {@link JacksonJsonProvider}. This class exercises the real save envelope through:
+ *
+ * <ul>
+ *   <li>Jackson {@code JavaType} (what {@code JacksonJsonProvider} constructs)
+ *   <li>{@link JacksonJsonProvider#readFrom}
+ *   <li>CXF {@link ServerProviderFactory#createMessageBodyReader}
+ *   <li>an in-process CXF server PUT
+ * </ul>
+ */
+@Tag("UnitTest")
+public class AclListCxfUnmarshallTest {
+
+  static final String DF_SAVE =
+      "{\"AclList\":[{"
+          + "\"id\":7,"
+          + "\"name\":\"By_Author ACL\","
+          + "\"objectId\":5,"
+          + "\"objectType\":31,"
+          + "\"objectGuid\":{\"stringValue\":\"0-31-5\"},"
+          + "\"aclEntries\":["
+          + "{\"name\":\"Default\",\"principal\":{\"name\":\"Default\"},"
+          + "\"type\":{\"name\":\"Default\",\"type\":\"USER\"},"
+          + "\"permissions\":[{\"permission\":\"READ\"}]},"
+          + "{\"name\":\"AnyCommunity\",\"principal\":{\"name\":\"AnyCommunity\"},"
+          + "\"type\":{\"name\":\"AnyCommunity\",\"type\":\"COMMUNITY\"},"
+          + "\"permissions\":[{\"permission\":\"RUNTIME_VISIBLE\"}]},"
+          + "{\"name\":\"Admin\",\"principal\":{\"name\":\"Admin\"},"
+          + "\"type\":{\"name\":\"Admin\",\"type\":\"USER\"},"
+          + "\"permissions\":[{\"permission\":\"READ\"}]}"
+          + "]}]}";
+
+  private Server server;
+
+  @AfterEach
+  public void stopServer() {
+    if (server != null) {
+      server.stop();
+      server.destroy();
+      server = null;
+    }
+  }
+
+  @Test
+  public void productionJavaTypeUnmarshalsEnvelopeToAclListNotArrayList() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    JavaType javaType = mapper.getTypeFactory().constructType(AclList.class);
+    Object raw = mapper.readValue(DF_SAVE, javaType);
+    assertInstanceOf(AclList.class, raw, "JavaType path must not return raw ArrayList: " + raw);
+    AclList list = (AclList) raw;
+    assertEquals(1, list.size());
+    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+  }
+
+  @Test
+  public void jacksonJsonProviderReadFromReturnsAclList() throws Exception {
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(AclList.class));
+    @SuppressWarnings("unchecked")
+    Class<Object> declared = (Class<Object>) (Class<?>) AclList.class;
+    Object raw =
+        jackson.readFrom(
+            declared,
+            AclList.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(DF_SAVE.getBytes(StandardCharsets.UTF_8)));
+    assertInstanceOf(
+        AclList.class, raw, "JacksonJsonProvider.readFrom must return AclList, not " + typeOf(raw));
+    assertEquals(1, ((AclList) raw).size());
+  }
+
+  @Test
+  public void cxfFactorySelectsReadableProviderAndReturnsAclList() throws Exception {
+    ServerProviderFactory factory = ServerProviderFactory.createInstance(null);
+    AclListJsonReader custom = new AclListJsonReader();
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(AclList.class));
+    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+
+    MessageImpl message = new MessageImpl();
+    MessageBodyReader<AclList> selected =
+        factory.createMessageBodyReader(
+            AclList.class,
+            AclList.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            message);
+    assertNotNull(selected, "CXF must find a MessageBodyReader for AclList");
+    assertTrue(
+        selected.isReadable(
+            AclList.class, AclList.class, new Annotation[0], MediaType.APPLICATION_JSON_TYPE),
+        selected.getClass().getName());
+
+    AclList list =
+        selected.readFrom(
+            AclList.class,
+            AclList.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(DF_SAVE.getBytes(StandardCharsets.UTF_8)));
+    assertInstanceOf(AclList.class, list);
+    assertEquals(1, list.size());
+    assertEquals("By_Author ACL", list.get(0).getName().orElse(null));
+    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+  }
+
+  @Test
+  public void cxfPutBulkSaveEnvelopeIsHttp200AndAclList() throws Exception {
+    AtomicReference<AclList> captured = new AtomicReference<>();
+    IAclAdaptor adaptor = mock(IAclAdaptor.class);
+    doAnswer(
+            inv -> {
+              Object arg = inv.getArgument(0);
+              assertInstanceOf(
+                  AclList.class, arg, "saveAcls must receive AclList, not " + typeOf(arg));
+              captured.set((AclList) arg);
+              return null;
+            })
+        .when(adaptor)
+        .saveAcls(any());
+
+    AclResource resource = new AclResource();
+    var field = AclResource.class.getDeclaredField("adaptor");
+    field.setAccessible(true);
+    field.set(resource, adaptor);
+
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(AclList.class));
+
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setAddress("local://issue-3391-acl-bulk");
+    sf.setServiceBean(resource);
+    sf.setProviders(
+        List.of(
+            new AclListJsonReader(),
+            jackson,
+            new JacksonContextResolver(),
+            new WebApplicationExceptionMapper()));
+    server = sf.create();
+    assertNotNull(server, "CXF local server must start");
+
+    WebClient client =
+        WebClient.create("local://issue-3391-acl-bulk")
+            .accept(MediaType.APPLICATION_JSON)
+            .type(MediaType.APPLICATION_JSON)
+            .path("/acls/bulk");
+    Response response = client.put(DF_SAVE);
+    assertEquals(
+        200,
+        response.getStatus(),
+        "PUT {\"AclList\":[...]} must be HTTP 200; body=" + response.readEntity(String.class));
+    AclList saved = captured.get();
+    assertNotNull(saved, "adaptor.saveAcls must be invoked");
+    assertEquals(1, saved.size());
+    assertEquals(31, saved.get(0).getObjectType());
+    assertEquals(5, saved.get(0).getObjectId());
+    assertEquals(3, saved.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals("Default", saved.get(0).getAclEntries().orElseThrow().get(0).getName().orElse(null));
+    assertEquals(
+        "AnyCommunity", saved.get(0).getAclEntries().orElseThrow().get(1).getName().orElse(null));
+    assertEquals("Admin", saved.get(0).getAclEntries().orElseThrow().get(2).getName().orElse(null));
+  }
+
+  @Test
+  public void cxfPutBareArrayIsHttp200AndAclList() throws Exception {
+    AtomicReference<AclList> captured = new AtomicReference<>();
+    IAclAdaptor adaptor = mock(IAclAdaptor.class);
+    doAnswer(
+            inv -> {
+              Object arg = inv.getArgument(0);
+              assertInstanceOf(AclList.class, arg, "saveAcls must receive AclList, not " + typeOf(arg));
+              captured.set((AclList) arg);
+              return null;
+            })
+        .when(adaptor)
+        .saveAcls(any());
+
+    AclResource resource = new AclResource();
+    var field = AclResource.class.getDeclaredField("adaptor");
+    field.setAccessible(true);
+    field.set(resource, adaptor);
+
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setAddress("local://issue-3391-acl-bulk-bare");
+    sf.setServiceBean(resource);
+    sf.setProviders(
+        List.of(
+            new AclListJsonReader(),
+            new JacksonJsonProvider(),
+            new JacksonContextResolver(),
+            new WebApplicationExceptionMapper()));
+    server = sf.create();
+
+    WebClient client =
+        WebClient.create("local://issue-3391-acl-bulk-bare")
+            .accept(MediaType.APPLICATION_JSON)
+            .type(MediaType.APPLICATION_JSON)
+            .path("/acls/bulk");
+    Response response =
+        client.put("[{\"name\":\"By_Author ACL\",\"objectType\":31,\"objectId\":5}]");
+    assertEquals(200, response.getStatus(), response.readEntity(String.class));
+    AclList saved = captured.get();
+    assertNotNull(saved);
+    assertEquals(1, saved.size());
+    assertEquals("By_Author ACL", saved.get(0).getName().orElse(null));
+    assertEquals(31, saved.get(0).getObjectType());
+  }
+
+  private static String typeOf(Object raw) {
+    if (raw == null) {
+      return "null";
+    }
+    return raw.getClass().getName() + (raw instanceof ArrayList && !(raw instanceof AclList)
+        ? " (raw ArrayList)"
+        : "");
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
@@ -89,6 +89,23 @@ public class AclListJsonReaderTest {
   public void isReadableOnlyForAclList() {
     AclListJsonReader reader = new AclListJsonReader();
     assertTrue(reader.isReadable(AclList.class, AclList.class, null, null));
+    assertTrue(
+        reader.isReadable(
+            AclList.class, AclList.class, null, jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE));
+    assertTrue(
+        reader.isReadable(
+            AclList.class,
+            AclList.class,
+            null,
+            jakarta.ws.rs.core.MediaType.valueOf("application/json; charset=UTF-8")));
     assertTrue(!reader.isReadable(Acl.class, Acl.class, null, null));
+  }
+
+  @Test
+  public void parseNodeAcceptsEnvelope() {
+    AclList list = AclListJsonReader.parseNode(
+        tools.jackson.databind.json.JsonMapper.builder().build().readTree(DF_SAVE));
+    assertEquals(1, list.size());
+    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
   }
 }

--- a/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
@@ -145,6 +145,16 @@ public class AclListSerialDeserialTest {
   }
 
   @Test
+  public void productionJavaTypeIsAclListNotRawArrayList() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
+    String clientBody =
+        "{\"AclList\":[{\"id\":7,\"name\":\"By_Author ACL\",\"objectType\":31,\"aclEntries\":[]}]}";
+    Object raw = mapper.readValue(clientBody, mapper.getTypeFactory().constructType(AclList.class));
+    assertTrue(raw instanceof AclList, "expected AclList, got " + (raw == null ? "null" : raw.getClass()));
+    assertEquals(1, ((AclList) raw).size());
+  }
+
+  @Test
   public void productionMapperAcceptsClientAclListEnvelope() {
     ObjectMapper mapper = new JacksonContextResolver().getContext(AclList.class);
     String clientBody =

--- a/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
@@ -62,9 +62,24 @@ public class AclResourceTest {
     acl.setName("By_Author ACL");
     list.add(acl);
 
-    Status status = resource.saveAcls(list);
+    Status status = resource.persistAcls(list);
     assertEquals(200, status.getStatusCode());
     verify(adaptor).saveAcls(eq(list));
+  }
+
+  @Test
+  public void saveAclsJsonParsesEnvelope() throws Exception {
+    Status status =
+        resource.saveAcls("{\"AclList\":[{\"name\":\"By_Author ACL\",\"objectType\":31}]}");
+    assertEquals(200, status.getStatusCode());
+    verify(adaptor).saveAcls(any(AclList.class));
+  }
+
+  @Test
+  public void saveAclsJsonParsesBareArray() throws Exception {
+    Status status = resource.saveAcls("[{\"name\":\"By_Author ACL\",\"objectType\":31}]");
+    assertEquals(200, status.getStatusCode());
+    verify(adaptor).saveAcls(any(AclList.class));
   }
 
   @Test
@@ -73,7 +88,7 @@ public class AclResourceTest {
     doThrow(new RuntimeException("denied")).when(adaptor).saveAcls(any());
 
     WebApplicationException ex =
-        assertThrows(WebApplicationException.class, () -> resource.saveAcls(list));
+        assertThrows(WebApplicationException.class, () -> resource.persistAcls(list));
     assertEquals(500, ex.getResponse().getStatus());
   }
 


### PR DESCRIPTION
## Summary

PUT `/services/acls/bulk` still returned HTTP 400 `ClassCastException: Cannot cast java.util.ArrayList to com.percussion.rest.acls.AclList` on Display Format Object ACL Save after #3387. `AclListJsonReader` was listed ahead of `jacksonProvider`, but the live CXF pipeline still selected Jackson (and Jettison rejected a bare array).

This PR:

- Adds `AclListDeserializer` so Jackson instantiates `AclList`, not a raw `ArrayList`.
- Binds PUT `/acls/bulk` as a JSON string then `AclListJsonReader.parse` (`{"AclList":[…]}` or `[{…}]`).
- Builds `PSGuid` from `type`/`uuid`/`hostId` when `stringValue` is blank (`raw may not be blank`).
- Adds a CXF/JAX-RS pipeline test that the real save envelope unmarshals to `AclList`.

Parent: #2640 / slice of #3378.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3391
Partial #3378 #2640

## Test plan

1. Standalone `cd rest && ../mvnw clean install` — BUILD SUCCESS, Tests run: 399, Failures: 0.
2. Standalone `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS.
3. H2 QA: `perc-devctl qa-up --skip-image-build` → `qa-health` → hot-deploy rest + sitemanage + perc-system jars into WAR `WEB-INF/lib` + in-cell Jetty restart → `qa-health`.
4. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js` — 1 passed.
5. Confirm PUT save is HTTP 200 and reopen still shows Default + AnyCommunity + USER Admin.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (envelope bind + guid without stringValue)
- [x] **Unit / module tests** — CXF unmarshal, reader, resource, `ApiUtils.convertGuid`; standalone clean install green
- [x] **WebUI + Playwright** — existing spec `developer-object-acl-display-format-save.spec.js` passed on H2 QA
- [x] **Build gates** — rest + sitemanage standalone `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — N/A (JSON/JAX-RS only; no filesystem path construction)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:** `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 399, Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS
- **downstream_checked:** grepped `extends AclList` / `new AclList() {` (none). `AclResource.saveAcls` now takes `String` (JAX-RS only; no Java callers outside rest tests). sitemanage standalone install green.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:44970` `QA_CONTAINER=perc-matrix-cms-h2`
- qa-health: `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy`
- deploy: docker cp rest + sitemanage + perc-system jars to `WEB-INF/lib`; in-cell `StopJetty.sh` / `StartJetty.sh` (not docker restart)
- Playwright: `npm run test:surface -- --path tests/developer-object-acl-display-format-save.spec.js` — 1 passed (4.6s)
- console-clean=yes
- server.log-clean=yes (for the passing test window; one earlier session ERROR at 22:47 was the pre-fix persist attempt)

> Co-Authored by Grok Build 1.0.3 using grok-4.6 with agent night-issue-prs.
