### PR TITLE
fix(utils): count PSDateRange days as inclusive calendar dates

### DIFF
--- a/docs/ai-generated/code-reviews/psdaterange-daysinrange-erlang.md
+++ b/docs/ai-generated/code-reviews/psdaterange-daysinrange-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — PSDateRange.getDaysInRange calendar-day count
+
+**Branch:** `main` (uncommitted vs `HEAD` `23533bc0862e96e4d84ef203f93cce67155c452b`)  
+**Scope:** local working tree vs `HEAD` (two files)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests required for changed date math (met); Calendar leftover fields / Interval whole-day undercount (this is the fix); no path I/O.
+
+## Summary
+
+`PSDateRange.getDaysInRange()` stopped using `Days.daysIn(new Interval(start, end.plusDays(1)))`, which counts whole chronology days and undercounts by one whenever start millis-of-day is greater than end millis-of-day. The new implementation is `Days.daysBetween(start.toLocalDate(), end.toLocalDate()).getDays() + 1` — inclusive calendar days, time ignored — which matches the class contract and `getGranularityBreakdown()` day walks.
+
+`PSDateRangeTest.createDate` now `clear()`s the `Calendar` before `set(year, month-1, day)`, so leftover `MILLISECOND` from `getInstance()` cannot re-flake the existing midnight assertions. Two new cases lock the regression (Feb 28 23:59:59.999 → Mar 2 00:00:00.000, and 800ms vs 100ms).
+
+Call site `PSTrafficService` uses `getDaysInRange()` as a DAY duration for the previous window. Date-only `MM/dd/yyyy` parse paths are unchanged; time-bearing ranges that previously undercounted now get the correct inclusive length. That is the intended fix, not a silent contract break.
+
+Implementer evidence: `cd modules/utils && ../../mvnw.cmd clean install` BUILD SUCCESS; Tests run 387, Failures 0, Errors 0, Skipped 9; `PSDateRangeTest` 6/6.
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path construction, temp files, or path assertions.
+
+## Change-class closure
+
+Internal utility bugfix + existing unit test class. No Spring scan, REST adaptor, WebUI, Playwright, or `product-docs/` companion required. Module `AGENTS.md` absent under `modules/utils/`.
+
+## Issues
+
+None.
+
+## Suggestion (non-blocking)
+
+Optional extra assertion: same calendar day with different clock times (e.g. 00:00:00.800 → 23:59:59.100) expecting `1`. The two added cases already prove the undercount class; this would only document the same-day bound.
+
+## Pattern candidate (do not commit without human rule review)
+
+`Calendar.set(y, m, d, h, min, s)` does not zero `MILLISECOND`. Pairing leftover millis with `Days.daysIn(Interval)` / `daysBetween(DateTime, DateTime)` undercounts when start millis-of-day exceeds end. Prefer `LocalDate` day counts, or `cal.clear()` / explicit `MILLISECOND = 0`.

--- a/modules/utils/src/main/java/com/percussion/utils/date/PSDateRange.java
+++ b/modules/utils/src/main/java/com/percussion/utils/date/PSDateRange.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
 import org.joda.time.Days;
-import org.joda.time.Interval;
 
 /**
  * Class to encapsulate a date range. The granularity calculation functions all ignore the time
@@ -226,10 +225,12 @@ public class PSDateRange {
   }
 
   /**
-   * @return The number of days spanned by this range, regardless of the granularity setting.
+   * @return The number of inclusive calendar days spanned by this range, regardless of the
+   *     granularity setting. Time of day is ignored so a start later in the clock than the end
+   *     cannot undercount (as {@code Days.daysIn(Interval)} does).
    */
   public int getDaysInRange() {
-    return Days.daysIn(new Interval(start, end.plusDays(1))).getDays();
+    return Days.daysBetween(start.toLocalDate(), end.toLocalDate()).getDays() + 1;
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/utils/date/PSDateRangeTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/date/PSDateRangeTest.java
@@ -42,7 +42,8 @@ public class PSDateRangeTest {
    */
   private Date createDate(int year, int month, int day) {
     Calendar cal = Calendar.getInstance();
-    cal.set(year, month - 1, day, 0, 0, 0);
+    cal.clear();
+    cal.set(year, month - 1, day);
     return cal.getTime();
   }
 
@@ -216,6 +217,32 @@ public class PSDateRangeTest {
     d2 = createDate(2013, 1, 1);
     range = new PSDateRange(d1, d2);
     assertEquals(367, range.getDaysInRange());
+
+    // Time of day must not change the inclusive calendar-day count. The previous
+    // Interval-based implementation undercounted when start millis-of-day >
+    // end millis-of-day (the flake at the Feb 28–Mar 2 assertion above).
+    Calendar cal = Calendar.getInstance();
+    cal.clear();
+    cal.set(2010, Calendar.FEBRUARY, 28, 23, 59, 59);
+    cal.set(Calendar.MILLISECOND, 999);
+    d1 = cal.getTime();
+    cal.clear();
+    cal.set(2010, Calendar.MARCH, 2, 0, 0, 0);
+    cal.set(Calendar.MILLISECOND, 0);
+    d2 = cal.getTime();
+    range = new PSDateRange(d1, d2);
+    assertEquals(3, range.getDaysInRange());
+
+    cal.clear();
+    cal.set(2010, Calendar.FEBRUARY, 28, 0, 0, 0);
+    cal.set(Calendar.MILLISECOND, 800);
+    d1 = cal.getTime();
+    cal.clear();
+    cal.set(2010, Calendar.MARCH, 2, 0, 0, 0);
+    cal.set(Calendar.MILLISECOND, 100);
+    d2 = cal.getTime();
+    range = new PSDateRange(d1, d2);
+    assertEquals(3, range.getDaysInRange());
   }
 
   @Test


### PR DESCRIPTION
## Summary

`PSDateRange.getDaysInRange()` counted whole millisecond days via `Days.daysIn(new Interval(start, end.plusDays(1)))`. Leftover `Calendar` milliseconds (and any real range whose start time-of-day is later than end) undercounted by one. That is why `PSDateRangeTest.testDayGranularity` failed with `expected: <3> but was: <2>` for 2010-02-28 through 2010-03-02.

The method now counts inclusive calendar days with `Days.daysBetween(start.toLocalDate(), end.toLocalDate()).getDays() + 1`, matching the class contract that granularity functions ignore time of day. The test helper clears the `Calendar` before setting the date, and two time-of-day cases lock the previous flake.

Erlang pre-commit review: **approve** (`docs/ai-generated/code-reviews/psdaterange-daysinrange-erlang.md`).

## Test plan

1. `cd modules/utils` then `..\..\mvnw.cmd clean install` (standalone; do not skip tests).
2. Confirm `PSDateRangeTest` is green (including `testDayGranularity`).
3. Confirm module suite: Tests run 387, Failures 0, Errors 0, Skipped 9 (or current equivalent with no new failures).

Already run locally: **BUILD SUCCESS**, Tests run: 387, Failures: 0, Errors: 0, Skipped: 9.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal `modules/utils` date helper + unit test
- [x] **Unit / module tests** — time-of-day regression cases added; `modules/utils` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd modules/utils && ../../mvnw.cmd clean install` BUILD SUCCESS
- [x] **Cross-platform** — **N/A** (no path/file I/O)

> Co-Authored by Grok 4.6 using grok-4.6 with agent Grok.
