### PR TITLE
fix(acl): flush managed ACLs on upgrade package install (#3397)

### DIFF
--- a/docs/ai-generated/code-reviews/acl-package-install-entity-copy-erlang.md
+++ b/docs/ai-generated/code-reviews/acl-package-install-entity-copy-erlang.md
@@ -1,0 +1,118 @@
+# Erlang review — ACL package-install entity copy (`fix/acl-package-install-entity-copy`)
+
+**Date:** 2026-08-14  
+**Reviewer:** Erlang Shen (independent of implementer)  
+**Target:** uncommitted working tree vs `origin/main` (GitHub `main` raw used as base proxy)
+
+## Summary
+
+Upgrade package install (`perc.responsiveTemplates`, `perc.twitterSummaryCards`) failed after #3387 because `internalPersist` always `session.merge`d an already-persistent ACL graph, and `PSAclEntryImpl.merge` had a 2021 empty-`if` (`if (...);`) that always `addPsPermission`’d the incoming `PSAccessLevelImpl` — including rows that already shared a SYSID with the managed collection. Hibernate 6/7 `EntityCopyNotAllowedObserver` then threw `Multiple representations of the same entity [PSAccessLevelImpl]`; the service logged `Error persisting Acl` (118× on the cited upgrade).
+
+The production repair is the right one: clone missing permission types without SYSID, drop types absent from incoming, flush a session-managed ACL instead of merging it, and short-circuit `findExistingPersistIdentity` when the source is already the session identity. First-pass gap (untested persist-path) is closed: `persistInSession` / `isSessionIdentity` are extracted and covered by Mockito tests. Merge tests now use a distinct incoming SYSID so `HashSet.equals` cannot hide an attach. No remaining bugs.
+
+## Scope
+
+- Base: `origin/main` (reconstructed from GitHub `main` raw of the three production files; no shell `git` in this subagent)
+- Head: uncommitted work on `fix/acl-package-install-entity-copy`
+- Files: 4 (3 modified, 1 new) as listed by the author
+  - `system/services/src/com/percussion/services/security/data/PSAclEntryImpl.java`
+  - `system/services/src/com/percussion/services/security/impl/PSAclService.java`
+  - `system/services/src/com/percussion/services/security/PSAclPersistMerger.java` (comment only)
+  - `system/src/test/java/com/percussion/services/security/data/PSAclEntryImplMergeTest.java` (new)
+- Prior reports: `docs/ai-generated/code-reviews/3384-display-format-acl-persist-erlang.md` (topic parent); also `3378-display-format-acl-save-400-erlang.md`, `3391-acl-bulk-arraylist-cast-erlang.md`, `3282-objectacl-sysid-collision-erlang.md`
+- Memory patterns hit: missing behavioral tests for new logic; Hibernate `@Version` / `session.merge` / managed-entity residuals; empty / accidental control-flow (stray `;`); change-class companions (entity merge + persist path + tests)
+- Cross-platform path review: **no issues** (no filesystem I/O, path joins, or path assertions)
+- Product documentation: **N/A** — persist/upgrade defect; no operator-facing ACL semantics change
+- Independence: this reviewer did not author the change
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: **yes**
+
+Product/test files only. Do **not** include `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md` in the commit unless a human has explicitly approved that rule-file draft.
+
+## Issues
+
+### Issue 1 -- Severity: bug
+- File: `system/services/src/com/percussion/services/security/impl/PSAclService.java:680`
+- Description: `internalPersist` now branches `session.contains` → `flush()` else `session.merge()`. That is the #3387 half of the upgrade failure (always-merge of a `createAcl` persist()ed graph with bidirectional EAGER entries/permissions). `findExistingPersistIdentity` also gained a `session.contains(src)` short-circuit (`PSAclService.java:736`). Neither decision is exercised by a test. `PSAclEntryImplMergeTest` covers only the empty-`if` / clone-without-SYSID half. A one-line revert to always-merge would re-break package install and would still be green.
+- Suggestion: Add a focused unit test (Mockito `Session` + package-visible helper, or a small `persistManagedVsDetached` method extracted from `internalPersist`) that asserts:
+  1. when `session.contains(acl)` is true, `merge` is **never** called and `flush` is;
+  2. when `contains` is false and no existing identity is found, `merge` **is** called;
+  3. when `contains(src)` is true, `findExistingPersistIdentity` returns `src` and does not `session.get` a second representation.
+  Place it next to `PSAclPersistMergerTest` / `PSAclServiceTransactionalEntryPointsTest`. Then re-review.
+- Status: fixed
+- Pattern-id: tests.missing-behavioral
+
+### Issue 2 -- Severity: suggestion
+- File: `system/src/test/java/com/percussion/services/security/data/PSAclEntryImplMergeTest.java:50`
+- Description: `samePermissionTypeIsNotDuplicated` and `mergeDoesNotAttachSharedSysidTwiceOnAclImplMerge` use the same SYSID **and** default `aclEntryId == 0` on both graphs. `PSAccessLevelImpl.equals` is `(id, aclEntryId, permission)`, so `HashSet.add` of the incoming entity is a no-op even on the **old** empty-`if` code. Those two tests would not fail if someone re-introduced `addPsPermission(incoming)` for an already-present ordinal. `incomingPermissionEntityIsNotAttached` is the test that actually fails on origin/main.
+- Suggestion: Give the incoming entry a distinct id (or distinct `aclEntryId`) so Java-equals cannot hide an attach, **or** assert the collection identity set does not contain the incoming instance (`assertFalse(target.getPsPermissions().contains(incomingDelete))` is insufficient for the same reason — prefer `assertTrue(target perms stream noneMatch(p -> p == incomingDelete))` after forcing a non-equal incoming row). Keep `incomingPermissionEntityIsNotAttached` as the primary lock.
+- Status: fixed
+- Pattern-id: tests.happy-path-only
+
+### Issue 3 -- Severity: nit
+- File: `system/services/src/com/percussion/services/security/PSAclPersistMerger.java:41`
+- Description: Method javadoc still says “the instance Hibernate should merge/persist.” The new class comment correctly says package-install of an already-persistent ACL must **not** `session.merge`. Callers that only read the method javadoc will do the wrong thing.
+- Suggestion: Change the `@return` line to “the session identity to flush if managed, or the detached/transient instance to `session.merge`.”
+- Status: fixed
+
+## What looks correct (not issues)
+
+- Origin/main `PSAclEntryImpl.merge` really is `if (!curPer.containsKey(...)); { addPsPermission(newAccess); }` — the stray semicolon is the 2021 defect. Replacing it with `new PSAccessLevelImpl(this, incoming.getPermission())` matches the copy-ctor used for new entries in `PSAclImpl.merge` (`new PSAclEntryImpl(this, entryImpl)`).
+- Removal of ordinals absent from incoming is preserved (`psPermissions.removeAll` after `keySet().removeAll(incomingOrdinals)`).
+- `createAcl` + `saveAcls` (same or later transaction): `contains` short-circuit **or** `session.get` + `mergeOntoExisting` + flush. Both avoid merge of a managed bidirectional graph.
+- REST `#3384` path (`AclAdaptor` already `mergeOntoExisting`s, then `saveAcls`) still works: new permission types are cloned without SYSID; existing types keep the managed row. Old empty-`if` could have added a second DELETE row (`id=0` vs persisted SYSID — `HashSet`/`PersistentSet` both accept that).
+- `PSAclPersistMerger.mergeOntoExisting` body unchanged; `existing == incoming` already no-ops. Comment-only edit is accurate.
+- New test file copyright is Intersoft 2026; legacy production headers left Percussion. JUnit 5. No new Spring beans / REST surface / product-docs required.
+- Change-class companions otherwise present: entity merge + persist branch + unit test file. Missing piece is Issue 1 only.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] No `Path` / `File` construction added
+- [x] Tests do not assert OS-specific path strings
+- [x] No scripts
+
+## Handoff
+
+- Re-reviewed: uncommitted ACL persist/entity-copy fix vs `origin/main` (product + tests).
+- Prior Issue 1/2/3: **fixed**. No new bugs.
+- Recommendation: **approve**. May commit/push: **yes** (exclude unapproved `patterns.md`).
+- Artifact: `docs/ai-generated/code-reviews/acl-package-install-entity-copy-erlang.md`
+
+## Re-review
+
+**Date:** 2026-08-14 (same day, after request-changes)  
+**Diff:** uncommitted vs `HEAD` / `origin/main` (no commits on branch). Files: `PSAclPersistMerger.java`, `PSAclService.java`, `PSAclEntryImpl.java`, `PSAclPersistMergerTest.java`, new `PSAclEntryImplMergeTest.java`, plus leftover `patterns.md` (not re-touched this pass).
+
+### Prior issues
+
+| Issue | Result |
+|-------|--------|
+| 1 bug — persist `contains`→flush vs merge untested | **Fixed.** `PSAclPersistMerger.persistInSession` / `isSessionIdentity` extracted. `PSAclService.internalPersist` calls `persistInSession`; `findExistingPersistIdentity` returns `src` when `isSessionIdentity`. Tests: `managedAclFlushesAndDoesNotMerge`, `detachedAclIsMerged`, `sessionIdentityDoesNotLookUpSecondRepresentation`, `detachedIsNotSessionIdentity`, `persistInSessionRejectsNulls`. |
+| 2 suggestion — HashSet.equals hid attach | **Fixed.** Incoming DELETE SYSID is `99L` (target keeps `SHARED_DELETE_SYSID`). `samePermissionTypeIsNotDuplicated` asserts `noneMatch(p -> p == incomingDelete)`. `mergeDoesNotAttachSharedSysidTwiceOnAclImplMerge` would see `deleteCount == 2` if incoming were attached. |
+| 3 nit — `mergeOntoExisting` `@return` | **Fixed.** Javadoc now says flush-if-managed / `session.merge` if detached. |
+
+### New findings
+
+None.
+
+`sessionIdentityDoesNotLookUpSecondRepresentation` only exercises `isSessionIdentity` (which never calls `session.get`); the service short-circuit is a three-line glue return. Acceptable — the non-trivial persist decision is locked by `persistInSession` tests. Class javadoc on `PSAclPersistMergerTest` still leads with #3384 only; not blocking.
+
+### Commit hygiene (not a code defect)
+
+Working tree still has `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md` (one Hibernate entity-copy line from the first review). Root `AGENTS.md` **Human review of agent rules** — leave it uncommitted unless the human approves that rule diff.
+
+### Cross-platform path checklist
+
+Unchanged: no filesystem I/O. No issues.
+
+### Gate
+
+approve — May commit/push: **yes**

--- a/system/services/src/com/percussion/services/security/PSAclPersistMerger.java
+++ b/system/services/src/com/percussion/services/security/PSAclPersistMerger.java
@@ -18,15 +18,49 @@ package com.percussion.services.security;
 
 import com.percussion.services.security.data.PSAclImpl;
 import com.percussion.utils.guid.IPSGuid;
+import org.hibernate.Session;
 
 /**
  * Merge a converted REST/wire ACL onto an existing Hibernate identity so save
  * updates {@code PSX_ACLS} instead of inserting a duplicate {@code PK_PSX_ACLS}
- * (#3384).
+ * (#3384). Package-install save of an already-persistent ACL must not {@code
+ * session.merge} that graph — flush the session identity instead.
  */
 public final class PSAclPersistMerger {
 
   private PSAclPersistMerger() {}
+
+  /**
+   * {@code true} when {@code entity} is already the Hibernate session identity
+   * (for example after {@code createAcl} {@code persist()}, or a package-install
+   * load in the same session).
+   */
+  public static boolean isSessionIdentity(Session session, Object entity) {
+    return session != null && entity != null && session.contains(entity);
+  }
+
+  /**
+   * Flush a managed ACL; {@code session.merge} only a detached/transient one.
+   * Merging a managed bidirectional EAGER ACL graph raises Hibernate {@code
+   * Multiple representations of the same entity [PSAccessLevelImpl]}.
+   *
+   * @param session open Hibernate session, never {@code null}
+   * @param acl ACL to persist, never {@code null}
+   * @return the session identity (managed input, or merge result)
+   */
+  public static IPSAcl persistInSession(Session session, IPSAcl acl) {
+    if (session == null) {
+      throw new IllegalArgumentException("session may not be null");
+    }
+    if (acl == null) {
+      throw new IllegalArgumentException("acl may not be null");
+    }
+    if (isSessionIdentity(session, acl)) {
+      session.flush();
+      return acl;
+    }
+    return (IPSAcl) session.merge(acl);
+  }
 
   /**
    * Copy incoming name/description/entries onto {@code existing} while keeping
@@ -37,7 +71,8 @@ public final class PSAclPersistMerger {
    *     a first insert
    * @param incoming converted payload, not {@code null} when {@code existing} is
    *     {@code null}
-   * @return the instance Hibernate should merge/persist
+   * @return the session identity to flush if managed, or the detached/transient
+   *     instance to {@code session.merge}
    */
   public static PSAclImpl mergeOntoExisting(PSAclImpl existing, PSAclImpl incoming) {
     if (existing == null) {

--- a/system/services/src/com/percussion/services/security/data/PSAclEntryImpl.java
+++ b/system/services/src/com/percussion/services/security/data/PSAclEntryImpl.java
@@ -685,9 +685,15 @@ public class PSAclEntryImpl implements IPSAclEntry
    }
 
    /**
-    * Performs a shallow copy, merging permissions from the supplied entry,
-    * handling additions and deletes, ignores id and aclid.
-    * 
+    * Merge permission types from {@code srcEntry} onto this entry.
+    *
+    * <p>Adds missing permission types as <strong>new</strong> {@link
+    * PSAccessLevelImpl} rows (no SYSID). Does not attach the source permission
+    * entities — those often share SYSIDs with the already-managed collection
+    * (package install / REST save), and Hibernate then fails with {@code
+    * Multiple representations of the same entity [PSAccessLevelImpl]} during
+    * {@code session.merge}.
+    *
     * @param srcEntry The source entry, may not be <code>null</code>.
     */
    public void merge(PSAclEntryImpl srcEntry)
@@ -695,42 +701,30 @@ public class PSAclEntryImpl implements IPSAclEntry
       if (srcEntry == null)
          throw new IllegalArgumentException("srcEntry may not be null");
 
-      log.debug("Merging aclEntry name="+name+" type="+type);
+      log.debug("Merging aclEntry name={} type={}", name, type);
       name = srcEntry.name;
       type = srcEntry.type;
 
-    
-      Set<Short> updatePer = new HashSet<>();
-      
-      for (PSAccessLevelImpl updateAccess : srcEntry.getPsPermissions())
-      {
-         updatePer.add(updateAccess.getPermission().getOrdinal());
-         }
-      
-      
-      HashMap<Short,PSAccessLevelImpl> curPer = new HashMap<>();
-      HashSet<Short> newPer = new HashSet<>();
-      
+      Map<Short, PSAccessLevelImpl> currentByOrdinal = new HashMap<>();
       for (PSAccessLevelImpl currAccess : getPsPermissions())
+      {
+         currentByOrdinal.put(currAccess.getPermission().getOrdinal(), currAccess);
+      }
+
+      Set<Short> incomingOrdinals = new HashSet<>();
+      for (PSAccessLevelImpl incoming : srcEntry.getPsPermissions())
+      {
+         short ordinal = incoming.getPermission().getOrdinal();
+         incomingOrdinals.add(ordinal);
+         if (!currentByOrdinal.containsKey(ordinal))
          {
-         curPer.put(currAccess.getPermission().getOrdinal(), currAccess);
+            addPsPermission(new PSAccessLevelImpl(this, incoming.getPermission()));
          }
-
-      for (PSAccessLevelImpl newAccess : srcEntry.getPsPermissions())
-      {
-         newPer.add(newAccess.getPermission().getOrdinal());
-         if (!curPer.containsKey(newAccess.getPermission().getOrdinal()));
-      {
-            addPsPermission(newAccess);
       }
+
+      currentByOrdinal.keySet().removeAll(incomingOrdinals);
+      psPermissions.removeAll(currentByOrdinal.values());
    }
-
-      curPer.keySet().removeAll(newPer);
-      
-      psPermissions.removeAll(curPer.values());
-     
-      
-      }
 
   
 

--- a/system/services/src/com/percussion/services/security/impl/PSAclService.java
+++ b/system/services/src/com/percussion/services/security/impl/PSAclService.java
@@ -661,6 +661,7 @@ public class PSAclService implements IPSAclService
    public List<IPSAcl> internalPersist(List<IPSAcl> aclList) throws PSServiceSecurityException
    {
       List<IPSAcl> updatedList = new ArrayList<>();
+      Session session = getSession();
 
       for (IPSAcl iacl : aclList)
       {
@@ -670,7 +671,7 @@ public class PSAclService implements IPSAclService
                if (iacl instanceof PSAclImpl src) {
                   iacl = PSAclPersistMerger.mergeOntoExisting(findExistingPersistIdentity(src), src);
                }
-              iacl = (IPSAcl) getSession().merge(iacl);
+               iacl = PSAclPersistMerger.persistInSession(session, iacl);
                updatedList.add(iacl);
                 ms_logger.debug("Save complete.");
             } catch (Exception ex) {
@@ -685,7 +686,7 @@ public class PSAclService implements IPSAclService
          }
       }
 
-      getSession().flush();
+      session.flush();
       for (IPSAcl saved : updatedList) {
          evictAclSecondLevelCache(saved);
       }
@@ -719,9 +720,14 @@ public class PSAclService implements IPSAclService
       {
          return null;
       }
+      Session session = getSession();
+      if (PSAclPersistMerger.isSessionIdentity(session, src))
+      {
+         return src;
+      }
       if (src.getId() != 0)
       {
-         PSAclImpl byId = getSession().get(PSAclImpl.class, src.getId());
+         PSAclImpl byId = session.get(PSAclImpl.class, src.getId());
          if (byId != null)
          {
             return byId;

--- a/system/src/test/java/com/percussion/services/security/PSAclPersistMergerTest.java
+++ b/system/src/test/java/com/percussion/services/security/PSAclPersistMergerTest.java
@@ -17,9 +17,16 @@
 package com.percussion.services.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
 import com.percussion.services.security.data.PSAccessLevelImpl;
@@ -27,6 +34,7 @@ import com.percussion.services.security.data.PSAclEntryImpl;
 import com.percussion.services.security.data.PSAclImpl;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.hibernate.Session;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -91,6 +99,63 @@ class PSAclPersistMergerTest {
     assertEquals(31, merged.getObjectType());
     assertEquals(5, merged.getObjectId());
     assertTrue(merged.getObjectGuid().toString().contains("31"));
+  }
+
+  @Test
+  void managedAclFlushesAndDoesNotMerge() {
+    Session session = mock(Session.class);
+    PSAclImpl acl = newAcl(42, 3, 31, 5);
+    when(session.contains(acl)).thenReturn(true);
+
+    IPSAcl result = PSAclPersistMerger.persistInSession(session, acl);
+
+    assertSame(acl, result);
+    verify(session).flush();
+    verify(session, never()).merge(any());
+  }
+
+  @Test
+  void detachedAclIsMerged() {
+    Session session = mock(Session.class);
+    PSAclImpl incoming = newAcl(42, null, 31, 5);
+    PSAclImpl merged = newAcl(42, 1, 31, 5);
+    when(session.contains(incoming)).thenReturn(false);
+    when(session.merge(incoming)).thenReturn(merged);
+
+    IPSAcl result = PSAclPersistMerger.persistInSession(session, incoming);
+
+    assertSame(merged, result);
+    verify(session).merge(incoming);
+    verify(session, never()).flush();
+  }
+
+  @Test
+  void sessionIdentityDoesNotLookUpSecondRepresentation() {
+    Session session = mock(Session.class);
+    PSAclImpl src = newAcl(42, 3, 31, 5);
+    when(session.contains(src)).thenReturn(true);
+
+    assertTrue(PSAclPersistMerger.isSessionIdentity(session, src));
+    verify(session, never()).get(any(Class.class), any());
+    verify(session, never()).get(any(String.class), any());
+  }
+
+  @Test
+  void detachedIsNotSessionIdentity() {
+    Session session = mock(Session.class);
+    PSAclImpl src = newAcl(42, 3, 31, 5);
+    when(session.contains(src)).thenReturn(false);
+
+    assertFalse(PSAclPersistMerger.isSessionIdentity(session, src));
+  }
+
+  @Test
+  void persistInSessionRejectsNulls() {
+    Session session = mock(Session.class);
+    PSAclImpl acl = newAcl(1, 0, 31, 5);
+    assertThrows(IllegalArgumentException.class, () -> PSAclPersistMerger.persistInSession(null, acl));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSAclPersistMerger.persistInSession(session, null));
   }
 
   private static PSAclImpl newAcl(long id, Integer version, int objectType, long objectId) {

--- a/system/src/test/java/com/percussion/services/security/data/PSAclEntryImplMergeTest.java
+++ b/system/src/test/java/com/percussion/services/security/data/PSAclEntryImplMergeTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.security.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
+import com.percussion.services.security.PSPermissions;
+import com.percussion.services.security.PSTypedPrincipal;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link PSAclEntryImpl#merge(PSAclEntryImpl)}.
+ *
+ * <p>Upgrade package install ({@code perc.responsiveTemplates}) failed after #3387 because {@code
+ * merge} always attached the incoming {@link PSAccessLevelImpl} (stray {@code if (...);} ).
+ * Hibernate then saw two representations of the same permission SYSID.
+ */
+@Tag("UnitTest")
+class PSAclEntryImplMergeTest {
+
+  private static final long SHARED_DELETE_SYSID = 8896224446637942734L;
+
+  @Test
+  void nullSourceThrows() {
+    PSAclEntryImpl target = entry("Default", PrincipalTypes.USER, PSPermissions.OWNER);
+    assertThrows(IllegalArgumentException.class, () -> target.merge(null));
+  }
+
+  @Test
+  void samePermissionTypeIsNotDuplicated() {
+    PSAclEntryImpl target = entry("Default", PrincipalTypes.USER, PSPermissions.DELETE);
+    setPermissionId(target, PSPermissions.DELETE, SHARED_DELETE_SYSID);
+
+    PSAclEntryImpl incoming = entry("Default", PrincipalTypes.USER, PSPermissions.DELETE);
+    // Distinct incoming SYSID so HashSet.equals cannot hide an attach.
+    setPermissionId(incoming, PSPermissions.DELETE, 99L);
+
+    PSAccessLevelImpl incomingDelete = only(incoming, PSPermissions.DELETE);
+    target.merge(incoming);
+
+    assertEquals(1, target.getPsPermissions().size());
+    PSAccessLevelImpl kept = only(target, PSPermissions.DELETE);
+    assertEquals(SHARED_DELETE_SYSID, kept.getId());
+    assertNotSame(incomingDelete, kept);
+    assertTrue(
+        target.getPsPermissions().stream().noneMatch(p -> p == incomingDelete),
+        "must keep the target permission instance, not attach the incoming entity");
+  }
+
+  @Test
+  void incomingPermissionEntityIsNotAttached() {
+    PSAclEntryImpl target = entry("Default", PrincipalTypes.USER, PSPermissions.OWNER);
+    PSAclEntryImpl incoming =
+        entry("Default", PrincipalTypes.USER, PSPermissions.OWNER, PSPermissions.READ);
+
+    PSAccessLevelImpl incomingRead = only(incoming, PSPermissions.READ);
+    incomingRead.setId(42L);
+
+    target.merge(incoming);
+
+    assertEquals(
+        Set.of(PSPermissions.OWNER, PSPermissions.READ),
+        target.getPsPermissions().stream()
+            .map(PSAccessLevelImpl::getPermission)
+            .collect(Collectors.toSet()));
+    PSAccessLevelImpl addedRead = only(target, PSPermissions.READ);
+    assertNotSame(incomingRead, addedRead);
+    assertEquals(0L, addedRead.getId(), "new permission row must not copy the incoming SYSID");
+  }
+
+  @Test
+  void permissionTypesAbsentFromIncomingAreRemoved() {
+    PSAclEntryImpl target =
+        entry("Editor", PrincipalTypes.ROLE, PSPermissions.READ, PSPermissions.UPDATE);
+    PSAclEntryImpl incoming = entry("Editor", PrincipalTypes.ROLE, PSPermissions.READ);
+
+    target.merge(incoming);
+
+    assertEquals(1, target.getPsPermissions().size());
+    assertEquals(PSPermissions.READ, target.getPsPermissions().iterator().next().getPermission());
+  }
+
+  @Test
+  void mergeDoesNotAttachSharedSysidTwiceOnAclImplMerge() {
+    PSAclImpl existing = new PSAclImpl();
+    existing.setId(7);
+    existing.setName("By_Author ACL");
+    PSAclEntryImpl existingDefault =
+        entry("Default", PrincipalTypes.USER, PSPermissions.DELETE, PSPermissions.OWNER);
+    setPermissionId(existingDefault, PSPermissions.DELETE, SHARED_DELETE_SYSID);
+    existing.addEntry(existingDefault);
+
+    PSAclImpl incoming = new PSAclImpl();
+    incoming.setId(7);
+    incoming.setName("temp");
+    PSAclEntryImpl incomingDefault =
+        entry("Default", PrincipalTypes.USER, PSPermissions.DELETE, PSPermissions.OWNER);
+    setPermissionId(incomingDefault, PSPermissions.DELETE, 99L);
+    incoming.addEntry(incomingDefault);
+
+    existing.merge(incoming);
+
+    PSAclEntryImpl mergedDefault =
+        existing.getEntries().stream()
+            .filter(e -> "Default".equals(((PSAclEntryImpl) e).getName()))
+            .map(PSAclEntryImpl.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(2, mergedDefault.getPsPermissions().size());
+    long deleteCount =
+        mergedDefault.getPsPermissions().stream()
+            .filter(p -> p.getPermission() == PSPermissions.DELETE)
+            .count();
+    assertEquals(1, deleteCount);
+    assertEquals(SHARED_DELETE_SYSID, only(mergedDefault, PSPermissions.DELETE).getId());
+  }
+
+  private static PSAclEntryImpl entry(
+      String name, PrincipalTypes type, PSPermissions... permissions) {
+    PSAclEntryImpl entry = new PSAclEntryImpl(new PSTypedPrincipal(name, type));
+    for (PSPermissions permission : permissions) {
+      entry.addPermission(new PSAccessLevelImpl(entry, permission));
+    }
+    return entry;
+  }
+
+  private static void setPermissionId(
+      PSAclEntryImpl entry, PSPermissions permission, long id) {
+    only(entry, permission).setId(id);
+  }
+
+  private static PSAccessLevelImpl only(PSAclEntryImpl entry, PSPermissions permission) {
+    return entry.getPsPermissions().stream()
+        .filter(p -> p.getPermission() == permission)
+        .findFirst()
+        .orElseThrow();
+  }
+}


### PR DESCRIPTION
## Summary

Upgrade install after a full `main` build failed ACL persist on every startup. `server.log` showed ~118 `Error persisting Acl` lines, then:

- `Multiple representations of the same entity [PSAccessLevelImpl]`
- `Transaction silently rolled back`
- `perc.responsiveTemplates` and `perc.twitterSummaryCards` failed to install

Two cooperating defects:

1. **#3387** made every `saveAcls` call `session.merge`. Package install / `createAcl` already `persist()`s that ACL. Hibernate 7 rejects merge of the managed bidirectional EAGER entries/permissions graph.
2. **`PSAclEntryImpl.merge`** had a 2021 empty `if (...);` that always attached incoming `PSAccessLevelImpl` entities (shared SYSIDs from package/REST payloads).

This PR flushes a session-managed ACL instead of merging it, clones missing permission types without SYSID, and short-circuits identity lookup when the incoming ACL is already the session instance.

Fixes #3397  
Residual of #3384 / PR #3387

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS
2. Confirm `PSAclEntryImplMergeTest` (5) and `PSAclPersistMergerTest` (9) pass
3. After merge: rebuild/redeploy `perc-system` to the upgrade install (`C:\Installs\8.2-july-29`), restart
4. Confirm no `Error persisting Acl` / `Multiple representations of PSAccessLevelImpl` on startup
5. Confirm `perc.responsiveTemplates` and `perc.twitterSummaryCards` install
6. Confirm Display Format Object ACL save/GET from #3384 still works (no duplicate `PK_PSX_ACLS`)

## Checklist

- [x] **Product documentation** — **N/A** (persist/upgrade defect; no new operator-facing ACL semantics)
- [x] **Unit / module tests** — `PSAclEntryImplMergeTest` (5), `PSAclPersistMergerTest` (9 including flush-vs-merge)
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (`Tests run: 2181, Failures: 0, Errors: 0, Skipped: 241`); no new warnings attributable to this change (pre-existing javadoc noise)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS
- **downstream_checked:** no public API signature change; `persistInSession` / `isSessionIdentity` added on existing helper; rest/sitemanage ACL save still goes through `saveAcls`

## Erlang

`docs/ai-generated/code-reviews/acl-package-install-entity-copy-erlang.md` — approve (re-review after persist-path tests).

Rule-file draft `modules/ai-shared-develop/.../skills/erlang-review/patterns.md` left **uncommitted** (human review of agent rules).

> Co-Authored by Grok 4.6 using grok-4.6 with agent Grok.
