### PR TITLE
fix(utils): treat non-listener bind failures as offline DTS

### DIFF
--- a/docs/ai-generated/code-reviews/fix-install-port-excluded-range-offline-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-install-port-excluded-range-offline-erlang.md
@@ -1,0 +1,71 @@
+## Summary
+
+`InstallUtil.portAvailable` (used as the inverse of “CMS/DTS/Derby appears
+running”) treated every failed TCP bind as a live listener. On Windows hosts
+whose dynamic TCP range overlaps Hyper-V **excluded port ranges**,
+`ServerSocket(0)` can issue a port that binds once and then refuses every later
+bind. Offline install gates then aborted as if DTS were up. The same bind-only
+probe also still lost the GH-2779 UDP race when both bind phases failed.
+
+The patch adds a third phase: if exclusive and `SO_REUSEADDR` binds both fail,
+confirm a TCP listener with a short connect to loopback and other local
+interface addresses. Bind failures that are not accepts (excluded ranges,
+residual UDP races) report available. Tests retry port allocation until a
+post-close rebind succeeds, and cover the new listen-confirm helper.
+
+## Scope
+
+- Base: `origin/main` @ `dbae733efb`
+- Head: working tree (install-port files only; `patterns.md` not in this change)
+- Files: 3 (`modules/utils/src/main/java/com/percussion/install/InstallUtil.java`,
+  `modules/utils/src/test/java/com/percussion/install/InstallUtilRunningServerTest.java`,
+  this report)
+- Prior report: `fix-install-port-tcp-detection-erlang.md` (GH-2779 TCP-only bind)
+- Memory patterns hit: installer port-detection false positive; tests must
+  exercise behavior not only happy-path bind success
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+### Notes
+
+- **Call-site semantic** — `checkTomcatServerRunning`, `checkServerRunning`, and
+  `isDerbyRunning` all use `!portAvailable` as “process is listening”.
+  `isBindableTcpPort` is a separate bind-only helper and is unchanged. Phase 3
+  aligns `portAvailable` with the running-gate meaning without changing the
+  bind-to-choose-a-port path.
+- **LAN-only listeners** — connect probes walk up, non-link-local addresses so a
+  Tomcat bound only to a NIC IP is still detected. Loopback is tried first
+  (typical `0.0.0.0` / dual-stack product bind).
+- **Behavioral coverage** — `isLocalTcpPortAccepting_tracksListener` proves the
+  new helper; `findDistinctFreePorts_remainAvailableAfterRelease` plus the
+  existing placeholder/literal offline tests cover the original false-positive;
+  `portAvailable_roundTrip` and bound-connector tests still cover the positive
+  (running) direction.
+- **Build evidence** — `cd modules/utils && ..\..\mvnw.cmd clean install` →
+  **BUILD SUCCESS**. `InstallUtilRunningServerTest`: Tests run: 11, Failures: 0.
+  Focused class rerun 8/8 green. No new compiler warnings on the touched files
+  (pre-existing javadoc warning baseline on the module is unchanged).
+- **Cross-platform path review** — N/A. No filesystem path joins, temp hardcodes,
+  or path-string assertions added. Sockets use `InetSocketAddress` / NIO-unrelated
+  `java.net`.
+- **Product documentation** — N/A. Internal install probe; no operator-facing
+  procedure, config key, or UI change. Fewer false “DTS is running” blocks is a
+  bugfix of existing gate behavior.
+
+### Non-blocking
+
+- Phase 3 may spend up to `200ms` per local address when a NIC blackholes SYNs
+  instead of RST. Install checks a handful of ports; acceptable. Do not cache
+  interface lists across process lifetime without invalidation (adapters come
+  and go).

--- a/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
+++ b/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
@@ -36,10 +36,14 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.NetworkInterface;
 import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,6 +56,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.jar.JarEntry;
@@ -808,14 +814,18 @@ public class InstallUtil {
     return isRunning;
   }
 
+  /** Localhost connect timeout for the listen-confirm phase of {@link #portAvailable(int)}. */
+  private static final int LOCAL_LISTEN_PROBE_TIMEOUT_MS = 200;
+
   /**
-   * Checks whether a TCP port can be bound.
+   * Checks whether a TCP port is free of a listening server.
    *
    * <p>This is a <strong>TCP-only</strong> probe. Callers (DTS Tomcat connector / Server shutdown
-   * ports, Derby JDBC, CMS Jetty bind checks) care about TCP listeners only. A UDP-only binding on
-   * the same port number must not make the port look unavailable.
+   * ports, Derby JDBC, CMS Jetty bind checks) use {@code !portAvailable} as “server appears
+   * running”. A UDP-only binding, a Windows Hyper-V excluded port range, or a brief {@code
+   * TIME_WAIT} must not look like a running server.
    *
-   * <p>Implementation uses a two-phase bind to stay deterministic on Windows Winsock (GH-2779):
+   * <p>Implementation (GH-2779 plus excluded-range false positives):
    *
    * <ol>
    *   <li>Bind without {@code SO_REUSEADDR}. Succeeds when no TCP socket holds the port (including
@@ -824,10 +834,13 @@ public class InstallUtil {
    *   <li>If that fails, bind with {@code SO_REUSEADDR} so a port briefly in {@code TIME_WAIT} from
    *       a previous close is still reported available (Linux holds TIME_WAIT ~60s; without this
    *       path offline-detection tests flake after a recent DTS close on the same host).
+   *   <li>If both binds fail, confirm a TCP listener with a short connect to local addresses. Bind
+   *       failures that are not listeners (excluded port ranges, residual UDP races) are treated as
+   *       available so install/upgrade gates do not abort on a stopped DTS.
    * </ol>
    *
    * @param port the TCP port to check for availability
-   * @return {@code true} when the TCP port can be bound, otherwise {@code false}
+   * @return {@code true} when no local TCP listener is accepting on the port
    */
   public static boolean portAvailable(int port) {
     InetSocketAddress address = new InetSocketAddress(port);
@@ -850,9 +863,77 @@ public class InstallUtil {
       ss.bind(address);
       return true;
     } catch (IOException e) {
-      logError("Port Availability Check Failed." + e.getMessage());
-      return false;
+      if (isLocalTcpPortAccepting(port)) {
+        logError("Port Availability Check Failed." + e.getMessage());
+        return false;
+      }
+      return true;
     }
+  }
+
+  /**
+   * Whether a TCP accept is reachable on a local address for {@code port}.
+   *
+   * @param port TCP port to probe
+   * @return {@code true} when a connect to loopback or another local interface succeeds
+   */
+  static boolean isLocalTcpPortAccepting(int port) {
+    for (InetAddress addr : localListenProbeAddresses()) {
+      try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress(addr, port), LOCAL_LISTEN_PROBE_TIMEOUT_MS);
+        return true;
+      } catch (IOException ignored) {
+        // refused / unreachable — try next local address
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Loopback first, then other non-link-local addresses of up interfaces (LAN-only Tomcat bind).
+   *
+   * @return at least the platform loopback address
+   */
+  private static List<InetAddress> localListenProbeAddresses() {
+    LinkedHashSet<InetAddress> addrs = new LinkedHashSet<>();
+    addrs.add(InetAddress.getLoopbackAddress());
+    try {
+      addrs.add(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}));
+    } catch (UnknownHostException ignored) {
+      // 4-byte IPv4 loopback is always valid; ignore defensive
+    }
+    try {
+      InetAddress host = InetAddress.getLocalHost();
+      if (!host.isAnyLocalAddress()) {
+        addrs.add(host);
+      }
+    } catch (UnknownHostException ignored) {
+      // hostname may be unresolvable in some CI images
+    }
+    try {
+      Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+      while (nics != null && nics.hasMoreElements()) {
+        NetworkInterface nic = nics.nextElement();
+        try {
+          if (!nic.isUp()) {
+            continue;
+          }
+        } catch (SocketException e) {
+          continue;
+        }
+        Enumeration<InetAddress> inetAddrs = nic.getInetAddresses();
+        while (inetAddrs.hasMoreElements()) {
+          InetAddress addr = inetAddrs.nextElement();
+          if (addr.isLinkLocalAddress() || addr.isMulticastAddress() || addr.isAnyLocalAddress()) {
+            continue;
+          }
+          addrs.add(addr);
+        }
+      }
+    } catch (SocketException ignored) {
+      // interface walk is best-effort; loopback probes above still run
+    }
+    return List.copyOf(addrs);
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/install/InstallUtilRunningServerTest.java
+++ b/modules/utils/src/test/java/com/percussion/install/InstallUtilRunningServerTest.java
@@ -18,6 +18,7 @@ package com.percussion.install;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,7 +56,12 @@ public class InstallUtilRunningServerTest {
     Path root = writeDtsLayout(ports[0], ports[1], false);
     assertFalse(
         InstallUtil.checkTomcatServerRunning(root.toString()),
-        "free connector port must not look like a running DTS");
+        () ->
+            "free connector port must not look like a running DTS (ports "
+                + ports[0]
+                + ", "
+                + ports[1]
+                + ")");
   }
 
   @Test
@@ -88,7 +94,12 @@ public class InstallUtilRunningServerTest {
     Path root = writeDtsLayout(ports[0], ports[1], true);
     assertFalse(
         InstallUtil.checkTomcatServerRunning(root.toString()),
-        "free connector + shutdown ports must not look like a running DTS");
+        () ->
+            "free connector + shutdown ports must not look like a running DTS (ports "
+                + ports[0]
+                + ", "
+                + ports[1]
+                + ")");
   }
 
   @Test
@@ -163,6 +174,51 @@ public class InstallUtilRunningServerTest {
         "port must look available again after TCP holder closed (TIME_WAIT tolerant)");
   }
 
+  @Test
+  void isLocalTcpPortAccepting_tracksListener() throws Exception {
+    int port = findFreePort();
+    assertFalse(
+        InstallUtil.isLocalTcpPortAccepting(port),
+        "nothing should accept on a freshly allocated free port");
+    try (ServerSocket hold = new ServerSocket()) {
+      hold.setReuseAddress(false);
+      hold.bind(new InetSocketAddress(port));
+      assertTrue(
+          InstallUtil.isLocalTcpPortAccepting(port),
+          "exclusive TCP listener must be reachable on a local address");
+    }
+    assertFalse(
+        InstallUtil.isLocalTcpPortAccepting(port),
+        "listener close must leave the port not accepting");
+  }
+
+  /**
+   * Allocated "free" ports must still be bindable after the probe sockets close. Windows Hyper-V
+   * excluded ranges can make {@code ServerSocket(0)} return a port that binds once and then looks
+   * occupied, which made offline DTS checks treat a stopped instance as running.
+   */
+  @Test
+  void findDistinctFreePorts_remainAvailableAfterRelease() throws Exception {
+    final int iterations = 20;
+    for (int i = 0; i < iterations; i++) {
+      final int iteration = i;
+      int[] ports = findDistinctFreePorts(2);
+      assertNotEquals(ports[0], ports[1], "allocated ports must be distinct");
+      assertTrue(
+          InstallUtil.portAvailable(ports[0]),
+          () -> "connector probe port still available (iteration " + iteration + ")");
+      assertTrue(
+          InstallUtil.portAvailable(ports[1]),
+          () -> "shutdown probe port still available (iteration " + iteration + ")");
+      assertTrue(
+          canRebindTcpPort(ports[0]),
+          () -> "connector probe port still bindable (iteration " + iteration + ")");
+      assertTrue(
+          canRebindTcpPort(ports[1]),
+          () -> "shutdown probe port still bindable (iteration " + iteration + ")");
+    }
+  }
+
   /**
    * @param connectorPort HTTP connector port (literal or value of {@code ${http.port}})
    * @param shutdownPort {@code Server/@port} — must be free for offline assertions; never hardcode
@@ -202,39 +258,92 @@ public class InstallUtilRunningServerTest {
   }
 
   private static int findFreePort() throws IOException {
-    try (ServerSocket ss = new ServerSocket(0)) {
-      ss.setReuseAddress(true);
-      return ss.getLocalPort();
-    }
+    return findDistinctFreePorts(1)[0];
   }
 
   /**
-   * Allocate {@code n} distinct free ports. Holds all sockets open until the last bind so the OS
-   * cannot re-issue the same ephemeral port twice in a row.
+   * Allocate {@code n} distinct free ports that remain bindable after the probe sockets close.
+   *
+   * <p>Holds all sockets open until the last bind so the OS cannot re-issue the same ephemeral port
+   * twice in a row. Then re-checks a real TCP rebind: on Windows, Hyper-V excluded port ranges can
+   * make {@code ServerSocket(0)} return a port that binds once and refuses every later bind.
    */
   private static int[] findDistinctFreePorts(int n) throws IOException {
     if (n < 1) {
       throw new IllegalArgumentException("n must be >= 1");
     }
-    ServerSocket[] holders = new ServerSocket[n];
-    int[] ports = new int[n];
-    try {
-      for (int i = 0; i < n; i++) {
-        holders[i] = new ServerSocket(0);
-        holders[i].setReuseAddress(true);
-        ports[i] = holders[i].getLocalPort();
+    final int maxAttempts = 32;
+    IOException lastBindFailure = null;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      ServerSocket[] holders = new ServerSocket[n];
+      int[] ports = new int[n];
+      try {
+        for (int i = 0; i < n; i++) {
+          ServerSocket ss = new ServerSocket();
+          ss.setReuseAddress(false);
+          ss.bind(new InetSocketAddress(0));
+          holders[i] = ss;
+          ports[i] = ss.getLocalPort();
+        }
+      } catch (IOException e) {
+        lastBindFailure = e;
+        closeQuietly(holders);
+        continue;
       }
-    } finally {
-      for (ServerSocket ss : holders) {
-        if (ss != null) {
-          try {
-            ss.close();
-          } catch (IOException ignored) {
-            // best-effort close of probe sockets
-          }
+      closeQuietly(holders);
+
+      boolean stillBindable = true;
+      for (int port : ports) {
+        if (!canRebindTcpPort(port)) {
+          stillBindable = false;
+          break;
+        }
+      }
+      if (stillBindable) {
+        return ports;
+      }
+    }
+    throw new IOException(
+        "Could not allocate "
+            + n
+            + " distinct free TCP ports that remain bindable after "
+            + maxAttempts
+            + " attempts",
+        lastBindFailure);
+  }
+
+  /**
+   * Two-phase TCP bind (no connect fallback). Used to reject Windows excluded-range ports that
+   * {@link InstallUtil#portAvailable(int)} correctly reports as "not a listener" but that later
+   * {@code new ServerSocket(port)} would fail to hold.
+   */
+  private static boolean canRebindTcpPort(int port) {
+    InetSocketAddress address = new InetSocketAddress(port);
+    try (ServerSocket ss = new ServerSocket()) {
+      ss.setReuseAddress(false);
+      ss.bind(address);
+      return true;
+    } catch (IOException ignored) {
+      // TIME_WAIT or excluded — try reuse bind
+    }
+    try (ServerSocket ss = new ServerSocket()) {
+      ss.setReuseAddress(true);
+      ss.bind(address);
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private static void closeQuietly(ServerSocket[] holders) {
+    for (ServerSocket ss : holders) {
+      if (ss != null) {
+        try {
+          ss.close();
+        } catch (IOException ignored) {
+          // best-effort close of probe sockets
         }
       }
     }
-    return ports;
   }
 }


### PR DESCRIPTION
## Summary

`InstallUtil.portAvailable` (used by DTS/CMS/Derby running gates as `!portAvailable`) treated every failed TCP bind as a live listener. On Windows, Hyper-V **excluded port ranges** can make `ServerSocket(0)` issue a port that binds once and then refuses every later bind. `checkTomcatServerRunning` then reported a stopped DTS as running, which failed `InstallUtilRunningServerTest.checkTomcatServerRunning_placeholderFreePortIsOffline` in the `utils` suite.

This change adds a third probe phase: if exclusive and `SO_REUSEADDR` binds both fail, confirm a TCP listener with a short connect to loopback and other local interface addresses. Bind failures that are not accepts (excluded ranges, residual UDP races) report available. Test port allocation retries until a post-close rebind succeeds.

Follow-up to the GH-2779 TCP-only bind work. No operator-facing procedure or config change.

## Test plan

1. `cd modules/utils` then `..\..\mvnw.cmd clean install` (standalone; JDK 21).
2. Confirm **BUILD SUCCESS** and `InstallUtilRunningServerTest` green (11 tests).
3. Optional on Windows with Hyper-V: rerun `InstallUtilRunningServerTest` several times; offline placeholder/literal tests must stay green.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal install probe / unit-test flake; no operator procedure, config key, or UI change
- [x] **Unit / module tests** — `isLocalTcpPortAccepting_tracksListener`, `findDistinctFreePorts_remainAvailableAfterRelease`, existing offline DTS tests; `cd modules/utils && ..\..\mvnw.cmd clean install` **BUILD SUCCESS**
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd modules/utils && ..\..\mvnw.cmd clean install` **BUILD SUCCESS**; no new warnings on touched files
- [x] **Cross-platform** — **N/A** for filesystem paths (socket probe only); connect uses `InetSocketAddress` / loopback + local NICs

Erlang: `docs/ai-generated/code-reviews/fix-install-port-excluded-range-offline-erlang.md` — approve, may commit/push.

> Co-Authored by Grok 4.6 using grok-4.6 with agent grok.
