### PR TITLE
fix(nav): seed sample-site NavTree without check-in (#3400)

### DIFF
--- a/docs/ai-generated/code-reviews/navtree-first-open-skip-checkin-erlang.md
+++ b/docs/ai-generated/code-reviews/navtree-first-open-skip-checkin-erlang.md
@@ -1,0 +1,69 @@
+# Erlang review — first-open NavTree skip check-in
+
+**Reviewer:** Erlang Shen (independent of implementer)  
+**Date:** 2026-08-14  
+**Branch:** `fix/navtree-first-open-skip-checkin` (uncommitted vs `HEAD`)
+
+## Summary
+
+First-open sample-site NavTree seed no longer hand-rolls `saveItems` + `addFolderChildren` + best-effort `checkinItems`. It now calls `IPSManagedNavService.addNavTreeToFolder`, the same save-without-check-in path as New Site (#3364), so a failed Default Workflow check-in cannot mark the surrounding Spring transaction rollback-only. `PSComponentSummary` aging getters no longer unbox Hibernate-null `NEXTAGINGTRANSITION` / `CONTENTAGINGTIME` (the `sys_wfPerformTransition` NPE). Tests and product-docs companions are present and behavioral. One non-blocking observability suggestion.
+
+## Scope
+
+- Base: `HEAD` `37ef7110b4` (`origin/main`; branch has no unique commits)
+- Head: uncommitted working tree on `fix/navtree-first-open-skip-checkin`
+- Files: 5 changed (0 staged)
+  - `projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java`
+  - `projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java`
+  - `system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java`
+  - `system/src/test/java/com/percussion/cms/objectstore/PSComponentSummaryTest.java`
+  - `product-docs/8.2/admin/architecture-navigation.md`
+- Prior report: none for this branch slug. Related: `docs/ai-generated/code-reviews/3364-create-site-navtree-500-erlang.md`, `docs/ai-generated/code-reviews/3352-seed-navtree-sample-sites-erlang.md`
+- Memory patterns hit: missing behavioral tests (covered); change-class closure (product-docs + peer `addNavTreeToFolder` tests); check-in in same Spring tx marks rollback-only (aligned with #3364); non-portable path I/O (none)
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+### Issue 1 -- Severity: suggestion
+- File: `projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java:1736`
+- Description: `addNavTreeQuietly` logs the create failure at `debug` with `e.toString()` only. The terminal `ensureNavTreeForSite` warn (`Could not create NavTree for site…`) has no cause. At default INFO, a real first-open seed failure (missing folder, unregistered percNavTree type, save exception) is harder to diagnose than the previous warn-with-cause.
+- Suggestion: Keep expected first-attempt / race failures at debug. On the terminal warn (both workflow ids failed and re-find is empty), include the last exception (`log.warn("…", e)` or a captured cause). Do not restore a warn on the successful-create path.
+- Status: addressed (terminal warn now includes last create exception; expected first-attempt failures stay at debug)
+
+## Cross-platform path checklist
+
+Applied. No filesystem path construction, OS temp roots, separator joins, or path-string assertions. CMS folder roots (`//Sites/Demo`) are repository paths, not OS paths. Cross-platform path review: no issues.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| First-open seed uses `addNavTreeToFolder` (no dual `createNavTreeAllowingCheckout` path) | Done — method removed, not shimmed |
+| Behavioral sitemanage tests (create, workflow retry, fail → empty 200, no-folder, race re-find, never `checkinItems` at this layer) | Done |
+| Peer `PSManagedNavServiceAddNavTreeToFolderTest` (save without check-in; no `checkinItems`) | Already on `main` via #3364; not in this diff |
+| Null-safe aging getters + unit test | Done (`0` for next transition matches workflow reset / adapter; `-1` for aging time matches prior javadoc) |
+| Product-docs operator note (no auto check-in; Explorer check-in if still checked out) | Done — `product-docs/8.2/admin/architecture-navigation.md` |
+| New REST / WebUI screen | N/A — same `GET …/section/tree/{site}` empty-200 / seed contract |
+
+## Residual (not blocking)
+
+- Other `PSComponentSummary` `Integer` getters (`getContentStateId`, `getWorkflowAppId`, revisions) still unbox. `saveItems` normally populates those; the documented check-in NPE was `m_nextAgingTransition`. Widen only if Explorer check-in of a seeded NavTree still NPEs.
+- `verify(contentSrv, never()).checkinItems` on the section-service mock cannot see inside `navService`. Acceptable because `PSManagedNavServiceAddNavTreeToFolderTest` already pins that contract.
+- Pre-PR Maven (author): standalone `cd projects/sitemanage` → `../../mvnw.cmd clean install` and `cd system` → `../mvnw.cmd clean install`. This review did not run those builds.
+
+## Inspected (beyond the hunk)
+
+- `PSManagedNavService.addNavTreeToFolder` — `saveItems(..., false, false)`, attach, no `checkinItems`
+- `IPSManagedNavService` Javadoc (save without check-in)
+- `findOrCreateNavTree` / `loadTree` empty-200 path
+- `PSExitPerformTransition` reset of next aging to `0`; `PSComponentSummaryAdapterTest` expects `0`
+- `intformat` / `parseIntegerOrNull` already treat null/0 as the XML sentinel
+- Module `projects/sitemanage/AGENTS.md`, `system/AGENTS.md`

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -70,9 +70,12 @@ Sample / demo sites installed with **Install sample sites**
 new-install seed) ship as site rows and folders only. The first time an
 Admin or Designer opens **Navigation** for that site (or the server handles
 `GET /Rhythmyx/services/sitemanage/section/tree/{siteName}`), the product
-**creates a NavTree** at the site folder root when the folder exists. The
-tree panel then shows `role="tree"` with at least the root item. Operators
-do **not** need to create navigation by hand for those demo sites.
+**creates a NavTree** at the site folder root when the folder exists (same
+save-without-check-in path as **New Site**). The tree panel then shows
+`role="tree"` with at least the root item. Operators do **not** need to
+create navigation by hand for those demo sites. A first-open seed does not
+run a workflow check-in; if the new item is still checked out, check it in
+from Explorer when you want it public.
 
 The same create-on-first-open applies to any other entitled site that has a
 folder root but no NavTree yet (same path as **New Site**).

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -31,10 +31,7 @@ import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummary;
-import com.percussion.cms.objectstore.PSCoreItem;
-import com.percussion.cms.objectstore.PSDateValue;
 import com.percussion.cms.objectstore.PSFolder;
-import com.percussion.cms.objectstore.PSItemField;
 import com.percussion.comments.data.PSCommentsSummary;
 import com.percussion.comments.service.IPSCommentsService;
 import com.percussion.error.PSNotFoundException;
@@ -1688,10 +1685,13 @@ public class PSSiteSectionService implements IPSSiteSectionService {
   }
 
   /**
-   * Create a NavTree under {@code folderRoot}. Sample / FastForward folders
-   * often have {@code WORKFLOWAPPID=-1}; a resolved folder workflow can fail
-   * check-in ({@code m_nextAgingTransition} NPE). Try the folder workflow,
-   * then the system default ({@code -1}). On a race, re-find.
+   * Create a NavTree under {@code folderRoot} via {@link
+   * IPSManagedNavService#addNavTreeToFolder}. That path saves without check-in
+   * (#3364): sample-site Default Workflow can NPE in {@code
+   * sys_wfPerformTransition} ({@code m_nextAgingTransition}), and a failed
+   * {@code checkinItems} marks the surrounding Spring transaction
+   * rollback-only. Try the system default workflow ({@code -1}), then the
+   * folder workflow. On a race, re-find.
    */
   IPSGuid ensureNavTreeForSite(IPSSite site, String folderRoot) {
     String siteName = site.getName();
@@ -1707,12 +1707,30 @@ public class PSSiteSectionService implements IPSSiteSectionService {
           folderRoot,
           e.toString());
     }
-    // Do not use addNavTreeToFolder here: sample-site Default Workflow NPEs
-    // in sys_wfPerformTransition on check-in (ERROR in Managed Navigation).
-    // Save without check-in, attach to the folder, then best-effort checkin.
-    IPSGuid created = createNavTreeAllowingCheckout(folderRoot, navName, navTitle, -1);
+    Exception lastCreateError = null;
+    IPSGuid created = null;
+    try {
+      created = navSrv.addNavTreeToFolder(folderRoot, navName, navTitle, -1);
+    } catch (Exception e) {
+      lastCreateError = e;
+      log.debug(
+          "addNavTreeToFolder failed path={} name={} workflow=-1: {}",
+          folderRoot,
+          navName,
+          e.toString());
+    }
     if (created == null && workflowId != -1) {
-      created = createNavTreeAllowingCheckout(folderRoot, navName, navTitle, workflowId);
+      try {
+        created = navSrv.addNavTreeToFolder(folderRoot, navName, navTitle, workflowId);
+      } catch (Exception e) {
+        lastCreateError = e;
+        log.debug(
+            "addNavTreeToFolder failed path={} name={} workflow={}: {}",
+            folderRoot,
+            navName,
+            workflowId,
+            e.toString());
+      }
     }
     if (created != null) {
       log.info("Created NavTree for site '{}' under {}", siteName, folderRoot);
@@ -1722,57 +1740,16 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     if (raced != null) {
       return raced;
     }
-    log.warn("Could not create NavTree for site '{}' at {}", siteName, folderRoot);
-    return null;
-  }
-
-  /**
-   * Create a percNavTree and attach it to {@code folderRoot} without requiring
-   * a successful workflow check-in. Sample-site Default Workflow can NPE in
-   * {@code sys_wfPerformTransition} during check-in; the item is still a valid
-   * nav root once it is a folder child (#3352).
-   */
-  IPSGuid createNavTreeAllowingCheckout(
-      String folderRoot, String navName, String navTitle, int workflowId) {
-    try {
-      List<String> typeNames = navSrv.getNavTreeContentTypeNames();
-      if (typeNames == null || typeNames.isEmpty()) {
-        log.warn("No NavTree content type is registered; cannot seed {}", folderRoot);
-        return null;
-      }
-      PSCoreItem coreItem = contentSrv.createItems(typeNames.get(0), 1).get(0);
-      coreItem.setTextField("sys_title", navName);
-      coreItem.setTextField("displaytitle", navTitle);
-      PSItemField startDate = coreItem.getFieldByName("sys_contentstartdate");
-      if (startDate != null) {
-        startDate.addValue(new PSDateValue(new Date()));
-      }
-      if (workflowId != -1) {
-        coreItem.setTextField("sys_workflowid", String.valueOf(workflowId));
-      }
-      List<IPSGuid> guids = contentSrv.saveItems(List.of(coreItem), false, false);
-      if (guids == null || guids.isEmpty() || guids.get(0) == null) {
-        return null;
-      }
-      contentSrv.addFolderChildren(folderRoot, guids);
-      try {
-        contentSrv.checkinItems(guids, null);
-      } catch (Exception checkinEx) {
-        log.warn(
-            "NavTree {} attached under {} but checkin failed; tree is still usable. Cause: {}",
-            navName,
-            folderRoot,
-            checkinEx.toString());
-      }
-      return guids.get(0);
-    } catch (Exception e) {
+    if (lastCreateError != null) {
       log.warn(
-          "createNavTreeAllowingCheckout failed path={} name={}: {}",
+          "Could not create NavTree for site '{}' at {}: {}",
+          siteName,
           folderRoot,
-          navName,
-          e.toString());
-      return null;
+          lastCreateError.toString());
+    } else {
+      log.warn("Could not create NavTree for site '{}' at {}", siteName, folderRoot);
     }
+    return null;
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
@@ -28,13 +28,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.utils.guid.IPSGuid;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import org.mockito.Mockito;
 
 import com.percussion.comments.service.IPSCommentsService;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
@@ -117,7 +114,7 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
   }
 
   @Test
-  void loadTreeCreatesNavTreeOnFirstOpenWithoutForcedCheckin() throws Exception {
+  void loadTreeCreatesNavTreeOnFirstOpenWithoutCheckin() throws Exception {
     PSLegacyGuid created = new PSLegacyGuid(364, 1);
     stubCreateNavTreeSave(created);
     stubCreatedNavTreeLoad(created);
@@ -126,28 +123,32 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
     assertEquals(new PSLegacyGuid(364, -1).toString(), tree.getId());
     assertEquals("Demo", tree.getTitle());
     assertEquals("//Sites/Demo", tree.getFolderPath().orElse(null));
-    verify(contentSrv).addFolderChildren(eq("//Sites/Demo"), any());
-    verify(contentSrv).checkinItems(any(), eq(null));
+    verify(navService).addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", -1);
+    verify(contentSrv, never()).checkinItems(any(), eq(null));
     verify(siteMgr, never()).deleteSite(any());
   }
 
   @Test
-  void loadTreeKeepsRootWhenCheckinFailsAfterAttach() throws Exception {
+  void loadTreeRetriesFolderWorkflowThenKeepsRoot() throws Exception {
     PSLegacyGuid created = new PSLegacyGuid(365, 1);
-    stubCreateNavTreeSave(created);
+    when(pageDaoHelper.getWorkflowIdForPath("//Sites/Demo")).thenReturn(4);
+    when(navService.addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", -1))
+        .thenThrow(new RuntimeException("default workflow failed"));
+    when(navService.addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", 4))
+        .thenReturn(created);
     stubCreatedNavTreeLoad(created);
-    Mockito.doThrow(new RuntimeException("checkin aging NPE"))
-        .when(contentSrv)
-        .checkinItems(any(), eq(null));
 
     PSSectionNode tree = service.loadTree("Demo");
     assertEquals(new PSLegacyGuid(365, -1).toString(), tree.getId());
+    verify(navService).addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", -1);
+    verify(navService).addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", 4);
+    verify(contentSrv, never()).checkinItems(any(), eq(null));
   }
 
   @Test
   void loadTreeReturnsEmptyNodeWhenNavTreeCreateFails() throws Exception {
-    when(navService.getNavTreeContentTypeNames()).thenReturn(List.of("percNavTree"));
-    when(contentSrv.createItems("percNavTree", 1)).thenThrow(new RuntimeException("folder missing"));
+    when(navService.addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt()))
+        .thenThrow(new RuntimeException("folder missing"));
 
     PSSectionNode tree = service.loadTree("Demo");
     assertNotNull(tree);
@@ -160,7 +161,8 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
 
   @Test
   void loadRootReturnsEmptySectionWhenCreateFailsAndDoesNotDeleteSite() throws Exception {
-    when(navService.getNavTreeContentTypeNames()).thenReturn(Collections.emptyList());
+    when(navService.addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt()))
+        .thenThrow(new RuntimeException("no nav type"));
 
     PSSiteSection root = service.loadRoot("Demo");
     assertNotNull(root);
@@ -179,13 +181,14 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
     assertNull(tree.getId());
     assertTrue(tree.getChildNodes().isEmpty());
     verify(contentSrv, never()).createItems(anyString(), anyInt());
+    verify(navService, never()).addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt());
   }
 
   @Test
   void loadTreeUsesExistingNavTreeAfterConcurrentCreate() throws Exception {
     PSLegacyGuid raced = new PSLegacyGuid(361, 1);
-    when(navService.getNavTreeContentTypeNames()).thenReturn(List.of("percNavTree"));
-    when(contentSrv.createItems("percNavTree", 1)).thenThrow(new RuntimeException("already has"));
+    when(navService.addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt()))
+        .thenThrow(new RuntimeException("already has"));
     when(navService.findNavigationIdFromFolder("//Sites/Demo")).thenReturn(null, raced);
     stubCreatedNavTreeLoad(raced);
 
@@ -194,11 +197,9 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
     assertEquals("Demo", tree.getTitle());
   }
 
-  private void stubCreateNavTreeSave(IPSGuid created) throws Exception {
-    when(navService.getNavTreeContentTypeNames()).thenReturn(List.of("percNavTree"));
-    PSCoreItem item = Mockito.mock(PSCoreItem.class);
-    when(contentSrv.createItems("percNavTree", 1)).thenReturn(List.of(item));
-    when(contentSrv.saveItems(any(), eq(false), eq(false))).thenReturn(List.of(created));
+  private void stubCreateNavTreeSave(IPSGuid created) {
+    when(navService.addNavTreeToFolder("//Sites/Demo", "Demo-NavTree", "Demo", -1))
+        .thenReturn(created);
   }
 
   private void stubCreatedNavTreeLoad(IPSGuid navGuid) {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -398,10 +398,10 @@ public final class PSComponentSummary extends PSDbComponent implements Serializa
   }
 
   /**
-   * @return content aging time in seconds. -1 if never set.
+   * @return content aging time in seconds. -1 if never set (including a null column).
    */
   public int getContentAgingTime() {
-    return m_contentAgingTime;
+    return m_contentAgingTime == null ? -1 : m_contentAgingTime;
   }
 
   /**
@@ -454,10 +454,12 @@ public final class PSComponentSummary extends PSDbComponent implements Serializa
   }
 
   /**
-   * @return Next aging transition id. -1 if not applicable.
+   * @return Next aging transition id. {@code 0} if not applicable (null or unset {@code
+   *     NEXTAGINGTRANSITION}). Never unboxes a null {@link Integer} — a new item's check-in
+   *     used to NPE here in {@code sys_wfPerformTransition}.
    */
   public int getNextAgingTransition() {
-    return m_nextAgingTransition;
+    return m_nextAgingTransition == null ? 0 : m_nextAgingTransition;
   }
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSComponentSummaryTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSComponentSummaryTest.java
@@ -303,4 +303,24 @@ public class PSComponentSummaryTest {
     assertSame(injected, field.get(summary));
     assertNotNull(summary.getParentFolderRelationships());
   }
+
+  /**
+   * Hibernate leaves NEXTAGINGTRANSITION / CONTENTAGINGTIME null on a new
+   * CONTENTSTATUS row. Primitive getters must not unbox that to an NPE —
+   * {@code sys_wfPerformTransition} hits these on check-in of a freshly
+   * seeded NavTree.
+   */
+  @Test
+  public void testNullAgingFieldsDoNotUnbox() {
+    PSComponentSummary summary =
+        new PSComponentSummary(300, 1, 1, 1, PSComponentSummary.TYPE_ITEM, "nav_aging", 301, -1);
+
+    assertEquals(0, summary.getNextAgingTransition());
+    assertEquals(-1, summary.getContentAgingTime());
+
+    summary.setNextAgingTransition(12);
+    summary.setContentAgingTime(30);
+    assertEquals(12, summary.getNextAgingTransition());
+    assertEquals(30, summary.getContentAgingTime());
+  }
 }


### PR DESCRIPTION
## Summary

Opening Navigation for sample sites `Corporate_Investments` / `Enterprise_Investments` seeded a NavTree on first open (#3352) then called best-effort `checkinItems`. Sample-site Default Workflow fails that check-in (`PSErrorsException` / `m_nextAgingTransition` NPE in `sys_wfPerformTransition`). #3364 already stopped calling `checkinItems` on **New Site** because a failed check-in marks the surrounding Spring transaction rollback-only.

This change:

- Seeds first-open NavTree via `addNavTreeToFolder` (save + attach, **no** check-in).
- Makes `PSComponentSummary.getNextAgingTransition()` / `getContentAgingTime()` null-safe so a later Explorer check-in does not unbox Hibernate-null aging columns.
- Updates product-docs: operators may check the seeded item in from Explorer if it is still checked out.

Fixes #3400
Partial #3352
Partial #3364

## Test plan

1. Local install with sample sites: open Navigation for Corporate Investments and Enterprise Investments.
2. Confirm a tree renders (`role="tree"`).
3. Confirm `server.log` has **no** `NavTree … attached … but checkin failed` WARN.
4. Second open should reuse the existing tree (INFO create line only on first open).
5. If the seeded item is still checked out, check it in from Explorer.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md`
- [x] **Unit / module tests** — `PSSiteSectionServiceLoadTreeEmptyTest` (7), `PSComponentSummaryTest` (6); standalone clean install
  - `cd system` → `../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2130, Failures: 0, Errors: 0, Skipped: 238
  - `cd projects/sitemanage` → `../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1151, Failures: 0, Errors: 0, Skipped: 125
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — perc-system then sitemanage standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path/file I/O; CMS folder roots are `//Sites/…`)

Erlang: approve (`docs/ai-generated/code-reviews/navtree-first-open-skip-checkin-erlang.md`).

> Co-Authored by Grok Build using grok-4.6 with agent grok-tui.
