### PR TITLE
fix(webui): Security Audit Log must not throw on non-string target

### DIFF
--- a/WebUI/src/main/ts/admin/tools/SecurityAuditLogViewer.tsx
+++ b/WebUI/src/main/ts/admin/tools/SecurityAuditLogViewer.tsx
@@ -88,12 +88,45 @@ export function formatEventTime(value: unknown): string {
   return "—";
 }
 
+/**
+ * Coerce a wire field to display text. Jackson / WRAP_ROOT may deliver
+ * numbers (content-id targets) or objects; calling {@code .trim()} on those
+ * throws and blanks the Security Audit Log via AdminSectionErrorBoundary.
+ */
+export function auditCellText(value: unknown): string {
+  if (value == null || value === "") {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  const rec =
+    typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  if (rec) {
+    for (const key of ["text", "value", "name", "label"] as const) {
+      const inner = rec[key];
+      if (typeof inner === "string" && inner.trim()) {
+        return inner.trim();
+      }
+    }
+  }
+  return "";
+}
+
 /** Truncate for table cells; when longer than max, keeps {@code max} chars then ellipsis. */
-export function truncate(text: string | undefined, max = 80): string {
-  if (!text) {
+export function truncate(text: unknown, max = 80): string {
+  const t = auditCellText(text);
+  if (!t) {
     return "—";
   }
-  const t = text.trim();
   if (t.length <= max) {
     return t;
   }
@@ -595,10 +628,18 @@ export const SecurityAuditLogViewer: React.FC = () => {
                         <td style={tdStyle}>
                           {formatEventTime(row.eventTime)}
                         </td>
-                        <td style={tdStyle}>{row.moduleCode || "—"}</td>
-                        <td style={tdStyle}>{row.eventType || "—"}</td>
-                        <td style={tdStyle}>{row.outcome || "—"}</td>
-                        <td style={tdStyle}>{row.actor || "—"}</td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.moduleCode) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.eventType) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.outcome) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.actor) || "—"}
+                        </td>
                         <td style={tdStyle}>{truncate(row.target, 40)}</td>
                         <td style={tdStyle}>
                           {truncate(row.userMessage, 60)}
@@ -725,7 +766,7 @@ export const SecurityAuditLogViewer: React.FC = () => {
                   }}
                   data-testid="audit-detail-user-message"
                 >
-                  {detail.userMessage || "—"}
+                  {auditCellText(detail.userMessage) || "—"}
                 </dd>
                 <dt style={{ fontWeight: 600, gridColumn: "1 / -1", marginTop: 8 }}>
                   {message(ADMIN_MSG.AUDIT_COL_LOG_MESSAGE)}
@@ -745,7 +786,7 @@ export const SecurityAuditLogViewer: React.FC = () => {
                   }}
                   data-testid="audit-detail-log-message"
                 >
-                  {detail.logMessage || "—"}
+                  {auditCellText(detail.logMessage) || "—"}
                 </dd>
               </dl>
             )}
@@ -762,14 +803,15 @@ function DetailRow({
   testId,
 }: {
   label: string;
-  value?: string | null;
+  value?: unknown;
   testId?: string;
 }): React.ReactElement {
+  const text = auditCellText(value);
   return (
     <>
       <dt style={{ fontWeight: 600, color: "#64748b" }}>{label}</dt>
       <dd style={{ margin: 0 }} data-testid={testId}>
-        {value && String(value).trim() ? value : "—"}
+        {text || "—"}
       </dd>
     </>
   );

--- a/WebUI/src/test/ts/admin/SecurityAuditLogViewer.test.tsx
+++ b/WebUI/src/test/ts/admin/SecurityAuditLogViewer.test.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  auditCellText,
   formatAuditPageSummary,
   formatEventTime,
   SecurityAuditLogViewer,
@@ -95,6 +96,43 @@ describe("SecurityAuditLogViewer", () => {
     const out = truncate(long, 40);
     expect(out.endsWith("…")).toBe(true);
     expect(out.slice(0, -1)).toHaveLength(40);
+  });
+
+  it("truncate does not throw on non-string wire values", () => {
+    expect(truncate(1131, 40)).toBe("1131");
+    expect(truncate({ value: "list" }, 40)).toBe("list");
+    expect(truncate({ text: "  wrapped  " }, 40)).toBe("wrapped");
+    expect(truncate({ epochSecond: 1 }, 40)).toBe("—");
+    expect(auditCellText(1131)).toBe("1131");
+    expect(auditCellText(null)).toBe("");
+  });
+
+  it("renders rows when target is a number (no AdminSectionErrorBoundary)", async () => {
+    vi.mocked(auditApi.queryAuditLogEntries).mockResolvedValue({
+      entries: [
+        {
+          ...sampleEntry,
+          target: 1131 as unknown as string,
+          userMessage: { value: "Content item 1131 created" } as unknown as string,
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+
+    render(<SecurityAuditLogViewer />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`audit-log-row-${sampleEntry.auditId}`),
+      ).toBeDefined();
+    });
+    expect(screen.queryByTestId("admin-section-error")).toBeNull();
+    expect(screen.getByTestId("audit-log-table").textContent).toContain("1131");
+    expect(screen.getByTestId("audit-log-table").textContent).toContain(
+      "Content item 1131 created",
+    );
   });
 
   it("renders table rows after successful load", async () => {

--- a/docs/ai-generated/code-reviews/audit-log-truncate-nonstring-erlang.md
+++ b/docs/ai-generated/code-reviews/audit-log-truncate-nonstring-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — `fix/audit-log-truncate-nonstring`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)  
+**Date:** 2026-08-15  
+**Scope:** uncommitted vs `HEAD` on `fix/audit-log-truncate-nonstring`.  
+**Memory patterns hit:** structural/token tests vs behavior; UI crash from untyped wire values.
+
+## Summary
+
+`SecurityAuditLogViewer.truncate` assumed `string` and called `.trim()`. Live wire `target` is sometimes a number (content-id) or wrapped object. That throws `e.trim is not a function` and `AdminSectionErrorBoundary` replaces the tool even though REST `AUDIT_VIEW` succeeded.
+
+Fix: `auditCellText(unknown)` coerces primitives / `{value,text,name,label}`; `truncate` uses it. Table cells and detail rows go through the same helper. Vitest covers number/`{value}` and a render that must not throw. Playwright asserts `admin-section-error` is absent.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none remaining for this throw
+- Behavioral tests: Vitest + Playwright assertion
+- Playwright companion: updated `admin-security-audit-log.spec.js`
+- Agent rule files: none
+- Cross-platform: **N/A** (no path I/O)
+
+## Tests
+
+`npm run test -- SecurityAuditLogViewer` (WebUI frontend): 10 passed.

--- a/modules/perc-qa-automation/frontend/tests/admin-security-audit-log.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/admin-security-audit-log.spec.js
@@ -78,6 +78,9 @@ test.describe("Admin Security Audit Log @security-audit-log @admin", () => {
       timeout: 30_000,
     });
     await expect(page.getByTestId("audit-log-empty")).toHaveCount(0);
+    // Non-string target/userMessage must not throw (e.trim is not a function)
+    // and replace the tool with AdminSectionErrorBoundary.
+    await expect(page.getByTestId("admin-section-error")).toHaveCount(0);
   });
 
   test("Admin can apply module filter without error chrome", async ({


### PR DESCRIPTION
## Summary

Admin → System Tools → Security Audit Log crashed with `TypeError: e.trim is not a function` at `truncate` (`SecurityAuditLogViewer.tsx:96`), caught by `AdminSectionErrorBoundary`. REST `AUDIT_VIEW` still logged SUCCESS.

`truncate` assumed a string. Jackson can deliver `target` as a **number** (content-item ids like `1131`) or a wrapped object. Objects/numbers are truthy, so `.trim()` threw.

`auditCellText(unknown)` now coerces primitives and `{value,text,name,label}` wrappers. Table and detail cells use it. Vitest covers the throw path. Playwright asserts the error boundary is not shown.

## Test plan

1. `cd WebUI/src/main/frontend` → `npm run test -- SecurityAuditLogViewer` — 10 passed.
2. After a WebUI hot-deploy / rebuild, open Admin → System Tools → Security Audit Log: table rows visible, no “Unable to load Security Audit Log”.
3. Playwright (when CMS up): `npm run test:surface -- --path tests/admin-security-audit-log.spec.js` from `modules/perc-qa-automation/frontend`.

## Checklist

- [x] **Product documentation** — **N/A** (crash fix of existing System Tools Security Audit Log; no new operator procedure)
- [x] **Unit / module tests** — Vitest `SecurityAuditLogViewer` 10 passed
- [x] **WebUI + Playwright** — `admin-security-audit-log.spec.js` asserts `admin-section-error` count 0
- [x] **Build gates** — frontend Vitest green; full `WebUI` `mvnw clean install` not re-run this turn (focused Vitest only)
- [x] **Cross-platform** — **N/A** (no path I/O)

> Co-Authored by Grok Build using grok-4.6 with agent grok-tui.