### PR TITLE
fix(rest): User/Role/ObjectSummary wire getters must not return Optional (#3388)

### DIFF
--- a/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3388 REST DTO wire getters must not return Optional
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3388-rest-dto-wire-getters`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+First incremental slice of #3388: convert REST `User`, `Role`, and `ObjectSummary`
+wire getters from `Optional<T>` to plain nullable types with `@JsonInclude(NON_NULL)`.
+Callers that used `.orElse()` / `.ifPresent()` on those getters were updated in
+`rest` and `projects/sitemanage`. Production-mapper round-trips assert no
+`empty`/`present` Optional-bean keys.
+
+`rest/AGENTS.md` wire-getter convention is drafted in the working tree and is
+**not** part of this commit (root AGENTS.md human-review gate for rule files).
+
+## Scope
+
+Uncommitted product work vs `origin/main` on `fix/issue-3388-rest-dto-wire-getters`.
+Excluded from commit: `rest/AGENTS.md` (agent-instruction draft).
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — **addressed** (JacksonContextResolver production mapper + UsersTest/RolesTest contract)
+- Incomplete change-class closure — **addressed** (DTO + rest callers + sitemanage UserAdaptor/ApiUtils + reverse-dep install)
+- Agent rule file without human review — **honored** (`rest/AGENTS.md` left uncommitted)
+- Cross-platform path checklist — N/A (no new filesystem I/O)
+
+## Issues
+
+None that block commit.
+
+## Notes (not blocking)
+
+- Remaining ~47 `public Optional<…>` DTO getters stay as later incremental PRs
+  (DisplayFormatProperty, Template, Page/Widget/SeoInfo, Acl leftovers, etc.).
+- Nested `Guid.getUntypedString()` is still Optional; ObjectSummary tests with a
+  constructed Guid did not emit `empty`/`present` keys (field-level `stringValue`
+  already uses `@JsonProperty` + `@JsonIgnore` on the Optional helper).
+- This is a public getter signature change (`Optional<T>` → `T`). Grep found no
+  anonymous subclasses; sitemanage standalone clean install is the reverse-dep gate.
+
+## Tests
+
+- `JacksonContextResolverOptionalTest` — 7 tests (prior ContentType/TemplateSummary + User/Role/ObjectSummary)
+- `UsersTest` / `RolesTest` — unset scalars nullable; list getters still never-null
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 421, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1217, Failures: 0, Skipped: 125
+
+## Cross-platform path checklist
+
+N/A — no new `File`/`Path` construction.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -476,9 +476,9 @@ public class ApiUtils {
   public static PSRole convertRole(Role role) {
     PSRole ret = new PSRole();
 
-    ret.setDescription(orNull(role.getDescription()));
-    ret.setHomepage(orNull(role.getHomePage()));
-    ret.setName(orNull(role.getName()));
+    ret.setDescription(role.getDescription());
+    ret.setHomepage(role.getHomePage());
+    ret.setName(role.getName());
     ret.setUsers(role.getUsers());
 
     return ret;

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
@@ -142,9 +142,9 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       boolean isNewUser = false;
 
       try {
-        var findUsers = userService.getUserNames(user.getUserName().orElse(null));
-        if (findUsers.getUsers().contains(user.getUserName().orElse(null))) {
-          newUser = userService.find(user.getUserName().orElse(null));
+        var findUsers = userService.getUserNames(user.getUserName());
+        if (findUsers.getUsers().contains(user.getUserName())) {
+          newUser = userService.find(user.getUserName());
         } else {
           newUser = new PSUser();
           isNewUser = true;
@@ -154,11 +154,11 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
         isNewUser = true;
       }
 
-      newUser.setName(user.getUserName().orElse(null));
+      newUser.setName(user.getUserName());
       newUser.setRoles(user.getRoles());
 
-      if (user.getEmailAddress().isPresent()) {
-        newUser.setEmail(user.getEmailAddress().orElse(null));
+      if (user.getEmailAddress() != null) {
+        newUser.setEmail(user.getEmailAddress());
       }
 
       // newUser.setRoles(user.getRoles()); // Already set above
@@ -167,14 +167,14 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       if (!isNewUser) {
         newUser = userService.update(newUser);
       } else {
-        if (user.getUserType().orElse("").equalsIgnoreCase(PSUserProviderType.INTERNAL.name())) {
+        if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.INTERNAL.name())) {
           newUser = userService.create(newUser);
-        } else if (user.getUserType()
-            .orElse("")
-            .equalsIgnoreCase(PSUserProviderType.DIRECTORY.name())) {
+        } else if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.DIRECTORY.name())) {
           var newUsers = new PSImportUsers();
           var dirUsers = new ArrayList<PSExternalUser>();
-          dirUsers.add(new PSExternalUser(user.getUserName().orElse(null)));
+          dirUsers.add(new PSExternalUser(user.getUserName()));
           newUsers.setExternalUsers(dirUsers);
           var importUsers = userService.importDirectoryUsers(newUsers);
 
@@ -184,8 +184,8 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
             // Handle new imports and treat duplicates as if they should be updates
             if (impU.getStatus() == ImportStatus.SUCCESS
                 || impU.getStatus() == ImportStatus.DUPLICATE) {
-              newUser.setEmail(user.getEmailAddress().orElse(null));
-              newUser.setName(user.getUserName().orElse(null));
+              newUser.setEmail(user.getEmailAddress());
+              newUser.setName(user.getUserName());
               newUser.setProviderType(PSUserProviderType.DIRECTORY);
               newUser.setRoles(user.getRoles());
               newUser = userService.update(newUser);

--- a/rest/src/main/java/com/percussion/rest/ObjectSummary.java
+++ b/rest/src/main/java/com/percussion/rest/ObjectSummary.java
@@ -21,8 +21,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.acls.UserAccessLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * High-level catalog summary, including security ACLs, for an object on the system.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code label}, {@code description}, and {@code guid} when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement
 @Schema(
@@ -78,32 +86,32 @@ public class ObjectSummary {
     this.id = id;
   }
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -126,8 +134,8 @@ public class ObjectSummary {
     this.objectLocked = objectLocked;
   }
 
-  public Optional<ObjectLockSummary> getLockSummary() {
-    return Optional.ofNullable(lockSummary);
+  public ObjectLockSummary getLockSummary() {
+    return lockSummary;
   }
 
   public void setLockSummary(ObjectLockSummary lockSummary) {

--- a/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
+++ b/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
@@ -494,7 +494,7 @@ public class AssetsResource {
       var requestThreadMap = new HashMap<>(PSRequestInfoBase.getRequestInfoMap());
       var currentUser = (String) PSRequestInfoBase.getRequestInfo(PSRequestInfo.KEY_USER);
       var user = userAdaptor.getUser(null, currentUser);
-      var toAddress = user.getEmailAddress().orElse(null);
+      var toAddress = user.getEmailAddress();
       CompletableFuture.runAsync(
           () -> {
             try {

--- a/rest/src/main/java/com/percussion/rest/roles/Role.java
+++ b/rest/src/main/java/com/percussion/rest/roles/Role.java
@@ -19,15 +19,23 @@
 
 package com.percussion.rest.roles;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!" */
+/**
+ * Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code description}, and {@code homePage} when set. Optional-returning getters historically
+ * serialized as empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue
+ * #3388). Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "Role")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "Role", description = "Represents a system Role that a user may belong to.")
 public class Role {
 
@@ -60,24 +68,24 @@ public class Role {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getHomePage() {
-    return Optional.ofNullable(homePage);
+  public String getHomePage() {
+    return homePage;
   }
 
   public void setHomePage(String homePage) {

--- a/rest/src/main/java/com/percussion/rest/users/User.java
+++ b/rest/src/main/java/com/percussion/rest/users/User.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.users;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.LinkRef;
 import com.percussion.rest.communities.Community;
 import com.percussion.rest.communities.CommunityList;
@@ -26,10 +27,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a User. Sunny Sal: "User ka hero, login ka zero!" */
+/**
+ * Represents a User. Sunny Sal: "User ka hero, login ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code
+ * userName}, {@code firstName}, and related scalars when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "User")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "User", description = "Represents a User.")
 public class User {
 
@@ -101,56 +110,56 @@ public class User {
     // Default constructor
   }
 
-  public Optional<CommunityList> getUserCommunities() {
-    return Optional.ofNullable(userCommunities);
+  public CommunityList getUserCommunities() {
+    return userCommunities;
   }
 
   public void setUserCommunities(CommunityList userCommunities) {
     this.userCommunities = userCommunities;
   }
 
-  public Optional<Community> getSelectedCommunity() {
-    return Optional.ofNullable(selectedCommunity);
+  public Community getSelectedCommunity() {
+    return selectedCommunity;
   }
 
   public void setSelectedCommunity(Community selectedCommunity) {
     this.selectedCommunity = selectedCommunity;
   }
 
-  public Optional<String> getUserName() {
-    return Optional.ofNullable(userName);
+  public String getUserName() {
+    return userName;
   }
 
   public void setUserName(String userName) {
     this.userName = userName;
   }
 
-  public Optional<String> getFirstName() {
-    return Optional.ofNullable(firstName);
+  public String getFirstName() {
+    return firstName;
   }
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
-  public Optional<String> getLastName() {
-    return Optional.ofNullable(lastName);
+  public String getLastName() {
+    return lastName;
   }
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
-  public Optional<String> getEmailAddress() {
-    return Optional.ofNullable(emailAddress);
+  public String getEmailAddress() {
+    return emailAddress;
   }
 
   public void setEmailAddress(String emailAddress) {
     this.emailAddress = emailAddress;
   }
 
-  public Optional<String> getUserType() {
-    return Optional.ofNullable(userType);
+  public String getUserType() {
+    return userType;
   }
 
   public void setUserType(String userType) {
@@ -223,8 +232,8 @@ public class User {
     this.recentTemplates = recentTemplates;
   }
 
-  public Optional<LinkRef> getPersonalPage() {
-    return Optional.ofNullable(personalPage);
+  public LinkRef getPersonalPage() {
+    return personalPage;
   }
 
   public void setPersonalPage(LinkRef personalPage) {
@@ -253,8 +262,8 @@ public class User {
     this.roles = roles;
   }
 
-  public Optional<String> getPassword() {
-    return Optional.ofNullable(password);
+  public String getPassword() {
+    return password;
   }
 
   public void setPassword(String password) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,13 +16,17 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.roles.Role;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
+import com.percussion.rest.users.User;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,8 +35,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). User / Role /
+ * ObjectSummary follow the same plain-getter rule (issue #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +116,82 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void user_serializesPlainScalarsNotOptionalBeans() {
+    User user = new User();
+    user.setUserName("admin");
+    user.setFirstName("Ada");
+    user.setLastName("Lovelace");
+    user.setEmailAddress("ada@example.com");
+    user.setUserType("INTERNAL");
+
+    ObjectMapper userMapper = new JacksonContextResolver().getContext(User.class);
+    String json = userMapper.writeValueAsString(user);
+    assertTrue(json.contains("\"userName\""), json);
+    assertTrue(json.contains("admin"), json);
+    assertTrue(json.contains("\"firstName\""), json);
+    assertTrue(json.contains("Ada"), json);
+    assertTrue(json.contains("\"lastName\""), json);
+    assertTrue(json.contains("\"emailAddress\""), json);
+    assertTrue(json.contains("\"userType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    User roundTrip = userMapper.readValue(json, User.class);
+    assertEquals("admin", roundTrip.getUserName(), json);
+    assertEquals("Ada", roundTrip.getFirstName(), json);
+    assertEquals("INTERNAL", roundTrip.getUserType(), json);
+  }
+
+  @Test
+  void role_serializesPlainScalarsNotOptionalBeans() {
+    Role role = new Role();
+    role.setName("Editor");
+    role.setDescription("Edit content");
+    role.setHomePage("Dashboard");
+
+    ObjectMapper roleMapper = new JacksonContextResolver().getContext(Role.class);
+    String json = roleMapper.writeValueAsString(role);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Editor"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"homePage\""), json);
+    assertTrue(json.contains("Dashboard"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Role roundTrip = roleMapper.readValue(json, Role.class);
+    assertEquals("Editor", roundTrip.getName(), json);
+    assertEquals("Dashboard", roundTrip.getHomePage(), json);
+  }
+
+  @Test
+  void objectSummary_serializesNameLabelGuidNotOptionalBeans() {
+    ObjectSummary summary = new ObjectSummary();
+    summary.setName("Default");
+    summary.setLabel("Default ACL");
+    summary.setDescription("Site ACL");
+    summary.setGuid(new Guid("0-13-10"));
+
+    ObjectMapper summaryMapper = new JacksonContextResolver().getContext(ObjectSummary.class);
+    String json = summaryMapper.writeValueAsString(summary);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-13-10") || json.contains("10"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ObjectSummary roundTrip = summaryMapper.readValue(json, ObjectSummary.class);
+    assertEquals("Default", roundTrip.getName(), json);
+    assertEquals("Default ACL", roundTrip.getLabel(), json);
+    assertNotNull(roundTrip.getGuid(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
+++ b/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.roles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,9 @@ public class RolesTest extends MainTest {
   @Test
   public void testNeverNull() {
     var r = new Role();
-    assertNotNull(r.getDescription(), "Should never be null");
-    assertNotNull(r.getName(), "Should never be null");
-    assertNotNull(r.getDescription(), "Should never be null");
+    assertNull(r.getDescription(), "Unset wire scalars are nullable");
+    assertNull(r.getName(), "Unset wire scalars are nullable");
+    assertNull(r.getHomePage(), "Unset wire scalars are nullable");
     assertNotNull(r.getUsers(), "Should never be null");
   }
 }

--- a/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
@@ -25,6 +25,7 @@ import com.percussion.rest.errors.UnknownUserException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +50,8 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toUpdate = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(user.getUserName().orElse(""))) {
+      if (Objects.toString(u.getUserName(), "")
+          .equalsIgnoreCase(Objects.toString(user.getUserName(), ""))) {
         toUpdate = u;
         break;
       }
@@ -58,9 +60,15 @@ public class UserTestAdaptor implements IUserAdaptor {
       // New user logic could go here
     } else {
       toUpdate.setBookmarkedPages(user.getBookmarkedPages());
-      user.getEmailAddress().ifPresent(toUpdate::setEmailAddress);
-      user.getFirstName().ifPresent(toUpdate::setFirstName);
-      user.getLastName().ifPresent(toUpdate::setLastName);
+      if (user.getEmailAddress() != null) {
+        toUpdate.setEmailAddress(user.getEmailAddress());
+      }
+      if (user.getFirstName() != null) {
+        toUpdate.setFirstName(user.getFirstName());
+      }
+      if (user.getLastName() != null) {
+        toUpdate.setLastName(user.getLastName());
+      }
     }
     return null;
   }
@@ -72,7 +80,7 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toDelete = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(userName)) {
+      if (Objects.toString(u.getUserName(), "").equalsIgnoreCase(userName)) {
         toDelete = u;
         break;
       }

--- a/rest/src/test/java/com/percussion/rest/users/UsersTest.java
+++ b/rest/src/test/java/com/percussion/rest/users/UsersTest.java
@@ -20,6 +20,7 @@
 package com.percussion.rest.users;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -31,10 +32,10 @@ public class UsersTest extends MainTest {
     var u = new User();
 
     assertNotNull(u.getBookmarkedPages(), "Should never be null");
-    assertNotNull(u.getEmailAddress(), "Should never be null");
-    assertNotNull(u.getFirstName(), "Should never be null");
-    assertNotNull(u.getLastName(), "Should never be null");
-    assertNotNull(u.getPersonalPage(), "Should never be null");
+    assertNull(u.getEmailAddress(), "Unset wire scalars are nullable");
+    assertNull(u.getFirstName(), "Unset wire scalars are nullable");
+    assertNull(u.getLastName(), "Unset wire scalars are nullable");
+    assertNull(u.getPersonalPage(), "Unset wire objects are nullable");
     assertNotNull(u.getPersonAssets(), "Should never be null");
     assertNotNull(u.getRecentAssetFolders(), "Should never be null");
     assertNotNull(u.getRecentAssetTypes(), "Should never be null");
@@ -42,7 +43,7 @@ public class UsersTest extends MainTest {
     assertNotNull(u.getRecentSiteFolders(), "Should never be null");
     assertNotNull(u.getRoles(), "Should never be null");
     assertNotNull(u.getRecentTemplates(), "Should never be null");
-    assertNotNull(u.getUserName(), "Should never be null");
-    assertNotNull(u.getUserType(), "Should never be null");
+    assertNull(u.getUserName(), "Unset wire scalars are nullable");
+    assertNull(u.getUserType(), "Unset wire scalars are nullable");
   }
 }


### PR DESCRIPTION
## Summary

REST wire DTOs `User`, `Role`, and `ObjectSummary` returned `Optional<T>` from JSON getters. That produced Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189).

This PR converts those three high-traffic Developer/Explorer types to **plain nullable getters/setters** with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.ifPresent()` (`UserTestAdaptor`, `UsersTest`, `RolesTest`, `AssetsResource`, sitemanage `UserAdaptor` / `ApiUtils.convertRole`).

Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.

**Partial #3388** — first incremental family only. Remaining `public Optional<…>` DTO getters stay for follow-up PRs. `rest/AGENTS.md` wire-getter convention is drafted in the worktree and **not committed** (root AGENTS.md human-review gate for agent-instruction files). Ask if you want that rule diff in a follow-up commit.

Operator: Grok: night-issue-prs (model grok-4.6)

Parent tracker: #3388

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — Tests run: 421, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1217, Failures: 0, Skipped: 125
3. Confirm `JacksonContextResolverOptionalTest` (7 tests) covers User / Role / ObjectSummary round-trips
4. After merge: spot-check Developer/Admin Users + Roles JSON and any ObjectSummary catalog table (no `empty`/`present` beans)

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): wire-getter type change only; no documented request/response example currently shows Optional-bean JSON
- [x] **Unit / module tests** — behavioral Jackson round-trips + UsersTest/RolesTest contract; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-dep sitemanage because public getter signatures changed
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 421, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1217, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public `Optional<T>` → `T` getters). Grep for `extends User|Role|ObjectSummary` and `new Type() {` — no anonymous subclasses. Standalone sitemanage clean install green.

## C5 UI proof

N/A — backend REST DTO / adaptor change only; no WebUI/Playwright surface.

## Residual

Next incremental family (DisplayFormatProperty / Template / Page) will be filed as a child of #3388.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
