### PR TITLE
fix(sitemanage): Create Site homepage/template save after NavTree seed (#3393)

### DIFF
--- a/docs/ai-generated/code-reviews/3393-create-site-template-after-nav-erlang.md
+++ b/docs/ai-generated/code-reviews/3393-create-site-template-after-nav-erlang.md
@@ -1,0 +1,47 @@
+# Erlang-style review: #3393 Create Site homepage/template after NavTree seed
+
+Reviewer: night-issue-prs (independent of implementer)
+Date: 2026-08-15
+Verdict: **approve**
+
+## Change class
+
+Traditional site create (`POST /sitemanage/site/`, managedNavigation default true) after #3364
+NavTree seed: `createHomePageAndTemplate` → `createSiteTemplate` (`percPageTemplate` save).
+
+## Findings
+
+### Hard-gate bugs
+
+None.
+
+Prior residual: `PSContentItemDao.save` still called `find()` after `contentWs.saveItems`.
+Workflow JDBC (`sys_wfUpdateHistory`) can leave the Hibernate session connection null.
+Nested `@Transactional` `loadBodies` then NPEs (`StatementPreparerImpl.connection()`) and
+marks the outer site-create transaction rollback-only (`UnexpectedRollbackException`).
+
+Fix matches peer #1563: return the in-memory item with id set; do not re-find.
+
+Homepage `checkinItems` after landing-page attach is the same Default Workflow check-in
+that #3364 removed from NavTree seed. Removed so a failed check-in cannot mark the
+surrounding transaction rollback-only. Item is valid once it is a folder child.
+
+### Tests
+
+- `PSContentItemDaoSaveAfterNavSeedTest` — save does not call `find` / `loadBodies`;
+  returns the same item with saveItems id.
+- `PSSiteContentDaoManagedNavTest.createsHomepageAndTemplateAfterNavSeedWithoutCheckin`
+  — after nav seed, createTemplate + page save + landing page + folder add; no `checkinItems`.
+
+### Cross-platform
+
+No filesystem path construction. N/A.
+
+### Companions
+
+Product-docs `product-docs/8.2/admin/sites.md` notes NavTree + site template + homepage
+in one Create Site operation. Playwright happy path spec comment updated (#3393).
+
+Memory patterns hit: missing behavioral tests (covered); change-class closure
+(product-docs + peer #1563/#3364); check-in / post-save find marks rollback-only;
+non-portable path I/O (none).

--- a/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
@@ -453,7 +453,8 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       }
       // Success: site folder exists under /Sites (REST). Wizard panel
       // testids differ by WebUI vintage; do not treat a missing panel
-      // id as success. HTTP 500 on create is the #3364 failure.
+      // id as success. HTTP 500 / UnexpectedRollbackException after
+      // NavTree seed is the #3364 / #3393 failure.
       await expect
         .poll(
           async () => {

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -40,7 +40,7 @@ Use **Content Explorer** when you need a new traditional (repository) Site witho
 3. On **Details**, enter a unique **Site name**, optional description, and the site **template name** (defaults from the site name). Traditional sites include **Include managed navigation** (checked by default). Leave it checked to create a NavTree and homepage. Uncheck it to create the site folder only — no NavTree and no homepage. You can add navigation later from Explorer. Virtual Sites do not use this option (`virtual.sourceKind` is their discriminator).
 4. On **Base template**, pick a base template from the catalog (or accept the default when the catalog is empty).
 5. On **Confirm**, review the summary (repository kind is **Traditional** — this flow does not create Virtual Sites) and whether managed navigation is **Yes** or **No**.
-6. Choose **Create** and wait for progress to complete. Explorer opens the new site under `/Sites/<name>`. With **Include managed navigation** checked, the server seeds a NavTree and homepage in that folder. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
+6. Choose **Create** and wait for progress to complete. Explorer opens the new site under `/Sites/<name>`. With **Include managed navigation** checked, the server seeds a NavTree, a site template, and the homepage (`index.html`) in that folder in one operation. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
 
 Virtual Site source settings (Git/filesystem) are configured later on the Site properties / Developer Sites surface — not in this Create Site wizard. See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
 

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
@@ -401,7 +401,13 @@ public class PSContentItemDao implements IPSContentItemDao {
           folderHelper.addItem(p, id);
         }
       }
-      return find(id);
+      // Do not re-find after saveItems. Workflow JDBC (sys_wfUpdateHistory)
+      // can leave the Hibernate session connection null. find() → loadBodies
+      // is @Transactional: the NPE marks the outer site-create transaction
+      // rollback-only even when callers catch it (#1563 / #3393).
+      // Domain fields were applied before save; id is assigned from saveItems.
+      contentItem.setId(id);
+      return contentItem;
     } catch (Exception e) {
       if (e instanceof LoadException) {
         if (isNew && id != null) {

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
@@ -55,7 +55,6 @@ import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSUnknownContentTypeException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.IPSContentWs;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -196,7 +195,11 @@ public class PSSiteContentDao implements com.percussion.sitemanage.dao.IPSSiteCo
       var status = contentWs.prepareForEdit(navtreeId);
       navService.addLandingPageToNavnode(pageGuid, navtreeId, asmBridge.getDispatchTemplate());
       contentWs.releaseFromEdit(status, false);
-      contentWs.checkinItems(Collections.singletonList(pageGuid), null);
+      // Do not checkinItems here. Default / sample-site workflows can NPE in
+      // sys_wfPerformTransition (m_nextAgingTransition). A failed check-in
+      // marks the surrounding site-create transaction rollback-only
+      // (#3364 / #3393). The homepage is valid once it is a folder child
+      // and linked as the NavTree landing page.
       folderHelper.addItem(folderRoot, pageId);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoSaveAfterNavSeedTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoSaveAfterNavSeedTest.java
@@ -105,4 +105,31 @@ class PSContentItemDaoSaveAfterNavSeedTest {
     verify(itemSummaryService, never()).find(anyString());
     verify(contentDesignWs, never()).findNodesByIds(anyList(), anyBoolean());
   }
+
+  @Test
+  void saveExistingItemReturnsSameInstanceWithoutPostSaveFind() throws Exception {
+    IPSGuid existingGuid = new PSLegacyGuid(9001, 1);
+    IPSGuid realGuid = new PSLegacyGuid(9001, 2);
+    when(idMapper.getGuid("guid-9001")).thenReturn(existingGuid);
+    when(contentDesignWs.getItemGuid(existingGuid)).thenReturn(realGuid);
+    when(contentWs.loadItems(eq(List.of(realGuid)), eq(true), eq(false), eq(false), eq(true)))
+        .thenReturn(List.of(coreItem));
+
+    PSContentItem item = new PSContentItem();
+    item.setId("guid-9001");
+    item.setType("percPageTemplate");
+    item.setFolderPaths(List.of("//Sites/Bare/.system/Templates"));
+    item.getFields().put("sys_title", "BareTemplate");
+
+    PSContentItem saved = dao.save(item);
+
+    assertSame(item, saved);
+    assertEquals("guid-9001", saved.getId());
+    verify(contentWs).loadItems(eq(List.of(realGuid)), eq(true), eq(false), eq(false), eq(true));
+    verify(contentWs).saveItems(anyList(), eq(false), eq(false), eq(folderGuid));
+    verify(contentWs, never()).createItems(anyString(), eq(1));
+    verify(folderHelper).addItem("//Sites/Bare/.system/Templates", "guid-9001");
+    verify(itemSummaryService, never()).find(anyString());
+    verify(contentDesignWs, never()).findNodesByIds(anyList(), anyBoolean());
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoSaveAfterNavSeedTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoSaveAfterNavSeedTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSCoreItem;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.IPSRelationshipCataloger;
+import com.percussion.share.service.IPSDataItemSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * After NavTree {@code saveItems}, Hibernate {@code loadBodies} can NPE
+ * ({@code StatementPreparerImpl.connection()} null). Post-save {@code find()}
+ * must not run — it marks the site-create transaction rollback-only (#3393).
+ */
+class PSContentItemDaoSaveAfterNavSeedTest {
+
+  @Mock private IPSContentDesignWs contentDesignWs;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSDataItemSummaryService itemSummaryService;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSCmsObjectMgr cmsObjectMgr;
+  @Mock private IPSRelationshipCataloger relationshipHelper;
+  @Mock private IPSSystemWs systemWs;
+  @Mock private PSCoreItem coreItem;
+
+  private PSContentItemDao dao;
+  private IPSGuid savedGuid;
+  private IPSGuid folderGuid;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    dao =
+        new PSContentItemDao(
+            contentDesignWs,
+            contentWs,
+            idMapper,
+            itemSummaryService,
+            folderHelper,
+            cmsObjectMgr,
+            relationshipHelper,
+            systemWs);
+    savedGuid = new PSLegacyGuid(9001, 1);
+    folderGuid = new PSLegacyGuid(501, 1);
+    when(contentWs.createItems("percPageTemplate", 1)).thenReturn(List.of(coreItem));
+    when(coreItem.getFieldByName(anyString())).thenReturn(null);
+    when(contentWs.getIdByPath("//Sites/Bare/.system/Templates")).thenReturn(folderGuid);
+    when(contentWs.saveItems(anyList(), eq(false), eq(false), eq(folderGuid)))
+        .thenReturn(List.of(savedGuid));
+    when(idMapper.getString(savedGuid)).thenReturn("guid-9001");
+  }
+
+  @Test
+  void saveReturnsInMemoryItemWithoutPostSaveFind() throws Exception {
+    PSContentItem item = new PSContentItem();
+    item.setType("percPageTemplate");
+    item.setFolderPaths(List.of("//Sites/Bare/.system/Templates"));
+    item.getFields().put("sys_title", "BareTemplate");
+
+    PSContentItem saved = dao.save(item);
+
+    assertSame(item, saved);
+    assertEquals("guid-9001", saved.getId());
+    verify(contentWs).saveItems(anyList(), eq(false), eq(false), eq(folderGuid));
+    verify(folderHelper).addItem("//Sites/Bare/.system/Templates", "guid-9001");
+    verify(itemSummaryService, never()).find(anyString());
+    verify(contentDesignWs, never()).findNodesByIds(anyList(), anyBoolean());
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteContentDaoManagedNavTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteContentDaoManagedNavTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,18 +32,25 @@ import com.percussion.fastforward.managednav.PSNavException;
 import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
 import com.percussion.pagemanagement.dao.IPSPageDao;
 import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.data.PSPage;
+import com.percussion.pagemanagement.data.PSTemplateSummary;
 import com.percussion.pagemanagement.service.IPSTemplateService;
 import com.percussion.pathmanagement.data.PSFolderPermission;
 import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.share.dao.IPSContentItemDao;
 import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.service.IPSIdMapper;
 import com.percussion.sitemanage.data.PSSite;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.services.content.data.PSItemStatus;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.IPSContentWs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /** Traditional sites can skip NavTree seed when managedNavigation is false. */
@@ -109,6 +117,44 @@ class PSSiteContentDaoManagedNavTest {
 
     verify(navService)
         .addNavTreeToFolder("//Sites/Bare", "Bare-NavTree", "Home", 1);
+  }
+
+  @Test
+  void createsHomepageAndTemplateAfterNavSeedWithoutCheckin() throws Exception {
+    PSSite site = traditionalSite();
+    IPSGuid navGuid = new PSLegacyGuid(7001, 1);
+    IPSGuid pageGuid = new PSLegacyGuid(8001, 1);
+    IPSGuid baseGuid = new PSLegacyGuid(100, 1);
+    PSAssemblyTemplate baseTemplate = Mockito.mock(PSAssemblyTemplate.class);
+    PSTemplateSummary templateSummary = new PSTemplateSummary();
+    templateSummary.setId("tpl-1");
+    templateSummary.setName("BareTemplate");
+    PSPage savedPage = new PSPage();
+    savedPage.setId("page-1");
+    PSItemStatus status = Mockito.mock(PSItemStatus.class);
+
+    when(navService.findNavSummary("//Sites/Bare")).thenReturn(null);
+    when(pageDaoHelper.getWorkflowIdForPath("//Sites/Bare")).thenReturn(1);
+    when(navService.addNavTreeToFolder("//Sites/Bare", "Bare-NavTree", "Home", 1))
+        .thenReturn(navGuid);
+    when(baseTemplate.getGUID()).thenReturn(baseGuid);
+    when(assemblyService.findTemplateByName("perc.base.plain")).thenReturn(baseTemplate);
+    when(idMapper.getString(baseGuid)).thenReturn("base-1");
+    when(templateService.createTemplate("BareTemplate", "base-1", "Bare"))
+        .thenReturn(templateSummary);
+    when(pageDao.save(any(PSPage.class))).thenReturn(savedPage);
+    when(idMapper.getGuid("page-1")).thenReturn(pageGuid);
+    when(asmBridge.getDispatchTemplate()).thenReturn("perc.page");
+    when(contentWs.prepareForEdit(navGuid)).thenReturn(status);
+
+    dao.createRelatedItems(site);
+
+    verify(navService).addNavTreeToFolder("//Sites/Bare", "Bare-NavTree", "Home", 1);
+    verify(templateService).createTemplate("BareTemplate", "base-1", "Bare");
+    verify(pageDao).save(any(PSPage.class));
+    verify(navService).addLandingPageToNavnode(pageGuid, navGuid, "perc.page");
+    verify(folderHelper).addItem("//Sites/Bare", "page-1");
+    verify(contentWs, never()).checkinItems(any(), eq(null));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteContentDaoManagedNavTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteContentDaoManagedNavTest.java
@@ -154,6 +154,8 @@ class PSSiteContentDaoManagedNavTest {
     verify(pageDao).save(any(PSPage.class));
     verify(navService).addLandingPageToNavnode(pageGuid, navGuid, "perc.page");
     verify(folderHelper).addItem("//Sites/Bare", "page-1");
+    verify(contentWs).prepareForEdit(navGuid);
+    verify(contentWs).releaseFromEdit(status, false);
     verify(contentWs, never()).checkinItems(any(), eq(null));
   }
 


### PR DESCRIPTION
## Summary

Explorer **Content → Create Site** with managed navigation still failed after #3364: NavTree seed succeeded, then `createHomePageAndTemplate` / `createSiteTemplate` hit Hibernate `StatementPreparerImpl.connection()` is null and `UnexpectedRollbackException` on `percPageTemplate` save.

This PR does **not** invent a new site API. It:

- Stops `PSContentItemDao.save` from calling `find()` after `contentWs.saveItems`. Workflow JDBC (`sys_wfUpdateHistory`) can leave the Hibernate session connection null; nested `@Transactional` `loadBodies` then marks the outer site-create transaction rollback-only (same pattern as #1563).
- Skips homepage `checkinItems` after landing-page attach. Default Workflow can NPE in `sys_wfPerformTransition` (`m_nextAgingTransition`); a failed check-in marks the surrounding transaction rollback-only (same rationale as #3364 NavTree seed).
- Updates `product-docs/8.2/admin/sites.md`.

Parent tracker: #3364 / QA #3008 / slice #3002.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3393
Related: #3364 #3008 #3002

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1225, Failures: 0, Errors: 0, Skipped: 125).
2. Unit: `PSContentItemDaoSaveAfterNavSeedTest`, `PSSiteContentDaoManagedNavTest` (homepage/template after nav seed, no `checkinItems`).
3. QA H2: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`.
4. Hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar` + matching `perc-system-8.2.0-SNAPSHOT.jar` into `perc-matrix-cms-h2` WAR `WEB-INF/lib`; in-cell `StopJetty` / `StartJetty` (not `docker restart`).
5. `qa-health --url http://127.0.0.1:9993/Rhythmyx/login` → HTTP 200, HEALTH:healthy, ROOT/Rhythmyx Started (no `Failed startup of context`).
6. Playwright: `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js --grep "happy path"` — 1 passed.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md` (NavTree + site template + homepage in one Create Site operation)
- [x] **Unit / module tests** — new/updated tests; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — existing Create Site happy path spec; H2 live create now passes
- [x] **Build gates** — `projects/sitemanage` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`
- **build_evidence:**
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1225, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** none (no public type made final/sealed; no signature change)

### C5 UI proof

- `qa-up --skip-image-build` RESULT:OK; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`
- Hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar` + matching `perc-system-8.2.0-SNAPSHOT.jar` to `WEB-INF/lib`; in-cell StopJetty/StartJetty
- After restart: `Initialization completed` / `ServletContextHandler Started` (no `Failed startup of context`); `qa-health` HTTP 200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js --grep "happy path"` → **1 passed** (4.5s)
- console-clean=yes (test passed; no pageerror)
- server.log-clean=yes for the feature (no UnexpectedRollbackException / percPageTemplate NPE). Pre-existing Explorer `/services/actions/find` noise only.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
