### PR TITLE
fix(rest): DisplayFormatProperty/Template/Page wire getters must not return Optional (#3407)

### DIFF
--- a/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3407-rest-dto-wire-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)  
+**Date:** 2026-08-15  
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3407-rest-dto-wire-getters`.  
+**Memory patterns hit:** Optional wire getters drop fields / emit `empty`/`present` beans; public getter signature change requires reverse-dep compile.
+
+## Summary
+
+REST wire DTOs `DisplayFormatProperty`, `Template`, `TemplateBinding`, and the Page family (`Page`, `Widget`, `SeoInfo`, `Region`, `CalendarInfo`, `CodeInfo`, `WorkflowInfo`) returned `Optional<T>` from JSON getters. That produces Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189 / User-Role-ObjectSummary #3388).
+
+This change converts those types to plain nullable getters/setters with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.ifPresent()` / `Optional.flatMap` (`PagesResource`, sitemanage `PageAdaptor` / `AssetAdaptor`). `ApiUtils.orEmpty(Collection)` was added so converted list getters compile without an Optional wrapper. `PageAdaptor.findWidget` still unwraps `PSWidgetItem.getName()` (`Optional`) when comparing to the now-plain REST `Widget.getName()`.
+
+Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.
+
+`TemplateDetail` already used plain getters. Virtual Site / LocationScheme / Folder families were left for #3411–#3413. `rest/AGENTS.md` was not committed (human rule review).
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none remaining for this family
+- Behavioral tests: JacksonContextResolverOptionalTest (9 tests, including new family round-trips)
+- Playwright companion: N/A (no WebUI product screen change)
+- Agent rule files: none
+- Cross-platform: **N/A** (no path I/O)
+- C2: public `Optional<T>` → `T` getters. Grep for `extends DisplayFormatProperty|Template|Page|Widget|SeoInfo|Region|CalendarInfo|CodeInfo|WorkflowInfo` and `new Type() {` — no anonymous subclasses of the REST types. sitemanage `Template` subclasses are `com.percussion.sitemanage.service.Template`, not the REST DTO. Standalone sitemanage clean install green.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 423, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -165,6 +165,17 @@ public class ApiUtils {
   }
 
   /**
+   * Return an empty collection if the collection is null.
+   *
+   * @param col the collection, may be {@code null}
+   * @param <T> the element type
+   * @return the collection or an empty one
+   */
+  public static <T> Collection<T> orEmpty(Collection<T> col) {
+    return col == null ? List.of() : col;
+  }
+
+  /**
    * Generic unwrapping helper. If the supplied object is an {@link Optional} it will return the
    * contained value or null; otherwise the value is returned unchanged. This allows callers to
    * uniformly access getters which may or may not return Optionals without needing to know the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
@@ -266,10 +266,10 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
     try {
       var oldPSAsset = this.assetService.load(id);
       var workflowInfo = this.getWorkflowInfo(oldPSAsset);
-      // determine the requested end state - WorkflowInfo stores Optionals now
-      String endState = ApiUtils.orNull(workflowInfo.getState());
+      // determine the requested end state
+      String endState = workflowInfo.getState();
       if (asset.getWorkflow().isPresent()) {
-        String state = ApiUtils.orNull(asset.getWorkflow().get().getState());
+        String state = asset.getWorkflow().get().getState();
         if (StringUtils.isNotBlank(state)) {
           endState = state;
         }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
@@ -335,7 +335,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         // not widgets in it from the template
         boolean regionEditable = (instanceSize == 0 || owner.equals(PSMergedRegionOwner.PAGE));
 
-        boolean clearRegion = updateRegion.getWidgets().isEmpty();
+        boolean clearRegion =
+            updateRegion.getWidgets() == null || updateRegion.getWidgets().isEmpty();
         List<PSWidgetItem> updateWidgetList = new ArrayList<>();
         List<PSWidgetItem> newWidgetList = new ArrayList<>();
 
@@ -344,23 +345,23 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSWidgetItem existingWidget = findWidget(existingInstances, updateWidget);
 
           if (existingWidget == null && regionEditable) {
-            if (StringUtils.isNotEmpty(ApiUtils.orNull(updateWidget.getId()))) {
+            if (StringUtils.isNotEmpty(updateWidget.getId())) {
               throw new RuntimeException(
                   "Cannot find widget id "
-                      + ApiUtils.orNull(updateWidget.getId())
+                      + updateWidget.getId()
                       + " on region "
                       + updateRegion.getName());
             }
 
-            if (StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getId()))
-                && StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getName()))) {
+            if (StringUtils.isEmpty(updateWidget.getId())
+                && StringUtils.isEmpty(updateWidget.getName())) {
               throw new RuntimeException("Must specify either id or name on widget");
             }
 
             existingWidget = new PSWidgetItem();
-            existingWidget.setDefinitionId(ApiUtils.orNull(updateWidget.getType()));
-            existingWidget.setId(ApiUtils.orNull(updateWidget.getId()));
-            existingWidget.setName(ApiUtils.orNull(updateWidget.getName()));
+            existingWidget.setDefinitionId(updateWidget.getType());
+            existingWidget.setId(updateWidget.getId());
+            existingWidget.setName(updateWidget.getName());
           }
           // will add placeholder nulls for non editable regions
           newWidgetList.add(existingWidget);
@@ -385,14 +386,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           }
 
           if (!clearRegion) {
-            pullTemplateRegionToPage(psPage, template, ApiUtils.orNull(updateRegion.getName()));
+            pullTemplateRegionToPage(psPage, template, updateRegion.getName());
           }
 
           psPage.getRegionBranches().setRegionWidgetAssociations(newWidgetAssoc);
 
           psPage
               .getRegionBranches()
-              .setRegionWidgets(ApiUtils.orNull(updateRegion.getName()), updateWidgetList);
+              .setRegionWidgets(updateRegion.getName(), updateWidgetList);
 
           savePage = true;
         }
@@ -543,8 +544,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         existingWidget = widget;
       }
       if (updateWidget.getName() != null
-          && widget.getName() != null
-          && updateWidget.getName().equals(widget.getName())) {
+          && widget.getName().isPresent()
+          && updateWidget.getName().equals(widget.getName().orElse(null))) {
         existingWidget = widget;
       }
     }
@@ -668,13 +669,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     var url =
         new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     var folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
     var pathServicePath = StringUtils.substring(folderUrl.getUrl(), 1);
 
     try {
@@ -690,7 +690,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       throw new BackendException(e.getMessage(), e);
     }
     if (psPage == null) {
-      if (PSFolderPathUtils.testHasInvalidChars(ApiUtils.orNull(toPage.getName()))) {
+      if (PSFolderPathUtils.testHasInvalidChars(toPage.getName())) {
         throw new IllegalArgumentException(
             "Cannot create a page with following chars in the name"
                 + SecureStringUtils.INVALID_ITEM_NAME_CHARACTERS);
@@ -705,9 +705,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     Page currentPage =
         getPage(
             baseUri,
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     return currentPage;
   }
@@ -748,10 +748,10 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       currentState = getWorkflowState(page);
     }
 
-    Optional<WorkflowInfo> wfOpt = toPage.getWorkflow();
-    Optional<String> stateOpt = wfOpt.flatMap(WorkflowInfo::getState);
-    if (stateOpt.isPresent() && StringUtils.isNotEmpty(stateOpt.get())) {
-      endState = stateOpt.get();
+    WorkflowInfo wfInfo = toPage.getWorkflow();
+    String state = wfInfo == null ? null : wfInfo.getState();
+    if (StringUtils.isNotEmpty(state)) {
+      endState = state;
     } else {
       endState = currentState;
     }
@@ -765,66 +765,59 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
 
     UrlParts folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
 
     // set default values
     if (newPage) {
-      page.setTitle(ApiUtils.orNull(toPage.getName()));
-      page.setLinkTitle(ApiUtils.orNull(toPage.getName()));
+      page.setTitle(toPage.getName());
+      page.setLinkTitle(toPage.getName());
     }
 
-    Optional<CodeInfo> codeOpt = toPage.getCode();
-    if (codeOpt.isPresent()) {
-      CodeInfo code = codeOpt.get();
-      String head = ApiUtils.orNull(code.getHead());
+    CodeInfo code = toPage.getCode();
+    if (code != null) {
+      String head = code.getHead();
       if (head != null) {
         page.setAdditionalHeadContent(head);
       }
-      String afterStart = ApiUtils.orNull(code.getAfterStart());
+      String afterStart = code.getAfterStart();
       if (afterStart != null) {
         page.setAfterBodyStartContent(afterStart);
       }
-      String beforeClose = ApiUtils.orNull(code.getBeforeClose());
+      String beforeClose = code.getBeforeClose();
       if (beforeClose != null) {
         page.setBeforeBodyCloseContent(beforeClose);
       }
     }
 
-    // `page` will be updated later so capture a final reference for lambda
-    final PSPage pageRef = page;
-    toPage
-        .getSeo()
-        .ifPresent(
-            seo -> {
-              if (seo.getMetaDescription() != null) {
-                pageRef.setDescription(ApiUtils.orNull(seo.getMetaDescription()));
-              }
+    SeoInfo seo = toPage.getSeo();
+    if (seo != null) {
+      if (seo.getMetaDescription() != null) {
+        page.setDescription(seo.getMetaDescription());
+      }
 
-              // default title to page name
-              if (seo.getBrowserTitle() != null) {
-                pageRef.setTitle(ApiUtils.orNull(seo.getBrowserTitle()));
-              }
+      // default title to page name
+      if (seo.getBrowserTitle() != null) {
+        page.setTitle(seo.getBrowserTitle());
+      }
 
-              Boolean hideSearch = seo.getHideSearch().orElse(null);
-              pageRef.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
+      Boolean hideSearch = seo.getHideSearch();
+      page.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
 
-              List<String> tags = seo.getTags().orElse(null);
-              if (tags != null) {
-                pageRef.setTags(tags);
-              }
-
-              // toPage.getSeo().getCategories();
-
-            });
+      List<String> tags = seo.getTags();
+      if (tags != null) {
+        page.setTags(tags);
+      }
+    }
     // default linktitle to name
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
-
-    if (toPage.getName() != null) {
-      page.setName(ApiUtils.orNull(toPage.getName()));
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
     }
 
-    String templateName = ApiUtils.orNull(toPage.getTemplateName());
+    if (toPage.getName() != null) {
+      page.setName(toPage.getName());
+    }
+
+    String templateName = toPage.getTemplateName();
 
     PSTemplate template = null;
     String templateId = null;
@@ -833,7 +826,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(toPage.getSiteName())));
+                  templateName, toPage.getSiteName()));
 
       page.setTemplateId(templateId);
     } else {
@@ -846,7 +839,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     template = templateService.load(templateId);
 
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
+    }
 
     updateRegionInfo(toPage, page, template);
     try {
@@ -867,8 +862,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     updateAssetInfo(baseUri, toPage, page, template);
 
-    CalendarInfo calInfo = ApiUtils.orNull(toPage.getCalendar());
-    List<String> categories = toPage.getSeo().flatMap(SeoInfo::getCategories).orElse(null);
+    CalendarInfo calInfo = toPage.getCalendar();
+    List<String> categories = toPage.getSeo() == null ? null : toPage.getSeo().getCategories();
 
     boolean isUpdated = false;
     FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss.S");
@@ -901,7 +896,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
     // Setting to null or empty string is the same as auto generate.
     if (toPage.getSummary() != null) {
-      if (StringUtils.isNotBlank(ApiUtils.orNull(toPage.getSummary()))) {
+      if (StringUtils.isNotBlank(toPage.getSummary())) {
         fields.put("auto_generate_summary", "0");
         fields.put("page_summary", toPage.getSummary());
       } else {
@@ -967,12 +962,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       emptyTemplateWidgetIds.add(emptyTemplateWidgetId.getId());
     }
 
-    List<Region> bodyRegions = ApiUtils.orNull(toPage.getBody());
+    List<Region> bodyRegions = toPage.getBody();
     if (bodyRegions != null) {
       for (Region region : bodyRegions) {
         PSMergedRegion systemRegion =
-            tree.getMergedRegionMap().get(ApiUtils.orNull(region.getName()));
-        List<Widget> widgets = ApiUtils.orNull(region.getWidgets());
+            tree.getMergedRegionMap().get(region.getName());
+        List<Widget> widgets = region.getWidgets();
         List<PSWidgetInstance> systemRegionWidgets = systemRegion.getWidgetInstances();
 
         if (widgets != null) {
@@ -990,7 +985,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
               String id = widgetItem.getId();
 
               PSRelationship assetRels = assetWidgets.get(id);
-              Asset asset = ApiUtils.orNull(widget.getAsset());
+              Asset asset = widget.getAsset();
 
               //
               if (assetRels != null && Boolean.TRUE.equals(asset.getRemove())) {
@@ -1005,8 +1000,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
                     PSAssetWidgetRelationship awRel =
                         new PSAssetWidgetRelationship(
                             page.getId(),
-                            Long.parseLong(ApiUtils.orNull(widget.getId())),
-                            ApiUtils.orNull(widget.getType()),
+                            Long.parseLong(widget.getId()),
+                            widget.getType(),
                             assetId,
                             0);
                     assetService.clearAssetWidgetRelationship(awRel);
@@ -1069,14 +1064,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         while (iterator.hasNext()) {
 
           PSOrphanedAssetSummary orphan = iterator.next();
-          if (StringUtils.equals(ApiUtils.orNull(widget.getName()), orphan.getName())
-              && StringUtils.equals(ApiUtils.orNull(widget.getType()), orphan.getType())) {
+          if (StringUtils.equals(widget.getName(), orphan.getName())
+              && StringUtils.equals(widget.getType(), orphan.getType())) {
             foundOrphan = true;
             PSAssetWidgetRelationship awRel =
                 new PSAssetWidgetRelationship(
                     page.getId(),
-                    Long.parseLong(ApiUtils.orNull(widget.getId())),
-                    ApiUtils.orNull(widget.getType()),
+                    Long.parseLong(widget.getId()),
+                    widget.getType(),
                     orphan.getId(),
                     0);
             try {
@@ -1096,7 +1091,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         if (!foundOrphan) {
           guidString =
               createAndAssociateLocalAsset(
-                  page.getId(), id, ApiUtils.orNull(widget.getType()), fields);
+                  page.getId(), id, widget.getType(), fields);
         }
       } else // existing asset
       {
@@ -1144,8 +1139,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 pathItem.getId(),
                 0);
         awRel.setResourceType(PSAssetResourceType.shared);
@@ -1158,8 +1153,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 idMapper.getString(assetRels.getDependent()),
                 0);
         assetService.shareLocalContent(
@@ -1174,8 +1169,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSAssetWidgetRelationship awRel =
               new PSAssetWidgetRelationship(
                   page.getId(),
-                  Long.parseLong(ApiUtils.orNull(widget.getId())),
-                  ApiUtils.orNull(widget.getType()),
+                  Long.parseLong(widget.getId()),
+                  widget.getType(),
                   pathItem.getId(),
                   0);
           awRel.setResourceType(PSAssetResourceType.shared);
@@ -1457,9 +1452,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String pageId = null;
       String templateName = null;
 
-      if (p != null && p.getId().isPresent() && p.getTemplateName().isPresent()) {
-        pageId = p.getId().get();
-        templateName = p.getTemplateName().get();
+      if (p != null && p.getId() != null && p.getTemplateName() != null) {
+        pageId = p.getId();
+        templateName = p.getTemplateName();
 
         if (pageId.isEmpty() || templateName.isEmpty()) {
           throw new PageNotFoundException();
@@ -1475,7 +1470,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(p.getSiteName())));
+                  templateName, p.getSiteName()));
 
       if (templateId != null) {
         ArrayList<String> pageIds = new ArrayList<>();

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.displayformat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.ValueList;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Optional;
 
-/** Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued. */
+/**
+ * Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits property
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(
     name = "DisplayFormatProperty",
     description =
@@ -54,40 +60,40 @@ public class DisplayFormatProperty {
     // Default constructor
   }
 
-  public Optional<String> getPropertyId() {
-    return Optional.ofNullable(propertyId);
+  public String getPropertyId() {
+    return propertyId;
   }
 
   public void setPropertyId(String propertyId) {
     this.propertyId = propertyId;
   }
 
-  public Optional<String> getPropertyName() {
-    return Optional.ofNullable(propertyName);
+  public String getPropertyName() {
+    return propertyName;
   }
 
   public void setPropertyName(String propertyName) {
     this.propertyName = propertyName;
   }
 
-  public Optional<String> getPropertyValue() {
-    return Optional.ofNullable(propertyValue);
+  public String getPropertyValue() {
+    return propertyValue;
   }
 
   public void setPropertyValue(String propertyValue) {
     this.propertyValue = propertyValue;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<ValueList> getPropertyValues() {
-    return Optional.ofNullable(propertyValues);
+  public ValueList getPropertyValues() {
+    return propertyValues;
   }
 
   public void setPropertyValues(ValueList propertyValues) {

--- a/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
@@ -19,13 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!" */
+/**
+ * Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits calendar
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CalendarInfo")
 @Schema(name = "CalendarInfo", description = "Represents Calendar information.")
 public class CalendarInfo {
@@ -42,10 +48,10 @@ public class CalendarInfo {
   /**
    * Gets the start date.
    *
-   * @return Optional containing the start date if present.
+   * @return the start date, or {@code null} if unset
    */
-  public Optional<Date> getStartDate() {
-    return Optional.ofNullable(startDate);
+  public Date getStartDate() {
+    return startDate;
   }
 
   public void setStartDate(Date startDate) {
@@ -55,10 +61,10 @@ public class CalendarInfo {
   /**
    * Gets the end date.
    *
-   * @return Optional containing the end date if present.
+   * @return the end date, or {@code null} if unset
    */
-  public Optional<Date> getEndDate() {
-    return Optional.ofNullable(endDate);
+  public Date getEndDate() {
+    return endDate;
   }
 
   public void setEndDate(Date endDate) {
@@ -68,10 +74,10 @@ public class CalendarInfo {
   /**
    * Gets the list of calendars.
    *
-   * @return Optional containing the list of calendars if present.
+   * @return the list of calendars, or {@code null} if unset
    */
-  public Optional<List<String>> getCalendars() {
-    return Optional.ofNullable(calendars);
+  public List<String> getCalendars() {
+    return calendars;
   }
 
   public void setCalendars(List<String> calendars) {

--- a/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!" */
+/**
+ * Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits code fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CodeInfo")
 @Schema(name = "CodeInfo", description = "Represents code information.")
 public class CodeInfo {
@@ -38,8 +44,8 @@ public class CodeInfo {
   private String beforeClose = "";
 
   /** Gets the head code. */
-  public Optional<String> getHead() {
-    return Optional.ofNullable(head);
+  public String getHead() {
+    return head;
   }
 
   public void setHead(String head) {
@@ -47,8 +53,8 @@ public class CodeInfo {
   }
 
   /** Gets the code after start. */
-  public Optional<String> getAfterStart() {
-    return Optional.ofNullable(afterStart);
+  public String getAfterStart() {
+    return afterStart;
   }
 
   public void setAfterStart(String afterStart) {
@@ -56,8 +62,8 @@ public class CodeInfo {
   }
 
   /** Gets the code before close. */
-  public Optional<String> getBeforeClose() {
-    return Optional.ofNullable(beforeClose);
+  public String getBeforeClose() {
+    return beforeClose;
   }
 
   public void setBeforeClose(String beforeClose) {

--- a/rest/src/main/java/com/percussion/rest/pages/Page.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Page.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -26,9 +27,14 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a page. Sunny Sal: "Page ka hero, content ka zero!" */
+/**
+ * Represents a page. Sunny Sal: "Page ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits page fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Page")
 @Schema(name = "Page", description = "Represents a page.")
 public class Page {
@@ -107,88 +113,88 @@ public class Page {
     this.bookmarkedUsers = bookmarkedUsers;
   }
 
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDisplayName() {
-    return Optional.ofNullable(displayName);
+  public String getDisplayName() {
+    return displayName;
   }
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<String> getSummary() {
-    return Optional.ofNullable(summary);
+  public String getSummary() {
+    return summary;
   }
 
   public void setSummary(String summary) {
     this.summary = summary;
   }
 
-  public Optional<Date> getOverridePostDate() {
-    return Optional.ofNullable(overridePostDate);
+  public Date getOverridePostDate() {
+    return overridePostDate;
   }
 
   public void setOverridePostDate(Date overridePostDate) {
     this.overridePostDate = overridePostDate;
   }
 
-  public Optional<WorkflowInfo> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public WorkflowInfo getWorkflow() {
+    return workflow;
   }
 
   public void setWorkflow(WorkflowInfo workflow) {
     this.workflow = workflow;
   }
 
-  public Optional<SeoInfo> getSeo() {
-    return Optional.ofNullable(seo);
+  public SeoInfo getSeo() {
+    return seo;
   }
 
   public void setSeo(SeoInfo seo) {
     this.seo = seo;
   }
 
-  public Optional<CalendarInfo> getCalendar() {
-    return Optional.ofNullable(calendar);
+  public CalendarInfo getCalendar() {
+    return calendar;
   }
 
   public void setCalendar(CalendarInfo calendar) {
     this.calendar = calendar;
   }
 
-  public Optional<CodeInfo> getCode() {
-    return Optional.ofNullable(code);
+  public CodeInfo getCode() {
+    return code;
   }
 
   public void setCode(CodeInfo code) {
     this.code = code;
   }
 
-  public Optional<List<Region>> getBody() {
-    return Optional.ofNullable(body);
+  public List<Region> getBody() {
+    return body;
   }
 
   public void setBody(List<Region> body) {
@@ -220,16 +226,16 @@ public class Page {
         + "]";
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getFolderPath() {
-    return Optional.ofNullable(folderPath);
+  public String getFolderPath() {
+    return folderPath;
   }
 
   public void setFolderPath(String folderPath) {

--- a/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
@@ -174,9 +174,9 @@ public class PagesResource {
       pageName = StringUtils.defaultString(m.group(5));
     }
 
-    String objectName = page.getName().orElse(null);
-    String objectPath = page.getFolderPath().orElse(null);
-    String objectSite = page.getSiteName().orElse(null);
+    String objectName = page.getName();
+    String objectPath = page.getFolderPath();
+    String objectSite = page.getSiteName();
 
     if (pageName == null || (objectName != null && !objectName.equals(pageName))) {
       throw new LocationMismatchException();

--- a/rest/src/main/java/com/percussion/rest/pages/Region.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Region.java
@@ -19,15 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents a region of a page either defined locally or by the template. Sunny Sal: "Region ka
  * hero, widgets ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits region
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Region")
 @Schema(
     name = "Region",
@@ -47,8 +51,8 @@ public class Region {
   private List<Widget> widgets;
 
   /** Gets the region name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -56,8 +60,8 @@ public class Region {
   }
 
   /** Gets the region type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -74,8 +78,8 @@ public class Region {
   }
 
   /** Gets the widgets in this region. */
-  public Optional<List<Widget>> getWidgets() {
-    return Optional.ofNullable(widgets);
+  public List<Widget> getWidgets() {
+    return widgets;
   }
 
   public void setWidgets(List<Widget> widgets) {

--- a/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!" */
+/**
+ * Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits SEO fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "SeoInfo")
 @Schema(name = "SeoInfo", description = "Represents information about the SEO.")
@@ -53,8 +57,8 @@ public class SeoInfo {
   private List<String> categories;
 
   /** Gets the browser title. */
-  public Optional<String> getBrowserTitle() {
-    return Optional.ofNullable(browserTitle);
+  public String getBrowserTitle() {
+    return browserTitle;
   }
 
   public void setBrowserTitle(String browserTitle) {
@@ -62,8 +66,8 @@ public class SeoInfo {
   }
 
   /** Gets the meta description. */
-  public Optional<String> getMetaDescription() {
-    return Optional.ofNullable(metaDescription);
+  public String getMetaDescription() {
+    return metaDescription;
   }
 
   public void setMetaDescription(String metaDescription) {
@@ -71,8 +75,8 @@ public class SeoInfo {
   }
 
   /** Gets the hide search flag. */
-  public Optional<Boolean> getHideSearch() {
-    return Optional.ofNullable(hideSearch);
+  public Boolean getHideSearch() {
+    return hideSearch;
   }
 
   public void setHideSearch(Boolean hideSearch) {
@@ -80,8 +84,8 @@ public class SeoInfo {
   }
 
   /** Gets the tags. */
-  public Optional<List<String>> getTags() {
-    return Optional.ofNullable(tags);
+  public List<String> getTags() {
+    return tags;
   }
 
   public void setTags(List<String> tags) {
@@ -89,8 +93,8 @@ public class SeoInfo {
   }
 
   /** Gets the categories. */
-  public Optional<List<String>> getCategories() {
-    return Optional.ofNullable(categories);
+  public List<String> getCategories() {
+    return categories;
   }
 
   public void setCategories(List<String> categories) {

--- a/rest/src/main/java/com/percussion/rest/pages/Widget.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Widget.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.assets.Asset;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!" */
+/**
+ * Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits widget
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Widget")
 @Schema(name = "Widget", description = "Represents a Widget.")
@@ -57,8 +61,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget id. */
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
@@ -66,8 +70,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -75,8 +79,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -84,8 +88,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget scope. */
-  public Optional<String> getScope() {
-    return Optional.ofNullable(scope);
+  public String getScope() {
+    return scope;
   }
 
   public void setScope(String scope) {
@@ -93,8 +97,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets whether the widget is editable. */
-  public Optional<Boolean> getEditable() {
-    return Optional.ofNullable(editable);
+  public Boolean getEditable() {
+    return editable;
   }
 
   public void setEditable(Boolean editable) {
@@ -102,8 +106,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the asset within the widget. */
-  public Optional<Asset> getAsset() {
-    return Optional.ofNullable(asset);
+  public Asset getAsset() {
+    return asset;
   }
 
   public void setAsset(Asset asset) {

--- a/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!" */
+/**
+ * Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits workflow
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "WorkflowInfo")
 @Schema(name = "WorkflowInfo", description = "Represents information on the workflow.")
 public class WorkflowInfo {
@@ -41,8 +47,8 @@ public class WorkflowInfo {
   private String checkedOutUser;
 
   /** Gets the workflow name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -50,8 +56,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the workflow state. */
-  public Optional<String> getState() {
-    return Optional.ofNullable(state);
+  public String getState() {
+    return state;
   }
 
   public void setState(String state) {
@@ -59,8 +65,8 @@ public class WorkflowInfo {
   }
 
   /** Gets whether the item is checked out. */
-  public Optional<Boolean> getCheckedOut() {
-    return Optional.ofNullable(checkedOut);
+  public Boolean getCheckedOut() {
+    return checkedOut;
   }
 
   public void setCheckedOut(Boolean checkedOut) {
@@ -68,8 +74,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the user that has the item checked out. */
-  public Optional<String> getCheckedOutUser() {
-    return Optional.ofNullable(checkedOutUser);
+  public String getCheckedOutUser() {
+    return checkedOutUser;
   }
 
   public void setCheckedOutUser(String checkedOutUser) {

--- a/rest/src/main/java/com/percussion/rest/templates/Template.java
+++ b/rest/src/main/java/com/percussion/rest/templates/Template.java
@@ -19,12 +19,22 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-/** Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!" */
+/**
+ * Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits catalog
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Template")
 @Schema(name = "Template", description = "Represents an assembly Template")
 public class Template {
@@ -55,72 +65,72 @@ public class Template {
     // Default constructor
   }
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getLocationPrefix() {
-    return Optional.ofNullable(locationPrefix);
+  public String getLocationPrefix() {
+    return locationPrefix;
   }
 
   public void setLocationPrefix(String locationPrefix) {
     this.locationPrefix = locationPrefix;
   }
 
-  public Optional<String> getLocationSuffix() {
-    return Optional.ofNullable(locationSuffix);
+  public String getLocationSuffix() {
+    return locationSuffix;
   }
 
   public void setLocationSuffix(String locationSuffix) {
     this.locationSuffix = locationSuffix;
   }
 
-  public Optional<String> getAssembler() {
-    return Optional.ofNullable(assembler);
+  public String getAssembler() {
+    return assembler;
   }
 
   public void setAssembler(String assembler) {
     this.assembler = assembler;
   }
 
-  public Optional<String> getAssemblyUrl() {
-    return Optional.ofNullable(assemblyUrl);
+  public String getAssemblyUrl() {
+    return assemblyUrl;
   }
 
   public void setAssemblyUrl(String assemblyUrl) {
     this.assemblyUrl = assemblyUrl;
   }
 
-  public Optional<String> getStyleSheet() {
-    return Optional.ofNullable(styleSheet);
+  public String getStyleSheet() {
+    return styleSheet;
   }
 
   public void setStyleSheet(String styleSheet) {
@@ -143,48 +153,48 @@ public class Template {
     this.outputFormat = outputFormat;
   }
 
-  public Optional<Character> getPublishWhen() {
-    return Optional.ofNullable(publishWhen);
+  public Character getPublishWhen() {
+    return publishWhen;
   }
 
   public void setPublishWhen(Character publishWhen) {
     this.publishWhen = publishWhen;
   }
 
-  public Optional<Integer> getTemplateType() {
-    return Optional.ofNullable(templateType);
+  public Integer getTemplateType() {
+    return templateType;
   }
 
   public void setTemplateType(Integer templateType) {
     this.templateType = templateType;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getTemplate() {
-    return Optional.ofNullable(template);
+  public String getTemplate() {
+    return template;
   }
 
   public void setTemplate(String template) {
     this.template = template;
   }
 
-  public Optional<String> getMimeType() {
-    return Optional.ofNullable(mimeType);
+  public String getMimeType() {
+    return mimeType;
   }
 
   public void setMimeType(String mimeType) {
     this.mimeType = mimeType;
   }
 
-  public Optional<String> getCharset() {
-    return Optional.ofNullable(charset);
+  public String getCharset() {
+    return charset;
   }
 
   public void setCharset(String charset) {
@@ -207,16 +217,16 @@ public class Template {
     this.slots = slots;
   }
 
-  public Optional<Integer> getGlobalTemplateUsage() {
-    return Optional.ofNullable(globalTemplateUsage);
+  public Integer getGlobalTemplateUsage() {
+    return globalTemplateUsage;
   }
 
   public void setGlobalTemplateUsage(Integer globalTemplateUsage) {
     this.globalTemplateUsage = globalTemplateUsage;
   }
 
-  public Optional<Long> getGlobalTemplate() {
-    return Optional.ofNullable(globalTemplate);
+  public Long getGlobalTemplate() {
+    return globalTemplate;
   }
 
   public void setGlobalTemplate(Long globalTemplate) {

--- a/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
@@ -19,10 +19,16 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
-import java.util.Optional;
 
-/** Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!" */
+/**
+ * Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits binding
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TemplateBinding {
 
   private Guid bindingId;
@@ -36,24 +42,24 @@ public class TemplateBinding {
     // Default constructor
   }
 
-  public Optional<Guid> getBindingId() {
-    return Optional.ofNullable(bindingId);
+  public Guid getBindingId() {
+    return bindingId;
   }
 
   public void setBindingId(Guid bindingId) {
     this.bindingId = bindingId;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<Guid> getTemplateId() {
-    return Optional.ofNullable(templateId);
+  public Guid getTemplateId() {
+    return templateId;
   }
 
   public void setTemplateId(Guid templateId) {
@@ -68,16 +74,16 @@ public class TemplateBinding {
     this.executionOrder = executionOrder;
   }
 
-  public Optional<String> getVariable() {
-    return Optional.ofNullable(variable);
+  public String getVariable() {
+    return variable;
   }
 
   public void setVariable(String variable) {
     this.variable = variable;
   }
 
-  public Optional<String> getExpression() {
-    return Optional.ofNullable(expression);
+  public String getExpression() {
+    return expression;
   }
 
   public void setExpression(String expression) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,23 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.pages.CalendarInfo;
+import com.percussion.rest.pages.CodeInfo;
+import com.percussion.rest.pages.Page;
+import com.percussion.rest.pages.Region;
+import com.percussion.rest.pages.SeoInfo;
+import com.percussion.rest.pages.Widget;
+import com.percussion.rest.pages.WorkflowInfo;
+import com.percussion.rest.templates.Template;
+import com.percussion.rest.templates.TemplateBinding;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +43,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). DisplayFormatProperty
+ * / Template / Page family follow the same plain-getter rule (issue #3407). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +124,174 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void displayFormatProperty_serializesPlainScalarsNotOptionalBeans() {
+    DisplayFormatProperty prop = new DisplayFormatProperty();
+    prop.setPropertyId("1");
+    prop.setPropertyName("sortColumn");
+    prop.setPropertyValue("sys_title");
+    prop.setDescription("Default sort");
+
+    ObjectMapper propMapper =
+        new JacksonContextResolver().getContext(DisplayFormatProperty.class);
+    String json = propMapper.writeValueAsString(prop);
+    assertTrue(json.contains("\"propertyId\""), json);
+    assertTrue(json.contains("\"propertyName\""), json);
+    assertTrue(json.contains("sortColumn"), json);
+    assertTrue(json.contains("\"propertyValue\""), json);
+    assertTrue(json.contains("sys_title"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    DisplayFormatProperty roundTrip = propMapper.readValue(json, DisplayFormatProperty.class);
+    assertEquals("1", roundTrip.getPropertyId(), json);
+    assertEquals("sortColumn", roundTrip.getPropertyName(), json);
+    assertEquals("sys_title", roundTrip.getPropertyValue(), json);
+  }
+
+  @Test
+  void template_serializesNameLabelNotOptionalBeans() {
+    Template template = new Template();
+    template.setName("perc.page");
+    template.setLabel("Page");
+    template.setDescription("Page assembly");
+    template.setMimeType("text/html");
+
+    ObjectMapper templateMapper = new JacksonContextResolver().getContext(Template.class);
+    String json = templateMapper.writeValueAsString(template);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"mimeType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    Template roundTrip = templateMapper.readValue(json, Template.class);
+    assertEquals("perc.page", roundTrip.getName(), json);
+    assertEquals("Page", roundTrip.getLabel(), json);
+    assertEquals("text/html", roundTrip.getMimeType(), json);
+  }
+
+  @Test
+  void templateBinding_serializesVariableExpressionNotOptionalBeans() {
+    TemplateBinding binding = new TemplateBinding();
+    binding.setVariable("$rx");
+    binding.setExpression("$sys.template");
+    binding.setExecutionOrder(1);
+
+    ObjectMapper bindingMapper = new JacksonContextResolver().getContext(TemplateBinding.class);
+    String json = bindingMapper.writeValueAsString(binding);
+    assertTrue(json.contains("\"variable\""), json);
+    assertTrue(json.contains("$rx"), json);
+    assertTrue(json.contains("\"expression\""), json);
+    assertTrue(json.contains("$sys.template"), json);
+    assertNoOptionalBeanKeys(json);
+
+    TemplateBinding roundTrip = bindingMapper.readValue(json, TemplateBinding.class);
+    assertEquals("$rx", roundTrip.getVariable(), json);
+    assertEquals("$sys.template", roundTrip.getExpression(), json);
+  }
+
+  @Test
+  void page_serializesNamePathNotOptionalBeans() {
+    Page page = new Page();
+    page.setId("1234");
+    page.setName("home.html");
+    page.setDisplayName("Home");
+    page.setSiteName("Help");
+    page.setFolderPath("docs");
+    page.setTemplateName("perc.page");
+    page.setSummary("Welcome");
+
+    SeoInfo seo = new SeoInfo();
+    seo.setBrowserTitle("Help Home");
+    seo.setMetaDescription("Landing page");
+    seo.setHideSearch(Boolean.FALSE);
+    page.setSeo(seo);
+
+    ObjectMapper pageMapper = new JacksonContextResolver().getContext(Page.class);
+    String json = pageMapper.writeValueAsString(page);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("home.html"), json);
+    assertTrue(json.contains("\"displayName\""), json);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("\"folderPath\""), json);
+    assertTrue(json.contains("\"templateName\""), json);
+    assertTrue(json.contains("\"browserTitle\""), json);
+    assertTrue(json.contains("Help Home"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Page roundTrip = pageMapper.readValue(json, Page.class);
+    assertEquals("1234", roundTrip.getId(), json);
+    assertEquals("home.html", roundTrip.getName(), json);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertNotNull(roundTrip.getSeo(), json);
+    assertEquals("Help Home", roundTrip.getSeo().getBrowserTitle(), json);
+  }
+
+  @Test
+  void widgetAndPageFamily_serializePlainScalarsNotOptionalBeans() {
+    Widget widget = new Widget();
+    widget.setId("w1");
+    widget.setName("richText");
+    widget.setType("percRichText");
+    widget.setScope(Widget.SCOPE_LOCAL);
+    widget.setEditable(Boolean.TRUE);
+
+    ObjectMapper widgetMapper = new JacksonContextResolver().getContext(Widget.class);
+    String widgetJson = widgetMapper.writeValueAsString(widget);
+    assertTrue(widgetJson.contains("\"name\""), widgetJson);
+    assertTrue(widgetJson.contains("richText"), widgetJson);
+    assertTrue(widgetJson.contains("\"type\""), widgetJson);
+    assertNoOptionalBeanKeys(widgetJson);
+    Widget widgetRoundTrip = widgetMapper.readValue(widgetJson, Widget.class);
+    assertEquals("w1", widgetRoundTrip.getId(), widgetJson);
+    assertEquals("percRichText", widgetRoundTrip.getType(), widgetJson);
+
+    Region region = new Region();
+    region.setName("content");
+    region.setType("TEMPLATE");
+    region.setWidgets(List.of(widget));
+    ObjectMapper regionMapper = new JacksonContextResolver().getContext(Region.class);
+    String regionJson = regionMapper.writeValueAsString(region);
+    assertTrue(regionJson.contains("\"name\""), regionJson);
+    assertTrue(regionJson.contains("content"), regionJson);
+    assertNoOptionalBeanKeys(regionJson);
+
+    WorkflowInfo workflow = new WorkflowInfo();
+    workflow.setName("Default Workflow");
+    workflow.setState("Draft");
+    workflow.setCheckedOut(Boolean.FALSE);
+    ObjectMapper wfMapper = new JacksonContextResolver().getContext(WorkflowInfo.class);
+    String wfJson = wfMapper.writeValueAsString(workflow);
+    assertTrue(wfJson.contains("\"name\""), wfJson);
+    assertTrue(wfJson.contains("Draft"), wfJson);
+    assertNoOptionalBeanKeys(wfJson);
+    WorkflowInfo wfRoundTrip = wfMapper.readValue(wfJson, WorkflowInfo.class);
+    assertEquals("Default Workflow", wfRoundTrip.getName(), wfJson);
+    assertEquals("Draft", wfRoundTrip.getState(), wfJson);
+
+    CodeInfo code = new CodeInfo();
+    code.setHead("<script></script>");
+    ObjectMapper codeMapper = new JacksonContextResolver().getContext(CodeInfo.class);
+    String codeJson = codeMapper.writeValueAsString(code);
+    assertTrue(codeJson.contains("\"head\""), codeJson);
+    assertNoOptionalBeanKeys(codeJson);
+
+    CalendarInfo calendar = new CalendarInfo();
+    calendar.setCalendars(List.of("Default"));
+    ObjectMapper calMapper = new JacksonContextResolver().getContext(CalendarInfo.class);
+    String calJson = calMapper.writeValueAsString(calendar);
+    assertTrue(calJson.contains("\"calendars\""), calJson);
+    assertTrue(calJson.contains("Default"), calJson);
+    assertNoOptionalBeanKeys(calJson);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }


### PR DESCRIPTION
## Summary

REST wire DTOs `DisplayFormatProperty`, `Template`, `TemplateBinding`, and the Page family (`Page`, `Widget`, `SeoInfo`, `Region`, `CalendarInfo`, `CodeInfo`, `WorkflowInfo`) returned `Optional<T>` from JSON getters. That produced Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189 / User-Role-ObjectSummary #3388).

This PR converts those types to **plain nullable getters/setters** with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.ifPresent()` (`PagesResource`, sitemanage `PageAdaptor` / `AssetAdaptor`). Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.

`TemplateDetail` already used plain getters. Virtual Site / LocationScheme / Folder families stay for #3411–#3413. `rest/AGENTS.md` wire-getter convention is **not committed** (root AGENTS.md human-review gate).

Operator: Grok: night-issue-prs (model grok-4.6)

Parent tracker: #3388

Fixes #3407

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — Tests run: 423, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125
3. Confirm `JacksonContextResolverOptionalTest` (9 tests) covers DisplayFormatProperty / Template / TemplateBinding / Page family round-trips
4. After merge: spot-check Developer Display Format properties, Template detail, and Page JSON (no `empty`/`present` beans)

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): wire-getter type change only; no documented request/response example currently shows Optional-bean JSON
- [x] **Unit / module tests** — behavioral Jackson round-trips; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-dep sitemanage because public getter signatures changed
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 423, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public `Optional<T>` → `T` getters). Grep for `extends DisplayFormatProperty|Template|Page|Widget|SeoInfo|Region|CalendarInfo|CodeInfo|WorkflowInfo` and `new Type() {` — no anonymous subclasses of the REST types. sitemanage `Template` subclasses are `com.percussion.sitemanage.service.Template`, not the REST DTO. Standalone sitemanage clean install green.

## C5 UI proof

N/A — backend REST DTO / adaptor change only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.