### PR TITLE
fix(rest): Virtual Site + SiteMap wire getters must not return Optional (#3411)

### DIFF
--- a/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3411-virtualsite-sitemap-optional-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)
+**Date:** 2026-08-15
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3411-virtualsite-sitemap-optional-getters` (slice of #3388).
+**Memory patterns hit:** incomplete change-class closure; production-mapper tests vs bare `JsonMapper`; agent rule files require human review.
+
+## Summary
+
+Convert Virtual Site + SiteMap REST wire DTO getters from `Optional<T>` to plain nullable types so Jackson emits scalars, not Optional-bean `empty`/`present` keys.
+
+In scope: `VirtualSiteBuildRequest`, `VirtualSiteBuildResult`, `VirtualSitePreviewStatus`, `VirtualSitePublishResult`, `SiteMapOptions`. Callers in `rest` tests and `SitesAdaptor` / `SitesAdaptorTest` updated. Family methods appended to `JacksonContextResolverOptionalTest` using `new JacksonContextResolver().getContext(TheDto.class)`. `rest/AGENTS.md` not committed.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none
+- Behavioral tests: production-mapper round-trips + no `empty`/`present` keys for all five types; rest/sitemanage caller tests updated
+- Agent rule files: none (rest/AGENTS.md not touched)
+- Cross-platform: **pass** — no new filesystem path construction; existing `Path.of` / `blankToNull` path remains after getter conversion. Test JSON examples use `/` in string values (URL/JSON form, not OS joins)
+- Change-class companions: DTO getters + rest callers + sitemanage adaptor + production-mapper tests. No new adaptor interface (no MainTest stub). DisplayFormat/Template/Page, LocationScheme/Context/DeliveryType, Folder/Section left for sibling slices
+- C2: public getter signatures changed (`Optional<T>` → `T`). Grep found no `extends` / anonymous subclasses of the five types
+
+## Issues
+
+None.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 423, Failures: 0 (`JacksonContextResolverOptionalTest` 9 tests)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125 (`SitesAdaptorTest` 36 tests)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -412,15 +412,13 @@ public class SitesAdaptor implements ISiteAdaptor {
     Path safePublishRoot = requireSafeOutputRoot(publishRoot);
 
     VirtualSiteBuildResult built = buildVirtualSite(nameOrId, null);
-    Path buildOutput =
-        built.getOutputPath()
-            .filter(StringUtils::isNotBlank)
-            .map(Path::of)
-            .orElseThrow(
-                () ->
-                    new WebApplicationException(
-                        "Virtual Site build did not report an output path.",
-                        Response.Status.INTERNAL_SERVER_ERROR));
+    String outputPath = built.getOutputPath();
+    if (StringUtils.isBlank(outputPath)) {
+      throw new WebApplicationException(
+          "Virtual Site build did not report an output path.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    Path buildOutput = Path.of(outputPath);
 
     try {
       // Do not mention PSVirtualSitePublishCopyResult here: Spring lookup-method
@@ -888,7 +886,7 @@ public class SitesAdaptor implements ISiteAdaptor {
 
   Path resolveOutputRoot(VirtualSiteBuildRequest request, String siteKey) {
     String override =
-        request != null ? blankToNull(request.getOutputRoot().orElse(null)) : null;
+        request != null ? blankToNull(request.getOutputRoot()) : null;
     if (override != null) {
       Path path;
       try {
@@ -976,7 +974,9 @@ public class SitesAdaptor implements ISiteAdaptor {
       dto.setPublishPath(publishRoot.toAbsolutePath().normalize().toString());
     }
     if (built != null) {
-      built.getOutputPath().ifPresent(dto::setBuildOutputPath);
+      if (built.getOutputPath() != null) {
+        dto.setBuildOutputPath(built.getOutputPath());
+      }
       dto.setPagesWritten(built.getPagesWritten());
       dto.setLinkProblemCount(built.getLinkProblemCount());
       dto.setHasLinkProblems(built.getHasLinkProblems());

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -368,12 +368,12 @@ class SitesAdaptorTest {
     req.setOutputRoot(out.toString());
 
     VirtualSiteBuildResult result = building.buildVirtualSite("Help", req);
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("sample", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("sample", result.getSiteKey());
     assertEquals(2, result.getPagesWritten().intValue());
     assertEquals(0, result.getLinkProblemCount().intValue());
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
-    assertTrue(result.getOutputPath().isPresent());
+    assertTrue(result.getOutputPath() != null && !result.getOutputPath().isBlank());
     assertTrue(result.getWrittenFiles().contains("link-report.txt"));
   }
 
@@ -462,15 +462,15 @@ class SitesAdaptorTest {
         new SitesAdaptor(siteManager, () -> true, key -> staging, null);
 
     VirtualSitePublishResult result = publishing.publishVirtualSite("Help");
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("help-docs", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("help-docs", result.getSiteKey());
     assertEquals(1, result.getPagesWritten().intValue());
     assertTrue(result.getFilesCopied() >= 1);
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(publishTo.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(staging.resolve("8.2").resolve("index.html")));
     assertFalse(Files.exists(publishTo.resolve("_meta")));
-    assertTrue(result.getPublishPath().isPresent());
+    assertTrue(result.getPublishPath() != null && !result.getPublishPath().isBlank());
   }
 
   @Test
@@ -486,10 +486,10 @@ class SitesAdaptorTest {
     VirtualSitePublishResult dto =
         SitesAdaptor.toWirePublishResult("Help", "help-docs", built, publishRoot, 7);
 
-    assertEquals("Help", dto.getSiteName().orElse(null));
-    assertEquals("help-docs", dto.getSiteKey().orElse(null));
-    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath().orElse(null));
-    assertEquals(built.getOutputPath().orElse(null), dto.getBuildOutputPath().orElse(null));
+    assertEquals("Help", dto.getSiteName());
+    assertEquals("help-docs", dto.getSiteKey());
+    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath());
+    assertEquals(built.getOutputPath(), dto.getBuildOutputPath());
     assertEquals(3, dto.getPagesWritten().intValue());
     assertEquals(7, dto.getFilesCopied().intValue());
     assertEquals(1, dto.getLinkProblemCount().intValue());
@@ -552,7 +552,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.FALSE, status.getAvailable());
-    assertTrue(status.getMessage().orElse("").contains("No assembled"));
+    assertTrue(status.getMessage() != null && status.getMessage().contains("No assembled"));
   }
 
   @Test
@@ -570,7 +570,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, status.getAvailable());
-    assertEquals("8.2/index.html", status.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", status.getHomePath());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
@@ -17,9 +17,15 @@
 
 package com.percussion.rest.sites;
 
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
-/** Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!" */
+/**
+ * Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!"
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SiteMapOptions {
 
   private boolean navigationBased = true;
@@ -47,40 +53,40 @@ public class SiteMapOptions {
     this.includeFolder = includeFolder;
   }
 
-  public Optional<String> getTimeZone() {
-    return Optional.ofNullable(timeZone);
+  public String getTimeZone() {
+    return timeZone;
   }
 
   public void setTimeZone(String timeZone) {
     this.timeZone = timeZone;
   }
 
-  public Optional<SiteMapDateFormat> getDateFormat() {
-    return Optional.ofNullable(dateFormat);
+  public SiteMapDateFormat getDateFormat() {
+    return dateFormat;
   }
 
   public void setDateFormat(SiteMapDateFormat dateFormat) {
     this.dateFormat = dateFormat;
   }
 
-  public Optional<String> getFileName() {
-    return Optional.ofNullable(fileName);
+  public String getFileName() {
+    return fileName;
   }
 
   public void setFileName(String fileName) {
     this.fileName = fileName;
   }
 
-  public Optional<String> getUseSiteMapIndex() {
-    return Optional.ofNullable(useSiteMapIndex);
+  public String getUseSiteMapIndex() {
+    return useSiteMapIndex;
   }
 
   public void setUseSiteMapIndex(String useSiteMapIndex) {
     this.useSiteMapIndex = useSiteMapIndex;
   }
 
-  public Optional<SiteMapType> getSiteMapType() {
-    return Optional.ofNullable(siteMapType);
+  public SiteMapType getSiteMapType() {
+    return siteMapType;
   }
 
   public void setSiteMapType(SiteMapType siteMapType) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Optional body for {@code POST /sites/{nameOrId}/virtual/build}.
  *
  * <p>When omitted or empty, the server chooses a default output directory under the CMS install
  * {@code tmp/virtual-sites/} tree (or the JVM temp directory when the install root is unavailable).
+ *
+ * <p>Wire getters return plain {@code String} (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,8 +47,8 @@ public class VirtualSiteBuildRequest {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getOutputRoot() {
-    return Optional.ofNullable(outputRoot);
+  public String getOutputRoot() {
+    return outputRoot;
   }
 
   public void setOutputRoot(String outputRoot) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of a CMS-integrated Virtual Site static build ({@code POST
@@ -30,6 +29,9 @@ import java.util.Optional;
  * <p>Maps from system {@code PSVirtualSiteBuildResult}: pages assembled, link-problem summary, and
  * absolute output path. Build may complete successfully while still reporting link problems (HTTP
  * 200 with {@code hasLinkProblems=true}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -75,24 +77,24 @@ public class VirtualSiteBuildResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Whether a last Virtual Site static build can be previewed from the product UI ({@code GET
  * /sites/{nameOrId}/virtual/preview}).
  *
  * <p>Missing or failed builds return HTTP 200 with {@code available=false} and a message — not 500.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePreviewStatus")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -62,24 +64,24 @@ public class VirtualSitePreviewStatus {
     this.available = available;
   }
 
-  public Optional<String> getHomePath() {
-    return Optional.ofNullable(homePath);
+  public String getHomePath() {
+    return homePath;
   }
 
   public void setHomePath(String homePath) {
     this.homePath = homePath;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {
     this.outputPath = outputPath;
   }
 
-  public Optional<String> getMessage() {
-    return Optional.ofNullable(message);
+  public String getMessage() {
+    return message;
   }
 
   public void setMessage(String message) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
@@ -21,11 +21,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of {@code POST /sites/{nameOrId}/virtual/publish}: build-then-copy to the Site filesystem
  * publish root ({@code IPSSite.root}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePublishResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -70,32 +72,32 @@ public class VirtualSitePublishResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getPublishPath() {
-    return Optional.ofNullable(publishPath);
+  public String getPublishPath() {
+    return publishPath;
   }
 
   public void setPublishPath(String publishPath) {
     this.publishPath = publishPath;
   }
 
-  public Optional<String> getBuildOutputPath() {
-    return Optional.ofNullable(buildOutputPath);
+  public String getBuildOutputPath() {
+    return buildOutputPath;
   }
 
   public void setBuildOutputPath(String buildOutputPath) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,19 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.sites.SiteMapDateFormat;
+import com.percussion.rest.sites.SiteMapOptions;
+import com.percussion.rest.sites.SiteMapType;
+import com.percussion.rest.sites.VirtualSiteBuildRequest;
+import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +39,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Virtual Site +
+ * SiteMap wire DTOs follow the same plain-getter rule (issue #3411 / #3388). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +120,142 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void virtualSiteBuildRequest_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildRequest request = new VirtualSiteBuildRequest();
+    request.setOutputRoot("C:/tmp/product-docs-site");
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"outputRoot\""), json);
+    assertTrue(json.contains("C:/tmp/product-docs-site"), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildRequest roundTrip =
+        requestMapper.readValue(json, VirtualSiteBuildRequest.class);
+    assertEquals("C:/tmp/product-docs-site", roundTrip.getOutputRoot(), json);
+  }
+
+  @Test
+  void virtualSiteBuildResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildResult result = new VirtualSiteBuildResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"siteKey\""), json);
+    assertTrue(json.contains("product-docs"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"pagesWritten\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildResult roundTrip = resultMapper.readValue(json, VirtualSiteBuildResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("product-docs", roundTrip.getSiteKey(), json);
+    assertEquals("C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getOutputPath(), json);
+    assertEquals(42, roundTrip.getPagesWritten(), json);
+  }
+
+  @Test
+  void virtualSitePreviewStatus_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(true);
+    status.setHomePath("8.2/index.html");
+    status.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    status.setMessage("ready");
+
+    ObjectMapper statusMapper =
+        new JacksonContextResolver().getContext(VirtualSitePreviewStatus.class);
+    String json = statusMapper.writeValueAsString(status);
+    assertTrue(json.contains("\"homePath\""), json);
+    assertTrue(json.contains("8.2/index.html"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"message\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePreviewStatus roundTrip =
+        statusMapper.readValue(json, VirtualSitePreviewStatus.class);
+    assertEquals(Boolean.TRUE, roundTrip.getAvailable(), json);
+    assertEquals("8.2/index.html", roundTrip.getHomePath(), json);
+    assertEquals("ready", roundTrip.getMessage(), json);
+  }
+
+  @Test
+  void virtualSitePublishResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePublishResult result = new VirtualSitePublishResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setPublishPath("C:/inetpub/wwwroot/help");
+    result.setBuildOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setFilesCopied(50);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSitePublishResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"publishPath\""), json);
+    assertTrue(json.contains("\"buildOutputPath\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePublishResult roundTrip =
+        resultMapper.readValue(json, VirtualSitePublishResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("C:/inetpub/wwwroot/help", roundTrip.getPublishPath(), json);
+    assertEquals(
+        "C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getBuildOutputPath(), json);
+    assertEquals(50, roundTrip.getFilesCopied(), json);
+  }
+
+  @Test
+  void siteMapOptions_serializesPlainScalarsNotOptionalBeans() {
+    SiteMapOptions options = new SiteMapOptions();
+    options.setNavigationBased(true);
+    options.setIncludeFolder(false);
+    options.setTimeZone("UTC");
+    options.setDateFormat(SiteMapDateFormat.DAY);
+    options.setFileName("sitemap.xml");
+    options.setUseSiteMapIndex("true");
+    options.setSiteMapType(SiteMapType.STANDARD);
+    options.setDefaultFrequency(0.5);
+
+    ObjectMapper optionsMapper = new JacksonContextResolver().getContext(SiteMapOptions.class);
+    String json = optionsMapper.writeValueAsString(options);
+    assertTrue(json.contains("\"timeZone\""), json);
+    assertTrue(json.contains("UTC"), json);
+    assertTrue(json.contains("\"dateFormat\""), json);
+    assertTrue(json.contains("DAY"), json);
+    assertTrue(json.contains("\"fileName\""), json);
+    assertTrue(json.contains("sitemap.xml"), json);
+    assertTrue(json.contains("\"useSiteMapIndex\""), json);
+    assertTrue(json.contains("\"siteMapType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    SiteMapOptions roundTrip = optionsMapper.readValue(json, SiteMapOptions.class);
+    assertEquals("UTC", roundTrip.getTimeZone(), json);
+    assertEquals(SiteMapDateFormat.DAY, roundTrip.getDateFormat(), json);
+    assertEquals("sitemap.xml", roundTrip.getFileName(), json);
+    assertEquals("true", roundTrip.getUseSiteMapIndex(), json);
+    assertEquals(SiteMapType.STANDARD, roundTrip.getSiteMapType(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -173,7 +173,7 @@ public class SitesResourceTest {
 
     VirtualSiteBuildResult out = resource.buildVirtualSite("Help", req);
     assertEquals(3, out.getPagesWritten().intValue());
-    assertEquals("C:/tmp/out", out.getOutputPath().orElse(null));
+    assertEquals("C:/tmp/out", out.getOutputPath());
     verify(adaptor).buildVirtualSite("Help", req);
   }
 
@@ -197,7 +197,7 @@ public class SitesResourceTest {
 
     VirtualSitePreviewStatus out = resource.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, out.getAvailable());
-    assertEquals("8.2/index.html", out.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", out.getHomePath());
     verify(adaptor).getVirtualSitePreviewStatus("Help");
   }
 
@@ -253,7 +253,7 @@ public class SitesResourceTest {
     VirtualSitePublishResult out = resource.publishVirtualSite("Help");
     assertEquals(3, out.getPagesWritten().intValue());
     assertEquals(5, out.getFilesCopied().intValue());
-    assertEquals("C:/pub/help", out.getPublishPath().orElse(null));
+    assertEquals("C:/pub/help", out.getPublishPath());
     verify(adaptor).publishVirtualSite("Help");
   }
 

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -80,8 +80,8 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     result.setPagesWritten(0);
     result.setLinkProblemCount(0);
     result.setHasLinkProblems(false);
-    if (request != null && request.getOutputRoot().isPresent()) {
-      result.setOutputPath(request.getOutputRoot().get());
+    if (request != null && request.getOutputRoot() != null) {
+      result.setOutputPath(request.getOutputRoot());
     }
     return result;
   }


### PR DESCRIPTION
## Summary

Slice 3 of parent **#3388** (after #3407 / PR #3415). Convert the Virtual Site + SiteMap REST wire DTO family from `Optional<T>` getters to plain nullable getters so Developer Sites build/preview/publish JSON is scalars, not Optional beans.

Converted (same peer pattern as User/Role/ObjectSummary / PR #3406):

- `VirtualSiteBuildRequest`
- `VirtualSiteBuildResult`
- `VirtualSitePreviewStatus`
- `VirtualSitePublishResult`
- `SiteMapOptions` (also `@JsonInclude(NON_NULL)`)

Callers updated in `rest` tests and `projects/sitemanage` `SitesAdaptor` / `SitesAdaptorTest`. Family methods **appended** to `JacksonContextResolverOptionalTest` (production mapper `new JacksonContextResolver().getContext(TheDto.class)`); existing ContentType/TemplateSummary tests left intact so this can land beside #3407.

`rest/AGENTS.md` was **not** committed (human rule review).

Fixes #3411. Parent: #3388.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Review production-mapper round-trips in `JacksonContextResolverOptionalTest` — JSON must include scalar keys and must not contain `"empty"` / `"present"`.
2. Review `SitesResourceTest` / `SitesAdaptorTest` getter assertions (no `.orElse()` / `.isPresent()` on converted getters).
3. Standalone module clean installs (evidence below).

## Checklist

- [x] **Product documentation** — **N/A** (internal wire-getter convention; no operator/admin docs currently show Optional-bean JSON for these DTOs)
- [x] **Unit / module tests** — production-mapper family tests + caller updates; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone `clean install`; C2 reverse-dep `sitemanage` installed after `rest`
- [x] **Cross-platform** — **N/A** for new path joins; existing `Path.of` / `blankToNull` path unchanged except Optional unwrap

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: 423, Failures: 0 (`JacksonContextResolverOptionalTest` 9 tests)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: 1223, Failures: 0, Skipped: 125 (`SitesAdaptorTest` 36 tests)
  - No new warnings attributable to this change (existing javadoc/analyze baseline only)
- **downstream_checked:** `projects/sitemanage` standalone clean install (public getter signatures `Optional<T>` → `T`). Grep: no `extends` / anonymous subclasses of the five DTO types.

Erlang review: `docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md` — approve.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
