### PR TITLE
cluster: absorb REST Optional wire-getter PRs #3406 #3415 #3416

### DIFF
--- a/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3388 REST DTO wire getters must not return Optional
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3388-rest-dto-wire-getters`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+First incremental slice of #3388: convert REST `User`, `Role`, and `ObjectSummary`
+wire getters from `Optional<T>` to plain nullable types with `@JsonInclude(NON_NULL)`.
+Callers that used `.orElse()` / `.ifPresent()` on those getters were updated in
+`rest` and `projects/sitemanage`. Production-mapper round-trips assert no
+`empty`/`present` Optional-bean keys.
+
+`rest/AGENTS.md` wire-getter convention is drafted in the working tree and is
+**not** part of this commit (root AGENTS.md human-review gate for rule files).
+
+## Scope
+
+Uncommitted product work vs `origin/main` on `fix/issue-3388-rest-dto-wire-getters`.
+Excluded from commit: `rest/AGENTS.md` (agent-instruction draft).
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — **addressed** (JacksonContextResolver production mapper + UsersTest/RolesTest contract)
+- Incomplete change-class closure — **addressed** (DTO + rest callers + sitemanage UserAdaptor/ApiUtils + reverse-dep install)
+- Agent rule file without human review — **honored** (`rest/AGENTS.md` left uncommitted)
+- Cross-platform path checklist — N/A (no new filesystem I/O)
+
+## Issues
+
+None that block commit.
+
+## Notes (not blocking)
+
+- Remaining ~47 `public Optional<…>` DTO getters stay as later incremental PRs
+  (DisplayFormatProperty, Template, Page/Widget/SeoInfo, Acl leftovers, etc.).
+- Nested `Guid.getUntypedString()` is still Optional; ObjectSummary tests with a
+  constructed Guid did not emit `empty`/`present` keys (field-level `stringValue`
+  already uses `@JsonProperty` + `@JsonIgnore` on the Optional helper).
+- This is a public getter signature change (`Optional<T>` → `T`). Grep found no
+  anonymous subclasses; sitemanage standalone clean install is the reverse-dep gate.
+
+## Tests
+
+- `JacksonContextResolverOptionalTest` — 7 tests (prior ContentType/TemplateSummary + User/Role/ObjectSummary)
+- `UsersTest` / `RolesTest` — unset scalars nullable; list getters still never-null
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 421, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1217, Failures: 0, Skipped: 125
+
+## Cross-platform path checklist
+
+N/A — no new `File`/`Path` construction.

--- a/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3407-rest-dto-wire-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)  
+**Date:** 2026-08-15  
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3407-rest-dto-wire-getters`.  
+**Memory patterns hit:** Optional wire getters drop fields / emit `empty`/`present` beans; public getter signature change requires reverse-dep compile.
+
+## Summary
+
+REST wire DTOs `DisplayFormatProperty`, `Template`, `TemplateBinding`, and the Page family (`Page`, `Widget`, `SeoInfo`, `Region`, `CalendarInfo`, `CodeInfo`, `WorkflowInfo`) returned `Optional<T>` from JSON getters. That produces Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189 / User-Role-ObjectSummary #3388).
+
+This change converts those types to plain nullable getters/setters with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.ifPresent()` / `Optional.flatMap` (`PagesResource`, sitemanage `PageAdaptor` / `AssetAdaptor`). `ApiUtils.orEmpty(Collection)` was added so converted list getters compile without an Optional wrapper. `PageAdaptor.findWidget` still unwraps `PSWidgetItem.getName()` (`Optional`) when comparing to the now-plain REST `Widget.getName()`.
+
+Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.
+
+`TemplateDetail` already used plain getters. Virtual Site / LocationScheme / Folder families were left for #3411–#3413. `rest/AGENTS.md` was not committed (human rule review).
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none remaining for this family
+- Behavioral tests: JacksonContextResolverOptionalTest (9 tests, including new family round-trips)
+- Playwright companion: N/A (no WebUI product screen change)
+- Agent rule files: none
+- Cross-platform: **N/A** (no path I/O)
+- C2: public `Optional<T>` → `T` getters. Grep for `extends DisplayFormatProperty|Template|Page|Widget|SeoInfo|Region|CalendarInfo|CodeInfo|WorkflowInfo` and `new Type() {` — no anonymous subclasses of the REST types. sitemanage `Template` subclasses are `com.percussion.sitemanage.service.Template`, not the REST DTO. Standalone sitemanage clean install green.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 423, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125

--- a/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3411-virtualsite-sitemap-optional-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)
+**Date:** 2026-08-15
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3411-virtualsite-sitemap-optional-getters` (slice of #3388).
+**Memory patterns hit:** incomplete change-class closure; production-mapper tests vs bare `JsonMapper`; agent rule files require human review.
+
+## Summary
+
+Convert Virtual Site + SiteMap REST wire DTO getters from `Optional<T>` to plain nullable types so Jackson emits scalars, not Optional-bean `empty`/`present` keys.
+
+In scope: `VirtualSiteBuildRequest`, `VirtualSiteBuildResult`, `VirtualSitePreviewStatus`, `VirtualSitePublishResult`, `SiteMapOptions`. Callers in `rest` tests and `SitesAdaptor` / `SitesAdaptorTest` updated. Family methods appended to `JacksonContextResolverOptionalTest` using `new JacksonContextResolver().getContext(TheDto.class)`. `rest/AGENTS.md` not committed.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none
+- Behavioral tests: production-mapper round-trips + no `empty`/`present` keys for all five types; rest/sitemanage caller tests updated
+- Agent rule files: none (rest/AGENTS.md not touched)
+- Cross-platform: **pass** — no new filesystem path construction; existing `Path.of` / `blankToNull` path remains after getter conversion. Test JSON examples use `/` in string values (URL/JSON form, not OS joins)
+- Change-class companions: DTO getters + rest callers + sitemanage adaptor + production-mapper tests. No new adaptor interface (no MainTest stub). DisplayFormat/Template/Page, LocationScheme/Context/DeliveryType, Folder/Section left for sibling slices
+- C2: public getter signatures changed (`Optional<T>` → `T`). Grep found no `extends` / anonymous subclasses of the five types
+
+## Issues
+
+None.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 423, Failures: 0 (`JacksonContextResolverOptionalTest` 9 tests)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125 (`SitesAdaptorTest` 36 tests)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -165,6 +165,17 @@ public class ApiUtils {
   }
 
   /**
+   * Return an empty collection if the collection is null.
+   *
+   * @param col the collection, may be {@code null}
+   * @param <T> the element type
+   * @return the collection or an empty one
+   */
+  public static <T> Collection<T> orEmpty(Collection<T> col) {
+    return col == null ? List.of() : col;
+  }
+
+  /**
    * Generic unwrapping helper. If the supplied object is an {@link Optional} it will return the
    * contained value or null; otherwise the value is returned unchanged. This allows callers to
    * uniformly access getters which may or may not return Optionals without needing to know the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -476,9 +476,9 @@ public class ApiUtils {
   public static PSRole convertRole(Role role) {
     PSRole ret = new PSRole();
 
-    ret.setDescription(orNull(role.getDescription()));
-    ret.setHomepage(orNull(role.getHomePage()));
-    ret.setName(orNull(role.getName()));
+    ret.setDescription(role.getDescription());
+    ret.setHomepage(role.getHomePage());
+    ret.setName(role.getName());
     ret.setUsers(role.getUsers());
 
     return ret;

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
@@ -266,10 +266,10 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
     try {
       var oldPSAsset = this.assetService.load(id);
       var workflowInfo = this.getWorkflowInfo(oldPSAsset);
-      // determine the requested end state - WorkflowInfo stores Optionals now
-      String endState = ApiUtils.orNull(workflowInfo.getState());
+      // determine the requested end state
+      String endState = workflowInfo.getState();
       if (asset.getWorkflow().isPresent()) {
-        String state = ApiUtils.orNull(asset.getWorkflow().get().getState());
+        String state = asset.getWorkflow().get().getState();
         if (StringUtils.isNotBlank(state)) {
           endState = state;
         }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
@@ -335,7 +335,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         // not widgets in it from the template
         boolean regionEditable = (instanceSize == 0 || owner.equals(PSMergedRegionOwner.PAGE));
 
-        boolean clearRegion = updateRegion.getWidgets().isEmpty();
+        boolean clearRegion =
+            updateRegion.getWidgets() == null || updateRegion.getWidgets().isEmpty();
         List<PSWidgetItem> updateWidgetList = new ArrayList<>();
         List<PSWidgetItem> newWidgetList = new ArrayList<>();
 
@@ -344,23 +345,23 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSWidgetItem existingWidget = findWidget(existingInstances, updateWidget);
 
           if (existingWidget == null && regionEditable) {
-            if (StringUtils.isNotEmpty(ApiUtils.orNull(updateWidget.getId()))) {
+            if (StringUtils.isNotEmpty(updateWidget.getId())) {
               throw new RuntimeException(
                   "Cannot find widget id "
-                      + ApiUtils.orNull(updateWidget.getId())
+                      + updateWidget.getId()
                       + " on region "
                       + updateRegion.getName());
             }
 
-            if (StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getId()))
-                && StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getName()))) {
+            if (StringUtils.isEmpty(updateWidget.getId())
+                && StringUtils.isEmpty(updateWidget.getName())) {
               throw new RuntimeException("Must specify either id or name on widget");
             }
 
             existingWidget = new PSWidgetItem();
-            existingWidget.setDefinitionId(ApiUtils.orNull(updateWidget.getType()));
-            existingWidget.setId(ApiUtils.orNull(updateWidget.getId()));
-            existingWidget.setName(ApiUtils.orNull(updateWidget.getName()));
+            existingWidget.setDefinitionId(updateWidget.getType());
+            existingWidget.setId(updateWidget.getId());
+            existingWidget.setName(updateWidget.getName());
           }
           // will add placeholder nulls for non editable regions
           newWidgetList.add(existingWidget);
@@ -385,14 +386,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           }
 
           if (!clearRegion) {
-            pullTemplateRegionToPage(psPage, template, ApiUtils.orNull(updateRegion.getName()));
+            pullTemplateRegionToPage(psPage, template, updateRegion.getName());
           }
 
           psPage.getRegionBranches().setRegionWidgetAssociations(newWidgetAssoc);
 
           psPage
               .getRegionBranches()
-              .setRegionWidgets(ApiUtils.orNull(updateRegion.getName()), updateWidgetList);
+              .setRegionWidgets(updateRegion.getName(), updateWidgetList);
 
           savePage = true;
         }
@@ -543,8 +544,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         existingWidget = widget;
       }
       if (updateWidget.getName() != null
-          && widget.getName() != null
-          && updateWidget.getName().equals(widget.getName())) {
+          && widget.getName().isPresent()
+          && updateWidget.getName().equals(widget.getName().orElse(null))) {
         existingWidget = widget;
       }
     }
@@ -668,13 +669,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     var url =
         new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     var folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
     var pathServicePath = StringUtils.substring(folderUrl.getUrl(), 1);
 
     try {
@@ -690,7 +690,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       throw new BackendException(e.getMessage(), e);
     }
     if (psPage == null) {
-      if (PSFolderPathUtils.testHasInvalidChars(ApiUtils.orNull(toPage.getName()))) {
+      if (PSFolderPathUtils.testHasInvalidChars(toPage.getName())) {
         throw new IllegalArgumentException(
             "Cannot create a page with following chars in the name"
                 + SecureStringUtils.INVALID_ITEM_NAME_CHARACTERS);
@@ -705,9 +705,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     Page currentPage =
         getPage(
             baseUri,
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     return currentPage;
   }
@@ -748,10 +748,10 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       currentState = getWorkflowState(page);
     }
 
-    Optional<WorkflowInfo> wfOpt = toPage.getWorkflow();
-    Optional<String> stateOpt = wfOpt.flatMap(WorkflowInfo::getState);
-    if (stateOpt.isPresent() && StringUtils.isNotEmpty(stateOpt.get())) {
-      endState = stateOpt.get();
+    WorkflowInfo wfInfo = toPage.getWorkflow();
+    String state = wfInfo == null ? null : wfInfo.getState();
+    if (StringUtils.isNotEmpty(state)) {
+      endState = state;
     } else {
       endState = currentState;
     }
@@ -765,66 +765,59 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
 
     UrlParts folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
 
     // set default values
     if (newPage) {
-      page.setTitle(ApiUtils.orNull(toPage.getName()));
-      page.setLinkTitle(ApiUtils.orNull(toPage.getName()));
+      page.setTitle(toPage.getName());
+      page.setLinkTitle(toPage.getName());
     }
 
-    Optional<CodeInfo> codeOpt = toPage.getCode();
-    if (codeOpt.isPresent()) {
-      CodeInfo code = codeOpt.get();
-      String head = ApiUtils.orNull(code.getHead());
+    CodeInfo code = toPage.getCode();
+    if (code != null) {
+      String head = code.getHead();
       if (head != null) {
         page.setAdditionalHeadContent(head);
       }
-      String afterStart = ApiUtils.orNull(code.getAfterStart());
+      String afterStart = code.getAfterStart();
       if (afterStart != null) {
         page.setAfterBodyStartContent(afterStart);
       }
-      String beforeClose = ApiUtils.orNull(code.getBeforeClose());
+      String beforeClose = code.getBeforeClose();
       if (beforeClose != null) {
         page.setBeforeBodyCloseContent(beforeClose);
       }
     }
 
-    // `page` will be updated later so capture a final reference for lambda
-    final PSPage pageRef = page;
-    toPage
-        .getSeo()
-        .ifPresent(
-            seo -> {
-              if (seo.getMetaDescription() != null) {
-                pageRef.setDescription(ApiUtils.orNull(seo.getMetaDescription()));
-              }
+    SeoInfo seo = toPage.getSeo();
+    if (seo != null) {
+      if (seo.getMetaDescription() != null) {
+        page.setDescription(seo.getMetaDescription());
+      }
 
-              // default title to page name
-              if (seo.getBrowserTitle() != null) {
-                pageRef.setTitle(ApiUtils.orNull(seo.getBrowserTitle()));
-              }
+      // default title to page name
+      if (seo.getBrowserTitle() != null) {
+        page.setTitle(seo.getBrowserTitle());
+      }
 
-              Boolean hideSearch = seo.getHideSearch().orElse(null);
-              pageRef.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
+      Boolean hideSearch = seo.getHideSearch();
+      page.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
 
-              List<String> tags = seo.getTags().orElse(null);
-              if (tags != null) {
-                pageRef.setTags(tags);
-              }
-
-              // toPage.getSeo().getCategories();
-
-            });
+      List<String> tags = seo.getTags();
+      if (tags != null) {
+        page.setTags(tags);
+      }
+    }
     // default linktitle to name
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
-
-    if (toPage.getName() != null) {
-      page.setName(ApiUtils.orNull(toPage.getName()));
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
     }
 
-    String templateName = ApiUtils.orNull(toPage.getTemplateName());
+    if (toPage.getName() != null) {
+      page.setName(toPage.getName());
+    }
+
+    String templateName = toPage.getTemplateName();
 
     PSTemplate template = null;
     String templateId = null;
@@ -833,7 +826,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(toPage.getSiteName())));
+                  templateName, toPage.getSiteName()));
 
       page.setTemplateId(templateId);
     } else {
@@ -846,7 +839,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     template = templateService.load(templateId);
 
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
+    }
 
     updateRegionInfo(toPage, page, template);
     try {
@@ -867,8 +862,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     updateAssetInfo(baseUri, toPage, page, template);
 
-    CalendarInfo calInfo = ApiUtils.orNull(toPage.getCalendar());
-    List<String> categories = toPage.getSeo().flatMap(SeoInfo::getCategories).orElse(null);
+    CalendarInfo calInfo = toPage.getCalendar();
+    List<String> categories = toPage.getSeo() == null ? null : toPage.getSeo().getCategories();
 
     boolean isUpdated = false;
     FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss.S");
@@ -901,7 +896,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
     // Setting to null or empty string is the same as auto generate.
     if (toPage.getSummary() != null) {
-      if (StringUtils.isNotBlank(ApiUtils.orNull(toPage.getSummary()))) {
+      if (StringUtils.isNotBlank(toPage.getSummary())) {
         fields.put("auto_generate_summary", "0");
         fields.put("page_summary", toPage.getSummary());
       } else {
@@ -967,12 +962,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       emptyTemplateWidgetIds.add(emptyTemplateWidgetId.getId());
     }
 
-    List<Region> bodyRegions = ApiUtils.orNull(toPage.getBody());
+    List<Region> bodyRegions = toPage.getBody();
     if (bodyRegions != null) {
       for (Region region : bodyRegions) {
         PSMergedRegion systemRegion =
-            tree.getMergedRegionMap().get(ApiUtils.orNull(region.getName()));
-        List<Widget> widgets = ApiUtils.orNull(region.getWidgets());
+            tree.getMergedRegionMap().get(region.getName());
+        List<Widget> widgets = region.getWidgets();
         List<PSWidgetInstance> systemRegionWidgets = systemRegion.getWidgetInstances();
 
         if (widgets != null) {
@@ -990,7 +985,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
               String id = widgetItem.getId();
 
               PSRelationship assetRels = assetWidgets.get(id);
-              Asset asset = ApiUtils.orNull(widget.getAsset());
+              Asset asset = widget.getAsset();
 
               //
               if (assetRels != null && Boolean.TRUE.equals(asset.getRemove())) {
@@ -1005,8 +1000,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
                     PSAssetWidgetRelationship awRel =
                         new PSAssetWidgetRelationship(
                             page.getId(),
-                            Long.parseLong(ApiUtils.orNull(widget.getId())),
-                            ApiUtils.orNull(widget.getType()),
+                            Long.parseLong(widget.getId()),
+                            widget.getType(),
                             assetId,
                             0);
                     assetService.clearAssetWidgetRelationship(awRel);
@@ -1069,14 +1064,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         while (iterator.hasNext()) {
 
           PSOrphanedAssetSummary orphan = iterator.next();
-          if (StringUtils.equals(ApiUtils.orNull(widget.getName()), orphan.getName())
-              && StringUtils.equals(ApiUtils.orNull(widget.getType()), orphan.getType())) {
+          if (StringUtils.equals(widget.getName(), orphan.getName())
+              && StringUtils.equals(widget.getType(), orphan.getType())) {
             foundOrphan = true;
             PSAssetWidgetRelationship awRel =
                 new PSAssetWidgetRelationship(
                     page.getId(),
-                    Long.parseLong(ApiUtils.orNull(widget.getId())),
-                    ApiUtils.orNull(widget.getType()),
+                    Long.parseLong(widget.getId()),
+                    widget.getType(),
                     orphan.getId(),
                     0);
             try {
@@ -1096,7 +1091,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         if (!foundOrphan) {
           guidString =
               createAndAssociateLocalAsset(
-                  page.getId(), id, ApiUtils.orNull(widget.getType()), fields);
+                  page.getId(), id, widget.getType(), fields);
         }
       } else // existing asset
       {
@@ -1144,8 +1139,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 pathItem.getId(),
                 0);
         awRel.setResourceType(PSAssetResourceType.shared);
@@ -1158,8 +1153,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 idMapper.getString(assetRels.getDependent()),
                 0);
         assetService.shareLocalContent(
@@ -1174,8 +1169,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSAssetWidgetRelationship awRel =
               new PSAssetWidgetRelationship(
                   page.getId(),
-                  Long.parseLong(ApiUtils.orNull(widget.getId())),
-                  ApiUtils.orNull(widget.getType()),
+                  Long.parseLong(widget.getId()),
+                  widget.getType(),
                   pathItem.getId(),
                   0);
           awRel.setResourceType(PSAssetResourceType.shared);
@@ -1457,9 +1452,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String pageId = null;
       String templateName = null;
 
-      if (p != null && p.getId().isPresent() && p.getTemplateName().isPresent()) {
-        pageId = p.getId().get();
-        templateName = p.getTemplateName().get();
+      if (p != null && p.getId() != null && p.getTemplateName() != null) {
+        pageId = p.getId();
+        templateName = p.getTemplateName();
 
         if (pageId.isEmpty() || templateName.isEmpty()) {
           throw new PageNotFoundException();
@@ -1475,7 +1470,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(p.getSiteName())));
+                  templateName, p.getSiteName()));
 
       if (templateId != null) {
         ArrayList<String> pageIds = new ArrayList<>();

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -412,15 +412,13 @@ public class SitesAdaptor implements ISiteAdaptor {
     Path safePublishRoot = requireSafeOutputRoot(publishRoot);
 
     VirtualSiteBuildResult built = buildVirtualSite(nameOrId, null);
-    Path buildOutput =
-        built.getOutputPath()
-            .filter(StringUtils::isNotBlank)
-            .map(Path::of)
-            .orElseThrow(
-                () ->
-                    new WebApplicationException(
-                        "Virtual Site build did not report an output path.",
-                        Response.Status.INTERNAL_SERVER_ERROR));
+    String outputPath = built.getOutputPath();
+    if (StringUtils.isBlank(outputPath)) {
+      throw new WebApplicationException(
+          "Virtual Site build did not report an output path.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    Path buildOutput = Path.of(outputPath);
 
     try {
       // Do not mention PSVirtualSitePublishCopyResult here: Spring lookup-method
@@ -888,7 +886,7 @@ public class SitesAdaptor implements ISiteAdaptor {
 
   Path resolveOutputRoot(VirtualSiteBuildRequest request, String siteKey) {
     String override =
-        request != null ? blankToNull(request.getOutputRoot().orElse(null)) : null;
+        request != null ? blankToNull(request.getOutputRoot()) : null;
     if (override != null) {
       Path path;
       try {
@@ -976,7 +974,9 @@ public class SitesAdaptor implements ISiteAdaptor {
       dto.setPublishPath(publishRoot.toAbsolutePath().normalize().toString());
     }
     if (built != null) {
-      built.getOutputPath().ifPresent(dto::setBuildOutputPath);
+      if (built.getOutputPath() != null) {
+        dto.setBuildOutputPath(built.getOutputPath());
+      }
       dto.setPagesWritten(built.getPagesWritten());
       dto.setLinkProblemCount(built.getLinkProblemCount());
       dto.setHasLinkProblems(built.getHasLinkProblems());

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
@@ -142,9 +142,9 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       boolean isNewUser = false;
 
       try {
-        var findUsers = userService.getUserNames(user.getUserName().orElse(null));
-        if (findUsers.getUsers().contains(user.getUserName().orElse(null))) {
-          newUser = userService.find(user.getUserName().orElse(null));
+        var findUsers = userService.getUserNames(user.getUserName());
+        if (findUsers.getUsers().contains(user.getUserName())) {
+          newUser = userService.find(user.getUserName());
         } else {
           newUser = new PSUser();
           isNewUser = true;
@@ -154,11 +154,11 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
         isNewUser = true;
       }
 
-      newUser.setName(user.getUserName().orElse(null));
+      newUser.setName(user.getUserName());
       newUser.setRoles(user.getRoles());
 
-      if (user.getEmailAddress().isPresent()) {
-        newUser.setEmail(user.getEmailAddress().orElse(null));
+      if (user.getEmailAddress() != null) {
+        newUser.setEmail(user.getEmailAddress());
       }
 
       // newUser.setRoles(user.getRoles()); // Already set above
@@ -167,14 +167,14 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       if (!isNewUser) {
         newUser = userService.update(newUser);
       } else {
-        if (user.getUserType().orElse("").equalsIgnoreCase(PSUserProviderType.INTERNAL.name())) {
+        if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.INTERNAL.name())) {
           newUser = userService.create(newUser);
-        } else if (user.getUserType()
-            .orElse("")
-            .equalsIgnoreCase(PSUserProviderType.DIRECTORY.name())) {
+        } else if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.DIRECTORY.name())) {
           var newUsers = new PSImportUsers();
           var dirUsers = new ArrayList<PSExternalUser>();
-          dirUsers.add(new PSExternalUser(user.getUserName().orElse(null)));
+          dirUsers.add(new PSExternalUser(user.getUserName()));
           newUsers.setExternalUsers(dirUsers);
           var importUsers = userService.importDirectoryUsers(newUsers);
 
@@ -184,8 +184,8 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
             // Handle new imports and treat duplicates as if they should be updates
             if (impU.getStatus() == ImportStatus.SUCCESS
                 || impU.getStatus() == ImportStatus.DUPLICATE) {
-              newUser.setEmail(user.getEmailAddress().orElse(null));
-              newUser.setName(user.getUserName().orElse(null));
+              newUser.setEmail(user.getEmailAddress());
+              newUser.setName(user.getUserName());
               newUser.setProviderType(PSUserProviderType.DIRECTORY);
               newUser.setRoles(user.getRoles());
               newUser = userService.update(newUser);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -368,12 +368,12 @@ class SitesAdaptorTest {
     req.setOutputRoot(out.toString());
 
     VirtualSiteBuildResult result = building.buildVirtualSite("Help", req);
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("sample", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("sample", result.getSiteKey());
     assertEquals(2, result.getPagesWritten().intValue());
     assertEquals(0, result.getLinkProblemCount().intValue());
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
-    assertTrue(result.getOutputPath().isPresent());
+    assertTrue(result.getOutputPath() != null && !result.getOutputPath().isBlank());
     assertTrue(result.getWrittenFiles().contains("link-report.txt"));
   }
 
@@ -462,15 +462,15 @@ class SitesAdaptorTest {
         new SitesAdaptor(siteManager, () -> true, key -> staging, null);
 
     VirtualSitePublishResult result = publishing.publishVirtualSite("Help");
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("help-docs", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("help-docs", result.getSiteKey());
     assertEquals(1, result.getPagesWritten().intValue());
     assertTrue(result.getFilesCopied() >= 1);
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(publishTo.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(staging.resolve("8.2").resolve("index.html")));
     assertFalse(Files.exists(publishTo.resolve("_meta")));
-    assertTrue(result.getPublishPath().isPresent());
+    assertTrue(result.getPublishPath() != null && !result.getPublishPath().isBlank());
   }
 
   @Test
@@ -486,10 +486,10 @@ class SitesAdaptorTest {
     VirtualSitePublishResult dto =
         SitesAdaptor.toWirePublishResult("Help", "help-docs", built, publishRoot, 7);
 
-    assertEquals("Help", dto.getSiteName().orElse(null));
-    assertEquals("help-docs", dto.getSiteKey().orElse(null));
-    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath().orElse(null));
-    assertEquals(built.getOutputPath().orElse(null), dto.getBuildOutputPath().orElse(null));
+    assertEquals("Help", dto.getSiteName());
+    assertEquals("help-docs", dto.getSiteKey());
+    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath());
+    assertEquals(built.getOutputPath(), dto.getBuildOutputPath());
     assertEquals(3, dto.getPagesWritten().intValue());
     assertEquals(7, dto.getFilesCopied().intValue());
     assertEquals(1, dto.getLinkProblemCount().intValue());
@@ -552,7 +552,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.FALSE, status.getAvailable());
-    assertTrue(status.getMessage().orElse("").contains("No assembled"));
+    assertTrue(status.getMessage() != null && status.getMessage().contains("No assembled"));
   }
 
   @Test
@@ -570,7 +570,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, status.getAvailable());
-    assertEquals("8.2/index.html", status.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", status.getHomePath());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/ObjectSummary.java
+++ b/rest/src/main/java/com/percussion/rest/ObjectSummary.java
@@ -21,8 +21,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.acls.UserAccessLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * High-level catalog summary, including security ACLs, for an object on the system.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code label}, {@code description}, and {@code guid} when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement
 @Schema(
@@ -78,32 +86,32 @@ public class ObjectSummary {
     this.id = id;
   }
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -126,8 +134,8 @@ public class ObjectSummary {
     this.objectLocked = objectLocked;
   }
 
-  public Optional<ObjectLockSummary> getLockSummary() {
-    return Optional.ofNullable(lockSummary);
+  public ObjectLockSummary getLockSummary() {
+    return lockSummary;
   }
 
   public void setLockSummary(ObjectLockSummary lockSummary) {

--- a/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
+++ b/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
@@ -494,7 +494,7 @@ public class AssetsResource {
       var requestThreadMap = new HashMap<>(PSRequestInfoBase.getRequestInfoMap());
       var currentUser = (String) PSRequestInfoBase.getRequestInfo(PSRequestInfo.KEY_USER);
       var user = userAdaptor.getUser(null, currentUser);
-      var toAddress = user.getEmailAddress().orElse(null);
+      var toAddress = user.getEmailAddress();
       CompletableFuture.runAsync(
           () -> {
             try {

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.displayformat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.ValueList;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Optional;
 
-/** Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued. */
+/**
+ * Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits property
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(
     name = "DisplayFormatProperty",
     description =
@@ -54,40 +60,40 @@ public class DisplayFormatProperty {
     // Default constructor
   }
 
-  public Optional<String> getPropertyId() {
-    return Optional.ofNullable(propertyId);
+  public String getPropertyId() {
+    return propertyId;
   }
 
   public void setPropertyId(String propertyId) {
     this.propertyId = propertyId;
   }
 
-  public Optional<String> getPropertyName() {
-    return Optional.ofNullable(propertyName);
+  public String getPropertyName() {
+    return propertyName;
   }
 
   public void setPropertyName(String propertyName) {
     this.propertyName = propertyName;
   }
 
-  public Optional<String> getPropertyValue() {
-    return Optional.ofNullable(propertyValue);
+  public String getPropertyValue() {
+    return propertyValue;
   }
 
   public void setPropertyValue(String propertyValue) {
     this.propertyValue = propertyValue;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<ValueList> getPropertyValues() {
-    return Optional.ofNullable(propertyValues);
+  public ValueList getPropertyValues() {
+    return propertyValues;
   }
 
   public void setPropertyValues(ValueList propertyValues) {

--- a/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
@@ -19,13 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!" */
+/**
+ * Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits calendar
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CalendarInfo")
 @Schema(name = "CalendarInfo", description = "Represents Calendar information.")
 public class CalendarInfo {
@@ -42,10 +48,10 @@ public class CalendarInfo {
   /**
    * Gets the start date.
    *
-   * @return Optional containing the start date if present.
+   * @return the start date, or {@code null} if unset
    */
-  public Optional<Date> getStartDate() {
-    return Optional.ofNullable(startDate);
+  public Date getStartDate() {
+    return startDate;
   }
 
   public void setStartDate(Date startDate) {
@@ -55,10 +61,10 @@ public class CalendarInfo {
   /**
    * Gets the end date.
    *
-   * @return Optional containing the end date if present.
+   * @return the end date, or {@code null} if unset
    */
-  public Optional<Date> getEndDate() {
-    return Optional.ofNullable(endDate);
+  public Date getEndDate() {
+    return endDate;
   }
 
   public void setEndDate(Date endDate) {
@@ -68,10 +74,10 @@ public class CalendarInfo {
   /**
    * Gets the list of calendars.
    *
-   * @return Optional containing the list of calendars if present.
+   * @return the list of calendars, or {@code null} if unset
    */
-  public Optional<List<String>> getCalendars() {
-    return Optional.ofNullable(calendars);
+  public List<String> getCalendars() {
+    return calendars;
   }
 
   public void setCalendars(List<String> calendars) {

--- a/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!" */
+/**
+ * Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits code fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CodeInfo")
 @Schema(name = "CodeInfo", description = "Represents code information.")
 public class CodeInfo {
@@ -38,8 +44,8 @@ public class CodeInfo {
   private String beforeClose = "";
 
   /** Gets the head code. */
-  public Optional<String> getHead() {
-    return Optional.ofNullable(head);
+  public String getHead() {
+    return head;
   }
 
   public void setHead(String head) {
@@ -47,8 +53,8 @@ public class CodeInfo {
   }
 
   /** Gets the code after start. */
-  public Optional<String> getAfterStart() {
-    return Optional.ofNullable(afterStart);
+  public String getAfterStart() {
+    return afterStart;
   }
 
   public void setAfterStart(String afterStart) {
@@ -56,8 +62,8 @@ public class CodeInfo {
   }
 
   /** Gets the code before close. */
-  public Optional<String> getBeforeClose() {
-    return Optional.ofNullable(beforeClose);
+  public String getBeforeClose() {
+    return beforeClose;
   }
 
   public void setBeforeClose(String beforeClose) {

--- a/rest/src/main/java/com/percussion/rest/pages/Page.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Page.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -26,9 +27,14 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a page. Sunny Sal: "Page ka hero, content ka zero!" */
+/**
+ * Represents a page. Sunny Sal: "Page ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits page fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Page")
 @Schema(name = "Page", description = "Represents a page.")
 public class Page {
@@ -107,88 +113,88 @@ public class Page {
     this.bookmarkedUsers = bookmarkedUsers;
   }
 
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDisplayName() {
-    return Optional.ofNullable(displayName);
+  public String getDisplayName() {
+    return displayName;
   }
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<String> getSummary() {
-    return Optional.ofNullable(summary);
+  public String getSummary() {
+    return summary;
   }
 
   public void setSummary(String summary) {
     this.summary = summary;
   }
 
-  public Optional<Date> getOverridePostDate() {
-    return Optional.ofNullable(overridePostDate);
+  public Date getOverridePostDate() {
+    return overridePostDate;
   }
 
   public void setOverridePostDate(Date overridePostDate) {
     this.overridePostDate = overridePostDate;
   }
 
-  public Optional<WorkflowInfo> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public WorkflowInfo getWorkflow() {
+    return workflow;
   }
 
   public void setWorkflow(WorkflowInfo workflow) {
     this.workflow = workflow;
   }
 
-  public Optional<SeoInfo> getSeo() {
-    return Optional.ofNullable(seo);
+  public SeoInfo getSeo() {
+    return seo;
   }
 
   public void setSeo(SeoInfo seo) {
     this.seo = seo;
   }
 
-  public Optional<CalendarInfo> getCalendar() {
-    return Optional.ofNullable(calendar);
+  public CalendarInfo getCalendar() {
+    return calendar;
   }
 
   public void setCalendar(CalendarInfo calendar) {
     this.calendar = calendar;
   }
 
-  public Optional<CodeInfo> getCode() {
-    return Optional.ofNullable(code);
+  public CodeInfo getCode() {
+    return code;
   }
 
   public void setCode(CodeInfo code) {
     this.code = code;
   }
 
-  public Optional<List<Region>> getBody() {
-    return Optional.ofNullable(body);
+  public List<Region> getBody() {
+    return body;
   }
 
   public void setBody(List<Region> body) {
@@ -220,16 +226,16 @@ public class Page {
         + "]";
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getFolderPath() {
-    return Optional.ofNullable(folderPath);
+  public String getFolderPath() {
+    return folderPath;
   }
 
   public void setFolderPath(String folderPath) {

--- a/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
@@ -174,9 +174,9 @@ public class PagesResource {
       pageName = StringUtils.defaultString(m.group(5));
     }
 
-    String objectName = page.getName().orElse(null);
-    String objectPath = page.getFolderPath().orElse(null);
-    String objectSite = page.getSiteName().orElse(null);
+    String objectName = page.getName();
+    String objectPath = page.getFolderPath();
+    String objectSite = page.getSiteName();
 
     if (pageName == null || (objectName != null && !objectName.equals(pageName))) {
       throw new LocationMismatchException();

--- a/rest/src/main/java/com/percussion/rest/pages/Region.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Region.java
@@ -19,15 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents a region of a page either defined locally or by the template. Sunny Sal: "Region ka
  * hero, widgets ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits region
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Region")
 @Schema(
     name = "Region",
@@ -47,8 +51,8 @@ public class Region {
   private List<Widget> widgets;
 
   /** Gets the region name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -56,8 +60,8 @@ public class Region {
   }
 
   /** Gets the region type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -74,8 +78,8 @@ public class Region {
   }
 
   /** Gets the widgets in this region. */
-  public Optional<List<Widget>> getWidgets() {
-    return Optional.ofNullable(widgets);
+  public List<Widget> getWidgets() {
+    return widgets;
   }
 
   public void setWidgets(List<Widget> widgets) {

--- a/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!" */
+/**
+ * Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits SEO fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "SeoInfo")
 @Schema(name = "SeoInfo", description = "Represents information about the SEO.")
@@ -53,8 +57,8 @@ public class SeoInfo {
   private List<String> categories;
 
   /** Gets the browser title. */
-  public Optional<String> getBrowserTitle() {
-    return Optional.ofNullable(browserTitle);
+  public String getBrowserTitle() {
+    return browserTitle;
   }
 
   public void setBrowserTitle(String browserTitle) {
@@ -62,8 +66,8 @@ public class SeoInfo {
   }
 
   /** Gets the meta description. */
-  public Optional<String> getMetaDescription() {
-    return Optional.ofNullable(metaDescription);
+  public String getMetaDescription() {
+    return metaDescription;
   }
 
   public void setMetaDescription(String metaDescription) {
@@ -71,8 +75,8 @@ public class SeoInfo {
   }
 
   /** Gets the hide search flag. */
-  public Optional<Boolean> getHideSearch() {
-    return Optional.ofNullable(hideSearch);
+  public Boolean getHideSearch() {
+    return hideSearch;
   }
 
   public void setHideSearch(Boolean hideSearch) {
@@ -80,8 +84,8 @@ public class SeoInfo {
   }
 
   /** Gets the tags. */
-  public Optional<List<String>> getTags() {
-    return Optional.ofNullable(tags);
+  public List<String> getTags() {
+    return tags;
   }
 
   public void setTags(List<String> tags) {
@@ -89,8 +93,8 @@ public class SeoInfo {
   }
 
   /** Gets the categories. */
-  public Optional<List<String>> getCategories() {
-    return Optional.ofNullable(categories);
+  public List<String> getCategories() {
+    return categories;
   }
 
   public void setCategories(List<String> categories) {

--- a/rest/src/main/java/com/percussion/rest/pages/Widget.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Widget.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.assets.Asset;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!" */
+/**
+ * Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits widget
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Widget")
 @Schema(name = "Widget", description = "Represents a Widget.")
@@ -57,8 +61,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget id. */
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
@@ -66,8 +70,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -75,8 +79,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -84,8 +88,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget scope. */
-  public Optional<String> getScope() {
-    return Optional.ofNullable(scope);
+  public String getScope() {
+    return scope;
   }
 
   public void setScope(String scope) {
@@ -93,8 +97,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets whether the widget is editable. */
-  public Optional<Boolean> getEditable() {
-    return Optional.ofNullable(editable);
+  public Boolean getEditable() {
+    return editable;
   }
 
   public void setEditable(Boolean editable) {
@@ -102,8 +106,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the asset within the widget. */
-  public Optional<Asset> getAsset() {
-    return Optional.ofNullable(asset);
+  public Asset getAsset() {
+    return asset;
   }
 
   public void setAsset(Asset asset) {

--- a/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!" */
+/**
+ * Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits workflow
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "WorkflowInfo")
 @Schema(name = "WorkflowInfo", description = "Represents information on the workflow.")
 public class WorkflowInfo {
@@ -41,8 +47,8 @@ public class WorkflowInfo {
   private String checkedOutUser;
 
   /** Gets the workflow name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -50,8 +56,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the workflow state. */
-  public Optional<String> getState() {
-    return Optional.ofNullable(state);
+  public String getState() {
+    return state;
   }
 
   public void setState(String state) {
@@ -59,8 +65,8 @@ public class WorkflowInfo {
   }
 
   /** Gets whether the item is checked out. */
-  public Optional<Boolean> getCheckedOut() {
-    return Optional.ofNullable(checkedOut);
+  public Boolean getCheckedOut() {
+    return checkedOut;
   }
 
   public void setCheckedOut(Boolean checkedOut) {
@@ -68,8 +74,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the user that has the item checked out. */
-  public Optional<String> getCheckedOutUser() {
-    return Optional.ofNullable(checkedOutUser);
+  public String getCheckedOutUser() {
+    return checkedOutUser;
   }
 
   public void setCheckedOutUser(String checkedOutUser) {

--- a/rest/src/main/java/com/percussion/rest/roles/Role.java
+++ b/rest/src/main/java/com/percussion/rest/roles/Role.java
@@ -19,15 +19,23 @@
 
 package com.percussion.rest.roles;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!" */
+/**
+ * Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code description}, and {@code homePage} when set. Optional-returning getters historically
+ * serialized as empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue
+ * #3388). Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "Role")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "Role", description = "Represents a system Role that a user may belong to.")
 public class Role {
 
@@ -60,24 +68,24 @@ public class Role {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getHomePage() {
-    return Optional.ofNullable(homePage);
+  public String getHomePage() {
+    return homePage;
   }
 
   public void setHomePage(String homePage) {

--- a/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
@@ -17,9 +17,15 @@
 
 package com.percussion.rest.sites;
 
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
-/** Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!" */
+/**
+ * Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!"
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SiteMapOptions {
 
   private boolean navigationBased = true;
@@ -47,40 +53,40 @@ public class SiteMapOptions {
     this.includeFolder = includeFolder;
   }
 
-  public Optional<String> getTimeZone() {
-    return Optional.ofNullable(timeZone);
+  public String getTimeZone() {
+    return timeZone;
   }
 
   public void setTimeZone(String timeZone) {
     this.timeZone = timeZone;
   }
 
-  public Optional<SiteMapDateFormat> getDateFormat() {
-    return Optional.ofNullable(dateFormat);
+  public SiteMapDateFormat getDateFormat() {
+    return dateFormat;
   }
 
   public void setDateFormat(SiteMapDateFormat dateFormat) {
     this.dateFormat = dateFormat;
   }
 
-  public Optional<String> getFileName() {
-    return Optional.ofNullable(fileName);
+  public String getFileName() {
+    return fileName;
   }
 
   public void setFileName(String fileName) {
     this.fileName = fileName;
   }
 
-  public Optional<String> getUseSiteMapIndex() {
-    return Optional.ofNullable(useSiteMapIndex);
+  public String getUseSiteMapIndex() {
+    return useSiteMapIndex;
   }
 
   public void setUseSiteMapIndex(String useSiteMapIndex) {
     this.useSiteMapIndex = useSiteMapIndex;
   }
 
-  public Optional<SiteMapType> getSiteMapType() {
-    return Optional.ofNullable(siteMapType);
+  public SiteMapType getSiteMapType() {
+    return siteMapType;
   }
 
   public void setSiteMapType(SiteMapType siteMapType) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Optional body for {@code POST /sites/{nameOrId}/virtual/build}.
  *
  * <p>When omitted or empty, the server chooses a default output directory under the CMS install
  * {@code tmp/virtual-sites/} tree (or the JVM temp directory when the install root is unavailable).
+ *
+ * <p>Wire getters return plain {@code String} (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,8 +47,8 @@ public class VirtualSiteBuildRequest {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getOutputRoot() {
-    return Optional.ofNullable(outputRoot);
+  public String getOutputRoot() {
+    return outputRoot;
   }
 
   public void setOutputRoot(String outputRoot) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of a CMS-integrated Virtual Site static build ({@code POST
@@ -30,6 +29,9 @@ import java.util.Optional;
  * <p>Maps from system {@code PSVirtualSiteBuildResult}: pages assembled, link-problem summary, and
  * absolute output path. Build may complete successfully while still reporting link problems (HTTP
  * 200 with {@code hasLinkProblems=true}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -75,24 +77,24 @@ public class VirtualSiteBuildResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Whether a last Virtual Site static build can be previewed from the product UI ({@code GET
  * /sites/{nameOrId}/virtual/preview}).
  *
  * <p>Missing or failed builds return HTTP 200 with {@code available=false} and a message — not 500.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePreviewStatus")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -62,24 +64,24 @@ public class VirtualSitePreviewStatus {
     this.available = available;
   }
 
-  public Optional<String> getHomePath() {
-    return Optional.ofNullable(homePath);
+  public String getHomePath() {
+    return homePath;
   }
 
   public void setHomePath(String homePath) {
     this.homePath = homePath;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {
     this.outputPath = outputPath;
   }
 
-  public Optional<String> getMessage() {
-    return Optional.ofNullable(message);
+  public String getMessage() {
+    return message;
   }
 
   public void setMessage(String message) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
@@ -21,11 +21,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of {@code POST /sites/{nameOrId}/virtual/publish}: build-then-copy to the Site filesystem
  * publish root ({@code IPSSite.root}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePublishResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -70,32 +72,32 @@ public class VirtualSitePublishResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getPublishPath() {
-    return Optional.ofNullable(publishPath);
+  public String getPublishPath() {
+    return publishPath;
   }
 
   public void setPublishPath(String publishPath) {
     this.publishPath = publishPath;
   }
 
-  public Optional<String> getBuildOutputPath() {
-    return Optional.ofNullable(buildOutputPath);
+  public String getBuildOutputPath() {
+    return buildOutputPath;
   }
 
   public void setBuildOutputPath(String buildOutputPath) {

--- a/rest/src/main/java/com/percussion/rest/templates/Template.java
+++ b/rest/src/main/java/com/percussion/rest/templates/Template.java
@@ -19,12 +19,22 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-/** Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!" */
+/**
+ * Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits catalog
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Template")
 @Schema(name = "Template", description = "Represents an assembly Template")
 public class Template {
@@ -55,72 +65,72 @@ public class Template {
     // Default constructor
   }
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getLocationPrefix() {
-    return Optional.ofNullable(locationPrefix);
+  public String getLocationPrefix() {
+    return locationPrefix;
   }
 
   public void setLocationPrefix(String locationPrefix) {
     this.locationPrefix = locationPrefix;
   }
 
-  public Optional<String> getLocationSuffix() {
-    return Optional.ofNullable(locationSuffix);
+  public String getLocationSuffix() {
+    return locationSuffix;
   }
 
   public void setLocationSuffix(String locationSuffix) {
     this.locationSuffix = locationSuffix;
   }
 
-  public Optional<String> getAssembler() {
-    return Optional.ofNullable(assembler);
+  public String getAssembler() {
+    return assembler;
   }
 
   public void setAssembler(String assembler) {
     this.assembler = assembler;
   }
 
-  public Optional<String> getAssemblyUrl() {
-    return Optional.ofNullable(assemblyUrl);
+  public String getAssemblyUrl() {
+    return assemblyUrl;
   }
 
   public void setAssemblyUrl(String assemblyUrl) {
     this.assemblyUrl = assemblyUrl;
   }
 
-  public Optional<String> getStyleSheet() {
-    return Optional.ofNullable(styleSheet);
+  public String getStyleSheet() {
+    return styleSheet;
   }
 
   public void setStyleSheet(String styleSheet) {
@@ -143,48 +153,48 @@ public class Template {
     this.outputFormat = outputFormat;
   }
 
-  public Optional<Character> getPublishWhen() {
-    return Optional.ofNullable(publishWhen);
+  public Character getPublishWhen() {
+    return publishWhen;
   }
 
   public void setPublishWhen(Character publishWhen) {
     this.publishWhen = publishWhen;
   }
 
-  public Optional<Integer> getTemplateType() {
-    return Optional.ofNullable(templateType);
+  public Integer getTemplateType() {
+    return templateType;
   }
 
   public void setTemplateType(Integer templateType) {
     this.templateType = templateType;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getTemplate() {
-    return Optional.ofNullable(template);
+  public String getTemplate() {
+    return template;
   }
 
   public void setTemplate(String template) {
     this.template = template;
   }
 
-  public Optional<String> getMimeType() {
-    return Optional.ofNullable(mimeType);
+  public String getMimeType() {
+    return mimeType;
   }
 
   public void setMimeType(String mimeType) {
     this.mimeType = mimeType;
   }
 
-  public Optional<String> getCharset() {
-    return Optional.ofNullable(charset);
+  public String getCharset() {
+    return charset;
   }
 
   public void setCharset(String charset) {
@@ -207,16 +217,16 @@ public class Template {
     this.slots = slots;
   }
 
-  public Optional<Integer> getGlobalTemplateUsage() {
-    return Optional.ofNullable(globalTemplateUsage);
+  public Integer getGlobalTemplateUsage() {
+    return globalTemplateUsage;
   }
 
   public void setGlobalTemplateUsage(Integer globalTemplateUsage) {
     this.globalTemplateUsage = globalTemplateUsage;
   }
 
-  public Optional<Long> getGlobalTemplate() {
-    return Optional.ofNullable(globalTemplate);
+  public Long getGlobalTemplate() {
+    return globalTemplate;
   }
 
   public void setGlobalTemplate(Long globalTemplate) {

--- a/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
@@ -19,10 +19,16 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
-import java.util.Optional;
 
-/** Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!" */
+/**
+ * Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits binding
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TemplateBinding {
 
   private Guid bindingId;
@@ -36,24 +42,24 @@ public class TemplateBinding {
     // Default constructor
   }
 
-  public Optional<Guid> getBindingId() {
-    return Optional.ofNullable(bindingId);
+  public Guid getBindingId() {
+    return bindingId;
   }
 
   public void setBindingId(Guid bindingId) {
     this.bindingId = bindingId;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<Guid> getTemplateId() {
-    return Optional.ofNullable(templateId);
+  public Guid getTemplateId() {
+    return templateId;
   }
 
   public void setTemplateId(Guid templateId) {
@@ -68,16 +74,16 @@ public class TemplateBinding {
     this.executionOrder = executionOrder;
   }
 
-  public Optional<String> getVariable() {
-    return Optional.ofNullable(variable);
+  public String getVariable() {
+    return variable;
   }
 
   public void setVariable(String variable) {
     this.variable = variable;
   }
 
-  public Optional<String> getExpression() {
-    return Optional.ofNullable(expression);
+  public String getExpression() {
+    return expression;
   }
 
   public void setExpression(String expression) {

--- a/rest/src/main/java/com/percussion/rest/users/User.java
+++ b/rest/src/main/java/com/percussion/rest/users/User.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.users;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.LinkRef;
 import com.percussion.rest.communities.Community;
 import com.percussion.rest.communities.CommunityList;
@@ -26,10 +27,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a User. Sunny Sal: "User ka hero, login ka zero!" */
+/**
+ * Represents a User. Sunny Sal: "User ka hero, login ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code
+ * userName}, {@code firstName}, and related scalars when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "User")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "User", description = "Represents a User.")
 public class User {
 
@@ -101,56 +110,56 @@ public class User {
     // Default constructor
   }
 
-  public Optional<CommunityList> getUserCommunities() {
-    return Optional.ofNullable(userCommunities);
+  public CommunityList getUserCommunities() {
+    return userCommunities;
   }
 
   public void setUserCommunities(CommunityList userCommunities) {
     this.userCommunities = userCommunities;
   }
 
-  public Optional<Community> getSelectedCommunity() {
-    return Optional.ofNullable(selectedCommunity);
+  public Community getSelectedCommunity() {
+    return selectedCommunity;
   }
 
   public void setSelectedCommunity(Community selectedCommunity) {
     this.selectedCommunity = selectedCommunity;
   }
 
-  public Optional<String> getUserName() {
-    return Optional.ofNullable(userName);
+  public String getUserName() {
+    return userName;
   }
 
   public void setUserName(String userName) {
     this.userName = userName;
   }
 
-  public Optional<String> getFirstName() {
-    return Optional.ofNullable(firstName);
+  public String getFirstName() {
+    return firstName;
   }
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
-  public Optional<String> getLastName() {
-    return Optional.ofNullable(lastName);
+  public String getLastName() {
+    return lastName;
   }
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
-  public Optional<String> getEmailAddress() {
-    return Optional.ofNullable(emailAddress);
+  public String getEmailAddress() {
+    return emailAddress;
   }
 
   public void setEmailAddress(String emailAddress) {
     this.emailAddress = emailAddress;
   }
 
-  public Optional<String> getUserType() {
-    return Optional.ofNullable(userType);
+  public String getUserType() {
+    return userType;
   }
 
   public void setUserType(String userType) {
@@ -223,8 +232,8 @@ public class User {
     this.recentTemplates = recentTemplates;
   }
 
-  public Optional<LinkRef> getPersonalPage() {
-    return Optional.ofNullable(personalPage);
+  public LinkRef getPersonalPage() {
+    return personalPage;
   }
 
   public void setPersonalPage(LinkRef personalPage) {
@@ -253,8 +262,8 @@ public class User {
     this.roles = roles;
   }
 
-  public Optional<String> getPassword() {
-    return Optional.ofNullable(password);
+  public String getPassword() {
+    return password;
   }
 
   public void setPassword(String password) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,23 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.pages.CalendarInfo;
+import com.percussion.rest.pages.CodeInfo;
+import com.percussion.rest.pages.Page;
+import com.percussion.rest.pages.Region;
+import com.percussion.rest.pages.SeoInfo;
+import com.percussion.rest.pages.Widget;
+import com.percussion.rest.pages.WorkflowInfo;
+import com.percussion.rest.templates.Template;
+import com.percussion.rest.templates.TemplateBinding;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +43,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). DisplayFormatProperty
+ * / Template / Page family follow the same plain-getter rule (issue #3407). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +124,174 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void displayFormatProperty_serializesPlainScalarsNotOptionalBeans() {
+    DisplayFormatProperty prop = new DisplayFormatProperty();
+    prop.setPropertyId("1");
+    prop.setPropertyName("sortColumn");
+    prop.setPropertyValue("sys_title");
+    prop.setDescription("Default sort");
+
+    ObjectMapper propMapper =
+        new JacksonContextResolver().getContext(DisplayFormatProperty.class);
+    String json = propMapper.writeValueAsString(prop);
+    assertTrue(json.contains("\"propertyId\""), json);
+    assertTrue(json.contains("\"propertyName\""), json);
+    assertTrue(json.contains("sortColumn"), json);
+    assertTrue(json.contains("\"propertyValue\""), json);
+    assertTrue(json.contains("sys_title"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    DisplayFormatProperty roundTrip = propMapper.readValue(json, DisplayFormatProperty.class);
+    assertEquals("1", roundTrip.getPropertyId(), json);
+    assertEquals("sortColumn", roundTrip.getPropertyName(), json);
+    assertEquals("sys_title", roundTrip.getPropertyValue(), json);
+  }
+
+  @Test
+  void template_serializesNameLabelNotOptionalBeans() {
+    Template template = new Template();
+    template.setName("perc.page");
+    template.setLabel("Page");
+    template.setDescription("Page assembly");
+    template.setMimeType("text/html");
+
+    ObjectMapper templateMapper = new JacksonContextResolver().getContext(Template.class);
+    String json = templateMapper.writeValueAsString(template);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"mimeType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    Template roundTrip = templateMapper.readValue(json, Template.class);
+    assertEquals("perc.page", roundTrip.getName(), json);
+    assertEquals("Page", roundTrip.getLabel(), json);
+    assertEquals("text/html", roundTrip.getMimeType(), json);
+  }
+
+  @Test
+  void templateBinding_serializesVariableExpressionNotOptionalBeans() {
+    TemplateBinding binding = new TemplateBinding();
+    binding.setVariable("$rx");
+    binding.setExpression("$sys.template");
+    binding.setExecutionOrder(1);
+
+    ObjectMapper bindingMapper = new JacksonContextResolver().getContext(TemplateBinding.class);
+    String json = bindingMapper.writeValueAsString(binding);
+    assertTrue(json.contains("\"variable\""), json);
+    assertTrue(json.contains("$rx"), json);
+    assertTrue(json.contains("\"expression\""), json);
+    assertTrue(json.contains("$sys.template"), json);
+    assertNoOptionalBeanKeys(json);
+
+    TemplateBinding roundTrip = bindingMapper.readValue(json, TemplateBinding.class);
+    assertEquals("$rx", roundTrip.getVariable(), json);
+    assertEquals("$sys.template", roundTrip.getExpression(), json);
+  }
+
+  @Test
+  void page_serializesNamePathNotOptionalBeans() {
+    Page page = new Page();
+    page.setId("1234");
+    page.setName("home.html");
+    page.setDisplayName("Home");
+    page.setSiteName("Help");
+    page.setFolderPath("docs");
+    page.setTemplateName("perc.page");
+    page.setSummary("Welcome");
+
+    SeoInfo seo = new SeoInfo();
+    seo.setBrowserTitle("Help Home");
+    seo.setMetaDescription("Landing page");
+    seo.setHideSearch(Boolean.FALSE);
+    page.setSeo(seo);
+
+    ObjectMapper pageMapper = new JacksonContextResolver().getContext(Page.class);
+    String json = pageMapper.writeValueAsString(page);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("home.html"), json);
+    assertTrue(json.contains("\"displayName\""), json);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("\"folderPath\""), json);
+    assertTrue(json.contains("\"templateName\""), json);
+    assertTrue(json.contains("\"browserTitle\""), json);
+    assertTrue(json.contains("Help Home"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Page roundTrip = pageMapper.readValue(json, Page.class);
+    assertEquals("1234", roundTrip.getId(), json);
+    assertEquals("home.html", roundTrip.getName(), json);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertNotNull(roundTrip.getSeo(), json);
+    assertEquals("Help Home", roundTrip.getSeo().getBrowserTitle(), json);
+  }
+
+  @Test
+  void widgetAndPageFamily_serializePlainScalarsNotOptionalBeans() {
+    Widget widget = new Widget();
+    widget.setId("w1");
+    widget.setName("richText");
+    widget.setType("percRichText");
+    widget.setScope(Widget.SCOPE_LOCAL);
+    widget.setEditable(Boolean.TRUE);
+
+    ObjectMapper widgetMapper = new JacksonContextResolver().getContext(Widget.class);
+    String widgetJson = widgetMapper.writeValueAsString(widget);
+    assertTrue(widgetJson.contains("\"name\""), widgetJson);
+    assertTrue(widgetJson.contains("richText"), widgetJson);
+    assertTrue(widgetJson.contains("\"type\""), widgetJson);
+    assertNoOptionalBeanKeys(widgetJson);
+    Widget widgetRoundTrip = widgetMapper.readValue(widgetJson, Widget.class);
+    assertEquals("w1", widgetRoundTrip.getId(), widgetJson);
+    assertEquals("percRichText", widgetRoundTrip.getType(), widgetJson);
+
+    Region region = new Region();
+    region.setName("content");
+    region.setType("TEMPLATE");
+    region.setWidgets(List.of(widget));
+    ObjectMapper regionMapper = new JacksonContextResolver().getContext(Region.class);
+    String regionJson = regionMapper.writeValueAsString(region);
+    assertTrue(regionJson.contains("\"name\""), regionJson);
+    assertTrue(regionJson.contains("content"), regionJson);
+    assertNoOptionalBeanKeys(regionJson);
+
+    WorkflowInfo workflow = new WorkflowInfo();
+    workflow.setName("Default Workflow");
+    workflow.setState("Draft");
+    workflow.setCheckedOut(Boolean.FALSE);
+    ObjectMapper wfMapper = new JacksonContextResolver().getContext(WorkflowInfo.class);
+    String wfJson = wfMapper.writeValueAsString(workflow);
+    assertTrue(wfJson.contains("\"name\""), wfJson);
+    assertTrue(wfJson.contains("Draft"), wfJson);
+    assertNoOptionalBeanKeys(wfJson);
+    WorkflowInfo wfRoundTrip = wfMapper.readValue(wfJson, WorkflowInfo.class);
+    assertEquals("Default Workflow", wfRoundTrip.getName(), wfJson);
+    assertEquals("Draft", wfRoundTrip.getState(), wfJson);
+
+    CodeInfo code = new CodeInfo();
+    code.setHead("<script></script>");
+    ObjectMapper codeMapper = new JacksonContextResolver().getContext(CodeInfo.class);
+    String codeJson = codeMapper.writeValueAsString(code);
+    assertTrue(codeJson.contains("\"head\""), codeJson);
+    assertNoOptionalBeanKeys(codeJson);
+
+    CalendarInfo calendar = new CalendarInfo();
+    calendar.setCalendars(List.of("Default"));
+    ObjectMapper calMapper = new JacksonContextResolver().getContext(CalendarInfo.class);
+    String calJson = calMapper.writeValueAsString(calendar);
+    assertTrue(calJson.contains("\"calendars\""), calJson);
+    assertTrue(calJson.contains("Default"), calJson);
+    assertNoOptionalBeanKeys(calJson);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,19 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.sites.SiteMapDateFormat;
+import com.percussion.rest.sites.SiteMapOptions;
+import com.percussion.rest.sites.SiteMapType;
+import com.percussion.rest.sites.VirtualSiteBuildRequest;
+import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +39,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Virtual Site +
+ * SiteMap wire DTOs follow the same plain-getter rule (issue #3411 / #3388). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +120,142 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void virtualSiteBuildRequest_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildRequest request = new VirtualSiteBuildRequest();
+    request.setOutputRoot("C:/tmp/product-docs-site");
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"outputRoot\""), json);
+    assertTrue(json.contains("C:/tmp/product-docs-site"), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildRequest roundTrip =
+        requestMapper.readValue(json, VirtualSiteBuildRequest.class);
+    assertEquals("C:/tmp/product-docs-site", roundTrip.getOutputRoot(), json);
+  }
+
+  @Test
+  void virtualSiteBuildResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildResult result = new VirtualSiteBuildResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"siteKey\""), json);
+    assertTrue(json.contains("product-docs"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"pagesWritten\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildResult roundTrip = resultMapper.readValue(json, VirtualSiteBuildResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("product-docs", roundTrip.getSiteKey(), json);
+    assertEquals("C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getOutputPath(), json);
+    assertEquals(42, roundTrip.getPagesWritten(), json);
+  }
+
+  @Test
+  void virtualSitePreviewStatus_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(true);
+    status.setHomePath("8.2/index.html");
+    status.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    status.setMessage("ready");
+
+    ObjectMapper statusMapper =
+        new JacksonContextResolver().getContext(VirtualSitePreviewStatus.class);
+    String json = statusMapper.writeValueAsString(status);
+    assertTrue(json.contains("\"homePath\""), json);
+    assertTrue(json.contains("8.2/index.html"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"message\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePreviewStatus roundTrip =
+        statusMapper.readValue(json, VirtualSitePreviewStatus.class);
+    assertEquals(Boolean.TRUE, roundTrip.getAvailable(), json);
+    assertEquals("8.2/index.html", roundTrip.getHomePath(), json);
+    assertEquals("ready", roundTrip.getMessage(), json);
+  }
+
+  @Test
+  void virtualSitePublishResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePublishResult result = new VirtualSitePublishResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setPublishPath("C:/inetpub/wwwroot/help");
+    result.setBuildOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setFilesCopied(50);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSitePublishResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"publishPath\""), json);
+    assertTrue(json.contains("\"buildOutputPath\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePublishResult roundTrip =
+        resultMapper.readValue(json, VirtualSitePublishResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("C:/inetpub/wwwroot/help", roundTrip.getPublishPath(), json);
+    assertEquals(
+        "C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getBuildOutputPath(), json);
+    assertEquals(50, roundTrip.getFilesCopied(), json);
+  }
+
+  @Test
+  void siteMapOptions_serializesPlainScalarsNotOptionalBeans() {
+    SiteMapOptions options = new SiteMapOptions();
+    options.setNavigationBased(true);
+    options.setIncludeFolder(false);
+    options.setTimeZone("UTC");
+    options.setDateFormat(SiteMapDateFormat.DAY);
+    options.setFileName("sitemap.xml");
+    options.setUseSiteMapIndex("true");
+    options.setSiteMapType(SiteMapType.STANDARD);
+    options.setDefaultFrequency(0.5);
+
+    ObjectMapper optionsMapper = new JacksonContextResolver().getContext(SiteMapOptions.class);
+    String json = optionsMapper.writeValueAsString(options);
+    assertTrue(json.contains("\"timeZone\""), json);
+    assertTrue(json.contains("UTC"), json);
+    assertTrue(json.contains("\"dateFormat\""), json);
+    assertTrue(json.contains("DAY"), json);
+    assertTrue(json.contains("\"fileName\""), json);
+    assertTrue(json.contains("sitemap.xml"), json);
+    assertTrue(json.contains("\"useSiteMapIndex\""), json);
+    assertTrue(json.contains("\"siteMapType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    SiteMapOptions roundTrip = optionsMapper.readValue(json, SiteMapOptions.class);
+    assertEquals("UTC", roundTrip.getTimeZone(), json);
+    assertEquals(SiteMapDateFormat.DAY, roundTrip.getDateFormat(), json);
+    assertEquals("sitemap.xml", roundTrip.getFileName(), json);
+    assertEquals("true", roundTrip.getUseSiteMapIndex(), json);
+    assertEquals(SiteMapType.STANDARD, roundTrip.getSiteMapType(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,13 +16,17 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.roles.Role;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
+import com.percussion.rest.users.User;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,8 +35,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). User / Role /
+ * ObjectSummary follow the same plain-getter rule (issue #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +116,82 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void user_serializesPlainScalarsNotOptionalBeans() {
+    User user = new User();
+    user.setUserName("admin");
+    user.setFirstName("Ada");
+    user.setLastName("Lovelace");
+    user.setEmailAddress("ada@example.com");
+    user.setUserType("INTERNAL");
+
+    ObjectMapper userMapper = new JacksonContextResolver().getContext(User.class);
+    String json = userMapper.writeValueAsString(user);
+    assertTrue(json.contains("\"userName\""), json);
+    assertTrue(json.contains("admin"), json);
+    assertTrue(json.contains("\"firstName\""), json);
+    assertTrue(json.contains("Ada"), json);
+    assertTrue(json.contains("\"lastName\""), json);
+    assertTrue(json.contains("\"emailAddress\""), json);
+    assertTrue(json.contains("\"userType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    User roundTrip = userMapper.readValue(json, User.class);
+    assertEquals("admin", roundTrip.getUserName(), json);
+    assertEquals("Ada", roundTrip.getFirstName(), json);
+    assertEquals("INTERNAL", roundTrip.getUserType(), json);
+  }
+
+  @Test
+  void role_serializesPlainScalarsNotOptionalBeans() {
+    Role role = new Role();
+    role.setName("Editor");
+    role.setDescription("Edit content");
+    role.setHomePage("Dashboard");
+
+    ObjectMapper roleMapper = new JacksonContextResolver().getContext(Role.class);
+    String json = roleMapper.writeValueAsString(role);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Editor"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"homePage\""), json);
+    assertTrue(json.contains("Dashboard"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Role roundTrip = roleMapper.readValue(json, Role.class);
+    assertEquals("Editor", roundTrip.getName(), json);
+    assertEquals("Dashboard", roundTrip.getHomePage(), json);
+  }
+
+  @Test
+  void objectSummary_serializesNameLabelGuidNotOptionalBeans() {
+    ObjectSummary summary = new ObjectSummary();
+    summary.setName("Default");
+    summary.setLabel("Default ACL");
+    summary.setDescription("Site ACL");
+    summary.setGuid(new Guid("0-13-10"));
+
+    ObjectMapper summaryMapper = new JacksonContextResolver().getContext(ObjectSummary.class);
+    String json = summaryMapper.writeValueAsString(summary);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-13-10") || json.contains("10"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ObjectSummary roundTrip = summaryMapper.readValue(json, ObjectSummary.class);
+    assertEquals("Default", roundTrip.getName(), json);
+    assertEquals("Default ACL", roundTrip.getLabel(), json);
+    assertNotNull(roundTrip.getGuid(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
+++ b/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.roles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,9 @@ public class RolesTest extends MainTest {
   @Test
   public void testNeverNull() {
     var r = new Role();
-    assertNotNull(r.getDescription(), "Should never be null");
-    assertNotNull(r.getName(), "Should never be null");
-    assertNotNull(r.getDescription(), "Should never be null");
+    assertNull(r.getDescription(), "Unset wire scalars are nullable");
+    assertNull(r.getName(), "Unset wire scalars are nullable");
+    assertNull(r.getHomePage(), "Unset wire scalars are nullable");
     assertNotNull(r.getUsers(), "Should never be null");
   }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -173,7 +173,7 @@ public class SitesResourceTest {
 
     VirtualSiteBuildResult out = resource.buildVirtualSite("Help", req);
     assertEquals(3, out.getPagesWritten().intValue());
-    assertEquals("C:/tmp/out", out.getOutputPath().orElse(null));
+    assertEquals("C:/tmp/out", out.getOutputPath());
     verify(adaptor).buildVirtualSite("Help", req);
   }
 
@@ -197,7 +197,7 @@ public class SitesResourceTest {
 
     VirtualSitePreviewStatus out = resource.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, out.getAvailable());
-    assertEquals("8.2/index.html", out.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", out.getHomePath());
     verify(adaptor).getVirtualSitePreviewStatus("Help");
   }
 
@@ -253,7 +253,7 @@ public class SitesResourceTest {
     VirtualSitePublishResult out = resource.publishVirtualSite("Help");
     assertEquals(3, out.getPagesWritten().intValue());
     assertEquals(5, out.getFilesCopied().intValue());
-    assertEquals("C:/pub/help", out.getPublishPath().orElse(null));
+    assertEquals("C:/pub/help", out.getPublishPath());
     verify(adaptor).publishVirtualSite("Help");
   }
 

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -80,8 +80,8 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     result.setPagesWritten(0);
     result.setLinkProblemCount(0);
     result.setHasLinkProblems(false);
-    if (request != null && request.getOutputRoot().isPresent()) {
-      result.setOutputPath(request.getOutputRoot().get());
+    if (request != null && request.getOutputRoot() != null) {
+      result.setOutputPath(request.getOutputRoot());
     }
     return result;
   }

--- a/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
@@ -25,6 +25,7 @@ import com.percussion.rest.errors.UnknownUserException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +50,8 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toUpdate = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(user.getUserName().orElse(""))) {
+      if (Objects.toString(u.getUserName(), "")
+          .equalsIgnoreCase(Objects.toString(user.getUserName(), ""))) {
         toUpdate = u;
         break;
       }
@@ -58,9 +60,15 @@ public class UserTestAdaptor implements IUserAdaptor {
       // New user logic could go here
     } else {
       toUpdate.setBookmarkedPages(user.getBookmarkedPages());
-      user.getEmailAddress().ifPresent(toUpdate::setEmailAddress);
-      user.getFirstName().ifPresent(toUpdate::setFirstName);
-      user.getLastName().ifPresent(toUpdate::setLastName);
+      if (user.getEmailAddress() != null) {
+        toUpdate.setEmailAddress(user.getEmailAddress());
+      }
+      if (user.getFirstName() != null) {
+        toUpdate.setFirstName(user.getFirstName());
+      }
+      if (user.getLastName() != null) {
+        toUpdate.setLastName(user.getLastName());
+      }
     }
     return null;
   }
@@ -72,7 +80,7 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toDelete = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(userName)) {
+      if (Objects.toString(u.getUserName(), "").equalsIgnoreCase(userName)) {
         toDelete = u;
         break;
       }

--- a/rest/src/test/java/com/percussion/rest/users/UsersTest.java
+++ b/rest/src/test/java/com/percussion/rest/users/UsersTest.java
@@ -20,6 +20,7 @@
 package com.percussion.rest.users;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -31,10 +32,10 @@ public class UsersTest extends MainTest {
     var u = new User();
 
     assertNotNull(u.getBookmarkedPages(), "Should never be null");
-    assertNotNull(u.getEmailAddress(), "Should never be null");
-    assertNotNull(u.getFirstName(), "Should never be null");
-    assertNotNull(u.getLastName(), "Should never be null");
-    assertNotNull(u.getPersonalPage(), "Should never be null");
+    assertNull(u.getEmailAddress(), "Unset wire scalars are nullable");
+    assertNull(u.getFirstName(), "Unset wire scalars are nullable");
+    assertNull(u.getLastName(), "Unset wire scalars are nullable");
+    assertNull(u.getPersonalPage(), "Unset wire objects are nullable");
     assertNotNull(u.getPersonAssets(), "Should never be null");
     assertNotNull(u.getRecentAssetFolders(), "Should never be null");
     assertNotNull(u.getRecentAssetTypes(), "Should never be null");
@@ -42,7 +43,7 @@ public class UsersTest extends MainTest {
     assertNotNull(u.getRecentSiteFolders(), "Should never be null");
     assertNotNull(u.getRoles(), "Should never be null");
     assertNotNull(u.getRecentTemplates(), "Should never be null");
-    assertNotNull(u.getUserName(), "Should never be null");
-    assertNotNull(u.getUserType(), "Should never be null");
+    assertNull(u.getUserName(), "Unset wire scalars are nullable");
+    assertNull(u.getUserType(), "Unset wire scalars are nullable");
   }
 }


### PR DESCRIPTION
## Summary

Overnight issue workers opened three sibling REST DTO wire-getter PRs against `main` (parent epic #3388). Each independently appended production-mapper cases to the same shared test file, so later merges of #3406 / #3415 / #3416 would collide on `JacksonContextResolverOptionalTest.java`. `ApiUtils.java` is also shared by #3406 and #3415.

This cluster absorbs all three onto one tip with **union** semantics: every family test and caller update is kept.

**Thrash files**
- `rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java` (#3406 + #3415 + #3416)
- `projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java` (#3406 + #3415)

No product-docs change: backend wire-getter convention only (JSON scalars instead of Optional beans). Not a Human QA candidate.

Partial #3388 #3407 #3411

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
| --- | --- | --- | --- | --- |
| yes | #3406 | `fix/issue-3388-rest-dto-wire-getters-2` | yes | User / Role / ObjectSummary |
| yes | #3415 | `fix/issue-3407-rest-dto-wire-getters` | yes | DisplayFormatProperty / Template / Page family |
| yes | #3416 | `fix/issue-3411-virtualsite-sitemap-optional-getters` | yes | Virtual Site + SiteMap |

Left open (not this thrash group): #3414, #3409, #3408.

## Test plan

1. Review unioned `JacksonContextResolverOptionalTest` — 17 tests covering ContentType, TemplateSummary, User/Role/ObjectSummary, DisplayFormat/Template/Page, and Virtual Site/SiteMap families.
2. Confirm no Optional-bean `empty`/`present` keys on those wire types.
3. Do **not** merge the superseded PRs.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): backend REST DTO/adaptor wire-getter conversion only
- [x] **Unit / module tests** — unioned mapper tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps grepped
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## modules_built

`rest,projects/sitemanage`

## build_evidence

- `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 431, Failures: 0, Errors: 0, Skipped: 0 (`JacksonContextResolverOptionalTest`: 17 tests).
- `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125 (`SitesAdaptorTest`: 36 tests).

Public getter signatures changed `Optional<T>` → `T`. Reverse-dep grep: no subclasses of the REST DTOs (sitemanage `AssignTemplate` extends `com.percussion.sitemanage.service.Template`, not the REST type). `sitemanage` standalone install is the known reverse-dep.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs-cluster.