### PR TITLE
fix(rest): LocationScheme/Context/DeliveryType wire getters must not return Optional (#3412)

### DIFF
--- a/docs/ai-generated/code-reviews/3412-location-scheme-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3412-location-scheme-wire-getters-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review: #3412 LocationScheme / Context / DeliveryType wire getters
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3412-location-scheme-wire-getters`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+Slice 4 of parent #3388 converts publishing-location REST wire DTOs
+(`LocationScheme`, `LocationSchemeParameter`, `Context`, `DeliveryType`) from
+`Optional<T>` getters to plain nullable getters with existing
+`@JsonInclude(NON_NULL)`. sitemanage `ContextAdaptor` / `DeliveryTypeAdaptor`
+callers that unwrapped those getters via `ApiUtils.orNull` / `flatMap` now use
+the plain values. Guid `getStringValue()` remains Optional + `@JsonIgnore`
+(out of this slice).
+
+Production-mapper tests appended to `JacksonContextResolverOptionalTest` use
+`new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no
+`empty`/`present` Optional-bean keys, plus round-trip field equality.
+
+Memory patterns hit: incomplete change-class closure (callers + production
+mapper tests); behavioral tests required for wire-shape change.
+
+## Issues
+
+None (no bugs, no missing behavioral tests, no path/file I/O).
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or path assertions.
+
+## Change-class companions
+
+| Companion | Status |
+| --- | --- |
+| Peer getter style (`ContentType` / PR #3406) | Done |
+| `JacksonContextResolverOptionalTest` family methods | Appended (8 tests total) |
+| rest / sitemanage callers of converted getters | Updated |
+| `rest/AGENTS.md` wire-getter rule | Not committed (human rule review) |
+| product-docs | N/A (no documented Optional-bean JSON example) |
+| Playwright / WebUI | N/A |
+
+## Build evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 422, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125
+- C2: public `Optional<T>` → `T` getters. Grep for anonymous `extends` / `new Type() {` — none. Reverse-dep sitemanage standalone install green.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
@@ -105,7 +105,7 @@ public class ContextAdaptor implements IContextsAdaptor {
   public Context createOrUpdateContext(URI baseURI, Context context) throws BackendException {
     try {
       IPSPublishingContext ctx;
-      Guid idGuid = ApiUtils.orNull(context.getId());
+      Guid idGuid = context.getId();
       String idStr = (idGuid == null) ? null : ApiUtils.orNull(idGuid.getStringValue());
       if (idStr == null || StringUtils.isBlank(idStr)) {
         ctx = siteManager.createContext();
@@ -145,7 +145,7 @@ public class ContextAdaptor implements IContextsAdaptor {
 
   private IPSPublishingContext copyContext(Context context) {
     var ret = new PSPublishingContext();
-    Guid idGuid = ApiUtils.orNull(context.getId());
+    Guid idGuid = context.getId();
     if (idGuid != null) {
       String idStr = ApiUtils.orNull(idGuid.getStringValue());
       if (idStr != null) {
@@ -153,11 +153,12 @@ public class ContextAdaptor implements IContextsAdaptor {
         ret.setGUID(guid);
       }
     }
-    ret.setName(ApiUtils.orNull(context.getName()));
-    ret.setDescription(ApiUtils.orNull(context.getDescription()));
+    ret.setName(context.getName());
+    ret.setDescription(context.getDescription());
     Guid schemeId = null;
-    if (context.getDefaultScheme() != null) {
-      schemeId = ApiUtils.orNull(context.getDefaultScheme().flatMap(LocationScheme::getSchemeId));
+    LocationScheme defaultScheme = context.getDefaultScheme();
+    if (defaultScheme != null) {
+      schemeId = defaultScheme.getSchemeId();
     }
     if (schemeId != null) {
       String schemeStr = ApiUtils.orNull(schemeId.getStringValue());

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
@@ -64,22 +64,18 @@ public class DeliveryTypeAdaptor implements IDeliveryTypeAdaptor {
   @Override
   public DeliveryType updateDeliveryType(URI baseURI, DeliveryType type) throws BackendException {
     try {
-      Guid idGuid = ApiUtils.orNull(type.getId());
+      Guid idGuid = type.getId();
       String idStr = ApiUtils.orNull(idGuid == null ? null : idGuid.getStringValue());
       if (idGuid == null || StringUtils.isBlank(idStr)) {
         // Create new delivery type
         var create = pubService.createDeliveryType();
         create.setUnpublishingRequiresAssembly(type.isUnpublishingRequiresAssembly());
-        create.setName(ApiUtils.orNull(type.getName()));
-        create.setDescription(ApiUtils.orNull(type.getDescription()));
-        create.setBeanName(ApiUtils.orNull(type.getBeanName()));
+        create.setName(type.getName());
+        create.setDescription(type.getDescription());
+        create.setBeanName(type.getBeanName());
         pubService.saveDeliveryType(create);
         return copyDeliveryType(create);
       } else {
-        // unwrap Optionals before copying
-        type.setName(ApiUtils.orNull(type.getName()));
-        type.setDescription(ApiUtils.orNull(type.getDescription()));
-        type.setBeanName(ApiUtils.orNull(type.getBeanName()));
         var update = copyDeliveryType(type);
         pubService.saveDeliveryType(update);
         // Load after save
@@ -122,11 +118,11 @@ public class DeliveryTypeAdaptor implements IDeliveryTypeAdaptor {
 
   private IPSDeliveryType copyDeliveryType(DeliveryType type) {
     var ret = new PSDeliveryType();
-    ret.setBeanName(ApiUtils.orNull(type.getBeanName()));
-    ret.setDescription(ApiUtils.orNull(type.getDescription()));
-    ret.setName(ApiUtils.orNull(type.getName()));
+    ret.setBeanName(type.getBeanName());
+    ret.setDescription(type.getDescription());
+    ret.setName(type.getName());
     ret.setUnpublishingRequiresAssembly(type.isUnpublishingRequiresAssembly());
-    ret.setGUID(ApiUtils.convertGuid(ApiUtils.orNull(type.getId())));
+    ret.setGUID(ApiUtils.convertGuid(type.getId()));
     return ret;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/contexts/Context.java
+++ b/rest/src/main/java/com/percussion/rest/contexts/Context.java
@@ -25,9 +25,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a publishing Context in Percussion CMS. */
+/**
+ * Represents a publishing Context in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and nested {@code defaultScheme} when set. Optional-returning getters historically serialized as
+ * empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "Context")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a publishing Context")
@@ -79,48 +84,48 @@ public class Context {
     this.locationSchemes = locationSchemes;
   }
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<LocationScheme> getDefaultScheme() {
-    return Optional.ofNullable(defaultScheme);
+  public LocationScheme getDefaultScheme() {
+    return defaultScheme;
   }
 
   public void setDefaultScheme(LocationScheme defaultScheme) {
     this.defaultScheme = defaultScheme;
   }
 
-  public Optional<List<LocationScheme>> getLocationSchemes() {
-    return Optional.ofNullable(locationSchemes);
+  public List<LocationScheme> getLocationSchemes() {
+    return locationSchemes;
   }
 
   public void setLocationSchemes(List<LocationScheme> locationSchemes) {

--- a/rest/src/main/java/com/percussion/rest/deliverytypes/DeliveryType.java
+++ b/rest/src/main/java/com/percussion/rest/deliverytypes/DeliveryType.java
@@ -22,9 +22,14 @@ import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Delivery Type in Percussion CMS. */
+/**
+ * Represents a Delivery Type in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code beanName} when set. Optional-returning getters historically serialized as empty/present
+ * beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "DeliveryType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Delivery Type.")
@@ -57,32 +62,32 @@ public class DeliveryType {
 
   public DeliveryType() {}
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getBeanName() {
-    return Optional.ofNullable(beanName);
+  public String getBeanName() {
+    return beanName;
   }
 
   public void setBeanName(String beanName) {

--- a/rest/src/main/java/com/percussion/rest/locationscheme/LocationScheme.java
+++ b/rest/src/main/java/com/percussion/rest/locationscheme/LocationScheme.java
@@ -23,9 +23,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Location Scheme. Sunny Sal: "Location scheme ka hero, publishing ka zero!" */
+/**
+ * Represents a Location Scheme.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code schemeId}, and related fields when set. Optional-returning getters historically serialized
+ * as empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 /
+ * #3388). Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "LocationScheme")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Location Scheme")
@@ -67,24 +73,24 @@ public class LocationScheme {
     // Default constructor
   }
 
-  public Optional<Guid> getSchemeId() {
-    return Optional.ofNullable(schemeId);
+  public Guid getSchemeId() {
+    return schemeId;
   }
 
   public void setSchemeId(Guid schemeId) {
     this.schemeId = schemeId;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -107,24 +113,24 @@ public class LocationScheme {
     this.contentTypeId = contentTypeId;
   }
 
-  public Optional<Guid> getContext() {
-    return Optional.ofNullable(context);
+  public Guid getContext() {
+    return context;
   }
 
   public void setContext(Guid context) {
     this.context = context;
   }
 
-  public Optional<String> getLocationSchemeGenerator() {
-    return Optional.ofNullable(locationSchemeGenerator);
+  public String getLocationSchemeGenerator() {
+    return locationSchemeGenerator;
   }
 
   public void setLocationSchemeGenerator(String locationSchemeGenerator) {
     this.locationSchemeGenerator = locationSchemeGenerator;
   }
 
-  public Optional<LocationSchemeParameterList> getParameters() {
-    return Optional.ofNullable(parameters);
+  public LocationSchemeParameterList getParameters() {
+    return parameters;
   }
 
   public void setParameters(LocationSchemeParameterList parameters) {

--- a/rest/src/main/java/com/percussion/rest/locationscheme/LocationSchemeParameter.java
+++ b/rest/src/main/java/com/percussion/rest/locationscheme/LocationSchemeParameter.java
@@ -22,9 +22,14 @@ package com.percussion.rest.locationscheme;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Location Scheme Parameter. Sunny Sal: "Parameter ka power, scheme ka tower!" */
+/**
+ * Represents a Location Scheme Parameter.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code value} when set. Optional-returning getters historically serialized as empty/present
+ * beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "LocationSchemeParameter")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Location Scheme Parameter")
@@ -46,32 +51,32 @@ public class LocationSchemeParameter {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<Integer> getSequence() {
-    return Optional.ofNullable(sequence);
+  public Integer getSequence() {
+    return sequence;
   }
 
   public void setSequence(Integer sequence) {
     this.sequence = sequence;
   }
 
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
     this.type = type;
   }
 
-  public Optional<String> getValue() {
-    return Optional.ofNullable(value);
+  public String getValue() {
+    return value;
   }
 
   public void setValue(String value) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,18 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.contexts.Context;
+import com.percussion.rest.deliverytypes.DeliveryType;
+import com.percussion.rest.locationscheme.LocationScheme;
+import com.percussion.rest.locationscheme.LocationSchemeParameter;
+import com.percussion.rest.locationscheme.LocationSchemeParameterList;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +38,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). LocationScheme /
+ * Context / DeliveryType follow the same plain-getter contract (issue #3412). All use plain getters
+ * under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +119,122 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void locationScheme_serializesNameNotOptionalBeans() {
+    LocationScheme scheme = new LocationScheme();
+    scheme.setSchemeId(new Guid("0-113-42"));
+    scheme.setName("generic");
+    scheme.setDescription("Generic location scheme");
+    scheme.setLocationSchemeGenerator("sys_GenericLocationSchemeGenerator");
+    scheme.setTemplateId(1018);
+    scheme.setContentTypeId(311);
+
+    ObjectMapper schemeMapper = new JacksonContextResolver().getContext(LocationScheme.class);
+    String json = schemeMapper.writeValueAsString(scheme);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("generic"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"locationSchemeGenerator\""), json);
+    assertTrue(json.contains("sys_GenericLocationSchemeGenerator"), json);
+    assertNoOptionalBeanKeys(json);
+
+    LocationScheme roundTrip = schemeMapper.readValue(json, LocationScheme.class);
+    assertEquals("generic", roundTrip.getName(), json);
+    assertEquals("Generic location scheme", roundTrip.getDescription(), json);
+    assertNotNull(roundTrip.getSchemeId(), json);
+  }
+
+  @Test
+  void locationSchemeParameter_serializesNameValueNotOptionalBeans() {
+    LocationSchemeParameter param = new LocationSchemeParameter();
+    param.setName("ext");
+    param.setSequence(1);
+    param.setType("String");
+    param.setValue(".html");
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(LocationSchemeParameter.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("ext"), json);
+    assertTrue(json.contains("\"value\""), json);
+    assertTrue(json.contains(".html"), json);
+    assertTrue(json.contains("\"sequence\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    LocationSchemeParameter roundTrip = paramMapper.readValue(json, LocationSchemeParameter.class);
+    assertEquals("ext", roundTrip.getName(), json);
+    assertEquals(".html", roundTrip.getValue(), json);
+    assertEquals(1, roundTrip.getSequence(), json);
+  }
+
+  @Test
+  void context_serializesNameAndNestedSchemeNotOptionalBeans() {
+    LocationScheme defaultScheme = new LocationScheme();
+    defaultScheme.setName("generic");
+    defaultScheme.setSchemeId(new Guid("0-113-42"));
+
+    LocationSchemeParameter param = new LocationSchemeParameter();
+    param.setName("ext");
+    param.setValue(".html");
+    LocationSchemeParameterList params = new LocationSchemeParameterList(List.of(param));
+    defaultScheme.setParameters(params);
+
+    Context context = new Context();
+    context.setId(new Guid("0-101-1"));
+    context.setName("Publish");
+    context.setDescription("Publish context");
+    context.setDefaultScheme(defaultScheme);
+    context.setLocationSchemes(List.of(defaultScheme));
+
+    ObjectMapper contextMapper = new JacksonContextResolver().getContext(Context.class);
+    String json = contextMapper.writeValueAsString(context);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("\"defaultScheme\""), json);
+    assertTrue(json.contains("generic"), json);
+    assertTrue(json.contains("\"locationSchemes\""), json);
+    assertTrue(json.contains("ext"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Context roundTrip = contextMapper.readValue(json, Context.class);
+    assertEquals("Publish", roundTrip.getName(), json);
+    assertNotNull(roundTrip.getDefaultScheme(), json);
+    assertEquals("generic", roundTrip.getDefaultScheme().getName(), json);
+    assertNotNull(roundTrip.getLocationSchemes(), json);
+    assertEquals(1, roundTrip.getLocationSchemes().size(), json);
+  }
+
+  @Test
+  void deliveryType_serializesNameBeanNotOptionalBeans() {
+    DeliveryType type = new DeliveryType();
+    type.setId(new Guid("0-115-7"));
+    type.setName("filesystem");
+    type.setDescription("File system delivery");
+    type.setBeanName("sys_fileDeliveryType");
+    type.setUnpublishingRequiresAssembly(false);
+
+    ObjectMapper typeMapper = new JacksonContextResolver().getContext(DeliveryType.class);
+    String json = typeMapper.writeValueAsString(type);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("filesystem"), json);
+    assertTrue(json.contains("\"beanName\""), json);
+    assertTrue(json.contains("sys_fileDeliveryType"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    DeliveryType roundTrip = typeMapper.readValue(json, DeliveryType.class);
+    assertEquals("filesystem", roundTrip.getName(), json);
+    assertEquals("sys_fileDeliveryType", roundTrip.getBeanName(), json);
+    assertEquals("File system delivery", roundTrip.getDescription(), json);
+    assertFalse(roundTrip.isUnpublishingRequiresAssembly(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }


### PR DESCRIPTION
## Summary

REST wire DTOs `LocationScheme`, `LocationSchemeParameter`, `Context`, and `DeliveryType` returned `Optional<T>` from JSON getters. That produced Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189).

This PR converts those publishing-location types to **plain nullable getters/setters** with existing `@JsonInclude(NON_NULL)` and updates sitemanage callers that used `ApiUtils.orNull(...)` / `flatMap` on the converted getters (`ContextAdaptor`, `DeliveryTypeAdaptor`).

Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.

**Partial #3388** — slice 4 only. Folder/Section (#3413) and Asset (#3418) stay out of scope. `rest/AGENTS.md` wire-getter convention is **not committed** (human rule review).

Operator: Grok: night-issue-prs (model grok-4.6)

Parent tracker: #3388

Fixes #3412

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — Tests run: 422, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125
3. Confirm `JacksonContextResolverOptionalTest` (8 tests) covers LocationScheme / LocationSchemeParameter / Context / DeliveryType round-trips
4. After merge: spot-check publishing Context / DeliveryType / LocationScheme JSON (no `empty`/`present` beans)

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): wire-getter type change only; no documented request/response example currently shows Optional-bean JSON
- [x] **Unit / module tests** — behavioral Jackson round-trips; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-dep sitemanage because public getter signatures changed
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 422, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public `Optional<T>` → `T` getters). Grep for `extends LocationScheme|LocationSchemeParameter|Context|DeliveryType` and `new Type() {` — no anonymous subclasses. Standalone sitemanage clean install green.

## C5 UI proof

N/A — backend REST DTO / adaptor change only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
