### PR TITLE
fix(rest): Folder/Section/path-request wire getters must not return Optional (#3413)

### DIFF
--- a/docs/ai-generated/code-reviews/3413-folder-section-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3413-folder-section-wire-getters-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #3413 Folder / Section / path-request wire getters
+
+**Branch:** `fix/issue-3413-folder-section-wire-getters`  
+**Scope:** uncommitted vs `HEAD` + commits not in `origin/main`  
+**Date:** 2026-08-15  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** REST DTO `Optional` getters serialize as empty/present beans or drop fields under `@JsonInclude(NON_NULL)` (ContentType #1693 / TemplateSummary #2189 / sibling #3412).
+
+## Summary
+
+Converts Explorer folder/section REST wire DTOs from `Optional<T>` getters to plain nullable getters with `@JsonInclude(NON_NULL)`, matching `ContentType` / LocationScheme (#3412) peer style. Updates `FoldersResource` and `FolderAdaptor` callers that used `.orElse()` / `.isPresent()` / `ApiUtils.orNull` / `ApiUtils.orEmpty` on converted getters. Appends production-mapper round-trip tests to `JacksonContextResolverOptionalTest` (does not rewrite existing methods).
+
+## Issues
+
+None (gate-blocking).
+
+## Notes (non-blocking)
+
+- `LinkRef` (parent of `SectionLinkRef`) still returns `Optional` for `name`/`href` — out of scope; nested landing-page JSON is asserted not to emit empty/present keys under the production mapper.
+- `rest/AGENTS.md` wire-getter convention remains uncommitted (human rule review).
+- Cross-platform path checklist: **N/A** (no filesystem I/O).
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 423, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
@@ -100,7 +100,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -336,7 +335,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       throw new BackendException(e);
     }
 
-    String folderNameStr = ApiUtils.orNull(folder.getName());
+    String folderNameStr = folder.getName();
     if (folderNameStr != null
         && StringUtils.startsWith(folderNameStr, EXTERNAL_SECTION_NAME_PREFIX)) {
       folder.setName(StringUtils.substringAfter(folderNameStr, EXTERNAL_SECTION_NAME_PREFIX));
@@ -363,7 +362,7 @@ public class FolderAdaptor implements IFolderAdaptor {
 
     List<String> existingFolders = new ArrayList<>();
     if (folder.getSubsections() != null) {
-      for (SectionLinkRef section : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef section : folder.getSubsections()) {
         existingFolders.add(ApiUtils.orNull(section.getName()));
       }
     }
@@ -524,38 +523,32 @@ public class FolderAdaptor implements IFolderAdaptor {
     try {
       checkAPIPermission();
 
-      String baseName = ApiUtils.orNull(folder.getName());
-      String baseSite = ApiUtils.orNull(folder.getSiteName());
-      String basePath = ApiUtils.orNull(folder.getPath());
+      String baseName = folder.getName();
+      String baseSite = folder.getSiteName();
+      String basePath = folder.getPath();
       Folder existingFolder = null;
       boolean newFolder = false;
       boolean byId =
-          StringUtils.isNotEmpty(ApiUtils.orNull(folder.getId()))
-              && ApiUtils.orNull(folder.getSiteName()) == null
-              && ApiUtils.orNull(folder.getPath()) == null
-              && ApiUtils.orNull(folder.getName()) == null;
+          StringUtils.isNotEmpty(folder.getId())
+              && folder.getSiteName() == null
+              && folder.getPath() == null
+              && folder.getName() == null;
       try {
         if (byId) {
 
-          existingFolder = getFolder(baseUri, ApiUtils.orNull(folder.getId()));
+          existingFolder = getFolder(baseUri, folder.getId());
         } else {
           existingFolder =
-              getFolder(
-                  baseUri,
-                  ApiUtils.orNull(folder.getSiteName()),
-                  ApiUtils.orNull(folder.getPath()),
-                  ApiUtils.orNull(folder.getName()));
+              getFolder(baseUri, folder.getSiteName(), folder.getPath(), folder.getName());
         }
       } catch (FolderNotFoundException | BackendException e) {
         newFolder = true;
-        if (StringUtils.isEmpty(ApiUtils.orNull(folder.getPath()))
-            && StringUtils.isEmpty(ApiUtils.orNull(folder.getName())))
+        if (StringUtils.isEmpty(folder.getPath()) && StringUtils.isEmpty(folder.getName()))
           throw new BackendException(
-              "Trying to create site root folder.  Create site first : "
-                  + ApiUtils.orNull(folder.getSiteName()));
+              "Trying to create site root folder.  Create site first : " + folder.getSiteName());
       }
 
-      if (!byId && existingFolder == null && ApiUtils.orNull(folder.getId()) != null) {
+      if (!byId && existingFolder == null && folder.getId() != null) {
         // If id is passed into update and it looks as if the item does not
         // already exist, we are probably trying to update a purged item, or
         // the id is from a different item.
@@ -563,14 +556,14 @@ public class FolderAdaptor implements IFolderAdaptor {
       }
 
       if (existingFolder != null
-          && ApiUtils.orNull(folder.getId()) != null
-          && ApiUtils.orNull(existingFolder.getId()) != null
-          && !ApiUtils.orNull(existingFolder.getId()).equals(ApiUtils.orNull(folder.getId())))
+          && folder.getId() != null
+          && existingFolder.getId() != null
+          && !existingFolder.getId().equals(folder.getId()))
         throw new BackendException(
             "Id "
-                + ApiUtils.orNull(folder.getId())
+                + folder.getId()
                 + " passed into update but Id does not match item referenced by site and path "
-                + ApiUtils.orNull(existingFolder.getId()));
+                + existingFolder.getId());
 
       if (newFolder) {
         String folderId = createNewFolder(baseUri, folder);
@@ -579,7 +572,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       } else {
         folder = modifyExistingFolder(baseUri, existingFolder, folder);
       }
-      if (ApiUtils.orNull(folder.getName()).equalsIgnoreCase("")) {
+      if ("".equalsIgnoreCase(folder.getName())) {
         folder.setName(baseName);
         folder.setSiteName(baseSite);
         folder.setPath(basePath);
@@ -594,12 +587,12 @@ public class FolderAdaptor implements IFolderAdaptor {
   private Folder modifyExistingFolder(URI baseUri, Folder existingFolder, Folder folder)
       throws IPSPathService.PSPathServiceException, PSDataServiceException, BackendException {
 
-    String realName = ApiUtils.orNull(folder.getName());
-    SectionInfo existingSec = existingFolder.getSectionInfo().orElse(null);
+    String realName = folder.getName();
+    SectionInfo existingSec = existingFolder.getSectionInfo();
     if (existingSec != null) {
-      Optional<String> existingType = existingSec.getType();
-      if (existingType.isPresent()
-          && existingType.get().equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
+      String existingType = existingSec.getType();
+      if (existingType != null
+          && existingType.equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
         realName = EXTERNAL_SECTION_NAME_PREFIX + realName;
       }
     }
@@ -609,7 +602,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     UrlParts folderSections = null;
 
     try {
-      PSLocator loc = idMapper.getLocator(ApiUtils.orNull(existingFolder.getId()));
+      PSLocator loc = idMapper.getLocator(existingFolder.getId());
       loc.setRevision(-1);
       pathItem = folderHelper.findItemById(idMapper.getString(loc));
     } catch (IPSDataService.DataServiceLoadException
@@ -636,22 +629,19 @@ public class FolderAdaptor implements IFolderAdaptor {
     updateFolderProperties(folder, pathItem.getId(), existingFolder);
 
     // Skip the section stuff for Asset folders.
-    if (!"Assets".equals(ApiUtils.orNull(folder.getSiteName()))) {
-      Optional<SectionInfo> reqSectionOpt = folder.getSectionInfo();
-      Optional<SectionInfo> currSectionOpt = existingFolder.getSectionInfo();
-      if (reqSectionOpt.isPresent() && currSectionOpt.isEmpty()) {
+    if (!"Assets".equals(folder.getSiteName())) {
+      SectionInfo reqSection = folder.getSectionInfo();
+      SectionInfo currSection = existingFolder.getSectionInfo();
+      if (reqSection != null && currSection == null) {
         convertFolderToSection(
-            folderSections.getUrl(),
-            ApiUtils.orNull(folder.getName()),
-            ApiUtils.orNull(folder.getSiteName()),
-            reqSectionOpt.get());
+            folderSections.getUrl(), folder.getName(), folder.getSiteName(), reqSection);
       }
 
       updateLandingPage(folder, existingFolder, folderSections.getUrl());
 
       updateSectionInfo(folder, folderSections.getUrl(), existingFolder);
 
-      reorderSiteSection(baseUri, ApiUtils.orNull(existingFolder.getId()), folder, existingFolder);
+      reorderSiteSection(baseUri, existingFolder.getId(), folder, existingFolder);
     }
 
     return existingFolder;
@@ -684,13 +674,12 @@ public class FolderAdaptor implements IFolderAdaptor {
 
   private void updateLandingPage(Folder folder, Folder existingFolder, String folderPath)
       throws IPSPathService.PSPathServiceException, PSDataServiceException, BackendException {
-    SectionInfo reqSectionInfo = folder.getSectionInfo().orElse(null);
-    SectionInfo currSectionInfo = existingFolder.getSectionInfo().orElse(null);
+    SectionInfo reqSectionInfo = folder.getSectionInfo();
+    SectionInfo currSectionInfo = existingFolder.getSectionInfo();
 
     if (reqSectionInfo != null && currSectionInfo != null) {
-      LinkRef reqLanding = reqSectionInfo.getLandingPage().orElse(null);
-      LinkRef existingLanding =
-          existingFolder.getSectionInfo().flatMap(SectionInfo::getLandingPage).orElse(null);
+      LinkRef reqLanding = reqSectionInfo.getLandingPage();
+      LinkRef existingLanding = currSectionInfo.getLandingPage();
 
       String reqName = ApiUtils.orNull(reqLanding == null ? null : reqLanding.getName());
       String existingName =
@@ -699,7 +688,8 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (reqName != null && !reqName.equals(existingName)) {
         // get child folders
         boolean foundPage = false;
-        for (LinkRef page : ApiUtils.orEmpty(existingFolder.getPages())) {
+        List<LinkRef> existingPages = existingFolder.getPages();
+        for (LinkRef page : existingPages == null ? List.<LinkRef>of() : existingPages) {
           if (reqName.equals(ApiUtils.orNull(page.getName()))) {
             foundPage = true;
             break;
@@ -739,7 +729,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       PSSiteSection currentSection = sectionService.load(idMapper.getString(id));
 
       PSFolderProperties folderProps =
-          folderHelper.findFolderProperties(ApiUtils.orNull(existingFolder.getId()));
+          folderHelper.findFolderProperties(existingFolder.getId());
 
       if (currentSection.getSectionType() == PSSectionTypeEnum.section) {
         PSSiteSectionProperties req = new PSSiteSectionProperties();
@@ -753,18 +743,18 @@ public class FolderAdaptor implements IFolderAdaptor {
         req.setTarget(currentSection.getTarget());
         req.setTitle(currentSection.getTitle());
 
-        SectionInfo toSection = folder.getSectionInfo().orElse(null);
+        SectionInfo toSection = folder.getSectionInfo();
         if (toSection != null) {
-          if (toSection.getDisplayTitle().isPresent()) {
-            req.setTitle(toSection.getDisplayTitle().get());
+          if (toSection.getDisplayTitle() != null) {
+            req.setTitle(toSection.getDisplayTitle());
           }
 
-          if (toSection.getNavClass().isPresent()) {
-            req.setCssClassNames(toSection.getNavClass().get());
+          if (toSection.getNavClass() != null) {
+            req.setCssClassNames(toSection.getNavClass());
           }
 
-          if (toSection.getTargetWindow().isPresent()) {
-            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow().get()));
+          if (toSection.getTargetWindow() != null) {
+            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow()));
           }
         }
         // update landing page
@@ -784,20 +774,18 @@ public class FolderAdaptor implements IFolderAdaptor {
                 : currentSection.getTarget();
         req.setTarget(target);
 
-        SectionInfo toSection = folder.getSectionInfo().orElse(null);
+        SectionInfo toSection = folder.getSectionInfo();
         if (toSection != null) {
-          if (toSection.getDisplayTitle().isPresent())
-            req.setLinkTitle(toSection.getDisplayTitle().get());
+          if (toSection.getDisplayTitle() != null) req.setLinkTitle(toSection.getDisplayTitle());
 
-          if (toSection.getNavClass().isPresent())
-            req.setCssClassNames(toSection.getNavClass().get());
+          if (toSection.getNavClass() != null) req.setCssClassNames(toSection.getNavClass());
 
-          if (toSection.getTargetWindow().isPresent()) {
-            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow().get()));
+          if (toSection.getTargetWindow() != null) {
+            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow()));
           }
 
-          if (toSection.getExternalLinkUrl().isPresent()) {
-            req.setExternalUrl(toSection.getExternalLinkUrl().get());
+          if (toSection.getExternalLinkUrl() != null) {
+            req.setExternalUrl(toSection.getExternalLinkUrl());
           }
         }
 
@@ -814,24 +802,23 @@ public class FolderAdaptor implements IFolderAdaptor {
     String parentFolderPath = StringUtils.substringBeforeLast(folderPath, "/" + folderName);
 
     String name = "index.html";
-    Optional<LinkRef> landOpt = sectionInfo.getLandingPage();
+    LinkRef landOpt = sectionInfo.getLandingPage();
     // compute landing name and if available override default
-    String landingName = landOpt.flatMap(LinkRef::getName).orElse(null);
+    String landingName = landOpt == null ? null : landOpt.getName().orElse(null);
     if (landingName != null) {
       name = landingName;
     }
     // CMS-3210 - NC
     boolean exists = checkIfPageExists(folderPath + "/" + name);
 
-    String templateId =
-        getTemplateIdForName(ApiUtils.orNull(sectionInfo.getTemplateName()), siteName);
+    String templateId = getTemplateIdForName(sectionInfo.getTemplateName(), siteName);
 
     if (!exists) {
       PSPage page = new PSPage();
       page.setFolderPath("/" + folderPath);
 
       String title =
-          StringUtils.defaultString(ApiUtils.orNull(sectionInfo.getDisplayTitle()), folderName);
+          StringUtils.defaultString(sectionInfo.getDisplayTitle(), folderName);
 
       page.setName(name);
       page.setTitle(title);
@@ -884,13 +871,13 @@ public class FolderAdaptor implements IFolderAdaptor {
     List<String> requestedSubSections = new ArrayList<>();
 
     if (folder.getSubsections() != null) {
-      if (folder.getSectionInfo().isEmpty() && existingFolder.getSectionInfo().isEmpty())
+      if (folder.getSectionInfo() == null && existingFolder.getSectionInfo() == null)
         throw new BackendException("non-section folders cannot have subsections");
       String nameCheck = null;
-      for (SectionLinkRef subsection : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef subsection : folder.getSubsections()) {
         String secName = ApiUtils.orNull(subsection.getName());
         String secHref = ApiUtils.orNull(subsection.getHref());
-        if (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name()))
+        if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
           nameCheck = secName + "-" + secHref;
         else nameCheck = secName;
 
@@ -904,10 +891,10 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       if (existingFolder.getSubsections() != null) {
 
-        for (SectionLinkRef subsection : ApiUtils.orEmpty(existingFolder.getSubsections())) {
+        for (SectionLinkRef subsection : existingFolder.getSubsections()) {
           String secName = ApiUtils.orNull(subsection.getName());
           String secHref = ApiUtils.orNull(subsection.getHref());
-          if (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name()))
+          if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
             nameCheck = secName + "-" + secHref;
           else nameCheck = secName;
 
@@ -919,19 +906,14 @@ public class FolderAdaptor implements IFolderAdaptor {
       subSectionsToCreate.removeAll(existingSubSections);
 
       for (String createName : subSectionsToCreate) {
-        for (SectionLinkRef subsection : ApiUtils.orEmpty(folder.getSubsections())) {
+        for (SectionLinkRef subsection : folder.getSubsections()) {
           String nameVal = ApiUtils.orNull(subsection.getName());
           String hrefVal = ApiUtils.orNull(subsection.getHref());
           if (nameVal.equals(createName)
-              || (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name())
+              || (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType())
                   && createName.equals(nameVal + "-" + hrefVal))) {
             createSubSection(
-                baseUri,
-                existingFolder,
-                folder,
-                nameVal,
-                ApiUtils.orNull(subsection.getType()),
-                hrefVal);
+                baseUri, existingFolder, folder, nameVal, subsection.getType(), hrefVal);
           }
         }
       }
@@ -948,19 +930,13 @@ public class FolderAdaptor implements IFolderAdaptor {
   private String createNewFolder(URI baseUri, Folder folder)
       throws PSDataServiceException, IPSPathService.PSPathServiceException, BackendException {
 
-    UrlParts fullUrl =
-        new UrlParts(
-            ApiUtils.orNull(folder.getSiteName()),
-            ApiUtils.orNull(folder.getPath()),
-            ApiUtils.orNull(folder.getName()));
-    UrlParts parentUrl =
-        new UrlParts(ApiUtils.orNull(folder.getSiteName()), ApiUtils.orNull(folder.getPath()), "");
+    UrlParts fullUrl = new UrlParts(folder.getSiteName(), folder.getPath(), folder.getName());
+    UrlParts parentUrl = new UrlParts(folder.getSiteName(), folder.getPath(), "");
 
     PSPathItem newFolder = null;
 
     // Create a folder with a section.
-    if (!ApiUtils.orNull(folder.getSiteName()).equals("Assets")
-        && folder.getSectionInfo().isPresent()) {
+    if (!"Assets".equals(folder.getSiteName()) && folder.getSectionInfo() != null) {
       newFolder = createNewSection(folder, parentUrl);
     } else
     // Create a regular folder
@@ -976,8 +952,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     updateFolderProperties(folder, newFolder.getId(), null);
 
     // create subsections
-    if (!ApiUtils.orNull(folder.getSiteName()).equals("Assets"))
-      createSubSections(baseUri, folder, folder);
+    if (!"Assets".equals(folder.getSiteName())) createSubSections(baseUri, folder, folder);
 
     return newFolder.getId();
   }
@@ -998,17 +973,17 @@ public class FolderAdaptor implements IFolderAdaptor {
       throws BackendException, PSDataServiceException, IPSPathService.PSPathServiceException {
 
     if (folder.getSubsections() != null) {
-      if (folder.getSectionInfo().isEmpty())
+      if (folder.getSectionInfo() == null)
         throw new BackendException("non-section folders cannot have subsections");
 
-      for (SectionLinkRef subSection : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef subSection : folder.getSubsections()) {
         String name = ApiUtils.orNull(subSection.getName());
         createSubSection(
             baseUri,
             existingFolder,
             folder,
             name,
-            ApiUtils.orNull(subSection.getType()),
+            subSection.getType(),
             ApiUtils.orNull(subSection.getHref()));
       }
     }
@@ -1029,16 +1004,15 @@ public class FolderAdaptor implements IFolderAdaptor {
 
     if (!type.equalsIgnoreCase(PSSectionTypeEnum.sectionlink.name())) {
       Folder subFolder = new Folder();
-      subFolder.setSiteName(ApiUtils.orNull(folder.getSiteName()));
-      subFolder.setPath(
-          ApiUtils.orNull(folder.getPath()) + "/" + ApiUtils.orNull(folder.getName()));
+      subFolder.setSiteName(folder.getSiteName());
+      subFolder.setPath(folder.getPath() + "/" + folder.getName());
       subFolder.setName(name);
 
-      String wf = ApiUtils.orNull(folder.getWorkflow());
+      String wf = folder.getWorkflow();
       if (wf != null) {
         subFolder.setWorkflow(wf);
       } else if (existingFolder != null) {
-        wf = ApiUtils.orNull(existingFolder.getWorkflow());
+        wf = existingFolder.getWorkflow();
         if (wf != null) {
           subFolder.setWorkflow(wf);
         }
@@ -1052,11 +1026,12 @@ public class FolderAdaptor implements IFolderAdaptor {
         subSectionInfo.setExternalLinkUrl(extUrl);
       subSectionInfo.setDisplayTitle(name);
       String templateName = null;
-      Optional<SectionInfo> folderSection = folder.getSectionInfo();
-      if (folderSection.flatMap(SectionInfo::getTemplateName).isPresent())
-        templateName = folderSection.flatMap(SectionInfo::getTemplateName).get();
-      else if (existingFolder.getSectionInfo().flatMap(SectionInfo::getTemplateName).isPresent())
-        templateName = existingFolder.getSectionInfo().flatMap(SectionInfo::getTemplateName).get();
+      SectionInfo folderSection = folder.getSectionInfo();
+      if (folderSection != null && folderSection.getTemplateName() != null)
+        templateName = folderSection.getTemplateName();
+      else if (existingFolder.getSectionInfo() != null
+          && existingFolder.getSectionInfo().getTemplateName() != null)
+        templateName = existingFolder.getSectionInfo().getTemplateName();
 
       subSectionInfo.setTemplateName(templateName);
 
@@ -1070,11 +1045,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (toGuid == null)
         throw new BackendException(
             "Cannot create section link to section that does not yet exist " + path);
-      UrlParts fromFolder =
-          new UrlParts(
-              ApiUtils.orNull(folder.getSiteName()),
-              ApiUtils.orNull(folder.getPath()),
-              ApiUtils.orNull(folder.getName()));
+      UrlParts fromFolder = new UrlParts(folder.getSiteName(), folder.getPath(), folder.getName());
       String fromGuid = getNavGuidByPath(fromFolder.getUrl());
       sectionService.createSectionLink(toGuid, fromGuid);
     }
@@ -1111,18 +1082,18 @@ public class FolderAdaptor implements IFolderAdaptor {
           "can only create section folders that are child folders of other sections.");
     }
 
-    SectionInfo section = folder.getSectionInfo().orElse(null);
+    SectionInfo section = folder.getSectionInfo();
     PSSiteSection newSection = null;
-    String sectionType = section == null ? null : ApiUtils.orNull(section.getType());
+    String sectionType = section == null ? null : section.getType();
     if (sectionType != null
         && sectionType.equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
       PSCreateExternalLinkSection req = new PSCreateExternalLinkSection();
-      req.setCssClassNames(section == null ? null : ApiUtils.orNull(section.getNavClass()));
-      req.setExternalUrl(section == null ? null : ApiUtils.orNull(section.getExternalLinkUrl()));
+      req.setCssClassNames(section == null ? null : section.getNavClass());
+      req.setExternalUrl(section == null ? null : section.getExternalLinkUrl());
       req.setFolderPath(parentFolderUrl);
-      req.setLinkTitle(section == null ? null : ApiUtils.orNull(section.getDisplayTitle()));
+      req.setLinkTitle(section == null ? null : section.getDisplayTitle());
       req.setSectionType(PSSectionTypeEnum.externallink);
-      String targetWindow = section == null ? null : ApiUtils.orNull(section.getTargetWindow());
+      String targetWindow = section == null ? null : section.getTargetWindow();
       PSSectionTargetEnum target =
           (targetWindow == null)
               ? PSSectionTargetEnum._self
@@ -1138,30 +1109,31 @@ public class FolderAdaptor implements IFolderAdaptor {
       request.setFolderPath(parentFolderUrl);
 
       // get specified landing page name or use index if does not exist.
-      if (section != null && section.getLandingPage().flatMap(LinkRef::getName).isPresent()) {
-        request.setPageName(section.getLandingPage().flatMap(LinkRef::getName).orElse(null));
+      LinkRef landing = section == null ? null : section.getLandingPage();
+      String landingName = landing == null ? null : landing.getName().orElse(null);
+      if (landingName != null) {
+        request.setPageName(landingName);
       } else {
         request.setPageName("index.html");
       }
-      String displayTitle = section == null ? null : ApiUtils.orNull(section.getDisplayTitle());
+      String displayTitle = section == null ? null : section.getDisplayTitle();
       if (displayTitle == null) {
-        displayTitle = ApiUtils.orNull(folder.getName());
+        displayTitle = folder.getName();
       }
 
       request.setPageLinkTitle(displayTitle);
       request.setPageTitle(displayTitle);
-      request.setPageUrlIdentifier(ApiUtils.orNull(folder.getName()));
+      request.setPageUrlIdentifier(folder.getName());
       request.setSectionType(PSSectionTypeEnum.section);
       IPSGuid template = null;
 
-      if (section == null || section.getTemplateName().orElse(null) == null) {
+      if (section == null || section.getTemplateName() == null) {
         throw new BackendException("templateName is required for section");
       }
       try {
         template =
             templateService.findUserTemplateIdByName(
-                section == null ? null : section.getTemplateName().orElse(null),
-                ApiUtils.orNull(folder.getSiteName()));
+                section.getTemplateName(), folder.getSiteName());
       } catch (PSParametersValidationException | IPSDataService.DataServiceLoadException e) {
         throw new BackendException("Cannot find template " + section.getTemplateName());
       }
@@ -1177,7 +1149,7 @@ public class FolderAdaptor implements IFolderAdaptor {
   }
 
   private boolean updateWorkflow(Folder folder, PSFolderProperties folderProperties) {
-    String requestWorkflow = ApiUtils.orNull(folder.getWorkflow());
+    String requestWorkflow = folder.getWorkflow();
     if (requestWorkflow != null) {
       int wfid;
       if (requestWorkflow.equalsIgnoreCase("[default]")) {
@@ -1202,26 +1174,25 @@ public class FolderAdaptor implements IFolderAdaptor {
     Access accessLevel = permission.getAccessLevel();
 
     boolean isSection =
-        ((existingFolder != null && existingFolder.getSectionInfo().isPresent())
-            || folder.getSectionInfo().isPresent());
+        (existingFolder != null && existingFolder.getSectionInfo() != null)
+            || folder.getSectionInfo() != null;
 
     // Need to change to write if we are converting to a section and the
     // original access level was ADMIN
 
     if (existingFolder != null
         && isSection
-        && existingFolder.getSectionInfo().isEmpty()
-        && existingFolder.getAccessLevel().orElse("").equals("ADMIN")) {
+        && existingFolder.getSectionInfo() == null
+        && "ADMIN".equals(existingFolder.getAccessLevel())) {
       folder.setAccessLevel("WRITE");
       changed = true;
     }
 
     // FB: EC_UNRELATED_TYPES NC 1-16-16
-    if (folder.getAccessLevel().isPresent()
-        && !folder.getAccessLevel().get().equals(accessLevel.name())) {
+    if (folder.getAccessLevel() != null && !folder.getAccessLevel().equals(accessLevel.name())) {
       // default for section is write, does not allow admin. default for
       // non section is admin. Unknown will be set to correct default
-      String level = ApiUtils.orNull(folder.getAccessLevel());
+      String level = folder.getAccessLevel();
       if (isSection) {
         if (!(level.equals("READ") || level.equals("WRITE"))) {
           level = "WRITE";
@@ -1234,7 +1205,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       changed = true;
     }
 
-    Collection<String> editUsers = ApiUtils.orEmpty(folder.getEditUsers());
+    Collection<String> editUsers = folder.getEditUsers();
     if (editUsers != null) {
       List<String> serverUsers = new ArrayList<>();
       List<Principal> writePrincipals = permission.getWritePrincipals();

--- a/rest/src/main/java/com/percussion/rest/MoveFolderItem.java
+++ b/rest/src/main/java/com/percussion/rest/MoveFolderItem.java
@@ -18,18 +18,22 @@
 package com.percussion.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * This class is posted to the REST service as part of a request to move an item (from its original
  * folder) to a new (target) folder. All paths are relative to its current root folder.
  *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits path
+ * scalars (issue #3413 / #3388).
+ *
  * @author yubingchen
  */
 @XmlRootElement(name = "MoveFolderItem")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a request to move a folder item.")
 public class MoveFolderItem {
   @Schema(required = true, description = "path")
@@ -53,8 +57,8 @@ public class MoveFolderItem {
    *
    * @return the target folder path, not blank for a valid folder path.
    */
-  public Optional<String> getTargetFolderPath() {
-    return Optional.ofNullable(targetFolderPath);
+  public String getTargetFolderPath() {
+    return targetFolderPath;
   }
 
   /**
@@ -71,8 +75,8 @@ public class MoveFolderItem {
    *
    * @return item path, not blank for a valid path.
    */
-  public Optional<String> getItemPath() {
-    return Optional.ofNullable(itemPath);
+  public String getItemPath() {
+    return itemPath;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/folders/CopyFolderItemRequest.java
+++ b/rest/src/main/java/com/percussion/rest/folders/CopyFolderItemRequest.java
@@ -20,13 +20,19 @@
 package com.percussion.rest.folders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a request to copy a folder or item. Sunny Sal: "Copy ka request aaya, boss!" */
+/**
+ * Represents a request to copy a folder or item.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits path
+ * scalars (issue #3413 / #3388).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a request to copy a folder or item")
 public class CopyFolderItemRequest {
 
@@ -51,10 +57,10 @@ public class CopyFolderItemRequest {
   /**
    * Gets the target folder path.
    *
-   * @return Optional containing the target folder path if present
+   * @return the target folder path, or {@code null} if unset
    */
-  public Optional<String> getTargetFolderPath() {
-    return Optional.ofNullable(targetFolderPath);
+  public String getTargetFolderPath() {
+    return targetFolderPath;
   }
 
   public void setTargetFolderPath(String targetFolderPath) {
@@ -64,10 +70,10 @@ public class CopyFolderItemRequest {
   /**
    * Gets the item path.
    *
-   * @return Optional containing the item path if present
+   * @return the item path, or {@code null} if unset
    */
-  public Optional<String> getItemPath() {
-    return Optional.ofNullable(itemPath);
+  public String getItemPath() {
+    return itemPath;
   }
 
   public void setItemPath(String itemPath) {

--- a/rest/src/main/java/com/percussion/rest/folders/Folder.java
+++ b/rest/src/main/java/com/percussion/rest/folders/Folder.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.folders;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.core.UriBuilder;
@@ -26,12 +27,18 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
- * Represents a folder or section based on a folder. Sunny Sal: "Folder ka hero, structure ka zero!"
+ * Represents a folder or section based on a folder.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code path}, {@code siteName}, and related fields when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3413 / #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
  */
 @XmlRootElement(name = "Folder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a folder or section based on a folder")
 public class Folder {
 
@@ -112,24 +119,24 @@ public class Folder {
     this.communityId = communityId;
   }
 
-  public Optional<String> getCommunityName() {
-    return Optional.ofNullable(communityName);
+  public String getCommunityName() {
+    return communityName;
   }
 
   public void setCommunityName(String communityName) {
     this.communityName = communityName;
   }
 
-  public Optional<String> getDefaultDisplayFormatName() {
-    return Optional.ofNullable(defaultDisplayFormatName);
+  public String getDefaultDisplayFormatName() {
+    return defaultDisplayFormatName;
   }
 
   public void setDefaultDisplayFormatName(String defaultDisplayFormatName) {
     this.defaultDisplayFormatName = defaultDisplayFormatName;
   }
 
-  public Optional<String> getLocale() {
-    return Optional.ofNullable(locale);
+  public String getLocale() {
+    return locale;
   }
 
   public void setLocale(String locale) {
@@ -147,96 +154,96 @@ public class Folder {
     this.recentUsers = recentUsers;
   }
 
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getPath() {
-    return Optional.ofNullable(path);
+  public String getPath() {
+    return path;
   }
 
   public void setPath(String path) {
     this.path = path;
   }
 
-  public Optional<String> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public String getWorkflow() {
+    return workflow;
   }
 
   public void setWorkflow(String workflow) {
     this.workflow = workflow;
   }
 
-  public Optional<SectionInfo> getSectionInfo() {
-    return Optional.ofNullable(sectionInfo);
+  public SectionInfo getSectionInfo() {
+    return sectionInfo;
   }
 
   public void setSectionInfo(SectionInfo sectionInfo) {
     this.sectionInfo = sectionInfo;
   }
 
-  public Optional<List<LinkRef>> getPages() {
-    return Optional.ofNullable(pages);
+  public List<LinkRef> getPages() {
+    return pages;
   }
 
   public void setPages(List<LinkRef> pages) {
     this.pages = pages;
   }
 
-  public Optional<List<LinkRef>> getAssets() {
-    return Optional.ofNullable(assets);
+  public List<LinkRef> getAssets() {
+    return assets;
   }
 
   public void setAssets(List<LinkRef> assets) {
     this.assets = assets;
   }
 
-  public Optional<List<LinkRef>> getSubfolders() {
-    return Optional.ofNullable(subfolders);
+  public List<LinkRef> getSubfolders() {
+    return subfolders;
   }
 
   public void setSubfolders(List<LinkRef> subfolders) {
     this.subfolders = subfolders;
   }
 
-  public Optional<List<SectionLinkRef>> getSubsections() {
-    return Optional.ofNullable(subsections);
+  public List<SectionLinkRef> getSubsections() {
+    return subsections;
   }
 
   public void setSubsections(List<SectionLinkRef> subsections) {
     this.subsections = subsections;
   }
 
-  public Optional<String> getAccessLevel() {
-    return Optional.ofNullable(accessLevel);
+  public String getAccessLevel() {
+    return accessLevel;
   }
 
   public void setAccessLevel(String accessLevel) {
     this.accessLevel = accessLevel;
   }
 
-  public Optional<List<String>> getEditUsers() {
-    return Optional.ofNullable(editUsers);
+  public List<String> getEditUsers() {
+    return editUsers;
   }
 
   public void setEditUsers(List<String> editUsers) {

--- a/rest/src/main/java/com/percussion/rest/folders/FoldersResource.java
+++ b/rest/src/main/java/com/percussion/rest/folders/FoldersResource.java
@@ -209,9 +209,9 @@ public class FoldersResource {
         folderName = StringUtils.defaultString(m.group(5));
       }
 
-      String objectName = folder.getName().orElse(null);
-      String objectPath = folder.getPath().orElse(null);
-      String objectSite = folder.getSiteName().orElse(null);
+      String objectName = folder.getName();
+      String objectPath = folder.getPath();
+      String objectSite = folder.getSiteName();
 
       if (objectName != null && !objectName.equals(folderName)) {
         throw new LocationMismatchException();
@@ -221,7 +221,7 @@ public class FoldersResource {
         throw new LocationMismatchException();
       }
       folder.setName(folderName);
-      folder.setPath(folder.getPath().orElse(null));
+      folder.setPath(objectPath);
       folder.setSiteName(siteName);
 
       folder = folderAdaptor.updateFolder(uriInfo.getBaseUri(), folder);
@@ -368,9 +368,7 @@ public class FoldersResource {
   public Status moveFolderItem(MoveFolderItem moveRequest) {
     try {
       folderAdaptor.moveFolderItem(
-          uriInfo.getBaseUri(),
-          moveRequest.getItemPath().orElse(null),
-          moveRequest.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), moveRequest.getItemPath(), moveRequest.getTargetFolderPath());
       return new Status("Moved OK");
     } catch (BackendException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -404,9 +402,7 @@ public class FoldersResource {
   public Status moveFolder(MoveFolderItem moveRequest) {
     try {
       folderAdaptor.moveFolderItem(
-          uriInfo.getBaseUri(),
-          moveRequest.getItemPath().orElse(null),
-          moveRequest.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), moveRequest.getItemPath(), moveRequest.getTargetFolderPath());
       return new Status("Moved OK");
     } catch (BackendException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -441,9 +437,7 @@ public class FoldersResource {
   public Status copyFolderItem(CopyFolderItemRequest request) {
     try {
       folderAdaptor.copyFolderItem(
-          uriInfo.getBaseUri(),
-          request.getItemPath().orElse(null),
-          request.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), request.getItemPath(), request.getTargetFolderPath());
       return new Status(200, "Copied OK");
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -477,9 +471,7 @@ public class FoldersResource {
   public Status copyFolder(CopyFolderItemRequest request) {
     try {
       folderAdaptor.copyFolder(
-          uriInfo.getBaseUri(),
-          request.getItemPath().orElse(null),
-          request.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), request.getItemPath(), request.getTargetFolderPath());
       return new Status(200, "Copied OK");
     } catch (NotFoundException nfe) {
       return new Status(404, "Not Found");

--- a/rest/src/main/java/com/percussion/rest/folders/SectionInfo.java
+++ b/rest/src/main/java/com/percussion/rest/folders/SectionInfo.java
@@ -24,9 +24,14 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents section information for a folder. Sunny Sal: "Section info ka boss!" */
+/**
+ * Represents section information for a folder.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars when
+ * set. Optional-returning getters historically serialized as empty/present beans (issue #3413 /
+ * #3388).
+ */
 @XmlRootElement(name = "SectionInfo")
 @JsonInclude(Include.NON_NULL)
 public class SectionInfo {
@@ -60,56 +65,56 @@ public class SectionInfo {
   @Schema(name = "externalLinkUrl", description = "Link to the external source.")
   private String externalLinkUrl;
 
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
     this.type = type;
   }
 
-  public Optional<String> getDisplayTitle() {
-    return Optional.ofNullable(displayTitle);
+  public String getDisplayTitle() {
+    return displayTitle;
   }
 
   public void setDisplayTitle(String displayTitle) {
     this.displayTitle = displayTitle;
   }
 
-  public Optional<String> getTargetWindow() {
-    return Optional.ofNullable(targetWindow);
+  public String getTargetWindow() {
+    return targetWindow;
   }
 
   public void setTargetWindow(String targetWindow) {
     this.targetWindow = targetWindow;
   }
 
-  public Optional<String> getNavClass() {
-    return Optional.ofNullable(navClass);
+  public String getNavClass() {
+    return navClass;
   }
 
   public void setNavClass(String navClass) {
     this.navClass = navClass;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<LinkRef> getLandingPage() {
-    return Optional.ofNullable(landingPage);
+  public LinkRef getLandingPage() {
+    return landingPage;
   }
 
   public void setLandingPage(LinkRef landingPage) {
     this.landingPage = landingPage;
   }
 
-  public Optional<String> getExternalLinkUrl() {
-    return Optional.ofNullable(externalLinkUrl);
+  public String getExternalLinkUrl() {
+    return externalLinkUrl;
   }
 
   public void setExternalLinkUrl(String externalLinkUrl) {

--- a/rest/src/main/java/com/percussion/rest/folders/SectionLinkRef.java
+++ b/rest/src/main/java/com/percussion/rest/folders/SectionLinkRef.java
@@ -20,16 +20,20 @@
 package com.percussion.rest.folders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
- * Represents a section link reference. Sunny Sal: "Section link ka reference, navigation ka sense!"
+ * Represents a section link reference.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code type}
+ * as a scalar (issue #3413 / #3388).
  */
 @XmlRootElement(name = "SectionLinkRef")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SectionLinkRef extends LinkRef {
 
   @Schema(
@@ -64,10 +68,10 @@ public class SectionLinkRef extends LinkRef {
   /**
    * Gets the type of the section link.
    *
-   * @return Optional containing the type if present
+   * @return the type, or {@code null} if unset
    */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,19 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.LinkRef;
+import com.percussion.rest.MoveFolderItem;
+import com.percussion.rest.folders.CopyFolderItemRequest;
+import com.percussion.rest.folders.Folder;
+import com.percussion.rest.folders.SectionInfo;
+import com.percussion.rest.folders.SectionLinkRef;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -111,5 +119,140 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void folder_serializesNamePathSiteNotOptionalBeans() {
+    Folder folder = new Folder();
+    folder.setId("guid-1");
+    folder.setName("News");
+    folder.setSiteName("Corporate");
+    folder.setPath("sections");
+    folder.setWorkflow("default");
+    folder.setAccessLevel(Folder.ACCESS_LEVEL_WRITE);
+    folder.setCommunityName("Default");
+    folder.setDefaultDisplayFormatName("Related Content");
+    folder.setLocale("en-us");
+    folder.setEditUsers(List.of("Admin"));
+
+    SectionInfo info = new SectionInfo();
+    info.setType("section");
+    info.setDisplayTitle("News Section");
+    info.setTargetWindow("_self");
+    info.setNavClass("nav-news");
+    info.setTemplateName("perc.page");
+    info.setLandingPage(new LinkRef("index.html", "http://example.com/index.html"));
+    folder.setSectionInfo(info);
+
+    folder.setPages(List.of(new LinkRef("index.html", "http://example.com/index.html")));
+    folder.setSubfolders(List.of(new LinkRef("archive", "http://example.com/archive")));
+    folder.setSubsections(
+        List.of(new SectionLinkRef("Press", "http://example.com/press", SectionLinkRef.TYPE_INTERNAL)));
+
+    ObjectMapper folderMapper = new JacksonContextResolver().getContext(Folder.class);
+    String json = folderMapper.writeValueAsString(folder);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("News"), json);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Corporate"), json);
+    assertTrue(json.contains("\"path\""), json);
+    assertTrue(json.contains("sections"), json);
+    assertTrue(json.contains("\"sectionInfo\""), json);
+    assertTrue(json.contains("News Section"), json);
+    assertTrue(json.contains("\"subsections\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    Folder roundTrip = folderMapper.readValue(json, Folder.class);
+    assertEquals("News", roundTrip.getName(), json);
+    assertEquals("Corporate", roundTrip.getSiteName(), json);
+    assertEquals("sections", roundTrip.getPath(), json);
+    assertNotNull(roundTrip.getSectionInfo(), json);
+    assertEquals("News Section", roundTrip.getSectionInfo().getDisplayTitle(), json);
+    assertEquals("perc.page", roundTrip.getSectionInfo().getTemplateName(), json);
+  }
+
+  @Test
+  void sectionInfo_serializesScalarsNotOptionalBeans() {
+    SectionInfo info = new SectionInfo();
+    info.setType("externallink");
+    info.setDisplayTitle("Partner");
+    info.setTargetWindow("_blank");
+    info.setNavClass("nav-ext");
+    info.setTemplateName("perc.page");
+    info.setExternalLinkUrl("https://partner.example");
+    info.setLandingPage(new LinkRef("home", "https://partner.example/"));
+
+    ObjectMapper infoMapper = new JacksonContextResolver().getContext(SectionInfo.class);
+    String json = infoMapper.writeValueAsString(info);
+    assertTrue(json.contains("\"displayTitle\""), json);
+    assertTrue(json.contains("Partner"), json);
+    assertTrue(json.contains("\"externalLinkUrl\""), json);
+    assertTrue(json.contains("https://partner.example"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    SectionInfo roundTrip = infoMapper.readValue(json, SectionInfo.class);
+    assertEquals("externallink", roundTrip.getType(), json);
+    assertEquals("Partner", roundTrip.getDisplayTitle(), json);
+    assertEquals("https://partner.example", roundTrip.getExternalLinkUrl(), json);
+    assertNotNull(roundTrip.getLandingPage(), json);
+  }
+
+  @Test
+  void sectionLinkRef_serializesTypeNotOptionalBeans() {
+    SectionLinkRef ref =
+        new SectionLinkRef("Press", "http://example.com/press", SectionLinkRef.TYPE_EXTERNAL);
+
+    ObjectMapper refMapper = new JacksonContextResolver().getContext(SectionLinkRef.class);
+    String json = refMapper.writeValueAsString(ref);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains(SectionLinkRef.TYPE_EXTERNAL), json);
+    assertTrue(json.contains("Press"), json);
+    assertNoOptionalBeanKeys(json);
+
+    SectionLinkRef roundTrip = refMapper.readValue(json, SectionLinkRef.class);
+    assertEquals(SectionLinkRef.TYPE_EXTERNAL, roundTrip.getType(), json);
+    assertEquals("Press", roundTrip.getName().orElse(null), json);
+  }
+
+  @Test
+  void copyFolderItemRequest_serializesPathsNotOptionalBeans() {
+    CopyFolderItemRequest req =
+        new CopyFolderItemRequest("/Sites/A/dest", "/Sites/A/src/page.html");
+
+    ObjectMapper reqMapper = new JacksonContextResolver().getContext(CopyFolderItemRequest.class);
+    String json = reqMapper.writeValueAsString(req);
+    assertTrue(json.contains("\"targetFolderPath\""), json);
+    assertTrue(json.contains("/Sites/A/dest"), json);
+    assertTrue(json.contains("\"itemPath\""), json);
+    assertTrue(json.contains("/Sites/A/src/page.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    CopyFolderItemRequest roundTrip = reqMapper.readValue(json, CopyFolderItemRequest.class);
+    assertEquals("/Sites/A/dest", roundTrip.getTargetFolderPath(), json);
+    assertEquals("/Sites/A/src/page.html", roundTrip.getItemPath(), json);
+  }
+
+  @Test
+  void moveFolderItem_serializesPathsNotOptionalBeans() {
+    MoveFolderItem req = new MoveFolderItem("/Sites/A/src/page.html", "/Sites/A/dest");
+
+    ObjectMapper reqMapper = new JacksonContextResolver().getContext(MoveFolderItem.class);
+    String json = reqMapper.writeValueAsString(req);
+    assertTrue(json.contains("\"targetFolderPath\""), json);
+    assertTrue(json.contains("/Sites/A/dest"), json);
+    assertTrue(json.contains("\"itemPath\""), json);
+    assertTrue(json.contains("/Sites/A/src/page.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    MoveFolderItem roundTrip = reqMapper.readValue(json, MoveFolderItem.class);
+    assertEquals("/Sites/A/dest", roundTrip.getTargetFolderPath(), json);
+    assertEquals("/Sites/A/src/page.html", roundTrip.getItemPath(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }


### PR DESCRIPTION
## Summary

REST wire DTOs `Folder`, `SectionInfo`, `SectionLinkRef`, `CopyFolderItemRequest`, and `MoveFolderItem` returned `Optional<T>` from JSON getters. That produced Optional-bean keys (`empty`/`present`) or dropped Explorer folder fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189).

This PR converts those Folder / Section / path-request types to **plain nullable getters/setters** with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.isPresent()` / `ApiUtils.orNull` / `ApiUtils.orEmpty` on the converted getters (`FoldersResource`, `FolderAdaptor`).

Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.

**Partial #3388** — slice 5 only. Asset (#3418), Community (#3419), and Acl (#3420) stay out of scope. `rest/AGENTS.md` wire-getter convention is **not committed** (human rule review).

Operator: Grok: night-issue-prs (model grok-4.6)

Parent tracker: #3388

Fixes #3413

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — Tests run: 423, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125
3. Confirm `JacksonContextResolverOptionalTest` (9 tests) covers Folder / SectionInfo / SectionLinkRef / CopyFolderItemRequest / MoveFolderItem round-trips
4. After merge: spot-check Explorer folder JSON (no `empty`/`present` beans)

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): wire-getter type change only; no documented request/response example currently shows Optional-bean JSON
- [x] **Unit / module tests** — behavioral Jackson round-trips; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-dep sitemanage because public getter signatures changed
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 423, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public `Optional<T>` → `T` getters). Grep for `extends Folder|SectionInfo|SectionLinkRef|CopyFolderItemRequest|MoveFolderItem` and `new Type() {` — no anonymous subclasses. Standalone sitemanage clean install green.

## C5 UI proof

N/A — backend REST DTO / adaptor change only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
