### PR TITLE
cluster: absorb REST Optional wire-getter PRs #3417 #3421 #3422

### DIFF
--- a/WebUI/src/main/ts/admin/tools/SecurityAuditLogViewer.tsx
+++ b/WebUI/src/main/ts/admin/tools/SecurityAuditLogViewer.tsx
@@ -88,12 +88,45 @@ export function formatEventTime(value: unknown): string {
   return "—";
 }
 
+/**
+ * Coerce a wire field to display text. Jackson / WRAP_ROOT may deliver
+ * numbers (content-id targets) or objects; calling {@code .trim()} on those
+ * throws and blanks the Security Audit Log via AdminSectionErrorBoundary.
+ */
+export function auditCellText(value: unknown): string {
+  if (value == null || value === "") {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  const rec =
+    typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  if (rec) {
+    for (const key of ["text", "value", "name", "label"] as const) {
+      const inner = rec[key];
+      if (typeof inner === "string" && inner.trim()) {
+        return inner.trim();
+      }
+    }
+  }
+  return "";
+}
+
 /** Truncate for table cells; when longer than max, keeps {@code max} chars then ellipsis. */
-export function truncate(text: string | undefined, max = 80): string {
-  if (!text) {
+export function truncate(text: unknown, max = 80): string {
+  const t = auditCellText(text);
+  if (!t) {
     return "—";
   }
-  const t = text.trim();
   if (t.length <= max) {
     return t;
   }
@@ -595,10 +628,18 @@ export const SecurityAuditLogViewer: React.FC = () => {
                         <td style={tdStyle}>
                           {formatEventTime(row.eventTime)}
                         </td>
-                        <td style={tdStyle}>{row.moduleCode || "—"}</td>
-                        <td style={tdStyle}>{row.eventType || "—"}</td>
-                        <td style={tdStyle}>{row.outcome || "—"}</td>
-                        <td style={tdStyle}>{row.actor || "—"}</td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.moduleCode) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.eventType) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.outcome) || "—"}
+                        </td>
+                        <td style={tdStyle}>
+                          {auditCellText(row.actor) || "—"}
+                        </td>
                         <td style={tdStyle}>{truncate(row.target, 40)}</td>
                         <td style={tdStyle}>
                           {truncate(row.userMessage, 60)}
@@ -725,7 +766,7 @@ export const SecurityAuditLogViewer: React.FC = () => {
                   }}
                   data-testid="audit-detail-user-message"
                 >
-                  {detail.userMessage || "—"}
+                  {auditCellText(detail.userMessage) || "—"}
                 </dd>
                 <dt style={{ fontWeight: 600, gridColumn: "1 / -1", marginTop: 8 }}>
                   {message(ADMIN_MSG.AUDIT_COL_LOG_MESSAGE)}
@@ -745,7 +786,7 @@ export const SecurityAuditLogViewer: React.FC = () => {
                   }}
                   data-testid="audit-detail-log-message"
                 >
-                  {detail.logMessage || "—"}
+                  {auditCellText(detail.logMessage) || "—"}
                 </dd>
               </dl>
             )}
@@ -762,14 +803,15 @@ function DetailRow({
   testId,
 }: {
   label: string;
-  value?: string | null;
+  value?: unknown;
   testId?: string;
 }): React.ReactElement {
+  const text = auditCellText(value);
   return (
     <>
       <dt style={{ fontWeight: 600, color: "#64748b" }}>{label}</dt>
       <dd style={{ margin: 0 }} data-testid={testId}>
-        {value && String(value).trim() ? value : "—"}
+        {text || "—"}
       </dd>
     </>
   );

--- a/WebUI/src/test/ts/admin/SecurityAuditLogViewer.test.tsx
+++ b/WebUI/src/test/ts/admin/SecurityAuditLogViewer.test.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  auditCellText,
   formatAuditPageSummary,
   formatEventTime,
   SecurityAuditLogViewer,
@@ -95,6 +96,43 @@ describe("SecurityAuditLogViewer", () => {
     const out = truncate(long, 40);
     expect(out.endsWith("…")).toBe(true);
     expect(out.slice(0, -1)).toHaveLength(40);
+  });
+
+  it("truncate does not throw on non-string wire values", () => {
+    expect(truncate(1131, 40)).toBe("1131");
+    expect(truncate({ value: "list" }, 40)).toBe("list");
+    expect(truncate({ text: "  wrapped  " }, 40)).toBe("wrapped");
+    expect(truncate({ epochSecond: 1 }, 40)).toBe("—");
+    expect(auditCellText(1131)).toBe("1131");
+    expect(auditCellText(null)).toBe("");
+  });
+
+  it("renders rows when target is a number (no AdminSectionErrorBoundary)", async () => {
+    vi.mocked(auditApi.queryAuditLogEntries).mockResolvedValue({
+      entries: [
+        {
+          ...sampleEntry,
+          target: 1131 as unknown as string,
+          userMessage: { value: "Content item 1131 created" } as unknown as string,
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+
+    render(<SecurityAuditLogViewer />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`audit-log-row-${sampleEntry.auditId}`),
+      ).toBeDefined();
+    });
+    expect(screen.queryByTestId("admin-section-error")).toBeNull();
+    expect(screen.getByTestId("audit-log-table").textContent).toContain("1131");
+    expect(screen.getByTestId("audit-log-table").textContent).toContain(
+      "Content item 1131 created",
+    );
   });
 
   it("renders table rows after successful load", async () => {

--- a/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3388-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3388 REST DTO wire getters must not return Optional
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3388-rest-dto-wire-getters`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+First incremental slice of #3388: convert REST `User`, `Role`, and `ObjectSummary`
+wire getters from `Optional<T>` to plain nullable types with `@JsonInclude(NON_NULL)`.
+Callers that used `.orElse()` / `.ifPresent()` on those getters were updated in
+`rest` and `projects/sitemanage`. Production-mapper round-trips assert no
+`empty`/`present` Optional-bean keys.
+
+`rest/AGENTS.md` wire-getter convention is drafted in the working tree and is
+**not** part of this commit (root AGENTS.md human-review gate for rule files).
+
+## Scope
+
+Uncommitted product work vs `origin/main` on `fix/issue-3388-rest-dto-wire-getters`.
+Excluded from commit: `rest/AGENTS.md` (agent-instruction draft).
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — **addressed** (JacksonContextResolver production mapper + UsersTest/RolesTest contract)
+- Incomplete change-class closure — **addressed** (DTO + rest callers + sitemanage UserAdaptor/ApiUtils + reverse-dep install)
+- Agent rule file without human review — **honored** (`rest/AGENTS.md` left uncommitted)
+- Cross-platform path checklist — N/A (no new filesystem I/O)
+
+## Issues
+
+None that block commit.
+
+## Notes (not blocking)
+
+- Remaining ~47 `public Optional<…>` DTO getters stay as later incremental PRs
+  (DisplayFormatProperty, Template, Page/Widget/SeoInfo, Acl leftovers, etc.).
+- Nested `Guid.getUntypedString()` is still Optional; ObjectSummary tests with a
+  constructed Guid did not emit `empty`/`present` keys (field-level `stringValue`
+  already uses `@JsonProperty` + `@JsonIgnore` on the Optional helper).
+- This is a public getter signature change (`Optional<T>` → `T`). Grep found no
+  anonymous subclasses; sitemanage standalone clean install is the reverse-dep gate.
+
+## Tests
+
+- `JacksonContextResolverOptionalTest` — 7 tests (prior ContentType/TemplateSummary + User/Role/ObjectSummary)
+- `UsersTest` / `RolesTest` — unset scalars nullable; list getters still never-null
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 421, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1217, Failures: 0, Skipped: 125
+
+## Cross-platform path checklist
+
+N/A — no new `File`/`Path` construction.

--- a/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3407-rest-dto-wire-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3407-rest-dto-wire-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)  
+**Date:** 2026-08-15  
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3407-rest-dto-wire-getters`.  
+**Memory patterns hit:** Optional wire getters drop fields / emit `empty`/`present` beans; public getter signature change requires reverse-dep compile.
+
+## Summary
+
+REST wire DTOs `DisplayFormatProperty`, `Template`, `TemplateBinding`, and the Page family (`Page`, `Widget`, `SeoInfo`, `Region`, `CalendarInfo`, `CodeInfo`, `WorkflowInfo`) returned `Optional<T>` from JSON getters. That produces Optional-bean keys (`empty`/`present`) or dropped catalog fields under `@JsonInclude(NON_NULL)` (same failure as ContentType #1693 / TemplateSummary #2189 / User-Role-ObjectSummary #3388).
+
+This change converts those types to plain nullable getters/setters with `@JsonInclude(NON_NULL)` and updates callers that used `.orElse()` / `.ifPresent()` / `Optional.flatMap` (`PagesResource`, sitemanage `PageAdaptor` / `AssetAdaptor`). `ApiUtils.orEmpty(Collection)` was added so converted list getters compile without an Optional wrapper. `PageAdaptor.findWidget` still unwraps `PSWidgetItem.getName()` (`Optional`) when comparing to the now-plain REST `Widget.getName()`.
+
+Production-mapper tests use `new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no Optional-bean keys.
+
+`TemplateDetail` already used plain getters. Virtual Site / LocationScheme / Folder families were left for #3411–#3413. `rest/AGENTS.md` was not committed (human rule review).
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none remaining for this family
+- Behavioral tests: JacksonContextResolverOptionalTest (9 tests, including new family round-trips)
+- Playwright companion: N/A (no WebUI product screen change)
+- Agent rule files: none
+- Cross-platform: **N/A** (no path I/O)
+- C2: public `Optional<T>` → `T` getters. Grep for `extends DisplayFormatProperty|Template|Page|Widget|SeoInfo|Region|CalendarInfo|CodeInfo|WorkflowInfo` and `new Type() {` — no anonymous subclasses of the REST types. sitemanage `Template` subclasses are `com.percussion.sitemanage.service.Template`, not the REST DTO. Standalone sitemanage clean install green.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — Tests run: 423, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1223, Failures: 0, Skipped: 125

--- a/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3411-virtualsite-sitemap-optional-getters-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — `fix/issue-3411-virtualsite-sitemap-optional-getters`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)
+**Date:** 2026-08-15
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3411-virtualsite-sitemap-optional-getters` (slice of #3388).
+**Memory patterns hit:** incomplete change-class closure; production-mapper tests vs bare `JsonMapper`; agent rule files require human review.
+
+## Summary
+
+Convert Virtual Site + SiteMap REST wire DTO getters from `Optional<T>` to plain nullable types so Jackson emits scalars, not Optional-bean `empty`/`present` keys.
+
+In scope: `VirtualSiteBuildRequest`, `VirtualSiteBuildResult`, `VirtualSitePreviewStatus`, `VirtualSitePublishResult`, `SiteMapOptions`. Callers in `rest` tests and `SitesAdaptor` / `SitesAdaptorTest` updated. Family methods appended to `JacksonContextResolverOptionalTest` using `new JacksonContextResolver().getContext(TheDto.class)`. `rest/AGENTS.md` not committed.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none
+- Behavioral tests: production-mapper round-trips + no `empty`/`present` keys for all five types; rest/sitemanage caller tests updated
+- Agent rule files: none (rest/AGENTS.md not touched)
+- Cross-platform: **pass** — no new filesystem path construction; existing `Path.of` / `blankToNull` path remains after getter conversion. Test JSON examples use `/` in string values (URL/JSON form, not OS joins)
+- Change-class companions: DTO getters + rest callers + sitemanage adaptor + production-mapper tests. No new adaptor interface (no MainTest stub). DisplayFormat/Template/Page, LocationScheme/Context/DeliveryType, Folder/Section left for sibling slices
+- C2: public getter signatures changed (`Optional<T>` → `T`). Grep found no `extends` / anonymous subclasses of the five types
+
+## Issues
+
+None.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 423, Failures: 0 (`JacksonContextResolverOptionalTest` 9 tests)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125 (`SitesAdaptorTest` 36 tests)

--- a/docs/ai-generated/code-reviews/3412-location-scheme-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3412-location-scheme-wire-getters-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review: #3412 LocationScheme / Context / DeliveryType wire getters
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3412-location-scheme-wire-getters`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+## Summary
+
+Slice 4 of parent #3388 converts publishing-location REST wire DTOs
+(`LocationScheme`, `LocationSchemeParameter`, `Context`, `DeliveryType`) from
+`Optional<T>` getters to plain nullable getters with existing
+`@JsonInclude(NON_NULL)`. sitemanage `ContextAdaptor` / `DeliveryTypeAdaptor`
+callers that unwrapped those getters via `ApiUtils.orNull` / `flatMap` now use
+the plain values. Guid `getStringValue()` remains Optional + `@JsonIgnore`
+(out of this slice).
+
+Production-mapper tests appended to `JacksonContextResolverOptionalTest` use
+`new JacksonContextResolver().getContext(TheDto.class)` and assert JSON has no
+`empty`/`present` Optional-bean keys, plus round-trip field equality.
+
+Memory patterns hit: incomplete change-class closure (callers + production
+mapper tests); behavioral tests required for wire-shape change.
+
+## Issues
+
+None (no bugs, no missing behavioral tests, no path/file I/O).
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or path assertions.
+
+## Change-class companions
+
+| Companion | Status |
+| --- | --- |
+| Peer getter style (`ContentType` / PR #3406) | Done |
+| `JacksonContextResolverOptionalTest` family methods | Appended (8 tests total) |
+| rest / sitemanage callers of converted getters | Updated |
+| `rest/AGENTS.md` wire-getter rule | Not committed (human rule review) |
+| product-docs | N/A (no documented Optional-bean JSON example) |
+| Playwright / WebUI | N/A |
+
+## Build evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 422, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125
+- C2: public `Optional<T>` → `T` getters. Grep for anonymous `extends` / `new Type() {` — none. Reverse-dep sitemanage standalone install green.

--- a/docs/ai-generated/code-reviews/3413-folder-section-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3413-folder-section-wire-getters-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #3413 Folder / Section / path-request wire getters
+
+**Branch:** `fix/issue-3413-folder-section-wire-getters`  
+**Scope:** uncommitted vs `HEAD` + commits not in `origin/main`  
+**Date:** 2026-08-15  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** REST DTO `Optional` getters serialize as empty/present beans or drop fields under `@JsonInclude(NON_NULL)` (ContentType #1693 / TemplateSummary #2189 / sibling #3412).
+
+## Summary
+
+Converts Explorer folder/section REST wire DTOs from `Optional<T>` getters to plain nullable getters with `@JsonInclude(NON_NULL)`, matching `ContentType` / LocationScheme (#3412) peer style. Updates `FoldersResource` and `FolderAdaptor` callers that used `.orElse()` / `.isPresent()` / `ApiUtils.orNull` / `ApiUtils.orEmpty` on converted getters. Appends production-mapper round-trip tests to `JacksonContextResolverOptionalTest` (does not rewrite existing methods).
+
+## Issues
+
+None (gate-blocking).
+
+## Notes (non-blocking)
+
+- `LinkRef` (parent of `SectionLinkRef`) still returns `Optional` for `name`/`href` — out of scope; nested landing-page JSON is asserted not to emit empty/present keys under the production mapper.
+- `rest/AGENTS.md` wire-getter convention remains uncommitted (human rule review).
+- Cross-platform path checklist: **N/A** (no filesystem I/O).
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 423, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1223, Failures: 0, Skipped: 125

--- a/docs/ai-generated/code-reviews/audit-log-truncate-nonstring-erlang.md
+++ b/docs/ai-generated/code-reviews/audit-log-truncate-nonstring-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — `fix/audit-log-truncate-nonstring`
+
+**Reviewer:** Erlang Shen (independent; did not author this change)  
+**Date:** 2026-08-15  
+**Scope:** uncommitted vs `HEAD` on `fix/audit-log-truncate-nonstring`.  
+**Memory patterns hit:** structural/token tests vs behavior; UI crash from untyped wire values.
+
+## Summary
+
+`SecurityAuditLogViewer.truncate` assumed `string` and called `.trim()`. Live wire `target` is sometimes a number (content-id) or wrapped object. That throws `e.trim is not a function` and `AdminSectionErrorBoundary` replaces the tool even though REST `AUDIT_VIEW` succeeded.
+
+Fix: `auditCellText(unknown)` coerces primitives / `{value,text,name,label}`; `truncate` uses it. Table cells and detail rows go through the same helper. Vitest covers number/`{value}` and a render that must not throw. Playwright asserts `admin-section-error` is absent.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- **May commit/push: yes** (feature branch)
+- Bugs: none remaining for this throw
+- Behavioral tests: Vitest + Playwright assertion
+- Playwright companion: updated `admin-security-audit-log.spec.js`
+- Agent rule files: none
+- Cross-platform: **N/A** (no path I/O)
+
+## Tests
+
+`npm run test -- SecurityAuditLogViewer` (WebUI frontend): 10 passed.

--- a/modules/perc-qa-automation/frontend/tests/admin-security-audit-log.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/admin-security-audit-log.spec.js
@@ -78,6 +78,9 @@ test.describe("Admin Security Audit Log @security-audit-log @admin", () => {
       timeout: 30_000,
     });
     await expect(page.getByTestId("audit-log-empty")).toHaveCount(0);
+    // Non-string target/userMessage must not throw (e.trim is not a function)
+    // and replace the tool with AdminSectionErrorBoundary.
+    await expect(page.getByTestId("admin-section-error")).toHaveCount(0);
   });
 
   test("Admin can apply module filter without error chrome", async ({

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -165,6 +165,17 @@ public class ApiUtils {
   }
 
   /**
+   * Return an empty collection if the collection is null.
+   *
+   * @param col the collection, may be {@code null}
+   * @param <T> the element type
+   * @return the collection or an empty one
+   */
+  public static <T> Collection<T> orEmpty(Collection<T> col) {
+    return col == null ? List.of() : col;
+  }
+
+  /**
    * Generic unwrapping helper. If the supplied object is an {@link Optional} it will return the
    * contained value or null; otherwise the value is returned unchanged. This allows callers to
    * uniformly access getters which may or may not return Optionals without needing to know the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -476,9 +476,9 @@ public class ApiUtils {
   public static PSRole convertRole(Role role) {
     PSRole ret = new PSRole();
 
-    ret.setDescription(orNull(role.getDescription()));
-    ret.setHomepage(orNull(role.getHomePage()));
-    ret.setName(orNull(role.getName()));
+    ret.setDescription(role.getDescription());
+    ret.setHomepage(role.getHomePage());
+    ret.setName(role.getName());
     ret.setUsers(role.getUsers());
 
     return ret;

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
@@ -266,10 +266,10 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
     try {
       var oldPSAsset = this.assetService.load(id);
       var workflowInfo = this.getWorkflowInfo(oldPSAsset);
-      // determine the requested end state - WorkflowInfo stores Optionals now
-      String endState = ApiUtils.orNull(workflowInfo.getState());
+      // determine the requested end state
+      String endState = workflowInfo.getState();
       if (asset.getWorkflow().isPresent()) {
-        String state = ApiUtils.orNull(asset.getWorkflow().get().getState());
+        String state = asset.getWorkflow().get().getState();
         if (StringUtils.isNotBlank(state)) {
           endState = state;
         }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
@@ -105,7 +105,7 @@ public class ContextAdaptor implements IContextsAdaptor {
   public Context createOrUpdateContext(URI baseURI, Context context) throws BackendException {
     try {
       IPSPublishingContext ctx;
-      Guid idGuid = ApiUtils.orNull(context.getId());
+      Guid idGuid = context.getId();
       String idStr = (idGuid == null) ? null : ApiUtils.orNull(idGuid.getStringValue());
       if (idStr == null || StringUtils.isBlank(idStr)) {
         ctx = siteManager.createContext();
@@ -145,7 +145,7 @@ public class ContextAdaptor implements IContextsAdaptor {
 
   private IPSPublishingContext copyContext(Context context) {
     var ret = new PSPublishingContext();
-    Guid idGuid = ApiUtils.orNull(context.getId());
+    Guid idGuid = context.getId();
     if (idGuid != null) {
       String idStr = ApiUtils.orNull(idGuid.getStringValue());
       if (idStr != null) {
@@ -153,11 +153,12 @@ public class ContextAdaptor implements IContextsAdaptor {
         ret.setGUID(guid);
       }
     }
-    ret.setName(ApiUtils.orNull(context.getName()));
-    ret.setDescription(ApiUtils.orNull(context.getDescription()));
+    ret.setName(context.getName());
+    ret.setDescription(context.getDescription());
     Guid schemeId = null;
-    if (context.getDefaultScheme() != null) {
-      schemeId = ApiUtils.orNull(context.getDefaultScheme().flatMap(LocationScheme::getSchemeId));
+    LocationScheme defaultScheme = context.getDefaultScheme();
+    if (defaultScheme != null) {
+      schemeId = defaultScheme.getSchemeId();
     }
     if (schemeId != null) {
       String schemeStr = ApiUtils.orNull(schemeId.getStringValue());

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
@@ -64,22 +64,18 @@ public class DeliveryTypeAdaptor implements IDeliveryTypeAdaptor {
   @Override
   public DeliveryType updateDeliveryType(URI baseURI, DeliveryType type) throws BackendException {
     try {
-      Guid idGuid = ApiUtils.orNull(type.getId());
+      Guid idGuid = type.getId();
       String idStr = ApiUtils.orNull(idGuid == null ? null : idGuid.getStringValue());
       if (idGuid == null || StringUtils.isBlank(idStr)) {
         // Create new delivery type
         var create = pubService.createDeliveryType();
         create.setUnpublishingRequiresAssembly(type.isUnpublishingRequiresAssembly());
-        create.setName(ApiUtils.orNull(type.getName()));
-        create.setDescription(ApiUtils.orNull(type.getDescription()));
-        create.setBeanName(ApiUtils.orNull(type.getBeanName()));
+        create.setName(type.getName());
+        create.setDescription(type.getDescription());
+        create.setBeanName(type.getBeanName());
         pubService.saveDeliveryType(create);
         return copyDeliveryType(create);
       } else {
-        // unwrap Optionals before copying
-        type.setName(ApiUtils.orNull(type.getName()));
-        type.setDescription(ApiUtils.orNull(type.getDescription()));
-        type.setBeanName(ApiUtils.orNull(type.getBeanName()));
         var update = copyDeliveryType(type);
         pubService.saveDeliveryType(update);
         // Load after save
@@ -122,11 +118,11 @@ public class DeliveryTypeAdaptor implements IDeliveryTypeAdaptor {
 
   private IPSDeliveryType copyDeliveryType(DeliveryType type) {
     var ret = new PSDeliveryType();
-    ret.setBeanName(ApiUtils.orNull(type.getBeanName()));
-    ret.setDescription(ApiUtils.orNull(type.getDescription()));
-    ret.setName(ApiUtils.orNull(type.getName()));
+    ret.setBeanName(type.getBeanName());
+    ret.setDescription(type.getDescription());
+    ret.setName(type.getName());
     ret.setUnpublishingRequiresAssembly(type.isUnpublishingRequiresAssembly());
-    ret.setGUID(ApiUtils.convertGuid(ApiUtils.orNull(type.getId())));
+    ret.setGUID(ApiUtils.convertGuid(type.getId()));
     return ret;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
@@ -100,7 +100,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -336,7 +335,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       throw new BackendException(e);
     }
 
-    String folderNameStr = ApiUtils.orNull(folder.getName());
+    String folderNameStr = folder.getName();
     if (folderNameStr != null
         && StringUtils.startsWith(folderNameStr, EXTERNAL_SECTION_NAME_PREFIX)) {
       folder.setName(StringUtils.substringAfter(folderNameStr, EXTERNAL_SECTION_NAME_PREFIX));
@@ -363,7 +362,7 @@ public class FolderAdaptor implements IFolderAdaptor {
 
     List<String> existingFolders = new ArrayList<>();
     if (folder.getSubsections() != null) {
-      for (SectionLinkRef section : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef section : folder.getSubsections()) {
         existingFolders.add(ApiUtils.orNull(section.getName()));
       }
     }
@@ -524,38 +523,32 @@ public class FolderAdaptor implements IFolderAdaptor {
     try {
       checkAPIPermission();
 
-      String baseName = ApiUtils.orNull(folder.getName());
-      String baseSite = ApiUtils.orNull(folder.getSiteName());
-      String basePath = ApiUtils.orNull(folder.getPath());
+      String baseName = folder.getName();
+      String baseSite = folder.getSiteName();
+      String basePath = folder.getPath();
       Folder existingFolder = null;
       boolean newFolder = false;
       boolean byId =
-          StringUtils.isNotEmpty(ApiUtils.orNull(folder.getId()))
-              && ApiUtils.orNull(folder.getSiteName()) == null
-              && ApiUtils.orNull(folder.getPath()) == null
-              && ApiUtils.orNull(folder.getName()) == null;
+          StringUtils.isNotEmpty(folder.getId())
+              && folder.getSiteName() == null
+              && folder.getPath() == null
+              && folder.getName() == null;
       try {
         if (byId) {
 
-          existingFolder = getFolder(baseUri, ApiUtils.orNull(folder.getId()));
+          existingFolder = getFolder(baseUri, folder.getId());
         } else {
           existingFolder =
-              getFolder(
-                  baseUri,
-                  ApiUtils.orNull(folder.getSiteName()),
-                  ApiUtils.orNull(folder.getPath()),
-                  ApiUtils.orNull(folder.getName()));
+              getFolder(baseUri, folder.getSiteName(), folder.getPath(), folder.getName());
         }
       } catch (FolderNotFoundException | BackendException e) {
         newFolder = true;
-        if (StringUtils.isEmpty(ApiUtils.orNull(folder.getPath()))
-            && StringUtils.isEmpty(ApiUtils.orNull(folder.getName())))
+        if (StringUtils.isEmpty(folder.getPath()) && StringUtils.isEmpty(folder.getName()))
           throw new BackendException(
-              "Trying to create site root folder.  Create site first : "
-                  + ApiUtils.orNull(folder.getSiteName()));
+              "Trying to create site root folder.  Create site first : " + folder.getSiteName());
       }
 
-      if (!byId && existingFolder == null && ApiUtils.orNull(folder.getId()) != null) {
+      if (!byId && existingFolder == null && folder.getId() != null) {
         // If id is passed into update and it looks as if the item does not
         // already exist, we are probably trying to update a purged item, or
         // the id is from a different item.
@@ -563,14 +556,14 @@ public class FolderAdaptor implements IFolderAdaptor {
       }
 
       if (existingFolder != null
-          && ApiUtils.orNull(folder.getId()) != null
-          && ApiUtils.orNull(existingFolder.getId()) != null
-          && !ApiUtils.orNull(existingFolder.getId()).equals(ApiUtils.orNull(folder.getId())))
+          && folder.getId() != null
+          && existingFolder.getId() != null
+          && !existingFolder.getId().equals(folder.getId()))
         throw new BackendException(
             "Id "
-                + ApiUtils.orNull(folder.getId())
+                + folder.getId()
                 + " passed into update but Id does not match item referenced by site and path "
-                + ApiUtils.orNull(existingFolder.getId()));
+                + existingFolder.getId());
 
       if (newFolder) {
         String folderId = createNewFolder(baseUri, folder);
@@ -579,7 +572,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       } else {
         folder = modifyExistingFolder(baseUri, existingFolder, folder);
       }
-      if (ApiUtils.orNull(folder.getName()).equalsIgnoreCase("")) {
+      if ("".equalsIgnoreCase(folder.getName())) {
         folder.setName(baseName);
         folder.setSiteName(baseSite);
         folder.setPath(basePath);
@@ -594,12 +587,12 @@ public class FolderAdaptor implements IFolderAdaptor {
   private Folder modifyExistingFolder(URI baseUri, Folder existingFolder, Folder folder)
       throws IPSPathService.PSPathServiceException, PSDataServiceException, BackendException {
 
-    String realName = ApiUtils.orNull(folder.getName());
-    SectionInfo existingSec = existingFolder.getSectionInfo().orElse(null);
+    String realName = folder.getName();
+    SectionInfo existingSec = existingFolder.getSectionInfo();
     if (existingSec != null) {
-      Optional<String> existingType = existingSec.getType();
-      if (existingType.isPresent()
-          && existingType.get().equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
+      String existingType = existingSec.getType();
+      if (existingType != null
+          && existingType.equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
         realName = EXTERNAL_SECTION_NAME_PREFIX + realName;
       }
     }
@@ -609,7 +602,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     UrlParts folderSections = null;
 
     try {
-      PSLocator loc = idMapper.getLocator(ApiUtils.orNull(existingFolder.getId()));
+      PSLocator loc = idMapper.getLocator(existingFolder.getId());
       loc.setRevision(-1);
       pathItem = folderHelper.findItemById(idMapper.getString(loc));
     } catch (IPSDataService.DataServiceLoadException
@@ -636,22 +629,19 @@ public class FolderAdaptor implements IFolderAdaptor {
     updateFolderProperties(folder, pathItem.getId(), existingFolder);
 
     // Skip the section stuff for Asset folders.
-    if (!"Assets".equals(ApiUtils.orNull(folder.getSiteName()))) {
-      Optional<SectionInfo> reqSectionOpt = folder.getSectionInfo();
-      Optional<SectionInfo> currSectionOpt = existingFolder.getSectionInfo();
-      if (reqSectionOpt.isPresent() && currSectionOpt.isEmpty()) {
+    if (!"Assets".equals(folder.getSiteName())) {
+      SectionInfo reqSection = folder.getSectionInfo();
+      SectionInfo currSection = existingFolder.getSectionInfo();
+      if (reqSection != null && currSection == null) {
         convertFolderToSection(
-            folderSections.getUrl(),
-            ApiUtils.orNull(folder.getName()),
-            ApiUtils.orNull(folder.getSiteName()),
-            reqSectionOpt.get());
+            folderSections.getUrl(), folder.getName(), folder.getSiteName(), reqSection);
       }
 
       updateLandingPage(folder, existingFolder, folderSections.getUrl());
 
       updateSectionInfo(folder, folderSections.getUrl(), existingFolder);
 
-      reorderSiteSection(baseUri, ApiUtils.orNull(existingFolder.getId()), folder, existingFolder);
+      reorderSiteSection(baseUri, existingFolder.getId(), folder, existingFolder);
     }
 
     return existingFolder;
@@ -684,13 +674,12 @@ public class FolderAdaptor implements IFolderAdaptor {
 
   private void updateLandingPage(Folder folder, Folder existingFolder, String folderPath)
       throws IPSPathService.PSPathServiceException, PSDataServiceException, BackendException {
-    SectionInfo reqSectionInfo = folder.getSectionInfo().orElse(null);
-    SectionInfo currSectionInfo = existingFolder.getSectionInfo().orElse(null);
+    SectionInfo reqSectionInfo = folder.getSectionInfo();
+    SectionInfo currSectionInfo = existingFolder.getSectionInfo();
 
     if (reqSectionInfo != null && currSectionInfo != null) {
-      LinkRef reqLanding = reqSectionInfo.getLandingPage().orElse(null);
-      LinkRef existingLanding =
-          existingFolder.getSectionInfo().flatMap(SectionInfo::getLandingPage).orElse(null);
+      LinkRef reqLanding = reqSectionInfo.getLandingPage();
+      LinkRef existingLanding = currSectionInfo.getLandingPage();
 
       String reqName = ApiUtils.orNull(reqLanding == null ? null : reqLanding.getName());
       String existingName =
@@ -699,7 +688,8 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (reqName != null && !reqName.equals(existingName)) {
         // get child folders
         boolean foundPage = false;
-        for (LinkRef page : ApiUtils.orEmpty(existingFolder.getPages())) {
+        List<LinkRef> existingPages = existingFolder.getPages();
+        for (LinkRef page : existingPages == null ? List.<LinkRef>of() : existingPages) {
           if (reqName.equals(ApiUtils.orNull(page.getName()))) {
             foundPage = true;
             break;
@@ -739,7 +729,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       PSSiteSection currentSection = sectionService.load(idMapper.getString(id));
 
       PSFolderProperties folderProps =
-          folderHelper.findFolderProperties(ApiUtils.orNull(existingFolder.getId()));
+          folderHelper.findFolderProperties(existingFolder.getId());
 
       if (currentSection.getSectionType() == PSSectionTypeEnum.section) {
         PSSiteSectionProperties req = new PSSiteSectionProperties();
@@ -753,18 +743,18 @@ public class FolderAdaptor implements IFolderAdaptor {
         req.setTarget(currentSection.getTarget());
         req.setTitle(currentSection.getTitle());
 
-        SectionInfo toSection = folder.getSectionInfo().orElse(null);
+        SectionInfo toSection = folder.getSectionInfo();
         if (toSection != null) {
-          if (toSection.getDisplayTitle().isPresent()) {
-            req.setTitle(toSection.getDisplayTitle().get());
+          if (toSection.getDisplayTitle() != null) {
+            req.setTitle(toSection.getDisplayTitle());
           }
 
-          if (toSection.getNavClass().isPresent()) {
-            req.setCssClassNames(toSection.getNavClass().get());
+          if (toSection.getNavClass() != null) {
+            req.setCssClassNames(toSection.getNavClass());
           }
 
-          if (toSection.getTargetWindow().isPresent()) {
-            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow().get()));
+          if (toSection.getTargetWindow() != null) {
+            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow()));
           }
         }
         // update landing page
@@ -784,20 +774,18 @@ public class FolderAdaptor implements IFolderAdaptor {
                 : currentSection.getTarget();
         req.setTarget(target);
 
-        SectionInfo toSection = folder.getSectionInfo().orElse(null);
+        SectionInfo toSection = folder.getSectionInfo();
         if (toSection != null) {
-          if (toSection.getDisplayTitle().isPresent())
-            req.setLinkTitle(toSection.getDisplayTitle().get());
+          if (toSection.getDisplayTitle() != null) req.setLinkTitle(toSection.getDisplayTitle());
 
-          if (toSection.getNavClass().isPresent())
-            req.setCssClassNames(toSection.getNavClass().get());
+          if (toSection.getNavClass() != null) req.setCssClassNames(toSection.getNavClass());
 
-          if (toSection.getTargetWindow().isPresent()) {
-            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow().get()));
+          if (toSection.getTargetWindow() != null) {
+            req.setTarget(PSSectionTargetEnum.valueOf(toSection.getTargetWindow()));
           }
 
-          if (toSection.getExternalLinkUrl().isPresent()) {
-            req.setExternalUrl(toSection.getExternalLinkUrl().get());
+          if (toSection.getExternalLinkUrl() != null) {
+            req.setExternalUrl(toSection.getExternalLinkUrl());
           }
         }
 
@@ -814,24 +802,23 @@ public class FolderAdaptor implements IFolderAdaptor {
     String parentFolderPath = StringUtils.substringBeforeLast(folderPath, "/" + folderName);
 
     String name = "index.html";
-    Optional<LinkRef> landOpt = sectionInfo.getLandingPage();
+    LinkRef landOpt = sectionInfo.getLandingPage();
     // compute landing name and if available override default
-    String landingName = landOpt.flatMap(LinkRef::getName).orElse(null);
+    String landingName = landOpt == null ? null : landOpt.getName().orElse(null);
     if (landingName != null) {
       name = landingName;
     }
     // CMS-3210 - NC
     boolean exists = checkIfPageExists(folderPath + "/" + name);
 
-    String templateId =
-        getTemplateIdForName(ApiUtils.orNull(sectionInfo.getTemplateName()), siteName);
+    String templateId = getTemplateIdForName(sectionInfo.getTemplateName(), siteName);
 
     if (!exists) {
       PSPage page = new PSPage();
       page.setFolderPath("/" + folderPath);
 
       String title =
-          StringUtils.defaultString(ApiUtils.orNull(sectionInfo.getDisplayTitle()), folderName);
+          StringUtils.defaultString(sectionInfo.getDisplayTitle(), folderName);
 
       page.setName(name);
       page.setTitle(title);
@@ -884,13 +871,13 @@ public class FolderAdaptor implements IFolderAdaptor {
     List<String> requestedSubSections = new ArrayList<>();
 
     if (folder.getSubsections() != null) {
-      if (folder.getSectionInfo().isEmpty() && existingFolder.getSectionInfo().isEmpty())
+      if (folder.getSectionInfo() == null && existingFolder.getSectionInfo() == null)
         throw new BackendException("non-section folders cannot have subsections");
       String nameCheck = null;
-      for (SectionLinkRef subsection : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef subsection : folder.getSubsections()) {
         String secName = ApiUtils.orNull(subsection.getName());
         String secHref = ApiUtils.orNull(subsection.getHref());
-        if (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name()))
+        if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
           nameCheck = secName + "-" + secHref;
         else nameCheck = secName;
 
@@ -904,10 +891,10 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       if (existingFolder.getSubsections() != null) {
 
-        for (SectionLinkRef subsection : ApiUtils.orEmpty(existingFolder.getSubsections())) {
+        for (SectionLinkRef subsection : existingFolder.getSubsections()) {
           String secName = ApiUtils.orNull(subsection.getName());
           String secHref = ApiUtils.orNull(subsection.getHref());
-          if (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name()))
+          if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
             nameCheck = secName + "-" + secHref;
           else nameCheck = secName;
 
@@ -919,19 +906,14 @@ public class FolderAdaptor implements IFolderAdaptor {
       subSectionsToCreate.removeAll(existingSubSections);
 
       for (String createName : subSectionsToCreate) {
-        for (SectionLinkRef subsection : ApiUtils.orEmpty(folder.getSubsections())) {
+        for (SectionLinkRef subsection : folder.getSubsections()) {
           String nameVal = ApiUtils.orNull(subsection.getName());
           String hrefVal = ApiUtils.orNull(subsection.getHref());
           if (nameVal.equals(createName)
-              || (subsection.getType().equals(PSSectionTypeEnum.sectionlink.name())
+              || (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType())
                   && createName.equals(nameVal + "-" + hrefVal))) {
             createSubSection(
-                baseUri,
-                existingFolder,
-                folder,
-                nameVal,
-                ApiUtils.orNull(subsection.getType()),
-                hrefVal);
+                baseUri, existingFolder, folder, nameVal, subsection.getType(), hrefVal);
           }
         }
       }
@@ -948,19 +930,13 @@ public class FolderAdaptor implements IFolderAdaptor {
   private String createNewFolder(URI baseUri, Folder folder)
       throws PSDataServiceException, IPSPathService.PSPathServiceException, BackendException {
 
-    UrlParts fullUrl =
-        new UrlParts(
-            ApiUtils.orNull(folder.getSiteName()),
-            ApiUtils.orNull(folder.getPath()),
-            ApiUtils.orNull(folder.getName()));
-    UrlParts parentUrl =
-        new UrlParts(ApiUtils.orNull(folder.getSiteName()), ApiUtils.orNull(folder.getPath()), "");
+    UrlParts fullUrl = new UrlParts(folder.getSiteName(), folder.getPath(), folder.getName());
+    UrlParts parentUrl = new UrlParts(folder.getSiteName(), folder.getPath(), "");
 
     PSPathItem newFolder = null;
 
     // Create a folder with a section.
-    if (!ApiUtils.orNull(folder.getSiteName()).equals("Assets")
-        && folder.getSectionInfo().isPresent()) {
+    if (!"Assets".equals(folder.getSiteName()) && folder.getSectionInfo() != null) {
       newFolder = createNewSection(folder, parentUrl);
     } else
     // Create a regular folder
@@ -976,8 +952,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     updateFolderProperties(folder, newFolder.getId(), null);
 
     // create subsections
-    if (!ApiUtils.orNull(folder.getSiteName()).equals("Assets"))
-      createSubSections(baseUri, folder, folder);
+    if (!"Assets".equals(folder.getSiteName())) createSubSections(baseUri, folder, folder);
 
     return newFolder.getId();
   }
@@ -998,17 +973,17 @@ public class FolderAdaptor implements IFolderAdaptor {
       throws BackendException, PSDataServiceException, IPSPathService.PSPathServiceException {
 
     if (folder.getSubsections() != null) {
-      if (folder.getSectionInfo().isEmpty())
+      if (folder.getSectionInfo() == null)
         throw new BackendException("non-section folders cannot have subsections");
 
-      for (SectionLinkRef subSection : ApiUtils.orEmpty(folder.getSubsections())) {
+      for (SectionLinkRef subSection : folder.getSubsections()) {
         String name = ApiUtils.orNull(subSection.getName());
         createSubSection(
             baseUri,
             existingFolder,
             folder,
             name,
-            ApiUtils.orNull(subSection.getType()),
+            subSection.getType(),
             ApiUtils.orNull(subSection.getHref()));
       }
     }
@@ -1029,16 +1004,15 @@ public class FolderAdaptor implements IFolderAdaptor {
 
     if (!type.equalsIgnoreCase(PSSectionTypeEnum.sectionlink.name())) {
       Folder subFolder = new Folder();
-      subFolder.setSiteName(ApiUtils.orNull(folder.getSiteName()));
-      subFolder.setPath(
-          ApiUtils.orNull(folder.getPath()) + "/" + ApiUtils.orNull(folder.getName()));
+      subFolder.setSiteName(folder.getSiteName());
+      subFolder.setPath(folder.getPath() + "/" + folder.getName());
       subFolder.setName(name);
 
-      String wf = ApiUtils.orNull(folder.getWorkflow());
+      String wf = folder.getWorkflow();
       if (wf != null) {
         subFolder.setWorkflow(wf);
       } else if (existingFolder != null) {
-        wf = ApiUtils.orNull(existingFolder.getWorkflow());
+        wf = existingFolder.getWorkflow();
         if (wf != null) {
           subFolder.setWorkflow(wf);
         }
@@ -1052,11 +1026,12 @@ public class FolderAdaptor implements IFolderAdaptor {
         subSectionInfo.setExternalLinkUrl(extUrl);
       subSectionInfo.setDisplayTitle(name);
       String templateName = null;
-      Optional<SectionInfo> folderSection = folder.getSectionInfo();
-      if (folderSection.flatMap(SectionInfo::getTemplateName).isPresent())
-        templateName = folderSection.flatMap(SectionInfo::getTemplateName).get();
-      else if (existingFolder.getSectionInfo().flatMap(SectionInfo::getTemplateName).isPresent())
-        templateName = existingFolder.getSectionInfo().flatMap(SectionInfo::getTemplateName).get();
+      SectionInfo folderSection = folder.getSectionInfo();
+      if (folderSection != null && folderSection.getTemplateName() != null)
+        templateName = folderSection.getTemplateName();
+      else if (existingFolder.getSectionInfo() != null
+          && existingFolder.getSectionInfo().getTemplateName() != null)
+        templateName = existingFolder.getSectionInfo().getTemplateName();
 
       subSectionInfo.setTemplateName(templateName);
 
@@ -1070,11 +1045,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (toGuid == null)
         throw new BackendException(
             "Cannot create section link to section that does not yet exist " + path);
-      UrlParts fromFolder =
-          new UrlParts(
-              ApiUtils.orNull(folder.getSiteName()),
-              ApiUtils.orNull(folder.getPath()),
-              ApiUtils.orNull(folder.getName()));
+      UrlParts fromFolder = new UrlParts(folder.getSiteName(), folder.getPath(), folder.getName());
       String fromGuid = getNavGuidByPath(fromFolder.getUrl());
       sectionService.createSectionLink(toGuid, fromGuid);
     }
@@ -1111,18 +1082,18 @@ public class FolderAdaptor implements IFolderAdaptor {
           "can only create section folders that are child folders of other sections.");
     }
 
-    SectionInfo section = folder.getSectionInfo().orElse(null);
+    SectionInfo section = folder.getSectionInfo();
     PSSiteSection newSection = null;
-    String sectionType = section == null ? null : ApiUtils.orNull(section.getType());
+    String sectionType = section == null ? null : section.getType();
     if (sectionType != null
         && sectionType.equalsIgnoreCase(PSSectionTypeEnum.externallink.name())) {
       PSCreateExternalLinkSection req = new PSCreateExternalLinkSection();
-      req.setCssClassNames(section == null ? null : ApiUtils.orNull(section.getNavClass()));
-      req.setExternalUrl(section == null ? null : ApiUtils.orNull(section.getExternalLinkUrl()));
+      req.setCssClassNames(section == null ? null : section.getNavClass());
+      req.setExternalUrl(section == null ? null : section.getExternalLinkUrl());
       req.setFolderPath(parentFolderUrl);
-      req.setLinkTitle(section == null ? null : ApiUtils.orNull(section.getDisplayTitle()));
+      req.setLinkTitle(section == null ? null : section.getDisplayTitle());
       req.setSectionType(PSSectionTypeEnum.externallink);
-      String targetWindow = section == null ? null : ApiUtils.orNull(section.getTargetWindow());
+      String targetWindow = section == null ? null : section.getTargetWindow();
       PSSectionTargetEnum target =
           (targetWindow == null)
               ? PSSectionTargetEnum._self
@@ -1138,30 +1109,31 @@ public class FolderAdaptor implements IFolderAdaptor {
       request.setFolderPath(parentFolderUrl);
 
       // get specified landing page name or use index if does not exist.
-      if (section != null && section.getLandingPage().flatMap(LinkRef::getName).isPresent()) {
-        request.setPageName(section.getLandingPage().flatMap(LinkRef::getName).orElse(null));
+      LinkRef landing = section == null ? null : section.getLandingPage();
+      String landingName = landing == null ? null : landing.getName().orElse(null);
+      if (landingName != null) {
+        request.setPageName(landingName);
       } else {
         request.setPageName("index.html");
       }
-      String displayTitle = section == null ? null : ApiUtils.orNull(section.getDisplayTitle());
+      String displayTitle = section == null ? null : section.getDisplayTitle();
       if (displayTitle == null) {
-        displayTitle = ApiUtils.orNull(folder.getName());
+        displayTitle = folder.getName();
       }
 
       request.setPageLinkTitle(displayTitle);
       request.setPageTitle(displayTitle);
-      request.setPageUrlIdentifier(ApiUtils.orNull(folder.getName()));
+      request.setPageUrlIdentifier(folder.getName());
       request.setSectionType(PSSectionTypeEnum.section);
       IPSGuid template = null;
 
-      if (section == null || section.getTemplateName().orElse(null) == null) {
+      if (section == null || section.getTemplateName() == null) {
         throw new BackendException("templateName is required for section");
       }
       try {
         template =
             templateService.findUserTemplateIdByName(
-                section == null ? null : section.getTemplateName().orElse(null),
-                ApiUtils.orNull(folder.getSiteName()));
+                section.getTemplateName(), folder.getSiteName());
       } catch (PSParametersValidationException | IPSDataService.DataServiceLoadException e) {
         throw new BackendException("Cannot find template " + section.getTemplateName());
       }
@@ -1177,7 +1149,7 @@ public class FolderAdaptor implements IFolderAdaptor {
   }
 
   private boolean updateWorkflow(Folder folder, PSFolderProperties folderProperties) {
-    String requestWorkflow = ApiUtils.orNull(folder.getWorkflow());
+    String requestWorkflow = folder.getWorkflow();
     if (requestWorkflow != null) {
       int wfid;
       if (requestWorkflow.equalsIgnoreCase("[default]")) {
@@ -1202,26 +1174,25 @@ public class FolderAdaptor implements IFolderAdaptor {
     Access accessLevel = permission.getAccessLevel();
 
     boolean isSection =
-        ((existingFolder != null && existingFolder.getSectionInfo().isPresent())
-            || folder.getSectionInfo().isPresent());
+        (existingFolder != null && existingFolder.getSectionInfo() != null)
+            || folder.getSectionInfo() != null;
 
     // Need to change to write if we are converting to a section and the
     // original access level was ADMIN
 
     if (existingFolder != null
         && isSection
-        && existingFolder.getSectionInfo().isEmpty()
-        && existingFolder.getAccessLevel().orElse("").equals("ADMIN")) {
+        && existingFolder.getSectionInfo() == null
+        && "ADMIN".equals(existingFolder.getAccessLevel())) {
       folder.setAccessLevel("WRITE");
       changed = true;
     }
 
     // FB: EC_UNRELATED_TYPES NC 1-16-16
-    if (folder.getAccessLevel().isPresent()
-        && !folder.getAccessLevel().get().equals(accessLevel.name())) {
+    if (folder.getAccessLevel() != null && !folder.getAccessLevel().equals(accessLevel.name())) {
       // default for section is write, does not allow admin. default for
       // non section is admin. Unknown will be set to correct default
-      String level = ApiUtils.orNull(folder.getAccessLevel());
+      String level = folder.getAccessLevel();
       if (isSection) {
         if (!(level.equals("READ") || level.equals("WRITE"))) {
           level = "WRITE";
@@ -1234,7 +1205,7 @@ public class FolderAdaptor implements IFolderAdaptor {
       changed = true;
     }
 
-    Collection<String> editUsers = ApiUtils.orEmpty(folder.getEditUsers());
+    Collection<String> editUsers = folder.getEditUsers();
     if (editUsers != null) {
       List<String> serverUsers = new ArrayList<>();
       List<Principal> writePrincipals = permission.getWritePrincipals();

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
@@ -335,7 +335,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         // not widgets in it from the template
         boolean regionEditable = (instanceSize == 0 || owner.equals(PSMergedRegionOwner.PAGE));
 
-        boolean clearRegion = updateRegion.getWidgets().isEmpty();
+        boolean clearRegion =
+            updateRegion.getWidgets() == null || updateRegion.getWidgets().isEmpty();
         List<PSWidgetItem> updateWidgetList = new ArrayList<>();
         List<PSWidgetItem> newWidgetList = new ArrayList<>();
 
@@ -344,23 +345,23 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSWidgetItem existingWidget = findWidget(existingInstances, updateWidget);
 
           if (existingWidget == null && regionEditable) {
-            if (StringUtils.isNotEmpty(ApiUtils.orNull(updateWidget.getId()))) {
+            if (StringUtils.isNotEmpty(updateWidget.getId())) {
               throw new RuntimeException(
                   "Cannot find widget id "
-                      + ApiUtils.orNull(updateWidget.getId())
+                      + updateWidget.getId()
                       + " on region "
                       + updateRegion.getName());
             }
 
-            if (StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getId()))
-                && StringUtils.isEmpty(ApiUtils.orNull(updateWidget.getName()))) {
+            if (StringUtils.isEmpty(updateWidget.getId())
+                && StringUtils.isEmpty(updateWidget.getName())) {
               throw new RuntimeException("Must specify either id or name on widget");
             }
 
             existingWidget = new PSWidgetItem();
-            existingWidget.setDefinitionId(ApiUtils.orNull(updateWidget.getType()));
-            existingWidget.setId(ApiUtils.orNull(updateWidget.getId()));
-            existingWidget.setName(ApiUtils.orNull(updateWidget.getName()));
+            existingWidget.setDefinitionId(updateWidget.getType());
+            existingWidget.setId(updateWidget.getId());
+            existingWidget.setName(updateWidget.getName());
           }
           // will add placeholder nulls for non editable regions
           newWidgetList.add(existingWidget);
@@ -385,14 +386,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           }
 
           if (!clearRegion) {
-            pullTemplateRegionToPage(psPage, template, ApiUtils.orNull(updateRegion.getName()));
+            pullTemplateRegionToPage(psPage, template, updateRegion.getName());
           }
 
           psPage.getRegionBranches().setRegionWidgetAssociations(newWidgetAssoc);
 
           psPage
               .getRegionBranches()
-              .setRegionWidgets(ApiUtils.orNull(updateRegion.getName()), updateWidgetList);
+              .setRegionWidgets(updateRegion.getName(), updateWidgetList);
 
           savePage = true;
         }
@@ -543,8 +544,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         existingWidget = widget;
       }
       if (updateWidget.getName() != null
-          && widget.getName() != null
-          && updateWidget.getName().equals(widget.getName())) {
+          && widget.getName().isPresent()
+          && updateWidget.getName().equals(widget.getName().orElse(null))) {
         existingWidget = widget;
       }
     }
@@ -668,13 +669,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     var url =
         new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     var folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
     var pathServicePath = StringUtils.substring(folderUrl.getUrl(), 1);
 
     try {
@@ -690,7 +690,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       throw new BackendException(e.getMessage(), e);
     }
     if (psPage == null) {
-      if (PSFolderPathUtils.testHasInvalidChars(ApiUtils.orNull(toPage.getName()))) {
+      if (PSFolderPathUtils.testHasInvalidChars(toPage.getName())) {
         throw new IllegalArgumentException(
             "Cannot create a page with following chars in the name"
                 + SecureStringUtils.INVALID_ITEM_NAME_CHARACTERS);
@@ -705,9 +705,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     Page currentPage =
         getPage(
             baseUri,
-            ApiUtils.orNull(toPage.getSiteName()),
-            ApiUtils.orNull(toPage.getFolderPath()),
-            ApiUtils.orNull(toPage.getName()));
+            toPage.getSiteName(),
+            toPage.getFolderPath(),
+            toPage.getName());
 
     return currentPage;
   }
@@ -748,10 +748,10 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       currentState = getWorkflowState(page);
     }
 
-    Optional<WorkflowInfo> wfOpt = toPage.getWorkflow();
-    Optional<String> stateOpt = wfOpt.flatMap(WorkflowInfo::getState);
-    if (stateOpt.isPresent() && StringUtils.isNotEmpty(stateOpt.get())) {
-      endState = stateOpt.get();
+    WorkflowInfo wfInfo = toPage.getWorkflow();
+    String state = wfInfo == null ? null : wfInfo.getState();
+    if (StringUtils.isNotEmpty(state)) {
+      endState = state;
     } else {
       endState = currentState;
     }
@@ -765,66 +765,59 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
 
     UrlParts folderUrl =
-        new UrlParts(
-            ApiUtils.orNull(toPage.getSiteName()), ApiUtils.orNull(toPage.getFolderPath()), null);
+        new UrlParts(toPage.getSiteName(), toPage.getFolderPath(), null);
 
     // set default values
     if (newPage) {
-      page.setTitle(ApiUtils.orNull(toPage.getName()));
-      page.setLinkTitle(ApiUtils.orNull(toPage.getName()));
+      page.setTitle(toPage.getName());
+      page.setLinkTitle(toPage.getName());
     }
 
-    Optional<CodeInfo> codeOpt = toPage.getCode();
-    if (codeOpt.isPresent()) {
-      CodeInfo code = codeOpt.get();
-      String head = ApiUtils.orNull(code.getHead());
+    CodeInfo code = toPage.getCode();
+    if (code != null) {
+      String head = code.getHead();
       if (head != null) {
         page.setAdditionalHeadContent(head);
       }
-      String afterStart = ApiUtils.orNull(code.getAfterStart());
+      String afterStart = code.getAfterStart();
       if (afterStart != null) {
         page.setAfterBodyStartContent(afterStart);
       }
-      String beforeClose = ApiUtils.orNull(code.getBeforeClose());
+      String beforeClose = code.getBeforeClose();
       if (beforeClose != null) {
         page.setBeforeBodyCloseContent(beforeClose);
       }
     }
 
-    // `page` will be updated later so capture a final reference for lambda
-    final PSPage pageRef = page;
-    toPage
-        .getSeo()
-        .ifPresent(
-            seo -> {
-              if (seo.getMetaDescription() != null) {
-                pageRef.setDescription(ApiUtils.orNull(seo.getMetaDescription()));
-              }
+    SeoInfo seo = toPage.getSeo();
+    if (seo != null) {
+      if (seo.getMetaDescription() != null) {
+        page.setDescription(seo.getMetaDescription());
+      }
 
-              // default title to page name
-              if (seo.getBrowserTitle() != null) {
-                pageRef.setTitle(ApiUtils.orNull(seo.getBrowserTitle()));
-              }
+      // default title to page name
+      if (seo.getBrowserTitle() != null) {
+        page.setTitle(seo.getBrowserTitle());
+      }
 
-              Boolean hideSearch = seo.getHideSearch().orElse(null);
-              pageRef.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
+      Boolean hideSearch = seo.getHideSearch();
+      page.setNoindex((hideSearch != null && hideSearch) ? "true" : "false");
 
-              List<String> tags = seo.getTags().orElse(null);
-              if (tags != null) {
-                pageRef.setTags(tags);
-              }
-
-              // toPage.getSeo().getCategories();
-
-            });
+      List<String> tags = seo.getTags();
+      if (tags != null) {
+        page.setTags(tags);
+      }
+    }
     // default linktitle to name
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
-
-    if (toPage.getName() != null) {
-      page.setName(ApiUtils.orNull(toPage.getName()));
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
     }
 
-    String templateName = ApiUtils.orNull(toPage.getTemplateName());
+    if (toPage.getName() != null) {
+      page.setName(toPage.getName());
+    }
+
+    String templateName = toPage.getTemplateName();
 
     PSTemplate template = null;
     String templateId = null;
@@ -833,7 +826,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(toPage.getSiteName())));
+                  templateName, toPage.getSiteName()));
 
       page.setTemplateId(templateId);
     } else {
@@ -846,7 +839,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     template = templateService.load(templateId);
 
-    toPage.getDisplayName().ifPresent(page::setLinkTitle);
+    if (toPage.getDisplayName() != null) {
+      page.setLinkTitle(toPage.getDisplayName());
+    }
 
     updateRegionInfo(toPage, page, template);
     try {
@@ -867,8 +862,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
     updateAssetInfo(baseUri, toPage, page, template);
 
-    CalendarInfo calInfo = ApiUtils.orNull(toPage.getCalendar());
-    List<String> categories = toPage.getSeo().flatMap(SeoInfo::getCategories).orElse(null);
+    CalendarInfo calInfo = toPage.getCalendar();
+    List<String> categories = toPage.getSeo() == null ? null : toPage.getSeo().getCategories();
 
     boolean isUpdated = false;
     FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss.S");
@@ -901,7 +896,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
     }
     // Setting to null or empty string is the same as auto generate.
     if (toPage.getSummary() != null) {
-      if (StringUtils.isNotBlank(ApiUtils.orNull(toPage.getSummary()))) {
+      if (StringUtils.isNotBlank(toPage.getSummary())) {
         fields.put("auto_generate_summary", "0");
         fields.put("page_summary", toPage.getSummary());
       } else {
@@ -967,12 +962,12 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       emptyTemplateWidgetIds.add(emptyTemplateWidgetId.getId());
     }
 
-    List<Region> bodyRegions = ApiUtils.orNull(toPage.getBody());
+    List<Region> bodyRegions = toPage.getBody();
     if (bodyRegions != null) {
       for (Region region : bodyRegions) {
         PSMergedRegion systemRegion =
-            tree.getMergedRegionMap().get(ApiUtils.orNull(region.getName()));
-        List<Widget> widgets = ApiUtils.orNull(region.getWidgets());
+            tree.getMergedRegionMap().get(region.getName());
+        List<Widget> widgets = region.getWidgets();
         List<PSWidgetInstance> systemRegionWidgets = systemRegion.getWidgetInstances();
 
         if (widgets != null) {
@@ -990,7 +985,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
               String id = widgetItem.getId();
 
               PSRelationship assetRels = assetWidgets.get(id);
-              Asset asset = ApiUtils.orNull(widget.getAsset());
+              Asset asset = widget.getAsset();
 
               //
               if (assetRels != null && Boolean.TRUE.equals(asset.getRemove())) {
@@ -1005,8 +1000,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
                     PSAssetWidgetRelationship awRel =
                         new PSAssetWidgetRelationship(
                             page.getId(),
-                            Long.parseLong(ApiUtils.orNull(widget.getId())),
-                            ApiUtils.orNull(widget.getType()),
+                            Long.parseLong(widget.getId()),
+                            widget.getType(),
                             assetId,
                             0);
                     assetService.clearAssetWidgetRelationship(awRel);
@@ -1069,14 +1064,14 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         while (iterator.hasNext()) {
 
           PSOrphanedAssetSummary orphan = iterator.next();
-          if (StringUtils.equals(ApiUtils.orNull(widget.getName()), orphan.getName())
-              && StringUtils.equals(ApiUtils.orNull(widget.getType()), orphan.getType())) {
+          if (StringUtils.equals(widget.getName(), orphan.getName())
+              && StringUtils.equals(widget.getType(), orphan.getType())) {
             foundOrphan = true;
             PSAssetWidgetRelationship awRel =
                 new PSAssetWidgetRelationship(
                     page.getId(),
-                    Long.parseLong(ApiUtils.orNull(widget.getId())),
-                    ApiUtils.orNull(widget.getType()),
+                    Long.parseLong(widget.getId()),
+                    widget.getType(),
                     orphan.getId(),
                     0);
             try {
@@ -1096,7 +1091,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         if (!foundOrphan) {
           guidString =
               createAndAssociateLocalAsset(
-                  page.getId(), id, ApiUtils.orNull(widget.getType()), fields);
+                  page.getId(), id, widget.getType(), fields);
         }
       } else // existing asset
       {
@@ -1144,8 +1139,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 pathItem.getId(),
                 0);
         awRel.setResourceType(PSAssetResourceType.shared);
@@ -1158,8 +1153,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
         PSAssetWidgetRelationship awRel =
             new PSAssetWidgetRelationship(
                 page.getId(),
-                Long.parseLong(ApiUtils.orNull(widget.getId())),
-                ApiUtils.orNull(widget.getType()),
+                Long.parseLong(widget.getId()),
+                widget.getType(),
                 idMapper.getString(assetRels.getDependent()),
                 0);
         assetService.shareLocalContent(
@@ -1174,8 +1169,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
           PSAssetWidgetRelationship awRel =
               new PSAssetWidgetRelationship(
                   page.getId(),
-                  Long.parseLong(ApiUtils.orNull(widget.getId())),
-                  ApiUtils.orNull(widget.getType()),
+                  Long.parseLong(widget.getId()),
+                  widget.getType(),
                   pathItem.getId(),
                   0);
           awRel.setResourceType(PSAssetResourceType.shared);
@@ -1457,9 +1452,9 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String pageId = null;
       String templateName = null;
 
-      if (p != null && p.getId().isPresent() && p.getTemplateName().isPresent()) {
-        pageId = p.getId().get();
-        templateName = p.getTemplateName().get();
+      if (p != null && p.getId() != null && p.getTemplateName() != null) {
+        pageId = p.getId();
+        templateName = p.getTemplateName();
 
         if (pageId.isEmpty() || templateName.isEmpty()) {
           throw new PageNotFoundException();
@@ -1475,7 +1470,7 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
       String templateId =
           idMapper.getString(
               templateService.findUserTemplateIdByName(
-                  templateName, ApiUtils.orNull(p.getSiteName())));
+                  templateName, p.getSiteName()));
 
       if (templateId != null) {
         ArrayList<String> pageIds = new ArrayList<>();

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -412,15 +412,13 @@ public class SitesAdaptor implements ISiteAdaptor {
     Path safePublishRoot = requireSafeOutputRoot(publishRoot);
 
     VirtualSiteBuildResult built = buildVirtualSite(nameOrId, null);
-    Path buildOutput =
-        built.getOutputPath()
-            .filter(StringUtils::isNotBlank)
-            .map(Path::of)
-            .orElseThrow(
-                () ->
-                    new WebApplicationException(
-                        "Virtual Site build did not report an output path.",
-                        Response.Status.INTERNAL_SERVER_ERROR));
+    String outputPath = built.getOutputPath();
+    if (StringUtils.isBlank(outputPath)) {
+      throw new WebApplicationException(
+          "Virtual Site build did not report an output path.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    Path buildOutput = Path.of(outputPath);
 
     try {
       // Do not mention PSVirtualSitePublishCopyResult here: Spring lookup-method
@@ -888,7 +886,7 @@ public class SitesAdaptor implements ISiteAdaptor {
 
   Path resolveOutputRoot(VirtualSiteBuildRequest request, String siteKey) {
     String override =
-        request != null ? blankToNull(request.getOutputRoot().orElse(null)) : null;
+        request != null ? blankToNull(request.getOutputRoot()) : null;
     if (override != null) {
       Path path;
       try {
@@ -976,7 +974,9 @@ public class SitesAdaptor implements ISiteAdaptor {
       dto.setPublishPath(publishRoot.toAbsolutePath().normalize().toString());
     }
     if (built != null) {
-      built.getOutputPath().ifPresent(dto::setBuildOutputPath);
+      if (built.getOutputPath() != null) {
+        dto.setBuildOutputPath(built.getOutputPath());
+      }
       dto.setPagesWritten(built.getPagesWritten());
       dto.setLinkProblemCount(built.getLinkProblemCount());
       dto.setHasLinkProblems(built.getHasLinkProblems());

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/UserAdaptor.java
@@ -142,9 +142,9 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       boolean isNewUser = false;
 
       try {
-        var findUsers = userService.getUserNames(user.getUserName().orElse(null));
-        if (findUsers.getUsers().contains(user.getUserName().orElse(null))) {
-          newUser = userService.find(user.getUserName().orElse(null));
+        var findUsers = userService.getUserNames(user.getUserName());
+        if (findUsers.getUsers().contains(user.getUserName())) {
+          newUser = userService.find(user.getUserName());
         } else {
           newUser = new PSUser();
           isNewUser = true;
@@ -154,11 +154,11 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
         isNewUser = true;
       }
 
-      newUser.setName(user.getUserName().orElse(null));
+      newUser.setName(user.getUserName());
       newUser.setRoles(user.getRoles());
 
-      if (user.getEmailAddress().isPresent()) {
-        newUser.setEmail(user.getEmailAddress().orElse(null));
+      if (user.getEmailAddress() != null) {
+        newUser.setEmail(user.getEmailAddress());
       }
 
       // newUser.setRoles(user.getRoles()); // Already set above
@@ -167,14 +167,14 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
       if (!isNewUser) {
         newUser = userService.update(newUser);
       } else {
-        if (user.getUserType().orElse("").equalsIgnoreCase(PSUserProviderType.INTERNAL.name())) {
+        if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.INTERNAL.name())) {
           newUser = userService.create(newUser);
-        } else if (user.getUserType()
-            .orElse("")
-            .equalsIgnoreCase(PSUserProviderType.DIRECTORY.name())) {
+        } else if (StringUtils.equalsIgnoreCase(
+            user.getUserType(), PSUserProviderType.DIRECTORY.name())) {
           var newUsers = new PSImportUsers();
           var dirUsers = new ArrayList<PSExternalUser>();
-          dirUsers.add(new PSExternalUser(user.getUserName().orElse(null)));
+          dirUsers.add(new PSExternalUser(user.getUserName()));
           newUsers.setExternalUsers(dirUsers);
           var importUsers = userService.importDirectoryUsers(newUsers);
 
@@ -184,8 +184,8 @@ public class UserAdaptor extends SiteManageAdaptorBase implements IUserAdaptor {
             // Handle new imports and treat duplicates as if they should be updates
             if (impU.getStatus() == ImportStatus.SUCCESS
                 || impU.getStatus() == ImportStatus.DUPLICATE) {
-              newUser.setEmail(user.getEmailAddress().orElse(null));
-              newUser.setName(user.getUserName().orElse(null));
+              newUser.setEmail(user.getEmailAddress());
+              newUser.setName(user.getUserName());
               newUser.setProviderType(PSUserProviderType.DIRECTORY);
               newUser.setRoles(user.getRoles());
               newUser = userService.update(newUser);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -368,12 +368,12 @@ class SitesAdaptorTest {
     req.setOutputRoot(out.toString());
 
     VirtualSiteBuildResult result = building.buildVirtualSite("Help", req);
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("sample", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("sample", result.getSiteKey());
     assertEquals(2, result.getPagesWritten().intValue());
     assertEquals(0, result.getLinkProblemCount().intValue());
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
-    assertTrue(result.getOutputPath().isPresent());
+    assertTrue(result.getOutputPath() != null && !result.getOutputPath().isBlank());
     assertTrue(result.getWrittenFiles().contains("link-report.txt"));
   }
 
@@ -462,15 +462,15 @@ class SitesAdaptorTest {
         new SitesAdaptor(siteManager, () -> true, key -> staging, null);
 
     VirtualSitePublishResult result = publishing.publishVirtualSite("Help");
-    assertEquals("Help", result.getSiteName().orElse(null));
-    assertEquals("help-docs", result.getSiteKey().orElse(null));
+    assertEquals("Help", result.getSiteName());
+    assertEquals("help-docs", result.getSiteKey());
     assertEquals(1, result.getPagesWritten().intValue());
     assertTrue(result.getFilesCopied() >= 1);
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(publishTo.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(staging.resolve("8.2").resolve("index.html")));
     assertFalse(Files.exists(publishTo.resolve("_meta")));
-    assertTrue(result.getPublishPath().isPresent());
+    assertTrue(result.getPublishPath() != null && !result.getPublishPath().isBlank());
   }
 
   @Test
@@ -486,10 +486,10 @@ class SitesAdaptorTest {
     VirtualSitePublishResult dto =
         SitesAdaptor.toWirePublishResult("Help", "help-docs", built, publishRoot, 7);
 
-    assertEquals("Help", dto.getSiteName().orElse(null));
-    assertEquals("help-docs", dto.getSiteKey().orElse(null));
-    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath().orElse(null));
-    assertEquals(built.getOutputPath().orElse(null), dto.getBuildOutputPath().orElse(null));
+    assertEquals("Help", dto.getSiteName());
+    assertEquals("help-docs", dto.getSiteKey());
+    assertEquals(publishRoot.toAbsolutePath().normalize().toString(), dto.getPublishPath());
+    assertEquals(built.getOutputPath(), dto.getBuildOutputPath());
     assertEquals(3, dto.getPagesWritten().intValue());
     assertEquals(7, dto.getFilesCopied().intValue());
     assertEquals(1, dto.getLinkProblemCount().intValue());
@@ -552,7 +552,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.FALSE, status.getAvailable());
-    assertTrue(status.getMessage().orElse("").contains("No assembled"));
+    assertTrue(status.getMessage() != null && status.getMessage().contains("No assembled"));
   }
 
   @Test
@@ -570,7 +570,7 @@ class SitesAdaptorTest {
 
     VirtualSitePreviewStatus status = previewing.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, status.getAvailable());
-    assertEquals("8.2/index.html", status.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", status.getHomePath());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/MoveFolderItem.java
+++ b/rest/src/main/java/com/percussion/rest/MoveFolderItem.java
@@ -18,18 +18,22 @@
 package com.percussion.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * This class is posted to the REST service as part of a request to move an item (from its original
  * folder) to a new (target) folder. All paths are relative to its current root folder.
  *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits path
+ * scalars (issue #3413 / #3388).
+ *
  * @author yubingchen
  */
 @XmlRootElement(name = "MoveFolderItem")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a request to move a folder item.")
 public class MoveFolderItem {
   @Schema(required = true, description = "path")
@@ -53,8 +57,8 @@ public class MoveFolderItem {
    *
    * @return the target folder path, not blank for a valid folder path.
    */
-  public Optional<String> getTargetFolderPath() {
-    return Optional.ofNullable(targetFolderPath);
+  public String getTargetFolderPath() {
+    return targetFolderPath;
   }
 
   /**
@@ -71,8 +75,8 @@ public class MoveFolderItem {
    *
    * @return item path, not blank for a valid path.
    */
-  public Optional<String> getItemPath() {
-    return Optional.ofNullable(itemPath);
+  public String getItemPath() {
+    return itemPath;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/ObjectSummary.java
+++ b/rest/src/main/java/com/percussion/rest/ObjectSummary.java
@@ -21,8 +21,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.acls.UserAccessLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * High-level catalog summary, including security ACLs, for an object on the system.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code label}, {@code description}, and {@code guid} when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement
 @Schema(
@@ -78,32 +86,32 @@ public class ObjectSummary {
     this.id = id;
   }
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -126,8 +134,8 @@ public class ObjectSummary {
     this.objectLocked = objectLocked;
   }
 
-  public Optional<ObjectLockSummary> getLockSummary() {
-    return Optional.ofNullable(lockSummary);
+  public ObjectLockSummary getLockSummary() {
+    return lockSummary;
   }
 
   public void setLockSummary(ObjectLockSummary lockSummary) {

--- a/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
+++ b/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
@@ -494,7 +494,7 @@ public class AssetsResource {
       var requestThreadMap = new HashMap<>(PSRequestInfoBase.getRequestInfoMap());
       var currentUser = (String) PSRequestInfoBase.getRequestInfo(PSRequestInfo.KEY_USER);
       var user = userAdaptor.getUser(null, currentUser);
-      var toAddress = user.getEmailAddress().orElse(null);
+      var toAddress = user.getEmailAddress();
       CompletableFuture.runAsync(
           () -> {
             try {

--- a/rest/src/main/java/com/percussion/rest/contexts/Context.java
+++ b/rest/src/main/java/com/percussion/rest/contexts/Context.java
@@ -25,9 +25,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a publishing Context in Percussion CMS. */
+/**
+ * Represents a publishing Context in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and nested {@code defaultScheme} when set. Optional-returning getters historically serialized as
+ * empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "Context")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a publishing Context")
@@ -79,48 +84,48 @@ public class Context {
     this.locationSchemes = locationSchemes;
   }
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<LocationScheme> getDefaultScheme() {
-    return Optional.ofNullable(defaultScheme);
+  public LocationScheme getDefaultScheme() {
+    return defaultScheme;
   }
 
   public void setDefaultScheme(LocationScheme defaultScheme) {
     this.defaultScheme = defaultScheme;
   }
 
-  public Optional<List<LocationScheme>> getLocationSchemes() {
-    return Optional.ofNullable(locationSchemes);
+  public List<LocationScheme> getLocationSchemes() {
+    return locationSchemes;
   }
 
   public void setLocationSchemes(List<LocationScheme> locationSchemes) {

--- a/rest/src/main/java/com/percussion/rest/deliverytypes/DeliveryType.java
+++ b/rest/src/main/java/com/percussion/rest/deliverytypes/DeliveryType.java
@@ -22,9 +22,14 @@ import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Delivery Type in Percussion CMS. */
+/**
+ * Represents a Delivery Type in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code beanName} when set. Optional-returning getters historically serialized as empty/present
+ * beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "DeliveryType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Delivery Type.")
@@ -57,32 +62,32 @@ public class DeliveryType {
 
   public DeliveryType() {}
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getBeanName() {
-    return Optional.ofNullable(beanName);
+  public String getBeanName() {
+    return beanName;
   }
 
   public void setBeanName(String beanName) {

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatProperty.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.displayformat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.ValueList;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Optional;
 
-/** Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued. */
+/**
+ * Represents a property of a DisplayFormat. Properties may be multi-valued or single-valued.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits property
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(
     name = "DisplayFormatProperty",
     description =
@@ -54,40 +60,40 @@ public class DisplayFormatProperty {
     // Default constructor
   }
 
-  public Optional<String> getPropertyId() {
-    return Optional.ofNullable(propertyId);
+  public String getPropertyId() {
+    return propertyId;
   }
 
   public void setPropertyId(String propertyId) {
     this.propertyId = propertyId;
   }
 
-  public Optional<String> getPropertyName() {
-    return Optional.ofNullable(propertyName);
+  public String getPropertyName() {
+    return propertyName;
   }
 
   public void setPropertyName(String propertyName) {
     this.propertyName = propertyName;
   }
 
-  public Optional<String> getPropertyValue() {
-    return Optional.ofNullable(propertyValue);
+  public String getPropertyValue() {
+    return propertyValue;
   }
 
   public void setPropertyValue(String propertyValue) {
     this.propertyValue = propertyValue;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<ValueList> getPropertyValues() {
-    return Optional.ofNullable(propertyValues);
+  public ValueList getPropertyValues() {
+    return propertyValues;
   }
 
   public void setPropertyValues(ValueList propertyValues) {

--- a/rest/src/main/java/com/percussion/rest/folders/CopyFolderItemRequest.java
+++ b/rest/src/main/java/com/percussion/rest/folders/CopyFolderItemRequest.java
@@ -20,13 +20,19 @@
 package com.percussion.rest.folders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a request to copy a folder or item. Sunny Sal: "Copy ka request aaya, boss!" */
+/**
+ * Represents a request to copy a folder or item.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits path
+ * scalars (issue #3413 / #3388).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a request to copy a folder or item")
 public class CopyFolderItemRequest {
 
@@ -51,10 +57,10 @@ public class CopyFolderItemRequest {
   /**
    * Gets the target folder path.
    *
-   * @return Optional containing the target folder path if present
+   * @return the target folder path, or {@code null} if unset
    */
-  public Optional<String> getTargetFolderPath() {
-    return Optional.ofNullable(targetFolderPath);
+  public String getTargetFolderPath() {
+    return targetFolderPath;
   }
 
   public void setTargetFolderPath(String targetFolderPath) {
@@ -64,10 +70,10 @@ public class CopyFolderItemRequest {
   /**
    * Gets the item path.
    *
-   * @return Optional containing the item path if present
+   * @return the item path, or {@code null} if unset
    */
-  public Optional<String> getItemPath() {
-    return Optional.ofNullable(itemPath);
+  public String getItemPath() {
+    return itemPath;
   }
 
   public void setItemPath(String itemPath) {

--- a/rest/src/main/java/com/percussion/rest/folders/Folder.java
+++ b/rest/src/main/java/com/percussion/rest/folders/Folder.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.folders;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.core.UriBuilder;
@@ -26,12 +27,18 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
- * Represents a folder or section based on a folder. Sunny Sal: "Folder ka hero, structure ka zero!"
+ * Represents a folder or section based on a folder.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code path}, {@code siteName}, and related fields when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3413 / #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
  */
 @XmlRootElement(name = "Folder")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a folder or section based on a folder")
 public class Folder {
 
@@ -112,24 +119,24 @@ public class Folder {
     this.communityId = communityId;
   }
 
-  public Optional<String> getCommunityName() {
-    return Optional.ofNullable(communityName);
+  public String getCommunityName() {
+    return communityName;
   }
 
   public void setCommunityName(String communityName) {
     this.communityName = communityName;
   }
 
-  public Optional<String> getDefaultDisplayFormatName() {
-    return Optional.ofNullable(defaultDisplayFormatName);
+  public String getDefaultDisplayFormatName() {
+    return defaultDisplayFormatName;
   }
 
   public void setDefaultDisplayFormatName(String defaultDisplayFormatName) {
     this.defaultDisplayFormatName = defaultDisplayFormatName;
   }
 
-  public Optional<String> getLocale() {
-    return Optional.ofNullable(locale);
+  public String getLocale() {
+    return locale;
   }
 
   public void setLocale(String locale) {
@@ -147,96 +154,96 @@ public class Folder {
     this.recentUsers = recentUsers;
   }
 
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getPath() {
-    return Optional.ofNullable(path);
+  public String getPath() {
+    return path;
   }
 
   public void setPath(String path) {
     this.path = path;
   }
 
-  public Optional<String> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public String getWorkflow() {
+    return workflow;
   }
 
   public void setWorkflow(String workflow) {
     this.workflow = workflow;
   }
 
-  public Optional<SectionInfo> getSectionInfo() {
-    return Optional.ofNullable(sectionInfo);
+  public SectionInfo getSectionInfo() {
+    return sectionInfo;
   }
 
   public void setSectionInfo(SectionInfo sectionInfo) {
     this.sectionInfo = sectionInfo;
   }
 
-  public Optional<List<LinkRef>> getPages() {
-    return Optional.ofNullable(pages);
+  public List<LinkRef> getPages() {
+    return pages;
   }
 
   public void setPages(List<LinkRef> pages) {
     this.pages = pages;
   }
 
-  public Optional<List<LinkRef>> getAssets() {
-    return Optional.ofNullable(assets);
+  public List<LinkRef> getAssets() {
+    return assets;
   }
 
   public void setAssets(List<LinkRef> assets) {
     this.assets = assets;
   }
 
-  public Optional<List<LinkRef>> getSubfolders() {
-    return Optional.ofNullable(subfolders);
+  public List<LinkRef> getSubfolders() {
+    return subfolders;
   }
 
   public void setSubfolders(List<LinkRef> subfolders) {
     this.subfolders = subfolders;
   }
 
-  public Optional<List<SectionLinkRef>> getSubsections() {
-    return Optional.ofNullable(subsections);
+  public List<SectionLinkRef> getSubsections() {
+    return subsections;
   }
 
   public void setSubsections(List<SectionLinkRef> subsections) {
     this.subsections = subsections;
   }
 
-  public Optional<String> getAccessLevel() {
-    return Optional.ofNullable(accessLevel);
+  public String getAccessLevel() {
+    return accessLevel;
   }
 
   public void setAccessLevel(String accessLevel) {
     this.accessLevel = accessLevel;
   }
 
-  public Optional<List<String>> getEditUsers() {
-    return Optional.ofNullable(editUsers);
+  public List<String> getEditUsers() {
+    return editUsers;
   }
 
   public void setEditUsers(List<String> editUsers) {

--- a/rest/src/main/java/com/percussion/rest/folders/FoldersResource.java
+++ b/rest/src/main/java/com/percussion/rest/folders/FoldersResource.java
@@ -209,9 +209,9 @@ public class FoldersResource {
         folderName = StringUtils.defaultString(m.group(5));
       }
 
-      String objectName = folder.getName().orElse(null);
-      String objectPath = folder.getPath().orElse(null);
-      String objectSite = folder.getSiteName().orElse(null);
+      String objectName = folder.getName();
+      String objectPath = folder.getPath();
+      String objectSite = folder.getSiteName();
 
       if (objectName != null && !objectName.equals(folderName)) {
         throw new LocationMismatchException();
@@ -221,7 +221,7 @@ public class FoldersResource {
         throw new LocationMismatchException();
       }
       folder.setName(folderName);
-      folder.setPath(folder.getPath().orElse(null));
+      folder.setPath(objectPath);
       folder.setSiteName(siteName);
 
       folder = folderAdaptor.updateFolder(uriInfo.getBaseUri(), folder);
@@ -368,9 +368,7 @@ public class FoldersResource {
   public Status moveFolderItem(MoveFolderItem moveRequest) {
     try {
       folderAdaptor.moveFolderItem(
-          uriInfo.getBaseUri(),
-          moveRequest.getItemPath().orElse(null),
-          moveRequest.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), moveRequest.getItemPath(), moveRequest.getTargetFolderPath());
       return new Status("Moved OK");
     } catch (BackendException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -404,9 +402,7 @@ public class FoldersResource {
   public Status moveFolder(MoveFolderItem moveRequest) {
     try {
       folderAdaptor.moveFolderItem(
-          uriInfo.getBaseUri(),
-          moveRequest.getItemPath().orElse(null),
-          moveRequest.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), moveRequest.getItemPath(), moveRequest.getTargetFolderPath());
       return new Status("Moved OK");
     } catch (BackendException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -441,9 +437,7 @@ public class FoldersResource {
   public Status copyFolderItem(CopyFolderItemRequest request) {
     try {
       folderAdaptor.copyFolderItem(
-          uriInfo.getBaseUri(),
-          request.getItemPath().orElse(null),
-          request.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), request.getItemPath(), request.getTargetFolderPath());
       return new Status(200, "Copied OK");
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -477,9 +471,7 @@ public class FoldersResource {
   public Status copyFolder(CopyFolderItemRequest request) {
     try {
       folderAdaptor.copyFolder(
-          uriInfo.getBaseUri(),
-          request.getItemPath().orElse(null),
-          request.getTargetFolderPath().orElse(null));
+          uriInfo.getBaseUri(), request.getItemPath(), request.getTargetFolderPath());
       return new Status(200, "Copied OK");
     } catch (NotFoundException nfe) {
       return new Status(404, "Not Found");

--- a/rest/src/main/java/com/percussion/rest/folders/SectionInfo.java
+++ b/rest/src/main/java/com/percussion/rest/folders/SectionInfo.java
@@ -24,9 +24,14 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents section information for a folder. Sunny Sal: "Section info ka boss!" */
+/**
+ * Represents section information for a folder.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars when
+ * set. Optional-returning getters historically serialized as empty/present beans (issue #3413 /
+ * #3388).
+ */
 @XmlRootElement(name = "SectionInfo")
 @JsonInclude(Include.NON_NULL)
 public class SectionInfo {
@@ -60,56 +65,56 @@ public class SectionInfo {
   @Schema(name = "externalLinkUrl", description = "Link to the external source.")
   private String externalLinkUrl;
 
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
     this.type = type;
   }
 
-  public Optional<String> getDisplayTitle() {
-    return Optional.ofNullable(displayTitle);
+  public String getDisplayTitle() {
+    return displayTitle;
   }
 
   public void setDisplayTitle(String displayTitle) {
     this.displayTitle = displayTitle;
   }
 
-  public Optional<String> getTargetWindow() {
-    return Optional.ofNullable(targetWindow);
+  public String getTargetWindow() {
+    return targetWindow;
   }
 
   public void setTargetWindow(String targetWindow) {
     this.targetWindow = targetWindow;
   }
 
-  public Optional<String> getNavClass() {
-    return Optional.ofNullable(navClass);
+  public String getNavClass() {
+    return navClass;
   }
 
   public void setNavClass(String navClass) {
     this.navClass = navClass;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<LinkRef> getLandingPage() {
-    return Optional.ofNullable(landingPage);
+  public LinkRef getLandingPage() {
+    return landingPage;
   }
 
   public void setLandingPage(LinkRef landingPage) {
     this.landingPage = landingPage;
   }
 
-  public Optional<String> getExternalLinkUrl() {
-    return Optional.ofNullable(externalLinkUrl);
+  public String getExternalLinkUrl() {
+    return externalLinkUrl;
   }
 
   public void setExternalLinkUrl(String externalLinkUrl) {

--- a/rest/src/main/java/com/percussion/rest/folders/SectionLinkRef.java
+++ b/rest/src/main/java/com/percussion/rest/folders/SectionLinkRef.java
@@ -20,16 +20,20 @@
 package com.percussion.rest.folders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.rest.LinkRef;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
- * Represents a section link reference. Sunny Sal: "Section link ka reference, navigation ka sense!"
+ * Represents a section link reference.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code type}
+ * as a scalar (issue #3413 / #3388).
  */
 @XmlRootElement(name = "SectionLinkRef")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SectionLinkRef extends LinkRef {
 
   @Schema(
@@ -64,10 +68,10 @@ public class SectionLinkRef extends LinkRef {
   /**
    * Gets the type of the section link.
    *
-   * @return Optional containing the type if present
+   * @return the type, or {@code null} if unset
    */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {

--- a/rest/src/main/java/com/percussion/rest/locationscheme/LocationScheme.java
+++ b/rest/src/main/java/com/percussion/rest/locationscheme/LocationScheme.java
@@ -23,9 +23,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Location Scheme. Sunny Sal: "Location scheme ka hero, publishing ka zero!" */
+/**
+ * Represents a Location Scheme.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code schemeId}, and related fields when set. Optional-returning getters historically serialized
+ * as empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 /
+ * #3388). Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "LocationScheme")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Location Scheme")
@@ -67,24 +73,24 @@ public class LocationScheme {
     // Default constructor
   }
 
-  public Optional<Guid> getSchemeId() {
-    return Optional.ofNullable(schemeId);
+  public Guid getSchemeId() {
+    return schemeId;
   }
 
   public void setSchemeId(Guid schemeId) {
     this.schemeId = schemeId;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -107,24 +113,24 @@ public class LocationScheme {
     this.contentTypeId = contentTypeId;
   }
 
-  public Optional<Guid> getContext() {
-    return Optional.ofNullable(context);
+  public Guid getContext() {
+    return context;
   }
 
   public void setContext(Guid context) {
     this.context = context;
   }
 
-  public Optional<String> getLocationSchemeGenerator() {
-    return Optional.ofNullable(locationSchemeGenerator);
+  public String getLocationSchemeGenerator() {
+    return locationSchemeGenerator;
   }
 
   public void setLocationSchemeGenerator(String locationSchemeGenerator) {
     this.locationSchemeGenerator = locationSchemeGenerator;
   }
 
-  public Optional<LocationSchemeParameterList> getParameters() {
-    return Optional.ofNullable(parameters);
+  public LocationSchemeParameterList getParameters() {
+    return parameters;
   }
 
   public void setParameters(LocationSchemeParameterList parameters) {

--- a/rest/src/main/java/com/percussion/rest/locationscheme/LocationSchemeParameter.java
+++ b/rest/src/main/java/com/percussion/rest/locationscheme/LocationSchemeParameter.java
@@ -22,9 +22,14 @@ package com.percussion.rest.locationscheme;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Location Scheme Parameter. Sunny Sal: "Parameter ka power, scheme ka tower!" */
+/**
+ * Represents a Location Scheme Parameter.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code value} when set. Optional-returning getters historically serialized as empty/present
+ * beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue #3412 / #3388).
+ */
 @XmlRootElement(name = "LocationSchemeParameter")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Location Scheme Parameter")
@@ -46,32 +51,32 @@ public class LocationSchemeParameter {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<Integer> getSequence() {
-    return Optional.ofNullable(sequence);
+  public Integer getSequence() {
+    return sequence;
   }
 
   public void setSequence(Integer sequence) {
     this.sequence = sequence;
   }
 
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
     this.type = type;
   }
 
-  public Optional<String> getValue() {
-    return Optional.ofNullable(value);
+  public String getValue() {
+    return value;
   }
 
   public void setValue(String value) {

--- a/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CalendarInfo.java
@@ -19,13 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!" */
+/**
+ * Represents Calendar information. Sunny Sal: "Calendar ka hero, date ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits calendar
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CalendarInfo")
 @Schema(name = "CalendarInfo", description = "Represents Calendar information.")
 public class CalendarInfo {
@@ -42,10 +48,10 @@ public class CalendarInfo {
   /**
    * Gets the start date.
    *
-   * @return Optional containing the start date if present.
+   * @return the start date, or {@code null} if unset
    */
-  public Optional<Date> getStartDate() {
-    return Optional.ofNullable(startDate);
+  public Date getStartDate() {
+    return startDate;
   }
 
   public void setStartDate(Date startDate) {
@@ -55,10 +61,10 @@ public class CalendarInfo {
   /**
    * Gets the end date.
    *
-   * @return Optional containing the end date if present.
+   * @return the end date, or {@code null} if unset
    */
-  public Optional<Date> getEndDate() {
-    return Optional.ofNullable(endDate);
+  public Date getEndDate() {
+    return endDate;
   }
 
   public void setEndDate(Date endDate) {
@@ -68,10 +74,10 @@ public class CalendarInfo {
   /**
    * Gets the list of calendars.
    *
-   * @return Optional containing the list of calendars if present.
+   * @return the list of calendars, or {@code null} if unset
    */
-  public Optional<List<String>> getCalendars() {
-    return Optional.ofNullable(calendars);
+  public List<String> getCalendars() {
+    return calendars;
   }
 
   public void setCalendars(List<String> calendars) {

--- a/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/CodeInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!" */
+/**
+ * Represents code information for a page. Sunny Sal: "Code ka info, page ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits code fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "CodeInfo")
 @Schema(name = "CodeInfo", description = "Represents code information.")
 public class CodeInfo {
@@ -38,8 +44,8 @@ public class CodeInfo {
   private String beforeClose = "";
 
   /** Gets the head code. */
-  public Optional<String> getHead() {
-    return Optional.ofNullable(head);
+  public String getHead() {
+    return head;
   }
 
   public void setHead(String head) {
@@ -47,8 +53,8 @@ public class CodeInfo {
   }
 
   /** Gets the code after start. */
-  public Optional<String> getAfterStart() {
-    return Optional.ofNullable(afterStart);
+  public String getAfterStart() {
+    return afterStart;
   }
 
   public void setAfterStart(String afterStart) {
@@ -56,8 +62,8 @@ public class CodeInfo {
   }
 
   /** Gets the code before close. */
-  public Optional<String> getBeforeClose() {
-    return Optional.ofNullable(beforeClose);
+  public String getBeforeClose() {
+    return beforeClose;
   }
 
   public void setBeforeClose(String beforeClose) {

--- a/rest/src/main/java/com/percussion/rest/pages/Page.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Page.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -26,9 +27,14 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a page. Sunny Sal: "Page ka hero, content ka zero!" */
+/**
+ * Represents a page. Sunny Sal: "Page ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits page fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Page")
 @Schema(name = "Page", description = "Represents a page.")
 public class Page {
@@ -107,88 +113,88 @@ public class Page {
     this.bookmarkedUsers = bookmarkedUsers;
   }
 
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
     this.id = id;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDisplayName() {
-    return Optional.ofNullable(displayName);
+  public String getDisplayName() {
+    return displayName;
   }
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<String> getSummary() {
-    return Optional.ofNullable(summary);
+  public String getSummary() {
+    return summary;
   }
 
   public void setSummary(String summary) {
     this.summary = summary;
   }
 
-  public Optional<Date> getOverridePostDate() {
-    return Optional.ofNullable(overridePostDate);
+  public Date getOverridePostDate() {
+    return overridePostDate;
   }
 
   public void setOverridePostDate(Date overridePostDate) {
     this.overridePostDate = overridePostDate;
   }
 
-  public Optional<WorkflowInfo> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public WorkflowInfo getWorkflow() {
+    return workflow;
   }
 
   public void setWorkflow(WorkflowInfo workflow) {
     this.workflow = workflow;
   }
 
-  public Optional<SeoInfo> getSeo() {
-    return Optional.ofNullable(seo);
+  public SeoInfo getSeo() {
+    return seo;
   }
 
   public void setSeo(SeoInfo seo) {
     this.seo = seo;
   }
 
-  public Optional<CalendarInfo> getCalendar() {
-    return Optional.ofNullable(calendar);
+  public CalendarInfo getCalendar() {
+    return calendar;
   }
 
   public void setCalendar(CalendarInfo calendar) {
     this.calendar = calendar;
   }
 
-  public Optional<CodeInfo> getCode() {
-    return Optional.ofNullable(code);
+  public CodeInfo getCode() {
+    return code;
   }
 
   public void setCode(CodeInfo code) {
     this.code = code;
   }
 
-  public Optional<List<Region>> getBody() {
-    return Optional.ofNullable(body);
+  public List<Region> getBody() {
+    return body;
   }
 
   public void setBody(List<Region> body) {
@@ -220,16 +226,16 @@ public class Page {
         + "]";
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getFolderPath() {
-    return Optional.ofNullable(folderPath);
+  public String getFolderPath() {
+    return folderPath;
   }
 
   public void setFolderPath(String folderPath) {

--- a/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
@@ -174,9 +174,9 @@ public class PagesResource {
       pageName = StringUtils.defaultString(m.group(5));
     }
 
-    String objectName = page.getName().orElse(null);
-    String objectPath = page.getFolderPath().orElse(null);
-    String objectSite = page.getSiteName().orElse(null);
+    String objectName = page.getName();
+    String objectPath = page.getFolderPath();
+    String objectSite = page.getSiteName();
 
     if (pageName == null || (objectName != null && !objectName.equals(pageName))) {
       throw new LocationMismatchException();

--- a/rest/src/main/java/com/percussion/rest/pages/Region.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Region.java
@@ -19,15 +19,19 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents a region of a page either defined locally or by the template. Sunny Sal: "Region ka
  * hero, widgets ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits region
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Region")
 @Schema(
     name = "Region",
@@ -47,8 +51,8 @@ public class Region {
   private List<Widget> widgets;
 
   /** Gets the region name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -56,8 +60,8 @@ public class Region {
   }
 
   /** Gets the region type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -74,8 +78,8 @@ public class Region {
   }
 
   /** Gets the widgets in this region. */
-  public Optional<List<Widget>> getWidgets() {
-    return Optional.ofNullable(widgets);
+  public List<Widget> getWidgets() {
+    return widgets;
   }
 
   public void setWidgets(List<Widget> widgets) {

--- a/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/SeoInfo.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!" */
+/**
+ * Represents information about the SEO. Sunny Sal: "SEO ka info, ranking ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits SEO fields
+ * when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "SeoInfo")
 @Schema(name = "SeoInfo", description = "Represents information about the SEO.")
@@ -53,8 +57,8 @@ public class SeoInfo {
   private List<String> categories;
 
   /** Gets the browser title. */
-  public Optional<String> getBrowserTitle() {
-    return Optional.ofNullable(browserTitle);
+  public String getBrowserTitle() {
+    return browserTitle;
   }
 
   public void setBrowserTitle(String browserTitle) {
@@ -62,8 +66,8 @@ public class SeoInfo {
   }
 
   /** Gets the meta description. */
-  public Optional<String> getMetaDescription() {
-    return Optional.ofNullable(metaDescription);
+  public String getMetaDescription() {
+    return metaDescription;
   }
 
   public void setMetaDescription(String metaDescription) {
@@ -71,8 +75,8 @@ public class SeoInfo {
   }
 
   /** Gets the hide search flag. */
-  public Optional<Boolean> getHideSearch() {
-    return Optional.ofNullable(hideSearch);
+  public Boolean getHideSearch() {
+    return hideSearch;
   }
 
   public void setHideSearch(Boolean hideSearch) {
@@ -80,8 +84,8 @@ public class SeoInfo {
   }
 
   /** Gets the tags. */
-  public Optional<List<String>> getTags() {
-    return Optional.ofNullable(tags);
+  public List<String> getTags() {
+    return tags;
   }
 
   public void setTags(List<String> tags) {
@@ -89,8 +93,8 @@ public class SeoInfo {
   }
 
   /** Gets the categories. */
-  public Optional<List<String>> getCategories() {
-    return Optional.ofNullable(categories);
+  public List<String> getCategories() {
+    return categories;
   }
 
   public void setCategories(List<String> categories) {

--- a/rest/src/main/java/com/percussion/rest/pages/Widget.java
+++ b/rest/src/main/java/com/percussion/rest/pages/Widget.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.assets.Asset;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!" */
+/**
+ * Represents a Widget. Sunny Sal: "Widget ka hero, content ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits widget
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Widget")
 @Schema(name = "Widget", description = "Represents a Widget.")
@@ -57,8 +61,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget id. */
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   public void setId(String id) {
@@ -66,8 +70,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -75,8 +79,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget type. */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {
@@ -84,8 +88,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the widget scope. */
-  public Optional<String> getScope() {
-    return Optional.ofNullable(scope);
+  public String getScope() {
+    return scope;
   }
 
   public void setScope(String scope) {
@@ -93,8 +97,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets whether the widget is editable. */
-  public Optional<Boolean> getEditable() {
-    return Optional.ofNullable(editable);
+  public Boolean getEditable() {
+    return editable;
   }
 
   public void setEditable(Boolean editable) {
@@ -102,8 +106,8 @@ public class Widget implements Cloneable {
   }
 
   /** Gets the asset within the widget. */
-  public Optional<Asset> getAsset() {
-    return Optional.ofNullable(asset);
+  public Asset getAsset() {
+    return asset;
   }
 
   public void setAsset(Asset asset) {

--- a/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
+++ b/rest/src/main/java/com/percussion/rest/pages/WorkflowInfo.java
@@ -19,11 +19,17 @@
 
 package com.percussion.rest.pages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!" */
+/**
+ * Represents information on the workflow. Sunny Sal: "Workflow ka info, process ka hero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits workflow
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "WorkflowInfo")
 @Schema(name = "WorkflowInfo", description = "Represents information on the workflow.")
 public class WorkflowInfo {
@@ -41,8 +47,8 @@ public class WorkflowInfo {
   private String checkedOutUser;
 
   /** Gets the workflow name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -50,8 +56,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the workflow state. */
-  public Optional<String> getState() {
-    return Optional.ofNullable(state);
+  public String getState() {
+    return state;
   }
 
   public void setState(String state) {
@@ -59,8 +65,8 @@ public class WorkflowInfo {
   }
 
   /** Gets whether the item is checked out. */
-  public Optional<Boolean> getCheckedOut() {
-    return Optional.ofNullable(checkedOut);
+  public Boolean getCheckedOut() {
+    return checkedOut;
   }
 
   public void setCheckedOut(Boolean checkedOut) {
@@ -68,8 +74,8 @@ public class WorkflowInfo {
   }
 
   /** Gets the user that has the item checked out. */
-  public Optional<String> getCheckedOutUser() {
-    return Optional.ofNullable(checkedOutUser);
+  public String getCheckedOutUser() {
+    return checkedOutUser;
   }
 
   public void setCheckedOutUser(String checkedOutUser) {

--- a/rest/src/main/java/com/percussion/rest/roles/Role.java
+++ b/rest/src/main/java/com/percussion/rest/roles/Role.java
@@ -19,15 +19,23 @@
 
 package com.percussion.rest.roles;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!" */
+/**
+ * Represents a system Role that a user may belong to. Sunny Sal: "Role ka hero, users ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name},
+ * {@code description}, and {@code homePage} when set. Optional-returning getters historically
+ * serialized as empty/present beans or dropped fields under {@code @JsonInclude(NON_NULL)} (issue
+ * #3388). Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "Role")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "Role", description = "Represents a system Role that a user may belong to.")
 public class Role {
 
@@ -60,24 +68,24 @@ public class Role {
     // Default constructor
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getHomePage() {
-    return Optional.ofNullable(homePage);
+  public String getHomePage() {
+    return homePage;
   }
 
   public void setHomePage(String homePage) {

--- a/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteMapOptions.java
@@ -17,9 +17,15 @@
 
 package com.percussion.rest.sites;
 
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
-/** Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!" */
+/**
+ * Options for sitemap generation. Sunny Sal: "Sitemap options ka boss!"
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SiteMapOptions {
 
   private boolean navigationBased = true;
@@ -47,40 +53,40 @@ public class SiteMapOptions {
     this.includeFolder = includeFolder;
   }
 
-  public Optional<String> getTimeZone() {
-    return Optional.ofNullable(timeZone);
+  public String getTimeZone() {
+    return timeZone;
   }
 
   public void setTimeZone(String timeZone) {
     this.timeZone = timeZone;
   }
 
-  public Optional<SiteMapDateFormat> getDateFormat() {
-    return Optional.ofNullable(dateFormat);
+  public SiteMapDateFormat getDateFormat() {
+    return dateFormat;
   }
 
   public void setDateFormat(SiteMapDateFormat dateFormat) {
     this.dateFormat = dateFormat;
   }
 
-  public Optional<String> getFileName() {
-    return Optional.ofNullable(fileName);
+  public String getFileName() {
+    return fileName;
   }
 
   public void setFileName(String fileName) {
     this.fileName = fileName;
   }
 
-  public Optional<String> getUseSiteMapIndex() {
-    return Optional.ofNullable(useSiteMapIndex);
+  public String getUseSiteMapIndex() {
+    return useSiteMapIndex;
   }
 
   public void setUseSiteMapIndex(String useSiteMapIndex) {
     this.useSiteMapIndex = useSiteMapIndex;
   }
 
-  public Optional<SiteMapType> getSiteMapType() {
-    return Optional.ofNullable(siteMapType);
+  public SiteMapType getSiteMapType() {
+    return siteMapType;
   }
 
   public void setSiteMapType(SiteMapType siteMapType) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildRequest.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Optional body for {@code POST /sites/{nameOrId}/virtual/build}.
  *
  * <p>When omitted or empty, the server chooses a default output directory under the CMS install
  * {@code tmp/virtual-sites/} tree (or the JVM temp directory when the install root is unavailable).
+ *
+ * <p>Wire getters return plain {@code String} (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,8 +47,8 @@ public class VirtualSiteBuildRequest {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getOutputRoot() {
-    return Optional.ofNullable(outputRoot);
+  public String getOutputRoot() {
+    return outputRoot;
   }
 
   public void setOutputRoot(String outputRoot) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteBuildResult.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of a CMS-integrated Virtual Site static build ({@code POST
@@ -30,6 +29,9 @@ import java.util.Optional;
  * <p>Maps from system {@code PSVirtualSiteBuildResult}: pages assembled, link-problem summary, and
  * absolute output path. Build may complete successfully while still reporting link problems (HTTP
  * 200 with {@code hasLinkProblems=true}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSiteBuildResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -75,24 +77,24 @@ public class VirtualSiteBuildResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePreviewStatus.java
@@ -19,13 +19,15 @@ package com.percussion.rest.sites;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Whether a last Virtual Site static build can be previewed from the product UI ({@code GET
  * /sites/{nameOrId}/virtual/preview}).
  *
  * <p>Missing or failed builds return HTTP 200 with {@code available=false} and a message — not 500.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePreviewStatus")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -62,24 +64,24 @@ public class VirtualSitePreviewStatus {
     this.available = available;
   }
 
-  public Optional<String> getHomePath() {
-    return Optional.ofNullable(homePath);
+  public String getHomePath() {
+    return homePath;
   }
 
   public void setHomePath(String homePath) {
     this.homePath = homePath;
   }
 
-  public Optional<String> getOutputPath() {
-    return Optional.ofNullable(outputPath);
+  public String getOutputPath() {
+    return outputPath;
   }
 
   public void setOutputPath(String outputPath) {
     this.outputPath = outputPath;
   }
 
-  public Optional<String> getMessage() {
-    return Optional.ofNullable(message);
+  public String getMessage() {
+    return message;
   }
 
   public void setMessage(String message) {

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSitePublishResult.java
@@ -21,11 +21,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Outcome of {@code POST /sites/{nameOrId}/virtual/publish}: build-then-copy to the Site filesystem
  * publish root ({@code IPSSite.root}).
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson emits scalars, not
+ * Optional-bean {@code empty}/{@code present} keys (#3411 / #3388).
  */
 @XmlRootElement(name = "VirtualSitePublishResult")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -70,32 +72,32 @@ public class VirtualSitePublishResult {
     // Default constructor for JAX-RS / Jackson
   }
 
-  public Optional<String> getSiteName() {
-    return Optional.ofNullable(siteName);
+  public String getSiteName() {
+    return siteName;
   }
 
   public void setSiteName(String siteName) {
     this.siteName = siteName;
   }
 
-  public Optional<String> getSiteKey() {
-    return Optional.ofNullable(siteKey);
+  public String getSiteKey() {
+    return siteKey;
   }
 
   public void setSiteKey(String siteKey) {
     this.siteKey = siteKey;
   }
 
-  public Optional<String> getPublishPath() {
-    return Optional.ofNullable(publishPath);
+  public String getPublishPath() {
+    return publishPath;
   }
 
   public void setPublishPath(String publishPath) {
     this.publishPath = publishPath;
   }
 
-  public Optional<String> getBuildOutputPath() {
-    return Optional.ofNullable(buildOutputPath);
+  public String getBuildOutputPath() {
+    return buildOutputPath;
   }
 
   public void setBuildOutputPath(String buildOutputPath) {

--- a/rest/src/main/java/com/percussion/rest/templates/Template.java
+++ b/rest/src/main/java/com/percussion/rest/templates/Template.java
@@ -19,12 +19,22 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-/** Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!" */
+/**
+ * Represents an assembly Template. Sunny Sal: "Template ka hero, slots ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits catalog
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "Template")
 @Schema(name = "Template", description = "Represents an assembly Template")
 public class Template {
@@ -55,72 +65,72 @@ public class Template {
     // Default constructor
   }
 
-  public Optional<Guid> getId() {
-    return Optional.ofNullable(id);
+  public Guid getId() {
+    return id;
   }
 
   public void setId(Guid id) {
     this.id = id;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getLocationPrefix() {
-    return Optional.ofNullable(locationPrefix);
+  public String getLocationPrefix() {
+    return locationPrefix;
   }
 
   public void setLocationPrefix(String locationPrefix) {
     this.locationPrefix = locationPrefix;
   }
 
-  public Optional<String> getLocationSuffix() {
-    return Optional.ofNullable(locationSuffix);
+  public String getLocationSuffix() {
+    return locationSuffix;
   }
 
   public void setLocationSuffix(String locationSuffix) {
     this.locationSuffix = locationSuffix;
   }
 
-  public Optional<String> getAssembler() {
-    return Optional.ofNullable(assembler);
+  public String getAssembler() {
+    return assembler;
   }
 
   public void setAssembler(String assembler) {
     this.assembler = assembler;
   }
 
-  public Optional<String> getAssemblyUrl() {
-    return Optional.ofNullable(assemblyUrl);
+  public String getAssemblyUrl() {
+    return assemblyUrl;
   }
 
   public void setAssemblyUrl(String assemblyUrl) {
     this.assemblyUrl = assemblyUrl;
   }
 
-  public Optional<String> getStyleSheet() {
-    return Optional.ofNullable(styleSheet);
+  public String getStyleSheet() {
+    return styleSheet;
   }
 
   public void setStyleSheet(String styleSheet) {
@@ -143,48 +153,48 @@ public class Template {
     this.outputFormat = outputFormat;
   }
 
-  public Optional<Character> getPublishWhen() {
-    return Optional.ofNullable(publishWhen);
+  public Character getPublishWhen() {
+    return publishWhen;
   }
 
   public void setPublishWhen(Character publishWhen) {
     this.publishWhen = publishWhen;
   }
 
-  public Optional<Integer> getTemplateType() {
-    return Optional.ofNullable(templateType);
+  public Integer getTemplateType() {
+    return templateType;
   }
 
   public void setTemplateType(Integer templateType) {
     this.templateType = templateType;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getTemplate() {
-    return Optional.ofNullable(template);
+  public String getTemplate() {
+    return template;
   }
 
   public void setTemplate(String template) {
     this.template = template;
   }
 
-  public Optional<String> getMimeType() {
-    return Optional.ofNullable(mimeType);
+  public String getMimeType() {
+    return mimeType;
   }
 
   public void setMimeType(String mimeType) {
     this.mimeType = mimeType;
   }
 
-  public Optional<String> getCharset() {
-    return Optional.ofNullable(charset);
+  public String getCharset() {
+    return charset;
   }
 
   public void setCharset(String charset) {
@@ -207,16 +217,16 @@ public class Template {
     this.slots = slots;
   }
 
-  public Optional<Integer> getGlobalTemplateUsage() {
-    return Optional.ofNullable(globalTemplateUsage);
+  public Integer getGlobalTemplateUsage() {
+    return globalTemplateUsage;
   }
 
   public void setGlobalTemplateUsage(Integer globalTemplateUsage) {
     this.globalTemplateUsage = globalTemplateUsage;
   }
 
-  public Optional<Long> getGlobalTemplate() {
-    return Optional.ofNullable(globalTemplate);
+  public Long getGlobalTemplate() {
+    return globalTemplate;
   }
 
   public void setGlobalTemplate(Long globalTemplate) {

--- a/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplateBinding.java
@@ -19,10 +19,16 @@
 
 package com.percussion.rest.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
-import java.util.Optional;
 
-/** Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!" */
+/**
+ * Represents a Template Binding. Sunny Sal: "Binding ka hero, expression ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits binding
+ * fields when set instead of Optional-bean {@code empty}/{@code present} keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TemplateBinding {
 
   private Guid bindingId;
@@ -36,24 +42,24 @@ public class TemplateBinding {
     // Default constructor
   }
 
-  public Optional<Guid> getBindingId() {
-    return Optional.ofNullable(bindingId);
+  public Guid getBindingId() {
+    return bindingId;
   }
 
   public void setBindingId(Guid bindingId) {
     this.bindingId = bindingId;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<Guid> getTemplateId() {
-    return Optional.ofNullable(templateId);
+  public Guid getTemplateId() {
+    return templateId;
   }
 
   public void setTemplateId(Guid templateId) {
@@ -68,16 +74,16 @@ public class TemplateBinding {
     this.executionOrder = executionOrder;
   }
 
-  public Optional<String> getVariable() {
-    return Optional.ofNullable(variable);
+  public String getVariable() {
+    return variable;
   }
 
   public void setVariable(String variable) {
     this.variable = variable;
   }
 
-  public Optional<String> getExpression() {
-    return Optional.ofNullable(expression);
+  public String getExpression() {
+    return expression;
   }
 
   public void setExpression(String expression) {

--- a/rest/src/main/java/com/percussion/rest/users/User.java
+++ b/rest/src/main/java/com/percussion/rest/users/User.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.users;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.LinkRef;
 import com.percussion.rest.communities.Community;
 import com.percussion.rest.communities.CommunityList;
@@ -26,10 +27,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-/** Represents a User. Sunny Sal: "User ka hero, login ka zero!" */
+/**
+ * Represents a User. Sunny Sal: "User ka hero, login ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code
+ * userName}, {@code firstName}, and related scalars when set. Optional-returning getters
+ * historically serialized as empty/present beans or dropped fields under {@code
+ * @JsonInclude(NON_NULL)} (issue #3388). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
+ */
 @XmlRootElement(name = "User")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "User", description = "Represents a User.")
 public class User {
 
@@ -101,56 +110,56 @@ public class User {
     // Default constructor
   }
 
-  public Optional<CommunityList> getUserCommunities() {
-    return Optional.ofNullable(userCommunities);
+  public CommunityList getUserCommunities() {
+    return userCommunities;
   }
 
   public void setUserCommunities(CommunityList userCommunities) {
     this.userCommunities = userCommunities;
   }
 
-  public Optional<Community> getSelectedCommunity() {
-    return Optional.ofNullable(selectedCommunity);
+  public Community getSelectedCommunity() {
+    return selectedCommunity;
   }
 
   public void setSelectedCommunity(Community selectedCommunity) {
     this.selectedCommunity = selectedCommunity;
   }
 
-  public Optional<String> getUserName() {
-    return Optional.ofNullable(userName);
+  public String getUserName() {
+    return userName;
   }
 
   public void setUserName(String userName) {
     this.userName = userName;
   }
 
-  public Optional<String> getFirstName() {
-    return Optional.ofNullable(firstName);
+  public String getFirstName() {
+    return firstName;
   }
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
-  public Optional<String> getLastName() {
-    return Optional.ofNullable(lastName);
+  public String getLastName() {
+    return lastName;
   }
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
-  public Optional<String> getEmailAddress() {
-    return Optional.ofNullable(emailAddress);
+  public String getEmailAddress() {
+    return emailAddress;
   }
 
   public void setEmailAddress(String emailAddress) {
     this.emailAddress = emailAddress;
   }
 
-  public Optional<String> getUserType() {
-    return Optional.ofNullable(userType);
+  public String getUserType() {
+    return userType;
   }
 
   public void setUserType(String userType) {
@@ -223,8 +232,8 @@ public class User {
     this.recentTemplates = recentTemplates;
   }
 
-  public Optional<LinkRef> getPersonalPage() {
-    return Optional.ofNullable(personalPage);
+  public LinkRef getPersonalPage() {
+    return personalPage;
   }
 
   public void setPersonalPage(LinkRef personalPage) {
@@ -253,8 +262,8 @@ public class User {
     this.roles = roles;
   }
 
-  public Optional<String> getPassword() {
-    return Optional.ofNullable(password);
+  public String getPassword() {
+    return password;
   }
 
   public void setPassword(String password) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,23 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.pages.CalendarInfo;
+import com.percussion.rest.pages.CodeInfo;
+import com.percussion.rest.pages.Page;
+import com.percussion.rest.pages.Region;
+import com.percussion.rest.pages.SeoInfo;
+import com.percussion.rest.pages.Widget;
+import com.percussion.rest.pages.WorkflowInfo;
+import com.percussion.rest.templates.Template;
+import com.percussion.rest.templates.TemplateBinding;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +43,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). DisplayFormatProperty
+ * / Template / Page family follow the same plain-getter rule (issue #3407). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +124,174 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void displayFormatProperty_serializesPlainScalarsNotOptionalBeans() {
+    DisplayFormatProperty prop = new DisplayFormatProperty();
+    prop.setPropertyId("1");
+    prop.setPropertyName("sortColumn");
+    prop.setPropertyValue("sys_title");
+    prop.setDescription("Default sort");
+
+    ObjectMapper propMapper =
+        new JacksonContextResolver().getContext(DisplayFormatProperty.class);
+    String json = propMapper.writeValueAsString(prop);
+    assertTrue(json.contains("\"propertyId\""), json);
+    assertTrue(json.contains("\"propertyName\""), json);
+    assertTrue(json.contains("sortColumn"), json);
+    assertTrue(json.contains("\"propertyValue\""), json);
+    assertTrue(json.contains("sys_title"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    DisplayFormatProperty roundTrip = propMapper.readValue(json, DisplayFormatProperty.class);
+    assertEquals("1", roundTrip.getPropertyId(), json);
+    assertEquals("sortColumn", roundTrip.getPropertyName(), json);
+    assertEquals("sys_title", roundTrip.getPropertyValue(), json);
+  }
+
+  @Test
+  void template_serializesNameLabelNotOptionalBeans() {
+    Template template = new Template();
+    template.setName("perc.page");
+    template.setLabel("Page");
+    template.setDescription("Page assembly");
+    template.setMimeType("text/html");
+
+    ObjectMapper templateMapper = new JacksonContextResolver().getContext(Template.class);
+    String json = templateMapper.writeValueAsString(template);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"mimeType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    Template roundTrip = templateMapper.readValue(json, Template.class);
+    assertEquals("perc.page", roundTrip.getName(), json);
+    assertEquals("Page", roundTrip.getLabel(), json);
+    assertEquals("text/html", roundTrip.getMimeType(), json);
+  }
+
+  @Test
+  void templateBinding_serializesVariableExpressionNotOptionalBeans() {
+    TemplateBinding binding = new TemplateBinding();
+    binding.setVariable("$rx");
+    binding.setExpression("$sys.template");
+    binding.setExecutionOrder(1);
+
+    ObjectMapper bindingMapper = new JacksonContextResolver().getContext(TemplateBinding.class);
+    String json = bindingMapper.writeValueAsString(binding);
+    assertTrue(json.contains("\"variable\""), json);
+    assertTrue(json.contains("$rx"), json);
+    assertTrue(json.contains("\"expression\""), json);
+    assertTrue(json.contains("$sys.template"), json);
+    assertNoOptionalBeanKeys(json);
+
+    TemplateBinding roundTrip = bindingMapper.readValue(json, TemplateBinding.class);
+    assertEquals("$rx", roundTrip.getVariable(), json);
+    assertEquals("$sys.template", roundTrip.getExpression(), json);
+  }
+
+  @Test
+  void page_serializesNamePathNotOptionalBeans() {
+    Page page = new Page();
+    page.setId("1234");
+    page.setName("home.html");
+    page.setDisplayName("Home");
+    page.setSiteName("Help");
+    page.setFolderPath("docs");
+    page.setTemplateName("perc.page");
+    page.setSummary("Welcome");
+
+    SeoInfo seo = new SeoInfo();
+    seo.setBrowserTitle("Help Home");
+    seo.setMetaDescription("Landing page");
+    seo.setHideSearch(Boolean.FALSE);
+    page.setSeo(seo);
+
+    ObjectMapper pageMapper = new JacksonContextResolver().getContext(Page.class);
+    String json = pageMapper.writeValueAsString(page);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("home.html"), json);
+    assertTrue(json.contains("\"displayName\""), json);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("\"folderPath\""), json);
+    assertTrue(json.contains("\"templateName\""), json);
+    assertTrue(json.contains("\"browserTitle\""), json);
+    assertTrue(json.contains("Help Home"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Page roundTrip = pageMapper.readValue(json, Page.class);
+    assertEquals("1234", roundTrip.getId(), json);
+    assertEquals("home.html", roundTrip.getName(), json);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertNotNull(roundTrip.getSeo(), json);
+    assertEquals("Help Home", roundTrip.getSeo().getBrowserTitle(), json);
+  }
+
+  @Test
+  void widgetAndPageFamily_serializePlainScalarsNotOptionalBeans() {
+    Widget widget = new Widget();
+    widget.setId("w1");
+    widget.setName("richText");
+    widget.setType("percRichText");
+    widget.setScope(Widget.SCOPE_LOCAL);
+    widget.setEditable(Boolean.TRUE);
+
+    ObjectMapper widgetMapper = new JacksonContextResolver().getContext(Widget.class);
+    String widgetJson = widgetMapper.writeValueAsString(widget);
+    assertTrue(widgetJson.contains("\"name\""), widgetJson);
+    assertTrue(widgetJson.contains("richText"), widgetJson);
+    assertTrue(widgetJson.contains("\"type\""), widgetJson);
+    assertNoOptionalBeanKeys(widgetJson);
+    Widget widgetRoundTrip = widgetMapper.readValue(widgetJson, Widget.class);
+    assertEquals("w1", widgetRoundTrip.getId(), widgetJson);
+    assertEquals("percRichText", widgetRoundTrip.getType(), widgetJson);
+
+    Region region = new Region();
+    region.setName("content");
+    region.setType("TEMPLATE");
+    region.setWidgets(List.of(widget));
+    ObjectMapper regionMapper = new JacksonContextResolver().getContext(Region.class);
+    String regionJson = regionMapper.writeValueAsString(region);
+    assertTrue(regionJson.contains("\"name\""), regionJson);
+    assertTrue(regionJson.contains("content"), regionJson);
+    assertNoOptionalBeanKeys(regionJson);
+
+    WorkflowInfo workflow = new WorkflowInfo();
+    workflow.setName("Default Workflow");
+    workflow.setState("Draft");
+    workflow.setCheckedOut(Boolean.FALSE);
+    ObjectMapper wfMapper = new JacksonContextResolver().getContext(WorkflowInfo.class);
+    String wfJson = wfMapper.writeValueAsString(workflow);
+    assertTrue(wfJson.contains("\"name\""), wfJson);
+    assertTrue(wfJson.contains("Draft"), wfJson);
+    assertNoOptionalBeanKeys(wfJson);
+    WorkflowInfo wfRoundTrip = wfMapper.readValue(wfJson, WorkflowInfo.class);
+    assertEquals("Default Workflow", wfRoundTrip.getName(), wfJson);
+    assertEquals("Draft", wfRoundTrip.getState(), wfJson);
+
+    CodeInfo code = new CodeInfo();
+    code.setHead("<script></script>");
+    ObjectMapper codeMapper = new JacksonContextResolver().getContext(CodeInfo.class);
+    String codeJson = codeMapper.writeValueAsString(code);
+    assertTrue(codeJson.contains("\"head\""), codeJson);
+    assertNoOptionalBeanKeys(codeJson);
+
+    CalendarInfo calendar = new CalendarInfo();
+    calendar.setCalendars(List.of("Default"));
+    ObjectMapper calMapper = new JacksonContextResolver().getContext(CalendarInfo.class);
+    String calJson = calMapper.writeValueAsString(calendar);
+    assertTrue(calJson.contains("\"calendars\""), calJson);
+    assertTrue(calJson.contains("Default"), calJson);
+    assertNoOptionalBeanKeys(calJson);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,19 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.sites.SiteMapDateFormat;
+import com.percussion.rest.sites.SiteMapOptions;
+import com.percussion.rest.sites.SiteMapType;
+import com.percussion.rest.sites.VirtualSiteBuildRequest;
+import com.percussion.rest.sites.VirtualSiteBuildResult;
+import com.percussion.rest.sites.VirtualSitePreviewStatus;
+import com.percussion.rest.sites.VirtualSitePublishResult;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -31,8 +39,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Virtual Site +
+ * SiteMap wire DTOs follow the same plain-getter rule (issue #3411 / #3388). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +120,142 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void virtualSiteBuildRequest_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildRequest request = new VirtualSiteBuildRequest();
+    request.setOutputRoot("C:/tmp/product-docs-site");
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"outputRoot\""), json);
+    assertTrue(json.contains("C:/tmp/product-docs-site"), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildRequest roundTrip =
+        requestMapper.readValue(json, VirtualSiteBuildRequest.class);
+    assertEquals("C:/tmp/product-docs-site", roundTrip.getOutputRoot(), json);
+  }
+
+  @Test
+  void virtualSiteBuildResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSiteBuildResult result = new VirtualSiteBuildResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSiteBuildResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"siteKey\""), json);
+    assertTrue(json.contains("product-docs"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"pagesWritten\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSiteBuildResult roundTrip = resultMapper.readValue(json, VirtualSiteBuildResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("product-docs", roundTrip.getSiteKey(), json);
+    assertEquals("C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getOutputPath(), json);
+    assertEquals(42, roundTrip.getPagesWritten(), json);
+  }
+
+  @Test
+  void virtualSitePreviewStatus_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePreviewStatus status = new VirtualSitePreviewStatus();
+    status.setAvailable(true);
+    status.setHomePath("8.2/index.html");
+    status.setOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    status.setMessage("ready");
+
+    ObjectMapper statusMapper =
+        new JacksonContextResolver().getContext(VirtualSitePreviewStatus.class);
+    String json = statusMapper.writeValueAsString(status);
+    assertTrue(json.contains("\"homePath\""), json);
+    assertTrue(json.contains("8.2/index.html"), json);
+    assertTrue(json.contains("\"outputPath\""), json);
+    assertTrue(json.contains("\"message\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePreviewStatus roundTrip =
+        statusMapper.readValue(json, VirtualSitePreviewStatus.class);
+    assertEquals(Boolean.TRUE, roundTrip.getAvailable(), json);
+    assertEquals("8.2/index.html", roundTrip.getHomePath(), json);
+    assertEquals("ready", roundTrip.getMessage(), json);
+  }
+
+  @Test
+  void virtualSitePublishResult_serializesPlainScalarsNotOptionalBeans() {
+    VirtualSitePublishResult result = new VirtualSitePublishResult();
+    result.setSiteName("Help");
+    result.setSiteKey("product-docs");
+    result.setPublishPath("C:/inetpub/wwwroot/help");
+    result.setBuildOutputPath("C:/Rhythmyx/tmp/virtual-sites/product-docs");
+    result.setPagesWritten(42);
+    result.setFilesCopied(50);
+    result.setLinkProblemCount(0);
+    result.setHasLinkProblems(false);
+
+    ObjectMapper resultMapper =
+        new JacksonContextResolver().getContext(VirtualSitePublishResult.class);
+    String json = resultMapper.writeValueAsString(result);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"publishPath\""), json);
+    assertTrue(json.contains("\"buildOutputPath\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    VirtualSitePublishResult roundTrip =
+        resultMapper.readValue(json, VirtualSitePublishResult.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("C:/inetpub/wwwroot/help", roundTrip.getPublishPath(), json);
+    assertEquals(
+        "C:/Rhythmyx/tmp/virtual-sites/product-docs", roundTrip.getBuildOutputPath(), json);
+    assertEquals(50, roundTrip.getFilesCopied(), json);
+  }
+
+  @Test
+  void siteMapOptions_serializesPlainScalarsNotOptionalBeans() {
+    SiteMapOptions options = new SiteMapOptions();
+    options.setNavigationBased(true);
+    options.setIncludeFolder(false);
+    options.setTimeZone("UTC");
+    options.setDateFormat(SiteMapDateFormat.DAY);
+    options.setFileName("sitemap.xml");
+    options.setUseSiteMapIndex("true");
+    options.setSiteMapType(SiteMapType.STANDARD);
+    options.setDefaultFrequency(0.5);
+
+    ObjectMapper optionsMapper = new JacksonContextResolver().getContext(SiteMapOptions.class);
+    String json = optionsMapper.writeValueAsString(options);
+    assertTrue(json.contains("\"timeZone\""), json);
+    assertTrue(json.contains("UTC"), json);
+    assertTrue(json.contains("\"dateFormat\""), json);
+    assertTrue(json.contains("DAY"), json);
+    assertTrue(json.contains("\"fileName\""), json);
+    assertTrue(json.contains("sitemap.xml"), json);
+    assertTrue(json.contains("\"useSiteMapIndex\""), json);
+    assertTrue(json.contains("\"siteMapType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    SiteMapOptions roundTrip = optionsMapper.readValue(json, SiteMapOptions.class);
+    assertEquals("UTC", roundTrip.getTimeZone(), json);
+    assertEquals(SiteMapDateFormat.DAY, roundTrip.getDateFormat(), json);
+    assertEquals("sitemap.xml", roundTrip.getFileName(), json);
+    assertEquals("true", roundTrip.getUseSiteMapIndex(), json);
+    assertEquals(SiteMapType.STANDARD, roundTrip.getSiteMapType(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,19 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.LinkRef;
+import com.percussion.rest.MoveFolderItem;
+import com.percussion.rest.folders.CopyFolderItemRequest;
+import com.percussion.rest.folders.Folder;
+import com.percussion.rest.folders.SectionInfo;
+import com.percussion.rest.folders.SectionLinkRef;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
@@ -111,5 +119,140 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void folder_serializesNamePathSiteNotOptionalBeans() {
+    Folder folder = new Folder();
+    folder.setId("guid-1");
+    folder.setName("News");
+    folder.setSiteName("Corporate");
+    folder.setPath("sections");
+    folder.setWorkflow("default");
+    folder.setAccessLevel(Folder.ACCESS_LEVEL_WRITE);
+    folder.setCommunityName("Default");
+    folder.setDefaultDisplayFormatName("Related Content");
+    folder.setLocale("en-us");
+    folder.setEditUsers(List.of("Admin"));
+
+    SectionInfo info = new SectionInfo();
+    info.setType("section");
+    info.setDisplayTitle("News Section");
+    info.setTargetWindow("_self");
+    info.setNavClass("nav-news");
+    info.setTemplateName("perc.page");
+    info.setLandingPage(new LinkRef("index.html", "http://example.com/index.html"));
+    folder.setSectionInfo(info);
+
+    folder.setPages(List.of(new LinkRef("index.html", "http://example.com/index.html")));
+    folder.setSubfolders(List.of(new LinkRef("archive", "http://example.com/archive")));
+    folder.setSubsections(
+        List.of(new SectionLinkRef("Press", "http://example.com/press", SectionLinkRef.TYPE_INTERNAL)));
+
+    ObjectMapper folderMapper = new JacksonContextResolver().getContext(Folder.class);
+    String json = folderMapper.writeValueAsString(folder);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("News"), json);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Corporate"), json);
+    assertTrue(json.contains("\"path\""), json);
+    assertTrue(json.contains("sections"), json);
+    assertTrue(json.contains("\"sectionInfo\""), json);
+    assertTrue(json.contains("News Section"), json);
+    assertTrue(json.contains("\"subsections\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    Folder roundTrip = folderMapper.readValue(json, Folder.class);
+    assertEquals("News", roundTrip.getName(), json);
+    assertEquals("Corporate", roundTrip.getSiteName(), json);
+    assertEquals("sections", roundTrip.getPath(), json);
+    assertNotNull(roundTrip.getSectionInfo(), json);
+    assertEquals("News Section", roundTrip.getSectionInfo().getDisplayTitle(), json);
+    assertEquals("perc.page", roundTrip.getSectionInfo().getTemplateName(), json);
+  }
+
+  @Test
+  void sectionInfo_serializesScalarsNotOptionalBeans() {
+    SectionInfo info = new SectionInfo();
+    info.setType("externallink");
+    info.setDisplayTitle("Partner");
+    info.setTargetWindow("_blank");
+    info.setNavClass("nav-ext");
+    info.setTemplateName("perc.page");
+    info.setExternalLinkUrl("https://partner.example");
+    info.setLandingPage(new LinkRef("home", "https://partner.example/"));
+
+    ObjectMapper infoMapper = new JacksonContextResolver().getContext(SectionInfo.class);
+    String json = infoMapper.writeValueAsString(info);
+    assertTrue(json.contains("\"displayTitle\""), json);
+    assertTrue(json.contains("Partner"), json);
+    assertTrue(json.contains("\"externalLinkUrl\""), json);
+    assertTrue(json.contains("https://partner.example"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    SectionInfo roundTrip = infoMapper.readValue(json, SectionInfo.class);
+    assertEquals("externallink", roundTrip.getType(), json);
+    assertEquals("Partner", roundTrip.getDisplayTitle(), json);
+    assertEquals("https://partner.example", roundTrip.getExternalLinkUrl(), json);
+    assertNotNull(roundTrip.getLandingPage(), json);
+  }
+
+  @Test
+  void sectionLinkRef_serializesTypeNotOptionalBeans() {
+    SectionLinkRef ref =
+        new SectionLinkRef("Press", "http://example.com/press", SectionLinkRef.TYPE_EXTERNAL);
+
+    ObjectMapper refMapper = new JacksonContextResolver().getContext(SectionLinkRef.class);
+    String json = refMapper.writeValueAsString(ref);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains(SectionLinkRef.TYPE_EXTERNAL), json);
+    assertTrue(json.contains("Press"), json);
+    assertNoOptionalBeanKeys(json);
+
+    SectionLinkRef roundTrip = refMapper.readValue(json, SectionLinkRef.class);
+    assertEquals(SectionLinkRef.TYPE_EXTERNAL, roundTrip.getType(), json);
+    assertEquals("Press", roundTrip.getName().orElse(null), json);
+  }
+
+  @Test
+  void copyFolderItemRequest_serializesPathsNotOptionalBeans() {
+    CopyFolderItemRequest req =
+        new CopyFolderItemRequest("/Sites/A/dest", "/Sites/A/src/page.html");
+
+    ObjectMapper reqMapper = new JacksonContextResolver().getContext(CopyFolderItemRequest.class);
+    String json = reqMapper.writeValueAsString(req);
+    assertTrue(json.contains("\"targetFolderPath\""), json);
+    assertTrue(json.contains("/Sites/A/dest"), json);
+    assertTrue(json.contains("\"itemPath\""), json);
+    assertTrue(json.contains("/Sites/A/src/page.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    CopyFolderItemRequest roundTrip = reqMapper.readValue(json, CopyFolderItemRequest.class);
+    assertEquals("/Sites/A/dest", roundTrip.getTargetFolderPath(), json);
+    assertEquals("/Sites/A/src/page.html", roundTrip.getItemPath(), json);
+  }
+
+  @Test
+  void moveFolderItem_serializesPathsNotOptionalBeans() {
+    MoveFolderItem req = new MoveFolderItem("/Sites/A/src/page.html", "/Sites/A/dest");
+
+    ObjectMapper reqMapper = new JacksonContextResolver().getContext(MoveFolderItem.class);
+    String json = reqMapper.writeValueAsString(req);
+    assertTrue(json.contains("\"targetFolderPath\""), json);
+    assertTrue(json.contains("/Sites/A/dest"), json);
+    assertTrue(json.contains("\"itemPath\""), json);
+    assertTrue(json.contains("/Sites/A/src/page.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    MoveFolderItem roundTrip = reqMapper.readValue(json, MoveFolderItem.class);
+    assertEquals("/Sites/A/dest", roundTrip.getTargetFolderPath(), json);
+    assertEquals("/Sites/A/src/page.html", roundTrip.getItemPath(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -23,7 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.contexts.Context;
+import com.percussion.rest.deliverytypes.DeliveryType;
 import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.locationscheme.LocationScheme;
+import com.percussion.rest.locationscheme.LocationSchemeParameter;
+import com.percussion.rest.locationscheme.LocationSchemeParameterList;
 import com.percussion.rest.pages.CalendarInfo;
 import com.percussion.rest.pages.CodeInfo;
 import com.percussion.rest.pages.Page;
@@ -55,7 +60,8 @@ import tools.jackson.databind.ObjectMapper;
  * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). User / Role /
  * ObjectSummary follow the same plain-getter rule (issue #3388). DisplayFormatProperty / Template /
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
- * rule (issue #3411 / #3388). All use production {@link JacksonContextResolver} under {@code
+ * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
+ * plain-getter contract (issue #3412). All use production {@link JacksonContextResolver} under {@code
  * @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
@@ -498,6 +504,117 @@ class JacksonContextResolverOptionalTest {
     assertEquals(SiteMapType.STANDARD, roundTrip.getSiteMapType(), json);
   }
 
+
+  @Test
+  void locationScheme_serializesNameNotOptionalBeans() {
+    LocationScheme scheme = new LocationScheme();
+    scheme.setSchemeId(new Guid("0-113-42"));
+    scheme.setName("generic");
+    scheme.setDescription("Generic location scheme");
+    scheme.setLocationSchemeGenerator("sys_GenericLocationSchemeGenerator");
+    scheme.setTemplateId(1018);
+    scheme.setContentTypeId(311);
+
+    ObjectMapper schemeMapper = new JacksonContextResolver().getContext(LocationScheme.class);
+    String json = schemeMapper.writeValueAsString(scheme);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("generic"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"locationSchemeGenerator\""), json);
+    assertTrue(json.contains("sys_GenericLocationSchemeGenerator"), json);
+    assertNoOptionalBeanKeys(json);
+
+    LocationScheme roundTrip = schemeMapper.readValue(json, LocationScheme.class);
+    assertEquals("generic", roundTrip.getName(), json);
+    assertEquals("Generic location scheme", roundTrip.getDescription(), json);
+    assertNotNull(roundTrip.getSchemeId(), json);
+  }
+
+  @Test
+  void locationSchemeParameter_serializesNameValueNotOptionalBeans() {
+    LocationSchemeParameter param = new LocationSchemeParameter();
+    param.setName("ext");
+    param.setSequence(1);
+    param.setType("String");
+    param.setValue(".html");
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(LocationSchemeParameter.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("ext"), json);
+    assertTrue(json.contains("\"value\""), json);
+    assertTrue(json.contains(".html"), json);
+    assertTrue(json.contains("\"sequence\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    LocationSchemeParameter roundTrip = paramMapper.readValue(json, LocationSchemeParameter.class);
+    assertEquals("ext", roundTrip.getName(), json);
+    assertEquals(".html", roundTrip.getValue(), json);
+    assertEquals(1, roundTrip.getSequence(), json);
+  }
+
+  @Test
+  void context_serializesNameAndNestedSchemeNotOptionalBeans() {
+    LocationScheme defaultScheme = new LocationScheme();
+    defaultScheme.setName("generic");
+    defaultScheme.setSchemeId(new Guid("0-113-42"));
+
+    LocationSchemeParameter param = new LocationSchemeParameter();
+    param.setName("ext");
+    param.setValue(".html");
+    LocationSchemeParameterList params = new LocationSchemeParameterList(List.of(param));
+    defaultScheme.setParameters(params);
+
+    Context context = new Context();
+    context.setId(new Guid("0-101-1"));
+    context.setName("Publish");
+    context.setDescription("Publish context");
+    context.setDefaultScheme(defaultScheme);
+    context.setLocationSchemes(List.of(defaultScheme));
+
+    ObjectMapper contextMapper = new JacksonContextResolver().getContext(Context.class);
+    String json = contextMapper.writeValueAsString(context);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("\"defaultScheme\""), json);
+    assertTrue(json.contains("generic"), json);
+    assertTrue(json.contains("\"locationSchemes\""), json);
+    assertTrue(json.contains("ext"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Context roundTrip = contextMapper.readValue(json, Context.class);
+    assertEquals("Publish", roundTrip.getName(), json);
+    assertNotNull(roundTrip.getDefaultScheme(), json);
+    assertEquals("generic", roundTrip.getDefaultScheme().getName(), json);
+    assertNotNull(roundTrip.getLocationSchemes(), json);
+    assertEquals(1, roundTrip.getLocationSchemes().size(), json);
+  }
+
+  @Test
+  void deliveryType_serializesNameBeanNotOptionalBeans() {
+    DeliveryType type = new DeliveryType();
+    type.setId(new Guid("0-115-7"));
+    type.setName("filesystem");
+    type.setDescription("File system delivery");
+    type.setBeanName("sys_fileDeliveryType");
+    type.setUnpublishingRequiresAssembly(false);
+
+    ObjectMapper typeMapper = new JacksonContextResolver().getContext(DeliveryType.class);
+    String json = typeMapper.writeValueAsString(type);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("filesystem"), json);
+    assertTrue(json.contains("\"beanName\""), json);
+    assertTrue(json.contains("sys_fileDeliveryType"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    DeliveryType roundTrip = typeMapper.readValue(json, DeliveryType.class);
+    assertEquals("filesystem", roundTrip.getName(), json);
+    assertEquals("sys_fileDeliveryType", roundTrip.getBeanName(), json);
+    assertEquals("File system delivery", roundTrip.getDescription(), json);
+    assertFalse(roundTrip.isUnpublishingRequiresAssembly(), json);
+  }
   private static void assertNoOptionalBeanKeys(String json) {
     assertFalse(
         json.contains("\"empty\"") || json.contains("\"present\""),

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,13 +16,17 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.roles.Role;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
+import com.percussion.rest.users.User;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,8 +35,9 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
- * getters under {@code @JsonInclude(NON_NULL)}.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). User / Role /
+ * ObjectSummary follow the same plain-getter rule (issue #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -111,5 +116,82 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void user_serializesPlainScalarsNotOptionalBeans() {
+    User user = new User();
+    user.setUserName("admin");
+    user.setFirstName("Ada");
+    user.setLastName("Lovelace");
+    user.setEmailAddress("ada@example.com");
+    user.setUserType("INTERNAL");
+
+    ObjectMapper userMapper = new JacksonContextResolver().getContext(User.class);
+    String json = userMapper.writeValueAsString(user);
+    assertTrue(json.contains("\"userName\""), json);
+    assertTrue(json.contains("admin"), json);
+    assertTrue(json.contains("\"firstName\""), json);
+    assertTrue(json.contains("Ada"), json);
+    assertTrue(json.contains("\"lastName\""), json);
+    assertTrue(json.contains("\"emailAddress\""), json);
+    assertTrue(json.contains("\"userType\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    User roundTrip = userMapper.readValue(json, User.class);
+    assertEquals("admin", roundTrip.getUserName(), json);
+    assertEquals("Ada", roundTrip.getFirstName(), json);
+    assertEquals("INTERNAL", roundTrip.getUserType(), json);
+  }
+
+  @Test
+  void role_serializesPlainScalarsNotOptionalBeans() {
+    Role role = new Role();
+    role.setName("Editor");
+    role.setDescription("Edit content");
+    role.setHomePage("Dashboard");
+
+    ObjectMapper roleMapper = new JacksonContextResolver().getContext(Role.class);
+    String json = roleMapper.writeValueAsString(role);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Editor"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"homePage\""), json);
+    assertTrue(json.contains("Dashboard"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Role roundTrip = roleMapper.readValue(json, Role.class);
+    assertEquals("Editor", roundTrip.getName(), json);
+    assertEquals("Dashboard", roundTrip.getHomePage(), json);
+  }
+
+  @Test
+  void objectSummary_serializesNameLabelGuidNotOptionalBeans() {
+    ObjectSummary summary = new ObjectSummary();
+    summary.setName("Default");
+    summary.setLabel("Default ACL");
+    summary.setDescription("Site ACL");
+    summary.setGuid(new Guid("0-13-10"));
+
+    ObjectMapper summaryMapper = new JacksonContextResolver().getContext(ObjectSummary.class);
+    String json = summaryMapper.writeValueAsString(summary);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-13-10") || json.contains("10"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ObjectSummary roundTrip = summaryMapper.readValue(json, ObjectSummary.class);
+    assertEquals("Default", roundTrip.getName(), json);
+    assertEquals("Default ACL", roundTrip.getLabel(), json);
+    assertNotNull(roundTrip.getGuid(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
+++ b/rest/src/test/java/com/percussion/rest/roles/RolesTest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.roles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,9 @@ public class RolesTest extends MainTest {
   @Test
   public void testNeverNull() {
     var r = new Role();
-    assertNotNull(r.getDescription(), "Should never be null");
-    assertNotNull(r.getName(), "Should never be null");
-    assertNotNull(r.getDescription(), "Should never be null");
+    assertNull(r.getDescription(), "Unset wire scalars are nullable");
+    assertNull(r.getName(), "Unset wire scalars are nullable");
+    assertNull(r.getHomePage(), "Unset wire scalars are nullable");
     assertNotNull(r.getUsers(), "Should never be null");
   }
 }

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -173,7 +173,7 @@ public class SitesResourceTest {
 
     VirtualSiteBuildResult out = resource.buildVirtualSite("Help", req);
     assertEquals(3, out.getPagesWritten().intValue());
-    assertEquals("C:/tmp/out", out.getOutputPath().orElse(null));
+    assertEquals("C:/tmp/out", out.getOutputPath());
     verify(adaptor).buildVirtualSite("Help", req);
   }
 
@@ -197,7 +197,7 @@ public class SitesResourceTest {
 
     VirtualSitePreviewStatus out = resource.getVirtualSitePreviewStatus("Help");
     assertEquals(Boolean.TRUE, out.getAvailable());
-    assertEquals("8.2/index.html", out.getHomePath().orElse(null));
+    assertEquals("8.2/index.html", out.getHomePath());
     verify(adaptor).getVirtualSitePreviewStatus("Help");
   }
 
@@ -253,7 +253,7 @@ public class SitesResourceTest {
     VirtualSitePublishResult out = resource.publishVirtualSite("Help");
     assertEquals(3, out.getPagesWritten().intValue());
     assertEquals(5, out.getFilesCopied().intValue());
-    assertEquals("C:/pub/help", out.getPublishPath().orElse(null));
+    assertEquals("C:/pub/help", out.getPublishPath());
     verify(adaptor).publishVirtualSite("Help");
   }
 

--- a/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesTestAdaptor.java
@@ -80,8 +80,8 @@ public class SitesTestAdaptor implements ISiteAdaptor {
     result.setPagesWritten(0);
     result.setLinkProblemCount(0);
     result.setHasLinkProblems(false);
-    if (request != null && request.getOutputRoot().isPresent()) {
-      result.setOutputPath(request.getOutputRoot().get());
+    if (request != null && request.getOutputRoot() != null) {
+      result.setOutputPath(request.getOutputRoot());
     }
     return result;
   }

--- a/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/users/UserTestAdaptor.java
@@ -25,6 +25,7 @@ import com.percussion.rest.errors.UnknownUserException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +50,8 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toUpdate = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(user.getUserName().orElse(""))) {
+      if (Objects.toString(u.getUserName(), "")
+          .equalsIgnoreCase(Objects.toString(user.getUserName(), ""))) {
         toUpdate = u;
         break;
       }
@@ -58,9 +60,15 @@ public class UserTestAdaptor implements IUserAdaptor {
       // New user logic could go here
     } else {
       toUpdate.setBookmarkedPages(user.getBookmarkedPages());
-      user.getEmailAddress().ifPresent(toUpdate::setEmailAddress);
-      user.getFirstName().ifPresent(toUpdate::setFirstName);
-      user.getLastName().ifPresent(toUpdate::setLastName);
+      if (user.getEmailAddress() != null) {
+        toUpdate.setEmailAddress(user.getEmailAddress());
+      }
+      if (user.getFirstName() != null) {
+        toUpdate.setFirstName(user.getFirstName());
+      }
+      if (user.getLastName() != null) {
+        toUpdate.setLastName(user.getLastName());
+      }
     }
     return null;
   }
@@ -72,7 +80,7 @@ public class UserTestAdaptor implements IUserAdaptor {
     }
     User toDelete = null;
     for (var u : testUserData) {
-      if (u.getUserName().orElse("").equalsIgnoreCase(userName)) {
+      if (Objects.toString(u.getUserName(), "").equalsIgnoreCase(userName)) {
         toDelete = u;
         break;
       }

--- a/rest/src/test/java/com/percussion/rest/users/UsersTest.java
+++ b/rest/src/test/java/com/percussion/rest/users/UsersTest.java
@@ -20,6 +20,7 @@
 package com.percussion.rest.users;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.rest.MainTest;
 import org.junit.jupiter.api.Test;
@@ -31,10 +32,10 @@ public class UsersTest extends MainTest {
     var u = new User();
 
     assertNotNull(u.getBookmarkedPages(), "Should never be null");
-    assertNotNull(u.getEmailAddress(), "Should never be null");
-    assertNotNull(u.getFirstName(), "Should never be null");
-    assertNotNull(u.getLastName(), "Should never be null");
-    assertNotNull(u.getPersonalPage(), "Should never be null");
+    assertNull(u.getEmailAddress(), "Unset wire scalars are nullable");
+    assertNull(u.getFirstName(), "Unset wire scalars are nullable");
+    assertNull(u.getLastName(), "Unset wire scalars are nullable");
+    assertNull(u.getPersonalPage(), "Unset wire objects are nullable");
     assertNotNull(u.getPersonAssets(), "Should never be null");
     assertNotNull(u.getRecentAssetFolders(), "Should never be null");
     assertNotNull(u.getRecentAssetTypes(), "Should never be null");
@@ -42,7 +43,7 @@ public class UsersTest extends MainTest {
     assertNotNull(u.getRecentSiteFolders(), "Should never be null");
     assertNotNull(u.getRoles(), "Should never be null");
     assertNotNull(u.getRecentTemplates(), "Should never be null");
-    assertNotNull(u.getUserName(), "Should never be null");
-    assertNotNull(u.getUserType(), "Should never be null");
+    assertNull(u.getUserName(), "Unset wire scalars are nullable");
+    assertNull(u.getUserType(), "Unset wire scalars are nullable");
   }
 }


### PR DESCRIPTION
## Summary

Overnight issue workers opened two new REST Optional wire-getter PRs (#3421 LocationScheme/Context/DeliveryType, #3422 Folder/Section/path-request) against `main` after cluster #3417 already absorbed #3406 / #3415 / #3416. Each independently appends production-mapper cases to the same shared test, so later merges would collide on `JacksonContextResolverOptionalTest.java`.

This cluster absorbs #3417 + #3421 + #3422 onto one tip with **union** semantics: every family test and caller update is kept (26 `JacksonContextResolverOptionalTest` cases).

**Thrash files**
- `rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java` (#3417 + #3421 + #3422)

No product-docs change: backend wire-getter convention only (JSON scalars instead of Optional beans). Not a Human QA candidate.

Partial #3388 #3407 #3411 #3412 #3413

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
| --- | --- | --- | --- | --- |
| yes | #3417 | `cluster/night-issue-20260815-rest-dto-wire-getters` | yes | Prior cluster of #3406 / #3415 / #3416 (User/Role/ObjectSummary, DisplayFormat/Template/Page, Virtual Site + SiteMap) |
| yes | #3421 | `fix/issue-3412-location-scheme-wire-getters` | yes | LocationScheme / Context / DeliveryType |
| yes | #3422 | `fix/issue-3413-folder-section-wire-getters` | yes | Folder / Section / CopyFolderItemRequest / MoveFolderItem |

Left open (not this thrash group): #3414, #3409, #3408.

## Test plan

1. Review unioned `JacksonContextResolverOptionalTest` — 26 tests covering ContentType, TemplateSummary, User/Role/ObjectSummary, DisplayFormat/Template/Page, Virtual Site/SiteMap, LocationScheme/Context/DeliveryType, and Folder/Section/path-request families.
2. Confirm no Optional-bean `empty`/`present` keys on those wire types.
3. Do **not** merge the superseded PRs.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): backend REST DTO/adaptor wire-getter conversion only
- [x] **Unit / module tests** — unioned mapper tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps grepped
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## modules_built

`rest,projects/sitemanage`

## build_evidence

- `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 440, Failures: 0, Errors: 0, Skipped: 0 (`JacksonContextResolverOptionalTest`: 26 tests).
- `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125 (`SitesAdaptorTest`: 36 tests).

Public getter signatures changed `Optional<T>` → `T`. Reverse-dep grep: no subclasses of the REST DTOs (sitemanage `AssignTemplate` extends `com.percussion.sitemanage.service.Template`, not the REST type). List wrappers (`RoleList`, `LocationSchemeParameterList`, etc.) are not DTO subclasses. `sitemanage` standalone install is the known reverse-dep.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs-cluster.
