### PR TITLE
fix(rest): Asset/AssetField/BinaryFile wire getters must not return Optional (#3418)

### DIFF
--- a/docs/ai-generated/code-reviews/3418-asset-optional-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3418-asset-optional-wire-getters-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — issue #3418 Asset / AssetField / BinaryFile wire getters
+
+**Branch:** `fix/issue-3418-asset-optional-wire-getters`  
+**Scope:** uncommitted vs `HEAD` (origin/main)  
+**Date:** 2026-08-15  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+
+Memory patterns hit: change-class completeness (rest DTO + production-mapper tests + sitemanage callers); public getter signature change requires reverse-dep install; do not commit unreviewed `rest/AGENTS.md`.
+
+## Summary
+
+Slice 6 of parent #3388 converts REST wire getters on `Asset`, `AssetField`, and `BinaryFile` from `Optional<T>` to plain nullable types under `@JsonInclude(NON_NULL)`. Callers in `AssetsResource`, `AssetAdaptor`, and `PageAdaptor` no longer treat those getters as `Optional`. `WorkflowInfo` / `ImageInfo` class bodies are left unconverted; `ImageInfo` inherits the new `BinaryFile` scalar getters (expected).
+
+## Change-class closure
+
+| Companion | Status |
+| --- | --- |
+| Plain getters + `@JsonInclude(NON_NULL)` | Done |
+| Production `JacksonContextResolver` round-trip tests (append-only) | Done |
+| rest / sitemanage caller updates | Done |
+| Reverse-dep standalone `sitemanage` clean install | Done (`BUILD SUCCESS`) |
+| `rest/AGENTS.md` | Intentionally not committed (human rule review) |
+| product-docs | N/A — no documented Optional-bean JSON example |
+| Playwright / C5 | N/A — no WebUI screen change |
+
+## Issues
+
+None. No bugs, no missing behavioral tests for the new wire contract or MIME-type caller change, no non-portable path I/O.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or path assertions.
+
+## Tests / build
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 424, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1223, Failures: 0, Skipped: 125 (pre-existing skips)
+- C2 greps: `ImageInfo extends BinaryFile` only (production); no anonymous `new Asset() {` subclasses

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AssetAdaptor.java
@@ -87,7 +87,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
@@ -266,10 +265,10 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
     try {
       var oldPSAsset = this.assetService.load(id);
       var workflowInfo = this.getWorkflowInfo(oldPSAsset);
-      // determine the requested end state - WorkflowInfo stores Optionals now
+      // determine the requested end state — WorkflowInfo getters remain Optional (#3418)
       String endState = ApiUtils.orNull(workflowInfo.getState());
-      if (asset.getWorkflow().isPresent()) {
-        String state = ApiUtils.orNull(asset.getWorkflow().get().getState());
+      if (asset.getWorkflow() != null) {
+        String state = ApiUtils.orNull(asset.getWorkflow().getState());
         if (StringUtils.isNotBlank(state)) {
           endState = state;
         }
@@ -285,16 +284,14 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
         workflowInfo.setCheckedOutUser(userInfo.getCurrentUser());
       }
       oldPSAsset.getFields().put(lastModifiedDateFieldName, new Date());
-      String assetName = ApiUtils.orNull(asset.getName());
+      String assetName = asset.getName();
       if (StringUtils.isNotBlank(assetName) && !assetName.equals(oldPSAsset.getName())) {
         oldPSAsset.setName(assetName);
       }
       for (var field : asset.getFields()) {
-        oldPSAsset
-            .getFields()
-            .put(ApiUtils.orNull(field.getName()), ApiUtils.orNull(field.getValue()));
+        oldPSAsset.getFields().put(field.getName(), field.getValue());
       }
-      String assetFolder = ApiUtils.orNull(asset.getFolderPath());
+      String assetFolder = asset.getFolderPath();
       if (StringUtils.isNotBlank(assetFolder)) {
         if (assetFolder.endsWith("/")) {
           assetFolder = assetFolder.substring(0, assetFolder.length() - 1);
@@ -343,8 +340,8 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
   public Asset createSharedAsset(URI baseURI, String path, Asset asset) throws BackendException {
     var newAsset = new PSAsset();
     newAsset.setCategory(Category.ASSET);
-    String assetName = ApiUtils.orNull(asset.getName());
-    String assetType = ApiUtils.orNull(asset.getType());
+    String assetName = asset.getName();
+    String assetType = asset.getType();
     notBlank(assetName);
     notBlank(assetType);
     newAsset.setName(assetName);
@@ -353,10 +350,10 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
     // workflow initialization removed during API transition
     // TODO re-add when IPSWorkflowService exposes suitable methods
     if (assetBinaryTypes.contains(asset.getType())) {
-      String assetName2 = ApiUtils.orNull(asset.getName());
+      String assetName2 = asset.getName();
       boolean found =
           asset.getFields().stream()
-              .map(f -> ApiUtils.orNull(f.getName()))
+              .map(AssetField::getName)
               .anyMatch(n -> n != null && n.equalsIgnoreCase("displaytitle"));
       if (!found) {
         asset.getFields().add(new AssetField("displaytitle", assetName2));
@@ -384,11 +381,11 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
       if (asset.getFields() != null) {
         if (asset.getFields() != null) {
           for (var field : asset.getFields()) {
-            newAsset.getFields().put(ApiUtils.orNull(field.getName()), field.getValue());
+            newAsset.getFields().put(field.getName(), field.getValue());
           }
         }
       }
-      String folderPath = ApiUtils.orNull(asset.getFolderPath());
+      String folderPath = asset.getFolderPath();
       if (folderPath != null
           && StringUtils.isNotBlank(folderPath)
           && folderPath.startsWith(PSPathUtils.ASSETS_FINDER_ROOT)) {
@@ -399,9 +396,8 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
       this.assetService.validate(newAsset);
       newAsset = this.assetDao.save(newAsset);
       if (newAsset.getType().equals("percImageAsset")) {
-        Optional<ImageInfo> thumbOpt = asset.getThumbnail();
-        if (thumbOpt != null && thumbOpt.isPresent()) {
-          ImageInfo thumb = thumbOpt.get();
+        ImageInfo thumb = asset.getThumbnail();
+        if (thumb != null) {
           if (thumb.getWidth() != 0 && thumb.getHeight() != 0) {
             newAsset.getFields().put("img2_width", thumb.getWidth());
             newAsset.getFields().put("img2_height", thumb.getHeight());
@@ -674,7 +670,7 @@ public class AssetAdaptor extends SiteManageAdaptorBase implements IAssetAdaptor
 
     try {
       Asset a = getSharedAssetByPath(baseUri, pathServicePath);
-      PSAsset update = this.assetService.load(ApiUtils.orNull(a.getId()));
+      PSAsset update = this.assetService.load(a.getId());
       // Check it out
       if (!workflowHelper.isCheckedOutToCurrentUser(update.getId())) {
         itemWorkflowService.forceCheckOut(update.getId());

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PageAdaptor.java
@@ -1050,8 +1050,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
 
       fields = new HashMap<>();
       for (AssetField field : asset.getFields()) {
-        String fieldName = ApiUtils.orNull(field.getName());
-        String fieldValue = ApiUtils.orNull(field.getValue());
+        String fieldName = field.getName();
+        String fieldValue = field.getValue();
         if (fieldName != null) {
           fields.put(fieldName, fieldValue);
         }
@@ -1163,8 +1163,8 @@ public class PageAdaptor extends SiteManageAdaptorBase implements IPageAdaptor {
                 idMapper.getString(assetRels.getDependent()),
                 0);
         assetService.shareLocalContent(
-            ApiUtils.orNull(asset.getName()),
-            StringUtils.substringAfter(ApiUtils.orNull(asset.getFolderPath()), "/"),
+            asset.getName(),
+            StringUtils.substringAfter(asset.getFolderPath(), "/"),
             awRel);
 
       } else {

--- a/rest/src/main/java/com/percussion/rest/assets/Asset.java
+++ b/rest/src/main/java/com/percussion/rest/assets/Asset.java
@@ -29,7 +29,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /** Represents a shared asset. */
 @XmlRootElement(name = "Asset")
@@ -87,7 +86,7 @@ public class Asset {
   /** No-op constructor. */
   public Asset() {}
 
-  // --- Getters and Setters with Optional ---
+  // --- Getters and Setters (plain nullable wire types) ---
 
   /**
    * Returns the asset's custom fields.
@@ -110,10 +109,10 @@ public class Asset {
   /**
    * Returns the asset id.
    *
-   * @return the asset id, may be empty
+   * @return the asset id, may be {@code null}
    */
-  public Optional<String> getId() {
-    return Optional.ofNullable(id);
+  public String getId() {
+    return id;
   }
 
   /**
@@ -128,10 +127,10 @@ public class Asset {
   /**
    * Returns the asset name.
    *
-   * @return the name, may be empty
+   * @return the name, may be {@code null}
    */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   /**
@@ -146,10 +145,10 @@ public class Asset {
   /**
    * Returns the asset type.
    *
-   * @return the type, may be empty
+   * @return the type, may be {@code null}
    */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   /**
@@ -164,10 +163,10 @@ public class Asset {
   /**
    * Returns the asset's folder path.
    *
-   * @return the folder path, may be empty
+   * @return the folder path, may be {@code null}
    */
-  public Optional<String> getFolderPath() {
-    return Optional.ofNullable(folderPath);
+  public String getFolderPath() {
+    return folderPath;
   }
 
   /**
@@ -182,10 +181,10 @@ public class Asset {
   /**
    * Returns the workflow info for the asset.
    *
-   * @return the workflow info, may be empty
+   * @return the workflow info, may be {@code null}
    */
-  public Optional<WorkflowInfo> getWorkflow() {
-    return Optional.ofNullable(workflow);
+  public WorkflowInfo getWorkflow() {
+    return workflow;
   }
 
   /**
@@ -200,10 +199,10 @@ public class Asset {
   /**
    * Returns the last modification date.
    *
-   * @return the date, may be empty
+   * @return the date, may be {@code null}
    */
-  public Optional<Date> getLastModifiedDate() {
-    return Optional.ofNullable(lastModifiedDate);
+  public Date getLastModifiedDate() {
+    return lastModifiedDate;
   }
 
   /**
@@ -218,10 +217,10 @@ public class Asset {
   /**
    * Returns the creation date.
    *
-   * @return the date, may be empty
+   * @return the date, may be {@code null}
    */
-  public Optional<Date> getCreatedDate() {
-    return Optional.ofNullable(createdDate);
+  public Date getCreatedDate() {
+    return createdDate;
   }
 
   /**
@@ -236,10 +235,10 @@ public class Asset {
   /**
    * Returns the hypermedia links.
    *
-   * @return the links, may be empty
+   * @return the links, may be {@code null}
    */
-  public Optional<List<LinkRef>> getLinks() {
-    return Optional.ofNullable(links);
+  public List<LinkRef> getLinks() {
+    return links;
   }
 
   /**
@@ -254,10 +253,10 @@ public class Asset {
   /**
    * Returns the full-size image info.
    *
-   * @return the image info, may be empty
+   * @return the image info, may be {@code null}
    */
-  public Optional<ImageInfo> getImage() {
-    return Optional.ofNullable(image);
+  public ImageInfo getImage() {
+    return image;
   }
 
   /**
@@ -272,10 +271,10 @@ public class Asset {
   /**
    * Returns the thumbnail image info.
    *
-   * @return the thumbnail, may be empty
+   * @return the thumbnail, may be {@code null}
    */
-  public Optional<ImageInfo> getThumbnail() {
-    return Optional.ofNullable(thumbnail);
+  public ImageInfo getThumbnail() {
+    return thumbnail;
   }
 
   /**
@@ -290,10 +289,10 @@ public class Asset {
   /**
    * Returns the binary file payload.
    *
-   * @return the binary file, may be empty
+   * @return the binary file, may be {@code null}
    */
-  public Optional<BinaryFile> getFile() {
-    return Optional.ofNullable(file);
+  public BinaryFile getFile() {
+    return file;
   }
 
   /**
@@ -308,10 +307,10 @@ public class Asset {
   /**
    * Returns whether the asset should be removed on save.
    *
-   * @return the remove flag, may be empty
+   * @return the remove flag, may be {@code null}
    */
-  public Optional<Boolean> getRemove() {
-    return Optional.ofNullable(remove);
+  public Boolean getRemove() {
+    return remove;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/assets/AssetField.java
+++ b/rest/src/main/java/com/percussion/rest/assets/AssetField.java
@@ -18,14 +18,16 @@
 
 package com.percussion.rest.assets;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.Objects;
-import java.util.Optional;
 
 @XmlRootElement(name = "AssetField")
 @XmlType(propOrder = {})
+@JsonInclude(Include.NON_NULL)
 @Schema(description = "Represents an Asset field")
 public class AssetField {
 
@@ -41,16 +43,16 @@ public class AssetField {
     this.value = value;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getValue() {
-    return Optional.ofNullable(value);
+  public String getValue() {
+    return value;
   }
 
   public void setValue(String value) {

--- a/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
+++ b/rest/src/main/java/com/percussion/rest/assets/AssetsResource.java
@@ -250,12 +250,16 @@ public class AssetsResource {
     var filename = StringUtils.substringAfter(path, "/");
     var thumbReq = filename.startsWith("thumb_");
     var type = "application/octet-stream";
-    if (asset.getImage().isPresent() && thumbReq)
-      type = asset.getThumbnail().flatMap(ImageInfo::getType).orElse(type);
-    else if (asset.getFile().isPresent())
-      type = asset.getFile().flatMap(BinaryFile::getType).orElse(type);
-    else if (asset.getImage().isPresent())
-      type = asset.getImage().flatMap(ImageInfo::getType).orElse(type);
+    if (asset.getImage() != null && thumbReq) {
+      var thumbType = asset.getThumbnail() != null ? asset.getThumbnail().getType() : null;
+      if (thumbType != null) {
+        type = thumbType;
+      }
+    } else if (asset.getFile() != null && asset.getFile().getType() != null) {
+      type = asset.getFile().getType();
+    } else if (asset.getImage() != null && asset.getImage().getType() != null) {
+      type = asset.getImage().getType();
+    }
 
     var r =
         Response.ok(out)

--- a/rest/src/main/java/com/percussion/rest/assets/BinaryFile.java
+++ b/rest/src/main/java/com/percussion/rest/assets/BinaryFile.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
 @XmlRootElement(name = "BinaryFile")
 @JsonInclude(Include.NON_NULL)
@@ -35,16 +34,16 @@ public class BinaryFile {
   private long size;
   private String type;
 
-  public Optional<String> getFilename() {
-    return Optional.ofNullable(filename);
+  public String getFilename() {
+    return filename;
   }
 
   public void setFilename(String filename) {
     this.filename = filename;
   }
 
-  public Optional<String> getExtension() {
-    return Optional.ofNullable(extension);
+  public String getExtension() {
+    return extension;
   }
 
   public void setExtension(String extension) {
@@ -59,8 +58,8 @@ public class BinaryFile {
     this.size = size;
   }
 
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,9 +16,14 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.assets.Asset;
+import com.percussion.rest.assets.AssetField;
+import com.percussion.rest.assets.AssetFieldList;
+import com.percussion.rest.assets.BinaryFile;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
@@ -111,5 +116,86 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void asset_serializesPlainScalarsNotOptionalBeans() {
+    Asset asset = new Asset();
+    asset.setId("guid-1");
+    asset.setName("banner.png");
+    asset.setType("percImageAsset");
+    asset.setFolderPath("/Assets/uploads");
+    asset.setRemove(false);
+    asset.setFields(new AssetFieldList());
+    asset.getFields().add(new AssetField("alttext", "Hero banner"));
+
+    ObjectMapper assetMapper = new JacksonContextResolver().getContext(Asset.class);
+    String json = assetMapper.writeValueAsString(asset);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("banner.png"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains("percImageAsset"), json);
+    assertTrue(json.contains("\"folderPath\""), json);
+    assertTrue(json.contains("/Assets/uploads"), json);
+    assertTrue(json.contains("\"id\""), json);
+    assertTrue(json.contains("alttext"), json);
+    assertTrue(json.contains("Hero banner"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Asset roundTrip = assetMapper.readValue(json, Asset.class);
+    assertEquals("banner.png", roundTrip.getName(), json);
+    assertEquals("percImageAsset", roundTrip.getType(), json);
+    assertEquals("/Assets/uploads", roundTrip.getFolderPath(), json);
+    assertEquals("guid-1", roundTrip.getId(), json);
+    assertFalse(roundTrip.getRemove(), json);
+  }
+
+  @Test
+  void assetField_serializesNameValueNotOptionalBeans() {
+    AssetField field = new AssetField("displaytitle", "Home banner");
+
+    ObjectMapper fieldMapper = new JacksonContextResolver().getContext(AssetField.class);
+    String json = fieldMapper.writeValueAsString(field);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("displaytitle"), json);
+    assertTrue(json.contains("\"value\""), json);
+    assertTrue(json.contains("Home banner"), json);
+    assertNoOptionalBeanKeys(json);
+
+    AssetField roundTrip = fieldMapper.readValue(json, AssetField.class);
+    assertEquals("displaytitle", roundTrip.getName(), json);
+    assertEquals("Home banner", roundTrip.getValue(), json);
+  }
+
+  @Test
+  void binaryFile_serializesFilenameTypeNotOptionalBeans() {
+    BinaryFile file = new BinaryFile();
+    file.setFilename("report.pdf");
+    file.setExtension("pdf");
+    file.setType("application/pdf");
+    file.setSize(2048L);
+
+    ObjectMapper fileMapper = new JacksonContextResolver().getContext(BinaryFile.class);
+    String json = fileMapper.writeValueAsString(file);
+    assertTrue(json.contains("\"filename\""), json);
+    assertTrue(json.contains("report.pdf"), json);
+    assertTrue(json.contains("\"extension\""), json);
+    assertTrue(json.contains("pdf"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains("application/pdf"), json);
+    assertTrue(json.contains("2048"), json);
+    assertNoOptionalBeanKeys(json);
+
+    BinaryFile roundTrip = fileMapper.readValue(json, BinaryFile.class);
+    assertEquals("report.pdf", roundTrip.getFilename(), json);
+    assertEquals("pdf", roundTrip.getExtension(), json);
+    assertEquals("application/pdf", roundTrip.getType(), json);
+    assertEquals(2048L, roundTrip.getSize(), json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -168,6 +168,44 @@ class JacksonContextResolverOptionalTest {
   }
 
   @Test
+  void assetFamily_omitsNullWireFieldsFromJson() {
+    Asset asset = new Asset();
+    asset.setId("guid-nulls");
+    asset.setName(null);
+    asset.setType(null);
+    asset.setFolderPath(null);
+
+    ObjectMapper assetMapper = new JacksonContextResolver().getContext(Asset.class);
+    String assetJson = assetMapper.writeValueAsString(asset);
+    assertTrue(assetJson.contains("\"id\""), assetJson);
+    assertTrue(assetJson.contains("guid-nulls"), assetJson);
+    assertFalse(assetJson.contains("\"name\""), assetJson);
+    assertFalse(assetJson.contains("\"type\""), assetJson);
+    assertFalse(assetJson.contains("\"folderPath\""), assetJson);
+    assertNoOptionalBeanKeys(assetJson);
+
+    AssetField field = new AssetField();
+    field.setName(null);
+    field.setValue(null);
+    ObjectMapper fieldMapper = new JacksonContextResolver().getContext(AssetField.class);
+    String fieldJson = fieldMapper.writeValueAsString(field);
+    assertFalse(fieldJson.contains("\"name\""), fieldJson);
+    assertFalse(fieldJson.contains("\"value\""), fieldJson);
+    assertNoOptionalBeanKeys(fieldJson);
+
+    BinaryFile file = new BinaryFile();
+    file.setFilename(null);
+    file.setExtension(null);
+    file.setType(null);
+    ObjectMapper fileMapper = new JacksonContextResolver().getContext(BinaryFile.class);
+    String fileJson = fileMapper.writeValueAsString(file);
+    assertFalse(fileJson.contains("\"filename\""), fileJson);
+    assertFalse(fileJson.contains("\"extension\""), fileJson);
+    assertFalse(fileJson.contains("\"type\""), fileJson);
+    assertNoOptionalBeanKeys(fileJson);
+  }
+
+  @Test
   void binaryFile_serializesFilenameTypeNotOptionalBeans() {
     BinaryFile file = new BinaryFile();
     file.setFilename("report.pdf");

--- a/rest/src/test/java/com/percussion/rest/assets/AssetsTest.java
+++ b/rest/src/test/java/com/percussion/rest/assets/AssetsTest.java
@@ -109,6 +109,19 @@ public class AssetsTest {
   }
 
   @Test
+  void getBinary_keepsDefaultTypeWhenThumbRequestedButThumbnailNull() throws Exception {
+    Asset a = new Asset();
+    ImageInfo image = new ImageInfo();
+    image.setType("image/png");
+    a.setImage(image);
+    when(assetAdaptor.getBinary(anyString())).thenReturn(out -> {});
+    when(assetAdaptor.getSharedAssetByPath(any(), anyString())).thenReturn(a);
+
+    Response r = resource.getBinary("Assets/thumb_banner.png");
+    assertEquals("application/octet-stream", r.getHeaderString("Content-Type"));
+  }
+
+  @Test
   void getBinary_usesFileTypeWhenFilePresent() throws Exception {
     Asset a = new Asset();
     BinaryFile file = new BinaryFile();

--- a/rest/src/test/java/com/percussion/rest/assets/AssetsTest.java
+++ b/rest/src/test/java/com/percussion/rest/assets/AssetsTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import com.percussion.rest.errors.BackendException;
 import com.percussion.rest.users.IUserAdaptor;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,5 +77,47 @@ public class AssetsTest {
         .thenThrow(new BackendException("fail", new Exception("cause")));
     assertThrows(
         WebApplicationException.class, () -> resource.renameAsset("Assets/x.png", "y.png"));
+  }
+
+  @Test
+  void getBinary_usesImageTypeWhenPresent() throws Exception {
+    Asset a = new Asset();
+    ImageInfo image = new ImageInfo();
+    image.setType("image/png");
+    a.setImage(image);
+    when(assetAdaptor.getBinary(anyString())).thenReturn(out -> {});
+    when(assetAdaptor.getSharedAssetByPath(any(), anyString())).thenReturn(a);
+
+    Response r = resource.getBinary("Assets/uploads/banner.png");
+    assertEquals("image/png", r.getHeaderString("Content-Type"));
+  }
+
+  @Test
+  void getBinary_usesThumbnailTypeWhenThumbRequested() throws Exception {
+    Asset a = new Asset();
+    ImageInfo image = new ImageInfo();
+    image.setType("image/png");
+    a.setImage(image);
+    ImageInfo thumb = new ImageInfo();
+    thumb.setType("image/jpeg");
+    a.setThumbnail(thumb);
+    when(assetAdaptor.getBinary(anyString())).thenReturn(out -> {});
+    when(assetAdaptor.getSharedAssetByPath(any(), anyString())).thenReturn(a);
+
+    Response r = resource.getBinary("Assets/thumb_banner.png");
+    assertEquals("image/jpeg", r.getHeaderString("Content-Type"));
+  }
+
+  @Test
+  void getBinary_usesFileTypeWhenFilePresent() throws Exception {
+    Asset a = new Asset();
+    BinaryFile file = new BinaryFile();
+    file.setType("application/pdf");
+    a.setFile(file);
+    when(assetAdaptor.getBinary(anyString())).thenReturn(out -> {});
+    when(assetAdaptor.getSharedAssetByPath(any(), anyString())).thenReturn(a);
+
+    Response r = resource.getBinary("Assets/uploads/report.pdf");
+    assertEquals("application/pdf", r.getHeaderString("Content-Type"));
   }
 }


### PR DESCRIPTION
## Summary

Slice 6 of parent #3388: convert REST wire DTOs `Asset`, `AssetField`, and `BinaryFile` from `Optional<T>` getters to plain nullable getters/setters with `@JsonInclude(NON_NULL)`. Explorer/asset JSON is now scalars (and nested field/file objects), not Optional beans (`empty`/`present`).

Callers that used `.isPresent()` / `.orElse()` / `.flatMap()` on the converted getters were updated:

- `rest` `AssetsResource.getBinary` MIME-type selection
- `projects/sitemanage` `AssetAdaptor` (including `asset.getWorkflow()` null check; `WorkflowInfo.getState()` remains Optional)
- `PageAdaptor` asset field/name/path reads

Out of scope (sibling slices): `ImageInfo`/`WorkflowInfo` class bodies, Community, Acl. `ImageInfo` inherits the converted `BinaryFile` scalar getters. `rest/AGENTS.md` is not in this PR (human rule review).

Fixes #3418
Parent: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 424, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1223, Failures: 0, Skipped: 125 (pre-existing)
3. Review `JacksonContextResolverOptionalTest` Asset / AssetField / BinaryFile methods: production mapper, no `"empty"`/`"present"` keys, round-trip scalars.
4. Review `AssetsTest` `getBinary_*` MIME-type cases (image / thumbnail / file).
5. No live CMS / Playwright required (backend DTO + adaptor callers only).

## Checklist

- [x] **Product documentation** — N/A (not product-facing): wire-getter refactor; no documented request/response example currently shows Optional-bean JSON
- [x] **Unit / module tests** — production-mapper round-trips + `getBinary` MIME-type tests; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest` then reverse-dep `projects/sitemanage` (public getter signatures changed)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 424, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public getter signatures). Grep: `ImageInfo extends BinaryFile` only (production inheritance); no `new Asset() {` anonymous subclasses. Standalone `projects/sitemanage` clean install after installing `rest`.

### C5 UI proof

N/A — no WebUI / Explorer screen / Playwright surface in this slice.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
