### PR TITLE
fix(rest): Community family wire getters must not return Optional (#3419)

### DIFF
--- a/docs/ai-generated/code-reviews/3419-community-optional-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3419-community-optional-wire-getters-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: #3419 Community family plain wire getters
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3419-community-wire-getters`  
+**Scope:** uncommitted Community / CommunityRole / CommunityVisibility Optional→nullable conversion vs `origin/main`  
+**Memory patterns hit:** incomplete change-class closure; missing behavioral tests; agent rule files without human review; focused `-Dtest` vs module suite
+
+## Summary
+
+Slice 7 of parent #3388 converts the Community REST wire DTO family from `Optional<T>` getters to plain nullable getters under `@JsonInclude(NON_NULL)`, matching `ContentType` / sibling Asset family (#3418). Callers in `CommunityAdaptor` and `ApiUtils` that used `.orElse()` / `Optional.isEmpty()` are updated. Production-mapper round-trip tests were appended to `JacksonContextResolverOptionalTest` (not rewritten). `rest/AGENTS.md` was not committed.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None.
+
+### Change-class closure
+
+- Production DTOs: `Community`, `CommunityRole`, `CommunityVisibility` — plain getters, `@JsonInclude(NON_NULL)`, Optional helpers deleted (not left as `@JsonIgnore`).
+- Tests: `JacksonContextResolverOptionalTest` uses `new JacksonContextResolver().getContext(TheDto.class)`; asserts no `"empty"`/`"present"` keys; round-trips name/roleName/guid.
+- Callers: `CommunityResourceDetailTest`, `CommunityAdaptor`, `ApiUtils` compile against new signatures.
+- Existing `CommunitiesTestAdaptor` Spring stub unchanged (no new adaptor interface).
+- No WebUI / Playwright (C5 N/A).
+- Product-docs N/A — no documented Optional-bean JSON examples.
+- `rest/AGENTS.md` left uncommitted (human rule-review gate).
+
+### Cross-platform path checklist
+
+N/A — no filesystem path / I/O changes.
+
+### C2 API shape
+
+Public getter return types changed (`Optional<T>` → `T`). Grep found no `extends Community` / anonymous subclasses. Reverse-dep `projects/sitemanage` standalone `clean install` is green.
+
+## Build evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 421, Failures: 0, Errors: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -192,14 +192,14 @@ public class ApiUtils {
     Community ret =
         new Community(
             c.getId(), convertGuid(c.getGUID()), c.getName(), c.getDescription(), c.getLabel());
-    var optGuid = ret.getGuid();
+    var communityGuid = ret.getGuid();
 
     ArrayList<CommunityRole> roles = new ArrayList<>();
     // iterate role associations from PSCommunity
     for (IPSGuid roleGuid : c.getRoleAssociations()) {
       CommunityRole assoc = new CommunityRole();
-      assoc.setCommunityGuid(optGuid);
-      assoc.setCommunityId(optGuid != null ? optGuid.getLongValue() : 0L);
+      assoc.setCommunityGuid(communityGuid);
+      assoc.setCommunityId(communityGuid != null ? communityGuid.getLongValue() : 0L);
       assoc.setRoleId(roleGuid.longValue());
       assoc.setRoleGuid(convertGuid(roleGuid));
       roles.add(assoc);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -192,8 +192,7 @@ public class ApiUtils {
     Community ret =
         new Community(
             c.getId(), convertGuid(c.getGUID()), c.getName(), c.getDescription(), c.getLabel());
-    // unwrap Optional GUID for convenience
-    var optGuid = ret.getGuid().orElse(null);
+    var optGuid = ret.getGuid();
 
     ArrayList<CommunityRole> roles = new ArrayList<>();
     // iterate role associations from PSCommunity
@@ -268,12 +267,14 @@ public class ApiUtils {
   public static PSCommunity convertCommunity(Community c) {
     PSCommunity p = new PSCommunity();
 
-    p.setDescription(orNull(c.getDescription()));
-    p.setName(orNull(c.getName()));
+    p.setDescription(c.getDescription());
+    p.setName(c.getName());
     p = (PSCommunity) p.tuneClone(c.getId());
 
-    for (CommunityRole cr : orEmpty(c.getRoleList())) {
-      p.addRoleAssociation(convertGuid(orNull(cr.getRoleGuid())));
+    if (c.getRoleList() != null) {
+      for (CommunityRole cr : c.getRoleList()) {
+        p.addRoleAssociation(convertGuid(cr.getRoleGuid()));
+      }
     }
 
     return p;
@@ -293,8 +294,8 @@ public class ApiUtils {
       for (CommunityRole r : roleList) {
         PSCommunityRoleAssociation p_r =
             new PSCommunityRoleAssociation(
-                convertGuid(orNull(r.getCommunityGuid())), convertGuid(orNull(r.getRoleGuid())));
-        p_r.setRoleName(orNull(r.getRoleName()));
+                convertGuid(r.getCommunityGuid()), convertGuid(r.getRoleGuid()));
+        p_r.setRoleName(r.getRoleName());
         ret.add(p_r);
       }
     }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
@@ -100,10 +100,10 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     }
     String key = idOrName.trim();
     Community summary = resolveSummary(key);
-    if (summary == null || summary.getGuid().isEmpty()) {
+    if (summary == null || summary.getGuid() == null) {
       return null;
     }
-    Guid g = summary.getGuid().get();
+    Guid g = summary.getGuid();
     GuidList ids = new GuidList();
     ids.add(g);
     try {
@@ -141,7 +141,8 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     out.sort(
         (a, b) ->
             String.CASE_INSENSITIVE_ORDER.compare(
-                a.getRoleName().orElse(""), b.getRoleName().orElse("")));
+                a.getRoleName() == null ? "" : a.getRoleName(),
+                b.getRoleName() == null ? "" : b.getRoleName()));
     return out;
   }
 
@@ -151,12 +152,12 @@ public class CommunityAdaptor implements ICommunityAdaptor {
       throw new IllegalArgumentException("idOrName is required");
     }
     Community current = getCommunity(idOrName.trim());
-    if (current == null || current.getGuid().isEmpty()) {
+    if (current == null || current.getGuid() == null) {
       return null;
     }
     // Replace memberships on the REST DTO then save via design WS
     CommunityRoleList next = roles != null ? roles : new CommunityRoleList();
-    Guid communityGuid = current.getGuid().get();
+    Guid communityGuid = current.getGuid();
     for (CommunityRole r : next) {
       if (r == null) {
         continue;
@@ -199,7 +200,7 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     CommunityList byName = findCommunities(key);
     if (byName != null) {
       for (Community c : byName) {
-        if (c != null && key.equalsIgnoreCase(c.getName().orElse(null))) {
+        if (c != null && key.equalsIgnoreCase(c.getName())) {
           return c;
         }
       }
@@ -248,10 +249,10 @@ public class CommunityAdaptor implements ICommunityAdaptor {
   }
 
   private void enrichRoleNames(Community detail) {
-    if (detail == null || detail.getRoleList().isEmpty()) {
+    if (detail == null || detail.getRoleList() == null) {
       return;
     }
-    CommunityRoleList roles = detail.getRoleList().get();
+    CommunityRoleList roles = detail.getRoleList();
     if (roles == null || roles.isEmpty()) {
       return;
     }
@@ -271,7 +272,7 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     }
     for (CommunityRole r : roles) {
       if (r == null) continue;
-      if (StringUtils.isBlank(r.getRoleName().orElse(null))) {
+      if (StringUtils.isBlank(r.getRoleName())) {
         String n = namesByUuid.get(r.getRoleId());
         if (n != null) {
           r.setRoleName(n);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
@@ -253,7 +253,7 @@ public class CommunityAdaptor implements ICommunityAdaptor {
       return;
     }
     CommunityRoleList roles = detail.getRoleList();
-    if (roles == null || roles.isEmpty()) {
+    if (roles.isEmpty()) {
       return;
     }
     Map<Long, String> namesByUuid = new HashMap<>();

--- a/rest/src/main/java/com/percussion/rest/communities/Community.java
+++ b/rest/src/main/java/com/percussion/rest/communities/Community.java
@@ -23,9 +23,14 @@ import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Community in Percussion CMS. */
+/**
+ * Represents a Community in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style.
+ */
 @XmlRootElement
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
@@ -70,8 +75,8 @@ public class Community {
   }
 
   /** Gets the community GUID. */
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
@@ -79,8 +84,8 @@ public class Community {
   }
 
   /** Gets the community name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -88,8 +93,8 @@ public class Community {
   }
 
   /** Gets the community description. */
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -97,8 +102,8 @@ public class Community {
   }
 
   /** Gets the community label. */
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
@@ -106,8 +111,8 @@ public class Community {
   }
 
   /** Gets the list of roles associated with this community. */
-  public Optional<CommunityRoleList> getRoleList() {
-    return Optional.ofNullable(roleList);
+  public CommunityRoleList getRoleList() {
+    return roleList;
   }
 
   public void setRoleList(CommunityRoleList roleList) {

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityRole.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityRole.java
@@ -18,14 +18,20 @@
 
 package com.percussion.rest.communities;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Community Role association. */
+/**
+ * Represents a Community Role association.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}).
+ */
 @XmlRootElement(name = "CommunityRole")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Community Role association")
 public class CommunityRole {
 
@@ -55,16 +61,16 @@ public class CommunityRole {
     this.roleGuid = roleGuid;
   }
 
-  public Optional<Guid> getCommunityGuid() {
-    return Optional.ofNullable(communityGuid);
+  public Guid getCommunityGuid() {
+    return communityGuid;
   }
 
   public void setCommunityGuid(Guid communityGuid) {
     this.communityGuid = communityGuid;
   }
 
-  public Optional<Guid> getRoleGuid() {
-    return Optional.ofNullable(roleGuid);
+  public Guid getRoleGuid() {
+    return roleGuid;
   }
 
   public void setRoleGuid(Guid roleGuid) {
@@ -87,8 +93,8 @@ public class CommunityRole {
     this.roleId = roleId;
   }
 
-  public Optional<String> getRoleName() {
-    return Optional.ofNullable(roleName);
+  public String getRoleName() {
+    return roleName;
   }
 
   public void setRoleName(String roleName) {

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityVisibility.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityVisibility.java
@@ -25,9 +25,13 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents the visibility of a community and its visible objects. */
+/**
+ * Represents the visibility of a community and its visible objects.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}).
+ */
 @XmlRootElement
 @Schema
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -63,16 +67,16 @@ public class CommunityVisibility {
     this.id = id;
   }
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<ObjectSummaryList> getVisibleObjects() {
-    return Optional.ofNullable(visibleObjects);
+  public ObjectSummaryList getVisibleObjects() {
+    return visibleObjects;
   }
 
   public void setVisibleObjects(ObjectSummaryList visibleObjects) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -18,6 +18,7 @@ package com.percussion.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.communities.Community;
@@ -190,7 +191,8 @@ class JacksonContextResolverOptionalTest {
 
     CommunityVisibility roundTrip = visibilityMapper.readValue(json, CommunityVisibility.class);
     assertEquals(10L, roundTrip.getId(), json);
-    assertTrue(roundTrip.getGuid() != null, json);
+    assertNotNull(roundTrip.getGuid(), json);
+    assertEquals("0-13-10", roundTrip.getGuid().getStringValue().orElse(null), json);
   }
 
   private static void assertNoOptionalBeanKeys(String json) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,9 +16,13 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.communities.Community;
+import com.percussion.rest.communities.CommunityRole;
+import com.percussion.rest.communities.CommunityVisibility;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
@@ -111,5 +115,87 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void community_serializesPlainScalarsNotOptionalBeans() {
+    Community community = new Community();
+    community.setId(10L);
+    community.setName("Default");
+    community.setLabel("Default Community");
+    community.setDescription("The default community");
+    community.setGuid(new Guid("0-13-10"));
+
+    ObjectMapper communityMapper = new JacksonContextResolver().getContext(Community.class);
+    String json = communityMapper.writeValueAsString(community);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("Default Community"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-13-10") || json.contains("10"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Community roundTrip = communityMapper.readValue(json, Community.class);
+    assertEquals("Default", roundTrip.getName(), json);
+    assertEquals("Default Community", roundTrip.getLabel(), json);
+    assertEquals("The default community", roundTrip.getDescription(), json);
+    assertEquals(10L, roundTrip.getId(), json);
+  }
+
+  @Test
+  void communityRole_serializesRoleNameNotOptionalBeans() {
+    CommunityRole role = new CommunityRole();
+    role.setCommunityId(10L);
+    role.setRoleId(2L);
+    role.setRoleName("Admin");
+    role.setCommunityGuid(new Guid("0-13-10"));
+    Guid roleGuid = new Guid();
+    roleGuid.setStringValue("0-8-2");
+    roleGuid.setType((short) 8);
+    roleGuid.setUuid(2);
+    role.setRoleGuid(roleGuid);
+
+    ObjectMapper roleMapper = new JacksonContextResolver().getContext(CommunityRole.class);
+    String json = roleMapper.writeValueAsString(role);
+    assertTrue(json.contains("\"roleName\""), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("\"communityId\""), json);
+    assertTrue(json.contains("\"roleId\""), json);
+    assertTrue(json.contains("\"communityGuid\""), json);
+    assertTrue(json.contains("\"roleGuid\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    CommunityRole roundTrip = roleMapper.readValue(json, CommunityRole.class);
+    assertEquals("Admin", roundTrip.getRoleName(), json);
+    assertEquals(10L, roundTrip.getCommunityId(), json);
+    assertEquals(2L, roundTrip.getRoleId(), json);
+  }
+
+  @Test
+  void communityVisibility_serializesGuidNotOptionalBeans() {
+    CommunityVisibility visibility = new CommunityVisibility();
+    visibility.setId(10L);
+    visibility.setGuid(new Guid("0-13-10"));
+
+    ObjectMapper visibilityMapper =
+        new JacksonContextResolver().getContext(CommunityVisibility.class);
+    String json = visibilityMapper.writeValueAsString(visibility);
+    assertTrue(json.contains("\"id\""), json);
+    assertTrue(json.contains("10"), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-13-10") || json.contains("13"), json);
+    assertNoOptionalBeanKeys(json);
+
+    CommunityVisibility roundTrip = visibilityMapper.readValue(json, CommunityVisibility.class);
+    assertEquals(10L, roundTrip.getId(), json);
+    assertTrue(roundTrip.getGuid() != null, json);
+  }
+
+  private static void assertNoOptionalBeanKeys(String json) {
+    assertFalse(
+        json.contains("\"empty\"") || json.contains("\"present\""),
+        "JSON must not contain Optional-bean empty/present keys: " + json);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/communities/CommunityResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/communities/CommunityResourceDetailTest.java
@@ -51,7 +51,7 @@ public class CommunityResourceDetailTest {
     c.setName("Default");
     c.setLabel("Default");
     when(adaptor.getCommunity(eq("Default"))).thenReturn(c);
-    assertEquals("Default", resource.getCommunity("Default").getName().orElse(null));
+    assertEquals("Default", resource.getCommunity("Default").getName());
   }
 
   @Test
@@ -59,7 +59,7 @@ public class CommunityResourceDetailTest {
     Community c = new Community();
     c.setName("ById");
     when(adaptor.getCommunity(eq("10"))).thenReturn(c);
-    assertEquals("ById", resource.getCommunity("10").getName().orElse(null));
+    assertEquals("ById", resource.getCommunity("10").getName());
   }
 
   @Test
@@ -67,7 +67,7 @@ public class CommunityResourceDetailTest {
     Community c = new Community();
     c.setName("ByGuid");
     when(adaptor.getCommunity(eq("0-13-10"))).thenReturn(c);
-    assertEquals("ByGuid", resource.getCommunity("0-13-10").getName().orElse(null));
+    assertEquals("ByGuid", resource.getCommunity("0-13-10").getName());
   }
 
   @Test
@@ -94,7 +94,7 @@ public class CommunityResourceDetailTest {
     list.add(r);
     when(adaptor.listAvailableRoles()).thenReturn(list);
     assertEquals(1, resource.listAvailableRoles().size());
-    assertEquals("Admin", resource.listAvailableRoles().get(0).getRoleName().orElse(null));
+    assertEquals("Admin", resource.listAvailableRoles().get(0).getRoleName());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class CommunityResourceDetailTest {
     updated.setName("Default");
     updated.setRoleList(body);
     when(adaptor.updateCommunityRoles(eq("Default"), any())).thenReturn(updated);
-    assertEquals("Default", resource.updateCommunityRoles("Default", body).getName().orElse(null));
+    assertEquals("Default", resource.updateCommunityRoles("Default", body).getName());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Slice 7 of parent #3388. Convert REST wire DTOs `Community`, `CommunityRole`, and `CommunityVisibility` from `Optional<T>` getters to plain nullable getters under `@JsonInclude(NON_NULL)` so community/visibility JSON is scalars, not Optional beans (`empty` / `present`).

Callers that used `.orElse()` / `Optional.isEmpty()` on converted getters are updated in `CommunityResourceDetailTest`, `CommunityAdaptor`, and `ApiUtils`. Production-mapper round-trip tests were appended to `JacksonContextResolverOptionalTest` (class not rewritten). `rest/AGENTS.md` is not committed (human rule review).

Out of scope: Asset family (#3418), Acl family (#3420).

Fixes #3419
Parent: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — standalone module suite green.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — reverse-dep compile + suite green after public getter signature change.
3. Confirm `JacksonContextResolverOptionalTest` serializes Community / CommunityRole / CommunityVisibility without `empty`/`present` keys and round-trips name / roleName / guid.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): wire-getter refactor; no documented Optional-bean JSON examples under product-docs
- [x] **Unit / module tests** — behavioral tests for new or changed non-trivial logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 421, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1223, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** public getter signatures changed (`Optional<T>` → `T`). Grep: no `extends Community` / anonymous subclasses. Standalone sitemanage clean install green.

## C5 UI proof

N/A — Java REST DTO / apibridge change only; no WebUI or Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.