### PR TITLE
fix(rest): Acl / AclEntry / UserAccessLevel plain wire getters (#3420)

### DIFF
--- a/docs/ai-generated/code-reviews/3420-acl-plain-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3420-acl-plain-wire-getters-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review — #3420 Acl / AclEntry / UserAccessLevel plain wire getters
+
+**Scope:** uncommitted branch `fix/issue-3420-acl-plain-wire-getters-rest` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** REST DTO wire getters must be plain nullable types + `@JsonInclude(NON_NULL)` (ContentType #1693 / TemplateSummary #2189 / parent #3388); production mapper tests must use `new JacksonContextResolver().getContext(TheDto.class)`; Object ACL bind/save envelope (#3378 / #3384 / #3391) must not regress; change-class companions (DTO + rest tests + sitemanage ApiUtils convert).
+
+## Summary
+
+Parent #3388 slice 8. `Acl`, `AclEntry`, and `UserAccessLevel` still exposed `Optional<T>` getters. `Acl`/`AclEntry` bandaged Optional getters with `@JsonIgnore` + field `@JsonProperty` (#3378). `UserAccessLevel` had no ignore, so `permission` could serialize as an Optional bean.
+
+This change:
+
+1. Converts the three wire DTOs to plain nullable getters/setters with class-level `@JsonInclude(NON_NULL)`.
+2. Deletes Optional wrapper getters (no leftover `@JsonIgnore` Optional helpers).
+3. Updates rest ACL bind/save/GET tests that called `.orElse()` / `.map()` / `.isPresent()`.
+4. Updates sitemanage `ApiUtils.convertAcl*` / `convertAclEntries` (`entry.getType()` and `p.getPermission()` null checks).
+5. Appends three `JacksonContextResolverOptionalTest` methods (production mapper, no `empty`/`present` keys).
+
+Does **not** retake Display Format ACL persist/GET. Does **not** commit `rest/AGENTS.md`. Does **not** add `OPTIONAL_FIELDS_SUPPORTED` or `jackson-datatype-jdk8`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Existing Object ACL envelope/Guid-string/Default-AnyCommunity tests remain and are green. Behavioral tests added for the converted family. No filesystem path construction.
+
+C2: public getter return types changed `Optional<T>` → `T`. Grep found no `extends Acl` / anonymous rest-DTO subclasses (system `IPSAcl extends java.security.acl.Acl` is unrelated). Reverse-dep `projects/sitemanage` standalone `clean install` is green.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] No path/file I/O in this diff (JSON/JAX-RS DTO + convert only)
+- [x] Tests do not assert OS-specific file paths
+- [x] Line-ending assertions not added
+
+## Issues
+
+None (hard-gate).
+
+### Nits
+
+- Primitive `id` / `objectId` / `objectType` still serialize as `0` when unset (`NON_NULL` does not omit primitives). Pre-existing; same as other converted families.
+
+## Product documentation
+
+N/A — no operator/integrator example currently shows Optional-bean JSON for this family. Wire scalars stay the same documented shape (`name`, `aclEntries`, `permission`).

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -494,18 +494,18 @@ public class ApiUtils {
     PSAclImpl p_acl = new PSAclImpl();
 
     p_acl.setId(acl.getId());
-    p_acl.setDescription(orNull(acl.getDescription()));
-    String name = orNull(acl.getName());
+    p_acl.setDescription(acl.getDescription());
+    String name = acl.getName();
     if (name == null || name.isBlank()) {
       name = "ACL";
     }
     p_acl.setName(name);
-    var convertedGuid = convertGuid(orNull(acl.getGuid()));
+    var convertedGuid = convertGuid(acl.getGuid());
     if (convertedGuid != null) {
       p_acl.setGUID(convertedGuid);
     }
     applyAclObjectIdentity(acl, p_acl);
-    p_acl.setEntries(convertAclEntries(orNull(acl.getAclEntries())));
+    p_acl.setEntries(convertAclEntries(acl.getAclEntries()));
 
     return p_acl;
   }
@@ -518,7 +518,7 @@ public class ApiUtils {
   static void applyAclObjectIdentity(Acl acl, PSAclImpl p_acl) {
     int objectType = acl.getObjectType();
     long objectId = acl.getObjectId();
-    Guid objectGuid = orNull(acl.getObjectGuid());
+    Guid objectGuid = acl.getObjectGuid();
     if (objectGuid != null) {
       String stringValue = orNull(objectGuid.getStringValue());
       if (stringValue != null
@@ -556,21 +556,21 @@ public class ApiUtils {
       PSAclEntryImpl p_entry = new PSAclEntryImpl();
 
       p_entry.setId(entry.getId());
-      p_entry.setName(orNull(entry.getName()));
+      p_entry.setName(entry.getName());
       p_entry.setAclId(entry.getAclId());
 
-      var principal = orNull(entry.getPrincipal());
+      var principal = entry.getPrincipal();
       if (principal != null && principal.getName() != null) {
         p_entry.setPrincipal(convertPrincipal(principal));
       } else if (p_entry.getName() == null
-          && entry.getType().isPresent()
-          && entry.getType().get().getName() != null) {
+          && entry.getType() != null
+          && entry.getType().getName() != null) {
         // Load path historically stored principal name on TypedPrincipal.name
-        p_entry.setName(entry.getType().get().getName());
+        p_entry.setName(entry.getType().getName());
       }
 
-      if (entry.getType().isPresent()) {
-        TypedPrincipal tp = entry.getType().get();
+      if (entry.getType() != null) {
+        TypedPrincipal tp = entry.getType();
         if (tp.getType() != null) {
           p_entry.setType(tp.getType());
         } else if (tp.getName() != null) {
@@ -583,9 +583,12 @@ public class ApiUtils {
         }
       }
 
-      for (UserAccessLevel p : orEmpty(entry.getPermissions())) {
-        if (p.getPermission().isPresent()) {
-          p_entry.addPermission(convertPermissions(p));
+      UserAccessLevelList levels = entry.getPermissions();
+      if (levels != null) {
+        for (UserAccessLevel p : levels) {
+          if (p.getPermission() != null) {
+            p_entry.addPermission(convertPermissions(p));
+          }
         }
       }
 
@@ -598,7 +601,7 @@ public class ApiUtils {
   public static PSAccessLevelImpl convertPermissions(UserAccessLevel p) {
     PSAccessLevelImpl p_a = new PSAccessLevelImpl();
 
-    Permissions perm = orNull(p.getPermission());
+    Permissions perm = p.getPermission();
     if (perm != null) {
       p_a.setPermission(PSPermissions.valueOf(perm.name()));
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsAclConvertTest.java
@@ -117,7 +117,7 @@ public class ApiUtilsAclConvertTest {
     assertNotNull(out);
     assertEquals(55, out.getId());
     // PSAccessLevelImpl defaults ordinal 0 → READ when permission was never set.
-    // convertAclEntries must filter isPresent() so these are not persisted as READ.
+    // convertAclEntries must filter null permission so these are not persisted as READ.
     assertEquals(PSPermissions.READ, out.getPermission());
   }
 
@@ -243,18 +243,18 @@ public class ApiUtilsAclConvertTest {
     addEntry(pAcl, "Admin", IPSTypedPrincipal.PrincipalTypes.USER, PSPermissions.OWNER);
 
     Acl rest = ApiUtils.convertAcl(pAcl);
-    assertNotNull(rest.getAclEntries().orElse(null));
-    assertEquals(3, rest.getAclEntries().get().size());
+    assertNotNull(rest.getAclEntries());
+    assertEquals(3, rest.getAclEntries().size());
     var names =
-        rest.getAclEntries().get().stream()
-            .map(e -> e.getName().orElse(""))
+        rest.getAclEntries().stream()
+            .map(e -> e.getName() == null ? "" : e.getName())
             .collect(Collectors.toSet());
     assertTrue(names.contains("Default"));
     assertTrue(names.contains("AnyCommunity"));
     assertTrue(names.contains("Admin"));
     assertEquals(31, rest.getObjectType());
     assertEquals(5, rest.getObjectId());
-    assertNotNull(rest.getObjectGuid().orElse(null));
+    assertNotNull(rest.getObjectGuid());
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/acls/Acl.java
+++ b/rest/src/main/java/com/percussion/rest/acls/Acl.java
@@ -17,7 +17,7 @@
 
 package com.percussion.rest.acls;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,11 +26,17 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** REST representation of an access control list. */
+/**
+ * REST representation of an access control list.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * scalars and nested objects, not Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3388 slice 8 / #3420).
+ */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Acl")
 public class Acl {
 
@@ -113,11 +119,10 @@ public class Acl {
   /**
    * Returns the ACL's GUID.
    *
-   * @return the GUID, may be empty
+   * @return the GUID, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   /**
@@ -132,11 +137,10 @@ public class Acl {
   /**
    * Returns the ACL's name.
    *
-   * @return the name, may be empty
+   * @return the name, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   /**
@@ -169,11 +173,10 @@ public class Acl {
   /**
    * Returns the ACL's description.
    *
-   * @return the description, may be empty
+   * @return the description, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   /**
@@ -188,11 +191,10 @@ public class Acl {
   /**
    * Returns the ACL's entries.
    *
-   * @return the entries, may be empty
+   * @return the entries, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<AclEntryList> getAclEntries() {
-    return Optional.ofNullable(aclEntries);
+  public AclEntryList getAclEntries() {
+    return aclEntries;
   }
 
   /**
@@ -225,11 +227,10 @@ public class Acl {
   /**
    * Returns the GUID of the secured object.
    *
-   * @return the object GUID, may be empty
+   * @return the object GUID, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<Guid> getObjectGuid() {
-    return Optional.ofNullable(objectGuid);
+  public Guid getObjectGuid() {
+    return objectGuid;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
@@ -18,7 +18,7 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rest.acls;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAccessType;
@@ -26,11 +26,17 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** REST representation of an ACL entry. */
+/**
+ * REST representation of an ACL entry.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * scalars and nested objects, not Optional beans. Matches {@link Acl} getter style (issue #3388
+ * slice 8 / #3420).
+ */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "AclEntry")
 public class AclEntry {
 
@@ -119,11 +125,10 @@ public class AclEntry {
   /**
    * Returns the entry name.
    *
-   * @return the name, may be empty
+   * @return the name, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   /**
@@ -138,11 +143,10 @@ public class AclEntry {
   /**
    * Returns the associated principal.
    *
-   * @return the principal, may be empty
+   * @return the principal, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<Principal> getPrincipal() {
-    return Optional.ofNullable(principal);
+  public Principal getPrincipal() {
+    return principal;
   }
 
   /**
@@ -157,11 +161,10 @@ public class AclEntry {
   /**
    * Returns the typed principal classification.
    *
-   * @return the type, may be empty
+   * @return the type, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<TypedPrincipal> getType() {
-    return Optional.ofNullable(type);
+  public TypedPrincipal getType() {
+    return type;
   }
 
   /**
@@ -176,11 +179,10 @@ public class AclEntry {
   /**
    * Returns the permissions granted by this entry.
    *
-   * @return the permissions, may be empty
+   * @return the permissions, may be {@code null}
    */
-  @JsonIgnore
-  public Optional<UserAccessLevelList> getPermissions() {
-    return Optional.ofNullable(permissions);
+  public UserAccessLevelList getPermissions() {
+    return permissions;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/acls/UserAccessLevel.java
+++ b/rest/src/main/java/com/percussion/rest/acls/UserAccessLevel.java
@@ -18,15 +18,22 @@
 
 package com.percussion.rest.acls;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percussion.rest.PermissionList;
 import com.percussion.rest.Permissions;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a user's access level for a given ACL. */
+/**
+ * Represents a user's access level for a given ACL.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * permission scalars, not Optional beans. Matches {@link Acl} getter style (issue #3388 slice 8 /
+ * #3420).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "User Access Level")
 public class UserAccessLevel {
 
@@ -54,16 +61,16 @@ public class UserAccessLevel {
     this.id = id;
   }
 
-  public Optional<Permissions> getPermission() {
-    return Optional.ofNullable(permission);
+  public Permissions getPermission() {
+    return permission;
   }
 
   public void setPermission(Permissions permission) {
     this.permission = permission;
   }
 
-  public Optional<PermissionList> getPermissions() {
-    return Optional.ofNullable(permissions);
+  public PermissionList getPermissions() {
+    return permissions;
   }
 
   public void setPermissions(PermissionList permissions) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,13 +16,23 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.Permissions;
+import com.percussion.rest.acls.Acl;
+import com.percussion.rest.acls.AclEntry;
+import com.percussion.rest.acls.AclEntryList;
+import com.percussion.rest.acls.AclList;
+import com.percussion.rest.acls.TypedPrincipal;
+import com.percussion.rest.acls.UserAccessLevel;
+import com.percussion.rest.acls.UserAccessLevelList;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
+import com.percussion.security.IPSTypedPrincipal;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -111,5 +121,96 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("\"templateLabel\""), json);
     assertTrue(json.contains("1037"), json);
     assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
+  }
+
+  @Test
+  void acl_serializesNameGuidEntriesNotOptionalBeans() {
+    ObjectMapper aclMapper = new JacksonContextResolver().getContext(Acl.class);
+    Acl acl = sampleAcl();
+
+    String json = aclMapper.writeValueAsString(acl);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("By_Author ACL"), json);
+    assertTrue(json.contains("Default"), json);
+    assertTrue(json.contains("AnyCommunity"), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("aclEntries") || json.contains("AclEntries"), json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertFalse(json.contains("\"present\""), json);
+
+    Acl roundTrip = aclMapper.readValue(json, Acl.class);
+    assertEquals("By_Author ACL", roundTrip.getName());
+    assertEquals(3, roundTrip.getAclEntries().size());
+    assertEquals("Default", roundTrip.getAclEntries().get(0).getName());
+  }
+
+  @Test
+  void aclList_serializesEnvelopeScalarsNotOptionalBeans() {
+    ObjectMapper listMapper = new JacksonContextResolver().getContext(AclList.class);
+    AclList list = new AclList();
+    list.add(sampleAcl());
+
+    String json = listMapper.writeValueAsString(list);
+    assertTrue(json.contains("\"AclList\"") || json.contains("By_Author ACL"), json);
+    assertTrue(json.contains("\"name\""), json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertFalse(json.contains("\"present\""), json);
+
+    AclList roundTrip = listMapper.readValue(json, AclList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("By_Author ACL", roundTrip.get(0).getName());
+    assertEquals(3, roundTrip.get(0).getAclEntries().size());
+  }
+
+  @Test
+  void userAccessLevel_serializesPermissionNotOptionalBean() {
+    ObjectMapper ualMapper = new JacksonContextResolver().getContext(UserAccessLevel.class);
+    UserAccessLevel level = new UserAccessLevel();
+    level.setId(9);
+    level.setPermission(Permissions.READ);
+
+    String json = ualMapper.writeValueAsString(level);
+    assertTrue(json.contains("READ"), json);
+    assertTrue(json.contains("\"permission\""), json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertFalse(json.contains("\"present\""), json);
+
+    UserAccessLevel roundTrip = ualMapper.readValue(json, UserAccessLevel.class);
+    assertEquals(Permissions.READ, roundTrip.getPermission());
+    assertEquals(9, roundTrip.getId());
+  }
+
+  private static Acl sampleAcl() {
+    Acl acl = new Acl();
+    acl.setId(7);
+    acl.setName("By_Author ACL");
+    acl.setObjectType(31);
+    acl.setObjectId(5);
+    Guid objectGuid = new Guid();
+    objectGuid.setStringValue("0-31-5");
+    acl.setObjectGuid(objectGuid);
+    AclEntryList entries = new AclEntryList();
+    entries.add(namedAclEntry("Default", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.READ));
+    entries.add(
+        namedAclEntry(
+            "AnyCommunity",
+            IPSTypedPrincipal.PrincipalTypes.COMMUNITY,
+            Permissions.RUNTIME_VISIBLE));
+    entries.add(namedAclEntry("Admin", IPSTypedPrincipal.PrincipalTypes.USER, Permissions.OWNER));
+    acl.setAclEntries(entries);
+    return acl;
+  }
+
+  private static AclEntry namedAclEntry(
+      String name, IPSTypedPrincipal.PrincipalTypes type, Permissions permission) {
+    AclEntry entry = new AclEntry();
+    entry.setName(name);
+    entry.setType(new TypedPrincipal(name, type));
+    UserAccessLevelList levels = new UserAccessLevelList();
+    UserAccessLevel level = new UserAccessLevel();
+    level.setPermission(permission);
+    levels.add(level);
+    entry.setPermissions(levels);
+    return entry;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/acls/AclListCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListCxfUnmarshallTest.java
@@ -103,7 +103,8 @@ public class AclListCxfUnmarshallTest {
     assertInstanceOf(AclList.class, raw, "JavaType path must not return raw ArrayList: " + raw);
     AclList list = (AclList) raw;
     assertEquals(1, list.size());
-    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals(
+        3, list.get(0).getAclEntries() == null ? 0 : list.get(0).getAclEntries().size());
   }
 
   @Test
@@ -161,8 +162,9 @@ public class AclListCxfUnmarshallTest {
             new ByteArrayInputStream(DF_SAVE.getBytes(StandardCharsets.UTF_8)));
     assertInstanceOf(AclList.class, list);
     assertEquals(1, list.size());
-    assertEquals("By_Author ACL", list.get(0).getName().orElse(null));
-    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals("By_Author ACL", list.get(0).getName());
+    assertEquals(
+        3, list.get(0).getAclEntries() == null ? 0 : list.get(0).getAclEntries().size());
   }
 
   @Test
@@ -217,11 +219,11 @@ public class AclListCxfUnmarshallTest {
     assertEquals(1, saved.size());
     assertEquals(31, saved.get(0).getObjectType());
     assertEquals(5, saved.get(0).getObjectId());
-    assertEquals(3, saved.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
-    assertEquals("Default", saved.get(0).getAclEntries().orElseThrow().get(0).getName().orElse(null));
     assertEquals(
-        "AnyCommunity", saved.get(0).getAclEntries().orElseThrow().get(1).getName().orElse(null));
-    assertEquals("Admin", saved.get(0).getAclEntries().orElseThrow().get(2).getName().orElse(null));
+        3, saved.get(0).getAclEntries() == null ? 0 : saved.get(0).getAclEntries().size());
+    assertEquals("Default", saved.get(0).getAclEntries().get(0).getName());
+    assertEquals("AnyCommunity", saved.get(0).getAclEntries().get(1).getName());
+    assertEquals("Admin", saved.get(0).getAclEntries().get(2).getName());
   }
 
   @Test
@@ -265,7 +267,7 @@ public class AclListCxfUnmarshallTest {
     AclList saved = captured.get();
     assertNotNull(saved);
     assertEquals(1, saved.size());
-    assertEquals("By_Author ACL", saved.get(0).getName().orElse(null));
+    assertEquals("By_Author ACL", saved.get(0).getName());
     assertEquals(31, saved.get(0).getObjectType());
   }
 

--- a/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListJsonReaderTest.java
@@ -53,20 +53,20 @@ public class AclListJsonReaderTest {
     assertInstanceOf(AclList.class, list);
     assertEquals(1, list.size());
     Acl acl = list.get(0);
-    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals("By_Author ACL", acl.getName());
     assertEquals(31, acl.getObjectType());
     assertEquals(5, acl.getObjectId());
-    assertEquals(3, acl.getAclEntries().map(AclEntryList::size).orElse(0));
-    assertEquals("Default", acl.getAclEntries().orElseThrow().get(0).getName().orElse(null));
-    assertEquals("AnyCommunity", acl.getAclEntries().orElseThrow().get(1).getName().orElse(null));
-    assertEquals("Admin", acl.getAclEntries().orElseThrow().get(2).getName().orElse(null));
+    assertEquals(3, acl.getAclEntries() == null ? 0 : acl.getAclEntries().size());
+    assertEquals("Default", acl.getAclEntries().get(0).getName());
+    assertEquals("AnyCommunity", acl.getAclEntries().get(1).getName());
+    assertEquals("Admin", acl.getAclEntries().get(2).getName());
   }
 
   @Test
   public void parseAcceptsBareArray() {
     AclList list = AclListJsonReader.parse("[{\"name\":\"x\",\"objectType\":31}]");
     assertEquals(1, list.size());
-    assertEquals("x", list.get(0).getName().orElse(null));
+    assertEquals("x", list.get(0).getName());
     assertEquals(31, list.get(0).getObjectType());
   }
 
@@ -106,6 +106,7 @@ public class AclListJsonReaderTest {
     AclList list = AclListJsonReader.parseNode(
         tools.jackson.databind.json.JsonMapper.builder().build().readTree(DF_SAVE));
     assertEquals(1, list.size());
-    assertEquals(3, list.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals(
+        3, list.get(0).getAclEntries() == null ? 0 : list.get(0).getAclEntries().size());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
@@ -118,12 +118,12 @@ public class AclListSerialDeserialTest {
     AclList roundTrip = mapper.readValue(json, AclList.class);
     assertEquals(1, roundTrip.size());
     Acl acl = roundTrip.get(0);
-    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals("By_Author ACL", acl.getName());
     assertEquals(5, acl.getObjectId());
     assertEquals(31, acl.getObjectType());
-    assertTrue(acl.getObjectGuid().isPresent());
-    assertEquals("0-31-5", acl.getObjectGuid().get().getStringValue().orElse(null));
-    assertEquals(3, acl.getAclEntries().map(AclEntryList::size).orElse(0));
+    assertNotNull(acl.getObjectGuid());
+    assertEquals("0-31-5", acl.getObjectGuid().getStringValue().orElse(null));
+    assertEquals(3, acl.getAclEntries() == null ? 0 : acl.getAclEntries().size());
   }
 
   @Test
@@ -140,7 +140,8 @@ public class AclListSerialDeserialTest {
 
     AclList roundTrip = mapper.readValue(json, AclList.class);
     assertEquals(1, roundTrip.size());
-    assertEquals(3, roundTrip.get(0).getAclEntries().map(AclEntryList::size).orElse(0));
+    assertEquals(
+        3, roundTrip.get(0).getAclEntries() == null ? 0 : roundTrip.get(0).getAclEntries().size());
     assertEquals(31, roundTrip.get(0).getObjectType());
   }
 
@@ -179,14 +180,14 @@ public class AclListSerialDeserialTest {
     AclList list = mapper.readValue(clientBody, AclList.class);
     assertEquals(1, list.size());
     Acl acl = list.get(0);
-    assertEquals("By_Author ACL", acl.getName().orElse(null));
+    assertEquals("By_Author ACL", acl.getName());
     assertEquals(31, acl.getObjectType());
     assertEquals(5, acl.getObjectId());
-    assertNotNull(acl.getAclEntries().orElse(null));
-    assertEquals(3, acl.getAclEntries().get().size());
-    assertEquals("Default", acl.getAclEntries().get().get(0).getName().orElse(null));
-    assertEquals("AnyCommunity", acl.getAclEntries().get().get(1).getName().orElse(null));
-    assertEquals("Admin", acl.getAclEntries().get().get(2).getName().orElse(null));
+    assertNotNull(acl.getAclEntries());
+    assertEquals(3, acl.getAclEntries().size());
+    assertEquals("Default", acl.getAclEntries().get(0).getName());
+    assertEquals("AnyCommunity", acl.getAclEntries().get(1).getName());
+    assertEquals("Admin", acl.getAclEntries().get(2).getName());
   }
 
   @Test
@@ -221,7 +222,7 @@ public class AclListSerialDeserialTest {
     AclList list = mapper.readValue(body, AclList.class);
     assertEquals(1, list.size());
     assertEquals(
-        "Admin", list.get(0).getAclEntries().orElseThrow().get(0).getPrincipal().orElseThrow().getName());
+        "Admin", list.get(0).getAclEntries().get(0).getPrincipal().getName());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclResourceTest.java
@@ -147,10 +147,10 @@ public class AclResourceTest {
     when(adaptor.loadAclForObject(any(Guid.class))).thenReturn(acl);
 
     Acl out = resource.loadAclForObject("0-31-5");
-    assertEquals(3, out.getAclEntries().orElseThrow().size());
-    assertEquals("Default", out.getAclEntries().get().get(0).getName().orElse(null));
-    assertEquals("AnyCommunity", out.getAclEntries().get().get(1).getName().orElse(null));
-    assertEquals("Admin", out.getAclEntries().get().get(2).getName().orElse(null));
+    assertEquals(3, out.getAclEntries().size());
+    assertEquals("Default", out.getAclEntries().get(0).getName());
+    assertEquals("AnyCommunity", out.getAclEntries().get(1).getName());
+    assertEquals("Admin", out.getAclEntries().get(2).getName());
     assertEquals(31, out.getObjectType());
     assertEquals(5, out.getObjectId());
   }


### PR DESCRIPTION
## Summary

Slice 8 of parent #3388. Convert REST wire DTOs `Acl`, `AclEntry`, and `UserAccessLevel` from `Optional<T>` getters to plain nullable getters under `@JsonInclude(NON_NULL)` so Object ACL JSON is scalars, not Optional beans (`empty` / `present`).

Existing Object ACL bind/save tests stay in place (`AclList` envelope, Guid string bind, Default/AnyCommunity specials). Do not regress #3378 / #3384 / #3391. Callers that used `.orElse()` / `.isPresent()` on converted getters are updated in `AclResourceTest`, `AclListSerialDeserialTest`, `AclListJsonReaderTest`, `AclListCxfUnmarshallTest`, and sitemanage `ApiUtils` / `ApiUtilsAclConvertTest`. Production-mapper round-trip tests were appended to `JacksonContextResolverOptionalTest` (class not rewritten). `rest/AGENTS.md` is not committed (human rule review). Display Format ACL persist/GET product path is not retaken.

Out of scope: Asset family (#3418), Community family (#3419).

Fixes #3420
Parent: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — standalone module suite green.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — reverse-dep compile + suite green after public getter signature change.
3. Confirm `JacksonContextResolverOptionalTest` serializes Acl / AclList / UserAccessLevel without `empty`/`present` keys and round-trips name / entries / permission.
4. Confirm existing ACL save/GET tests remain green (`AclList` envelope, Guid `stringValue`, Default / AnyCommunity / Admin entries).

## Checklist

- [x] **Product documentation** — N/A (not product-facing): wire-getter refactor; no documented Optional-bean JSON examples under product-docs
- [x] **Unit / module tests** — behavioral tests for new or changed non-trivial logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 421, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1151, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** public getter signatures changed (`Optional<T>` → `T`). Grep: no `extends` rest `Acl`/`AclEntry`/`UserAccessLevel` / anonymous subclasses (system `IPSAcl extends java.security.acl.Acl` is unrelated). Standalone sitemanage clean install green.

## C5 UI proof

N/A — Java REST DTO / apibridge change only; no WebUI or Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
