### PR TITLE
fix(rest): ContentList / ItemFilterRuleDefinitionParam plain wire getters (#3431)

### DIFF
--- a/docs/ai-generated/code-reviews/3431-contentlist-itemfilter-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3431-contentlist-itemfilter-wire-getters-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #3431 ContentList / ItemFilterRuleDefinitionParam wire getters
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3431-contentlist-itemfilter-wire-getters`  
+**Scope:** uncommitted vs `origin/main`  
+**Change class:** REST wire DTO Optional→plain nullable getters (parent #3388 slice 9)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure; missing behavioral tests; agent rule files without human review (avoided)
+
+## Summary
+
+Converts publishing Content List + ItemFilter rule-param REST wire getters from `Optional<T>` to plain nullable types with `@JsonInclude(NON_NULL)`, matching User / Role / ObjectSummary / Asset / Acl slices. Production `JacksonContextResolver` round-trip tests appended; no `empty`/`present` Optional-bean keys. Guid left untouched. `rest/AGENTS.md` not modified.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O, installers, or packaging. Tests use JSON strings only.
+
+## Issues
+
+None.
+
+## Notes
+
+- Public getter signatures changed (C2). Grep found no `extends ContentList` / anonymous subclasses. Reverse-dep `projects/sitemanage` standalone `clean install` green; adaptors only used setters on converted types.
+- Product-docs N/A: no operator-facing example currently shows Optional-bean JSON for these types.
+- UI/Playwright N/A: no WebUI screen change.

--- a/rest/src/main/java/com/percussion/rest/contentlists/ContentList.java
+++ b/rest/src/main/java/com/percussion/rest/contentlists/ContentList.java
@@ -24,9 +24,14 @@ import com.percussion.rest.itemfilter.ItemFilter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Content List in Percussion CMS. */
+/**
+ * Represents a Content List in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars and
+ * nested objects rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3388 / #3431).
+ */
 @XmlRootElement(name = "ContentList")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Content List")
@@ -84,32 +89,32 @@ public class ContentList {
 
   public ContentList() {}
 
-  public Optional<Guid> getContentListId() {
-    return Optional.ofNullable(contentListId);
+  public Guid getContentListId() {
+    return contentListId;
   }
 
   public void setContentListId(Guid contentListId) {
     this.contentListId = contentListId;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -124,40 +129,40 @@ public class ContentList {
     this.type = type;
   }
 
-  public Optional<String> getUrl() {
-    return Optional.ofNullable(url);
+  public String getUrl() {
+    return url;
   }
 
   public void setUrl(String url) {
     this.url = url;
   }
 
-  public Optional<Extension> getGenerator() {
-    return Optional.ofNullable(generator);
+  public Extension getGenerator() {
+    return generator;
   }
 
   public void setGenerator(Extension generator) {
     this.generator = generator;
   }
 
-  public Optional<Extension> getExpander() {
-    return Optional.ofNullable(expander);
+  public Extension getExpander() {
+    return expander;
   }
 
   public void setExpander(Extension expander) {
     this.expander = expander;
   }
 
-  public Optional<String> getEditionType() {
-    return Optional.ofNullable(editionType);
+  public String getEditionType() {
+    return editionType;
   }
 
   public void setEditionType(String editionType) {
     this.editionType = editionType;
   }
 
-  public Optional<ItemFilter> getItemFilter() {
-    return Optional.ofNullable(itemFilter);
+  public ItemFilter getItemFilter() {
+    return itemFilter;
   }
 
   public void setItemFilter(ItemFilter itemFilter) {

--- a/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterRuleDefinitionParam.java
+++ b/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterRuleDefinitionParam.java
@@ -19,12 +19,19 @@
 
 package com.percussion.rest.itemfilter;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents an ItemFilter Rule Parameter. Sunny Sal: "Rule parameter, filter ka accelerator!" */
+/**
+ * Represents an ItemFilter Rule Parameter.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code value} scalars rather than Optional beans ({@code empty}/{@code present}). Matches
+ * {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #3388 / #3431).
+ */
 @XmlRootElement(name = "ItemFilterRuleDefinitionParam")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents an ItemFilter Rule Parameter")
 public class ItemFilterRuleDefinitionParam {
 
@@ -39,8 +46,8 @@ public class ItemFilterRuleDefinitionParam {
   }
 
   /** Gets the parameter name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -48,8 +55,8 @@ public class ItemFilterRuleDefinitionParam {
   }
 
   /** Gets the parameter value. */
-  public Optional<String> getValue() {
-    return Optional.ofNullable(value);
+  public String getValue() {
+    return value;
   }
 
   public void setValue(String value) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -36,11 +36,17 @@ import com.percussion.rest.assets.BinaryFile;
 import com.percussion.rest.communities.Community;
 import com.percussion.rest.communities.CommunityRole;
 import com.percussion.rest.communities.CommunityVisibility;
+import com.percussion.rest.contentlists.ContentList;
+import com.percussion.rest.contentlists.ContentListList;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.contexts.Context;
 import com.percussion.rest.deliverytypes.DeliveryType;
 import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.extensions.Extension;
+import com.percussion.rest.itemfilter.ItemFilter;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinition;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinitionParam;
 import com.percussion.rest.folders.CopyFolderItemRequest;
 import com.percussion.rest.folders.Folder;
 import com.percussion.rest.folders.SectionInfo;
@@ -84,8 +90,9 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
- * @JsonInclude(NON_NULL)}.
+ * rule (issue #3413). ContentList / ItemFilterRuleDefinitionParam follow the same
+ * plain-getter contract (issue #3431 / #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -994,6 +1001,161 @@ class JacksonContextResolverOptionalTest {
     assertEquals(1, listRoundTrip.size());
     assertEquals("By_Author ACL", listRoundTrip.get(0).getName());
     assertEquals(3, listRoundTrip.get(0).getAclEntries().size());
+  }
+
+  @Test
+  void contentList_serializesPlainScalarsNotOptionalBeans() {
+    ContentList list = new ContentList();
+    list.setContentListId(new Guid("0-107-42"));
+    list.setVersion(3);
+    list.setName("full_site");
+    list.setDescription("Full site publish list");
+    list.setType("Normal");
+    list.setUrl("/Rhythmyx/contentlist?sys_deliverytype=filesystem");
+    list.setEditionType("Publish");
+
+    Extension generator = new Extension();
+    generator.setExtensionName("sys_SearchGenerator");
+    generator.setFqn("Java/global/percussion/system/sys_SearchGenerator");
+    list.setGenerator(generator);
+
+    ItemFilter filter = new ItemFilter();
+    filter.setName("public");
+    filter.setDescription("Public items");
+    list.setItemFilter(filter);
+
+    ObjectMapper listMapper = new JacksonContextResolver().getContext(ContentList.class);
+    String json = listMapper.writeValueAsString(list);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("full_site"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("Full site publish list"), json);
+    assertTrue(json.contains("\"url\""), json);
+    assertTrue(json.contains("\"editionType\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("\"itemFilter\""), json);
+    assertTrue(json.contains("public"), json);
+    assertTrue(json.contains("\"generator\""), json);
+    assertTrue(json.contains("sys_SearchGenerator"), json);
+    assertTrue(json.contains("\"contentListId\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    ContentList roundTrip = listMapper.readValue(json, ContentList.class);
+    assertEquals("full_site", roundTrip.getName(), json);
+    assertEquals("Full site publish list", roundTrip.getDescription(), json);
+    assertEquals("Publish", roundTrip.getEditionType(), json);
+    assertEquals(Integer.valueOf(3), roundTrip.getVersion(), json);
+    assertNotNull(roundTrip.getItemFilter(), json);
+    assertEquals("public", roundTrip.getItemFilter().getName(), json);
+    assertNotNull(roundTrip.getGenerator(), json);
+    assertEquals("sys_SearchGenerator", roundTrip.getGenerator().getExtensionName(), json);
+    assertNotNull(roundTrip.getContentListId(), json);
+  }
+
+  @Test
+  void contentList_omitsNullWireFieldsFromJson() {
+    ContentList list = new ContentList();
+    list.setName("incremental");
+    list.setType("Incremental");
+
+    ObjectMapper listMapper = new JacksonContextResolver().getContext(ContentList.class);
+    String json = listMapper.writeValueAsString(list);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("incremental"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertFalse(json.contains("\"description\""), json);
+    assertFalse(json.contains("\"url\""), json);
+    assertFalse(json.contains("\"contentListId\""), json);
+    assertFalse(json.contains("\"itemFilter\""), json);
+    assertFalse(json.contains("\"generator\""), json);
+    assertFalse(json.contains("\"expander\""), json);
+    assertFalse(json.contains("\"editionType\""), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void contentListList_serializesNamesNotOptionalBeans() {
+    ContentList list = new ContentList();
+    list.setName("full_site");
+    list.setEditionType("Publish");
+    ContentListList lists = new ContentListList(List.of(list));
+
+    ObjectMapper listsMapper = new JacksonContextResolver().getContext(ContentListList.class);
+    String json = listsMapper.writeValueAsString(lists);
+    assertTrue(json.contains("full_site"), json);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("ContentList") || json.startsWith("["), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void itemFilterRuleDefinitionParam_serializesNameValueNotOptionalBeans() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName("sys_authType");
+    param.setValue("1");
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(ItemFilterRuleDefinitionParam.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("sys_authType"), json);
+    assertTrue(json.contains("\"value\""), json);
+    assertTrue(json.contains("1"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ItemFilterRuleDefinitionParam roundTrip =
+        paramMapper.readValue(json, ItemFilterRuleDefinitionParam.class);
+    assertEquals("sys_authType", roundTrip.getName(), json);
+    assertEquals("1", roundTrip.getValue(), json);
+  }
+
+  @Test
+  void itemFilterRuleDefinitionParam_omitsNullWireFieldsFromJson() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName(null);
+    param.setValue(null);
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(ItemFilterRuleDefinitionParam.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertFalse(json.contains("\"name\""), json);
+    assertFalse(json.contains("\"value\""), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void itemFilterRuleDefinition_serializesNestedParamsNotOptionalBeans() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName("folderId");
+    param.setValue("301");
+
+    ItemFilterRuleDefinition rule = new ItemFilterRuleDefinition();
+    rule.setName("sys_FolderFilter");
+    rule.setParams(List.of(param));
+
+    ItemFilter filter = new ItemFilter();
+    filter.setName("site_folder");
+    filter.setDescription("Site folder filter");
+    filter.setRules(java.util.Set.of(rule));
+
+    ObjectMapper filterMapper = new JacksonContextResolver().getContext(ItemFilter.class);
+    String json = filterMapper.writeValueAsString(filter);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("site_folder"), json);
+    assertTrue(json.contains("sys_FolderFilter"), json);
+    assertTrue(json.contains("folderId"), json);
+    assertTrue(json.contains("301"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ItemFilter roundTrip = filterMapper.readValue(json, ItemFilter.class);
+    assertEquals("site_folder", roundTrip.getName(), json);
+    assertNotNull(roundTrip.getRules(), json);
+    assertEquals(1, roundTrip.getRules().size(), json);
+    ItemFilterRuleDefinition ruleRoundTrip = roundTrip.getRules().iterator().next();
+    assertEquals("sys_FolderFilter", ruleRoundTrip.getName(), json);
+    assertEquals("folderId", ruleRoundTrip.getParams().get(0).getName(), json);
+    assertEquals("301", ruleRoundTrip.getParams().get(0).getValue(), json);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent epic [#3388](https://github.com/intersoftdatalabs-in/percussioncms/issues/3388) slice 9.

REST wire DTOs `ContentList` and `ItemFilterRuleDefinitionParam` returned `Optional<T>` from JSON-facing getters. Jackson 3 then emitted Optional beans (`empty`/`present`) or dropped fields under `@JsonInclude(NON_NULL)`, so publishing Content List JSON was not scalars / nested objects.

This PR converts those getters to plain nullable types with `@JsonInclude(NON_NULL)` (same peer pattern as User / Role / ObjectSummary / Asset / Acl). Production-mapper round-trip tests were appended to `JacksonContextResolverOptionalTest`. Guid is unchanged. `rest/AGENTS.md` was not committed (human rule review).

No `rest` / `sitemanage` callers used `.orElse()` / `.ifPresent()` on the converted getters (`ItemFilterAdaptor` only sets params; `ContentListAdaptor` is a stub).

Fixes #3431
Parent: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install`
2. Confirm `JacksonContextResolverOptionalTest` (42 tests) includes ContentList / ItemFilterRuleDefinitionParam family methods; JSON has no `empty`/`present` keys.
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` (C2 reverse-dep after public getter signature change).
4. Reviewer: inspect `ContentList` / `ItemFilterRuleDefinitionParam` getters are plain nullable types.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal REST wire-getter refactor; no documented request/response example currently shows Optional-bean JSON for these types
- [x] **Unit / module tests** — behavioral production-mapper round-trip tests appended; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest` and reverse-dep `projects/sitemanage` (public getter signatures changed)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 465, Failures: 0, Errors: 0, Skipped: 0; `JacksonContextResolverOptionalTest` Tests run: 42, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1238, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public getter signatures changed). Grep: no `extends ContentList` / `new ContentList() {` / `extends ItemFilterRuleDefinitionParam` / `new ItemFilterRuleDefinitionParam() {` in tests or src. Standalone sitemanage clean install green.

## C5 UI proof

N/A — Java REST DTO getter conversion only; no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
