### PR TITLE
fix(rest): action request + PublishResponse / Status plain wire getters (#3432)

### DIFF
--- a/docs/ai-generated/code-reviews/3432-action-publish-status-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3432-action-publish-status-wire-getters-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3432 Action request + PublishResponse / Status wire getters
+
+**Branch:** `fix/issue-3432-action-publish-status-wire-getters`  
+**Base:** `origin/main`  
+**Date:** 2026-08-15  
+**Reviewer:** Erlang (independent of implementer)
+
+## Summary
+
+Convert Explorer action-menu request DTOs plus rest `PublishResponse` / `Status` from `Optional` wire getters to plain nullable getters so toolbar find/types bodies and publish/status JSON emit arrays/scalars, not Optional beans. Callers that used `.orElse()` on converted getters were updated. Production-mapper family tests appended to `JacksonContextResolverOptionalTest`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, no missing behavioral tests for changed logic, no non-portable path/file I/O.
+
+## Scope
+
+Uncommitted rest DTO/resource/test changes vs `HEAD` / `origin/main`. `rest/AGENTS.md` not in the change set (human rule review). `Guid` and sitemanage-internal `PSSitePublishResponse` unchanged.
+
+## Change-class closure
+
+Change class: REST wire-getter conversion (peer of User/Role/Acl / #3388 slices).
+
+- Production DTOs: `@JsonInclude(NON_NULL)` + plain getters
+- Resource caller: `ActionMenuResource.getAllowedContentTypeMenus` null-safe `int[]`
+- Rest unit tests: `FoldersTest`, `PagesTest`, `ActionMenuResourceTest`, `JacksonContextResolverOptionalTest`
+- Reverse-dep: sitemanage compiles against new signatures (EditionAdaptor / Status setters only)
+- Product-docs: N/A (no documented Optional-bean JSON examples)
+- Playwright: N/A (no WebUI screen change)
+- `rest/AGENTS.md`: not committed
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O.
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests for new/changed non-trivial logic — covered (resource null `contentIds` + mapper round-trip).
+- Incomplete change-class closure — companions from prior #3388 slices present.
+- Agent rule files not committed without human review.
+
+## Build evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 467, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1238, Failures: 0, Skipped: 125

--- a/rest/src/main/java/com/percussion/rest/Status.java
+++ b/rest/src/main/java/com/percussion/rest/Status.java
@@ -20,11 +20,13 @@ package com.percussion.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a generic REST API status response carrying a human-readable message and a numeric
  * status code.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code message} as a scalar, not an Optional bean (issue #3388 slice 10 / #3432).
  *
  * @author stephenbolton
  */
@@ -62,10 +64,10 @@ public class Status {
   }
 
   /**
-   * @return status message as Optional
+   * @return status message, or {@code null} if unset
    */
-  public Optional<String> getMessage() {
-    return Optional.ofNullable(message);
+  public String getMessage() {
+    return message;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -214,8 +214,8 @@ public class ActionMenuResource {
         @ApiResponse(responseCode = "500", description = "Error searching for Action Menu")
       })
   public ActionMenuList getAllowedContentTypeMenus(AllowedContentTypeMenusRequest request) {
-    var contentIds =
-        Arrays.stream(request.getContentIds().orElse(new int[0])).boxed().toArray(Integer[]::new);
+    int[] raw = request.getContentIds() != null ? request.getContentIds() : new int[0];
+    var contentIds = Arrays.stream(raw).boxed().toArray(Integer[]::new);
     return new ActionMenuList(adaptor.findAllowedContentTypes(contentIds));
   }
 

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
@@ -17,14 +17,20 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed content type menus. */
+/**
+ * Request object for allowed content type menus.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} as a JSON array, not an Optional bean (issue #3388 slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
 public class AllowedContentTypeMenusRequest {
 
@@ -37,10 +43,10 @@ public class AllowedContentTypeMenusRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
@@ -17,13 +17,19 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed template menus. */
+/**
+ * Request object for allowed template menus.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} as a JSON array, not an Optional bean (issue #3388 slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
 public class AllowedTemplateMenusRequest {
 
@@ -36,10 +42,10 @@ public class AllowedTemplateMenusRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -17,12 +17,19 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed workflow transitions. */
+/**
+ * Request object for allowed workflow transitions.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} and {@code assignmentTypeIds} as JSON arrays, not Optional beans (issue #3388
+ * slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllowedWorkflowTransitionsRequest {
 
   /** Content ids to evaluate transitions for. */
@@ -37,10 +44,10 @@ public class AllowedWorkflowTransitionsRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**
@@ -55,10 +62,10 @@ public class AllowedWorkflowTransitionsRequest {
   /**
    * Returns the assignment type ids.
    *
-   * @return the assignment type ids, may be empty
+   * @return the assignment type ids, or {@code null} if unset
    */
-  public Optional<int[]> getAssignmentTypeIds() {
-    return Optional.ofNullable(assignmentTypeIds);
+  public int[] getAssignmentTypeIds() {
+    return assignmentTypeIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/editions/PublishResponse.java
+++ b/rest/src/main/java/com/percussion/rest/editions/PublishResponse.java
@@ -18,17 +18,21 @@
 
 package com.percussion.rest.editions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Stores the information returned from a publish request.
  *
  * <p>Sunny Sal: "Publishing response received, boss!"
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code warningMessage} as a scalar, not an Optional bean (issue #3388 slice 10 / #3432).
  */
 @XmlRootElement(name = "EditionPublishResponse")
 @JsonRootName("EditionPublishResponse")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PublishResponse {
 
   private String siteName;
@@ -95,10 +99,10 @@ public class PublishResponse {
   }
 
   /**
-   * @return the warning message, if present.
+   * @return the warning message, or {@code null} if unset
    */
-  public Optional<String> getWarningMessage() {
-    return Optional.ofNullable(warningMessage);
+  public String getWarningMessage() {
+    return warningMessage;
   }
 
   /**

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.Permissions;
 import com.percussion.rest.acls.Acl;
+import com.percussion.rest.actions.AllowedContentTypeMenusRequest;
+import com.percussion.rest.actions.AllowedTemplateMenusRequest;
+import com.percussion.rest.actions.AllowedWorkflowTransitionsRequest;
+import com.percussion.rest.editions.PublishResponse;
 import com.percussion.rest.acls.AclEntry;
 import com.percussion.rest.acls.AclEntryList;
 import com.percussion.rest.acls.AclList;
@@ -71,6 +75,7 @@ import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import com.percussion.rest.users.User;
 import com.percussion.security.IPSTypedPrincipal;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -84,8 +89,9 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
- * @JsonInclude(NON_NULL)}.
+ * rule (issue #3413). Action-menu request + editions {@code PublishResponse} / {@code Status}
+ * follow the same rule (issue #3432 / #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -1011,6 +1017,133 @@ class JacksonContextResolverOptionalTest {
     UserAccessLevel ualRoundTrip = ualMapper.readValue(json, UserAccessLevel.class);
     assertEquals(Permissions.READ, ualRoundTrip.getPermission());
     assertEquals(9, ualRoundTrip.getId());
+  }
+
+  @Test
+  void allowedContentTypeMenusRequest_serializesContentIdsAsJsonArray() {
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {101, 102});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("101"), json);
+    assertTrue(json.contains("102"), json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedContentTypeMenusRequest roundTrip =
+        requestMapper.readValue(json, AllowedContentTypeMenusRequest.class);
+    assertTrue(Arrays.equals(new int[] {101, 102}, roundTrip.getContentIds()), json);
+  }
+
+  @Test
+  void allowedTemplateMenusRequest_serializesContentIdsAsJsonArray() {
+    AllowedTemplateMenusRequest request = new AllowedTemplateMenusRequest();
+    request.setContentIds(new int[] {201, 202});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedTemplateMenusRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("201"), json);
+    assertTrue(json.contains("202"), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedTemplateMenusRequest roundTrip =
+        requestMapper.readValue(json, AllowedTemplateMenusRequest.class);
+    assertTrue(Arrays.equals(new int[] {201, 202}, roundTrip.getContentIds()), json);
+  }
+
+  @Test
+  void allowedWorkflowTransitionsRequest_serializesIdsAsJsonArrays() {
+    AllowedWorkflowTransitionsRequest request = new AllowedWorkflowTransitionsRequest();
+    request.setContentIds(new int[] {301, 302});
+    request.setAssignmentTypeIds(new int[] {1, 2});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedWorkflowTransitionsRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("301"), json);
+    assertTrue(json.contains("\"assignmentTypeIds\""), json);
+    assertTrue(json.contains("1"), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedWorkflowTransitionsRequest roundTrip =
+        requestMapper.readValue(json, AllowedWorkflowTransitionsRequest.class);
+    assertTrue(Arrays.equals(new int[] {301, 302}, roundTrip.getContentIds()), json);
+    assertTrue(Arrays.equals(new int[] {1, 2}, roundTrip.getAssignmentTypeIds()), json);
+  }
+
+  @Test
+  void publishResponse_serializesWarningMessageNotOptionalBean() {
+    PublishResponse response = new PublishResponse();
+    response.setSiteName("Help");
+    response.setStatus("Completed");
+    response.setDelivered("10");
+    response.setFailures("0");
+    response.setWarningMessage("partial");
+    response.setJobid(42L);
+
+    ObjectMapper responseMapper = new JacksonContextResolver().getContext(PublishResponse.class);
+    String json = responseMapper.writeValueAsString(response);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"warningMessage\""), json);
+    assertTrue(json.contains("partial"), json);
+    assertTrue(json.contains("\"status\""), json);
+    assertTrue(json.contains("Completed"), json);
+    assertNoOptionalBeanKeys(json);
+
+    PublishResponse roundTrip = responseMapper.readValue(json, PublishResponse.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("partial", roundTrip.getWarningMessage(), json);
+    assertEquals(42L, roundTrip.getJobid(), json);
+  }
+
+  @Test
+  void status_serializesMessageNotOptionalBean() {
+    Status status = new Status(200, "Moved OK");
+
+    ObjectMapper statusMapper = new JacksonContextResolver().getContext(Status.class);
+    String json = statusMapper.writeValueAsString(status);
+    assertTrue(json.contains("\"message\""), json);
+    assertTrue(json.contains("Moved OK"), json);
+    assertTrue(json.contains("\"statusCode\""), json);
+    assertTrue(json.contains("200"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Status roundTrip = statusMapper.readValue(json, Status.class);
+    assertEquals("Moved OK", roundTrip.getMessage(), json);
+    assertEquals(200, roundTrip.getStatusCode(), json);
+  }
+
+  @Test
+  void actionPublishStatusFamily_omitsNullWireFieldsFromJson() {
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class);
+    String requestJson = requestMapper.writeValueAsString(request);
+    assertFalse(requestJson.contains("\"contentIds\""), requestJson);
+    assertNoOptionalBeanKeys(requestJson);
+
+    PublishResponse response = new PublishResponse();
+    response.setJobid(7L);
+    ObjectMapper responseMapper = new JacksonContextResolver().getContext(PublishResponse.class);
+    String responseJson = responseMapper.writeValueAsString(response);
+    assertTrue(responseJson.contains("\"jobid\"") || responseJson.contains("\"jobId\""), responseJson);
+    assertFalse(responseJson.contains("\"warningMessage\""), responseJson);
+    assertFalse(responseJson.contains("\"siteName\""), responseJson);
+    assertNoOptionalBeanKeys(responseJson);
+
+    Status status = new Status();
+    status.setStatusCode(0);
+    ObjectMapper statusMapper = new JacksonContextResolver().getContext(Status.class);
+    String statusJson = statusMapper.writeValueAsString(status);
+    assertFalse(statusJson.contains("\"message\""), statusJson);
+    assertNoOptionalBeanKeys(statusJson);
   }
 
   private static void assertNoOptionalBeanKeys(String json) {

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -4,11 +4,13 @@
 
 package com.percussion.rest.actions;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -100,5 +103,35 @@ public class ActionMenuResourceTest {
         assertThrows(WebApplicationException.class, () -> bare.getActionMenu("x"));
     assertEquals(500, getEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, getEx.getCause());
+  }
+
+  @Test
+  public void getAllowedContentTypeMenusPassesContentIdsArray() {
+    ActionMenu menu = new ActionMenu();
+    menu.setName("New");
+    when(adaptor.findAllowedContentTypes(any())).thenReturn(List.of(menu));
+
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {101, 102});
+    ActionMenuList out = resource.getAllowedContentTypeMenus(request);
+
+    assertEquals(1, out.size());
+    assertEquals("New", out.get(0).getName());
+    ArgumentCaptor<Integer[]> captor = ArgumentCaptor.forClass(Integer[].class);
+    verify(adaptor).findAllowedContentTypes(captor.capture());
+    assertArrayEquals(new Integer[] {101, 102}, captor.getValue());
+  }
+
+  @Test
+  public void getAllowedContentTypeMenusTreatsNullContentIdsAsEmpty() {
+    when(adaptor.findAllowedContentTypes(any())).thenReturn(List.of());
+
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    ActionMenuList out = resource.getAllowedContentTypeMenus(request);
+
+    assertTrue(out.isEmpty());
+    ArgumentCaptor<Integer[]> captor = ArgumentCaptor.forClass(Integer[].class);
+    verify(adaptor).findAllowedContentTypes(captor.capture());
+    assertArrayEquals(new Integer[0], captor.getValue());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/folders/FoldersTest.java
+++ b/rest/src/test/java/com/percussion/rest/folders/FoldersTest.java
@@ -53,7 +53,7 @@ public class FoldersTest {
   void moveFolderItem_callsAdaptor() throws Exception {
     MoveFolderItem req = new MoveFolderItem("/a/b", "/a/c");
     Status result = resource.moveFolderItem(req);
-    assertEquals("Moved OK", result.getMessage().orElse(null));
+    assertEquals("Moved OK", result.getMessage());
     verify(adaptor).moveFolderItem(uriInfo.getBaseUri(), "/a/b", "/a/c");
   }
 
@@ -70,7 +70,7 @@ public class FoldersTest {
   void moveFolder_callsAdaptor() throws Exception {
     MoveFolderItem req = new MoveFolderItem("/a/b", "/a/c");
     Status result = resource.moveFolder(req);
-    assertEquals("Moved OK", result.getMessage().orElse(null));
+    assertEquals("Moved OK", result.getMessage());
     verify(adaptor).moveFolderItem(uriInfo.getBaseUri(), "/a/b", "/a/c");
   }
 

--- a/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
+++ b/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
@@ -153,7 +153,7 @@ public class PagesTest {
     doNothing().when(adaptor).deletePage(any(), eq("sitea"), eq("path1"), eq("page1.html"));
 
     var status = resource.deletePage("Sites/sitea/path1/page1.html");
-    assertEquals("Deleted", status.getMessage().orElse(null));
+    assertEquals("Deleted", status.getMessage());
     verify(adaptor).deletePage(uriInfo.getBaseUri(), "sitea", "path1", "page1.html");
   }
 


### PR DESCRIPTION
## Summary

Parent: #3388 slice 10 (`#3432`). Convert Explorer action-menu request bodies and editions publish/status wire DTOs from `Optional<T>` getters to plain nullable getters so Jackson/CXF JSON emits arrays/scalars, not Optional beans (`empty`/`present`).

Converted:

- `AllowedContentTypeMenusRequest`
- `AllowedTemplateMenusRequest`
- `AllowedWorkflowTransitionsRequest`
- `com.percussion.rest.editions.PublishResponse`
- `com.percussion.rest.Status`

`ActionMenuResource.getAllowedContentTypeMenus` now treats a null `contentIds` as an empty `int[]`. Rest tests that called `Status.getMessage().orElse(...)` now use the plain getter. `contentIds` / `assignmentTypeIds` remain JSON arrays.

Out of scope (per issue): Guid Optional getters, sitemanage-internal `PSSitePublishResponse`, `rest/AGENTS.md` (human rule review).

Fixes #3432  
Parent tracker: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install`
2. Confirm `JacksonContextResolverOptionalTest` action/publish/status family methods serialize `contentIds` as JSON arrays and `message`/`warningMessage` as scalars with no `empty`/`present` keys.
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` (C2 reverse-dep after public getter signature change).
4. Optional live check: POST `/actions/find/types` with `{ "contentIds": [101, 102] }` still binds as a JSON array.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): wire-shape refactor; no documented Optional-bean JSON examples under `product-docs/`
- [x] **Unit / module tests** — production-mapper round-trip tests appended; ActionMenuResource null/`contentIds` tests; rest + sitemanage standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest`; reverse-dep `projects/sitemanage` because public getter signatures changed
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 467, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1238, Failures: 0, Skipped: 125
- **downstream_checked:** grepped monorepo for `extends` / anonymous subclasses of converted types (none). Standalone sitemanage clean install green (EditionAdaptor constructs `PublishResponse` setters only; Status callers use `setMessage`).

## C5 UI proof

N/A — Java REST DTO getter conversion only.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
