### PR TITLE
fix(rest): ExtensionFilter/MimeType/LinkRef/ObjectLock/RestError plain wire getters

### DIFF
--- a/docs/ai-generated/code-reviews/3430-extensionfilter-mimetype-linkref-resterror-erlang.md
+++ b/docs/ai-generated/code-reviews/3430-extensionfilter-mimetype-linkref-resterror-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review — #3430 ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError plain wire getters
+
+**Scope:** uncommitted branch `fix/issue-3430-optional-wire-getters` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** REST DTO wire getters must be plain nullable types + `@JsonInclude(NON_NULL)` (ContentType #1693 / TemplateSummary #2189 / parent #3388); production mapper tests must use `new JacksonContextResolver().getContext(TheDto.class)`; Guid `stringValue` `@JsonIgnore` bandage must not regress (#3200 / #3378); change-class companions (DTO + rest tests + sitemanage callers of converted getters).
+
+## Summary
+
+Parent #3388 slice 11. Remaining small wire types still exposed `Optional<T>` getters: `ExtensionFilterOptions`, `MimeType`, `LinkRef`, `ObjectLockSummary`, `RestError`, and `RestExceptionBase.getErrorData()`.
+
+This change:
+
+1. Converts those getters/setters to plain nullable types with class-level `@JsonInclude(NON_NULL)` on the wire DTOs (`RestExceptionBase` stays an exception; only `getErrorData()` is unwrapped).
+2. Updates `RestExceptionMapper` / `WebApplicationExceptionMapper` to pass `e.getErrorData()` without `.orElse(null)`.
+3. Updates sitemanage `ExtensionAdaptor` and `FolderAdaptor` (`LinkRef` / `SectionLinkRef` name/href) that used `ApiUtils.orNull(...)` / `.orElse(null)` on converted getters.
+4. Appends `JacksonContextResolverOptionalTest` family methods (production mapper, no `empty`/`present` keys) plus mapper tests for scalar `errorData`.
+
+Does **not** convert `Guid` Optional getters. Does **not** commit `rest/AGENTS.md`. Does **not** add `OPTIONAL_FIELDS_SUPPORTED` or `jackson-datatype-jdk8`. Sibling slices #3431 (ContentList) and #3432 (action/publish Status) remain on their own PRs.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Behavioral tests added for the converted family. Error mapping still returns `errorData` as a scalar. No filesystem path construction.
+
+C2: public getter return types changed `Optional<T>` → `T`. Grep found `SectionLinkRef extends LinkRef` (expected; inherits converted getters) and `RestExceptionBase` subclasses (do not override `getErrorData`). Reverse-dep `projects/sitemanage` standalone `clean install` is green.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] No path/file I/O in this diff (JSON/JAX-RS DTO + adaptor callers only)
+- [x] Tests do not assert OS-specific file paths
+- [x] Line-ending assertions not added
+
+## Issues
+
+None (hard-gate).
+
+### Nits
+
+- Primitive `remainingTime` on `ObjectLockSummary` still serializes as `0` when unset (`NON_NULL` does not omit primitives). Pre-existing; same as other converted families.
+
+## Product documentation
+
+N/A — no operator/integrator example currently shows Optional-bean JSON for this family. Wire scalars stay the same documented shape.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
@@ -134,10 +134,10 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
     try {
       var it =
           extensionService.getExtensionNames(
-              ApiUtils.orNull(filter.getHandlerNamePattern()),
-              ApiUtils.orNull(filter.getContext()),
-              ApiUtils.orNull(filter.getInterfacePattern()),
-              ApiUtils.orNull(filter.getExtensionNamePattern()));
+              filter.getHandlerNamePattern(),
+              filter.getContext(),
+              filter.getInterfacePattern(),
+              filter.getExtensionNamePattern());
       while (it.hasNext()) {
         var ref = it.next();
         response.add(copyExtensionRef(ref));

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
@@ -363,7 +363,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     List<String> existingFolders = new ArrayList<>();
     if (folder.getSubsections() != null) {
       for (SectionLinkRef section : folder.getSubsections()) {
-        existingFolders.add(ApiUtils.orNull(section.getName()));
+        existingFolders.add(section.getName());
       }
     }
     folder.setPages(folderPages);
@@ -681,16 +681,15 @@ public class FolderAdaptor implements IFolderAdaptor {
       LinkRef reqLanding = reqSectionInfo.getLandingPage();
       LinkRef existingLanding = currSectionInfo.getLandingPage();
 
-      String reqName = ApiUtils.orNull(reqLanding == null ? null : reqLanding.getName());
-      String existingName =
-          ApiUtils.orNull(existingLanding == null ? null : existingLanding.getName());
+      String reqName = reqLanding == null ? null : reqLanding.getName();
+      String existingName = existingLanding == null ? null : existingLanding.getName();
 
       if (reqName != null && !reqName.equals(existingName)) {
         // get child folders
         boolean foundPage = false;
         List<LinkRef> existingPages = existingFolder.getPages();
         for (LinkRef page : existingPages == null ? List.<LinkRef>of() : existingPages) {
-          if (reqName.equals(ApiUtils.orNull(page.getName()))) {
+          if (reqName.equals(page.getName())) {
             foundPage = true;
             break;
           }
@@ -804,7 +803,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     String name = "index.html";
     LinkRef landOpt = sectionInfo.getLandingPage();
     // compute landing name and if available override default
-    String landingName = landOpt == null ? null : landOpt.getName().orElse(null);
+    String landingName = landOpt == null ? null : landOpt.getName();
     if (landingName != null) {
       name = landingName;
     }
@@ -875,8 +874,8 @@ public class FolderAdaptor implements IFolderAdaptor {
         throw new BackendException("non-section folders cannot have subsections");
       String nameCheck = null;
       for (SectionLinkRef subsection : folder.getSubsections()) {
-        String secName = ApiUtils.orNull(subsection.getName());
-        String secHref = ApiUtils.orNull(subsection.getHref());
+        String secName = subsection.getName();
+        String secHref = subsection.getHref();
         if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
           nameCheck = secName + "-" + secHref;
         else nameCheck = secName;
@@ -892,8 +891,8 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (existingFolder.getSubsections() != null) {
 
         for (SectionLinkRef subsection : existingFolder.getSubsections()) {
-          String secName = ApiUtils.orNull(subsection.getName());
-          String secHref = ApiUtils.orNull(subsection.getHref());
+          String secName = subsection.getName();
+          String secHref = subsection.getHref();
           if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
             nameCheck = secName + "-" + secHref;
           else nameCheck = secName;
@@ -907,8 +906,8 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       for (String createName : subSectionsToCreate) {
         for (SectionLinkRef subsection : folder.getSubsections()) {
-          String nameVal = ApiUtils.orNull(subsection.getName());
-          String hrefVal = ApiUtils.orNull(subsection.getHref());
+          String nameVal = subsection.getName();
+          String hrefVal = subsection.getHref();
           if (nameVal.equals(createName)
               || (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType())
                   && createName.equals(nameVal + "-" + hrefVal))) {
@@ -977,14 +976,14 @@ public class FolderAdaptor implements IFolderAdaptor {
         throw new BackendException("non-section folders cannot have subsections");
 
       for (SectionLinkRef subSection : folder.getSubsections()) {
-        String name = ApiUtils.orNull(subSection.getName());
+        String name = subSection.getName();
         createSubSection(
             baseUri,
             existingFolder,
             folder,
             name,
             subSection.getType(),
-            ApiUtils.orNull(subSection.getHref()));
+            subSection.getHref());
       }
     }
   }
@@ -1110,7 +1109,7 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       // get specified landing page name or use index if does not exist.
       LinkRef landing = section == null ? null : section.getLandingPage();
-      String landingName = landing == null ? null : landing.getName().orElse(null);
+      String landingName = landing == null ? null : landing.getName();
       if (landingName != null) {
         request.setPageName(landingName);
       } else {

--- a/rest/src/main/java/com/percussion/rest/LinkRef.java
+++ b/rest/src/main/java/com/percussion/rest/LinkRef.java
@@ -18,12 +18,20 @@
 package com.percussion.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * Wire name/href pair for REST folder, page, and user recent-item links.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @XmlRootElement(name = "LinkRef")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "LinkRef")
 public class LinkRef {
   @Schema(required = false, description = "link")
@@ -40,16 +48,22 @@ public class LinkRef {
     this.href = href;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  /**
+   * @return link name, or {@code null} if unset
+   */
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getHref() {
-    return Optional.ofNullable(href);
+  /**
+   * @return href, or {@code null} if unset
+   */
+  public String getHref() {
+    return href;
   }
 
   public void setHref(String href) {

--- a/rest/src/main/java/com/percussion/rest/ObjectLockSummary.java
+++ b/rest/src/main/java/com/percussion/rest/ObjectLockSummary.java
@@ -20,8 +20,14 @@ package com.percussion.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * Multi-user lock summary on a catalog object.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement
 @Schema(description = "Represents a multi-user lock on an object in the system.")
@@ -44,16 +50,22 @@ public class ObjectLockSummary {
           "The date and time that the API client last checked this lock.  Can be used for retries.")
   private String callerAccessTime;
 
-  public Optional<String> getSession() {
-    return Optional.ofNullable(session);
+  /**
+   * @return lock session id, or {@code null} if unset
+   */
+  public String getSession() {
+    return session;
   }
 
   public void setSession(String session) {
     this.session = session;
   }
 
-  public Optional<String> getLocker() {
-    return Optional.ofNullable(locker);
+  /**
+   * @return locker username, or {@code null} if unset
+   */
+  public String getLocker() {
+    return locker;
   }
 
   public void setLocker(String locker) {
@@ -68,8 +80,11 @@ public class ObjectLockSummary {
     this.remainingTime = remainingTime;
   }
 
-  public Optional<String> getCallerAccessTime() {
-    return Optional.ofNullable(callerAccessTime);
+  /**
+   * @return last caller access time, or {@code null} if unset
+   */
+  public String getCallerAccessTime() {
+    return callerAccessTime;
   }
 
   public void setCallerAccessTime(String callerAccessTime) {

--- a/rest/src/main/java/com/percussion/rest/errors/RestError.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestError.java
@@ -19,14 +19,19 @@
 
 package com.percussion.rest.errors;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a REST error returned to the client. Sunny Sal: "Error ho gaya? No worries, this class
  * will tell you what went wrong!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code
+ * errorData} as a scalar/object rather than an Optional bean ({@code empty}/{@code present}).
+ * Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
  */
 @XmlRootElement(name = "Error")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RestError {
 
   private int errorCode;
@@ -91,12 +96,12 @@ public class RestError {
   }
 
   /**
-   * Returns the error data as an Optional.
+   * Returns the error payload.
    *
-   * @return Optional containing error data if present
+   * @return error data, or {@code null} if unset
    */
-  public Optional<Object> getErrorData() {
-    return Optional.ofNullable(errorData);
+  public Object getErrorData() {
+    return errorData;
   }
 
   public void setErrorData(Object errorData) {

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
@@ -22,7 +22,6 @@ package com.percussion.rest.errors;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 import java.util.ResourceBundle;
 
 /**
@@ -120,12 +119,12 @@ public class RestExceptionBase extends WebApplicationException {
   }
 
   /**
-   * Returns the error data as an Optional.
+   * Returns the in-process error payload for JAX-RS mapping.
    *
-   * @return Optional containing error data if present
+   * @return error data, or {@code null} if unset
    */
-  public Optional<Object> getErrorData() {
-    return Optional.ofNullable(errorData);
+  public Object getErrorData() {
+    return errorData;
   }
 
   public void setErrorData(Object errorData) {

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionMapper.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionMapper.java
@@ -50,7 +50,7 @@ public class RestExceptionMapper implements ExceptionMapper<RestExceptionBase> {
             e.getClass().getSimpleName(),
             e.getMessage(),
             e.getDetailMessage(),
-            e.getErrorData().orElse(null));
+            e.getErrorData());
 
     int status =
         e.getStatus() != null

--- a/rest/src/main/java/com/percussion/rest/errors/WebApplicationExceptionMapper.java
+++ b/rest/src/main/java/com/percussion/rest/errors/WebApplicationExceptionMapper.java
@@ -84,7 +84,7 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplica
             e.getClass().getSimpleName(),
             e.getMessage(),
             e.getDetailMessage(),
-            e.getErrorData().orElse(null));
+            e.getErrorData());
     int status =
         e.getStatus() != null
             ? e.getStatus().getStatusCode()

--- a/rest/src/main/java/com/percussion/rest/extensions/ExtensionFilterOptions.java
+++ b/rest/src/main/java/com/percussion/rest/extensions/ExtensionFilterOptions.java
@@ -22,9 +22,14 @@ package com.percussion.rest.extensions;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents options when filtering for extensions. Sunny Sal: "Filter lagao, result pao!" */
+/**
+ * Represents options when filtering for extensions. Sunny Sal: "Filter lagao, result pao!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @XmlRootElement(name = "ExtensionFilterOptions")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents options when filtering for extensions.")
@@ -67,32 +72,44 @@ public class ExtensionFilterOptions {
     // Default constructor
   }
 
-  public Optional<String> getHandlerNamePattern() {
-    return Optional.ofNullable(handlerNamePattern);
+  /**
+   * @return handler name pattern, or {@code null} if unset
+   */
+  public String getHandlerNamePattern() {
+    return handlerNamePattern;
   }
 
   public void setHandlerNamePattern(String handlerNamePattern) {
     this.handlerNamePattern = handlerNamePattern;
   }
 
-  public Optional<String> getContext() {
-    return Optional.ofNullable(context);
+  /**
+   * @return search context, or {@code null} if unset
+   */
+  public String getContext() {
+    return context;
   }
 
   public void setContext(String context) {
     this.context = context;
   }
 
-  public Optional<String> getInterfacePattern() {
-    return Optional.ofNullable(interfacePattern);
+  /**
+   * @return interface name pattern, or {@code null} if unset
+   */
+  public String getInterfacePattern() {
+    return interfacePattern;
   }
 
   public void setInterfacePattern(String interfacePattern) {
     this.interfacePattern = interfacePattern;
   }
 
-  public Optional<String> getExtensionNamePattern() {
-    return Optional.ofNullable(extensionNamePattern);
+  /**
+   * @return extension name pattern, or {@code null} if unset
+   */
+  public String getExtensionNamePattern() {
+    return extensionNamePattern;
   }
 
   public void setExtensionNamePattern(String extensionNamePattern) {

--- a/rest/src/main/java/com/percussion/rest/mimetypes/MimeType.java
+++ b/rest/src/main/java/com/percussion/rest/mimetypes/MimeType.java
@@ -22,10 +22,13 @@ package com.percussion.rest.mimetypes;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a Mime Type registered on the system. Sunny Sal: "MimeType ka hero, uploads ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
  */
 @Schema(name = "MimeType", description = "A mime type registered on the system")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,10 +48,10 @@ public class MimeType {
   /**
    * Gets the file extension associated with the MimeType.
    *
-   * @return Optional containing the extension if present
+   * @return the extension, or {@code null} if unset
    */
-  public Optional<String> getExtension() {
-    return Optional.ofNullable(extension);
+  public String getExtension() {
+    return extension;
   }
 
   public void setExtension(String extension) {
@@ -58,10 +61,10 @@ public class MimeType {
   /**
    * Gets the Mime Type string.
    *
-   * @return Optional containing the type if present
+   * @return the type, or {@code null} if unset
    */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -38,15 +38,18 @@ import com.percussion.rest.communities.CommunityRole;
 import com.percussion.rest.communities.CommunityVisibility;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.errors.RestError;
 import com.percussion.rest.contexts.Context;
 import com.percussion.rest.deliverytypes.DeliveryType;
 import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.extensions.ExtensionFilterOptions;
 import com.percussion.rest.folders.CopyFolderItemRequest;
 import com.percussion.rest.folders.Folder;
 import com.percussion.rest.folders.SectionInfo;
 import com.percussion.rest.folders.SectionLinkRef;
 import com.percussion.rest.LinkRef;
 import com.percussion.rest.MoveFolderItem;
+import com.percussion.rest.mimetypes.MimeType;
 import com.percussion.rest.locationscheme.LocationScheme;
 import com.percussion.rest.locationscheme.LocationSchemeParameter;
 import com.percussion.rest.locationscheme.LocationSchemeParameterList;
@@ -84,7 +87,8 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
+ * rule (issue #3413). ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError follow the
+ * same contract (issue #3430). All use production {@link JacksonContextResolver} under {@code
  * @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
@@ -730,7 +734,7 @@ class JacksonContextResolverOptionalTest {
 
     SectionLinkRef roundTrip = refMapper.readValue(json, SectionLinkRef.class);
     assertEquals(SectionLinkRef.TYPE_EXTERNAL, roundTrip.getType(), json);
-    assertEquals("Press", roundTrip.getName().orElse(null), json);
+    assertEquals("Press", roundTrip.getName(), json);
   }
 
   @Test
@@ -994,6 +998,125 @@ class JacksonContextResolverOptionalTest {
     assertEquals(1, listRoundTrip.size());
     assertEquals("By_Author ACL", listRoundTrip.get(0).getName());
     assertEquals(3, listRoundTrip.get(0).getAclEntries().size());
+  }
+
+  @Test
+  void extensionFilterOptions_serializesPlainScalarsNotOptionalBeans() {
+    ExtensionFilterOptions filter = new ExtensionFilterOptions();
+    filter.setHandlerNamePattern("Java");
+    filter.setContext("global/percussion/generic/");
+    filter.setInterfacePattern("com.percussion.extension.IPSExtension");
+    filter.setExtensionNamePattern("sys_*");
+
+    ObjectMapper filterMapper =
+        new JacksonContextResolver().getContext(ExtensionFilterOptions.class);
+    String json = filterMapper.writeValueAsString(filter);
+    assertTrue(json.contains("\"handlerNamePattern\""), json);
+    assertTrue(json.contains("Java"), json);
+    assertTrue(json.contains("\"context\""), json);
+    assertTrue(json.contains("global/percussion/generic/"), json);
+    assertTrue(json.contains("\"interfacePattern\""), json);
+    assertTrue(json.contains("\"extensionNamePattern\""), json);
+    assertTrue(json.contains("sys_*"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ExtensionFilterOptions roundTrip = filterMapper.readValue(json, ExtensionFilterOptions.class);
+    assertEquals("Java", roundTrip.getHandlerNamePattern(), json);
+    assertEquals("global/percussion/generic/", roundTrip.getContext(), json);
+    assertEquals("com.percussion.extension.IPSExtension", roundTrip.getInterfacePattern(), json);
+    assertEquals("sys_*", roundTrip.getExtensionNamePattern(), json);
+  }
+
+  @Test
+  void mimeType_serializesPlainScalarsNotOptionalBeans() {
+    MimeType mimeType = new MimeType();
+    mimeType.setExtension("pdf");
+    mimeType.setType("application/pdf");
+
+    ObjectMapper mimeMapper = new JacksonContextResolver().getContext(MimeType.class);
+    String json = mimeMapper.writeValueAsString(mimeType);
+    assertTrue(json.contains("\"extension\""), json);
+    assertTrue(json.contains("pdf"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains("application/pdf"), json);
+    assertNoOptionalBeanKeys(json);
+
+    MimeType roundTrip = mimeMapper.readValue(json, MimeType.class);
+    assertEquals("pdf", roundTrip.getExtension(), json);
+    assertEquals("application/pdf", roundTrip.getType(), json);
+  }
+
+  @Test
+  void linkRef_serializesNameHrefNotOptionalBeans() {
+    LinkRef ref = new LinkRef("index.html", "http://example.com/index.html");
+
+    ObjectMapper refMapper = new JacksonContextResolver().getContext(LinkRef.class);
+    String json = refMapper.writeValueAsString(ref);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("index.html"), json);
+    assertTrue(json.contains("\"href\""), json);
+    assertTrue(json.contains("http://example.com/index.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    LinkRef roundTrip = refMapper.readValue(json, LinkRef.class);
+    assertEquals("index.html", roundTrip.getName(), json);
+    assertEquals("http://example.com/index.html", roundTrip.getHref(), json);
+  }
+
+  @Test
+  void objectLockSummary_serializesPlainScalarsNotOptionalBeans() {
+    ObjectLockSummary lock = new ObjectLockSummary();
+    lock.setSession("sess-1");
+    lock.setLocker("Admin");
+    lock.setRemainingTime(120L);
+    lock.setCallerAccessTime("2026-08-15T12:00:00Z");
+
+    ObjectMapper lockMapper = new JacksonContextResolver().getContext(ObjectLockSummary.class);
+    String json = lockMapper.writeValueAsString(lock);
+    assertTrue(json.contains("\"session\""), json);
+    assertTrue(json.contains("sess-1"), json);
+    assertTrue(json.contains("\"locker\""), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("\"callerAccessTime\""), json);
+    assertTrue(json.contains("2026-08-15T12:00:00Z"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ObjectLockSummary roundTrip = lockMapper.readValue(json, ObjectLockSummary.class);
+    assertEquals("sess-1", roundTrip.getSession(), json);
+    assertEquals("Admin", roundTrip.getLocker(), json);
+    assertEquals(120L, roundTrip.getRemainingTime(), json);
+    assertEquals("2026-08-15T12:00:00Z", roundTrip.getCallerAccessTime(), json);
+  }
+
+  @Test
+  void restError_serializesErrorDataAsScalarNotOptionalBean() {
+    RestError error =
+        new RestError(42, "FolderNotFoundException", "Folder missing", "detail", "folder-id-9");
+
+    ObjectMapper errorMapper = new JacksonContextResolver().getContext(RestError.class);
+    String json = errorMapper.writeValueAsString(error);
+    assertTrue(json.contains("\"errorData\""), json);
+    assertTrue(json.contains("folder-id-9"), json);
+    assertTrue(json.contains("\"message\""), json);
+    assertTrue(json.contains("Folder missing"), json);
+    assertNoOptionalBeanKeys(json);
+
+    RestError roundTrip = errorMapper.readValue(json, RestError.class);
+    assertEquals(42, roundTrip.getErrorCode(), json);
+    assertEquals("Folder missing", roundTrip.getMessage(), json);
+    assertEquals("folder-id-9", roundTrip.getErrorData(), json);
+  }
+
+  @Test
+  void restError_omitsNullErrorDataFromJson() {
+    RestError error = new RestError(1, "UnexpectedException", "boom", null, null);
+
+    ObjectMapper errorMapper = new JacksonContextResolver().getContext(RestError.class);
+    String json = errorMapper.writeValueAsString(error);
+    assertTrue(json.contains("\"message\""), json);
+    assertFalse(json.contains("\"errorData\""), json);
+    assertFalse(json.contains("\"detailMessage\""), json);
+    assertNoOptionalBeanKeys(json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/errors/RestExceptionMapperTest.java
+++ b/rest/src/test/java/com/percussion/rest/errors/RestExceptionMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Maps {@link RestExceptionBase} to {@link RestError} with nullable {@code errorData} (issue
+ * #3430).
+ */
+class RestExceptionMapperTest {
+
+  private RestExceptionMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new RestExceptionMapper();
+  }
+
+  @Test
+  void mapsErrorDataAsScalarNotOptional() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.FOLDER_NOT_FOUND,
+            "Folder missing",
+            "path=/a",
+            "folder-id-9",
+            Response.Status.NOT_FOUND);
+
+    Response response = mapper.toResponse(ex);
+
+    assertEquals(404, response.getStatus());
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertEquals(RestErrorCode.FOLDER_NOT_FOUND.getNumVal(), body.getErrorCode());
+    assertEquals("Folder missing", body.getMessage());
+    assertEquals("path=/a", body.getDetailMessage());
+    assertEquals("folder-id-9", body.getErrorData());
+  }
+
+  @Test
+  void mapsNullErrorDataAsNull() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.OTHER, "boom", null, null, Response.Status.INTERNAL_SERVER_ERROR);
+
+    Response response = mapper.toResponse(ex);
+
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertNull(body.getErrorData());
+    assertEquals("boom", body.getMessage());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/errors/WebApplicationExceptionMapperTest.java
+++ b/rest/src/test/java/com/percussion/rest/errors/WebApplicationExceptionMapperTest.java
@@ -20,6 +20,7 @@ package com.percussion.rest.errors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -138,6 +139,24 @@ class WebApplicationExceptionMapperTest {
     assertEquals("RestExceptionBase", body.getErrorType());
     assertEquals("Folder missing", body.getMessage());
     assertEquals("path=/a", body.getDetailMessage());
+    assertNull(body.getErrorData());
+  }
+
+  @Test
+  void restExceptionBaseErrorDataIsScalarNotOptional() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.FOLDER_NOT_FOUND,
+            "Folder missing",
+            "path=/a",
+            "folder-id-9",
+            Response.Status.NOT_FOUND);
+
+    Response response = mapper.toResponse(ex);
+
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertEquals("folder-id-9", body.getErrorData());
+    assertEquals("Folder missing", body.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent [#3388](https://github.com/intersoftdatalabs-in/percussioncms/issues/3388) slice 11. Convert the remaining small REST wire DTO family from `Optional<T>` getters to plain nullable getters so Jackson/CXF JSON emits scalars, not Optional beans (`empty`/`present`).

Converted:

- `ExtensionFilterOptions`
- `MimeType`
- `LinkRef` (and inherited `SectionLinkRef` getters)
- `ObjectLockSummary`
- `RestError`
- `RestExceptionBase.getErrorData()` only

Callers updated: `RestExceptionMapper`, `WebApplicationExceptionMapper`, sitemanage `ExtensionAdaptor` and `FolderAdaptor` (`ApiUtils.orNull` / `.orElse(null)` on converted getters).

**Not changed:** `Guid` Optional getters (`stringValue` stays `@JsonIgnore` for Object ACL bind; do not regress #3200/#3378). `rest/AGENTS.md` not committed (human rule review). Sibling slices #3431 (ContentList) and #3432 (action/publish Status) stay on their own PRs.

Fixes #3430

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (C2: public getter signatures changed)
3. Confirm `JacksonContextResolverOptionalTest` family methods serialize scalars with no `empty`/`present` keys
4. Confirm REST error mapping still returns `errorData` as a scalar (`RestExceptionMapperTest` / `WebApplicationExceptionMapperTest`)

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal wire-getter convention; no operator/integrator example currently shows Optional-bean JSON for this family
- [x] **Unit / module tests** — production-mapper round-trips appended to `JacksonContextResolverOptionalTest`; mapper tests cover scalar `errorData`; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest` and reverse-dep `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 468, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1238, Failures: 0, Errors: 0, Skipped: 125
  - No new warnings attributable to this change (baseline javadoc/analyze warnings unchanged)
- **downstream_checked:** `projects/sitemanage` standalone clean install; grep `extends ExtensionFilterOptions|MimeType|LinkRef|ObjectLockSummary|RestError|RestExceptionBase` — `SectionLinkRef extends LinkRef` (expected) and existing `RestExceptionBase` subclasses (do not override `getErrorData`). No anonymous `new Type() {` subclasses.

C5 UI proof: N/A — Java REST DTO / adaptor-only; no WebUI surface.

Erlang review: `docs/ai-generated/code-reviews/3430-extensionfilter-mimetype-linkref-resterror-erlang.md` (approve).

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
