### PR TITLE
cluster: absorb REST Optional wire-getter PRs #3433 #3434 #3435

### DIFF
--- a/docs/ai-generated/code-reviews/3430-extensionfilter-mimetype-linkref-resterror-erlang.md
+++ b/docs/ai-generated/code-reviews/3430-extensionfilter-mimetype-linkref-resterror-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review — #3430 ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError plain wire getters
+
+**Scope:** uncommitted branch `fix/issue-3430-optional-wire-getters` vs `origin/main`.
+**Reviewer persona:** Erlang (independent of implementer).
+**Memory patterns hit:** REST DTO wire getters must be plain nullable types + `@JsonInclude(NON_NULL)` (ContentType #1693 / TemplateSummary #2189 / parent #3388); production mapper tests must use `new JacksonContextResolver().getContext(TheDto.class)`; Guid `stringValue` `@JsonIgnore` bandage must not regress (#3200 / #3378); change-class companions (DTO + rest tests + sitemanage callers of converted getters).
+
+## Summary
+
+Parent #3388 slice 11. Remaining small wire types still exposed `Optional<T>` getters: `ExtensionFilterOptions`, `MimeType`, `LinkRef`, `ObjectLockSummary`, `RestError`, and `RestExceptionBase.getErrorData()`.
+
+This change:
+
+1. Converts those getters/setters to plain nullable types with class-level `@JsonInclude(NON_NULL)` on the wire DTOs (`RestExceptionBase` stays an exception; only `getErrorData()` is unwrapped).
+2. Updates `RestExceptionMapper` / `WebApplicationExceptionMapper` to pass `e.getErrorData()` without `.orElse(null)`.
+3. Updates sitemanage `ExtensionAdaptor` and `FolderAdaptor` (`LinkRef` / `SectionLinkRef` name/href) that used `ApiUtils.orNull(...)` / `.orElse(null)` on converted getters.
+4. Appends `JacksonContextResolverOptionalTest` family methods (production mapper, no `empty`/`present` keys) plus mapper tests for scalar `errorData`.
+
+Does **not** convert `Guid` Optional getters. Does **not** commit `rest/AGENTS.md`. Does **not** add `OPTIONAL_FIELDS_SUPPORTED` or `jackson-datatype-jdk8`. Sibling slices #3431 (ContentList) and #3432 (action/publish Status) remain on their own PRs.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Behavioral tests added for the converted family. Error mapping still returns `errorData` as a scalar. No filesystem path construction.
+
+C2: public getter return types changed `Optional<T>` → `T`. Grep found `SectionLinkRef extends LinkRef` (expected; inherits converted getters) and `RestExceptionBase` subclasses (do not override `getErrorData`). Reverse-dep `projects/sitemanage` standalone `clean install` is green.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] No path/file I/O in this diff (JSON/JAX-RS DTO + adaptor callers only)
+- [x] Tests do not assert OS-specific file paths
+- [x] Line-ending assertions not added
+
+## Issues
+
+None (hard-gate).
+
+### Nits
+
+- Primitive `remainingTime` on `ObjectLockSummary` still serializes as `0` when unset (`NON_NULL` does not omit primitives). Pre-existing; same as other converted families.
+
+## Product documentation
+
+N/A — no operator/integrator example currently shows Optional-bean JSON for this family. Wire scalars stay the same documented shape.

--- a/docs/ai-generated/code-reviews/3431-contentlist-itemfilter-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3431-contentlist-itemfilter-wire-getters-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #3431 ContentList / ItemFilterRuleDefinitionParam wire getters
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3431-contentlist-itemfilter-wire-getters`  
+**Scope:** uncommitted vs `origin/main`  
+**Change class:** REST wire DTO Optional→plain nullable getters (parent #3388 slice 9)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure; missing behavioral tests; agent rule files without human review (avoided)
+
+## Summary
+
+Converts publishing Content List + ItemFilter rule-param REST wire getters from `Optional<T>` to plain nullable types with `@JsonInclude(NON_NULL)`, matching User / Role / ObjectSummary / Asset / Acl slices. Production `JacksonContextResolver` round-trip tests appended; no `empty`/`present` Optional-bean keys. Guid left untouched. `rest/AGENTS.md` not modified.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O, installers, or packaging. Tests use JSON strings only.
+
+## Issues
+
+None.
+
+## Notes
+
+- Public getter signatures changed (C2). Grep found no `extends ContentList` / anonymous subclasses. Reverse-dep `projects/sitemanage` standalone `clean install` green; adaptors only used setters on converted types.
+- Product-docs N/A: no operator-facing example currently shows Optional-bean JSON for these types.
+- UI/Playwright N/A: no WebUI screen change.

--- a/docs/ai-generated/code-reviews/3432-action-publish-status-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3432-action-publish-status-wire-getters-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — #3432 Action request + PublishResponse / Status wire getters
+
+**Branch:** `fix/issue-3432-action-publish-status-wire-getters`  
+**Base:** `origin/main`  
+**Date:** 2026-08-15  
+**Reviewer:** Erlang (independent of implementer)
+
+## Summary
+
+Convert Explorer action-menu request DTOs plus rest `PublishResponse` / `Status` from `Optional` wire getters to plain nullable getters so toolbar find/types bodies and publish/status JSON emit arrays/scalars, not Optional beans. Callers that used `.orElse()` on converted getters were updated. Production-mapper family tests appended to `JacksonContextResolverOptionalTest`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, no missing behavioral tests for changed logic, no non-portable path/file I/O.
+
+## Scope
+
+Uncommitted rest DTO/resource/test changes vs `HEAD` / `origin/main`. `rest/AGENTS.md` not in the change set (human rule review). `Guid` and sitemanage-internal `PSSitePublishResponse` unchanged.
+
+## Change-class closure
+
+Change class: REST wire-getter conversion (peer of User/Role/Acl / #3388 slices).
+
+- Production DTOs: `@JsonInclude(NON_NULL)` + plain getters
+- Resource caller: `ActionMenuResource.getAllowedContentTypeMenus` null-safe `int[]`
+- Rest unit tests: `FoldersTest`, `PagesTest`, `ActionMenuResourceTest`, `JacksonContextResolverOptionalTest`
+- Reverse-dep: sitemanage compiles against new signatures (EditionAdaptor / Status setters only)
+- Product-docs: N/A (no documented Optional-bean JSON examples)
+- Playwright: N/A (no WebUI screen change)
+- `rest/AGENTS.md`: not committed
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O.
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests for new/changed non-trivial logic — covered (resource null `contentIds` + mapper round-trip).
+- Incomplete change-class closure — companions from prior #3388 slices present.
+- Agent rule files not committed without human review.
+
+## Build evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 467, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1238, Failures: 0, Skipped: 125

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
@@ -134,10 +134,10 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
     try {
       var it =
           extensionService.getExtensionNames(
-              ApiUtils.orNull(filter.getHandlerNamePattern()),
-              ApiUtils.orNull(filter.getContext()),
-              ApiUtils.orNull(filter.getInterfacePattern()),
-              ApiUtils.orNull(filter.getExtensionNamePattern()));
+              filter.getHandlerNamePattern(),
+              filter.getContext(),
+              filter.getInterfacePattern(),
+              filter.getExtensionNamePattern());
       while (it.hasNext()) {
         var ref = it.next();
         response.add(copyExtensionRef(ref));

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
@@ -363,7 +363,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     List<String> existingFolders = new ArrayList<>();
     if (folder.getSubsections() != null) {
       for (SectionLinkRef section : folder.getSubsections()) {
-        existingFolders.add(ApiUtils.orNull(section.getName()));
+        existingFolders.add(section.getName());
       }
     }
     folder.setPages(folderPages);
@@ -681,16 +681,15 @@ public class FolderAdaptor implements IFolderAdaptor {
       LinkRef reqLanding = reqSectionInfo.getLandingPage();
       LinkRef existingLanding = currSectionInfo.getLandingPage();
 
-      String reqName = ApiUtils.orNull(reqLanding == null ? null : reqLanding.getName());
-      String existingName =
-          ApiUtils.orNull(existingLanding == null ? null : existingLanding.getName());
+      String reqName = reqLanding == null ? null : reqLanding.getName();
+      String existingName = existingLanding == null ? null : existingLanding.getName();
 
       if (reqName != null && !reqName.equals(existingName)) {
         // get child folders
         boolean foundPage = false;
         List<LinkRef> existingPages = existingFolder.getPages();
         for (LinkRef page : existingPages == null ? List.<LinkRef>of() : existingPages) {
-          if (reqName.equals(ApiUtils.orNull(page.getName()))) {
+          if (reqName.equals(page.getName())) {
             foundPage = true;
             break;
           }
@@ -804,7 +803,7 @@ public class FolderAdaptor implements IFolderAdaptor {
     String name = "index.html";
     LinkRef landOpt = sectionInfo.getLandingPage();
     // compute landing name and if available override default
-    String landingName = landOpt == null ? null : landOpt.getName().orElse(null);
+    String landingName = landOpt == null ? null : landOpt.getName();
     if (landingName != null) {
       name = landingName;
     }
@@ -875,8 +874,8 @@ public class FolderAdaptor implements IFolderAdaptor {
         throw new BackendException("non-section folders cannot have subsections");
       String nameCheck = null;
       for (SectionLinkRef subsection : folder.getSubsections()) {
-        String secName = ApiUtils.orNull(subsection.getName());
-        String secHref = ApiUtils.orNull(subsection.getHref());
+        String secName = subsection.getName();
+        String secHref = subsection.getHref();
         if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
           nameCheck = secName + "-" + secHref;
         else nameCheck = secName;
@@ -892,8 +891,8 @@ public class FolderAdaptor implements IFolderAdaptor {
       if (existingFolder.getSubsections() != null) {
 
         for (SectionLinkRef subsection : existingFolder.getSubsections()) {
-          String secName = ApiUtils.orNull(subsection.getName());
-          String secHref = ApiUtils.orNull(subsection.getHref());
+          String secName = subsection.getName();
+          String secHref = subsection.getHref();
           if (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType()))
             nameCheck = secName + "-" + secHref;
           else nameCheck = secName;
@@ -907,8 +906,8 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       for (String createName : subSectionsToCreate) {
         for (SectionLinkRef subsection : folder.getSubsections()) {
-          String nameVal = ApiUtils.orNull(subsection.getName());
-          String hrefVal = ApiUtils.orNull(subsection.getHref());
+          String nameVal = subsection.getName();
+          String hrefVal = subsection.getHref();
           if (nameVal.equals(createName)
               || (PSSectionTypeEnum.sectionlink.name().equals(subsection.getType())
                   && createName.equals(nameVal + "-" + hrefVal))) {
@@ -977,14 +976,14 @@ public class FolderAdaptor implements IFolderAdaptor {
         throw new BackendException("non-section folders cannot have subsections");
 
       for (SectionLinkRef subSection : folder.getSubsections()) {
-        String name = ApiUtils.orNull(subSection.getName());
+        String name = subSection.getName();
         createSubSection(
             baseUri,
             existingFolder,
             folder,
             name,
             subSection.getType(),
-            ApiUtils.orNull(subSection.getHref()));
+            subSection.getHref());
       }
     }
   }
@@ -1110,7 +1109,7 @@ public class FolderAdaptor implements IFolderAdaptor {
 
       // get specified landing page name or use index if does not exist.
       LinkRef landing = section == null ? null : section.getLandingPage();
-      String landingName = landing == null ? null : landing.getName().orElse(null);
+      String landingName = landing == null ? null : landing.getName();
       if (landingName != null) {
         request.setPageName(landingName);
       } else {

--- a/rest/src/main/java/com/percussion/rest/LinkRef.java
+++ b/rest/src/main/java/com/percussion/rest/LinkRef.java
@@ -18,12 +18,20 @@
 package com.percussion.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * Wire name/href pair for REST folder, page, and user recent-item links.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @XmlRootElement(name = "LinkRef")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "LinkRef")
 public class LinkRef {
   @Schema(required = false, description = "link")
@@ -40,16 +48,22 @@ public class LinkRef {
     this.href = href;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  /**
+   * @return link name, or {@code null} if unset
+   */
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getHref() {
-    return Optional.ofNullable(href);
+  /**
+   * @return href, or {@code null} if unset
+   */
+  public String getHref() {
+    return href;
   }
 
   public void setHref(String href) {

--- a/rest/src/main/java/com/percussion/rest/ObjectLockSummary.java
+++ b/rest/src/main/java/com/percussion/rest/ObjectLockSummary.java
@@ -20,8 +20,14 @@ package com.percussion.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
+/**
+ * Multi-user lock summary on a catalog object.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement
 @Schema(description = "Represents a multi-user lock on an object in the system.")
@@ -44,16 +50,22 @@ public class ObjectLockSummary {
           "The date and time that the API client last checked this lock.  Can be used for retries.")
   private String callerAccessTime;
 
-  public Optional<String> getSession() {
-    return Optional.ofNullable(session);
+  /**
+   * @return lock session id, or {@code null} if unset
+   */
+  public String getSession() {
+    return session;
   }
 
   public void setSession(String session) {
     this.session = session;
   }
 
-  public Optional<String> getLocker() {
-    return Optional.ofNullable(locker);
+  /**
+   * @return locker username, or {@code null} if unset
+   */
+  public String getLocker() {
+    return locker;
   }
 
   public void setLocker(String locker) {
@@ -68,8 +80,11 @@ public class ObjectLockSummary {
     this.remainingTime = remainingTime;
   }
 
-  public Optional<String> getCallerAccessTime() {
-    return Optional.ofNullable(callerAccessTime);
+  /**
+   * @return last caller access time, or {@code null} if unset
+   */
+  public String getCallerAccessTime() {
+    return callerAccessTime;
   }
 
   public void setCallerAccessTime(String callerAccessTime) {

--- a/rest/src/main/java/com/percussion/rest/Status.java
+++ b/rest/src/main/java/com/percussion/rest/Status.java
@@ -20,11 +20,13 @@ package com.percussion.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a generic REST API status response carrying a human-readable message and a numeric
  * status code.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code message} as a scalar, not an Optional bean (issue #3388 slice 10 / #3432).
  *
  * @author stephenbolton
  */
@@ -62,10 +64,10 @@ public class Status {
   }
 
   /**
-   * @return status message as Optional
+   * @return status message, or {@code null} if unset
    */
-  public Optional<String> getMessage() {
-    return Optional.ofNullable(message);
+  public String getMessage() {
+    return message;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -214,8 +214,8 @@ public class ActionMenuResource {
         @ApiResponse(responseCode = "500", description = "Error searching for Action Menu")
       })
   public ActionMenuList getAllowedContentTypeMenus(AllowedContentTypeMenusRequest request) {
-    var contentIds =
-        Arrays.stream(request.getContentIds().orElse(new int[0])).boxed().toArray(Integer[]::new);
+    int[] raw = request.getContentIds() != null ? request.getContentIds() : new int[0];
+    var contentIds = Arrays.stream(raw).boxed().toArray(Integer[]::new);
     return new ActionMenuList(adaptor.findAllowedContentTypes(contentIds));
   }
 

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
@@ -17,14 +17,20 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed content type menus. */
+/**
+ * Request object for allowed content type menus.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} as a JSON array, not an Optional bean (issue #3388 slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
 public class AllowedContentTypeMenusRequest {
 
@@ -37,10 +43,10 @@ public class AllowedContentTypeMenusRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
@@ -17,13 +17,19 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed template menus. */
+/**
+ * Request object for allowed template menus.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} as a JSON array, not an Optional bean (issue #3388 slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
 public class AllowedTemplateMenusRequest {
 
@@ -36,10 +42,10 @@ public class AllowedTemplateMenusRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -17,12 +17,19 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.Optional;
 
-/** Request object for allowed workflow transitions. */
+/**
+ * Request object for allowed workflow transitions.
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code contentIds} and {@code assignmentTypeIds} as JSON arrays, not Optional beans (issue #3388
+ * slice 10 / #3432).
+ */
 @XmlRootElement
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllowedWorkflowTransitionsRequest {
 
   /** Content ids to evaluate transitions for. */
@@ -37,10 +44,10 @@ public class AllowedWorkflowTransitionsRequest {
   /**
    * Returns the content ids.
    *
-   * @return the content ids, may be empty
+   * @return the content ids, or {@code null} if unset
    */
-  public Optional<int[]> getContentIds() {
-    return Optional.ofNullable(contentIds);
+  public int[] getContentIds() {
+    return contentIds;
   }
 
   /**
@@ -55,10 +62,10 @@ public class AllowedWorkflowTransitionsRequest {
   /**
    * Returns the assignment type ids.
    *
-   * @return the assignment type ids, may be empty
+   * @return the assignment type ids, or {@code null} if unset
    */
-  public Optional<int[]> getAssignmentTypeIds() {
-    return Optional.ofNullable(assignmentTypeIds);
+  public int[] getAssignmentTypeIds() {
+    return assignmentTypeIds;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/contentlists/ContentList.java
+++ b/rest/src/main/java/com/percussion/rest/contentlists/ContentList.java
@@ -24,9 +24,14 @@ import com.percussion.rest.itemfilter.ItemFilter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Content List in Percussion CMS. */
+/**
+ * Represents a Content List in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars and
+ * nested objects rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3388 / #3431).
+ */
 @XmlRootElement(name = "ContentList")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Content List")
@@ -84,32 +89,32 @@ public class ContentList {
 
   public ContentList() {}
 
-  public Optional<Guid> getContentListId() {
-    return Optional.ofNullable(contentListId);
+  public Guid getContentListId() {
+    return contentListId;
   }
 
   public void setContentListId(Guid contentListId) {
     this.contentListId = contentListId;
   }
 
-  public Optional<Integer> getVersion() {
-    return Optional.ofNullable(version);
+  public Integer getVersion() {
+    return version;
   }
 
   public void setVersion(Integer version) {
     this.version = version;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
@@ -124,40 +129,40 @@ public class ContentList {
     this.type = type;
   }
 
-  public Optional<String> getUrl() {
-    return Optional.ofNullable(url);
+  public String getUrl() {
+    return url;
   }
 
   public void setUrl(String url) {
     this.url = url;
   }
 
-  public Optional<Extension> getGenerator() {
-    return Optional.ofNullable(generator);
+  public Extension getGenerator() {
+    return generator;
   }
 
   public void setGenerator(Extension generator) {
     this.generator = generator;
   }
 
-  public Optional<Extension> getExpander() {
-    return Optional.ofNullable(expander);
+  public Extension getExpander() {
+    return expander;
   }
 
   public void setExpander(Extension expander) {
     this.expander = expander;
   }
 
-  public Optional<String> getEditionType() {
-    return Optional.ofNullable(editionType);
+  public String getEditionType() {
+    return editionType;
   }
 
   public void setEditionType(String editionType) {
     this.editionType = editionType;
   }
 
-  public Optional<ItemFilter> getItemFilter() {
-    return Optional.ofNullable(itemFilter);
+  public ItemFilter getItemFilter() {
+    return itemFilter;
   }
 
   public void setItemFilter(ItemFilter itemFilter) {

--- a/rest/src/main/java/com/percussion/rest/editions/PublishResponse.java
+++ b/rest/src/main/java/com/percussion/rest/editions/PublishResponse.java
@@ -18,17 +18,21 @@
 
 package com.percussion.rest.editions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Stores the information returned from a publish request.
  *
  * <p>Sunny Sal: "Publishing response received, boss!"
+ *
+ * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
+ * {@code warningMessage} as a scalar, not an Optional bean (issue #3388 slice 10 / #3432).
  */
 @XmlRootElement(name = "EditionPublishResponse")
 @JsonRootName("EditionPublishResponse")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PublishResponse {
 
   private String siteName;
@@ -95,10 +99,10 @@ public class PublishResponse {
   }
 
   /**
-   * @return the warning message, if present.
+   * @return the warning message, or {@code null} if unset
    */
-  public Optional<String> getWarningMessage() {
-    return Optional.ofNullable(warningMessage);
+  public String getWarningMessage() {
+    return warningMessage;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/errors/RestError.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestError.java
@@ -19,14 +19,19 @@
 
 package com.percussion.rest.errors;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a REST error returned to the client. Sunny Sal: "Error ho gaya? No worries, this class
  * will tell you what went wrong!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code
+ * errorData} as a scalar/object rather than an Optional bean ({@code empty}/{@code present}).
+ * Matches {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
  */
 @XmlRootElement(name = "Error")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RestError {
 
   private int errorCode;
@@ -91,12 +96,12 @@ public class RestError {
   }
 
   /**
-   * Returns the error data as an Optional.
+   * Returns the error payload.
    *
-   * @return Optional containing error data if present
+   * @return error data, or {@code null} if unset
    */
-  public Optional<Object> getErrorData() {
-    return Optional.ofNullable(errorData);
+  public Object getErrorData() {
+    return errorData;
   }
 
   public void setErrorData(Object errorData) {

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
@@ -22,7 +22,6 @@ package com.percussion.rest.errors;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 import java.util.ResourceBundle;
 
 /**
@@ -120,12 +119,12 @@ public class RestExceptionBase extends WebApplicationException {
   }
 
   /**
-   * Returns the error data as an Optional.
+   * Returns the in-process error payload for JAX-RS mapping.
    *
-   * @return Optional containing error data if present
+   * @return error data, or {@code null} if unset
    */
-  public Optional<Object> getErrorData() {
-    return Optional.ofNullable(errorData);
+  public Object getErrorData() {
+    return errorData;
   }
 
   public void setErrorData(Object errorData) {

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionMapper.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionMapper.java
@@ -50,7 +50,7 @@ public class RestExceptionMapper implements ExceptionMapper<RestExceptionBase> {
             e.getClass().getSimpleName(),
             e.getMessage(),
             e.getDetailMessage(),
-            e.getErrorData().orElse(null));
+            e.getErrorData());
 
     int status =
         e.getStatus() != null

--- a/rest/src/main/java/com/percussion/rest/errors/WebApplicationExceptionMapper.java
+++ b/rest/src/main/java/com/percussion/rest/errors/WebApplicationExceptionMapper.java
@@ -84,7 +84,7 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplica
             e.getClass().getSimpleName(),
             e.getMessage(),
             e.getDetailMessage(),
-            e.getErrorData().orElse(null));
+            e.getErrorData());
     int status =
         e.getStatus() != null
             ? e.getStatus().getStatusCode()

--- a/rest/src/main/java/com/percussion/rest/extensions/ExtensionFilterOptions.java
+++ b/rest/src/main/java/com/percussion/rest/extensions/ExtensionFilterOptions.java
@@ -22,9 +22,14 @@ package com.percussion.rest.extensions;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents options when filtering for extensions. Sunny Sal: "Filter lagao, result pao!" */
+/**
+ * Represents options when filtering for extensions. Sunny Sal: "Filter lagao, result pao!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
+ */
 @XmlRootElement(name = "ExtensionFilterOptions")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents options when filtering for extensions.")
@@ -67,32 +72,44 @@ public class ExtensionFilterOptions {
     // Default constructor
   }
 
-  public Optional<String> getHandlerNamePattern() {
-    return Optional.ofNullable(handlerNamePattern);
+  /**
+   * @return handler name pattern, or {@code null} if unset
+   */
+  public String getHandlerNamePattern() {
+    return handlerNamePattern;
   }
 
   public void setHandlerNamePattern(String handlerNamePattern) {
     this.handlerNamePattern = handlerNamePattern;
   }
 
-  public Optional<String> getContext() {
-    return Optional.ofNullable(context);
+  /**
+   * @return search context, or {@code null} if unset
+   */
+  public String getContext() {
+    return context;
   }
 
   public void setContext(String context) {
     this.context = context;
   }
 
-  public Optional<String> getInterfacePattern() {
-    return Optional.ofNullable(interfacePattern);
+  /**
+   * @return interface name pattern, or {@code null} if unset
+   */
+  public String getInterfacePattern() {
+    return interfacePattern;
   }
 
   public void setInterfacePattern(String interfacePattern) {
     this.interfacePattern = interfacePattern;
   }
 
-  public Optional<String> getExtensionNamePattern() {
-    return Optional.ofNullable(extensionNamePattern);
+  /**
+   * @return extension name pattern, or {@code null} if unset
+   */
+  public String getExtensionNamePattern() {
+    return extensionNamePattern;
   }
 
   public void setExtensionNamePattern(String extensionNamePattern) {

--- a/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterRuleDefinitionParam.java
+++ b/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterRuleDefinitionParam.java
@@ -19,12 +19,19 @@
 
 package com.percussion.rest.itemfilter;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
-/** Represents an ItemFilter Rule Parameter. Sunny Sal: "Rule parameter, filter ka accelerator!" */
+/**
+ * Represents an ItemFilter Rule Parameter.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits {@code name}
+ * and {@code value} scalars rather than Optional beans ({@code empty}/{@code present}). Matches
+ * {@link com.percussion.rest.contenttypes.ContentType} getter style (issue #3388 / #3431).
+ */
 @XmlRootElement(name = "ItemFilterRuleDefinitionParam")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents an ItemFilter Rule Parameter")
 public class ItemFilterRuleDefinitionParam {
 
@@ -39,8 +46,8 @@ public class ItemFilterRuleDefinitionParam {
   }
 
   /** Gets the parameter name. */
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
@@ -48,8 +55,8 @@ public class ItemFilterRuleDefinitionParam {
   }
 
   /** Gets the parameter value. */
-  public Optional<String> getValue() {
-    return Optional.ofNullable(value);
+  public String getValue() {
+    return value;
   }
 
   public void setValue(String value) {

--- a/rest/src/main/java/com/percussion/rest/mimetypes/MimeType.java
+++ b/rest/src/main/java/com/percussion/rest/mimetypes/MimeType.java
@@ -22,10 +22,13 @@ package com.percussion.rest.mimetypes;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Optional;
 
 /**
  * Represents a Mime Type registered on the system. Sunny Sal: "MimeType ka hero, uploads ka zero!"
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON emits scalars
+ * rather than Optional beans ({@code empty}/{@code present}). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #3430 / #3388).
  */
 @Schema(name = "MimeType", description = "A mime type registered on the system")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,10 +48,10 @@ public class MimeType {
   /**
    * Gets the file extension associated with the MimeType.
    *
-   * @return Optional containing the extension if present
+   * @return the extension, or {@code null} if unset
    */
-  public Optional<String> getExtension() {
-    return Optional.ofNullable(extension);
+  public String getExtension() {
+    return extension;
   }
 
   public void setExtension(String extension) {
@@ -58,10 +61,10 @@ public class MimeType {
   /**
    * Gets the Mime Type string.
    *
-   * @return Optional containing the type if present
+   * @return the type, or {@code null} if unset
    */
-  public Optional<String> getType() {
-    return Optional.ofNullable(type);
+  public String getType() {
+    return type;
   }
 
   public void setType(String type) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -38,15 +38,18 @@ import com.percussion.rest.communities.CommunityRole;
 import com.percussion.rest.communities.CommunityVisibility;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.errors.RestError;
 import com.percussion.rest.contexts.Context;
 import com.percussion.rest.deliverytypes.DeliveryType;
 import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.extensions.ExtensionFilterOptions;
 import com.percussion.rest.folders.CopyFolderItemRequest;
 import com.percussion.rest.folders.Folder;
 import com.percussion.rest.folders.SectionInfo;
 import com.percussion.rest.folders.SectionLinkRef;
 import com.percussion.rest.LinkRef;
 import com.percussion.rest.MoveFolderItem;
+import com.percussion.rest.mimetypes.MimeType;
 import com.percussion.rest.locationscheme.LocationScheme;
 import com.percussion.rest.locationscheme.LocationSchemeParameter;
 import com.percussion.rest.locationscheme.LocationSchemeParameterList;
@@ -84,7 +87,8 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
+ * rule (issue #3413). ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError follow the
+ * same contract (issue #3430). All use production {@link JacksonContextResolver} under {@code
  * @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
@@ -730,7 +734,7 @@ class JacksonContextResolverOptionalTest {
 
     SectionLinkRef roundTrip = refMapper.readValue(json, SectionLinkRef.class);
     assertEquals(SectionLinkRef.TYPE_EXTERNAL, roundTrip.getType(), json);
-    assertEquals("Press", roundTrip.getName().orElse(null), json);
+    assertEquals("Press", roundTrip.getName(), json);
   }
 
   @Test
@@ -994,6 +998,125 @@ class JacksonContextResolverOptionalTest {
     assertEquals(1, listRoundTrip.size());
     assertEquals("By_Author ACL", listRoundTrip.get(0).getName());
     assertEquals(3, listRoundTrip.get(0).getAclEntries().size());
+  }
+
+  @Test
+  void extensionFilterOptions_serializesPlainScalarsNotOptionalBeans() {
+    ExtensionFilterOptions filter = new ExtensionFilterOptions();
+    filter.setHandlerNamePattern("Java");
+    filter.setContext("global/percussion/generic/");
+    filter.setInterfacePattern("com.percussion.extension.IPSExtension");
+    filter.setExtensionNamePattern("sys_*");
+
+    ObjectMapper filterMapper =
+        new JacksonContextResolver().getContext(ExtensionFilterOptions.class);
+    String json = filterMapper.writeValueAsString(filter);
+    assertTrue(json.contains("\"handlerNamePattern\""), json);
+    assertTrue(json.contains("Java"), json);
+    assertTrue(json.contains("\"context\""), json);
+    assertTrue(json.contains("global/percussion/generic/"), json);
+    assertTrue(json.contains("\"interfacePattern\""), json);
+    assertTrue(json.contains("\"extensionNamePattern\""), json);
+    assertTrue(json.contains("sys_*"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ExtensionFilterOptions roundTrip = filterMapper.readValue(json, ExtensionFilterOptions.class);
+    assertEquals("Java", roundTrip.getHandlerNamePattern(), json);
+    assertEquals("global/percussion/generic/", roundTrip.getContext(), json);
+    assertEquals("com.percussion.extension.IPSExtension", roundTrip.getInterfacePattern(), json);
+    assertEquals("sys_*", roundTrip.getExtensionNamePattern(), json);
+  }
+
+  @Test
+  void mimeType_serializesPlainScalarsNotOptionalBeans() {
+    MimeType mimeType = new MimeType();
+    mimeType.setExtension("pdf");
+    mimeType.setType("application/pdf");
+
+    ObjectMapper mimeMapper = new JacksonContextResolver().getContext(MimeType.class);
+    String json = mimeMapper.writeValueAsString(mimeType);
+    assertTrue(json.contains("\"extension\""), json);
+    assertTrue(json.contains("pdf"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertTrue(json.contains("application/pdf"), json);
+    assertNoOptionalBeanKeys(json);
+
+    MimeType roundTrip = mimeMapper.readValue(json, MimeType.class);
+    assertEquals("pdf", roundTrip.getExtension(), json);
+    assertEquals("application/pdf", roundTrip.getType(), json);
+  }
+
+  @Test
+  void linkRef_serializesNameHrefNotOptionalBeans() {
+    LinkRef ref = new LinkRef("index.html", "http://example.com/index.html");
+
+    ObjectMapper refMapper = new JacksonContextResolver().getContext(LinkRef.class);
+    String json = refMapper.writeValueAsString(ref);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("index.html"), json);
+    assertTrue(json.contains("\"href\""), json);
+    assertTrue(json.contains("http://example.com/index.html"), json);
+    assertNoOptionalBeanKeys(json);
+
+    LinkRef roundTrip = refMapper.readValue(json, LinkRef.class);
+    assertEquals("index.html", roundTrip.getName(), json);
+    assertEquals("http://example.com/index.html", roundTrip.getHref(), json);
+  }
+
+  @Test
+  void objectLockSummary_serializesPlainScalarsNotOptionalBeans() {
+    ObjectLockSummary lock = new ObjectLockSummary();
+    lock.setSession("sess-1");
+    lock.setLocker("Admin");
+    lock.setRemainingTime(120L);
+    lock.setCallerAccessTime("2026-08-15T12:00:00Z");
+
+    ObjectMapper lockMapper = new JacksonContextResolver().getContext(ObjectLockSummary.class);
+    String json = lockMapper.writeValueAsString(lock);
+    assertTrue(json.contains("\"session\""), json);
+    assertTrue(json.contains("sess-1"), json);
+    assertTrue(json.contains("\"locker\""), json);
+    assertTrue(json.contains("Admin"), json);
+    assertTrue(json.contains("\"callerAccessTime\""), json);
+    assertTrue(json.contains("2026-08-15T12:00:00Z"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ObjectLockSummary roundTrip = lockMapper.readValue(json, ObjectLockSummary.class);
+    assertEquals("sess-1", roundTrip.getSession(), json);
+    assertEquals("Admin", roundTrip.getLocker(), json);
+    assertEquals(120L, roundTrip.getRemainingTime(), json);
+    assertEquals("2026-08-15T12:00:00Z", roundTrip.getCallerAccessTime(), json);
+  }
+
+  @Test
+  void restError_serializesErrorDataAsScalarNotOptionalBean() {
+    RestError error =
+        new RestError(42, "FolderNotFoundException", "Folder missing", "detail", "folder-id-9");
+
+    ObjectMapper errorMapper = new JacksonContextResolver().getContext(RestError.class);
+    String json = errorMapper.writeValueAsString(error);
+    assertTrue(json.contains("\"errorData\""), json);
+    assertTrue(json.contains("folder-id-9"), json);
+    assertTrue(json.contains("\"message\""), json);
+    assertTrue(json.contains("Folder missing"), json);
+    assertNoOptionalBeanKeys(json);
+
+    RestError roundTrip = errorMapper.readValue(json, RestError.class);
+    assertEquals(42, roundTrip.getErrorCode(), json);
+    assertEquals("Folder missing", roundTrip.getMessage(), json);
+    assertEquals("folder-id-9", roundTrip.getErrorData(), json);
+  }
+
+  @Test
+  void restError_omitsNullErrorDataFromJson() {
+    RestError error = new RestError(1, "UnexpectedException", "boom", null, null);
+
+    ObjectMapper errorMapper = new JacksonContextResolver().getContext(RestError.class);
+    String json = errorMapper.writeValueAsString(error);
+    assertTrue(json.contains("\"message\""), json);
+    assertFalse(json.contains("\"errorData\""), json);
+    assertFalse(json.contains("\"detailMessage\""), json);
+    assertNoOptionalBeanKeys(json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.Permissions;
 import com.percussion.rest.acls.Acl;
+import com.percussion.rest.actions.AllowedContentTypeMenusRequest;
+import com.percussion.rest.actions.AllowedTemplateMenusRequest;
+import com.percussion.rest.actions.AllowedWorkflowTransitionsRequest;
+import com.percussion.rest.editions.PublishResponse;
 import com.percussion.rest.acls.AclEntry;
 import com.percussion.rest.acls.AclEntryList;
 import com.percussion.rest.acls.AclList;
@@ -71,6 +75,7 @@ import com.percussion.rest.templates.TemplateSummary;
 import com.percussion.rest.templates.TemplateSummaryList;
 import com.percussion.rest.users.User;
 import com.percussion.security.IPSTypedPrincipal;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -84,8 +89,9 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
- * @JsonInclude(NON_NULL)}.
+ * rule (issue #3413). Action-menu request + editions {@code PublishResponse} / {@code Status}
+ * follow the same rule (issue #3432 / #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -1011,6 +1017,133 @@ class JacksonContextResolverOptionalTest {
     UserAccessLevel ualRoundTrip = ualMapper.readValue(json, UserAccessLevel.class);
     assertEquals(Permissions.READ, ualRoundTrip.getPermission());
     assertEquals(9, ualRoundTrip.getId());
+  }
+
+  @Test
+  void allowedContentTypeMenusRequest_serializesContentIdsAsJsonArray() {
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {101, 102});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("101"), json);
+    assertTrue(json.contains("102"), json);
+    assertFalse(json.contains("\"empty\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedContentTypeMenusRequest roundTrip =
+        requestMapper.readValue(json, AllowedContentTypeMenusRequest.class);
+    assertTrue(Arrays.equals(new int[] {101, 102}, roundTrip.getContentIds()), json);
+  }
+
+  @Test
+  void allowedTemplateMenusRequest_serializesContentIdsAsJsonArray() {
+    AllowedTemplateMenusRequest request = new AllowedTemplateMenusRequest();
+    request.setContentIds(new int[] {201, 202});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedTemplateMenusRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("201"), json);
+    assertTrue(json.contains("202"), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedTemplateMenusRequest roundTrip =
+        requestMapper.readValue(json, AllowedTemplateMenusRequest.class);
+    assertTrue(Arrays.equals(new int[] {201, 202}, roundTrip.getContentIds()), json);
+  }
+
+  @Test
+  void allowedWorkflowTransitionsRequest_serializesIdsAsJsonArrays() {
+    AllowedWorkflowTransitionsRequest request = new AllowedWorkflowTransitionsRequest();
+    request.setContentIds(new int[] {301, 302});
+    request.setAssignmentTypeIds(new int[] {1, 2});
+
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedWorkflowTransitionsRequest.class);
+    String json = requestMapper.writeValueAsString(request);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("301"), json);
+    assertTrue(json.contains("\"assignmentTypeIds\""), json);
+    assertTrue(json.contains("1"), json);
+    assertNoOptionalBeanKeys(json);
+
+    AllowedWorkflowTransitionsRequest roundTrip =
+        requestMapper.readValue(json, AllowedWorkflowTransitionsRequest.class);
+    assertTrue(Arrays.equals(new int[] {301, 302}, roundTrip.getContentIds()), json);
+    assertTrue(Arrays.equals(new int[] {1, 2}, roundTrip.getAssignmentTypeIds()), json);
+  }
+
+  @Test
+  void publishResponse_serializesWarningMessageNotOptionalBean() {
+    PublishResponse response = new PublishResponse();
+    response.setSiteName("Help");
+    response.setStatus("Completed");
+    response.setDelivered("10");
+    response.setFailures("0");
+    response.setWarningMessage("partial");
+    response.setJobid(42L);
+
+    ObjectMapper responseMapper = new JacksonContextResolver().getContext(PublishResponse.class);
+    String json = responseMapper.writeValueAsString(response);
+    assertTrue(json.contains("\"siteName\""), json);
+    assertTrue(json.contains("Help"), json);
+    assertTrue(json.contains("\"warningMessage\""), json);
+    assertTrue(json.contains("partial"), json);
+    assertTrue(json.contains("\"status\""), json);
+    assertTrue(json.contains("Completed"), json);
+    assertNoOptionalBeanKeys(json);
+
+    PublishResponse roundTrip = responseMapper.readValue(json, PublishResponse.class);
+    assertEquals("Help", roundTrip.getSiteName(), json);
+    assertEquals("partial", roundTrip.getWarningMessage(), json);
+    assertEquals(42L, roundTrip.getJobid(), json);
+  }
+
+  @Test
+  void status_serializesMessageNotOptionalBean() {
+    Status status = new Status(200, "Moved OK");
+
+    ObjectMapper statusMapper = new JacksonContextResolver().getContext(Status.class);
+    String json = statusMapper.writeValueAsString(status);
+    assertTrue(json.contains("\"message\""), json);
+    assertTrue(json.contains("Moved OK"), json);
+    assertTrue(json.contains("\"statusCode\""), json);
+    assertTrue(json.contains("200"), json);
+    assertNoOptionalBeanKeys(json);
+
+    Status roundTrip = statusMapper.readValue(json, Status.class);
+    assertEquals("Moved OK", roundTrip.getMessage(), json);
+    assertEquals(200, roundTrip.getStatusCode(), json);
+  }
+
+  @Test
+  void actionPublishStatusFamily_omitsNullWireFieldsFromJson() {
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    ObjectMapper requestMapper =
+        new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class);
+    String requestJson = requestMapper.writeValueAsString(request);
+    assertFalse(requestJson.contains("\"contentIds\""), requestJson);
+    assertNoOptionalBeanKeys(requestJson);
+
+    PublishResponse response = new PublishResponse();
+    response.setJobid(7L);
+    ObjectMapper responseMapper = new JacksonContextResolver().getContext(PublishResponse.class);
+    String responseJson = responseMapper.writeValueAsString(response);
+    assertTrue(responseJson.contains("\"jobid\"") || responseJson.contains("\"jobId\""), responseJson);
+    assertFalse(responseJson.contains("\"warningMessage\""), responseJson);
+    assertFalse(responseJson.contains("\"siteName\""), responseJson);
+    assertNoOptionalBeanKeys(responseJson);
+
+    Status status = new Status();
+    status.setStatusCode(0);
+    ObjectMapper statusMapper = new JacksonContextResolver().getContext(Status.class);
+    String statusJson = statusMapper.writeValueAsString(status);
+    assertFalse(statusJson.contains("\"message\""), statusJson);
+    assertNoOptionalBeanKeys(statusJson);
   }
 
   private static void assertNoOptionalBeanKeys(String json) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -36,11 +36,17 @@ import com.percussion.rest.assets.BinaryFile;
 import com.percussion.rest.communities.Community;
 import com.percussion.rest.communities.CommunityRole;
 import com.percussion.rest.communities.CommunityVisibility;
+import com.percussion.rest.contentlists.ContentList;
+import com.percussion.rest.contentlists.ContentListList;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.contexts.Context;
 import com.percussion.rest.deliverytypes.DeliveryType;
 import com.percussion.rest.displayformat.DisplayFormatProperty;
+import com.percussion.rest.extensions.Extension;
+import com.percussion.rest.itemfilter.ItemFilter;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinition;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinitionParam;
 import com.percussion.rest.folders.CopyFolderItemRequest;
 import com.percussion.rest.folders.Folder;
 import com.percussion.rest.folders.SectionInfo;
@@ -84,8 +90,9 @@ import tools.jackson.databind.ObjectMapper;
  * Page family follow the same rule (issue #3407). Virtual Site + SiteMap wire DTOs follow the same
  * rule (issue #3411 / #3388). LocationScheme / Context / DeliveryType follow the same
  * plain-getter contract (issue #3412). Folder / Section / path-request DTOs follow the same
- * rule (issue #3413). All use production {@link JacksonContextResolver} under {@code
- * @JsonInclude(NON_NULL)}.
+ * rule (issue #3413). ContentList / ItemFilterRuleDefinitionParam follow the same
+ * plain-getter contract (issue #3431 / #3388). All use production {@link
+ * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -994,6 +1001,161 @@ class JacksonContextResolverOptionalTest {
     assertEquals(1, listRoundTrip.size());
     assertEquals("By_Author ACL", listRoundTrip.get(0).getName());
     assertEquals(3, listRoundTrip.get(0).getAclEntries().size());
+  }
+
+  @Test
+  void contentList_serializesPlainScalarsNotOptionalBeans() {
+    ContentList list = new ContentList();
+    list.setContentListId(new Guid("0-107-42"));
+    list.setVersion(3);
+    list.setName("full_site");
+    list.setDescription("Full site publish list");
+    list.setType("Normal");
+    list.setUrl("/Rhythmyx/contentlist?sys_deliverytype=filesystem");
+    list.setEditionType("Publish");
+
+    Extension generator = new Extension();
+    generator.setExtensionName("sys_SearchGenerator");
+    generator.setFqn("Java/global/percussion/system/sys_SearchGenerator");
+    list.setGenerator(generator);
+
+    ItemFilter filter = new ItemFilter();
+    filter.setName("public");
+    filter.setDescription("Public items");
+    list.setItemFilter(filter);
+
+    ObjectMapper listMapper = new JacksonContextResolver().getContext(ContentList.class);
+    String json = listMapper.writeValueAsString(list);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("full_site"), json);
+    assertTrue(json.contains("\"description\""), json);
+    assertTrue(json.contains("Full site publish list"), json);
+    assertTrue(json.contains("\"url\""), json);
+    assertTrue(json.contains("\"editionType\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("\"itemFilter\""), json);
+    assertTrue(json.contains("public"), json);
+    assertTrue(json.contains("\"generator\""), json);
+    assertTrue(json.contains("sys_SearchGenerator"), json);
+    assertTrue(json.contains("\"contentListId\""), json);
+    assertNoOptionalBeanKeys(json);
+
+    ContentList roundTrip = listMapper.readValue(json, ContentList.class);
+    assertEquals("full_site", roundTrip.getName(), json);
+    assertEquals("Full site publish list", roundTrip.getDescription(), json);
+    assertEquals("Publish", roundTrip.getEditionType(), json);
+    assertEquals(Integer.valueOf(3), roundTrip.getVersion(), json);
+    assertNotNull(roundTrip.getItemFilter(), json);
+    assertEquals("public", roundTrip.getItemFilter().getName(), json);
+    assertNotNull(roundTrip.getGenerator(), json);
+    assertEquals("sys_SearchGenerator", roundTrip.getGenerator().getExtensionName(), json);
+    assertNotNull(roundTrip.getContentListId(), json);
+  }
+
+  @Test
+  void contentList_omitsNullWireFieldsFromJson() {
+    ContentList list = new ContentList();
+    list.setName("incremental");
+    list.setType("Incremental");
+
+    ObjectMapper listMapper = new JacksonContextResolver().getContext(ContentList.class);
+    String json = listMapper.writeValueAsString(list);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("incremental"), json);
+    assertTrue(json.contains("\"type\""), json);
+    assertFalse(json.contains("\"description\""), json);
+    assertFalse(json.contains("\"url\""), json);
+    assertFalse(json.contains("\"contentListId\""), json);
+    assertFalse(json.contains("\"itemFilter\""), json);
+    assertFalse(json.contains("\"generator\""), json);
+    assertFalse(json.contains("\"expander\""), json);
+    assertFalse(json.contains("\"editionType\""), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void contentListList_serializesNamesNotOptionalBeans() {
+    ContentList list = new ContentList();
+    list.setName("full_site");
+    list.setEditionType("Publish");
+    ContentListList lists = new ContentListList(List.of(list));
+
+    ObjectMapper listsMapper = new JacksonContextResolver().getContext(ContentListList.class);
+    String json = listsMapper.writeValueAsString(lists);
+    assertTrue(json.contains("full_site"), json);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("Publish"), json);
+    assertTrue(json.contains("ContentList") || json.startsWith("["), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void itemFilterRuleDefinitionParam_serializesNameValueNotOptionalBeans() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName("sys_authType");
+    param.setValue("1");
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(ItemFilterRuleDefinitionParam.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("sys_authType"), json);
+    assertTrue(json.contains("\"value\""), json);
+    assertTrue(json.contains("1"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ItemFilterRuleDefinitionParam roundTrip =
+        paramMapper.readValue(json, ItemFilterRuleDefinitionParam.class);
+    assertEquals("sys_authType", roundTrip.getName(), json);
+    assertEquals("1", roundTrip.getValue(), json);
+  }
+
+  @Test
+  void itemFilterRuleDefinitionParam_omitsNullWireFieldsFromJson() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName(null);
+    param.setValue(null);
+
+    ObjectMapper paramMapper =
+        new JacksonContextResolver().getContext(ItemFilterRuleDefinitionParam.class);
+    String json = paramMapper.writeValueAsString(param);
+    assertFalse(json.contains("\"name\""), json);
+    assertFalse(json.contains("\"value\""), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void itemFilterRuleDefinition_serializesNestedParamsNotOptionalBeans() {
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName("folderId");
+    param.setValue("301");
+
+    ItemFilterRuleDefinition rule = new ItemFilterRuleDefinition();
+    rule.setName("sys_FolderFilter");
+    rule.setParams(List.of(param));
+
+    ItemFilter filter = new ItemFilter();
+    filter.setName("site_folder");
+    filter.setDescription("Site folder filter");
+    filter.setRules(java.util.Set.of(rule));
+
+    ObjectMapper filterMapper = new JacksonContextResolver().getContext(ItemFilter.class);
+    String json = filterMapper.writeValueAsString(filter);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("site_folder"), json);
+    assertTrue(json.contains("sys_FolderFilter"), json);
+    assertTrue(json.contains("folderId"), json);
+    assertTrue(json.contains("301"), json);
+    assertNoOptionalBeanKeys(json);
+
+    ItemFilter roundTrip = filterMapper.readValue(json, ItemFilter.class);
+    assertEquals("site_folder", roundTrip.getName(), json);
+    assertNotNull(roundTrip.getRules(), json);
+    assertEquals(1, roundTrip.getRules().size(), json);
+    ItemFilterRuleDefinition ruleRoundTrip = roundTrip.getRules().iterator().next();
+    assertEquals("sys_FolderFilter", ruleRoundTrip.getName(), json);
+    assertEquals("folderId", ruleRoundTrip.getParams().get(0).getName(), json);
+    assertEquals("301", ruleRoundTrip.getParams().get(0).getValue(), json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -4,11 +4,13 @@
 
 package com.percussion.rest.actions;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -100,5 +103,35 @@ public class ActionMenuResourceTest {
         assertThrows(WebApplicationException.class, () -> bare.getActionMenu("x"));
     assertEquals(500, getEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, getEx.getCause());
+  }
+
+  @Test
+  public void getAllowedContentTypeMenusPassesContentIdsArray() {
+    ActionMenu menu = new ActionMenu();
+    menu.setName("New");
+    when(adaptor.findAllowedContentTypes(any())).thenReturn(List.of(menu));
+
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {101, 102});
+    ActionMenuList out = resource.getAllowedContentTypeMenus(request);
+
+    assertEquals(1, out.size());
+    assertEquals("New", out.get(0).getName());
+    ArgumentCaptor<Integer[]> captor = ArgumentCaptor.forClass(Integer[].class);
+    verify(adaptor).findAllowedContentTypes(captor.capture());
+    assertArrayEquals(new Integer[] {101, 102}, captor.getValue());
+  }
+
+  @Test
+  public void getAllowedContentTypeMenusTreatsNullContentIdsAsEmpty() {
+    when(adaptor.findAllowedContentTypes(any())).thenReturn(List.of());
+
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    ActionMenuList out = resource.getAllowedContentTypeMenus(request);
+
+    assertTrue(out.isEmpty());
+    ArgumentCaptor<Integer[]> captor = ArgumentCaptor.forClass(Integer[].class);
+    verify(adaptor).findAllowedContentTypes(captor.capture());
+    assertArrayEquals(new Integer[0], captor.getValue());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/errors/RestExceptionMapperTest.java
+++ b/rest/src/test/java/com/percussion/rest/errors/RestExceptionMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Maps {@link RestExceptionBase} to {@link RestError} with nullable {@code errorData} (issue
+ * #3430).
+ */
+class RestExceptionMapperTest {
+
+  private RestExceptionMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new RestExceptionMapper();
+  }
+
+  @Test
+  void mapsErrorDataAsScalarNotOptional() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.FOLDER_NOT_FOUND,
+            "Folder missing",
+            "path=/a",
+            "folder-id-9",
+            Response.Status.NOT_FOUND);
+
+    Response response = mapper.toResponse(ex);
+
+    assertEquals(404, response.getStatus());
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertEquals(RestErrorCode.FOLDER_NOT_FOUND.getNumVal(), body.getErrorCode());
+    assertEquals("Folder missing", body.getMessage());
+    assertEquals("path=/a", body.getDetailMessage());
+    assertEquals("folder-id-9", body.getErrorData());
+  }
+
+  @Test
+  void mapsNullErrorDataAsNull() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.OTHER, "boom", null, null, Response.Status.INTERNAL_SERVER_ERROR);
+
+    Response response = mapper.toResponse(ex);
+
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertNull(body.getErrorData());
+    assertEquals("boom", body.getMessage());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/errors/WebApplicationExceptionMapperTest.java
+++ b/rest/src/test/java/com/percussion/rest/errors/WebApplicationExceptionMapperTest.java
@@ -20,6 +20,7 @@ package com.percussion.rest.errors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -138,6 +139,24 @@ class WebApplicationExceptionMapperTest {
     assertEquals("RestExceptionBase", body.getErrorType());
     assertEquals("Folder missing", body.getMessage());
     assertEquals("path=/a", body.getDetailMessage());
+    assertNull(body.getErrorData());
+  }
+
+  @Test
+  void restExceptionBaseErrorDataIsScalarNotOptional() {
+    RestExceptionBase ex =
+        new RestExceptionBase(
+            RestErrorCode.FOLDER_NOT_FOUND,
+            "Folder missing",
+            "path=/a",
+            "folder-id-9",
+            Response.Status.NOT_FOUND);
+
+    Response response = mapper.toResponse(ex);
+
+    RestError body = assertInstanceOf(RestError.class, response.getEntity());
+    assertEquals("folder-id-9", body.getErrorData());
+    assertEquals("Folder missing", body.getMessage());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/folders/FoldersTest.java
+++ b/rest/src/test/java/com/percussion/rest/folders/FoldersTest.java
@@ -53,7 +53,7 @@ public class FoldersTest {
   void moveFolderItem_callsAdaptor() throws Exception {
     MoveFolderItem req = new MoveFolderItem("/a/b", "/a/c");
     Status result = resource.moveFolderItem(req);
-    assertEquals("Moved OK", result.getMessage().orElse(null));
+    assertEquals("Moved OK", result.getMessage());
     verify(adaptor).moveFolderItem(uriInfo.getBaseUri(), "/a/b", "/a/c");
   }
 
@@ -70,7 +70,7 @@ public class FoldersTest {
   void moveFolder_callsAdaptor() throws Exception {
     MoveFolderItem req = new MoveFolderItem("/a/b", "/a/c");
     Status result = resource.moveFolder(req);
-    assertEquals("Moved OK", result.getMessage().orElse(null));
+    assertEquals("Moved OK", result.getMessage());
     verify(adaptor).moveFolderItem(uriInfo.getBaseUri(), "/a/b", "/a/c");
   }
 

--- a/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
+++ b/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
@@ -153,7 +153,7 @@ public class PagesTest {
     doNothing().when(adaptor).deletePage(any(), eq("sitea"), eq("path1"), eq("page1.html"));
 
     var status = resource.deletePage("Sites/sitea/path1/page1.html");
-    assertEquals("Deleted", status.getMessage().orElse(null));
+    assertEquals("Deleted", status.getMessage());
     verify(adaptor).deletePage(uriInfo.getBaseUri(), "sitea", "path1", "page1.html");
   }
 


### PR DESCRIPTION
## Summary

Overnight cluster absorb of three owned `fix/issue-` PRs that all append production-mapper coverage to the same file (`rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java`). Sequential merge of #3433 then #3434 then #3435 would dirty that test file on every later PR; this union keeps every DTO conversion plus every mapper test.

**Thrash file:** `rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java`

Union semantics: javadoc lists #3431 / #3432 / #3430; imports and `@Test` methods from all three heads kept. Production DTO files do not overlap.

Parent epic: Partial #3388. Individual issues: Fixes #3431, Fixes #3432, Fixes #3430.

Do **not** merge the superseded PRs.

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #3433 | `fix/issue-3431-contentlist-itemfilter-wire-getters` | yes | ContentList / ItemFilterRuleDefinitionParam plain getters |
| yes | #3434 | `fix/issue-3432-action-publish-status-wire-getters` | yes | Action-menu requests + PublishResponse / Status |
| yes | #3435 | `fix/issue-3430-optional-wire-getters-rest` | yes | ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError |

## modules_built

`rest`, `projects/sitemanage`

## build_evidence

```
cd rest && ../mvnw.cmd clean install
→ BUILD SUCCESS; Tests run: 482, Failures: 0, Errors: 0, Skipped: 0
  JacksonContextResolverOptionalTest Tests run: 54, Failures: 0

cd projects/sitemanage && ../../mvnw.cmd clean install
→ BUILD SUCCESS; Tests run: 1238, Failures: 0, Errors: 0, Skipped: 125
```

C2 reverse-dep: public getter signatures changed (`Optional<T>` → nullable `T`). Known reverse-dep `projects/sitemanage` standalone clean install green (ExtensionAdaptor / FolderAdaptor included).

No new warnings attributable to this union (baseline javadoc/dependency-analyze only).

## Test plan

1. Review union of `JacksonContextResolverOptionalTest` — all three issue groups present, no leftover conflict markers.
2. Confirm superseded PRs #3433 #3434 #3435 are closed with a pointer here.
3. Human review only — do not merge this cluster automatically.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal REST DTO wire-getter convention; no operator/WebUI/installer procedure change
- [x] **Unit / module tests** — union mapper tests + module clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — standalone clean install `rest` then `projects/sitemanage`; reverse-dep sitemanage green
- [x] **Cross-platform** — **N/A** (no path/file I/O)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs-cluster.
