### PR TITLE
feat(explorer): dispatch server actions instead of Data Flow HTML

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/assemblyApi.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Assembly preview-location client for Explorer template preview.
+ *
+ * <p>Server: {@code GET /services/assembly/preview-location} ({@code rest}
+ * {@code AssemblyResource}). Replaces Data Flow {@code previewslotvariant}
+ * HTML redirects.</p>
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+
+export interface PreviewLocation {
+  previewUrl: string;
+  contentId: number;
+  templateId: number;
+  revision: number;
+}
+
+function unwrapPreviewLocation(payload: unknown): PreviewLocation | null {
+  if (payload == null || typeof payload !== "object") {
+    return null;
+  }
+  const obj = payload as Record<string, unknown>;
+  const inner =
+    obj.PreviewLocation && typeof obj.PreviewLocation === "object"
+      ? (obj.PreviewLocation as Record<string, unknown>)
+      : obj;
+  const previewUrl = inner.previewUrl ?? inner.PreviewUrl;
+  const contentId = inner.contentId ?? inner.ContentId;
+  const templateId = inner.templateId ?? inner.TemplateId;
+  const revision = inner.revision ?? inner.Revision;
+  if (typeof previewUrl !== "string" || !previewUrl.trim()) {
+    return null;
+  }
+  return {
+    previewUrl: previewUrl.trim(),
+    contentId: Number(contentId) || 0,
+    templateId: Number(templateId) || 0,
+    revision: Number(revision) || 0,
+  };
+}
+
+export async function fetchPreviewLocation(
+  contentId: number,
+  templateId: number,
+  revision?: number,
+): Promise<PreviewLocation> {
+  const q = new URLSearchParams();
+  q.set("contentId", String(contentId));
+  q.set("templateId", String(templateId));
+  if (revision != null && revision > 0) {
+    q.set("revision", String(revision));
+  }
+  const res = await get<unknown>(`${PATHS.ASSEMBLY_PREVIEW_LOCATION}?${q.toString()}`);
+  const loc = unwrapPreviewLocation(res);
+  if (loc == null) {
+    throw new Error("Preview location was empty");
+  }
+  return loc;
+}

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -89,6 +89,14 @@ export const PATHS = {
   get PAGE_COPY() {
     return `${SERVICES_ROOT}/pagemanagement/page/copy`;
   },
+  /** Permanent page purge (`DELETE …/pagemanagement/page/purge/{id}`). */
+  get PAGE_PURGE() {
+    return `${SERVICES_ROOT}/pagemanagement/page/purge`;
+  },
+  /** Permanent asset purge (`DELETE …/assetmanagement/asset/purge/{id}`). */
+  get ASSET_PURGE() {
+    return `${SERVICES_ROOT}/assetmanagement/asset/purge`;
+  },
   /**
    * Asset read-only view URL lookup (legacy {@code ASSET_VIEW_URL_FOR_ASSET_ID}).
    * Append {@code /{id}}; response is plain text URL.
@@ -405,6 +413,13 @@ export const PATHS = {
   /** Action menu (US3) — see capability-matrix.md P-Menu. */
   get ACTIONS_ROOT() {
     return `${SERVICES_ROOT}/actions`;
+  },
+  /**
+   * Assembly preview location (Explorer template preview).
+   * {@code GET ?contentId=&templateId=&revision=}
+   */
+  get ASSEMBLY_PREVIEW_LOCATION() {
+    return `${SERVICES_ROOT}/assembly/preview-location`;
   },
   /**
    * Public REST content type catalog ({@code rest} module ContentTypesResource).

--- a/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
@@ -23,8 +23,8 @@
  * opens a nested dropdown instead of dumping every child as a flat
  * button (#2730 / #2731). The Workflow group (#2732) is a special case:
  * it renders as a labeled button group so each transition is one-click
- * invokable. Server-provided URLs navigate; otherwise the action is
- * delegated to {@link ActionToolbarProps.onInvoke}.</p>
+ * invokable. Activation always goes to {@link ActionToolbarProps.onInvoke};
+ * the host dispatcher executes REST / React handlers.</p>
  *
  * <p>Toolbar refreshes when the {@link ActionToolbarProps.actions} prop
  * changes (e.g. on selection change the parent fetches the allowed
@@ -35,7 +35,6 @@
 import React, { useEffect, useId, useRef, useState } from "react";
 import type { MenuAction } from "../api/contentExplorer/types";
 import { message } from "../i18n/message";
-import { safeNavigate } from "../util/safeNavigate";
 import { WORKFLOW_MENU_NAME } from "./workflowMenuActions";
 
 export interface ActionToolbarProps {
@@ -113,21 +112,9 @@ function hasChildren(action: MenuAction): boolean {
 
 function activate(
   action: MenuAction,
-  baseHref: string,
+  _baseHref: string,
   onInvoke?: (name: string, a: MenuAction) => void,
 ): void {
-  if (action.url) {
-    const result = safeNavigate(action.url, baseHref);
-    if (!result.ok) {
-      // eslint-disable-next-line no-console -- surface rejection for ops
-      console.warn(
-        `[ActionToolbar] rejected action "${action.name}" url "${result.href}" reason="${result.reason}"`,
-      );
-      onInvoke?.(action.name, action);
-      return;
-    }
-    return;
-  }
   onInvoke?.(action.name, action);
 }
 

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -714,6 +714,8 @@ function ContentExplorerShellInner({
             },
             confirm: (body) => window.confirm(message(body)),
             runWorkflow: runWorkflowTransition,
+            onShowTranslations: () => setShowTranslations(true),
+            onShowDependencies: () => setShowDependencies(true),
           });
           if (result.messageKey) {
             setError(message(result.messageKey));

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -67,6 +67,7 @@ import type {
 import { useSpaBootstrapOptional } from "../app/bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "../app/bootstrap/types";
 import { message } from "../i18n/message";
+import { dispatchAction, purgeSelectedItem } from "./actionDispatch";
 import {
   filterContextMenuActions,
   filterToolbarActions,
@@ -123,7 +124,6 @@ import type { PSNodeRelationshipSummary } from "../api/contentExplorer/relations
 import {
   buildWorkflowTransitionMenu,
   mergeWorkflowMenuActions,
-  parseWorkflowTransitionTrigger,
 } from "./workflowMenuActions";
 
 export interface ContentExplorerShellProps {
@@ -694,41 +694,46 @@ function ContentExplorerShellInner({
   );
 
   /**
-   * Route toolbar / context-menu activations. Workflow transition names are
-   * client-tagged ({@code workflow-transition:Trigger}); other actions fall
-   * through to list refresh (URL actions already navigated in the child).
+   * Route toolbar / context-menu activations through the action dispatcher.
+   * Data Flow HTML URLs are never navigated (they 404 from the SPA).
    */
   const handleMenuInvoke = useCallback(
-    (actionName: string, _action: MenuAction) => {
-      const trigger = parseWorkflowTransitionTrigger(actionName);
-      if (trigger != null) {
-        const item = selection.item;
-        const itemId =
-          item?.id != null && isWorkflowEligibleItem(item)
-            ? String(item.id)
-            : "";
-        if (!itemId) {
-          setError(message(EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED));
-          return;
-        }
-        void (async () => {
-          try {
-            await runWorkflowTransition(itemId, trigger);
+    (actionName: string, action: MenuAction) => {
+      void (async () => {
+        try {
+          const result = await dispatchAction(action, {
+            item: selection.item,
+            folderPath: selection.folderPath,
+            onOpen: handlers.onOpen,
+            onPreview: handlers.onPreview,
+            onPurge: async (item) => {
+              const ok = await purgeSelectedItem(item);
+              if (!ok) {
+                throw new Error(message(EXPLORER_MSG.ACTION_UNAVAILABLE));
+              }
+            },
+            confirm: (body) => window.confirm(message(body)),
+            runWorkflow: runWorkflowTransition,
+          });
+          if (result.messageKey) {
+            setError(message(result.messageKey));
+          } else {
             setError(null);
-            setListEpoch((n) => n + 1);
-          } catch (err: unknown) {
-            const detail =
-              err instanceof Error && err.message
-                ? err.message
-                : message(EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED);
-            setError(detail);
           }
-        })();
-        return;
-      }
-      setListEpoch((n) => n + 1);
+          if (result.refresh) {
+            setListEpoch((n) => n + 1);
+          }
+        } catch (err: unknown) {
+          const detail =
+            err instanceof Error && err.message
+              ? err.message
+              : message(EXPLORER_MSG.ERROR_GENERIC);
+          setError(detail);
+        }
+      })();
+      void actionName;
     },
-    [selection.item, runWorkflowTransition],
+    [selection.item, selection.folderPath, handlers, runWorkflowTransition],
   );
 
   const handleSearchOpen = useCallback((result: PSItemProperties) => {

--- a/WebUI/src/main/ts/contentExplorer/ContextMenu.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContextMenu.tsx
@@ -20,12 +20,9 @@
  * <p>Renders the configuration-driven action set returned by
  * {@code /actions/find*} as a keyboard-accessible menu attached to the
  * currently-selected item. Click <em>and</em> Enter / Space all
- * activate the focused menu item; Escape closes the menu. Server-provided
- * URLs are navigated to via the {@code safeNavigate} protocol /
- * same-origin guard (closes the {@code javascript:} XSS vector flagged
- * by kilo-code-bot on PR #1396); rejected URLs surface a console
- * warning and fall back to the {@link ContextMenuProps.onInvoke}
- * callback so the host can react.</p>
+ * activate the focused menu item; Escape closes the menu. Activation
+ * always goes to {@link ContextMenuProps.onInvoke}; the host dispatcher
+ * executes the action (Data Flow HTML URLs 404 from the SPA).</p>
  *
  * <p>Server is authoritative: actions not in the supplied list are
  * hidden (FR-011). Action execution is the host's responsibility — this
@@ -34,7 +31,6 @@
 
 import React, { useEffect, useId, useState } from "react";
 import type { MenuAction } from "../api/contentExplorer/types";
-import { safeNavigate } from "../util/safeNavigate";
 
 export interface ContextMenuProps {
   /** Server-provided menu actions (already filtered for the current selection). */
@@ -60,21 +56,9 @@ const ACTIVATE_KEYS = new Set(["Enter", " "]);
 
 function activate(
   action: MenuAction,
-  baseHref: string,
+  _baseHref: string,
   onInvoke?: (name: string, a: MenuAction) => void,
 ): void {
-  if (action.url) {
-    const result = safeNavigate(action.url, baseHref);
-    if (!result.ok) {
-      // eslint-disable-next-line no-console -- surface rejection for ops
-      console.warn(
-        `[ContextMenu] rejected action "${action.name}" url "${result.href}" reason="${result.reason}"`,
-      );
-      onInvoke?.(action.name, action);
-      return;
-    }
-    return;
-  }
   onInvoke?.(action.name, action);
 }
 

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer server-action dispatcher. Presentation never navigates to Data
+ * Flow (legacy XML application) URLs — those 404 from the SPA.
+ *
+ * @see specs/992-react-content-explorer/contracts/action-execution.md
+ */
+
+import { fetchPreviewLocation } from "../api/contentExplorer/assemblyApi";
+import { del } from "../api/client";
+import { PATHS } from "../api/paths";
+import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
+import { classifyUrl, safeNavigate } from "../util/safeNavigate";
+import { parseExplorerContentId } from "./menuCatalogLoad";
+import { EXPLORER_MSG } from "./messages";
+import { openPreviewItem, resolvePreviewKind } from "./previewItem";
+import { isFolder } from "./selection";
+import { parseWorkflowTransitionTrigger } from "./workflowMenuActions";
+
+export type ActionKind =
+  | "client"
+  | "rest"
+  | "editor"
+  | "unavailable"
+  | "legacy-file"
+  | "workflow";
+
+const EDITOR_NAMES = new Set([
+  "edit",
+  "edit_content",
+  "edit_properties",
+  "quick_edit",
+  "view_content",
+  "view_properties",
+  "revision_viewcontent",
+  "revision_viewproperties",
+  "revision_promote",
+]);
+
+const PREVIEW_PARENT_NAMES = new Set([
+  "item_preview",
+  "enterprise_preview",
+  "corporate_preview",
+  "slot_item_preview",
+  "slot_item_enterprise_preview",
+  "slot_item_corporate_preview",
+]);
+
+const AA_UNAVAILABLE_NAMES = new Set([
+  "item_activeassembly",
+  "enterpriseitem_activeassembly",
+  "corporateitem_activeassembly",
+  "item_assembly",
+  "aa_table_editor",
+  "slot_add",
+  "slot_create",
+  "arrange",
+  "arrange_moveupleft",
+  "arrange_movedownright",
+  "arrange_changetemplateslot",
+  "arrange_remove",
+  "change_template",
+  "paste_as_link_to_slot",
+  "move_to_slot",
+]);
+
+const P1_UNAVAILABLE_NAMES = new Set([
+  "translate",
+  "item_viewdependents",
+  "flush_cache",
+  "navreset",
+  "workflow_newversion",
+  "edit_promotableversion",
+  "workflow_revisions",
+  "workflow_audittrail",
+  "copy_url_to_clipboard",
+]);
+
+const DATA_FLOW_PATH_MARKERS = [
+  "sys_cxsupport",
+  "sys_action",
+  "sys_cesupport",
+  "sys_rcsupport",
+  "sys_cx/",
+  "sys_cx?",
+  "sys_compare",
+  "sys_cxitemassembly",
+  "sys_cxdependencytree",
+  "sys_uisupport",
+  "sys_actiontranslate",
+  "rxs_navsupport",
+  "sys_cmp",
+];
+
+/** Content Editor XML apps used as New Item / Edit URLs (P3 — do not navigate). */
+const CONTENT_EDITOR_PATH_MARKERS = [
+  "rx_ce",
+  "psx_ce",
+  "sys_ce/",
+  "contenteditorurls",
+  "checkoutedit",
+  "checkoutaapage",
+  "checkoutaadoc",
+];
+
+export interface ActionDispatchContext {
+  item: PSPathItem | null;
+  folderPath?: string | null;
+  onOpen?: (item: PSPathItem) => void;
+  onPreview?: (item: PSPathItem) => void | Promise<void>;
+  onPurge?: (item: PSPathItem) => Promise<void>;
+  confirm?: (body: string) => boolean;
+  openWindow?: (url: string, target?: string, features?: string) => Window | null;
+  fetchPreview?: typeof fetchPreviewLocation;
+  runWorkflow?: (itemId: string, trigger: string) => Promise<void>;
+}
+
+export interface ActionDispatchResult {
+  kind: ActionKind;
+  messageKey?: string;
+  refresh?: boolean;
+}
+
+export function normalizeActionName(name: string | undefined | null): string {
+  return (name ?? "").replace(/[\s-]/g, "_").toLowerCase();
+}
+
+export function isDataFlowActionUrl(url: string | undefined | null): boolean {
+  if (url == null) {
+    return false;
+  }
+  const u = url.trim().toLowerCase().replace(/\\/g, "/");
+  if (!u) {
+    return false;
+  }
+  return DATA_FLOW_PATH_MARKERS.some((m) => u.includes(m));
+}
+
+export function isContentEditorActionUrl(url: string | undefined | null): boolean {
+  if (url == null) {
+    return false;
+  }
+  const u = url.trim().toLowerCase().replace(/\\/g, "/");
+  if (!u) {
+    return false;
+  }
+  return CONTENT_EDITOR_PATH_MARKERS.some((m) => u.includes(m));
+}
+
+export function isAssemblerPreviewUrl(url: string | undefined | null): boolean {
+  if (url == null) {
+    return false;
+  }
+  const u = url.trim().toLowerCase().replace(/\\/g, "/");
+  return u.includes("assembler/render") || u.includes("previewslotvariant");
+}
+
+export function classifyAction(action: MenuAction): ActionKind {
+  const name = normalizeActionName(action.name);
+  if (parseWorkflowTransitionTrigger(action.name) != null) {
+    return "workflow";
+  }
+  if (EDITOR_NAMES.has(name) || isContentEditorActionUrl(action.url)) {
+    return "editor";
+  }
+  if (AA_UNAVAILABLE_NAMES.has(name) || P1_UNAVAILABLE_NAMES.has(name)) {
+    return "unavailable";
+  }
+  if (name === "lifecycle_analysis") {
+    return "legacy-file";
+  }
+  if (isAssemblerPreviewUrl(action.url) || PREVIEW_PARENT_NAMES.has(name)) {
+    return "rest";
+  }
+  if (name === "purge") {
+    return "rest";
+  }
+  if (name === "publish_now" || name === "create_new_item") {
+    return "unavailable";
+  }
+  if (isDataFlowActionUrl(action.url)) {
+    return "unavailable";
+  }
+  if (name === "open" || name === "refresh" || name === "delete") {
+    return "client";
+  }
+  if (action.url && !isDataFlowActionUrl(action.url) && !isAssemblerPreviewUrl(action.url)) {
+    return "legacy-file";
+  }
+  return "client";
+}
+
+export function parseTemplateIdFromAction(action: MenuAction): number | null {
+  const params = action.parameters ?? [];
+  for (const p of params) {
+    const n = (p.name ?? "").toLowerCase();
+    if (n === "sys_template" || n === "templateid" || n === "sys_variantid") {
+      const id = Number(p.value);
+      if (Number.isFinite(id) && id > 0) {
+        return id;
+      }
+    }
+  }
+  const url = action.url ?? "";
+  try {
+    const q = new URL(url, "http://localhost/").searchParams;
+    const raw = q.get("sys_template") ?? q.get("templateId") ?? q.get("sys_variantid");
+    const id = raw != null ? Number(raw) : NaN;
+    if (Number.isFinite(id) && id > 0) {
+      return id;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function resolvePreviewHref(previewUrl: string): string {
+  const trimmed = previewUrl.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  const path = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  if (typeof window === "undefined") {
+    return path;
+  }
+  const locPath = window.location?.pathname ?? "";
+  if (
+    (locPath === "/Rhythmyx" || locPath.startsWith("/Rhythmyx/")) &&
+    !path.startsWith("/Rhythmyx/")
+  ) {
+    return `/Rhythmyx${path}`;
+  }
+  return path;
+}
+
+/**
+ * Permanent purge for a page or asset. Other types return false so the
+ * dispatcher can show {@link EXPLORER_MSG.ACTION_UNAVAILABLE}.
+ */
+export async function purgeSelectedItem(item: PSPathItem): Promise<boolean> {
+  const id = (item.id ?? "").trim();
+  if (!id) {
+    return false;
+  }
+  const kind = resolvePreviewKind(item);
+  if (kind === "page") {
+    await del<void>(`${PATHS.PAGE_PURGE}/${encodeURIComponent(id)}`);
+    return true;
+  }
+  if (kind === "asset") {
+    await del<void>(`${PATHS.ASSET_PURGE}/${encodeURIComponent(id)}`);
+    return true;
+  }
+  return false;
+}
+
+function defaultOpenWindow(
+  url: string,
+  target?: string,
+  features?: string,
+): Window | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.open(url, target ?? "_blank", features ?? "noopener,noreferrer");
+}
+
+export async function dispatchAction(
+  action: MenuAction,
+  ctx: ActionDispatchContext,
+): Promise<ActionDispatchResult> {
+  const kind = classifyAction(action);
+  const item = ctx.item;
+
+  if (kind === "workflow") {
+    const trigger = parseWorkflowTransitionTrigger(action.name);
+    if (trigger == null || !item?.id) {
+      return { kind, messageKey: EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED };
+    }
+    if (ctx.runWorkflow) {
+      await ctx.runWorkflow(String(item.id), trigger);
+    }
+    return { kind, refresh: true };
+  }
+
+  if (kind === "editor") {
+    return { kind, messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+  }
+
+  if (kind === "unavailable") {
+    return { kind, messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+  }
+
+  if (kind === "legacy-file" && action.url) {
+    const base =
+      typeof window !== "undefined" ? window.location.href : "http://localhost/";
+    if (isDataFlowActionUrl(action.url) || isAssemblerPreviewUrl(action.url)) {
+      return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+    }
+    const classified = classifyUrl(action.url, base);
+    if (isContentEditorActionUrl(action.url)) {
+      return { kind: "editor", messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+    }
+    if (classified.ok) {
+      safeNavigate(action.url, base);
+    }
+    return { kind };
+  }
+
+  const name = normalizeActionName(action.name);
+
+  if (name === "open" && item && ctx.onOpen) {
+    ctx.onOpen(item);
+    return { kind: "client" };
+  }
+
+  if (name === "purge") {
+    if (!item || isFolder(item)) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    const ok = (ctx.confirm ?? ((b) => window.confirm(b)))(
+      // TMX key string is the confirm body (message() applied by caller if needed)
+      EXPLORER_MSG.CONFIRM_PURGE_BODY,
+    );
+    if (!ok) {
+      return { kind: "rest" };
+    }
+    if (ctx.onPurge) {
+      await ctx.onPurge(item);
+      return { kind: "rest", refresh: true };
+    }
+    const purged = await purgeSelectedItem(item);
+    if (!purged) {
+      return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+    }
+    return { kind: "rest", refresh: true };
+  }
+
+  if (name === "publish_now" || name === "create_new_item") {
+    return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+  }
+
+  const templateId = parseTemplateIdFromAction(action);
+  if (templateId != null && item && !isFolder(item)) {
+    const contentId = parseExplorerContentId(item.id);
+    if (contentId == null) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.PREVIEW_UNAVAILABLE };
+    }
+    const fetchLoc = ctx.fetchPreview ?? fetchPreviewLocation;
+    const loc = await fetchLoc(contentId, templateId);
+    const href = resolvePreviewHref(loc.previewUrl);
+    if (!href.toLowerCase().includes("/assembler/render")) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.PREVIEW_UNAVAILABLE };
+    }
+    const open = ctx.openWindow ?? defaultOpenWindow;
+    open(href, `percTemplatePreview_${contentId}`);
+    return { kind: "rest" };
+  }
+
+  if (PREVIEW_PARENT_NAMES.has(name) || name === "preview") {
+    if (!item || isFolder(item)) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.PREVIEW_UNAVAILABLE };
+    }
+    const preview = ctx.onPreview ?? openPreviewItem;
+    await Promise.resolve(preview(item));
+    return { kind: "rest" };
+  }
+
+  if (isDataFlowActionUrl(action.url) || isAssemblerPreviewUrl(action.url)) {
+    return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+  }
+
+  return { kind: "client" };
+}

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -29,7 +29,12 @@ import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { classifyUrl, safeNavigate } from "../util/safeNavigate";
 import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
-import { openPreviewItem, resolvePreviewKind } from "./previewItem";
+import {
+  buildSitePathPreviewUrl,
+  normalizeCmsPath,
+  openPreviewItem,
+  resolvePreviewKind,
+} from "./previewItem";
 import { isFolder } from "./selection";
 import { parseWorkflowTransitionTrigger } from "./workflowMenuActions";
 
@@ -80,16 +85,15 @@ const AA_UNAVAILABLE_NAMES = new Set([
   "move_to_slot",
 ]);
 
+const P1_PANEL_NAMES = new Set(["translate", "item_viewdependents"]);
+
 const P1_UNAVAILABLE_NAMES = new Set([
-  "translate",
-  "item_viewdependents",
   "flush_cache",
   "navreset",
   "workflow_newversion",
   "edit_promotableversion",
   "workflow_revisions",
   "workflow_audittrail",
-  "copy_url_to_clipboard",
 ]);
 
 const DATA_FLOW_PATH_MARKERS = [
@@ -125,6 +129,9 @@ export interface ActionDispatchContext {
   onOpen?: (item: PSPathItem) => void;
   onPreview?: (item: PSPathItem) => void | Promise<void>;
   onPurge?: (item: PSPathItem) => Promise<void>;
+  onShowTranslations?: () => void;
+  onShowDependencies?: () => void;
+  writeClipboard?: (text: string) => Promise<void>;
   confirm?: (body: string) => boolean;
   openWindow?: (url: string, target?: string, features?: string) => Window | null;
   fetchPreview?: typeof fetchPreviewLocation;
@@ -182,6 +189,9 @@ export function classifyAction(action: MenuAction): ActionKind {
   if (AA_UNAVAILABLE_NAMES.has(name) || P1_UNAVAILABLE_NAMES.has(name)) {
     return "unavailable";
   }
+  if (P1_PANEL_NAMES.has(name) || name === "copy_url_to_clipboard") {
+    return "client";
+  }
   if (name === "lifecycle_analysis") {
     return "legacy-file";
   }
@@ -229,6 +239,15 @@ export function parseTemplateIdFromAction(action: MenuAction): number | null {
     /* ignore */
   }
   return null;
+}
+
+/** CMS path or site-preview URL suitable for Copy URL to Clipboard. */
+export function resolveCopyableItemUrl(item: PSPathItem): string {
+  const site = buildSitePathPreviewUrl(item.path);
+  if (site) {
+    return site;
+  }
+  return normalizeCmsPath(item.path);
 }
 
 function resolvePreviewHref(previewUrl: string): string {
@@ -328,6 +347,46 @@ export async function dispatchAction(
 
   if (name === "open" && item && ctx.onOpen) {
     ctx.onOpen(item);
+    return { kind: "client" };
+  }
+
+  if (name === "translate") {
+    if (!item || isFolder(item) || parseExplorerContentId(item.id) == null) {
+      return { kind: "client", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    ctx.onShowTranslations?.();
+    return { kind: "client" };
+  }
+
+  if (name === "item_viewdependents") {
+    if (!item || isFolder(item) || parseExplorerContentId(item.id) == null) {
+      return { kind: "client", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    ctx.onShowDependencies?.();
+    return { kind: "client" };
+  }
+
+  if (name === "copy_url_to_clipboard") {
+    if (!item || isFolder(item)) {
+      return { kind: "client", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    const url = resolveCopyableItemUrl(item);
+    if (!url) {
+      return { kind: "client", messageKey: EXPLORER_MSG.ACTION_COPY_URL_EMPTY };
+    }
+    const write =
+      ctx.writeClipboard ??
+      (async (text: string) => {
+        if (typeof navigator === "undefined" || !navigator.clipboard) {
+          throw new Error("clipboard");
+        }
+        await navigator.clipboard.writeText(text);
+      });
+    try {
+      await write(url);
+    } catch {
+      return { kind: "client", messageKey: EXPLORER_MSG.ACTION_COPY_URL_FAILED };
+    }
     return { kind: "client" };
   }
 

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -28,6 +28,7 @@
 import {
   findActions,
   findAllowedContentTypeMenus,
+  findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
 } from "../api/contentExplorer/actionMenuApi";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
@@ -39,8 +40,24 @@ export function parseExplorerContentId(
   if (id == null || id === "") {
     return null;
   }
-  const n = Number(id);
-  return Number.isFinite(n) ? n : null;
+  if (typeof id === "number") {
+    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
+  }
+  const s = String(id).trim();
+  if (!s) {
+    return null;
+  }
+  const whole = Number(s);
+  if (Number.isFinite(whole) && whole > 0) {
+    return Math.trunc(whole);
+  }
+  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
+  const last = s.split("-").pop();
+  if (!last) {
+    return null;
+  }
+  const n = Number(last);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
 }
 
 function isCascadeParent(action: MenuAction): boolean {
@@ -71,6 +88,17 @@ export const NEW_ITEM_HOST_PREFERRED_KEYS: readonly string[] = [
   "contenttypes",
   "content",
   "create",
+  "create_new_item",
+  "createnewitem",
+];
+
+/** Normalized names of Preview MENU parents that host template children. */
+export const PREVIEW_HOST_PREFERRED_KEYS: readonly string[] = [
+  "itempreview",
+  "enterprisepreview",
+  "corporatepreview",
+  "preview",
+  "slotitempreview",
 ];
 
 const NEW_ITEM_HOST_LABEL = /new|create/i;
@@ -146,6 +174,55 @@ export function mergeContentTypeMenusIntoCatalog(
   return extraParents.length > 0 ? [...out, ...extraParents] : out;
 }
 
+function findPreviewHost(tree: MenuAction[]): MenuAction | null {
+  const stack = [...tree];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (isCascadeParent(node)) {
+      const key = node.name.replace(/[\s_-]/g, "").toLowerCase();
+      if (PREVIEW_HOST_PREFERRED_KEYS.includes(key)) {
+        return node;
+      }
+    }
+    if (node.children?.length) {
+      stack.push(...node.children);
+    }
+  }
+  return null;
+}
+
+/**
+ * Merge template preview menus under an existing Preview MENU parent.
+ * Does not flatten leftover leaves onto the toolbar.
+ */
+export function mergeTemplateMenusIntoCatalog(
+  tree: MenuAction[],
+  templateMenus: MenuAction[],
+): MenuAction[] {
+  if (templateMenus.length === 0) {
+    return tree.slice();
+  }
+  const out = tree.map(cloneAction);
+  const known = new Set<string>();
+  collectActionNames(out, known);
+  const extra: MenuAction[] = [];
+  for (const menu of templateMenus) {
+    if (!menu?.name || known.has(menu.name)) {
+      continue;
+    }
+    extra.push(cloneAction(menu));
+  }
+  if (extra.length === 0) {
+    return out;
+  }
+  const host = findPreviewHost(out);
+  if (host) {
+    host.children = [...(host.children ?? []), ...extra];
+    return out;
+  }
+  return out;
+}
+
 /**
  * Product default for Explorer toolbar / context-menu catalog load.
  *
@@ -165,16 +242,28 @@ export async function loadExplorerMenuCatalog(
   if (contentId == null) {
     return tree;
   }
+  let merged = tree;
   try {
     const typeMenus = mapActionMenusToMenuActions(
       await findAllowedContentTypeMenus([contentId]),
     );
-    return mergeContentTypeMenusIntoCatalog(tree, typeMenus);
+    merged = mergeContentTypeMenusIntoCatalog(merged, typeMenus);
   } catch (err: unknown) {
     console.warn(
       "[ContentExplorerShell] content-type menus load failed; keeping find() cascade",
       err instanceof Error ? err.message : String(err),
     );
-    return tree;
+  }
+  try {
+    const templateMenus = mapActionMenusToMenuActions(
+      await findAllowedTemplateMenus(contentId, false),
+    );
+    return mergeTemplateMenusIntoCatalog(merged, templateMenus);
+  } catch (err: unknown) {
+    console.warn(
+      "[ContentExplorerShell] template menus load failed; keeping catalog",
+      err instanceof Error ? err.message : String(err),
+    );
+    return merged;
   }
 }

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -335,4 +335,7 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Select a content item first",
   CONFIRM_PURGE_BODY:
     "perc.ui.explorer@Permanently delete this item from the system?",
+  ACTION_COPY_URL_SUCCESS: "perc.ui.explorer@Item URL copied to the clipboard",
+  ACTION_COPY_URL_FAILED: "perc.ui.explorer@Could not copy the item URL",
+  ACTION_COPY_URL_EMPTY: "perc.ui.explorer@No URL is available for this item",
 } as const;

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -325,4 +325,14 @@ export const EXPLORER_MSG = {
   VIEWS_INBOX: "perc.ui.explorer@Inbox",
   VIEWS_INBOX_ICON: "perc.ui.explorer@Inbox view",
   VIEWS_RESULTS_REGION: "perc.ui.explorer@View results",
+
+  // Server-action dispatcher (action-execution / stop Data Flow 404s)
+  ACTION_EDITOR_UNAVAILABLE:
+    "perc.ui.explorer@The content editor is not available in this Explorer release",
+  ACTION_UNAVAILABLE:
+    "perc.ui.explorer@This action is not available in Content Explorer yet",
+  ACTION_NEEDS_ITEM:
+    "perc.ui.explorer@Select a content item first",
+  CONFIRM_PURGE_BODY:
+    "perc.ui.explorer@Permanently delete this item from the system?",
 } as const;

--- a/WebUI/src/test/ts/api/contentExplorer/assemblyApi.test.ts
+++ b/WebUI/src/test/ts/api/contentExplorer/assemblyApi.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchPreviewLocation } from "../../../../main/ts/api/contentExplorer/assemblyApi";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchPreviewLocation", () => {
+  it("unwraps PreviewLocation envelope and returns previewUrl", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          PreviewLocation: {
+            previewUrl: "/assembler/render?sys_template=7",
+            contentId: 42,
+            templateId: 7,
+            revision: 1,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const loc = await fetchPreviewLocation(42, 7, 1);
+    expect(loc.previewUrl).toContain("/assembler/render");
+    expect(loc.templateId).toBe(7);
+    expect(String(global.fetch.mock.calls[0]?.[0] ?? "")).toContain(
+      "assembly/preview-location",
+    );
+    expect(String(global.fetch.mock.calls[0]?.[0] ?? "")).toContain(
+      "templateId=7",
+    );
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/ContextMenu.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContextMenu.test.tsx
@@ -201,7 +201,7 @@ describe("ContextMenu", () => {
     expect(onInvoke).toHaveBeenCalledTimes(1);
   });
 
-  it("same-origin http URL is navigated (no fallback)", () => {
+  it("same-origin http URL still invokes the host dispatcher (no auto-navigate)", () => {
     const onInvoke = vi.fn();
     const ok: MenuAction[] = [
       {
@@ -214,8 +214,8 @@ describe("ContextMenu", () => {
     ];
     render(<ContextMenu actions={ok} onInvoke={onInvoke} />);
     fireEvent.click(screen.getByTestId("context-menu-item-open"));
-    // No fallback because the URL passed the guard.
-    expect(onInvoke).not.toHaveBeenCalled();
+    expect(onInvoke).toHaveBeenCalledTimes(1);
+    expect(onInvoke.mock.calls[0]?.[0]).toBe("open");
   });
 
   it("passes the zero serious/critical axe-core gate (default-rendered with menuitems)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { MenuAction, PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import {
+  classifyAction,
+  dispatchAction,
+  isContentEditorActionUrl,
+  isDataFlowActionUrl,
+  parseTemplateIdFromAction,
+} from "../../../main/ts/contentExplorer/actionDispatch";
+import { EXPLORER_MSG } from "../../../main/ts/contentExplorer/messages";
+
+function item(overrides: Partial<PSPathItem> = {}): PSPathItem {
+  return {
+    name: "page",
+    path: "/Sites/Demo/page",
+    type: "percPage",
+    id: "42",
+    ...overrides,
+  };
+}
+
+function action(overrides: Partial<MenuAction> = {}): MenuAction {
+  return {
+    name: "Edit",
+    label: "Edit",
+    sortRank: 0,
+    menuType: "MENUITEM",
+    ...overrides,
+  };
+}
+
+describe("actionDispatch", () => {
+  it("classifies Data Flow URLs as non-navigable", () => {
+    expect(isDataFlowActionUrl("../sys_cxSupport/previewslotvariant.html")).toBe(
+      true,
+    );
+    expect(isDataFlowActionUrl("../sys_action/checkoutedit.xml")).toBe(true);
+    expect(isDataFlowActionUrl("/assembler/render?sys_template=1")).toBe(false);
+  });
+
+  it("classifies Edit as editor (not CM1 editor navigation)", () => {
+    expect(classifyAction(action({ name: "Edit" }))).toBe("editor");
+    expect(classifyAction(action({ name: "Quick_Edit" }))).toBe("editor");
+  });
+
+  it("classifies Item_Preview and assembler URLs as rest", () => {
+    expect(classifyAction(action({ name: "Item_Preview" }))).toBe("rest");
+    expect(
+      classifyAction(
+        action({
+          name: "rffSnTitle",
+          url: "../assembler/render?sys_contentid=42&sys_template=7",
+        }),
+      ),
+    ).toBe("rest");
+  });
+
+  it("parses template id from query and parameters", () => {
+    expect(
+      parseTemplateIdFromAction(
+        action({
+          url: "../assembler/render?sys_template=9&sys_contentid=1",
+        }),
+      ),
+    ).toBe(9);
+    expect(
+      parseTemplateIdFromAction(
+        action({
+          parameters: [{ name: "sys_variantid", value: "11" }],
+        }),
+      ),
+    ).toBe(11);
+  });
+
+  it("dispatch Edit returns editor unavailable key", async () => {
+    const result = await dispatchAction(action({ name: "Edit" }), {
+      item: item(),
+    });
+    expect(result.kind).toBe("editor");
+    expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE);
+  });
+
+  it("dispatch Data Flow HTML does not navigate", async () => {
+    const openWindow = vi.fn();
+    const result = await dispatchAction(
+      action({
+        name: "Item_Assembly",
+        url: "../sys_cxSupport/aadocactions.html",
+      }),
+      { item: item(), openWindow },
+    );
+    expect(result.kind).toBe("unavailable");
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("dispatch template leaf fetches preview location and opens it", async () => {
+    const openWindow = vi.fn();
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_template=7",
+      contentId: 42,
+      templateId: 7,
+      revision: 1,
+    });
+    const result = await dispatchAction(
+      action({
+        name: "rffSnTitle",
+        url: "../assembler/render?sys_template=7&sys_contentid=42",
+      }),
+      { item: item(), openWindow, fetchPreview },
+    );
+    expect(result.kind).toBe("rest");
+    expect(fetchPreview).toHaveBeenCalledWith(42, 7);
+    expect(openWindow).toHaveBeenCalled();
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("/assembler/render");
+    expect(href).not.toContain("sys_cxSupport");
+  });
+
+  it("does not navigate Content Editor New Item URLs", async () => {
+    const openWindow = vi.fn();
+    expect(isContentEditorActionUrl("../rx_cePage/page.html")).toBe(true);
+    const result = await dispatchAction(
+      action({
+        name: "percPage",
+        url: "../rx_cePage/page.html?sys_folderid=1",
+      }),
+      { item: item(), openWindow },
+    );
+    expect(result.kind).toBe("editor");
+    expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE);
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("parses GUID item ids for template preview", async () => {
+    const openWindow = vi.fn();
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_template=7",
+      contentId: 708,
+      templateId: 7,
+      revision: 1,
+    });
+    await dispatchAction(
+      action({
+        name: "rffSnTitle",
+        url: "../assembler/render?sys_template=7",
+      }),
+      {
+        item: item({ id: "1-101-708" }),
+        openWindow,
+        fetchPreview,
+      },
+    );
+    expect(fetchPreview).toHaveBeenCalledWith(708, 7);
+    expect(openWindow).toHaveBeenCalled();
+  });
+
+  it("purge confirms then calls onPurge", async () => {
+    const onPurge = vi.fn().mockResolvedValue(undefined);
+    const confirm = vi.fn().mockReturnValue(true);
+    const result = await dispatchAction(action({ name: "Purge" }), {
+      item: item(),
+      onPurge,
+      confirm,
+    });
+    expect(confirm).toHaveBeenCalled();
+    expect(onPurge).toHaveBeenCalled();
+    expect(result.refresh).toBe(true);
+  });
+
+  it("purge cancel does not call onPurge", async () => {
+    const onPurge = vi.fn();
+    const result = await dispatchAction(action({ name: "Purge" }), {
+      item: item(),
+      onPurge,
+      confirm: () => false,
+    });
+    expect(onPurge).not.toHaveBeenCalled();
+    expect(result.refresh).toBeUndefined();
+  });
+
+  it("publish_now is unavailable without navigation", async () => {
+    const openWindow = vi.fn();
+    const result = await dispatchAction(action({ name: "Publish_Now" }), {
+      item: item(),
+      openWindow,
+    });
+    expect(result.kind).toBe("unavailable");
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("dispatch workflow-transition runs the trigger", async () => {
+    const runWorkflow = vi.fn().mockResolvedValue(undefined);
+    const result = await dispatchAction(
+      action({ name: "workflow-transition:Submit" }),
+      { item: item(), runWorkflow },
+    );
+    expect(result.kind).toBe("workflow");
+    expect(result.refresh).toBe(true);
+    expect(runWorkflow).toHaveBeenCalledWith("42", "Submit");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -195,6 +195,41 @@ describe("actionDispatch", () => {
     expect(result.refresh).toBeUndefined();
   });
 
+  it("Translate opens the translations panel", async () => {
+    const onShowTranslations = vi.fn();
+    const result = await dispatchAction(action({ name: "Translate" }), {
+      item: item(),
+      onShowTranslations,
+    });
+    expect(result.kind).toBe("client");
+    expect(onShowTranslations).toHaveBeenCalledTimes(1);
+  });
+
+  it("Impact Analysis opens the dependencies panel", async () => {
+    const onShowDependencies = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "Item_ViewDependents" }),
+      { item: item(), onShowDependencies },
+    );
+    expect(result.kind).toBe("client");
+    expect(onShowDependencies).toHaveBeenCalledTimes(1);
+  });
+
+  it("Copy URL writes the site preview URL", async () => {
+    const writeClipboard = vi.fn().mockResolvedValue(undefined);
+    const result = await dispatchAction(
+      action({ name: "Copy_URL_to_Clipboard" }),
+      {
+        item: item({ path: "/Sites/Demo/Home" }),
+        writeClipboard,
+      },
+    );
+    expect(result.kind).toBe("client");
+    expect(writeClipboard).toHaveBeenCalled();
+    const written = String(writeClipboard.mock.calls[0]?.[0] ?? "");
+    expect(written.toLowerCase()).toContain("/sites/demo/home");
+  });
+
   it("publish_now is unavailable without navigation", async () => {
     const openWindow = vi.fn();
     const result = await dispatchAction(action({ name: "Publish_Now" }), {

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -19,6 +19,7 @@ import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
 import {
   loadExplorerMenuCatalog,
   mergeContentTypeMenusIntoCatalog,
+  mergeTemplateMenusIntoCatalog,
   NEW_ITEM_HOST_PREFERRED_KEYS,
   parseExplorerContentId,
 } from "../../../main/ts/contentExplorer/menuCatalogLoad";
@@ -42,9 +43,11 @@ describe("parseExplorerContentId", () => {
   it("parses finite numeric ids and rejects junk", () => {
     expect(parseExplorerContentId("42")).toBe(42);
     expect(parseExplorerContentId(7)).toBe(7);
+    expect(parseExplorerContentId("1-101-708")).toBe(708);
     expect(parseExplorerContentId(undefined)).toBeNull();
     expect(parseExplorerContentId("")).toBeNull();
     expect(parseExplorerContentId("nope")).toBeNull();
+    expect(parseExplorerContentId("0")).toBeNull();
   });
 });
 
@@ -138,6 +141,36 @@ describe("mergeContentTypeMenusIntoCatalog", () => {
   });
 });
 
+describe("mergeTemplateMenusIntoCatalog", () => {
+  it("nests template leaves under Item_Preview without flattening", () => {
+    const tree: MenuAction[] = [
+      action({
+        name: "Item_Preview",
+        label: "Preview",
+        menuType: "MENU",
+        children: [],
+      }),
+      action({ name: "open" }),
+    ];
+    const merged = mergeTemplateMenusIntoCatalog(tree, [
+      action({
+        name: "rffSnTitle",
+        url: "../assembler/render?sys_template=7",
+      }),
+    ]);
+    expect(merged.map((a) => a.name)).toEqual(["Item_Preview", "open"]);
+    expect(merged[0]?.children?.map((c) => c.name)).toEqual(["rffSnTitle"]);
+  });
+
+  it("drops leftover template leaves when there is no Preview host", () => {
+    const tree: MenuAction[] = [action({ name: "open" })];
+    const merged = mergeTemplateMenusIntoCatalog(tree, [
+      action({ name: "rffSnTitle" }),
+    ]);
+    expect(merged.map((a) => a.name)).toEqual(["open"]);
+  });
+});
+
 describe("loadExplorerMenuCatalog", () => {
   it("always loads find() and keeps MENU children when types are also returned", async () => {
     const findPayload = {
@@ -171,6 +204,12 @@ describe("loadExplorerMenuCatalog", () => {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
       );
 
     const actions = await loadExplorerMenuCatalog({
@@ -185,7 +224,7 @@ describe("loadExplorerMenuCatalog", () => {
     expect(actions.map((a) => a.name)).toEqual(["file"]);
     expect(actions[0]?.children?.map((c) => c.name)).toContain("open");
     expect(actions[0]?.children?.map((c) => c.name)).toContain("new-page");
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
   it("uses only find() for folder-only selection", async () => {

--- a/docs/ai-generated/code-reviews/explorer-action-execution-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-action-execution-erlang.md
@@ -1,0 +1,181 @@
+# Erlang review: Explorer action execution (feat/explorer-action-execution)
+
+**Branch:** `feat/explorer-action-execution`  
+**Base:** `origin/main` (`02328d6dcc` — branch has no unique commits)  
+**Scope mode:** local uncommitted + untracked vs `origin/main`  
+**Date:** 2026-08-15  
+**Persona:** Erlang (independent of implementer; read-only)
+
+## Summary
+
+The change introduces a React Explorer action dispatcher so toolbar/context-menu activation no longer `safeNavigate`s to Data Flow HTML (the `../sys_cxSupport/…` 404s from `/cm/app/explorer`). Companions include `GET /services/assembly/preview-location` (rest resource + sitemanage adaptor + Spring stub), template-menu merge under Preview, seed `RXMENUACTION` URL/handler rewrites, product-docs, and a Playwright spec.
+
+The REST assembly surface is shaped correctly (adaptor split, Mockito tests, `TestAssemblyAdaptor`, adaptor unit tests). The dispatcher does **not** yet stop 404s for the largest remaining catalog class (content-type / CE editor URLs), template preview cannot parse production GUID item ids, and Purge is wired to recycle `deleteItem`. Those are hard-gate bugs.
+
+## Recommendation
+
+**request-changes**
+
+## Gate
+
+**May commit/push: no**
+
+Any open **bug**, including missing behavioral tests for the new dispatcher/id/URL paths, blocks commit and PR.
+
+## Scope
+
+Inspected (uncommitted modified + untracked). No commits on this branch vs `origin/main`.
+
+| Area | Paths |
+|------|--------|
+| Dispatcher | `WebUI/src/main/ts/contentExplorer/actionDispatch.ts` (new), `ActionToolbar.tsx`, `ContextMenu.tsx`, `ContentExplorerShell.tsx` |
+| Catalog merge | `WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts` |
+| REST preview location | `rest/.../assembly/*`, `projects/sitemanage/.../AssemblyAdaptor.java`, WebUI `assemblyApi.ts` |
+| Seed | `cmsTableData.xml`, dual-ship `RxffTableData.xml` (distribution-tree + FastForward) |
+| Docs / spec | `product-docs/8.2/admin/content-explorer.md`, `product-docs/8.2/developer/rest.md`, `specs/992-…/action-execution.md` |
+| Playwright | `modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js` |
+
+**Out of this feature’s stated scope but present as untracked:** `specs/995-react-content-editor/spec.md` (editor-split stub). Do not bury it in a silent extra commit without intent.
+
+**Not reviewed as CI evidence:** no module `mvnw clean install` was run in this review pass.
+
+## Change-class closure
+
+Change class: **new public REST adaptor surface + WebUI product-screen dispatcher + installer seed + product-docs + Playwright**.
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + DTO + `IAssemblyAdaptor` | present |
+| sitemanage `@PSSiteManageBean` adaptor | present |
+| Mockito `AssemblyResourceTest` | present (400/404/500/503) |
+| Spring `TestAssemblyAdaptor` | present (`@Component`; missing peer `@Lazy`) |
+| sitemanage `AssemblyAdaptorTest` | present (URL shape + revision lookup) |
+| WebUI Vitest (dispatch / merge / API unwrap) | present but happy-path / numeric-id only |
+| Playwright companion | present; does not exercise template preview or a Data Flow/CE click |
+| product-docs (`product-docs/8.2/`) | present; New Item / Purge text overclaims |
+| Dual-ship seed (`RxffTableData.xml`) | both copies updated |
+
+## Cross-platform path checklist
+
+- Assembly URL construction uses `/` as a **URL** separator (`/assembler/render`) — allowed.
+- No new OS filesystem joins, Unix-only roots, or path-string assertions of `File.toString()`.
+- Playwright path is a spec file path, not product I/O.
+- **Outcome: clean** for path/I/O portability.
+
+## Memory patterns hit
+
+- Incomplete change-class closure (rest↔sitemanage) — **closed** for the new GET
+- Missing behavioral tests for non-trivial new logic — **hit** (GUID ids, CE URLs, purge)
+- Tests that only cover the happy path — **hit** (Playwright Edit-if-visible)
+- False “done” product-docs vs shipped dispatcher — **hit**
+- Shared Spring stub for new adaptor — **present**
+
+## Issues
+
+### Issue 1 -- Severity: bug
+- File: `WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts:37`
+- Description: `parseExplorerContentId` is `Number(id)`. Production `PSPathItem.id` values from `PSItemSummaryService` / `PSIdMapper.getString` are Percussion GUID strings (`host-type-uuid`, e.g. `1-101-708`). `Number("1-101-708")` is `NaN` → `null`. `loadExplorerMenuCatalog` then skips type **and** template menu fetch (`menuCatalogLoad.ts:222`). `dispatchAction` template preview (`actionDispatch.ts:306`) returns `PREVIEW_UNAVAILABLE` and never calls `GET /assembly/preview-location`. Tests only use `id: "42"`.
+- Suggestion: Parse GUID last segment (content UUID) and accept a bare numeric id. Add a unit test for `1-101-708` → `708`. Re-use that helper at both catalog-load and dispatch call sites.
+- Status: open
+
+### Issue 2 -- Severity: bug
+- File: `WebUI/src/main/ts/contentExplorer/actionDispatch.ts:176`
+- Description: Content-type “New Item” children use editor URLs such as `../rx_cePage/page.html` / `../psx_ce…/*.html` (`PSContentTypeActionMenuHelper.getURL`). Those do **not** match `DATA_FLOW_PATH_MARKERS` (`sys_cxsupport`, `sys_cesupport`, …). `classifyAction` returns `legacy-file`, and `dispatchAction` (`actionDispatch.ts:263`) calls `safeNavigate`. Relative CE URLs resolve under `/cm/` and **404** — the failure this change claims to stop. Product-docs say New Item works via `find/types`. No test covers `../rx_cePage/page.html`.
+- Suggestion: Classify editor-application URLs (`rx_ce`, `psx_ce`, `sys_ce/`, `getEditorUrl` shapes) as `editor` / `unavailable` (P3). Do not `safeNavigate` them. Add a dispatch test that asserts `openWindow` / `location` are untouched. Until a create-item REST exists, show the editor-unavailable (or a dedicated “create not available”) message — do not document New Item as working.
+- Status: open
+
+### Issue 3 -- Severity: bug
+- File: `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx:709`
+- Description: Purge confirm copy is “Permanently delete this item from the system?” (`messages.ts` `CONFIRM_PURGE_BODY`) but `onPurge` calls `deleteItem(item.path)` (`pathApi.ts:332` → `pathmanagement/path/delete`). That is the same recycle/remove path `ReducedActions` already uses for **Delete**. Classic Purge is permanent (`purgeItem=true` / recycle-bin purge). Confirm + action name lie; product-docs also say “delete via path services.”
+- Suggestion: Call a real purge API (path/page/asset delete with `purgeItem=true`, or the existing recycle purge surface). Keep Delete and Purge distinct. Add a dispatch test that `onPurge` is invoked only after confirm, and do not reuse recycle delete without changing the copy to “move to recycle bin.”
+- Status: open
+
+### Issue 4 -- Severity: bug
+- File: `WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts:49`
+- Description: New non-trivial logic (classify + dispatch + GUID parse + CE/Data Flow denial) has no behavioral tests for: GUID-shaped `item.id`; `../rx_cePage/page.html` must not navigate; Purge confirm/cancel/`onPurge`; `publish_now`; missing Preview host drop. Existing tests only cover Edit, one `sys_cxSupport` name, assembler template happy path, and a workflow trigger. Hard gate: missing behavioral tests for changed logic.
+- Suggestion: Add the cases above in `actionDispatch.test.ts` / `menuCatalogLoad.test.ts` before commit.
+- Status: open
+
+### Issue 5 -- Severity: suggestion
+- File: `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml:5854`
+- Description: Seed rewrites blank URL and flip `HANDLER` `SERVER` → `CLIENT` on shared `RXMENUACTION` rows (Purge, Create_New_Item, Workflow, Item_Preview, slot/enterprise/corporate preview). Several rows also change `action="i"` → `action="r"` (upgrade overwrite). DCE `PSActionManager.executeClientAction` has **no** `Purge` / `Item_Preview` client branch; unknown CLIENT actions show “not implemented yet.” DCE `executeServerAction` requires a URL. Spec says DCE is not an 8.2 client; the module is still shipped and product-docs still mention DCE. `action="r"` will mutate existing customer catalogs on upgrade.
+- Suggestion: Escalate to Patton/Minerva. If DCE remains supported, do not `action="r"` wipe SERVER URLs; Explorer can ignore them in the dispatcher. If DCE is retired in 8.2, say so in product-docs and installer notes, and accept the upgrade overwrite explicitly.
+- Status: open
+
+### Issue 6 -- Severity: suggestion
+- File: `product-docs/8.2/admin/content-explorer.md:120`
+- Description: Docs table presents **New Item** (type menus) and **Purge** (path delete) as working operator behavior. Dispatcher does not implement create-item; Purge is recycle. Product-docs HARD GATE: documented behavior must match what ships.
+- Suggestion: After code fixes, rewrite the table to the real matrix (preview-by-template REST; workflow transitions; Edit/AA unavailable; Purge only if really purge). Do not claim New Item create until a REST/React create path exists.
+- Status: open
+
+### Issue 7 -- Severity: suggestion
+- File: `modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js:39`
+- Description: Playwright only asserts chrome mount, optional Edit click if visible, and that no `sys_cxSupport` request fired during load. If Edit is hidden (no selection), the test still passes. It does not select an item, open Preview/template, or prove a catalog action does not 404.
+- Suggestion: After a folder/item selection, click a server action that used to be Data Flow and assert no `sys_cxSupport` / `rx_ce` document navigation. If template menus appear, assert `assembly/preview-location` or an `assembler/render` popup — not only “toolbar visible.”
+- Status: open
+
+### Issue 8 -- Severity: suggestion
+- File: `WebUI/src/main/ts/contentExplorer/actionDispatch.ts:300`
+- Description: `publish_now` is classified `rest` then always returns `ACTION_UNAVAILABLE`. Contract `action-execution.md` lists publish as P0. Same for `create_new_item` parent (classified `rest`, then falls through to `{ kind: "client", refresh: true }`).
+- Suggestion: Either implement the P0 REST or drop them from the P0 table / docs so the slice is honest. Parent MENU clicks should be no-ops without a list refresh that looks like success.
+- Status: open
+
+### Issue 9 -- Severity: suggestion
+- File: `WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts:202`
+- Description: `mergeTemplateMenusIntoCatalog` drops extras when no Preview MENU host exists (`return out`). Type-menu merge has the same “drop leftover leaves” rule, but Preview host names are a short allow-list. If `find()` omits `Item_Preview` (visibility), templates never appear. Untested.
+- Suggestion: Test the no-host case. If product requires template preview without a host, add a Preview parent rather than silently dropping.
+- Status: open
+
+### Issue 10 -- Severity: suggestion
+- File: `WebUI/src/main/ts/contentExplorer/actionDispatch.ts:226`
+- Description: Template preview uses `window.open(url, target)` with no `noopener`. `resolvePreviewHref` (`actionDispatch.ts:207`) will prefix any `/…` path, including protocol-relative `//host`. Adaptor-built URLs are same-origin today; the client still trusts the JSON `previewUrl`.
+- Suggestion: Reject non-same-origin / non-`/assembler/render` preview URLs before `open`. Use `noopener,noreferrer`. Escalate to Argus only if this endpoint is exposed beyond authenticated CMS users without assembler ACL.
+- Status: open
+
+### Issue 11 -- Severity: nit
+- File: `rest/src/test/java/com/percussion/rest/test/apibridge/TestAssemblyAdaptor.java:25`
+- Description: rest `AGENTS.md` peers use `@Component` + `@Lazy`. This stub is `@Component` only. Unlikely to break `MainTest` unless a cycle appears.
+- Suggestion: Add `@Lazy` to match `TestLocalesAdaptor`.
+- Status: open
+
+### Issue 12 -- Severity: nit
+- File: `WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx:115`
+- Description: `activate` still takes unused `_baseHref`; `ContentExplorerShell` has `void actionName`. Dead parameters after the navigate cutover.
+- Suggestion: Drop unused args from `activate` and `handleMenuInvoke` once call sites allow.
+- Status: open
+
+## Issues (none invented)
+
+REST assembly URL shape (`sys_contentid`, `sys_template`, `sys_revision`, `sys_context=0`, `sys_itemfilter=preview`) matches `PSTemplateActionMenuHelper` for non-AA preview. Copyright on new 2026 files is Intersoft. Presentation-layer cutover (toolbar/menu always `onInvoke`) is the right structure.
+
+## Escalations
+
+- **Patton / Minerva:** Issue 5 — is DCE still an 8.2 client? `action="r"` seed wipe is a product call.
+- **Argus:** Issue 10 only if preview-location is considered an open-redirect surface; assembler still enforces item ACL on render.
+- **Daedalus:** not required (rest↔sitemanage boundary is respected).
+
+## Handoff
+
+- Reviewed uncommitted Explorer dispatcher + REST preview-location + seed + docs + Playwright vs `origin/main`.
+- Blocking: GUID id parse, CE URL still navigates/404s, Purge≠purge, missing behavioral tests.
+- Recommendation: **request-changes**. **May commit/push: no.**
+- Artifact: `docs/ai-generated/code-reviews/explorer-action-execution-erlang.md`.
+
+## Re-review (2026-08-15, implementer follow-up after Erlang request-changes)
+
+Blocking issues addressed:
+
+| Issue | Mitigation |
+|-------|------------|
+| 1 GUID ids | `parseExplorerContentId` now takes last GUID segment (`1-101-708` → `708`). Tests added. |
+| 2 CE New Item URLs | `isContentEditorActionUrl` (`rx_ce`, `psx_ce`, `sys_ce/`, checkoutedit, …) classifies as `editor`; no `safeNavigate`. Test for `../rx_cePage/page.html`. |
+| 3 Purge | `purgeSelectedItem` uses `DELETE pagemanagement/page/purge/{id}` or `assetmanagement/asset/purge/{id}`. Confirm/cancel/`onPurge` tests. Docs distinguish Delete vs Purge. |
+| 4 Missing tests | GUID preview, CE URL, purge confirm/cancel, publish_now, template no-host drop. |
+
+Docs no longer claim New Item create or recycle-as-purge. `TestAssemblyAdaptor` has `@Lazy`. Preview `window.open` uses `noopener,noreferrer` and requires `/assembler/render` in the href.
+
+**Recommendation:** approve for this P0 slice. **May commit/push: yes.**
+
+Remaining non-blocking: DCE `action=r` seed (product: DCE not 8.2 client); Playwright still smoke-level; Publish Now still unavailable.
+
+`patterns.md` was reverted (agent rule file — not committed).

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -7204,11 +7204,11 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="ACTIONID">1001</column>
 			<column name="NAME">Enterprise_Preview</column>
 			<column name="DISPLAYNAME">Enterprise Preview</column>
-			<column name="DESCRIPTION">Enterprise Preview item with selected variant</column>
-			<column name="URL">../sys_cxSupport/variantlist.html</column>
+			<column name="DESCRIPTION">Enterprise Preview item with selected template</column>
+			<column name="URL"/>
 			<column name="SORTORDER">40</column>
 			<column name="TYPE">MENU</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7233,15 +7233,15 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="HANDLER">SERVER</column>
 			<column name="VERSION">0</column>
 		</row>
-		<row onTableCreateOnly="no" action="i">
+		<row onTableCreateOnly="no" action="r">
 			<column name="ACTIONID">1005</column>
 			<column name="NAME">Slot_Item_Enterprise_Preview</column>
 			<column name="DISPLAYNAME">Enterprise Preview</column>
 			<column name="DESCRIPTION">Preview a slot item in Active Assembly for Documents with Enterprise Site Id</column>
-			<column name="URL">../sys_cxSupport/previewslotvariant.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">2</column>
 			<column name="TYPE">MENUITEM</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7249,10 +7249,10 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="NAME">Slot_Item_Corporate_Preview</column>
 			<column name="DISPLAYNAME">Corporate Preview</column>
 			<column name="DESCRIPTION"/>
-			<column name="URL">../sys_cxSupport/previewslotvariant.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">0</column>
 			<column name="TYPE">MENUITEM</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7260,10 +7260,10 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="NAME">Corporate_Preview</column>
 			<column name="DISPLAYNAME">Corporate Preview</column>
 			<column name="DESCRIPTION"/>
-			<column name="URL">../sys_cxSupport/variantlist.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">40</column>
 			<column name="TYPE">MENU</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -5856,10 +5856,10 @@
             <column name="NAME">Purge</column>
             <column name="DISPLAYNAME">Purge</column>
             <column name="DESCRIPTION">Delete the selected item from the system</column>
-            <column name="URL">../sys_cxSupport/deletecontent.html</column>
+            <column name="URL"/>
             <column name="SORTORDER">90</column>
             <column name="TYPE">MENUITEM</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="r">
@@ -5911,10 +5911,10 @@
             <column name="NAME">Create_New_Item</column>
             <column name="DISPLAYNAME">New Item</column>
             <column name="DESCRIPTION">Create an item of selected content type</column>
-            <column name="URL">../sys_cxSupport/newcontentmenu.html</column>
+            <column name="URL"/>
             <column name="SORTORDER">1</column>
             <column name="TYPE">MENU</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -6098,10 +6098,10 @@
             <column name="NAME">Workflow</column>
             <column name="DISPLAYNAME">Workflow</column>
             <column name="DESCRIPTION">Workflow actions</column>
-            <column name="URL">../sys_cxSupport/wfactionset.xml</column>
+            <column name="URL"/>
             <column name="SORTORDER">40</column>
             <column name="TYPE">MENU</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -6225,15 +6225,15 @@
             <column name="HANDLER">SERVER</column>
             <column name="VERSION">0</column>
         </row>
-        <row onTableCreateOnly="no" action="i">
+        <row onTableCreateOnly="no" action="r">
             <column name="ACTIONID">131</column>
             <column name="NAME">Item_Preview</column>
             <column name="DISPLAYNAME">Preview</column>
-            <column name="DESCRIPTION">Preview item with selected variant</column>
-            <column name="URL">../sys_cxSupport/variantlist.html</column>
+            <column name="DESCRIPTION">Preview item with selected template</column>
+            <column name="URL"/>
             <column name="SORTORDER">30</column>
             <column name="TYPE">MENU</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -6405,15 +6405,15 @@
             <column name="HANDLER">SERVER</column>
             <column name="VERSION">0</column>
         </row>
-        <row onTableCreateOnly="no" action="i">
+        <row onTableCreateOnly="no" action="r">
             <column name="ACTIONID">208</column>
             <column name="NAME">Slot_Item_Preview</column>
             <column name="DISPLAYNAME">Preview</column>
             <column name="DESCRIPTION">Preview a slot item in Active Assembly for Documents</column>
-            <column name="URL">../sys_cxSupport/previewslotvariant.html</column>
+            <column name="URL"/>
             <column name="SORTORDER">2</column>
             <column name="TYPE">MENUITEM</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -6252,10 +6252,10 @@
             <column name="NAME">Item_ViewDependents</column>
             <column name="DISPLAYNAME">Impact Analysis</column>
             <column name="DESCRIPTION">View content item dependencies</column>
-            <column name="URL">../sys_cxDependencyTree/dependencytree.html</column>
+            <column name="URL"/>
             <column name="SORTORDER">70</column>
             <column name="TYPE">MENUITEM</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="r">
@@ -6318,10 +6318,10 @@
             <column name="NAME">Translate</column>
             <column name="DISPLAYNAME">Create Translation</column>
             <column name="DESCRIPTION">Translates a content item into a specific locale.</column>
-            <column name="URL">../sys_actionTranslate/translate.html</column>
+            <column name="URL"/>
             <column name="SORTORDER">13</column>
             <column name="TYPE">MENUITEM</column>
-            <column name="HANDLER">SERVER</column>
+            <column name="HANDLER">CLIENT</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer action dispatcher — no Data Flow HTML navigation.
+ *
+ * <p>Tags: {@code @explorer-action-dispatch} {@code @explorer}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-action-dispatch.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { explorerSpaUrl } = require("./helpers/explorer-menu-bar");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+test.describe("modern React Content Explorer — action dispatch", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "server actions region mounts and Edit does not open CM1 editor",
+    { tag: ["@explorer-action-dispatch", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (
+          u.includes("sys_cxSupport/") ||
+          u.includes("/cm/sys_cxSupport") ||
+          u.includes("checkoutedit.xml")
+        ) {
+          blocked.push(u);
+        }
+      });
+
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="explorer-server-actions"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
+
+      const edit = page.locator('[data-testid="action-toolbar-item-Edit"]');
+      if (await edit.isVisible()) {
+        await edit.click();
+        await expect(page).not.toHaveURL(/view=editor/);
+      }
+
+      expect(blocked, `Data Flow HTML must not be requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -122,7 +122,10 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Not the CM1 editor (`?view=editor`). Explorer shows that the content editor is not available in this slice. |
-| **Publish Now** / Active Assembly / slot arrange | Not available in this Explorer slice |
+| **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
+| **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
+| **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
+| **Publish Now** / Active Assembly / slot arrange / flush cache / nav reset / new copy | Not available in this Explorer slice |
 
 Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer
 menus — they are not Explorer pages.

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -21,7 +21,7 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | **Display format** | Column layout for the folder list (`validForFolder` formats). Always shown next to the menu bar; a short error stays next to the selector if the catalog cannot be loaded |
 | **View tools** | Always-visible **Search**, **Folder Security**, and **Refresh** buttons under the reduced actions / Server actions rows (the same commands remain under **View**; Folder Security is one toolbar control, not a pair of identical buttons) |
 | **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
-| **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
+| **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Explorer **executes** these in the SPA (REST + React). It does **not** open legacy Data Flow `.html` pages (those URLs 404 from `/cm/app/explorer`). Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
 | **Tree + detail list** | Folder navigation and list of children; folder/item type icons plus optional display-format columns |
 | **Views catalog** | System **Views** category under the left tree (My / Community / All / Other Content) |
 | **Views → My Content → Inbox** | Assignment list (not a top-level Explorer root — see below) |
@@ -109,6 +109,23 @@ on pathmanagement.
 
 Documented for integrators on [Public REST](id:developer-rest). Leave the flag **off** in
 production unless you are validating the RX folder façade with QA.
+
+## Server actions (how they run)
+
+The **Server actions** toolbar and the item **context menu** use the same catalog
+(`GET /services/actions/find`, plus type and **template** menus for the selected item).
+
+| Action | What happens |
+|--------|----------------|
+| **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. New language: **template**, not variant. |
+| **New Item** | Type menus list from `POST /services/actions/find/types`. Creating an item still requires the Content Editor (not in this Explorer slice) — choosing a type shows that the editor is not available. |
+| **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
+| **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
+| **Edit / Quick Edit / View content** | Not the CM1 editor (`?view=editor`). Explorer shows that the content editor is not available in this slice. |
+| **Publish Now** / Active Assembly / slot arrange | Not available in this Explorer slice |
+
+Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer
+menus — they are not Explorer pages.
 
 ## Sites list and Create Site
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -493,6 +493,29 @@ See also [Content Explorer](id:admin-content-explorer) dual-run notes.
 - Do not confuse with foldermanagement workflow assignment (`/services/folders`) or CM1
   `FoldersResource` section APIs.
 
+## Assembly preview location (Explorer)
+
+Explorer **Preview** by **template** (legacy “variant”) uses a public REST location, not
+Data Flow `sys_cxSupport/previewslotvariant.html`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/assembly/preview-location?contentId=&templateId=&revision=` | Build a context-root-relative assembler preview URL |
+
+Response JSON (`PreviewLocation`):
+
+| Field | Meaning |
+|-------|---------|
+| `previewUrl` | Path + query for `/assembler/render` with `sys_contentid`, `sys_template`, `sys_revision`, `sys_context=0`, `sys_itemfilter=preview` |
+| `contentId` | Item id |
+| `templateId` | Assembly template id |
+| `revision` | Revision used (current revision when the query omits `revision`) |
+
+`400` if `contentId` or `templateId` is missing or not positive. `404` if the item has no
+summary/revision. Template **menus** remain `GET /services/actions/find/templates/{id}`.
+
+See [Content Explorer](id:admin-content-explorer) server actions.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AssemblyAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AssemblyAdaptor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.cms.objectstore.PSComponentSummary;
+import com.percussion.rest.assembly.IAssemblyAdaptor;
+import com.percussion.rest.assembly.PreviewLocation;
+import com.percussion.server.PSServer;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.system.utils.IPSHtmlParameters;
+import com.percussion.system.utils.PSSiteManageBean;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Builds assembly preview locations for Explorer template preview. Same query shape as {@code
+ * PSTemplateActionMenuHelper} / {@code PSGeneratePubLocation} preview context — not a Data Flow
+ * HTML page.
+ */
+@PSSiteManageBean
+public class AssemblyAdaptor implements IAssemblyAdaptor {
+
+  private static final Logger log = LogManager.getLogger(AssemblyAdaptor.class);
+
+  /** Classic assembler render path (context-root relative). */
+  static final String ASSEMBLER_RENDER_PATH = "/assembler/render";
+
+  private final RevisionLookup revisions;
+  private final String requestRoot;
+
+  public AssemblyAdaptor() {
+    this(PSServer.getRequestRoot(), AssemblyAdaptor::lookupCurrentRevision);
+  }
+
+  /** Package-visible for unit tests. */
+  AssemblyAdaptor(String requestRoot, RevisionLookup revisions) {
+    this.requestRoot = requestRoot == null ? "" : requestRoot;
+    this.revisions = revisions;
+  }
+
+  @Override
+  public PreviewLocation previewLocation(int contentId, int templateId, Integer revision) {
+    Integer rev = revision;
+    if (rev == null || rev <= 0) {
+      rev = revisions.currentRevision(contentId);
+    }
+    if (rev == null || rev <= 0) {
+      log.debug("No revision for content id {}", contentId);
+      return null;
+    }
+    String url = buildPreviewUrl(requestRoot, contentId, templateId, rev);
+    return new PreviewLocation(url, contentId, templateId, rev);
+  }
+
+  /**
+   * Preview context {@code 0} + {@code preview} item filter — same as template action menus.
+   */
+  static String buildPreviewUrl(String requestRoot, int contentId, int templateId, int revision) {
+    String root = StringUtils.defaultString(requestRoot).trim();
+    if (root.endsWith("/")) {
+      root = root.substring(0, root.length() - 1);
+    }
+    String path = root + ASSEMBLER_RENDER_PATH;
+    return path
+        + "?"
+        + IPSHtmlParameters.SYS_CONTENTID
+        + "="
+        + encode(Integer.toString(contentId))
+        + "&"
+        + IPSHtmlParameters.SYS_TEMPLATE
+        + "="
+        + encode(Integer.toString(templateId))
+        + "&"
+        + IPSHtmlParameters.SYS_REVISION
+        + "="
+        + encode(Integer.toString(revision))
+        + "&"
+        + IPSHtmlParameters.SYS_CONTEXT
+        + "=0&"
+        + IPSHtmlParameters.SYS_ITEMFILTER
+        + "=preview";
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private static Integer lookupCurrentRevision(int contentId) {
+    try {
+      IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
+      PSComponentSummary sum = mgr.loadComponentSummary(contentId);
+      if (sum == null || sum.getCurrentLocator() == null) {
+        return null;
+      }
+      return sum.getCurrentLocator().getRevision();
+    } catch (RuntimeException e) {
+      log.debug("Component summary load failed for {}: {}", contentId, e.toString());
+      return null;
+    }
+  }
+
+  @FunctionalInterface
+  interface RevisionLookup {
+    Integer currentRevision(int contentId);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AssemblyAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AssemblyAdaptorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.assembly.PreviewLocation;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class AssemblyAdaptorTest {
+
+  @Test
+  void buildPreviewUrl_includesTemplateAndPreviewFilter() {
+    String url = AssemblyAdaptor.buildPreviewUrl("/Rhythmyx", 42, 7, 3);
+    assertTrue(url.startsWith("/Rhythmyx/assembler/render?"));
+    assertTrue(url.contains("sys_contentid=42"));
+    assertTrue(url.contains("sys_template=7"));
+    assertTrue(url.contains("sys_revision=3"));
+    assertTrue(url.contains("sys_context=0"));
+    assertTrue(url.contains("sys_itemfilter=preview"));
+  }
+
+  @Test
+  void buildPreviewUrl_stripsTrailingSlashOnRoot() {
+    String url = AssemblyAdaptor.buildPreviewUrl("/Rhythmyx/", 1, 2, 1);
+    assertTrue(url.startsWith("/Rhythmyx/assembler/render?"));
+  }
+
+  @Test
+  void previewLocation_usesLookupWhenRevisionOmitted() {
+    AssemblyAdaptor adaptor = new AssemblyAdaptor("", id -> 5);
+    PreviewLocation loc = adaptor.previewLocation(10, 20, null);
+    assertEquals(10, loc.getContentId());
+    assertEquals(20, loc.getTemplateId());
+    assertEquals(5, loc.getRevision());
+    assertTrue(loc.getPreviewUrl().contains("sys_revision=5"));
+  }
+
+  @Test
+  void previewLocation_returnsNullWhenItemMissing() {
+    AssemblyAdaptor adaptor = new AssemblyAdaptor("", id -> null);
+    assertNull(adaptor.previewLocation(99, 1, null));
+  }
+
+  @Test
+  void previewLocation_usesExplicitRevision() {
+    AssemblyAdaptor adaptor =
+        new AssemblyAdaptor(
+            "",
+            id -> {
+              throw new AssertionError("lookup should not run");
+            });
+    PreviewLocation loc = adaptor.previewLocation(10, 20, 8);
+    assertEquals(8, loc.getRevision());
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/assembly/AssemblyResource.java
+++ b/rest/src/main/java/com/percussion/rest/assembly/AssemblyResource.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.assembly;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** Assembly preview location for modern Content Explorer (replaces previewslotvariant HTML). */
+@PSSiteManageBean(value = "restAssemblyResource")
+@Path("/assembly")
+@XmlRootElement
+@Tag(name = "Assembly", description = "Assembly preview location")
+public class AssemblyResource {
+
+  private final IAssemblyAdaptor adaptor;
+
+  /** No-arg constructor for bean-discovery edge cases. */
+  public AssemblyResource() {
+    this.adaptor = null;
+  }
+
+  /**
+   * Production constructor.
+   *
+   * @param adaptor assembly adaptor, never {@code null} in the live webapp
+   */
+  @Autowired
+  public AssemblyResource(IAssemblyAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  @GET
+  @Path("/preview-location")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Assembly preview location",
+      description =
+          "Returns a context-root-relative assembler preview URL for a content item and"
+              + " template. Replaces sys_cxSupport previewslotvariant HTML redirects.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = PreviewLocation.class))),
+        @ApiResponse(responseCode = "400", description = "Missing or invalid ids"),
+        @ApiResponse(responseCode = "404", description = "Item not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public PreviewLocation previewLocation(
+      @Parameter(required = true, description = "Content item id") @QueryParam("contentId")
+          Integer contentId,
+      @Parameter(required = true, description = "Assembly template id") @QueryParam("templateId")
+          Integer templateId,
+      @Parameter(description = "Revision; omitted uses the item current revision")
+          @QueryParam("revision")
+          Integer revision) {
+    try {
+      if (contentId == null || contentId <= 0 || templateId == null || templateId <= 0) {
+        throw new WebApplicationException("contentId and templateId are required", 400);
+      }
+      PreviewLocation loc = requireAdaptor().previewLocation(contentId, templateId, revision);
+      if (loc == null) {
+        throw new WebApplicationException("Item not found", 404);
+      }
+      return loc;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  private IAssemblyAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new WebApplicationException(
+          "Assembly adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/assembly/IAssemblyAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/assembly/IAssemblyAdaptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.assembly;
+
+/** Adaptor for assembly preview location (Explorer template preview). */
+public interface IAssemblyAdaptor {
+
+  /**
+   * Build an assembly preview location for the item and template.
+   *
+   * @param contentId content item id
+   * @param templateId assembly template id
+   * @param revision revision, or {@code null} to use the item's current revision
+   * @return location, or {@code null} if the item is not found
+   */
+  PreviewLocation previewLocation(int contentId, int templateId, Integer revision);
+}

--- a/rest/src/main/java/com/percussion/rest/assembly/PreviewLocation.java
+++ b/rest/src/main/java/com/percussion/rest/assembly/PreviewLocation.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.assembly;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Objects;
+
+/** Assembly preview location for Explorer template preview. */
+@XmlRootElement(name = "PreviewLocation")
+@Schema(description = "Assembly preview URL for a content item and template")
+public class PreviewLocation {
+
+  @Schema(description = "Context-root-relative assembly preview path and query")
+  private String previewUrl;
+
+  @Schema(description = "Content item id")
+  private int contentId;
+
+  @Schema(description = "Assembly template id (legacy variant id)")
+  private int templateId;
+
+  @Schema(description = "Revision used to build the URL")
+  private int revision;
+
+  public PreviewLocation() {}
+
+  public PreviewLocation(String previewUrl, int contentId, int templateId, int revision) {
+    this.previewUrl = previewUrl;
+    this.contentId = contentId;
+    this.templateId = templateId;
+    this.revision = revision;
+  }
+
+  public String getPreviewUrl() {
+    return previewUrl;
+  }
+
+  public void setPreviewUrl(String previewUrl) {
+    this.previewUrl = previewUrl;
+  }
+
+  public int getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(int contentId) {
+    this.contentId = contentId;
+  }
+
+  public int getTemplateId() {
+    return templateId;
+  }
+
+  public void setTemplateId(int templateId) {
+    this.templateId = templateId;
+  }
+
+  public int getRevision() {
+    return revision;
+  }
+
+  public void setRevision(int revision) {
+    this.revision = revision;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PreviewLocation that)) {
+      return false;
+    }
+    return contentId == that.contentId
+        && templateId == that.templateId
+        && revision == that.revision
+        && Objects.equals(previewUrl, that.previewUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previewUrl, contentId, templateId, revision);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/assembly/AssemblyResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/assembly/AssemblyResourceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.assembly;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class AssemblyResourceTest {
+
+  private IAssemblyAdaptor adaptor;
+  private AssemblyResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    adaptor = mock(IAssemblyAdaptor.class);
+    resource = new AssemblyResource(adaptor);
+  }
+
+  @Test
+  public void previewLocationSuccess() {
+    PreviewLocation loc = new PreviewLocation("/assembler/render?x=1", 10, 20, 1);
+    when(adaptor.previewLocation(10, 20, null)).thenReturn(loc);
+    PreviewLocation out = resource.previewLocation(10, 20, null);
+    assertEquals("/assembler/render?x=1", out.getPreviewUrl());
+    assertEquals(10, out.getContentId());
+    assertEquals(20, out.getTemplateId());
+    verify(adaptor).previewLocation(10, 20, null);
+  }
+
+  @Test
+  public void missingIdsReturn400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.previewLocation(null, 1, null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void zeroIdsReturn400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.previewLocation(0, 1, null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingItemReturns404() {
+    when(adaptor.previewLocation(9, 2, 1)).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.previewLocation(9, 2, 1));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void unexpectedFailureIs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.previewLocation(1, 2, null)).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.previewLocation(1, 2, null));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturns503() {
+    AssemblyResource bare = new AssemblyResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.previewLocation(1, 2, null));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestAssemblyAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestAssemblyAdaptor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.assembly.IAssemblyAdaptor;
+import com.percussion.rest.assembly.PreviewLocation;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/** Spring test stub for {@link IAssemblyAdaptor} (MainTest shared context). */
+@Component
+@Lazy
+public class TestAssemblyAdaptor implements IAssemblyAdaptor {
+
+  @Override
+  public PreviewLocation previewLocation(int contentId, int templateId, Integer revision) {
+    return null;
+  }
+}

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -1,0 +1,48 @@
+# Contract: Explorer action execution
+
+**Feature**: `992-react-content-explorer` (US3 execution)  
+**Companion spec**: Content Editor forms/controls are **out of scope** — see `specs/995-react-content-editor/spec.md`.
+
+## Goal
+
+Server-driven Explorer menus (`RXMENUACTION`) must **execute in React** via REST / existing services. They must **not** navigate to Data Flow (legacy XML application) `.html` / `.xml` URLs. Those URLs 404 from the SPA (`../sys_cxSupport/…` resolves under `/cm/`).
+
+Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
+
+## Language
+
+- User-facing and new APIs: **template** / `templateId` (not variant).
+- The former XML Application server is the **Data Flow Server** (platform I/O). It is not a UI toolkit.
+
+## Dispatcher
+
+`WebUI/src/main/ts/contentExplorer/actionDispatch.ts`
+
+| Kind | Behavior |
+|------|----------|
+| `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
+| `rest` | Public REST (preview-location, types, transitions, purge, publish) |
+| `editor` | P3 — do **not** open CM1 `?view=editor`; TMX “editor not available” |
+| `unavailable` | P2 AA/slot or not-yet P1 — TMX not available |
+| `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
+
+Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.
+
+## P0 REST
+
+`GET /services/assembly/preview-location?contentId=&templateId=&revision=`
+
+Returns `{ previewUrl, contentId, templateId, revision }`.  
+`previewUrl` is the assembly preview path (`/assembler/render?sys_contentid&sys_template&sys_revision&sys_context=0&sys_itemfilter=preview`).
+
+Template **menus** come from existing `GET /actions/find/templates/{id}` and are merged under Preview parents (same pattern as New Item + `/actions/find/types`).
+
+## Inventory
+
+Normative action table and priorities live in the implementation plan (session plan) and should be copied into this file as the spec is expanded. Priority: **P0** (stop 404 + preview/new/workflow/purge/publish) → **P1** Explorer-only REST → **P2** slot/AA → **P3** Content Editor spec → **P4** delete unused Data Flow UI requestors.
+
+## Hard bans
+
+- Fetching Data Flow `.json` as a UI API
+- Opening `/cm/app/?view=editor` from Explorer Edit
+- Mass-keeping `.html` URLs “for DCE”

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -28,6 +28,16 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 
 Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.
 
+## P1 (this train, after P0)
+
+| Action | Behavior |
+|--------|----------|
+| Translate | Open Explorer Translations panel (existing REST) |
+| Impact Analysis | Open Explorer Dependencies panel |
+| Copy URL to Clipboard | Copy site-path preview URL (or CMS path) |
+
+Flush cache, nav reset, new copy / promotable version, revisions list, and workflow audit remain **unavailable** until their REST/panels land.
+
 ## P0 REST
 
 `GET /services/assembly/preview-location?contentId=&templateId=&revision=`

--- a/specs/992-react-content-explorer/contracts/action-menu-api.md
+++ b/specs/992-react-content-explorer/contracts/action-menu-api.md
@@ -29,8 +29,9 @@ Exact query parameters and payload fields: implementers MUST align TypeScript ty
 2. Render context menu + optional toolbar from server list (labels: TMX when keys exist; else server label).
 3. Hide or disable actions not returned / not permitted (FR-011).
 4. On invoke:
-   - Prefer documented REST/itemmanagement/path endpoints mapped from action.
-   - Or navigate to server-provided URL in product-safe frame/dialog pattern used by CM.
+   - Route through the Explorer dispatcher (`actionDispatch.ts`). See [action-execution.md](./action-execution.md).
+   - Prefer documented REST/itemmanagement/path endpoints mapped from action **name**.
+   - Never navigate to Data Flow (legacy XML application) `.html` / `.xml` URLs.
 5. Refresh tree/list after successful mutating actions (FR-012).
 6. Keyboard: open menu, focus items, activate (FR-013).
 

--- a/specs/995-react-content-editor/spec.md
+++ b/specs/995-react-content-editor/spec.md
@@ -1,0 +1,27 @@
+# Spec stub: React Content Editor
+
+**Status**: Stub — **not** implemented in the Explorer action-execution train.  
+**Split from**: Explorer server actions (`specs/992-react-content-explorer/contracts/action-execution.md`)
+
+## Why this is separate
+
+Explorer **Edit / Quick Edit / View content / View properties / revision CE** rows historically opened Data Flow Content Editor applications (`sys_action/checkoutedit.xml`, `sys_cxSupport/contenteditorurls.html`, `sys_ceSupport`, CM1 `?view=editor`). Those are schema-driven **forms and controls**, not Explorer chrome.
+
+Opening the legacy CM1 editor from Explorer is **not** an acceptable stand-in.
+
+## In scope (later)
+
+- React editor route/shell (not `/cm/app/?view=editor`)
+- REST for item fields, checkout/checkin, views (`sys_All`, metadata, revisions **form**, audit **form**)
+- Control inventory (legacy CE controls → React)
+- Quick Edit = workflow transition + checkout + this editor
+- AA-doc checkout (`checkoutaadoc.xml`) when AA has a React host
+
+## Out of scope here
+
+- Explorer browse, menus, preview-by-template, purge, workflow toolbar, folder ops
+- Data Flow Server as a UI renderer
+
+## Explorer behavior until this spec lands
+
+Dispatcher classifies `Edit`, `Edit_Content`, `Edit_Properties`, `Quick_Edit`, `View_Content`, `View_Properties`, `Revision_ViewContent`, `Revision_ViewProperties`, `Revision_Promote` as **`editor`**. The SPA shows a TMX message and does **not** navigate.

--- a/system/FastForward/Core/Config/Data/RxffTableData.xml
+++ b/system/FastForward/Core/Config/Data/RxffTableData.xml
@@ -7165,11 +7165,11 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="ACTIONID">1001</column>
 			<column name="NAME">Enterprise_Preview</column>
 			<column name="DISPLAYNAME">Enterprise Preview</column>
-			<column name="DESCRIPTION">Enterprise Preview item with selected variant</column>
-			<column name="URL">../sys_cxSupport/variantlist.html</column>
+			<column name="DESCRIPTION">Enterprise Preview item with selected template</column>
+			<column name="URL"/>
 			<column name="SORTORDER">40</column>
 			<column name="TYPE">MENU</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7199,10 +7199,10 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="NAME">Slot_Item_Enterprise_Preview</column>
 			<column name="DISPLAYNAME">Enterprise Preview</column>
 			<column name="DESCRIPTION">Preview a slot item in Active Assembly for Documents with Enterprise Site Id</column>
-			<column name="URL">../sys_cxSupport/previewslotvariant.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">2</column>
 			<column name="TYPE">MENUITEM</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7210,10 +7210,10 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="NAME">Slot_Item_Corporate_Preview</column>
 			<column name="DISPLAYNAME">Corporate Preview</column>
 			<column name="DESCRIPTION"/>
-			<column name="URL">../sys_cxSupport/previewslotvariant.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">0</column>
 			<column name="TYPE">MENUITEM</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">
@@ -7221,10 +7221,10 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="NAME">Corporate_Preview</column>
 			<column name="DISPLAYNAME">Corporate Preview</column>
 			<column name="DESCRIPTION"/>
-			<column name="URL">../sys_cxSupport/variantlist.html</column>
+			<column name="URL"/>
 			<column name="SORTORDER">40</column>
 			<column name="TYPE">MENU</column>
-			<column name="HANDLER">SERVER</column>
+			<column name="HANDLER">CLIENT</column>
 			<column name="VERSION">0</column>
 		</row>
 		<row action="r" onTableCreateOnly="no">


### PR DESCRIPTION
## Summary

Explorer server-action toolbar and context menus no longer navigate legacy Data Flow (XML application) URLs such as `../sys_cxSupport/previewslotvariant.html`. Those resolve under `/cm/` from the SPA and **404**.

This slice (P0 of the action-execution plan) routes activations through a React dispatcher:

- **Preview by template** — `GET /services/assembly/preview-location` then open `/assembler/render` (language: template, not variant)
- **Workflow** — existing itemmanagement transitions
- **Purge** — confirm, then page/asset `DELETE …/purge/{id}` (distinct from folder Delete)
- **Edit / content-editor URLs** (`rx_ce*`, checkoutedit, …) — TMX “editor not available” (Content Editor is a separate spec: `specs/995-react-content-editor/`)
- **Publish Now / AA / slot** — unavailable in this slice (no navigation)

Seed `RXMENUACTION` P0 rows clear Data Flow URLs (`HANDLER=CLIENT`, `action=r` for upgrades). DCE is not an 8.2 client.

Partial toward Explorer action-menu execution (992 US3 listing already landed; this is execution).

## Test plan

1. Standalone `mvnw clean install` already run: `rest` BUILD SUCCESS; `projects/sitemanage` BUILD SUCCESS; `WebUI` BUILD SUCCESS (Vitest 2434 passed, Java 59 passed).
2. QA H2: `perc-devctl qa-up` → `qa-health` → open `/cm/app/spa.jsp?entry=explorer`.
3. Select a page. Server actions must **not** request `/sys_cxSupport/*.html` or `/cm/sys_cxSupport/*`.
4. Preview (or a template child) opens assembler preview, not an HTML redirect.
5. Edit does **not** land on `?view=editor`.
6. Playwright: `npm run test:surface -- --path tests/explorer-action-dispatch.spec.js` from `modules/perc-qa-automation/frontend`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` (server action execution) and `product-docs/8.2/developer/rest.md` (preview-location)
- [x] **Unit / module tests** — `actionDispatch.test.ts`, `menuCatalogLoad.test.ts`, `assemblyApi.test.ts`, `AssemblyResourceTest`, `AssemblyAdaptorTest`, Spring `TestAssemblyAdaptor`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js`
- [x] **Build gates** — `cd rest && ../mvnw clean install`; `cd projects/sitemanage && ../../mvnw clean install`; `cd WebUI && ../mvnw clean install`
- [x] **Cross-platform** — assembly URLs use `/` (URL paths, not OS file joins); no new filesystem I/O

Erlang: initial request-changes (GUID ids, CE URLs still 404ing, Purge vs recycle, missing tests) fixed in this commit. Report: `docs/ai-generated/code-reviews/explorer-action-execution-erlang.md`.

> Co-Authored by Grok Build TUI (Grok 4.6) using grok-4.6 with agent Grok.