### PR TITLE
fix(webui): asset picker SearchPanel mount + search execute (#3438)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
@@ -52,6 +52,7 @@
 
 import { post } from "../client";
 import { PATHS } from "../paths";
+import { toRepositorySearchFolderPath } from "../../contentExplorer/folderPath";
 import type {
   PSItemProperties,
   PSPagedItemPropertiesList,
@@ -105,7 +106,7 @@ export function normalizeSearchCriteria(
     sortOrder: criteria.sortOrder,
     formatId,
     searchFields: criteria.searchFields,
-    folderPath: criteria.folderPath,
+    folderPath: toRepositorySearchFolderPath(criteria.folderPath),
   };
   return out;
 }

--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -16,12 +16,63 @@
 
 import { get, post } from "../client";
 import { PATHS } from "../paths";
+import { toRepositorySearchFolderPath } from "../../contentExplorer/folderPath";
 import type {
   SearchDef,
   SearchExecuteRequest,
   SearchExecuteResult,
   SearchResultItem,
 } from "./types";
+
+/**
+ * Jackson / JAXB root for {@link SearchExecuteRequest}
+ * ({@code @XmlRootElement(name = "SearchExecuteRequest")}). CXF
+ * {@code UNWRAP_ROOT_VALUE} rejects a bare {@code folderPath} field
+ * (QA #2799 / #3438) — same envelope as {@code ViewExecuteRequest}.
+ */
+export const SEARCH_EXECUTE_REQUEST_ROOT = "SearchExecuteRequest";
+
+/** Wire envelope required by WRAP_ROOT_VALUE / JAXB on search execute. */
+export type SearchExecuteRequestEnvelope = {
+  SearchExecuteRequest: SearchExecuteRequest;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Wrap execute overrides under {@link SEARCH_EXECUTE_REQUEST_ROOT}.
+ * Does not double-wrap an already-enveloped payload. Folder paths are
+ * normalized to repository form ({@code //Sites}) so a host that still
+ * holds {@code /Sites} does not 400 on {@code getIdByPath}.
+ */
+export function wrapSearchExecuteRequest(
+  request?: SearchExecuteRequest | SearchExecuteRequestEnvelope | null,
+): SearchExecuteRequestEnvelope {
+  const rec = asRecord(request);
+  let inner: SearchExecuteRequest = {};
+  if (rec != null) {
+    const nested = rec[SEARCH_EXECUTE_REQUEST_ROOT];
+    if (asRecord(nested) != null) {
+      inner = nested as SearchExecuteRequest;
+    } else {
+      inner = request as SearchExecuteRequest;
+    }
+  }
+  const folderPath = toRepositorySearchFolderPath(inner.folderPath);
+  const rest: SearchExecuteRequest = { ...inner };
+  delete rest.folderPath;
+  return {
+    SearchExecuteRequest: {
+      ...rest,
+      ...(folderPath !== undefined ? { folderPath } : {}),
+    },
+  };
+}
 
 /**
  * Catalog-level design gaps (REST-GAPS-02). Server omits these on list rows;
@@ -133,10 +184,9 @@ export async function executeSearch(
     throw new Error("Search id or name is required");
   }
   const pathKey = encodeURIComponent(key);
-  const body = request ?? {};
   const payload = await post<unknown>(
     `${PATHS.SEARCHES}/${pathKey}/execute`,
-    body,
+    wrapSearchExecuteRequest(request),
   );
   return unwrapSearchExecuteResult(payload);
 }

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -59,6 +59,7 @@ import type {
 import { formatApiError } from "../api/client";
 import { message } from "../i18n/message";
 import { EXPLORER_MSG } from "./messages";
+import { toRepositorySearchFolderPath } from "./folderPath";
 
 export interface SearchPanelProps {
   /** Optional initial query (e.g. URL hash / deep-link). */
@@ -228,6 +229,7 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
         query: trimmed,
         startIndex: initialCriteria.startIndex ?? 1,
         maxResults: initialCriteria.maxResults ?? 25,
+        folderPath: toRepositorySearchFolderPath(initialCriteria.folderPath),
       });
       setStatus({ kind: "ready", query: trimmed, results });
     } catch (err: unknown) {
@@ -249,7 +251,7 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
     setStatus({ kind: "loading", query: display });
     try {
       const request: SearchExecuteRequest = {
-        folderPath: initialCriteria.folderPath,
+        folderPath: toRepositorySearchFolderPath(initialCriteria.folderPath),
         startIndex: initialCriteria.startIndex ?? 1,
         maxResults: initialCriteria.maxResults ?? 25,
         sortColumn: initialCriteria.sortColumn,
@@ -522,7 +524,7 @@ function SearchStatusView(props: {
           role="status"
           aria-live="polite"
           data-testid="search-panel-empty"
-          style={{ marginTop: 8, color: "#888" }}
+          style={{ marginTop: 8, color: "#595959" }}
         >
           {message(EXPLORER_MSG.SEARCH_EMPTY)}
         </p>
@@ -548,7 +550,7 @@ function SearchStatusView(props: {
           >
             <span style={{ flex: 1 }} data-mkd-lang-ignore="1">
               <strong>{r.title ?? r.name ?? r.id}</strong>
-              <small style={{ marginLeft: 6, color: "#888" }}>
+              <small style={{ marginLeft: 6, color: "#595959" }}>
                 {r.folderPath ?? r.type}
               </small>
             </span>

--- a/WebUI/src/main/ts/contentExplorer/folderPath.ts
+++ b/WebUI/src/main/ts/contentExplorer/folderPath.ts
@@ -172,3 +172,34 @@ export function resolveFolderPathFromSelection(
   }
   return normalizeExplorerFolderPath(folderPath);
 }
+
+/**
+ * Repository form required by content WS / search execute
+ * ({@code getIdByPath} rejects paths that do not start with {@code //}).
+ *
+ * <p>Explorer tree/list chrome uses a single leading slash ({@code /Sites}).
+ * Free-text search and saved-search execute must send {@code //Sites} (or
+ * {@code //Folders}, {@code //Assets}) or the server returns
+ * {@code Path: /Sites - must start with '//'} (#3438 / #2799).</p>
+ *
+ * <p>CMS paths always use {@code /} — this is not OS file I/O. Drive
+ * letters and backslashes are stripped only so a pasted Windows-style
+ * path still becomes a valid repository path.</p>
+ *
+ * @returns {@code //Sites/...} form, or {@code undefined} when empty
+ */
+export function toRepositorySearchFolderPath(
+  path: string | null | undefined,
+): string | undefined {
+  if (path == null) return undefined;
+  let p = path.trim().replace(/\\/g, "/");
+  if (p.length === 0) return undefined;
+  p = p.replace(/^[A-Za-z]:/, "");
+  if (p.length === 0) return undefined;
+  // Collapse all slashes first so //Sites and /Sites share one form.
+  p = p.replace(/\/{2,}/g, "/");
+  if (!p.startsWith("/")) {
+    p = `/${p}`;
+  }
+  return `/${p}`;
+}

--- a/WebUI/src/main/webapp/cm/app/assetPickerModern.jsp
+++ b/WebUI/src/main/webapp/cm/app/assetPickerModern.jsp
@@ -43,12 +43,14 @@
 </div>
 <script>
     (function () {
-        // Self-load the modern bridge (same pattern as the US6 hard-cut
-        // pages — idempotent, with cache-buster).
+        // Self-load the modern bridge (idempotent). Do NOT cache-bust
+        // perc-modern-ui.js: a ?cb= URL is a second ESM graph and the lazy
+        // ContentBrowser chunk then loads a second React (useState-null).
+        // URL must match the chunk import exactly (#3438 / #2799).
         if (!document.querySelector('script[src*="perc-modern-ui.js"]')) {
             var s = document.createElement("script");
             s.type = "module";
-            s.src = "/cm/modern/assets/perc-modern-ui.js?cb=" + Date.now();
+            s.src = "/cm/modern/assets/perc-modern-ui.js";
             document.head.appendChild(s);
         }
         function mountBrowser() {
@@ -57,7 +59,7 @@
                 return;
             }
             window.PercModernUI.mount("perc-content-browser-root", "ContentBrowser", {
-                initialPath: "/Sites",
+                initialPath: "//Sites",
                 mode: "select",
                 multiSelect: false,
                 allowFolderSelect: false,

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -195,6 +195,15 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     }
   });
 
+  it("assetPickerModern.jsp loads a single perc-modern-ui.js module URL (#3438)", () => {
+    const text = read(resolve(webappRoot, "cm/app/assetPickerModern.jsp"));
+    expect(text).toContain('s.src = "/cm/modern/assets/perc-modern-ui.js"');
+    expect(text).not.toMatch(/perc-modern-ui\.js\?cb=/);
+    expect(text).not.toMatch(/Date\.now\s*\(/);
+    expect(text).toContain('initialPath: "//Sites"');
+    expect(text).toContain("enableSearch: true");
+  });
+
   it("spa.jsp remains the authenticated SPA document (dual-tree aligned)", () => {
     const appSpa = resolve(webappRoot, "cm/app/spa.jsp");
     const pagesSpa = resolve(webappRoot, "cm/pages/app/spa.jsp");

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1511,7 +1511,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       folderPath?: string;
     };
     expect(criteria.query).toBe("demo page");
-    expect(criteria.folderPath).toBe("/Sites/Demo");
+    expect(criteria.folderPath).toBe("//Sites/Demo");
     await waitFor(() => {
       expect(screen.getByTestId("search-panel-results")).toBeInTheDocument();
     });

--- a/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
@@ -224,6 +224,25 @@ describe("SearchPanel", () => {
     expect(search).not.toHaveBeenCalled();
   });
 
+  it("normalizes free-text folderPath to repository form (#3438)", async () => {
+    const search = vi.fn().mockResolvedValue(makeResults([]));
+    render(
+      <SearchPanel
+        search={search}
+        listSavedSearches={emptyCatalog()}
+        initialCriteria={{ folderPath: "/Sites" }}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("search-panel-input"), {
+      target: { value: "welcome" },
+    });
+    fireEvent.click(screen.getByTestId("search-panel-submit"));
+    await waitFor(() => {
+      expect(search).toHaveBeenCalledTimes(1);
+    });
+    expect(search.mock.calls[0]?.[0]?.folderPath).toBe("//Sites");
+  });
+
   it("initialQuery triggers a search on mount", async () => {
     const search = vi.fn().mockResolvedValue(makeResults(ONE_ROW));
     render(
@@ -401,7 +420,7 @@ describe("SearchPanel", () => {
       });
       expect(executeSavedSearch.mock.calls[0]?.[0]).toBe("All Content");
       expect(executeSavedSearch.mock.calls[0]?.[1]).toMatchObject({
-        folderPath: "/Sites/Foo",
+        folderPath: "//Sites/Foo",
         maxResults: 10,
         startIndex: 1,
       });

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -20,6 +20,7 @@ import {
   isStrictCmsPathDescendant,
   normalizeExplorerFolderPath,
   resolveFolderPathFromSelection,
+  toRepositorySearchFolderPath,
 } from "../../../main/ts/contentExplorer/folderPath";
 
 describe("normalizeExplorerFolderPath (#2792)", () => {
@@ -144,5 +145,33 @@ describe("resolveFolderPathFromSelection (#2792)", () => {
     expect(
       resolveFolderPathFromSelection(null, "/Sites/X", "page"),
     ).toBeNull();
+  });
+});
+
+describe("toRepositorySearchFolderPath (#3438)", () => {
+  it("returns undefined for empty input", () => {
+    expect(toRepositorySearchFolderPath(null)).toBeUndefined();
+    expect(toRepositorySearchFolderPath(undefined)).toBeUndefined();
+    expect(toRepositorySearchFolderPath("")).toBeUndefined();
+    expect(toRepositorySearchFolderPath("   ")).toBeUndefined();
+  });
+
+  it("converts explorer /Sites form to repository //Sites", () => {
+    expect(toRepositorySearchFolderPath("/Sites")).toBe("//Sites");
+    expect(toRepositorySearchFolderPath("/Sites/Foo")).toBe("//Sites/Foo");
+    expect(toRepositorySearchFolderPath("Sites/Foo")).toBe("//Sites/Foo");
+  });
+
+  it("keeps an already-repository path", () => {
+    expect(toRepositorySearchFolderPath("//Sites")).toBe("//Sites");
+    expect(toRepositorySearchFolderPath("//Sites/Foo")).toBe("//Sites/Foo");
+    expect(toRepositorySearchFolderPath("//Folders/$System$/Assets")).toBe(
+      "//Folders/$System$/Assets",
+    );
+  });
+
+  it("normalizes backslashes and extra slashes", () => {
+    expect(toRepositorySearchFolderPath("\\Sites\\Foo")).toBe("//Sites/Foo");
+    expect(toRepositorySearchFolderPath("///Sites//Foo")).toBe("//Sites/Foo");
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/searchApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/searchApi.test.ts
@@ -57,6 +57,21 @@ describe("normalizeSearchCriteria (GH-2950)", () => {
     expect(out.startIndex).toBe(1);
     expect(out).not.toHaveProperty("caseSensitive");
   });
+
+  it("normalizes explorer folderPath to repository form (#3438)", () => {
+    const out = normalizeSearchCriteria({
+      query: "a",
+      folderPath: "/Sites",
+    });
+    expect(out.folderPath).toBe("//Sites");
+    expect(
+      normalizeSearchCriteria({ query: "a", folderPath: "//Sites/Foo" })
+        .folderPath,
+    ).toBe("//Sites/Foo");
+    expect(
+      normalizeSearchCriteria({ query: "a" }).folderPath,
+    ).toBeUndefined();
+  });
 });
 
 describe("searchExtended wire shape", () => {

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -20,6 +20,7 @@ import {
   listExplorerSavedSearches,
   listSearches,
   unwrapSearchExecuteResult,
+  wrapSearchExecuteRequest,
 } from "../../../main/ts/api/developer/searchesApi";
 import { PATHS } from "../../../main/ts/api/paths";
 
@@ -93,6 +94,49 @@ describe("listSearches", () => {
   });
 });
 
+describe("wrapSearchExecuteRequest", () => {
+  it("wraps flat overrides under SearchExecuteRequest for JAXB", () => {
+    expect(
+      wrapSearchExecuteRequest({
+        folderPath: "/Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      }),
+    ).toEqual({
+      SearchExecuteRequest: {
+        folderPath: "//Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      },
+    });
+  });
+
+  it("sends an empty SearchExecuteRequest root when overrides are omitted", () => {
+    expect(wrapSearchExecuteRequest()).toEqual({ SearchExecuteRequest: {} });
+    expect(wrapSearchExecuteRequest(null)).toEqual({ SearchExecuteRequest: {} });
+  });
+
+  it("does not double-wrap an already enveloped body", () => {
+    expect(
+      wrapSearchExecuteRequest({
+        SearchExecuteRequest: { startIndex: 2, maxResults: 10 },
+      }),
+    ).toEqual({
+      SearchExecuteRequest: { startIndex: 2, maxResults: 10 },
+    });
+  });
+
+  it("normalizes a single-slash folderPath on an already enveloped body", () => {
+    expect(
+      wrapSearchExecuteRequest({
+        SearchExecuteRequest: { folderPath: "/Sites", startIndex: 1 },
+      }),
+    ).toEqual({
+      SearchExecuteRequest: { folderPath: "//Sites", startIndex: 1 },
+    });
+  });
+});
+
 describe("executeSearch", () => {
   it("POSTs to /searches/{id}/execute with optional overrides", async () => {
     const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
@@ -127,9 +171,11 @@ describe("executeSearch", () => {
     );
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual({
-      folderPath: "/Sites/Foo",
-      startIndex: 1,
-      maxResults: 25,
+      SearchExecuteRequest: {
+        folderPath: "//Sites/Foo",
+        startIndex: 1,
+        maxResults: 25,
+      },
     });
     expect(result.children).toHaveLength(1);
     expect(result.children?.[0]?.title).toBe("Welcome");

--- a/docs/ai-generated/code-reviews/issue-3438-asset-picker-search-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3438-asset-picker-search-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — issue 3438 asset picker SearchPanel mount + execute
+
+**Branch:** `fix/issue-3438-asset-picker-search`  
+**Scope:** uncommitted WebUI + `host-asset-picker` Playwright vs `origin/main`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** pass
+
+## Summary
+
+Residual of QA Failed #2799. Three concrete defects on the Asset Picker host:
+
+1. Dual React from `perc-modern-ui.js?cb=` + `Date.now()` vs lazy chunk import of the unqueried URL.
+2. Free-text / execute `folderPath` sent as `/Sites` (`getIdByPath` requires `//`).
+3. Saved-search POST body was a bare `folderPath` object; CXF UNWRAP_ROOT_VALUE expects `SearchExecuteRequest`.
+
+Implementation matches peers (`wrapViewExecuteRequest`, `toRepositoryCmsPath`). Tests cover path normalize, envelope wrap, JSP module URL, and live Playwright without soft-skip.
+
+## Cross-platform path checklist
+
+CMS repository paths (`/Sites` vs `//Sites`) are URL-style, not OS file I/O. Helper strips optional drive letters / backslashes only so a pasted path still becomes `//Sites/...`. No hardcoded OS separators for filesystem work. Playwright uses `TEST_CMS_URL`. **Pass.**
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Memory patterns hit
+
+- Dual ESM / two React copies from cache-busted module URL vs lazy import
+- JAXB WRAP_ROOT_VALUE envelopes (`ViewExecuteRequest` peer)
+- Repository `//` prefix for content WS path APIs

--- a/modules/perc-qa-automation/frontend/tests/host-asset-picker.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/host-asset-picker.spec.js
@@ -112,25 +112,29 @@ test.describe("US2 host-asset-picker migration (SC-002)", () => {
   });
 
   /**
-   * #2793 ContentBrowser host search: asset picker mounts shared SearchPanel
-   * (catalog chrome + free-text). Soft-skip when modern bundle/host fixture
-   * has not yet shipped enableSearch (stale WAR / pre-merge deploy).
+   * #2793 / #3438: asset picker mounts shared SearchPanel. Must not
+   * soft-skip — ContentBrowser has to appear, and free-text / saved
+   * execute must not 400 on /Sites vs //Sites or a bare folderPath
+   * (SearchExecuteRequest envelope).
    */
-  test("asset-picker SearchPanel mounts when enableSearch is on @content-browser-search @host-asset-picker", async ({
+  test("asset-picker SearchPanel mounts and search is not 400 @content-browser-search @host-asset-picker", async ({
     page,
   }) => {
+    const searchHits = [];
+    page.on("response", (res) => {
+      const url = res.url();
+      if (
+        url.includes("/searchmanagement/") ||
+        /\/services\/searches\/[^/]+\/execute/.test(url)
+      ) {
+        searchHits.push({ url, status: res.status() });
+      }
+    });
+
     await page.goto(DIALOG_URL, { waitUntil: "networkidle" });
     const dialog = page.locator('[data-testid="content-browser"]');
     await expect(dialog).toBeVisible({ timeout: 15_000 });
-
-    const enableSearch = await dialog.getAttribute("data-enable-search");
-    if (enableSearch !== "true") {
-      test.skip(
-        true,
-        "Host fixture does not enable SearchPanel (data-enable-search!=true); soft-skip until #2793 WAR is deployed",
-      );
-      return;
-    }
+    await expect(dialog).toHaveAttribute("data-enable-search", "true");
 
     const searchHost = page.locator(
       '[data-testid="content-browser-search-panel"]',
@@ -138,7 +142,6 @@ test.describe("US2 host-asset-picker migration (SC-002)", () => {
     await expect(searchHost).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('[data-testid="search-panel-input"]')).toBeVisible();
     await expect(page.locator('[data-testid="search-panel-submit"]')).toBeVisible();
-    // Catalog settles to empty, error, or picker (same pattern as explorer-saved-search).
     await expect(
       page
         .locator(
@@ -146,7 +149,53 @@ test.describe("US2 host-asset-picker migration (SC-002)", () => {
         )
         .first(),
     ).toBeVisible({ timeout: 20_000 });
-    // 508 / a11y gate scoped to the SearchPanel host surface (#2793 review).
+
+    await page.locator('[data-testid="search-panel-input"]').fill("a");
+    await page.locator('[data-testid="search-panel-submit"]').click();
+    await expect(
+      page
+        .locator(
+          '[data-testid="search-panel-results"], [data-testid="search-panel-empty"], [data-testid="search-panel-error"]',
+        )
+        .first(),
+    ).toBeVisible({ timeout: 20_000 });
+
+    const bad = searchHits.filter((h) => h.status === 400);
+    expect(bad, `search 400s: ${JSON.stringify(bad)}`).toEqual([]);
+
+    const err = page.locator('[data-testid="search-panel-error"]');
+    if (await err.isVisible()) {
+      const text = (await err.textContent()) || "";
+      expect(text).not.toMatch(/must start with/i);
+      expect(text).not.toMatch(/JAXBException|SearchExecuteRequest/i);
+    }
+
+    const savedSelect = page.locator('[data-testid="search-panel-saved-select"]');
+    if (await savedSelect.isVisible()) {
+      const values = await savedSelect.locator("option").evaluateAll((opts) =>
+        opts.map((o) => o.value).filter((v) => v && v.trim().length > 0),
+      );
+      if (values.length > 0) {
+        await savedSelect.selectOption(values[0]);
+        const run = page.locator('[data-testid="search-panel-saved-run"]');
+        if (await run.isEnabled()) {
+          await run.click();
+          await expect(
+            page
+              .locator(
+                '[data-testid="search-panel-results"], [data-testid="search-panel-empty"], [data-testid="search-panel-error"]',
+              )
+              .first(),
+          ).toBeVisible({ timeout: 20_000 });
+          const badSaved = searchHits.filter((h) => h.status === 400);
+          expect(
+            badSaved,
+            `saved-search 400s: ${JSON.stringify(badSaved)}`,
+          ).toEqual([]);
+        }
+      }
+    }
+
     await expectNoSeriousA11yViolations(page, {
       scope: '[data-testid="content-browser-search-panel"]',
     });


### PR DESCRIPTION
## Summary

Residual of human QA **#2799** (epic **#2400**). The shipped Asset Picker host (`assetPickerModern.jsp`) returned 200 but never mounted `[data-testid=content-browser]` because it loaded `perc-modern-ui.js?cb=` + `Date.now()` while the lazy ContentBrowser chunk imported `perc-modern-ui.js` with no query — two React copies (`useState` on null). After a diagnostic remount, free-text search 400'd (`Path: /Sites - must start with '//'`) and saved-search Run JAXB-failed on a bare `folderPath` (expected `SearchExecuteRequest`).

This PR:

1. Loads a **single** `/cm/modern/assets/perc-modern-ui.js` module URL (no cache-buster) and seeds `initialPath: "//Sites"`. There is no `WebUI/war` copy of this JSP (`assetPicker` is app-tree only).
2. Normalizes SearchPanel / `searchExtended` / execute `folderPath` to repository form (`//Sites`) before the request.
3. POSTs saved-search execute as a `SearchExecuteRequest` envelope (peer `ViewExecuteRequest`).
4. Darkens result-row path text (`#595959`) so axe color-contrast passes after results appear.
5. Playwright `host-asset-picker` **no longer soft-skips** — asserts ContentBrowser mounts, SearchPanel is on, and search is not 400.

Fixes #3438  
Parent tracker: #2799  
Epic: #2400

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Env: QA H2 docker (`perc-devctl qa-up --skip-image-build`) as Admin.
2. Open `/Rhythmyx/cm/app/assetPickerModern.jsp`.
3. Confirm `[data-testid=content-browser]` mounts (no `useState` null / dual-React console error).
4. Confirm SearchPanel is visible (`data-enable-search=true`).
5. Run free-text Search — must not fail `Path: /Sites - must start with '//'`; results or honest empty.
6. If a saved search is listed, Run — must not JAXB-fail on `folderPath`.
7. Open / Reveal / Confirm can be exercised when rows exist.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): bugfix of residual picker host + REST envelope/path; operator Asset Picker steps are unchanged
- [x] **Unit / module tests** — Vitest for path normalize + `SearchExecuteRequest` envelope; JSP module-URL contract; standalone `cd WebUI && ../mvnw.cmd clean install` green
- [x] **WebUI + Playwright** — `host-asset-picker.spec.js` no soft-skip; 6 passed on QA H2
- [x] **Build gates** — WebUI standalone clean install (no skipTests); C2 N/A (no Java API / `final` / signature change)
- [x] **Cross-platform** — CMS repository paths use `/` (not OS file I/O); helper is URL-style `//Sites`

## C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-15T11:14:10-04:00, ~01:23). Vitest: **Test Files 325 passed, Tests 2448 passed**. No new module warnings attributable to this change (baseline javadoc/dependency-analyze only).
- **downstream_checked:** none (TypeScript/JSP/Playwright only; no Java public API / `final` / signature change; `rest` unchanged)

## C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (reused `percussion-matrix-cell:local`). Cell `perc-matrix-cms-h2` **Health=healthy**, `TEST_CMS_URL=http://127.0.0.1:9993`. `qa-health` flagged pre-existing FastForward gif import `PSDbStorageService Could not import item` noise (HTTP 200, not `Failed startup of context`).
- **hot-deploy:** copied `WebUI/target/generated-webui/cm/modern/assets/*` and `assetPickerModern.jsp` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/` (no docker restart).
- **Playwright:** from `modules/perc-qa-automation/frontend`: `npm run test:surface -- --path tests/host-asset-picker.spec.js` → **6 passed** (8.2s).
- **console-clean:** yes (suite green; ContentBrowser mounted; search not 400)
- **server.log-clean:** yes for this feature (no `must start with '//'` / JAXB / SearchExecuteRequest errors in the test window). Startup `PSSearchIndexFieldValueModifier` last-modifier noise predates the run.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
