### PR TITLE
fix(explorer): keep Assets on pathmanagement when Folder Mutations is on (#3363)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/rxFolderMutationsFlag.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/rxFolderMutationsFlag.ts
@@ -163,6 +163,36 @@ export function isRxFolderMutationsEnabled(): boolean {
 }
 
 /**
+ * Whether {@code lower} is {@code prefix} or a child segment of it.
+ * Trailing slashes are ignored so {@code /Assets/} matches {@code /assets}.
+ */
+function isPrefixOrEqual(lower: string, prefix: string): boolean {
+  let p = lower;
+  while (p.length > 1 && p.endsWith("/")) {
+    p = p.slice(0, -1);
+  }
+  return p === prefix || p.startsWith(`${prefix}/`);
+}
+
+/**
+ * CM1 library roots that live under {@code //Folders/$System$} in the
+ * repository but must stay on pathmanagement (#3363).
+ *
+ * <p>Explorer selection prefers {@code PathItem.folderPath}, so Assets is
+ * often {@code /Folders/$System$/Assets} (or {@code //Folders/$System$/Assets})
+ * rather than the finder id {@code /Assets}. A naive {@code /Folders/}
+ * prefix would incorrectly send create/rename/move to the RX façade.</p>
+ */
+function isNonRxSystemLibraryPath(normalizedLower: string): boolean {
+  return (
+    isPrefixOrEqual(normalizedLower, "/assets") ||
+    isPrefixOrEqual(normalizedLower, "/recycling") ||
+    isPrefixOrEqual(normalizedLower, "/folders/$system$/assets") ||
+    isPrefixOrEqual(normalizedLower, "/folders/$system$/recycling")
+  );
+}
+
+/**
  * Whether a CMS path is under an RX-capable root that the content-explorer
  * folders façade is intended to serve ({@code Folders} / {@code Sites}).
  *
@@ -170,6 +200,10 @@ export function isRxFolderMutationsEnabled(): boolean {
  * repository form ({@code //Folders/...}, {@code //Sites/...}). Other roots
  * ({@code /Assets}, {@code /Design}, {@code /Recycling}, …) stay on
  * pathmanagement even when the dual-run flag is on.</p>
+ *
+ * <p>Assets (and Recycling) are also non-RX when represented as
+ * {@code /Folders/$System$/Assets} or {@code //Folders/$System$/Assets}
+ * (#3363). Sibling folders under {@code $System$} remain RX-capable.</p>
  */
 export function isRxCapableFolderPath(path: string | null | undefined): boolean {
   if (path == null) {
@@ -194,6 +228,9 @@ export function isRxCapableFolderPath(path: string | null | undefined): boolean 
   // Strip one leading slash for comparison so //Folders and /Folders share logic.
   const withoutRepo = p.startsWith("//") ? p.slice(1) : p;
   const lower = withoutRepo.toLowerCase();
+  if (isNonRxSystemLibraryPath(lower)) {
+    return false;
+  }
   return (
     lower === "/folders" ||
     lower.startsWith("/folders/") ||

--- a/WebUI/src/test/ts/contentExplorer/folderMutations.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderMutations.test.ts
@@ -82,6 +82,37 @@ describe("folderMutations dual-run routing (#3074)", () => {
     });
     await addNewFolder("/Assets", "X");
     expect(last).toContain("/pathmanagement/path/addNewFolder");
+    expect(last).not.toContain("/content-explorer/folders");
+  });
+
+  it("flag on + $System$/Assets finder form: stays on pathmanagement (#3363)", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ PathItem: { name: "X", path: "/Assets/X" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await addNewFolder("/Folders/$System$/Assets", "X");
+    expect(last).toContain("/pathmanagement/path/addNewFolder");
+    expect(last).not.toContain("/content-explorer/folders");
+  });
+
+  it("flag on + $System$/Assets repository form: stays on pathmanagement (#3363)", async () => {
+    setRxFolderMutationsFlagOverride(true);
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(
+        JSON.stringify({ PathItem: { name: "X", path: "/Assets/X" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await addNewFolder("//Folders/$System$/Assets", "X");
+    expect(last).toContain("/pathmanagement/path/addNewFolder");
+    expect(last).not.toContain("/content-explorer/folders");
   });
 
   it("flag on: renameFolder loads by path then PUTs by id", async () => {

--- a/WebUI/src/test/ts/contentExplorer/rxFolderMutationsFlag.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/rxFolderMutationsFlag.test.ts
@@ -88,10 +88,31 @@ describe("isRxCapableFolderPath", () => {
     expect(isRxCapableFolderPath("/Recycling")).toBe(false);
   });
 
+  it("treats $System$/Assets as non-RX in finder and repository forms (#3363)", () => {
+    expect(isRxCapableFolderPath("/Folders/$System$/Assets")).toBe(false);
+    expect(isRxCapableFolderPath("/Folders/$System$/Assets/")).toBe(false);
+    expect(isRxCapableFolderPath("/Folders/$System$/Assets/uploads")).toBe(false);
+    expect(isRxCapableFolderPath("//Folders/$System$/Assets")).toBe(false);
+    expect(isRxCapableFolderPath("//Folders/$System$/Assets/uploads")).toBe(
+      false,
+    );
+    expect(isRxCapableFolderPath("/Assets")).toBe(false);
+    expect(isRxCapableFolderPath("/Assets/uploads")).toBe(false);
+    // $System$ itself and non-library siblings stay RX-capable.
+    expect(isRxCapableFolderPath("/Folders/$System$")).toBe(true);
+    expect(isRxCapableFolderPath("/Folders/$System$/Other")).toBe(true);
+    expect(isRxCapableFolderPath("/Folders/$System$/Recycling")).toBe(false);
+    expect(isRxCapableFolderPath("//Folders/$System$/Recycling/x")).toBe(false);
+  });
+
   it("shouldUseRxFolderMutations requires both flag and RX root", () => {
     setRxFolderMutationsFlagOverride(true);
     expect(shouldUseRxFolderMutations("/Folders/A")).toBe(true);
     expect(shouldUseRxFolderMutations("/Assets/A")).toBe(false);
+    expect(shouldUseRxFolderMutations("/Folders/$System$/Assets")).toBe(false);
+    expect(shouldUseRxFolderMutations("//Folders/$System$/Assets/uploads")).toBe(
+      false,
+    );
     setRxFolderMutationsFlagOverride(false);
     expect(shouldUseRxFolderMutations("/Folders/A")).toBe(false);
   });

--- a/docs/ai-generated/code-reviews/3363-assets-non-rx-path-erlang.md
+++ b/docs/ai-generated/code-reviews/3363-assets-non-rx-path-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3363 Assets stay on pathmanagement
+
+**Date:** 2026-08-15  
+**Branch:** `fix/issue-3363-assets-non-rx-path`  
+**Scope:** uncommitted vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class companions (Vitest + Playwright + product-docs); CMS paths use `/` (not OS separators).
+
+## Summary
+
+Content Explorer dual-run treated `/Folders/$System$/Assets` as RX because `isRxCapableFolderPath` used a `/folders/` prefix. Explorer selection prefers `PathItem.folderPath`, so Assets create/rename/move hit `/content-explorer/folders` and failed JAXB (`unexpected element name`). The fix excludes the Assets (and Recycling) library in finder and `$System$` repository forms. Sibling folders under `$System$` remain RX-capable.
+
+## Issues
+
+None (no bugs, no missing behavioral tests, no non-portable filesystem I/O).
+
+## Cross-platform path checklist
+
+- [x] No OS filesystem path construction; CMS paths always use `/`
+- [x] Existing drive-letter / backslash normalize kept
+- [x] Tests assert CMS path strings, not host OS paths
+- N/A: temp files, scripts, line endings
+
+## Companions
+
+| Kind | Evidence |
+|------|----------|
+| Production | `WebUI/src/main/ts/api/contentExplorer/rxFolderMutationsFlag.ts` |
+| Vitest | `$System$/Assets` finder + repo; flag-on stays on pathmanagement |
+| Playwright | `tests/bugs/bug-3363-assets-non-rx-path.spec.js` |
+| Product-docs | `product-docs/8.2/admin/content-explorer.md`, `developer/rest.md` |
+
+## Build
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire 59/0; Vitest 2440 passed
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3363-assets-non-rx-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3363-assets-non-rx-path.spec.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3363 — Assets create/rename/move stay on pathmanagement when Folder
+ * Mutations is on. Explorer selection often rewrites Assets to
+ * {@code /Folders/$System$/Assets} (or {@code //Folders/$System$/Assets});
+ * that must not route to {@code /content-explorer/folders}.
+ *
+ * Run after perc-devctl qa-up:
+ *   npm run test:surface -- --path tests/bugs/bug-3363-assets-non-rx-path.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { expectNoSeriousA11yViolations } = require("../helpers/a11y");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&rxFolderMutations=1&_=${Date.now()}`;
+
+function isCreateFolderUrl(url) {
+  const u = String(url || "");
+  return (
+    u.includes("/pathmanagement/path/addNewFolder") ||
+    /\/content-explorer\/folders(?:\?|$|\/)/.test(u)
+  );
+}
+
+test.describe("GH-3363 Assets stay on pathmanagement", () => {
+  test(
+    "Create folder under Assets does not POST content-explorer folders",
+    { tag: ["@explorer", "@folder-mutations", "@bug-3363"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      /** @type {Array<{ url: string, method: string }>} */
+      const mutations = [];
+      page.on("request", (req) => {
+        const url = req.url();
+        if (isCreateFolderUrl(url) && req.method() !== "OPTIONS") {
+          mutations.push({ url, method: req.method() });
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(EXPLORER_URL);
+      await page.waitForLoadState("networkidle").catch(() => undefined);
+
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      const chromeVisible = await shell
+        .isVisible({ timeout: 20_000 })
+        .catch(() => false);
+      if (!chromeVisible) {
+        test.skip(true, "Explorer shell not visible — routing covered by Vitest");
+        return;
+      }
+
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      }).catch(() => undefined);
+
+      const assetsNode = page
+        .locator(
+          [
+            '[data-testid="tree-node-/Assets/"]',
+            '[data-testid="tree-node-/Assets"]',
+            '[data-testid="tree-node-/Folders/$System$/Assets/"]',
+            '[data-testid="tree-node-/Folders/$System$/Assets"]',
+            '[data-testid="tree-node-//Folders/$System$/Assets"]',
+            '[data-testid*="tree-node"][data-testid*="Assets"]',
+          ].join(", "),
+        )
+        .first();
+      const assetsVisible = await assetsNode
+        .isVisible({ timeout: 12_000 })
+        .catch(() => false);
+      if (!assetsVisible) {
+        test.skip(true, "Assets tree node not visible — routing covered by Vitest");
+        return;
+      }
+      await assetsNode.click();
+      await page.waitForLoadState("networkidle").catch(() => undefined);
+
+      const createBtn = page.locator('[data-testid="action-create-folder"]').first();
+      const createVisible = await createBtn
+        .isVisible({ timeout: 8_000 })
+        .catch(() => false);
+      if (!createVisible || (await createBtn.isDisabled().catch(() => true))) {
+        test.skip(
+          true,
+          "Create folder not enabled under Assets — routing covered by Vitest",
+        );
+        return;
+      }
+
+      page.once("dialog", async (dialog) => {
+        await dialog.accept(`qa3363_${Date.now()}`);
+      });
+      await createBtn.click();
+      await page.waitForTimeout(2_500);
+
+      const hitRx = mutations.some((m) =>
+        m.url.includes("/content-explorer/folders"),
+      );
+      const hitPath = mutations.some((m) =>
+        m.url.includes("/pathmanagement/path/addNewFolder"),
+      );
+
+      expect(
+        hitRx,
+        `Assets must not use RX folders API: ${JSON.stringify(mutations)}`,
+      ).toBe(false);
+
+      if (!hitPath) {
+        test.skip(
+          true,
+          `Create did not POST addNewFolder (saw ${JSON.stringify(mutations)}); routing covered by Vitest`,
+        );
+        return;
+      }
+
+      const relatedConsole = consoleErrors.filter(
+        (t) =>
+          /unexpected element|AddFolderRequest|JAXBException|content-explorer\/folders/i.test(
+            t,
+          ) && !/favicon|ResizeObserver/i.test(t),
+      );
+      expect(relatedConsole, relatedConsole.join("\n")).toEqual([]);
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -103,8 +103,8 @@ on pathmanagement.
 | Name | `perc.explorer.rxFolderMutations` |
 | Default | **off** |
 | Enable in browser | Append `?rxFolderMutations=1` to the Explorer URL, or set storage key `perc.explorer.rxFolderMutations` to `true` |
-| Scope when on | `/Folders` and `/Sites` (and repository `//…` forms) only |
-| Unchanged | Browse/list, folder ACL (security panel), `/Assets` / `/Design` / `/Recycling` |
+| Scope when on | `/Folders` and `/Sites` (and repository `//…` forms) only. The Assets library is **not** in scope even when its repository path is `/Folders/$System$/Assets` or `//Folders/$System$/Assets`. |
+| Unchanged | Browse/list, folder ACL (security panel), `/Assets` (including `/Folders/$System$/Assets` and `//Folders/$System$/Assets`), `/Design`, `/Recycling` (including `/Folders/$System$/Recycling`) |
 | Copy folder | Public REST `POST /rest/folders/copy/folder` with a `CopyFolderItemRequest` root (`itemPath` + `targetFolderPath`). Not pathmanagement `moveItem` (that DTO is move-only). |
 
 Documented for integrators on [Public REST](id:developer-rest). Leave the flag **off** in

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -480,8 +480,8 @@ pathmanagement.
 | Operator property name | `perc.explorer.rxFolderMutations` |
 | Default | **off** (pathmanagement only — zero behavior change) |
 | Client enable (QA / dual-run) | URL `?rxFolderMutations=1`, or `sessionStorage` / `localStorage` key `perc.explorer.rxFolderMutations=true`, or `window.__PERC_RX_FOLDER_MUTATIONS__ = true` |
-| When on | Mutations under `/Folders` and `/Sites` (and `//Folders` / `//Sites`) use this REST surface |
-| Still on pathmanagement | List/paginate, ACL folder-properties save, non-RX roots (`/Assets`, `/Design`, `/Recycling`, …) |
+| When on | Mutations under `/Folders` and `/Sites` (and `//Folders` / `//Sites`) use this REST surface. Do **not** treat `/Folders/$System$/Assets` or `//Folders/$System$/Assets` as RX Folders — those are the Assets library. |
+| Still on pathmanagement | List/paginate, ACL folder-properties save, non-RX roots (`/Assets`, `/Folders/$System$/Assets`, `//Folders/$System$/Assets`, `/Design`, `/Recycling`, `/Folders/$System$/Recycling`, …) |
 | Copy folder | `POST /rest/folders/copy/folder` with JSON root `CopyFolderItemRequest` (`itemPath`, `targetFolderPath`). Explorer Copy / Subfolder Copy must not POST a bare `sourcePath` object to pathmanagement `moveItem` (HTTP 400 unexpected element `sourcePath`). |
 
 See also [Content Explorer](id:admin-content-explorer) dual-run notes.


### PR DESCRIPTION
## Summary

Content Explorer Folder Mutations dual-run treated the Assets library as an RX Folders path because the tree selection prefers `PathItem.folderPath` (`/Folders/$System$/Assets` or `//Folders/$System$/Assets`). Create/rename/move then posted to `/Rhythmyx/rest/content-explorer/folders` and failed with JAXB `unexpected element name` / expected `AddFolderRequest`.

`isRxCapableFolderPath` now treats `/Assets`, `/Folders/$System$/Assets`, and `//Folders/$System$/Assets` (and the same Recycling library forms) as **non-RX**, so mutations stay on pathmanagement. Sibling folders under `$System$` remain RX-capable.

Fixes #3363

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Surefire 59, Vitest 2440).
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. Enable Folder Mutations (`?rxFolderMutations=1`), open Explorer, select **Assets**, create a folder.
4. Network: `POST .../pathmanagement/path/addNewFolder` — **not** `POST .../content-explorer/folders`.
5. Confirm Folders/Sites still use the RX façade when the flag is on.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` and `product-docs/8.2/developer/rest.md` to document `$System$/Assets` as non-RX
- [x] **Unit / module tests** — Vitest for finder + repository `$System$/Assets`; existing flag-on + non-RX pathmanagement test extended
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3363-assets-non-rx-path.spec.js`
- [x] **Build gates** — standalone clean install on changed Maven modules; no API-shape / `final` change
- [x] **Cross-platform** — CMS paths always use `/`; existing drive-letter / backslash normalize kept

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-15T11:25:40-04:00). Surefire: Tests run: 59, Failures: 0. Vitest: Test Files 325 passed, Tests 2440 passed.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-15T11:25:59-04:00). Surefire: No tests to run (Playwright is not Maven Surefire).
- **downstream_checked:** none (no `final`/public API signature change; TS helper only)

### C5 UI proof (H2 Docker QA)

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (cell `perc-matrix-cms-h2`)
- **TEST_CMS_URL:** `http://127.0.0.1:9993`
- Hot-deploy: copied `WebUI/target/generated-webui/cm/modern/` → `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/` (no `docker restart`; no Jetty restart required for static SPA assets)
- `qa-health`: HTTP 200, Health=healthy; RESULT:FAIL DETAIL:server_log_errors on pre-existing FastForward `PSDbStorageService` import of `CI_PM_about.gif` (startup sample content, not this feature)
- Playwright:
  - `npm run test:surface -- --path tests/bugs/bug-3363-assets-non-rx-path.spec.js` → **1 passed** (5.5s)
  - `npm run test:golden` → **2 passed** (2.0s)
- **console-clean:** yes (spec asserts no JAXB / AddFolderRequest / content-explorer folders console errors)
- **server.log-clean:** yes for this feature (no JAXB / AddFolderRequest / content-explorer folders ERROR). Pre-existing noise: FastForward gif import; search-index date parse; `PSRuntimeExceptionMapper` "validated object is null" after login (also on golden, unrelated)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
