### PR TITLE
fix(webui): Developer Sites list bind after empty SiteList envelope (#3368)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -25,21 +25,44 @@ export const SITE_DESIGN_GAPS: string[] = [
 const LIST_WRAPPER_KEYS = [
   "SiteList",
   "siteList",
+  "SiteSummary",
+  "siteSummary",
   "Site",
   "site",
   "sites",
   "entries",
+  "item",
+  "Item",
 ] as const;
 
 /**
- * Parse GET /services/sites JSON.
+ * Parse GET /services/sites JSON (and the sitemanage SiteSummary list fallback).
  *
- * <p>Accepts a bare array or Jackson WRAP_ROOT envelopes ({@code SiteList} / {@code Site}).
- * Nested wraps ({@code {SiteList:{Site:[...]}}}) and per-item {@code {Site:{name}}} objects
- * are unwrapped so Developer Sites does not render a silent empty table after HTTP 200
- * (#3198). Unknown object shapes throw so the panel shows an error instead of empty.
+ * <p>Accepts a bare array or Jackson WRAP_ROOT envelopes ({@code SiteList} / {@code Site} /
+ * {@code SiteSummary}). Nested wraps ({@code {SiteList:{Site:[...]}}},
+ * {@code {SiteList:{sites:[...]}}}, JAXB {@code item}) and per-item {@code {Site:{name}}}
+ * objects are unwrapped so Developer Sites does not render a silent empty table after
+ * HTTP 200 (#3198 / #3368). Unknown object shapes throw so the panel shows an error
+ * instead of empty. XML text (wrong Content-Type) is parsed when {@code DOMParser} exists.
  */
 export function parseSiteList(payload: unknown): SiteDef[] {
+  if (typeof payload === "string") {
+    const trimmed = payload.trim();
+    if (!trimmed) {
+      return [];
+    }
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return parseSiteList(JSON.parse(trimmed) as unknown);
+      } catch {
+        throw new Error("Unexpected site list payload type");
+      }
+    }
+    if (trimmed.startsWith("<")) {
+      return parseXmlSiteList(trimmed);
+    }
+    throw new Error("Unexpected site list payload type");
+  }
   return collectSiteRows(payload, 0).map(normalizeSiteRow);
 }
 
@@ -55,6 +78,15 @@ function collectSiteRows(payload: unknown, depth: number): unknown[] {
   }
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
+    const emptyBean = collectionBeanEmpty(obj);
+    if (emptyBean === true) {
+      return [];
+    }
+    if (emptyBean === false) {
+      throw new Error(
+        "Unexpected site list payload (collection serialized as empty bean)",
+      );
+    }
     for (const key of LIST_WRAPPER_KEYS) {
       const raw = obj[key];
       if (raw == null) continue;
@@ -76,6 +108,19 @@ function collectSiteRows(payload: unknown, depth: number): unknown[] {
   throw new Error("Unexpected site list payload type");
 }
 
+/**
+ * Jackson may serialize an {@code ArrayList} subclass as {@code {empty:true|false}}
+ * instead of a JSON array (#3368 / ActionMenuList). {@code empty:true} is a real
+ * empty list; {@code empty:false} means rows were dropped.
+ */
+function collectionBeanEmpty(obj: Record<string, unknown>): boolean | null {
+  const keys = Object.keys(obj);
+  if (keys.length !== 1 || keys[0] !== "empty" || typeof obj.empty !== "boolean") {
+    return null;
+  }
+  return obj.empty;
+}
+
 function unwrapArrayItem(item: unknown, depth: number): unknown[] {
   if (item == null || typeof item !== "object" || Array.isArray(item)) {
     return item == null ? [] : [item];
@@ -84,11 +129,73 @@ function unwrapArrayItem(item: unknown, depth: number): unknown[] {
   if (looksLikeSite(obj)) {
     return [obj];
   }
-  const nested = obj.Site ?? obj.site;
+  const nested = obj.Site ?? obj.site ?? obj.SiteSummary ?? obj.siteSummary;
   if (nested != null && typeof nested === "object") {
     return collectSiteRows(nested, depth + 1);
   }
   return [obj];
+}
+
+function xmlLocalName(el: Element): string {
+  const raw = el.localName || el.tagName || "";
+  const colon = raw.lastIndexOf(":");
+  return colon >= 0 ? raw.slice(colon + 1) : raw;
+}
+
+function xmlDirectChildText(el: Element, names: string[]): string {
+  const want = new Set(names.map((n) => n.toLowerCase()));
+  for (const child of Array.from(el.children)) {
+    if (want.has(xmlLocalName(child).toLowerCase())) {
+      return (child.textContent || "").trim();
+    }
+  }
+  return "";
+}
+
+/**
+ * CXF may still emit XML when Accept negotiation misses JSON (#3368 content-type).
+ */
+function parseXmlSiteList(xml: string): SiteDef[] {
+  if (typeof DOMParser === "undefined") {
+    throw new Error("Unexpected site list payload type");
+  }
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  if (doc.getElementsByTagName("parsererror").length > 0) {
+    throw new Error("Unexpected site list payload type");
+  }
+  const rowTags = new Set(["site", "sitesummary", "item"]);
+  const rows: SiteDef[] = [];
+  const walk = (el: Element): void => {
+    const name = xmlLocalName(el).toLowerCase();
+    if (rowTags.has(name)) {
+      const siteName =
+        xmlDirectChildText(el, ["name"]) || (el.getAttribute("name") || "").trim();
+      const description = xmlDirectChildText(el, ["description"]);
+      const baseUrl = xmlDirectChildText(el, ["baseUrl", "base-url"]);
+      if (siteName) {
+        rows.push({
+          name: siteName,
+          description: description || undefined,
+          baseUrl: baseUrl || undefined,
+        });
+        return;
+      }
+    }
+    for (const child of Array.from(el.children)) {
+      walk(child);
+    }
+  };
+  if (doc.documentElement) {
+    walk(doc.documentElement);
+  }
+  if (rows.length > 0) {
+    return rows.map(normalizeSiteRow);
+  }
+  const rootName = doc.documentElement ? xmlLocalName(doc.documentElement).toLowerCase() : "";
+  if (rootName === "sitelist" || rootName === "sitesummary" || rootName === "sitesummarylist") {
+    return [];
+  }
+  throw new Error("Unexpected site list payload type");
 }
 
 const SITE_SIGNAL_KEYS = [
@@ -171,10 +278,58 @@ function withGaps(s: SiteDef): SiteDef {
   };
 }
 
-/** GET /services/sites */
+/**
+ * Catalog list URLs. Primary is public REST {@code /services/sites}. Trailing-slash
+ * and sitemanage {@code SiteSummary} are fallbacks when the primary bind is empty
+ * or an unreadable envelope (#3368).
+ */
+function siteListUrls(): string[] {
+  return [PATHS.SITES, `${PATHS.SITES}/`, `${PATHS.SITES_ALL}/`];
+}
+
+function isSessionRedirect(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { name?: string }).name === "SessionRedirectError"
+  );
+}
+
+/** GET /services/sites (sitemanage SiteSummary fallback when that list is empty). */
 export async function listSites(): Promise<SiteDef[]> {
-  const payload = await get<unknown>(PATHS.SITES);
-  return parseSiteList(payload).map(withGaps);
+  let lastError: unknown = null;
+  let sawEmpty = false;
+  const seen = new Set<string>();
+  for (const url of siteListUrls()) {
+    if (seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+    try {
+      const payload = await get<unknown>(url);
+      try {
+        const rows = parseSiteList(payload);
+        if (rows.length > 0) {
+          return rows.map(withGaps);
+        }
+        sawEmpty = true;
+      } catch (bindErr) {
+        lastError = bindErr;
+      }
+    } catch (httpErr) {
+      if (isSessionRedirect(httpErr)) {
+        throw httpErr;
+      }
+      lastError = httpErr;
+    }
+  }
+  if (sawEmpty) {
+    return [];
+  }
+  if (lastError != null) {
+    throw lastError;
+  }
+  return [];
 }
 
 /**

--- a/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.list.test.ts
@@ -118,6 +118,44 @@ describe("parseSiteList (#3198 bind)", () => {
       /Unexpected site list payload type/,
     );
   });
+
+  it("unwraps SiteList.sites (live Jackson / JAXB collection property)", () => {
+    expect(
+      parseSiteList({
+        SiteList: {
+          sites: [{ name: "Help", baseUrl: "https://h.example" }],
+        },
+      }),
+    ).toEqual([{ name: "Help", baseUrl: "https://h.example" }]);
+  });
+
+  it("unwraps sitemanage SiteSummary envelope (Home/Explorer list)", () => {
+    expect(parseSiteList({ SiteSummary: [{ name: "Corp", baseUrl: "https://c.example" }] })).toEqual(
+      [{ name: "Corp", baseUrl: "https://c.example" }],
+    );
+  });
+
+  it("unwraps JAXB item wrapper", () => {
+    expect(parseSiteList({ SiteList: { item: [{ name: "Help" }] } })).toEqual([{ name: "Help" }]);
+  });
+
+  it("treats {empty:true} collection bean as zero sites", () => {
+    expect(parseSiteList({ empty: true })).toEqual([]);
+    expect(parseSiteList({ SiteList: { empty: true } })).toEqual([]);
+  });
+
+  it("throws when collection bean is {empty:false} (rows dropped)", () => {
+    expect(() => parseSiteList({ empty: false })).toThrow(/empty bean/);
+    expect(() => parseSiteList({ SiteList: { empty: false } })).toThrow(/empty bean/);
+  });
+
+  it("parses JSON text and SiteList XML (wrong content-type leftovers)", () => {
+    expect(parseSiteList('{"SiteList":[{"name":"Help"}]}')).toEqual([{ name: "Help" }]);
+    expect(
+      parseSiteList("<SiteList><Site><name>Help</name><baseUrl>https://h.example</baseUrl></Site></SiteList>"),
+    ).toEqual([{ name: "Help", baseUrl: "https://h.example" }]);
+    expect(parseSiteList("<SiteList/>")).toEqual([]);
+  });
 });
 
 describe("coerceDisplayString", () => {
@@ -141,5 +179,36 @@ describe("listSites", () => {
     const out = await listSites();
     expect(out[0].name).toBe("Help");
     expect(out[0].designGaps?.length).toBeGreaterThan(0);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to sitemanage SiteSummary when SiteList is empty (#3368)", async () => {
+    get.mockImplementation(async (url: string) => {
+      if (String(url).includes("sitemanage/site")) {
+        return { SiteSummary: [{ name: "Corp", description: "main" }] };
+      }
+      return { SiteList: [] };
+    });
+    const out = await listSites();
+    expect(out[0].name).toBe("Corp");
+    expect(out[0].designGaps?.length).toBeGreaterThan(0);
+  });
+
+  it("falls back when SiteList serializes as empty-false bean (#3368)", async () => {
+    get.mockImplementation(async (url: string) => {
+      if (String(url).includes("sitemanage/site")) {
+        return { SiteSummary: [{ name: "Help" }] };
+      }
+      return { SiteList: { empty: false } };
+    });
+    const out = await listSites();
+    expect(out.map((s) => s.name)).toEqual(["Help"]);
+  });
+
+  it("returns empty only when every list source is empty", async () => {
+    get.mockResolvedValue({ SiteList: [] });
+    const out = await listSites();
+    expect(out).toEqual([]);
+    expect(get.mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/docs/ai-generated/code-reviews/3368-sites-list-bind-erlang.md
+++ b/docs/ai-generated/code-reviews/3368-sites-list-bind-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review: #3368 Developer Sites list bind
+
+**Branch:** `fix/issue-3368-sites-list-bind`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Date:** 2026-08-15
+
+## Summary
+
+Residual of QA #3129 / implement #3090 after #3198: Developer → Sites still showed an empty table after HTTP 200. `SiteList` is an `ArrayList` subclass; without `@JsonFormat(ARRAY)` Jackson can emit `{empty:false}` (peer: `ActionMenuList` #3379). The SPA `parseSiteList` from #3198 did not accept the live `SiteSummary` / `sites` / JAXB `item` envelopes or XML leftovers, and `listSites` did not fall back to the working sitemanage list.
+
+Changes:
+
+- `rest` `SiteList`: `@JsonFormat(shape = ARRAY)` + serial test asserts array, not `{empty}`.
+- `WebUI` `parseSiteList`: SiteSummary / sites / item / empty-bean / JSON-text / XML.
+- `listSites`: try `/services/sites`, trailing slash, then `/sitemanage/site/`; empty only when all sources are empty.
+- Playwright `bug-3368-developer-sites-list.spec.js` compares both APIs.
+- Product docs: `product-docs/8.2/admin/sites.md`, `developer/rest.md`.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable paths).
+
+## Cross-platform path checklist
+
+N/A for filesystem I/O. XML walk uses DOM, not path separators. Playwright URLs use `/`.
+
+## Tests
+
+- `rest`: `SiteListSerialDeserialTest` (array shape).
+- `WebUI` Vitest: live payload fixtures + listSites fallback.
+- Playwright surface spec for #3368.
+
+Memory patterns hit: ArrayList-subclass Jackson bean (`ActionMenuList`); silent empty catalog vs throw-on-unknown; change-class companions (Vitest + Playwright + product-docs).

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3368-developer-sites-list.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3368-developer-sites-list.spec.js
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer → Sites catalog bind residual (#3368 / parent #3129 / #3090).
+ *
+ * After #3198, GET /services/sites can still be HTTP 200 with a Jackson
+ * ArrayList bean ({empty:false}) or an empty SiteList while
+ * GET /sitemanage/site/ has SiteSummary rows. The SPA must list those sites.
+ *
+ * Surface-filtered QA mode:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/bugs/bug-3368-developer-sites-list.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
+const { catalogRowsSelector } = require("../helpers/developer-catalog-selectors");
+
+function developerSitesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "sites",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function unwrapSiteRows(body) {
+  if (body == null) {
+    return [];
+  }
+  if (Array.isArray(body)) {
+    return body;
+  }
+  if (typeof body !== "object") {
+    return [];
+  }
+  if (body.empty === true && Object.keys(body).length === 1) {
+    return [];
+  }
+  const nested =
+    body.SiteList ??
+    body.siteList ??
+    body.SiteSummary ??
+    body.siteSummary ??
+    body.Site ??
+    body.site ??
+    body.sites ??
+    body.item;
+  if (Array.isArray(nested)) {
+    return nested.map((row) =>
+      row && row.Site && typeof row.Site === "object" ? row.Site : row,
+    );
+  }
+  if (nested && typeof nested === "object") {
+    const inner =
+      nested.Site ??
+      nested.site ??
+      nested.sites ??
+      nested.SiteSummary ??
+      nested.item;
+    if (Array.isArray(inner)) {
+      return inner;
+    }
+    if (inner && typeof inner === "object" && (inner.name || inner.baseUrl)) {
+      return [inner];
+    }
+    if (nested.name || nested.baseUrl) {
+      return [nested];
+    }
+    if (nested.empty === true) {
+      return [];
+    }
+  }
+  return [];
+}
+
+function siteName(row) {
+  if (!row || typeof row !== "object") {
+    return "";
+  }
+  if (typeof row.name === "string") {
+    return row.name.trim();
+  }
+  if (row.name && typeof row.name.value === "string") {
+    return row.name.value.trim();
+  }
+  if (row.guid && typeof row.guid.stringValue === "string") {
+    return row.guid.stringValue.trim();
+  }
+  if (typeof row.guid === "string") {
+    return row.guid.trim();
+  }
+  return "";
+}
+
+function jsonHeaders() {
+  return {
+    ...adminBasicAuthHeaders(),
+    Accept: "application/json",
+  };
+}
+
+async function fetchList(request, path) {
+  const url = `${BASE_URL}${path}`;
+  const res = await request.get(url, { headers: jsonHeaders() });
+  const contentType = res.headers()["content-type"] || "";
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = await res.text();
+  }
+  return { url, status: res.status(), contentType, body, rows: unwrapSiteRows(body) };
+}
+
+test.describe("Developer Sites list bind (#3368)", () => {
+  test("REST: /services/sites is array-shaped; not an empty-false bean", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const sites = await fetchList(request, "/Rhythmyx/services/sites");
+    expect(sites.status, `GET ${sites.url} must be 2xx`).toBeGreaterThanOrEqual(200);
+    expect(sites.status, `GET ${sites.url} must not be error`).toBeLessThan(300);
+    const raw = JSON.stringify(sites.body).slice(0, 500);
+    const asBean =
+      sites.body &&
+      typeof sites.body === "object" &&
+      !Array.isArray(sites.body) &&
+      (sites.body.empty === false ||
+        (sites.body.SiteList &&
+          typeof sites.body.SiteList === "object" &&
+          !Array.isArray(sites.body.SiteList) &&
+          sites.body.SiteList.empty === false));
+    expect(asBean, `SiteList must not serialize as {empty:false} bean: ${raw}`).toBeFalsy();
+    expect(
+      Array.isArray(sites.rows),
+      `sites payload must unwrap to an array: ${raw}`,
+    ).toBe(true);
+    if (sites.rows.length > 0) {
+      expect(
+        siteName(sites.rows[0]),
+        `first site must expose string name: ${JSON.stringify(sites.rows[0]).slice(0, 400)}`,
+      ).toBeTruthy();
+    }
+  });
+
+  test("SPA lists sites when either REST or sitemanage has rows", async ({ page }) => {
+    test.setTimeout(90_000);
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      const loc = msg.location() && msg.location().url ? msg.location().url : "";
+      if (/404|Failed to load resource/i.test(text) && /favicon|fonts|\.map$/i.test(loc + text)) {
+        return;
+      }
+      if (/Failed to load resource: the server responded with a status of 404/i.test(text)) {
+        return;
+      }
+      consoleErrors.push(loc ? `${text} (${loc})` : text);
+    });
+
+    const restSites = await fetchList(page.request, "/Rhythmyx/services/sites");
+    const smSites = await fetchList(page.request, "/Rhythmyx/services/sitemanage/site/");
+    const restNamed = restSites.rows.filter((row) => siteName(row));
+    const smNamed = smSites.rows.filter((row) => siteName(row));
+    const apiHasRows = restNamed.length > 0 || smNamed.length > 0;
+
+    await loginAsAdmin(page);
+    await page.goto(developerSitesUrl(), { waitUntil: "networkidle" });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    if (apiHasRows) {
+      await expect(page.locator('[data-testid="developer-site-panel"]')).toBeVisible();
+      const rows = page.locator(catalogRowsSelector("developer-site-row"));
+      await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+      expect(await rows.count()).toBeGreaterThan(0);
+      await expect(page.locator('[data-testid="developer-site-empty"]')).toHaveCount(0);
+    } else {
+      await expect(page.locator('[data-testid="developer-site-empty"]')).toBeVisible();
+    }
+
+    expect(consoleErrors, `JS console/page errors: ${consoleErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -70,8 +70,11 @@ rejected by server validation with clear error messages.
 ### Browse Sites in Developer
 
 **Developer → Sites** lists **all** CMS Sites from `GET /services/sites` (traditional repository
-Sites, CM1 page-based Sites, and Virtual Sites). Sample / demo Sites appear when they exist on
-the server (for example after **Install sample sites**).
+Sites, CM1 page-based Sites, and Virtual Sites). The JSON envelope is a Jackson root-wrapped
+array (`{"SiteList":[{"name":"…",…}]}`), not an `{empty:false}` bean. Sample / demo Sites
+appear when they exist on the server (for example after **Install sample sites**). If that
+public list is empty or unreadable, the catalog also consults `GET /sitemanage/site/`
+(the same `SiteSummary` list Home and Explorer use) so existing Sites are not hidden.
 
 1. Sign in as an administrator (or a role that can open **Developer**).
 2. Open **Developer** → **Sites** (SPA entry `spa.jsp?entry=developer&section=sites`).
@@ -87,9 +90,10 @@ still mounts with site-specific empty copy and does not crash the page. See
 [Users, roles & security](id:admin-users-roles) for the same Object ACL behavior on
 Display Formats.
 
-Empty state (**No sites returned**) appears only when the list API has **zero** Sites. A
-successful HTTP 200 with Site entries must populate the table (never a silent blank). Load
-failures show **Could not load sites** rather than the empty state.
+Empty state (**No sites returned**) appears only when **every** list source has **zero**
+named Sites. A successful HTTP 200 with Site entries — including `SiteList`, nested
+`Site`/`sites`/`item` wraps, or `SiteSummary` — must populate the table (never a silent
+blank). Load failures show **Could not load sites** rather than the empty state.
 
 ### Configure Virtual Site source in the product UI
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -105,7 +105,7 @@ Example create body:
 
 | Operation | Path | Notes |
 |-----------|------|--------|
-| List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array. Each entry includes a plain string `name` when the Site has one. |
+| List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array — **not** `{ "empty": false }`. Each entry includes a plain string `name` when the Site has one. |
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag. PUT JSON is `{ "VirtualSiteProperties": { "sourceKind", "rootPath", "configFile", "siteKey" } }` (Jackson/JAXB root wrap). A flat `{ "sourceKind": … }` body returns **400** unexpected element `sourceKind`. |
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
@@ -113,8 +113,9 @@ Example create body:
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
 | Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root. Same action as **Developer → Sites → Publish Virtual Site** |
 
-An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty list JSON is the
-only empty-catalog case. See [Sites & content structure](id:admin-sites).
+An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty catalog chrome
+appears only when this list **and** the sitemanage `GET /sitemanage/site/` `SiteSummary` fallback
+are both empty. See [Sites & content structure](id:admin-sites).
 
 ## Templates (design catalog)
 

--- a/rest/src/main/java/com/percussion/rest/sites/SiteList.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SiteList.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.sites;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,9 +34,15 @@ import java.util.Collection;
  * JAXBException}: {@code Site nor any of its super class is known to this context} (#3090). Peer
  * pattern: {@code UserPreferenceList} (#2746), {@code RoleList}, {@code CommunityList}, ACL list
  * wrappers.
+ *
+ * <p>{@link JsonFormat.Shape#ARRAY} keeps Jackson from treating this {@code ArrayList} subclass as
+ * a bean ({@code {"empty":false}}) under {@code JacksonContextResolver} WRAP_ROOT_VALUE. That bean
+ * shape is HTTP 200 with no Site rows, so Developer Sites renders a silent empty table (#3368 /
+ * QA #3129). Peer: {@link com.percussion.rest.actions.ActionMenuList} (#3379).
  */
 @XmlRootElement(name = "SiteList")
 @JsonRootName("SiteList")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @ArraySchema(schema = @Schema(implementation = Site.class))
 @XmlSeeAlso(Site.class)
 public class SiteList extends ArrayList<Site> {

--- a/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SiteListSerialDeserialTest.java
@@ -96,13 +96,14 @@ public class SiteListSerialDeserialTest {
 
     String json = mapper.writeValueAsString(list);
     assertTrue(json.contains("\"SiteList\""), "expected WRAP_ROOT_VALUE SiteList: " + json);
+    assertTrue(json.contains("["), "SiteList must be a JSON array, not a bean: " + json);
     assertTrue(json.contains("\"name\""), "site name property must be present: " + json);
     assertTrue(json.contains("\"Help\""), "site name value must be present: " + json);
     assertTrue(json.contains("\"description\""), json);
     assertTrue(json.contains("\"baseUrl\""), json);
     assertFalse(
-        json.contains("\"empty\"") && !json.contains("\"name\":\"Help\""),
-        "name must be a plain string, not an Optional bean: " + json);
+        json.contains("\"empty\""),
+        "ArrayList subclass must not serialize as {empty:false} bean (#3368): " + json);
 
     SiteList roundTrip = mapper.readValue(json, SiteList.class);
     assertEquals(1, roundTrip.size());


### PR DESCRIPTION
## Summary

Developer → Sites still showed a silent empty table after the SiteList JAXB `@XmlSeeAlso` fix (#3090 / #3128) and the #3198 `parseSiteList` unwrap. Human QA on #3129: **no error, but no sites listed**.

`SiteList` extends `ArrayList<Site>`. Without `@JsonFormat(ARRAY)`, Jackson WRAP_ROOT can emit `{ "empty": false }` instead of `{ "SiteList": [ { "name": "…" } ] }` (same class of bug as `ActionMenuList` #3379). The SPA then treated that as empty or failed to unwrap the live `SiteSummary` / `sites` / JAXB `item` envelopes.

This PR:

- Forces `SiteList` JSON to a root-wrapped **array** (`@JsonFormat(shape = ARRAY)`).
- Expands `parseSiteList` for live envelopes (`SiteList.sites`, `SiteSummary`, JAXB `item`, `{empty:true|false}`, JSON/XML text leftovers).
- `listSites()` tries `GET /services/sites`, trailing slash, then `GET /sitemanage/site/` (Home/Explorer list). Empty chrome only when **all** sources have zero named sites.
- Playwright `bug-3368-developer-sites-list.spec.js` fails if either API has rows and the table is empty.

Fixes #3368  
Parent implement: #3090  
Do **not** close QA #3129 — please retest after this lands.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. QA H2 docker (`perc-devctl qa-up`) or local CMS with sample/demo sites.
2. `GET /Rhythmyx/services/sites` Accept JSON → HTTP 200, `{ "SiteList": [ … ] }` (not `{empty:false}`).
3. Sign in as Admin → Developer → Sites.
4. Confirm the table lists existing sites (name / description / URL / flags). Open a row → Site detail / Virtual Site source.
5. Empty state only when both `/services/sites` and `/sitemanage/site/` have zero named sites.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — Vitest `parseSiteList` live payloads + `listSites` fallback; `SiteListSerialDeserialTest` array shape
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3368-developer-sites-list.spec.js`
- [x] **Build gates** — standalone `mvnw clean install` on `rest` and `WebUI`
- [x] **Cross-platform** — N/A (no filesystem path I/O; DOM/JSON/URL only)

### C3 evidence

- **modules_built:** `rest`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **488**, Failures: 0
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **2446** passed (325 files)
- **downstream_checked:** none (annotation-only on `SiteList`; no `final`/signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, **TEST_CMS_URL=http://127.0.0.1:9993**, Health=healthy
- Hot-deploy: copied `WebUI/target/generated-webui/cm/modern/assets` into `…/Rhythmyx/cm/modern/assets`; in-cell `StopJetty`/`StartJetty` (did **not** `docker restart`)
- Playwright: `npm run test:surface -- --path tests/bugs/bug-3368-developer-sites-list.spec.js` → **2 passed** (REST array shape + SPA bind)
- console-clean=yes
- server.log-clean=yes for this feature after Jetty came back (`Initialization completed`). A mismatched newer `rest` SNAPSHOT on the 3-day image caused a transient `Failed startup of context` (`IAssemblyAdaptor`); the matching dist `rest` jar was restored before Playwright.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
