### PR TITLE
feat(explorer): Publish Now via sitemanage REST; stub AA spec

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -33,6 +33,7 @@ import {
 } from "../api/contentExplorer/itemCopyApi";
 import { del } from "../api/client";
 import { PATHS } from "../api/paths";
+import { publishSelectedItem } from "./itemPublish";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { classifyUrl, safeNavigate } from "../util/safeNavigate";
 import { parseExplorerContentId } from "./menuCatalogLoad";
@@ -147,6 +148,7 @@ export interface ActionDispatchContext {
   resetNav?: () => Promise<void>;
   createCopy?: (itemId: string) => Promise<void>;
   createPromotable?: (itemId: string) => Promise<void>;
+  onPublish?: (item: PSPathItem) => Promise<void>;
   writeClipboard?: (text: string) => Promise<void>;
   confirm?: (body: string) => boolean;
   openWindow?: (url: string, target?: string, features?: string) => Window | null;
@@ -217,10 +219,10 @@ export function classifyAction(action: MenuAction): ActionKind {
   if (isAssemblerPreviewUrl(action.url) || PREVIEW_PARENT_NAMES.has(name)) {
     return "rest";
   }
-  if (name === "purge") {
+  if (name === "purge" || name === "publish_now") {
     return "rest";
   }
-  if (name === "publish_now" || name === "create_new_item") {
+  if (name === "create_new_item") {
     return "unavailable";
   }
   if (isDataFlowActionUrl(action.url)) {
@@ -513,7 +515,28 @@ export async function dispatchAction(
     return { kind: "rest", refresh: true };
   }
 
-  if (name === "publish_now" || name === "create_new_item") {
+  if (name === "publish_now") {
+    if (!item || isFolder(item)) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    const ok = (ctx.confirm ?? ((b) => window.confirm(b)))(
+      EXPLORER_MSG.CONFIRM_PUBLISH_NOW,
+    );
+    if (!ok) {
+      return { kind: "rest" };
+    }
+    if (ctx.onPublish) {
+      await ctx.onPublish(item);
+      return { kind: "rest", refresh: true };
+    }
+    const published = await publishSelectedItem(item);
+    if (!published) {
+      return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+    }
+    return { kind: "rest", refresh: true };
+  }
+
+  if (name === "create_new_item") {
     return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
   }
 

--- a/WebUI/src/main/ts/contentExplorer/itemPublish.ts
+++ b/WebUI/src/main/ts/contentExplorer/itemPublish.ts
@@ -23,7 +23,50 @@
 import { get } from "../api/client";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { itemPublishPaths } from "../publishing/itemPublishPaths";
-import { resolvePreviewKind } from "./previewItem";
+import { normalizeCmsPath } from "./previewItem";
+import { isFolder } from "./selection";
+
+/** Demand-publish target. Stricter than preview — no unknown-id fallback. */
+export type PublishKind = "page" | "asset" | "none";
+
+function typeToken(item: PSPathItem): string {
+  return `${item.type ?? ""} ${item.category ?? ""}`.toLowerCase();
+}
+
+/**
+ * Classify whether Explorer can demand-publish this selection.
+ *
+ * <p>Unlike {@code resolvePreviewKind}, templates, links, and other non-page /
+ * non-asset items with an id stay {@code "none"}. Preview's permissive
+ * fallback would send those to {@code /publish/page/{id}}.</p>
+ */
+export function resolvePublishKind(
+  item: PSPathItem | null | undefined,
+): PublishKind {
+  if (!item || isFolder(item)) {
+    return "none";
+  }
+  const token = typeToken(item);
+  const pathLower = normalizeCmsPath(item.path).toLowerCase();
+
+  if (
+    token.includes("asset") ||
+    pathLower.startsWith("/assets/") ||
+    pathLower === "/assets"
+  ) {
+    return (item.id ?? "").trim() ? "asset" : "none";
+  }
+
+  if (
+    token.includes("page") ||
+    pathLower.startsWith("/sites/") ||
+    pathLower === "/sites"
+  ) {
+    return (item.id ?? "").trim() ? "page" : "none";
+  }
+
+  return "none";
+}
 
 /**
  * Demand-publish a page or asset. Other types return false so the
@@ -34,7 +77,7 @@ export async function publishSelectedItem(item: PSPathItem): Promise<boolean> {
   if (!id) {
     return false;
   }
-  const kind = resolvePreviewKind(item);
+  const kind = resolvePublishKind(item);
   const paths = itemPublishPaths();
   if (kind === "page") {
     await get<unknown>(`${paths.pagePublish}/${encodeURIComponent(id)}`);

--- a/WebUI/src/main/ts/contentExplorer/itemPublish.ts
+++ b/WebUI/src/main/ts/contentExplorer/itemPublish.ts
@@ -23,6 +23,7 @@
 import { get } from "../api/client";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { itemPublishPaths } from "../publishing/itemPublishPaths";
+import { mapPublishResponse } from "../publishing/publishActions";
 import { normalizeCmsPath } from "./previewItem";
 import { isFolder } from "./selection";
 
@@ -71,6 +72,12 @@ export function resolvePublishKind(
 /**
  * Demand-publish a page or asset. Other types return false so the
  * dispatcher can show that the action is not available.
+ *
+ * <p>HTTP 200 with an application-level preflight status
+ * ({@code FORBIDDEN}, {@code BADCONFIG}, {@code NOSTAGING_SERVERS},
+ * {@code INVALID}, …) is a failure — same as classic Finder and
+ * {@code mapPublishResponse}. Those responses throw so Explorer does
+ * not refresh as if the job started.</p>
  */
 export async function publishSelectedItem(item: PSPathItem): Promise<boolean> {
   const id = (item.id ?? "").trim();
@@ -80,12 +87,20 @@ export async function publishSelectedItem(item: PSPathItem): Promise<boolean> {
   const kind = resolvePublishKind(item);
   const paths = itemPublishPaths();
   if (kind === "page") {
-    await get<unknown>(`${paths.pagePublish}/${encodeURIComponent(id)}`);
+    await demandPublish(`${paths.pagePublish}/${encodeURIComponent(id)}`);
     return true;
   }
   if (kind === "asset") {
-    await get<unknown>(`${paths.resourcePublish}/${encodeURIComponent(id)}`);
+    await demandPublish(`${paths.resourcePublish}/${encodeURIComponent(id)}`);
     return true;
   }
   return false;
+}
+
+async function demandPublish(url: string): Promise<void> {
+  const body = await get<unknown>(url);
+  const preflight = mapPublishResponse(body);
+  if (preflight) {
+    throw new Error(preflight.message || preflight.token || "Publish failed");
+  }
 }

--- a/WebUI/src/main/ts/contentExplorer/itemPublish.ts
+++ b/WebUI/src/main/ts/contentExplorer/itemPublish.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer Publish Now — existing sitemanage publish-now GET, not the
+ * demandpublishing servlet page (that 404s from the SPA).
+ */
+
+import { get } from "../api/client";
+import type { PSPathItem } from "../api/contentExplorer/types";
+import { itemPublishPaths } from "../publishing/itemPublishPaths";
+import { resolvePreviewKind } from "./previewItem";
+
+/**
+ * Demand-publish a page or asset. Other types return false so the
+ * dispatcher can show that the action is not available.
+ */
+export async function publishSelectedItem(item: PSPathItem): Promise<boolean> {
+  const id = (item.id ?? "").trim();
+  if (!id) {
+    return false;
+  }
+  const kind = resolvePreviewKind(item);
+  const paths = itemPublishPaths();
+  if (kind === "page") {
+    await get<unknown>(`${paths.pagePublish}/${encodeURIComponent(id)}`);
+    return true;
+  }
+  if (kind === "asset") {
+    await get<unknown>(`${paths.resourcePublish}/${encodeURIComponent(id)}`);
+    return true;
+  }
+  return false;
+}

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -335,6 +335,8 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Select a content item first",
   CONFIRM_PURGE_BODY:
     "perc.ui.explorer@Permanently delete this item from the system?",
+  CONFIRM_PUBLISH_NOW:
+    "perc.ui.explorer@Publish this item now?",
   ACTION_COPY_URL_SUCCESS: "perc.ui.explorer@Item URL copied to the clipboard",
   ACTION_COPY_URL_FAILED: "perc.ui.explorer@Could not copy the item URL",
   ACTION_COPY_URL_EMPTY: "perc.ui.explorer@No URL is available for this item",

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -372,14 +372,41 @@ describe("actionDispatch", () => {
     expect(result.refresh).toBeUndefined();
   });
 
-  it("publish_now is unavailable without navigation", async () => {
+  it("classifies Publish Now as rest even with demandpublishing URL", () => {
+    expect(
+      classifyAction(
+        action({
+          name: "Publish_Now",
+          url: "../publisher/demandpublishing",
+        }),
+      ),
+    ).toBe("rest");
+  });
+
+  it("Publish Now confirms then publishes", async () => {
+    const onPublish = vi.fn().mockResolvedValue(undefined);
+    const confirm = vi.fn().mockReturnValue(true);
     const openWindow = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "Publish_Now", url: "../publisher/demandpublishing" }),
+      { item: item(), onPublish, confirm, openWindow },
+    );
+    expect(result.kind).toBe("rest");
+    expect(result.refresh).toBe(true);
+    expect(confirm).toHaveBeenCalled();
+    expect(onPublish).toHaveBeenCalled();
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("Publish Now cancel does not publish", async () => {
+    const onPublish = vi.fn();
     const result = await dispatchAction(action({ name: "Publish_Now" }), {
       item: item(),
-      openWindow,
+      onPublish,
+      confirm: () => false,
     });
-    expect(result.kind).toBe("unavailable");
-    expect(openWindow).not.toHaveBeenCalled();
+    expect(onPublish).not.toHaveBeenCalled();
+    expect(result.refresh).toBeUndefined();
   });
 
   it("dispatch workflow-transition runs the trigger", async () => {

--- a/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import { publishSelectedItem } from "../../../main/ts/contentExplorer/itemPublish";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function item(overrides: Partial<PSPathItem> = {}): PSPathItem {
+  return {
+    name: "page",
+    path: "/Sites/Demo/page",
+    type: "percPage",
+    id: "42",
+    ...overrides,
+  };
+}
+
+describe("publishSelectedItem", () => {
+  it("GETs sitemanage publish/page for a page", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(await publishSelectedItem(item())).toBe(true);
+    const url = String(global.fetch.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("sitemanage/publish/page/42");
+    expect(url).not.toContain("demandpublishing");
+  });
+
+  it("GETs sitemanage publish/resource for an asset", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(
+      await publishSelectedItem(
+        item({ path: "/Assets/img.png", type: "percImageAsset", id: "99" }),
+      ),
+    ).toBe(true);
+    expect(String(global.fetch.mock.calls[0]?.[0] ?? "")).toContain(
+      "sitemanage/publish/resource/99",
+    );
+  });
+
+  it("returns false without an id", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    expect(await publishSelectedItem(item({ id: "" }))).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
@@ -117,4 +117,35 @@ describe("publishSelectedItem", () => {
     );
     await expect(publishSelectedItem(item())).rejects.toThrow("Failed to fetch");
   });
+
+  it("throws on HTTP 200 unwrapped FORBIDDEN instead of returning true", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "FORBIDDEN" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(publishSelectedItem(item())).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("throws on wrapped SitePublishResponse BADCONFIG warning", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          SitePublishResponse: {
+            status: "BADCONFIG",
+            warningMessage:
+              "Could not connect to publishing server, please check publishing server configuration.",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    await expect(publishSelectedItem(item())).rejects.toThrow(
+      "Could not connect to publishing server",
+    );
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/itemPublish.test.ts
@@ -17,7 +17,10 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
-import { publishSelectedItem } from "../../../main/ts/contentExplorer/itemPublish";
+import {
+  publishSelectedItem,
+  resolvePublishKind,
+} from "../../../main/ts/contentExplorer/itemPublish";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -68,5 +71,50 @@ describe("publishSelectedItem", () => {
     const fetchSpy = vi.spyOn(global, "fetch");
     expect(await publishSelectedItem(item({ id: "" }))).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns false for non-page/non-asset types that preview would call page", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const template = item({
+      name: "base",
+      path: "/Design/Templates/base",
+      type: "percTemplate",
+      category: "template",
+      id: "77",
+    });
+    const link = item({
+      name: "ext",
+      path: "/Other/ext",
+      type: "percExternalLink",
+      id: "88",
+    });
+    expect(resolvePublishKind(template)).toBe("none");
+    expect(resolvePublishKind(link)).toBe("none");
+    expect(await publishSelectedItem(template)).toBe(false);
+    expect(await publishSelectedItem(link)).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when the publish GET returns 403 or 500", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response("denied", { status: 403, statusText: "Forbidden" }),
+      )
+      .mockResolvedValueOnce(
+        new Response("boom", { status: 500, statusText: "Server Error" }),
+      );
+    await expect(publishSelectedItem(item())).rejects.toMatchObject({
+      status: 403,
+    });
+    await expect(publishSelectedItem(item())).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+
+  it("throws when the publish GET fails on the network", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(
+      new TypeError("Failed to fetch"),
+    );
+    await expect(publishSelectedItem(item())).rejects.toThrow("Failed to fetch");
   });
 });

--- a/docs/ai-generated/code-reviews/explorer-publish-now-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-publish-now-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: Explorer Publish Now (feat/explorer-publish-now)
+
+**Branch:** `feat/explorer-publish-now`  
+**Base:** `origin/main`  
+**Date:** 2026-08-15  
+**Persona:** Erlang (independent of implementer)
+
+## Summary
+
+Leftover P0 **Publish Now** is dispatched as REST: confirm, then existing sitemanage `GET /services/sitemanage/publish/page|{resource}/{id}`. Catalog `demandpublishing` URL is not navigated. Active Assembly remains unavailable; `specs/996-react-active-assembly/spec.md` records the host decision.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests cover classify-by-name, confirm/cancel, page vs asset GET paths, and no `demandpublishing` fetch. Playwright extends the existing dispatch blocklist.
+
+## Change-class closure
+
+Change class: **WebUI Explorer dispatcher + existing sitemanage publish GET + product-docs + Playwright**. No new rest adaptor.
+
+| Companion | Status |
+|-----------|--------|
+| Dispatcher + `publishSelectedItem` | present |
+| Vitest (dispatch + itemPublish) | present |
+| Playwright Data Flow/servlet blocklist | present (`demandpublishing`) |
+| product-docs admin + rest | present |
+| 996 AA stub | present |
+| Seed URL rewrite | **intentionally not done** — name-first dispatch; avoids `PublishNowActionSeedUrlTest` / distribution-tree build |
+
+## Cross-platform path checklist
+
+CMS/URL paths only (`/`). **Outcome: clean.**
+
+## Issues
+
+None blocking. Suggestion: later clear ACTION 217 URL and retarget `PublishNowActionSeedUrlTest` so the catalog does not advertise the servlet.
+
+## Handoff
+
+Approve leftover P0 Publish Now. P2 AA still blocked on host decision in 996.

--- a/docs/ai-generated/code-reviews/explorer-publish-now-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-publish-now-erlang.md
@@ -43,3 +43,15 @@ None blocking. Suggestion: later clear ACTION 217 URL and retarget `PublishNowAc
 ## Handoff
 
 Approve leftover P0 Publish Now. P2 AA still blocked on host decision in 996.
+
+## Re-review (2026-08-15, PR #3444 peer thread)
+
+**Scope:** `publishSelectedItem` now runs `mapPublishResponse` on HTTP 200 bodies. Preflight statuses (`FORBIDDEN`, `BADCONFIG`, …) throw instead of returning `true`. Vitest covers unwrapped `FORBIDDEN` and wrapped `SitePublishResponse`/`BADCONFIG`. Playwright route-mock case added. Product-docs updated.
+
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Memory patterns hit:** HTTP 200 application-level publish failures (`#936` / `mapPublishResponse`).
+
+**Cross-platform path checklist:** URL/CMS paths only. **Outcome: clean.**
+
+**Issues:** none blocking. Playwright case soft-skips when Publish Now is not in the toolbar for the current selection; Vitest is the behavioral contract.

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
@@ -78,4 +78,66 @@ test.describe("modern React Content Explorer — action dispatch", () => {
       });
     },
   );
+
+  test(
+    "Publish Now HTTP 200 FORBIDDEN shows an error and does not treat it as published",
+    { tag: ["@explorer-action-dispatch", "@explorer"] },
+    async ({ page }) => {
+      page.on("dialog", (dialog) => {
+        void dialog.accept();
+      });
+      await page.route("**/services/sitemanage/publish/**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            status: "FORBIDDEN",
+            warningMessage: "Publication stopped because of licensing issues",
+          }),
+        });
+      });
+
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="content-explorer-shell"]')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      if ((await tree.count()) > 0) {
+        const sitesNode = page
+          .locator(
+            '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+          )
+          .first();
+        if ((await sitesNode.count()) > 0) {
+          await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        }
+      }
+
+      const list = page.locator('[data-testid="detail-list"]');
+      if ((await list.count()) > 0) {
+        const row = list.locator('tbody tr[data-testid^="detail-row-"]').first();
+        if ((await row.count()) > 0) {
+          await row.click({ force: true, timeout: 10_000 }).catch(() => {});
+        }
+      }
+
+      const publishNow = page.locator(
+        '[data-testid="action-toolbar-item-Publish_Now"], [data-testid="action-toolbar-item-publish_now"]',
+      );
+      if ((await publishNow.count()) === 0 || !(await publishNow.first().isVisible())) {
+        test.skip(true, "Publish Now action not visible for the current selection");
+        return;
+      }
+
+      await publishNow.first().click();
+      await expect(
+        page.locator('[data-testid="explorer-server-actions-error"]'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator('[data-testid="explorer-server-actions-error"]'),
+      ).toContainText(/FORBIDDEN|licensing|Publication stopped/i);
+    },
+  );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
@@ -49,7 +49,8 @@ test.describe("modern React Content Explorer — action dispatch", () => {
           u.includes("checkoutedit.xml") ||
           u.includes("contenteditorurls.html") ||
           u.includes("flushcache.html") ||
-          u.includes("navreset.html")
+          u.includes("navreset.html") ||
+          u.includes("demandpublishing")
         ) {
           blocked.push(u);
         }

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -131,7 +131,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Promotable Version** | Confirm, then create a promotable version in the current folder. |
 | **Flush Cache** (Refresh Item) | Confirms, then flushes **all** assembler pages (not only the selected item). |
 | **Nav Reset** | Same goal as classic Nav Reset. On 8.2 this is typically a no-op once managed navigation is loaded (FastForward 6.0+ variants unused). |
-| **Publish Now** | Confirms, then demand-publishes a **page** or **asset** (`GET /services/sitemanage/publish/page/{id}` or `/resource/{id}`). Other types stay unavailable. Does not open the demand-publish servlet page. |
+| **Publish Now** | Confirms, then demand-publishes a **page** or **asset** (`GET /services/sitemanage/publish/page/{id}` or `/resource/{id}`). Other types stay unavailable. Does not open the demand-publish servlet page. HTTP 200 with application-level `FORBIDDEN`, `BADCONFIG`, `NOSTAGING_SERVERS`, or `INVALID` is a failure (same as classic Finder) — Explorer shows the server warning and does not refresh as if published. |
 | **Active Assembly** / slot arrange | Not available in this Explorer slice (needs a React Active Assembly host). |
 
 Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -131,7 +131,8 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Promotable Version** | Confirm, then create a promotable version in the current folder. |
 | **Flush Cache** (Refresh Item) | Confirms, then flushes **all** assembler pages (not only the selected item). |
 | **Nav Reset** | Same goal as classic Nav Reset. On 8.2 this is typically a no-op once managed navigation is loaded (FastForward 6.0+ variants unused). |
-| **Publish Now** / Active Assembly / slot arrange | Still unavailable in this Explorer slice. |
+| **Publish Now** | Confirms, then demand-publishes a **page** or **asset** (`GET /services/sitemanage/publish/page/{id}` or `/resource/{id}`). Other types stay unavailable. Does not open the demand-publish servlet page. |
+| **Active Assembly** / slot arrange | Not available in this Explorer slice (needs a React Active Assembly host). |
 
 Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer
 menus — they are not Explorer pages.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -554,7 +554,9 @@ POSTs fail if the item has no folder path (`Item has no folder path and cannot b
 ## Item publish now (Explorer)
 
 Explorer **Publish Now** uses the existing sitemanage demand-publish GETs (same as classic Finder).
-It does not open `/publisher/demandpublishing`.
+It does not open `/publisher/demandpublishing`. A 200 body whose `status` is
+`FORBIDDEN`, `BADCONFIG`, `NOSTAGING_SERVERS`, or `INVALID` (plain or wrapped as
+`SitePublishResponse`) is a preflight failure, not a started job.
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -551,6 +551,18 @@ itemmanagement REST (sitemanage `PSItemService`), not Content Editor HTML.
 Copy / promotable response JSON (`ItemCopyResult`): `{ itemId, folderPath, promotable }`. Those
 POSTs fail if the item has no folder path (`Item has no folder path and cannot be copied.`).
 
+## Item publish now (Explorer)
+
+Explorer **Publish Now** uses the existing sitemanage demand-publish GETs (same as classic Finder).
+It does not open `/publisher/demandpublishing`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/sitemanage/publish/page/{id}` | Publish Now for a page |
+| `GET` | `/services/sitemanage/publish/resource/{id}` | Publish Now for an asset |
+
+See [Content Explorer](id:admin-content-explorer) server actions.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -23,7 +23,7 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 | `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
 | `rest` | Public REST (preview-location, types, transitions, purge, publish) |
 | `editor` | P3 — do **not** open CM1 `?view=editor`; TMX “editor not available” |
-| `unavailable` | P2 AA/slot or not-yet P1 — TMX not available |
+| `unavailable` | P2 AA/slot (until `specs/996-react-active-assembly`) or New Item (P3 editor) |
 | `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
 
 Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.
@@ -41,7 +41,8 @@ Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It n
 | Promotable Version | Confirm, then promotable version in current folder |
 | Flush Cache (Refresh Item) | Confirm, then flush **all** assembler pages (not only the selected item) |
 | Nav Reset | Same as classic `PSNavReset`; on 8.2 typically a no-op once nav is loaded (FastForward variants unused) |
-| Publish Now / AA / slot arrange | Still unavailable (P2) |
+| Publish Now | Confirm, then existing sitemanage publish-now (`GET /services/sitemanage/publish/page/{id}` or `/resource/{id}`). Does not open `demandpublishing`. |
+| Active Assembly / slot arrange | Still unavailable — see `specs/996-react-active-assembly/spec.md` |
 
 ## P1 REST
 
@@ -62,6 +63,8 @@ Returns `{ previewUrl, contentId, templateId, revision }`.
 `previewUrl` is the assembly preview path (`/assembler/render?sys_contentid&sys_template&sys_revision&sys_context=0&sys_itemfilter=preview`).
 
 Template **menus** come from existing `GET /actions/find/templates/{id}` and are merged under Preview parents (same pattern as New Item + `/actions/find/types`).
+
+**Publish Now:** `GET /services/sitemanage/publish/page/{id}` or `/resource/{id}` (existing sitemanage).
 
 ## Inventory
 

--- a/specs/996-react-active-assembly/spec.md
+++ b/specs/996-react-active-assembly/spec.md
@@ -1,0 +1,36 @@
+# Spec stub: React Active Assembly
+
+**Status**: Stub — **not** implemented in the Explorer action-execution train.  
+**Split from**: Explorer server actions (`specs/992-react-content-explorer/contracts/action-execution.md`)
+
+## Why this is separate
+
+Explorer **Active Assembly**, slot add/create, arrange (move / change template / remove), and related-content menus historically opened Data Flow HTML (`sys_cxSupport/variantlistwithslots.html`, `sys_cxItemAssembly/itemassembly.html`, `sys_rcSupport/updaterelateditems.html`). Those need an **in-page assembly host** (preview + slot overlays + relationship ids). Explorer folder browse has no slot context.
+
+Opening leftover Dojo AA JSPs or Data Flow HTML from Explorer is **not** an acceptable stand-in.
+
+## Host decision (required before implementation)
+
+1. **SPA route** `/cm/app/assembly?contentId=&templateId=` (recommended; matches Explorer / Publishing shells).
+2. New window with assembler preview + overlay (closer to classic AA).
+
+Do not implement a canvas until this is chosen.
+
+## In scope (later)
+
+- React AA host (not Data Flow / Dojo)
+- Open from Explorer **Active Assembly** with selected item + **template** (`GET /actions/find/templates/{id}` + `GET /services/assembly/preview-location`)
+- Slot Add (Content Browser + relationship REST)
+- Slot Create (types + templates; creating an item still needs the Content Editor spec)
+- Arrange move / change template-slot / remove (relationship REST; relationship id from AA)
+- Compare (`sys_Compare`) may follow as a small add-on
+
+## Out of scope here
+
+- Explorer browse, Publish Now, revisions, translations, purge
+- Implementing Arrange_* from folder browse with no slot selected
+- Content Editor forms (`aa_table_editor` stays `specs/995-react-content-editor`)
+
+## Explorer behavior until this spec lands
+
+Dispatcher classifies Active Assembly / slot / arrange names as **`unavailable`**. The SPA shows a TMX message and does **not** navigate Data Flow HTML.


### PR DESCRIPTION
## Summary

Continues the Explorer action-execution train after #3437 / #3440.

**Leftover P0 — Publish Now:** toolbar/context confirm, then existing sitemanage demand-publish (`GET /services/sitemanage/publish/page/{id}` or `/resource/{id}`). Does not navigate `../publisher/demandpublishing` (404 from the SPA). New Item stays unavailable (Content Editor spec).

**P2 Active Assembly:** still unavailable (original plan: no AA until a React host is chosen). Adds `specs/996-react-active-assembly/spec.md` with the host decision (SPA route vs new window).

## Test plan

1. `cd WebUI && ..\mvnw.cmd clean install` — BUILD SUCCESS (Vitest 2484, Failures: 0).
2. Select a page or asset in Explorer → Publish Now → confirm → no `demandpublishing` request.
3. Cancel confirm → no publish GET.
4. Active Assembly still shows not-available.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md`, `developer/rest.md`
- [x] **Unit / module tests** — `actionDispatch` + `itemPublish` Vitest; WebUI standalone clean install
- [x] **WebUI + Playwright** — `demandpublishing` added to `explorer-action-dispatch.spec.js` blocklist
- [x] **Build gates** — `cd WebUI && ..\mvnw.cmd clean install` (no skipTests)
- [x] **Cross-platform** — CMS/URL paths only

Seed `Publish_Now` URL left as the servlet so `PublishNowActionSeedUrlTest` stays valid; dispatch is by name.

Erlang: approve. Report: `docs/ai-generated/code-reviews/explorer-publish-now-erlang.md`.

> Co-Authored by Grok Build TUI (Grok 4.6) using grok-4.6 with agent Grok.