### PR TITLE
fix(rest): Guid plain nullable wire getters (#3445)

### DIFF
--- a/docs/ai-generated/code-reviews/3445-guid-nullable-wire-getters-erlang.md
+++ b/docs/ai-generated/code-reviews/3445-guid-nullable-wire-getters-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review — #3445 Guid plain nullable wire getters
+
+**Date:** 2026-08-15
+**Branch:** `fix/issue-3445-guid-nullable-wire-getters`
+**Recommendation:** approve
+**May commit/push:** yes
+**Gate:** approve
+
+## Summary
+
+Last remaining `rest/src/main/java` public `Optional` wire getters: `Guid.getStringValue()`
+and `Guid.getUntypedString()` now return plain nullable `String`. Field
+`@JsonProperty("stringValue")` is kept; `getStringValue()` stays `@JsonIgnore` so
+Object ACL still binds a JSON string (not an Optional bean). Production-mapper
+tests assert no `empty`/`present` keys. rest/sitemanage `.orElse()` / `.isPresent()`
+callers were updated.
+
+`rest/AGENTS.md` was not changed (human rule-review gate).
+
+## Scope
+
+Uncommitted product work vs `origin/main` on `fix/issue-3445-guid-nullable-wire-getters`.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — **addressed** (`JacksonContextResolverOptionalTest`
+  Guid methods + existing `GuidTest` / ACL bind tests)
+- Incomplete change-class closure — **addressed** (DTO + rest callers + sitemanage
+  apibridge + reverse-dep standalone install)
+- Agent rule file without human review — **honored** (`rest/AGENTS.md` not committed)
+- Cross-platform path checklist — N/A (no new filesystem I/O)
+
+## Issues
+
+None that block commit.
+
+## Notes (not blocking)
+
+- No remaining `public Optional<` under `rest/src/main/java`.
+- Product-docs already document `guid.stringValue` as a scalar string.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -190,7 +190,7 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
           return m;
         }
         if (m.getGuid() != null) {
-          String gsv = m.getGuid().getStringValue().orElse(null);
+          String gsv = m.getGuid().getStringValue();
           if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
             return m;
           }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -124,7 +124,7 @@ public class ApiUtils {
     if (guid == null) {
       return null;
     }
-    String raw = guid.getStringValue().orElse(null);
+    String raw = guid.getStringValue();
     if (raw != null && !raw.isBlank()) {
       return PSGuidManagerLocator.getGuidMgr().makeGuid(raw);
     }
@@ -532,7 +532,7 @@ public class ApiUtils {
     long objectId = acl.getObjectId();
     Guid objectGuid = acl.getObjectGuid();
     if (objectGuid != null) {
-      String stringValue = orNull(objectGuid.getStringValue());
+      String stringValue = objectGuid.getStringValue();
       if (stringValue != null
           && !stringValue.isBlank()
           && (objectGuid.getType() == 0 || objectGuid.getUuid() == 0)) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -413,7 +413,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   private IPSGuid resolveTemplateGuid(NamedObjectRef ref, String field) {
     IPSAssemblyService asm = PSAssemblyServiceLocator.getAssemblyService();
     if (ref.getGuid() != null) {
-      String sv = ref.getGuid().getStringValue().orElse(null);
+      String sv = ref.getGuid().getStringValue();
       if (StringUtils.isNotBlank(sv)) {
         try {
           IPSGuid g = ApiUtils.convertGuid(ref.getGuid());
@@ -466,7 +466,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     if (guid == null) {
       return 0;
     }
-    String sv = guid.getStringValue().orElse(null);
+    String sv = guid.getStringValue();
     if (StringUtils.isNotBlank(sv)) {
       try {
         IPSGuid g = ApiUtils.convertGuid(guid);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContextAdaptor.java
@@ -106,7 +106,7 @@ public class ContextAdaptor implements IContextsAdaptor {
     try {
       IPSPublishingContext ctx;
       Guid idGuid = context.getId();
-      String idStr = (idGuid == null) ? null : ApiUtils.orNull(idGuid.getStringValue());
+      String idStr = (idGuid == null) ? null : idGuid.getStringValue();
       if (idStr == null || StringUtils.isBlank(idStr)) {
         ctx = siteManager.createContext();
       } else {
@@ -147,7 +147,7 @@ public class ContextAdaptor implements IContextsAdaptor {
     var ret = new PSPublishingContext();
     Guid idGuid = context.getId();
     if (idGuid != null) {
-      String idStr = ApiUtils.orNull(idGuid.getStringValue());
+      String idStr = idGuid.getStringValue();
       if (idStr != null) {
         var guid = new PSGuid(idStr);
         ret.setGUID(guid);
@@ -161,7 +161,7 @@ public class ContextAdaptor implements IContextsAdaptor {
       schemeId = defaultScheme.getSchemeId();
     }
     if (schemeId != null) {
-      String schemeStr = ApiUtils.orNull(schemeId.getStringValue());
+      String schemeStr = schemeId.getStringValue();
       if (schemeStr != null) {
         ret.setDefaultSchemeId(new PSGuid(schemeStr));
       }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DeliveryTypeAdaptor.java
@@ -65,7 +65,7 @@ public class DeliveryTypeAdaptor implements IDeliveryTypeAdaptor {
   public DeliveryType updateDeliveryType(URI baseURI, DeliveryType type) throws BackendException {
     try {
       Guid idGuid = type.getId();
-      String idStr = ApiUtils.orNull(idGuid == null ? null : idGuid.getStringValue());
+      String idStr = idGuid == null ? null : idGuid.getStringValue();
       if (idGuid == null || StringUtils.isBlank(idStr)) {
         // Create new delivery type
         var create = pubService.createDeliveryType();

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -256,8 +256,8 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
    * @return wire string, or {@code null} when neither source has a usable id
    */
   private static String plainGuidString(Guid mapped, int displayId) {
-    if (mapped != null && mapped.getStringValue().isPresent()) {
-      String sv = mapped.getStringValue().get();
+    if (mapped != null && mapped.getStringValue() != null) {
+      String sv = mapped.getStringValue();
       if (sv != null && !sv.isBlank()) {
         return sv.trim();
       }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/RelationshipTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/RelationshipTypeAdaptor.java
@@ -121,7 +121,7 @@ public class RelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
         return withDesignGaps(t);
       }
       if (t.getGuid() != null) {
-        String guidStr = t.getGuid().getStringValue().orElse(null);
+        String guidStr = t.getGuid().getStringValue();
         if (guidStr != null && key.equalsIgnoreCase(guidStr)) {
           return withDesignGaps(t);
         }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
@@ -201,7 +201,7 @@ public class SlotsAdaptor implements ISlotsAdaptor {
     if (g == null) {
       throw new IllegalArgumentException("association[" + index + "]." + field + " is required");
     }
-    String sv = g.getStringValue().orElse(null);
+    String sv = g.getStringValue();
     if (StringUtils.isNotBlank(sv)) {
       try {
         return ApiUtils.convertGuid(g);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -329,8 +329,8 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
         String key =
             s.getName() != null
                 ? s.getName()
-                : (s.getGuid() != null && s.getGuid().getStringValue().isPresent()
-                    ? s.getGuid().getStringValue().get()
+                : (s.getGuid() != null && s.getGuid().getStringValue() != null
+                    ? s.getGuid().getStringValue()
                     : "?");
         throw new IllegalArgumentException("slots[" + (i - 1) + "] not found: " + key);
       }
@@ -340,8 +340,8 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
   }
 
   private IPSTemplateSlot resolveSlotRef(TemplateSlotSummary s) throws PSAssemblyException {
-    if (s.getGuid() != null && s.getGuid().getStringValue().isPresent()) {
-      String sv = s.getGuid().getStringValue().get();
+    if (s.getGuid() != null && s.getGuid().getStringValue() != null) {
+      String sv = s.getGuid().getStringValue();
       if (StringUtils.isNotBlank(sv)) {
         try {
           return asmSvc.loadSlot(ApiUtils.convertGuid(s.getGuid()));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
@@ -75,7 +75,7 @@ public class ApiUtilsActionMenuConvertTest {
     assertNotNull(converted.getGuid());
     assertEquals(
         "0-107-9",
-        converted.getGuid().getStringValue().orElse(null),
+        converted.getGuid().getStringValue(),
         "ACTION type 107 + actionId for Object ACL (#3380)");
     assertEquals(107, converted.getGuid().getType());
     assertEquals(9, converted.getGuid().getUuid());

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
@@ -69,10 +69,8 @@ class DisplayFormatAdaptorSafeKeyTest {
 
     assertNotNull(out, "adaptor should return a REST DisplayFormat");
     assertNotNull(out.getGuid(), "guid must be mapped for Object ACL");
-    assertTrue(
-        out.getGuid().getStringValue().isPresent(),
-        "guid.stringValue must be present for SPA binding");
-    String sv = out.getGuid().getStringValue().get();
+    assertNotNull(out.getGuid().getStringValue(), "guid.stringValue must be present for SPA binding");
+    String sv = out.getGuid().getStringValue();
     assertFalse(sv.isBlank(), "guid.stringValue must not be blank");
     // PSGuid#toString form host-type-uuid; uuid part is display id 301
     assertTrue(sv.endsWith("-301"), "unexpected guid form: " + sv);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorMapTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorMapTest.java
@@ -67,7 +67,7 @@ class ViewAdaptorMapTest {
     assertNotNull(d.getGuid());
     assertEquals(
         "0-301-123",
-        d.getGuid().getStringValue().orElse(null),
+        d.getGuid().getStringValue(),
         "view catalog/detail must emit Guid.stringValue for Object ACL (#3380)");
     assertTrue(d.isView());
     assertTrue(d.isStandardView());

--- a/rest/src/main/java/com/percussion/rest/Guid.java
+++ b/rest/src/main/java/com/percussion/rest/Guid.java
@@ -24,17 +24,23 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
+/**
+ * REST GUID wire DTO.
+ *
+ * <p>Wire getters return plain nullable {@link String}s (not {@code Optional}) so Jackson/CXF JSON
+ * emits {@code stringValue} / {@code untypedString} as scalars, not Optional beans ({@code
+ * empty}/{@code present}). {@code stringValue} is bound on the field so Object ACL can accept both
+ * a JSON string and {@code {stringValue}} (#3200 / #2951 / #3378 / #3384 / #3391 / #3445).
+ */
 @XmlRootElement(name = "Guid")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Guid")
 public class Guid {
 
   /**
-   * Serialized as a plain JSON string via the field (not {@link #getStringValue()}). The Optional
-   * getter is for Java callers; Jackson must not emit Optional as an object or the SPA cannot bind
-   * Object ACL (#3200 / #2951).
+   * Serialized as a plain JSON string via this field (not {@link #getStringValue()}). Jackson must
+   * not emit Optional as an object or the SPA cannot bind Object ACL (#3200 / #2951).
    */
   @JsonProperty("stringValue")
   @Schema(
@@ -88,8 +94,8 @@ public class Guid {
       readOnly = true)
   private long longValue;
 
-  public Optional<String> getUntypedString() {
-    return Optional.ofNullable(untypedString);
+  public String getUntypedString() {
+    return untypedString;
   }
 
   public void setUntypedString(String untypedString) {
@@ -128,9 +134,13 @@ public class Guid {
     this.longValue = longValue;
   }
 
+  /**
+   * Plain nullable string form for Java callers. Jackson serializes {@code stringValue} from the
+   * annotated field so Object ACL bind stays a scalar (#3200 / #3445).
+   */
   @JsonIgnore
-  public Optional<String> getStringValue() {
-    return Optional.ofNullable(stringValue);
+  public String getStringValue() {
+    return stringValue;
   }
 
   @JsonProperty("stringValue")

--- a/rest/src/main/java/com/percussion/rest/GuidList.java
+++ b/rest/src/main/java/com/percussion/rest/GuidList.java
@@ -40,7 +40,7 @@ public class GuidList extends ArrayList<Guid> {
   public String toString() {
     // Use Streams for concise joining
     return this.stream()
-        .map(guid -> guid.getStringValue().orElse(""))
+        .map(guid -> guid.getStringValue() != null ? guid.getStringValue() : "")
         .collect(Collectors.joining(" "));
   }
 }

--- a/rest/src/main/java/com/percussion/rest/GuidList.java
+++ b/rest/src/main/java/com/percussion/rest/GuidList.java
@@ -40,7 +40,11 @@ public class GuidList extends ArrayList<Guid> {
   public String toString() {
     // Use Streams for concise joining
     return this.stream()
-        .map(guid -> guid.getStringValue() != null ? guid.getStringValue() : "")
+        .map(
+            guid -> {
+              String sv = guid.getStringValue();
+              return sv != null ? sv : "";
+            })
         .collect(Collectors.joining(" "));
   }
 }

--- a/rest/src/test/java/com/percussion/rest/GuidListTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidListTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for {@link GuidList#toString()} after nullable {@link Guid#getStringValue()}. */
+class GuidListTest {
+
+  @Test
+  void toStringJoinsStringValuesAndTreatsNullAsEmpty() {
+    GuidList list = new GuidList();
+    list.add(new Guid("0-2-1"));
+    list.add(new Guid());
+    list.add(new Guid("0-2-3"));
+    assertEquals("0-2-1  0-2-3", list.toString());
+  }
+
+  @Test
+  void toStringOfEmptyListIsEmpty() {
+    assertEquals("", new GuidList().toString());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/GuidTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidTest.java
@@ -19,6 +19,8 @@ package com.percussion.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,13 +37,12 @@ class GuidTest {
   void stringConstructorSeedsAllFields() {
     Guid guid = new Guid("0-2-311");
 
-    assertTrue(guid.getStringValue().isPresent());
-    assertEquals("0-2-311", guid.getStringValue().get());
+    assertEquals("0-2-311", guid.getStringValue());
     assertEquals(0L, guid.getHostId());
     assertEquals((short) 2, guid.getType());
     assertEquals(311, guid.getUuid());
     assertTrue(guid.getLongValue() != 0L || guid.getUuid() == 311);
-    assertTrue(guid.getUntypedString().isPresent());
+    assertNotNull(guid.getUntypedString());
   }
 
   @Test
@@ -65,8 +66,8 @@ class GuidTest {
   @Test
   void defaultConstructorLeavesOptionalFieldsEmpty() {
     Guid guid = new Guid();
-    assertTrue(guid.getStringValue().isEmpty());
-    assertTrue(guid.getUntypedString().isEmpty());
+    assertNull(guid.getStringValue());
+    assertNull(guid.getUntypedString());
     assertEquals(0L, guid.getHostId());
     assertEquals(0, guid.getUuid());
   }

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -102,8 +102,9 @@ import tools.jackson.databind.ObjectMapper;
  * plain-getter contract (issue #3431 / #3388). Action-menu request + editions
  * {@code PublishResponse} / {@code Status} follow the same rule (issue #3432 / #3388).
  * ExtensionFilter / MimeType / LinkRef / ObjectLock / RestError follow the same
- * contract (issue #3430). All use production {@link
- * JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
+ * contract (issue #3430). {@link Guid} {@code stringValue} / {@code untypedString}
+ * follow the same plain-getter contract (issue #3445 / #3388). All use production
+ * {@link JacksonContextResolver} under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -253,6 +254,7 @@ class JacksonContextResolverOptionalTest {
     assertEquals("Default", roundTrip.getName(), json);
     assertEquals("Default ACL", roundTrip.getLabel(), json);
     assertNotNull(roundTrip.getGuid(), json);
+    assertEquals("0-13-10", roundTrip.getGuid().getStringValue(), json);
   }
 
   @Test
@@ -974,7 +976,7 @@ class JacksonContextResolverOptionalTest {
         visibilityMapper.readValue(json, CommunityVisibility.class);
     assertEquals(10L, visibilityRoundTrip.getId(), json);
     assertNotNull(visibilityRoundTrip.getGuid(), json);
-    assertEquals("0-13-10", visibilityRoundTrip.getGuid().getStringValue().orElse(null), json);
+    assertEquals("0-13-10", visibilityRoundTrip.getGuid().getStringValue(), json);
   }
 
   @Test
@@ -1430,6 +1432,45 @@ class JacksonContextResolverOptionalTest {
     String statusJson = statusMapper.writeValueAsString(status);
     assertFalse(statusJson.contains("\"message\""), statusJson);
     assertNoOptionalBeanKeys(statusJson);
+  }
+
+  @Test
+  void guid_serializesStringValueAsScalarNotOptionalBean() {
+    ObjectMapper guidMapper = new JacksonContextResolver().getContext(Guid.class);
+    Guid guid = new Guid("0-31-12");
+
+    String json = guidMapper.writeValueAsString(guid);
+    assertTrue(
+        json.contains("\"stringValue\":\"0-31-12\"")
+            || json.contains("\"stringValue\" : \"0-31-12\""),
+        json);
+    assertTrue(json.contains("\"untypedString\""), json);
+    assertFalse(json.contains("Optional["), json);
+    assertNoOptionalBeanKeys(json);
+
+    Guid roundTrip = guidMapper.readValue(json, Guid.class);
+    assertEquals("0-31-12", roundTrip.getStringValue(), json);
+    assertNotNull(roundTrip.getUntypedString(), json);
+  }
+
+  @Test
+  void guid_omitsNullStringValueFromJson() {
+    ObjectMapper guidMapper = new JacksonContextResolver().getContext(Guid.class);
+    Guid guid = new Guid();
+    guid.setType((short) 31);
+    guid.setUuid(5);
+
+    String json = guidMapper.writeValueAsString(guid);
+    assertFalse(json.contains("\"stringValue\""), json);
+    assertFalse(json.contains("\"untypedString\""), json);
+    assertNoOptionalBeanKeys(json);
+  }
+
+  @Test
+  void guid_bindsObjectFormStringValue() {
+    ObjectMapper guidMapper = new JacksonContextResolver().getContext(Guid.class);
+    Guid bound = guidMapper.readValue("{\"Guid\":{\"stringValue\":\"0-31-5\"}}", Guid.class);
+    assertEquals("0-31-5", bound.getStringValue());
   }
 
   private static void assertNoOptionalBeanKeys(String json) {

--- a/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/acls/AclListSerialDeserialTest.java
@@ -122,7 +122,7 @@ public class AclListSerialDeserialTest {
     assertEquals(5, acl.getObjectId());
     assertEquals(31, acl.getObjectType());
     assertNotNull(acl.getObjectGuid());
-    assertEquals("0-31-5", acl.getObjectGuid().getStringValue().orElse(null));
+    assertEquals("0-31-5", acl.getObjectGuid().getStringValue());
     assertEquals(3, acl.getAclEntries() == null ? 0 : acl.getAclEntries().size());
   }
 
@@ -233,7 +233,7 @@ public class AclListSerialDeserialTest {
             + "\"objectGuid\":{\"stringValue\":\"0-31-5\"},"
             + "\"owner\":{\"name\":\"Admin\",\"type\":\"USER\"}}}";
     CreateAclRequest req = mapper.readValue(wrapped, CreateAclRequest.class);
-    assertEquals("0-31-5", req.getObjectGuid().getStringValue().orElse(null));
+    assertEquals("0-31-5", req.getObjectGuid().getStringValue());
     assertEquals("Admin", req.getOwner().getName());
     assertEquals(IPSTypedPrincipal.PrincipalTypes.USER, req.getOwner().getType());
 
@@ -244,7 +244,8 @@ public class AclListSerialDeserialTest {
       assertTrue(
           result == null
               || result.getObjectGuid() == null
-              || result.getObjectGuid().getStringValue().orElse("").isBlank(),
+              || result.getObjectGuid().getStringValue() == null
+              || result.getObjectGuid().getStringValue().isBlank(),
           "flat CreateAclRequest must not bind under UNWRAP_ROOT_VALUE");
     } catch (Exception expected) {
       assertTrue(

--- a/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
@@ -233,7 +233,7 @@ public class SlotsResourceDetailTest {
     assertEquals(1, result.getAssociations().size());
     assertEquals(
         "0-2-301",
-        result.getAssociations().get(0).getContentTypeGuid().getStringValue().orElse(null));
+        result.getAssociations().get(0).getContentTypeGuid().getStringValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Last remaining REST wire DTO with public `Optional` getters: `com.percussion.rest.Guid`.

`getStringValue()` and `getUntypedString()` now return plain nullable `String` so production Jackson/CXF JSON emits scalar `stringValue` / `untypedString`, not Optional beans (`empty`/`present`). The field keeps `@JsonProperty("stringValue")` and the Java getter stays `@JsonIgnore` so Object ACL still binds a JSON string (`#3200` / `#2951` / `#3378` / `#3384` / `#3391`).

`rest` / `projects/sitemanage` callers that used `.orElse()` / `.isPresent()` on those getters were updated. `JacksonContextResolverOptionalTest` appends Guid methods (production mapper). `rest/AGENTS.md` was not changed (human rule-review gate).

Fixes #3445
Parent: #3388

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 497, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1250, Failures: 0, Skipped: 125
3. Confirm `GuidTest.jacksonSerializesStringValueAsJsonString` and new `JacksonContextResolverOptionalTest` Guid methods: no `empty`/`present` keys; `stringValue` is a JSON string
4. Confirm existing ACL bind tests stay green (`AclList` envelope, CreateAclRequest `{stringValue}`, Default/AnyCommunity)

## Checklist

- [x] **Product documentation** — N/A (not product-facing): documented REST examples already show scalar `guid.stringValue`; this is a wire-getter convention change with no new operator/integrator surface
- [x] **Unit / module tests** — Guid/OptionalTest/ACL bind tests updated; standalone `mvnw clean install` green on `rest` and `projects/sitemanage`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); C2 reverse-dep `projects/sitemanage` installed after public getter signature change
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 497, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1250, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 applied (public `Optional<String>` → `String` getters). Grep: no `extends Guid` / `new Guid() {` anonymous subclasses. Standalone sitemanage clean install green.

### C5 UI proof

N/A — Java REST DTO / adaptor callers only; no WebUI or Playwright surface.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
