### PR TITLE
feat(explorer): preview-first Active Assembly window

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -65,6 +65,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
           "architecture",
           "explorer",
           "profile",
+          "assembly",
           "unavailable");
 
   private static final String APP_PREFIX = "/cm/app";

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -530,6 +530,11 @@ export interface MenuAction {
   id?: number;
   /** Parent server action id when the catalog arrived flat (#3379). */
   parentId?: number;
+  /**
+   * Parent menu name stamped by the toolbar/context menu when a child is
+   * invoked. Distinguishes the same template under Preview vs Active Assembly.
+   */
+  parentName?: string;
   parameters?: ActionMenuParameter[];
   /** Empty unless the parent has cascading children. */
   children?: MenuAction[];

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -27,6 +27,7 @@ export const SPA_ENTRIES = [
   "architecture",
   "explorer",
   "profile",
+  "assembly",
   "unavailable",
 ] as const;
 

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -44,6 +44,10 @@ export interface ParsedSpaEntry {
   path?: string;
   /** Architecture site name (path or query; #3094). */
   site?: string;
+  /** Active Assembly item id (query contract). */
+  contentId?: string;
+  /** Active Assembly page/snippet template id (query contract). */
+  templateId?: string;
 }
 
 /**
@@ -147,6 +151,20 @@ export function parseEntryQuery(
     }
     case "profile":
       return { entry, clientPath: "/profile" };
+    case "assembly": {
+      const contentId = normalizeId(params.get("contentId"));
+      const templateId = normalizeId(params.get("templateId"));
+      const qs = new URLSearchParams();
+      if (contentId) qs.set("contentId", contentId);
+      if (templateId) qs.set("templateId", templateId);
+      const qstr = qs.toString();
+      return {
+        entry,
+        contentId,
+        templateId,
+        clientPath: qstr ? `/assembly?${qstr}` : "/assembly",
+      };
+    }
     case "unavailable":
       return { entry, clientPath: "/unavailable" };
     default:
@@ -167,6 +185,8 @@ export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
   if (parsed.serverId) params.set("serverId", parsed.serverId);
   if (parsed.path) params.set("path", parsed.path);
   if (parsed.site) params.set("site", parsed.site);
+  if (parsed.contentId) params.set("contentId", parsed.contentId);
+  if (parsed.templateId) params.set("templateId", parsed.templateId);
   return `/cm/app/spa.jsp?${params.toString()}`;
 }
 
@@ -292,6 +312,20 @@ export function parseClientPath(
     }
     case "profile":
       return { entry, clientPath: "/profile" };
+    case "assembly": {
+      const contentId = normalizeId(params.get("contentId"));
+      const templateId = normalizeId(params.get("templateId"));
+      const qs = new URLSearchParams();
+      if (contentId) qs.set("contentId", contentId);
+      if (templateId) qs.set("templateId", templateId);
+      const qstr = qs.toString();
+      return {
+        entry,
+        contentId,
+        templateId,
+        clientPath: qstr ? `/assembly?${qstr}` : "/assembly",
+      };
+    }
     case "unavailable":
       return { entry, clientPath: "/unavailable" };
     default:

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -16,16 +16,26 @@
  */
 
 import React from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { BrandBar, BrandFooter } from "../../ui-themes/components";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";
 
+function isBareAssemblyPath(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+  return segments.length === 1 && segments[0] === "assembly";
+}
+
 /**
  * Authenticated SPA chrome: brand bar, TopNav, feature outlet, footer.
  * Feature shells should use {@code embedded} (PR-3+) to avoid duplicate chrome.
+ * Active Assembly is chrome-less so the assembled preview is the canvas.
  */
 export function AppLayout(): React.ReactElement {
+  const { pathname } = useLocation();
+  if (isBareAssemblyPath(pathname)) {
+    return <Outlet />;
+  }
   return (
     <div className={styles.shell} data-testid="perc-spa-app">
       <BrandBar />

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -21,6 +21,7 @@ import { FeaturePlaceholder } from "./FeaturePlaceholder";
 import { AppLayout } from "./layout/AppLayout";
 import { AdminRoute } from "./routes/AdminRoute";
 import { ArchitectureRoute } from "./routes/ArchitectureRoute";
+import { AssemblyRoute } from "./routes/AssemblyRoute";
 import { DesignRoute } from "./routes/DesignRoute";
 import { DeveloperRoute } from "./routes/DeveloperRoute";
 import { ExplorerRoute } from "./routes/ExplorerRoute";
@@ -39,6 +40,7 @@ export function AppRoutes(): React.ReactElement {
   return (
     <Routes>
       <Route element={<AppLayout />}>
+        <Route path="assembly" element={<AssemblyRoute />} />
         <Route index element={<Navigate to="/home" replace />} />
         <Route path="home" element={<HomeRoute />} />
         <Route path="home/:section" element={<HomeRoute />} />

--- a/WebUI/src/main/ts/app/routes/AssemblyRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/AssemblyRoute.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { AssemblyHost } from "../../assembly/AssemblyHost";
+
+/**
+ * Chrome-less Active Assembly window (spec 996 preview-first slice).
+ * Mounted outside {@code AppLayout} so BrandBar / TopNav do not wrap the
+ * assembled preview.
+ */
+export function AssemblyRoute(): React.ReactElement {
+  return <AssemblyHost />;
+}

--- a/WebUI/src/main/ts/assembly/AssemblyHost.module.css
+++ b/WebUI/src/main/ts/assembly/AssemblyHost.module.css
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: system-ui, sans-serif;
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  padding: 8px 12px;
+  border-bottom: 1px solid #334155;
+  font-size: 13px;
+}
+
+.title {
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #1e3a5f;
+  color: #93c5fd;
+}
+
+.meta {
+  color: #94a3b8;
+}
+
+.label {
+  margin-right: 6px;
+  color: #94a3b8;
+}
+
+.select {
+  min-width: 12rem;
+  max-width: 24rem;
+  padding: 4px 8px;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  background: #1e293b;
+  color: #e2e8f0;
+  font: inherit;
+}
+
+.note {
+  flex: 1 1 16rem;
+  font-size: 11px;
+  color: #94a3b8;
+}
+
+.close {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  background: transparent;
+  color: #e2e8f0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+  background: #fff;
+}
+
+.iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.status {
+  padding: 2rem 1.5rem;
+  color: #334155;
+  font-size: 0.95rem;
+}

--- a/WebUI/src/main/ts/assembly/AssemblyHost.tsx
+++ b/WebUI/src/main/ts/assembly/AssemblyHost.tsx
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Preview-first Active Assembly host. Renders the assembled page or snippet
+ * template in an iframe with a light overlay. Slot arrange and
+ * contenteditable field editing are later slices (996 + 995).
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+import {
+  findAllowedTemplateMenus,
+  mapActionMenusToMenuActions,
+} from "../api/contentExplorer/actionMenuApi";
+import {
+  fetchPreviewLocation,
+  type PreviewLocation,
+} from "../api/contentExplorer/assemblyApi";
+import type { MenuAction } from "../api/contentExplorer/types";
+import { parseTemplateIdFromAction } from "../contentExplorer/actionDispatch";
+import { message } from "../i18n/message";
+import { parsePositiveInt, withCmsContextPrefix } from "./assemblyHostUrl";
+import styles from "./AssemblyHost.module.css";
+import { ASSEMBLY_MSG } from "./messages";
+
+export interface AssemblyTemplateOption {
+  id: number;
+  label: string;
+}
+
+export interface AssemblyHostProps {
+  fetchPreview?: (
+    contentId: number,
+    templateId: number,
+  ) => Promise<PreviewLocation>;
+  loadTemplates?: (contentId: number) => Promise<MenuAction[]>;
+}
+
+export function templateOptionsFromMenus(
+  menus: MenuAction[],
+): AssemblyTemplateOption[] {
+  const out: AssemblyTemplateOption[] = [];
+  const seen = new Set<number>();
+  for (const menu of menus) {
+    const id = parseTemplateIdFromAction(menu);
+    if (id == null || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    out.push({ id, label: menu.label || menu.name || String(id) });
+  }
+  return out;
+}
+
+export async function loadAssemblyTemplates(
+  contentId: number,
+): Promise<MenuAction[]> {
+  const aa = mapActionMenusToMenuActions(
+    await findAllowedTemplateMenus(contentId, true),
+  );
+  if (aa.length > 0) {
+    return aa;
+  }
+  return mapActionMenusToMenuActions(
+    await findAllowedTemplateMenus(contentId, false),
+  );
+}
+
+function resolveAssemblerHref(previewUrl: string): string | null {
+  const trimmed = previewUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const href = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : withCmsContextPrefix(trimmed.startsWith("/") ? trimmed : `/${trimmed}`);
+  if (!href.toLowerCase().includes("/assembler/render")) {
+    return null;
+  }
+  return href;
+}
+
+export function AssemblyHost({
+  fetchPreview = fetchPreviewLocation,
+  loadTemplates = loadAssemblyTemplates,
+}: AssemblyHostProps = {}): React.ReactElement {
+  const [params] = useSearchParams();
+  const contentId = parsePositiveInt(params.get("contentId"));
+  const requestedTemplateId = parsePositiveInt(params.get("templateId"));
+
+  const [templates, setTemplates] = useState<AssemblyTemplateOption[]>([]);
+  const [templateId, setTemplateId] = useState<number | null>(
+    requestedTemplateId,
+  );
+  const [previewHref, setPreviewHref] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(
+    contentId == null ? ASSEMBLY_MSG.MISSING_ITEM : null,
+  );
+  const [loading, setLoading] = useState(contentId != null);
+
+  useEffect(() => {
+    document.title = message(ASSEMBLY_MSG.TITLE);
+  }, []);
+
+  useEffect(() => {
+    if (contentId == null) {
+      setLoading(false);
+      setErrorKey(ASSEMBLY_MSG.MISSING_ITEM);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setErrorKey(null);
+    void (async () => {
+      try {
+        const menus = await loadTemplates(contentId);
+        if (cancelled) {
+          return;
+        }
+        const options = templateOptionsFromMenus(menus);
+        setTemplates(options);
+        const nextId =
+          (requestedTemplateId != null &&
+          (options.length === 0 ||
+            options.some((o) => o.id === requestedTemplateId))
+            ? requestedTemplateId
+            : null) ??
+          options[0]?.id ??
+          null;
+        setTemplateId(nextId);
+        if (nextId == null) {
+          setPreviewHref(null);
+          setErrorKey(ASSEMBLY_MSG.NO_TEMPLATE);
+          setLoading(false);
+        }
+      } catch {
+        if (cancelled) {
+          return;
+        }
+        if (requestedTemplateId != null) {
+          setTemplateId(requestedTemplateId);
+        } else {
+          setPreviewHref(null);
+          setErrorKey(ASSEMBLY_MSG.NO_TEMPLATE);
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, requestedTemplateId, loadTemplates]);
+
+  useEffect(() => {
+    if (contentId == null || templateId == null) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setErrorKey(null);
+    void (async () => {
+      try {
+        const loc = await fetchPreview(contentId, templateId);
+        if (cancelled) {
+          return;
+        }
+        const href = resolveAssemblerHref(loc.previewUrl);
+        if (href == null) {
+          setPreviewHref(null);
+          setErrorKey(ASSEMBLY_MSG.PREVIEW_FAILED);
+        } else {
+          setPreviewHref(href);
+        }
+      } catch {
+        if (!cancelled) {
+          setPreviewHref(null);
+          setErrorKey(ASSEMBLY_MSG.PREVIEW_FAILED);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, templateId, fetchPreview]);
+
+  const selectedLabel = useMemo(() => {
+    return templates.find((t) => t.id === templateId)?.label;
+  }, [templates, templateId]);
+
+  return (
+    <div className={styles.root} data-testid="assembly-host">
+      <header className={styles.bar} data-testid="assembly-overlay">
+        <span className={styles.title}>{message(ASSEMBLY_MSG.TITLE)}</span>
+        <span className={styles.badge}>{message(ASSEMBLY_MSG.BADGE_PREVIEW)}</span>
+        {contentId != null ? (
+          <span className={styles.meta} data-testid="assembly-content-id">
+            <span className={styles.label}>{message(ASSEMBLY_MSG.CONTENT_ID)}</span>
+            {contentId}
+          </span>
+        ) : null}
+        {templates.length > 0 ? (
+          <label>
+            <span className={styles.label}>{message(ASSEMBLY_MSG.TEMPLATE_LABEL)}</span>
+            <select
+              className={styles.select}
+              data-testid="assembly-template-select"
+              aria-label={message(ASSEMBLY_MSG.TEMPLATE_LABEL)}
+              value={templateId ?? ""}
+              onChange={(e) => {
+                const next = parsePositiveInt(e.target.value);
+                setTemplateId(next);
+              }}
+            >
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : selectedLabel || templateId != null ? (
+          <span className={styles.meta} data-testid="assembly-template-id">
+            <span className={styles.label}>{message(ASSEMBLY_MSG.TEMPLATE_LABEL)}</span>
+            {selectedLabel ?? templateId}
+          </span>
+        ) : null}
+        <span className={styles.note}>{message(ASSEMBLY_MSG.NOTE)}</span>
+        <button
+          type="button"
+          className={styles.close}
+          data-testid="assembly-close"
+          onClick={() => {
+            if (typeof window !== "undefined") {
+              window.close();
+            }
+          }}
+        >
+          {message(ASSEMBLY_MSG.CLOSE)}
+        </button>
+      </header>
+      <div className={styles.stage} data-testid="assembly-stage">
+        {errorKey ? (
+          <div className={styles.status} role="alert" data-testid="assembly-error">
+            {message(errorKey)}
+          </div>
+        ) : loading && !previewHref ? (
+          <div className={styles.status} role="status" data-testid="assembly-loading">
+            {message(ASSEMBLY_MSG.LOADING)}
+          </div>
+        ) : previewHref ? (
+          <iframe
+            className={styles.iframe}
+            data-testid="assembly-preview-frame"
+            title={message(ASSEMBLY_MSG.IFRAME_TITLE)}
+            src={previewHref}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/assembly/AssemblyHost.tsx
+++ b/WebUI/src/main/ts/assembly/AssemblyHost.tsx
@@ -104,9 +104,7 @@ export function AssemblyHost({
   const requestedTemplateId = parsePositiveInt(params.get("templateId"));
 
   const [templates, setTemplates] = useState<AssemblyTemplateOption[]>([]);
-  const [templateId, setTemplateId] = useState<number | null>(
-    requestedTemplateId,
-  );
+  const [templateId, setTemplateId] = useState<number | null>(null);
   const [previewHref, setPreviewHref] = useState<string | null>(null);
   const [errorKey, setErrorKey] = useState<string | null>(
     contentId == null ? ASSEMBLY_MSG.MISSING_ITEM : null,
@@ -134,10 +132,23 @@ export function AssemblyHost({
         }
         const options = templateOptionsFromMenus(menus);
         setTemplates(options);
+        const requestedInList =
+          requestedTemplateId != null &&
+          options.some((o) => o.id === requestedTemplateId);
+        if (
+          requestedTemplateId != null &&
+          options.length > 0 &&
+          !requestedInList
+        ) {
+          setTemplateId(null);
+          setPreviewHref(null);
+          setErrorKey(ASSEMBLY_MSG.TEMPLATE_MISMATCH);
+          setLoading(false);
+          return;
+        }
         const nextId =
-          (requestedTemplateId != null &&
-          (options.length === 0 ||
-            options.some((o) => o.id === requestedTemplateId))
+          (requestedInList ||
+          (requestedTemplateId != null && options.length === 0)
             ? requestedTemplateId
             : null) ??
           options[0]?.id ??
@@ -152,13 +163,10 @@ export function AssemblyHost({
         if (cancelled) {
           return;
         }
-        if (requestedTemplateId != null) {
-          setTemplateId(requestedTemplateId);
-        } else {
-          setPreviewHref(null);
-          setErrorKey(ASSEMBLY_MSG.NO_TEMPLATE);
-          setLoading(false);
-        }
+        setTemplateId(null);
+        setPreviewHref(null);
+        setErrorKey(ASSEMBLY_MSG.NO_TEMPLATE);
+        setLoading(false);
       }
     })();
     return () => {
@@ -217,6 +225,12 @@ export function AssemblyHost({
             {contentId}
           </span>
         ) : null}
+        {errorKey === ASSEMBLY_MSG.TEMPLATE_MISMATCH && requestedTemplateId != null ? (
+          <span className={styles.meta} data-testid="assembly-requested-template">
+            <span className={styles.label}>{message(ASSEMBLY_MSG.TEMPLATE_LABEL)}</span>
+            {requestedTemplateId}
+          </span>
+        ) : null}
         {templates.length > 0 ? (
           <label>
             <span className={styles.label}>{message(ASSEMBLY_MSG.TEMPLATE_LABEL)}</span>
@@ -237,10 +251,10 @@ export function AssemblyHost({
               ))}
             </select>
           </label>
-        ) : selectedLabel || templateId != null ? (
+        ) : selectedLabel || templateId != null || requestedTemplateId != null ? (
           <span className={styles.meta} data-testid="assembly-template-id">
             <span className={styles.label}>{message(ASSEMBLY_MSG.TEMPLATE_LABEL)}</span>
-            {selectedLabel ?? templateId}
+            {selectedLabel ?? templateId ?? requestedTemplateId}
           </span>
         ) : null}
         <span className={styles.note}>{message(ASSEMBLY_MSG.NOTE)}</span>

--- a/WebUI/src/main/ts/assembly/assemblyHostUrl.ts
+++ b/WebUI/src/main/ts/assembly/assemblyHostUrl.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Deep-link builder for the chrome-less Active Assembly window.
+ *
+ * <p>Server entry stays on the query contract
+ * {@code /cm/app/spa.jsp?entry=assembly&contentId=&templateId=}. The SPA
+ * rewrites that to {@code /cm/app/assembly?…}.</p>
+ */
+
+export const ASSEMBLY_WINDOW_FEATURES =
+  "popup=yes,width=1280,height=900,scrollbars=yes,resizable=yes";
+
+export function withCmsContextPrefix(path: string): string {
+  const trimmed = path.startsWith("/") ? path : `/${path}`;
+  if (typeof window === "undefined") {
+    return trimmed;
+  }
+  const locPath = window.location?.pathname ?? "";
+  if (
+    (locPath === "/Rhythmyx" || locPath.startsWith("/Rhythmyx/")) &&
+    !trimmed.startsWith("/Rhythmyx/")
+  ) {
+    return `/Rhythmyx${trimmed}`;
+  }
+  return trimmed;
+}
+
+export function parsePositiveInt(raw: string | null | undefined): number | null {
+  if (raw == null || !String(raw).trim()) {
+    return null;
+  }
+  const n = Number(String(raw).trim());
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+}
+
+/**
+ * Named-window URL for Explorer Active Assembly. {@code templateId} is
+ * optional — the host loads {@code isAA} page/snippet templates when omitted.
+ */
+export function buildAssemblyHostUrl(
+  contentId: number,
+  templateId?: number | null,
+): string {
+  const q = new URLSearchParams();
+  q.set("entry", "assembly");
+  q.set("contentId", String(contentId));
+  if (templateId != null && templateId > 0) {
+    q.set("templateId", String(templateId));
+  }
+  return withCmsContextPrefix(`/cm/app/spa.jsp?${q.toString()}`);
+}
+
+export function assemblyWindowName(contentId: number): string {
+  return `percAssembly_${contentId}`;
+}

--- a/WebUI/src/main/ts/assembly/messages.ts
+++ b/WebUI/src/main/ts/assembly/messages.ts
@@ -28,6 +28,8 @@ export const ASSEMBLY_MSG = {
   NOTE: "perc.ui.assembly@Assembled with the selected page or snippet template. Field editing will use the Content Editor.",
   MISSING_ITEM: "perc.ui.assembly@Open Active Assembly from Explorer with a content item selected.",
   NO_TEMPLATE: "perc.ui.assembly@No page or snippet template is available for this item.",
+  TEMPLATE_MISMATCH:
+    "perc.ui.assembly@The requested template is not in the available list.",
   PREVIEW_FAILED: "perc.ui.assembly@Could not load the assembled preview.",
   LOADING: "perc.ui.assembly@Loading assembled preview…",
   IFRAME_TITLE: "perc.ui.assembly@Assembled preview",

--- a/WebUI/src/main/ts/assembly/messages.ts
+++ b/WebUI/src/main/ts/assembly/messages.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TMX keys for the preview-first Active Assembly host (spec 996).
+ */
+
+export const ASSEMBLY_MSG = {
+  TITLE: "perc.ui.assembly@Active Assembly",
+  BADGE_PREVIEW: "perc.ui.assembly@Preview",
+  CONTENT_ID: "perc.ui.assembly@Content",
+  TEMPLATE_LABEL: "perc.ui.assembly@Template",
+  TEMPLATE_PLACEHOLDER: "perc.ui.assembly@Select a page or snippet template",
+  NOTE: "perc.ui.assembly@Assembled with the selected page or snippet template. Field editing will use the Content Editor.",
+  MISSING_ITEM: "perc.ui.assembly@Open Active Assembly from Explorer with a content item selected.",
+  NO_TEMPLATE: "perc.ui.assembly@No page or snippet template is available for this item.",
+  PREVIEW_FAILED: "perc.ui.assembly@Could not load the assembled preview.",
+  LOADING: "perc.ui.assembly@Loading assembled preview…",
+  IFRAME_TITLE: "perc.ui.assembly@Assembled preview",
+  CLOSE: "perc.ui.assembly@Close",
+};

--- a/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
@@ -112,10 +112,14 @@ function hasChildren(action: MenuAction): boolean {
 
 function activate(
   action: MenuAction,
-  _baseHref: string,
+  parent: MenuAction | undefined,
   onInvoke?: (name: string, a: MenuAction) => void,
 ): void {
-  onInvoke?.(action.name, action);
+  const payload =
+    parent?.name && !action.parentName
+      ? { ...action, parentName: parent.name }
+      : action;
+  onInvoke?.(action.name, payload);
 }
 
 export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
@@ -123,8 +127,6 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
   const [openMenu, setOpenMenu] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const baseId = useId();
-  const baseHref =
-    typeof window !== "undefined" ? window.location.href : "http://localhost/";
 
   useEffect(() => {
     setOpenMenu(null);
@@ -188,7 +190,7 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
                     data-testid={`action-toolbar-item-${c.name}`}
                     aria-label={c.label}
                     title={c.description ?? c.label}
-                    onClick={() => activate(c, baseHref, onInvoke)}
+                    onClick={() => activate(c, a, onInvoke)}
                     style={buttonStyle}
                   >
                     {c.label}
@@ -249,13 +251,13 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
                           title={child.description ?? child.label}
                           style={menuItemStyle}
                           onClick={() => {
-                            activate(child, baseHref, onInvoke);
+                            activate(child, a, onInvoke);
                             setOpenMenu(null);
                           }}
                           onKeyDown={(e) => {
                             if (ACTIVATE_KEYS.has(e.key)) {
                               e.preventDefault();
-                              activate(child, baseHref, onInvoke);
+                              activate(child, a, onInvoke);
                               setOpenMenu(null);
                             }
                           }}
@@ -276,7 +278,7 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
               data-testid={`action-toolbar-item-${a.name}`}
               aria-label={a.label}
               title={a.description ?? a.label}
-              onClick={() => activate(a, baseHref, onInvoke)}
+              onClick={() => activate(a, undefined, onInvoke)}
               style={buttonStyle}
             >
               {a.label}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -67,7 +67,11 @@ import type {
 import { useSpaBootstrapOptional } from "../app/bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "../app/bootstrap/types";
 import { message } from "../i18n/message";
-import { dispatchAction, purgeSelectedItem } from "./actionDispatch";
+import {
+  dispatchAction,
+  findMenuParentName,
+  purgeSelectedItem,
+} from "./actionDispatch";
 import {
   filterContextMenuActions,
   filterToolbarActions,
@@ -711,6 +715,12 @@ function ContentExplorerShellInner({
           const result = await dispatchAction(action, {
             item: selection.item,
             folderPath: selection.folderPath,
+            parentName:
+              action.parentName ??
+              findMenuParentName(
+                [...menuActions, ...(contextMenu?.actions ?? [])],
+                action.name,
+              ),
             onOpen: handlers.onOpen,
             onPreview: handlers.onPreview,
             onPurge: async (item) => {
@@ -742,7 +752,14 @@ function ContentExplorerShellInner({
       })();
       void actionName;
     },
-    [selection.item, selection.folderPath, handlers, runWorkflowTransition],
+    [
+      selection.item,
+      selection.folderPath,
+      handlers,
+      runWorkflowTransition,
+      menuActions,
+      contextMenu,
+    ],
   );
 
   const handleSearchOpen = useCallback((result: PSItemProperties) => {

--- a/WebUI/src/main/ts/contentExplorer/ContextMenu.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContextMenu.tsx
@@ -56,18 +56,20 @@ const ACTIVATE_KEYS = new Set(["Enter", " "]);
 
 function activate(
   action: MenuAction,
-  _baseHref: string,
+  parent: MenuAction | undefined,
   onInvoke?: (name: string, a: MenuAction) => void,
 ): void {
-  onInvoke?.(action.name, action);
+  const payload =
+    parent?.name && !action.parentName
+      ? { ...action, parentName: parent.name }
+      : action;
+  onInvoke?.(action.name, payload);
 }
 
 export function ContextMenu(props: ContextMenuProps): React.JSX.Element {
   const { actions, onInvoke, onClose, ariaLabel, className } = props;
   const [openPivot, setOpenPivot] = useState<string | null>(null);
   const baseId = useId();
-  const baseHref =
-    typeof window !== "undefined" ? window.location.href : "http://localhost/";
 
   useEffect(() => {
     setOpenPivot(null);
@@ -90,7 +92,7 @@ export function ContextMenu(props: ContextMenuProps): React.JSX.Element {
       if (isPivot) {
         setOpenPivot(expanded ? null : action.name);
       } else {
-        activate(action, baseHref, onInvoke);
+        activate(action, undefined, onInvoke);
       }
     }
   }
@@ -130,7 +132,7 @@ export function ContextMenu(props: ContextMenuProps): React.JSX.Element {
                     if (isPivot) {
                       setOpenPivot(expanded ? null : action.name);
                     } else {
-                      activate(action, baseHref, onInvoke);
+                      activate(action, undefined, onInvoke);
                     }
                   }}
                   onKeyDown={(e) => handleItemKey(e, action, isPivot, expanded)}
@@ -161,11 +163,11 @@ export function ContextMenu(props: ContextMenuProps): React.JSX.Element {
                           role="menuitem"
                           tabIndex={0}
                           data-testid={`context-menu-item-${c.name}`}
-                          onClick={() => activate(c, baseHref, onInvoke)}
+                          onClick={() => activate(c, action, onInvoke)}
                           onKeyDown={(e) => {
                             if (ACTIVATE_KEYS.has(e.key)) {
                               e.preventDefault();
-                              activate(c, baseHref, onInvoke);
+                              activate(c, action, onInvoke);
                             }
                           }}
                           style={{ cursor: "pointer" }}

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -35,6 +35,11 @@ import { del } from "../api/client";
 import { PATHS } from "../api/paths";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { classifyUrl, safeNavigate } from "../util/safeNavigate";
+import {
+  ASSEMBLY_WINDOW_FEATURES,
+  assemblyWindowName,
+  buildAssemblyHostUrl,
+} from "../assembly/assemblyHostUrl";
 import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
 import {
@@ -75,11 +80,15 @@ const PREVIEW_PARENT_NAMES = new Set([
   "slot_item_corporate_preview",
 ]);
 
-const AA_UNAVAILABLE_NAMES = new Set([
+/** Explorer Active Assembly parents — open the preview-first host (996). */
+export const AA_PREVIEW_PARENT_NAMES = new Set([
   "item_activeassembly",
   "enterpriseitem_activeassembly",
   "corporateitem_activeassembly",
   "item_assembly",
+]);
+
+const AA_UNAVAILABLE_NAMES = new Set([
   "aa_table_editor",
   "slot_add",
   "slot_create",
@@ -147,6 +156,8 @@ export interface ActionDispatchContext {
   resetNav?: () => Promise<void>;
   createCopy?: (itemId: string) => Promise<void>;
   createPromotable?: (itemId: string) => Promise<void>;
+  /** Parent menu name when the user activated a child (AA vs Preview). */
+  parentName?: string;
   writeClipboard?: (text: string) => Promise<void>;
   confirm?: (body: string) => boolean;
   openWindow?: (url: string, target?: string, features?: string) => Window | null;
@@ -208,6 +219,9 @@ export function classifyAction(action: MenuAction): ActionKind {
   if (EDITOR_NAMES.has(name) || isContentEditorActionUrl(action.url)) {
     return "editor";
   }
+  if (AA_PREVIEW_PARENT_NAMES.has(name)) {
+    return "rest";
+  }
   if (AA_UNAVAILABLE_NAMES.has(name)) {
     return "unavailable";
   }
@@ -233,6 +247,33 @@ export function classifyAction(action: MenuAction): ActionKind {
     return "legacy-file";
   }
   return "client";
+}
+
+/** Walk a menu tree and return the parent name that owns {@code childName}. */
+export function findMenuParentName(
+  actions: MenuAction[],
+  childName: string,
+): string | undefined {
+  for (const action of actions) {
+    if (action.children?.some((c) => c.name === childName)) {
+      return action.name;
+    }
+    const nested = findMenuParentName(action.children ?? [], childName);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+export function isAaPreviewAction(
+  actionName: string | undefined,
+  parentName?: string,
+): boolean {
+  return (
+    AA_PREVIEW_PARENT_NAMES.has(normalizeActionName(actionName)) ||
+    AA_PREVIEW_PARENT_NAMES.has(normalizeActionName(parentName))
+  );
 }
 
 export function parseTemplateIdFromAction(action: MenuAction): number | null {
@@ -515,6 +556,21 @@ export async function dispatchAction(
 
   if (name === "publish_now" || name === "create_new_item") {
     return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
+  }
+
+  if (isAaPreviewAction(action.name, ctx.parentName)) {
+    if (!item || isFolder(item)) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    const contentId = parseExplorerContentId(item.id);
+    if (contentId == null) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.PREVIEW_UNAVAILABLE };
+    }
+    const templateId = parseTemplateIdFromAction(action);
+    const href = buildAssemblyHostUrl(contentId, templateId);
+    const open = ctx.openWindow ?? defaultOpenWindow;
+    open(href, assemblyWindowName(contentId), ASSEMBLY_WINDOW_FEATURES);
+    return { kind: "rest" };
   }
 
   const templateId = parseTemplateIdFromAction(action);

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -101,6 +101,14 @@ export const PREVIEW_HOST_PREFERRED_KEYS: readonly string[] = [
   "slotitempreview",
 ];
 
+/** Normalized names of Active Assembly MENU parents that host AA templates. */
+export const AA_HOST_PREFERRED_KEYS: readonly string[] = [
+  "itemactiveassembly",
+  "enterpriseitemactiveassembly",
+  "corporateitemactiveassembly",
+  "itemassembly",
+];
+
 const NEW_ITEM_HOST_LABEL = /new|create/i;
 
 function findNewItemHost(tree: MenuAction[]): MenuAction | null {
@@ -223,6 +231,49 @@ export function mergeTemplateMenusIntoCatalog(
   return out;
 }
 
+function findAaHost(tree: MenuAction[]): MenuAction | null {
+  const stack = [...tree];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (isCascadeParent(node)) {
+      const key = node.name.replace(/[\s_-]/g, "").toLowerCase();
+      if (AA_HOST_PREFERRED_KEYS.includes(key)) {
+        return node;
+      }
+    }
+    if (node.children?.length) {
+      stack.push(...node.children);
+    }
+  }
+  return null;
+}
+
+/**
+ * Merge {@code isAA} template menus under an Active Assembly MENU parent.
+ * Same template names may also live under Preview — they are still attached
+ * here so AA children open the assembly host.
+ */
+export function mergeAaTemplateMenusIntoCatalog(
+  tree: MenuAction[],
+  templateMenus: MenuAction[],
+): MenuAction[] {
+  if (templateMenus.length === 0) {
+    return tree.slice();
+  }
+  const out = tree.map(cloneAction);
+  const extra = templateMenus.filter((m) => m?.name).map(cloneAction);
+  const host = findAaHost(out);
+  if (!host || extra.length === 0) {
+    return out;
+  }
+  const existing = new Set((host.children ?? []).map((c) => c.name));
+  host.children = [
+    ...(host.children ?? []),
+    ...extra.filter((e) => !existing.has(e.name)),
+  ];
+  return out;
+}
+
 /**
  * Product default for Explorer toolbar / context-menu catalog load.
  *
@@ -258,10 +309,21 @@ export async function loadExplorerMenuCatalog(
     const templateMenus = mapActionMenusToMenuActions(
       await findAllowedTemplateMenus(contentId, false),
     );
-    return mergeTemplateMenusIntoCatalog(merged, templateMenus);
+    merged = mergeTemplateMenusIntoCatalog(merged, templateMenus);
   } catch (err: unknown) {
     console.warn(
       "[ContentExplorerShell] template menus load failed; keeping catalog",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  try {
+    const aaMenus = mapActionMenusToMenuActions(
+      await findAllowedTemplateMenus(contentId, true),
+    );
+    return mergeAaTemplateMenusIntoCatalog(merged, aaMenus);
+  } catch (err: unknown) {
+    console.warn(
+      "[ContentExplorerShell] AA template menus load failed; keeping catalog",
       err instanceof Error ? err.message : String(err),
     );
     return merged;

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -59,7 +59,7 @@
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
                 || "design".equals(n) || "architecture".equals(n)
-                || "profile".equals(n)
+                || "profile".equals(n) || "assembly".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -59,7 +59,7 @@
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
                 || "design".equals(n) || "architecture".equals(n)
-                || "profile".equals(n)
+                || "profile".equals(n) || "assembly".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -65,6 +65,14 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void forwardsAssemblyEntry() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=assembly&contentId=42&templateId=7",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath(
+            "/cm/app/assembly", "contentId=42&templateId=7"));
+  }
+
+  @Test
   public void forwardsProfileEntry() {
     assertEquals(
         "/cm/app/spa.jsp?entry=profile",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -117,6 +117,29 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/profile").clientPath).toBe("/profile");
   });
 
+  it("maps assembly entry to chrome-less /assembly with ids", () => {
+    const p = parseEntryQuery(
+      "?entry=assembly&contentId=42&templateId=7",
+    );
+    expect(p.entry).toBe("assembly");
+    expect(p.contentId).toBe("42");
+    expect(p.templateId).toBe("7");
+    expect(p.clientPath).toBe("/assembly?contentId=42&templateId=7");
+    expect(parseClientPath("/assembly", "?contentId=42&templateId=7").entry).toBe(
+      "assembly",
+    );
+    expect(
+      toSpaEntryUrl({
+        entry: "assembly",
+        contentId: "42",
+        templateId: "7",
+        clientPath: "/assembly?contentId=42&templateId=7",
+      }),
+    ).toBe(
+      "/cm/app/spa.jsp?entry=assembly&contentId=42&templateId=7",
+    );
+  });
+
   it("toSpaEntryUrl rebuilds query contract", () => {
     const url = toSpaEntryUrl({
       entry: "home",

--- a/WebUI/src/test/ts/assembly/AssemblyHost.test.tsx
+++ b/WebUI/src/test/ts/assembly/AssemblyHost.test.tsx
@@ -101,6 +101,48 @@ describe("AssemblyHost", () => {
     expect(screen.getByTestId("assembly-template-select")).toBeTruthy();
   });
 
+  it("shows an error when template load fails even with a requested templateId", async () => {
+    const fetchPreview = vi.fn();
+    const loadTemplates = vi.fn().mockRejectedValue(new Error("catalog down"));
+    renderHost("?contentId=42&templateId=7", { fetchPreview, loadTemplates });
+    await waitFor(() => {
+      expect(screen.getByTestId("assembly-error").textContent).toMatch(
+        /no page or snippet template/i,
+      );
+    });
+    expect(fetchPreview).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("assembly-preview-frame")).toBeNull();
+  });
+
+  it("does not silently fall back when requestedTemplateId is not in options", async () => {
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_contentid=42&sys_template=3",
+      contentId: 42,
+      templateId: 3,
+      revision: 1,
+    });
+    const loadTemplates = vi.fn().mockResolvedValue([
+      {
+        name: "rffSnTitle",
+        label: "Title snippet",
+        sortRank: 0,
+        menuType: "MENUITEM",
+        parameters: [{ name: "sys_template", value: "3" }],
+      } satisfies MenuAction,
+    ]);
+    renderHost("?contentId=42&templateId=99", { fetchPreview, loadTemplates });
+    await waitFor(() => {
+      expect(screen.getByTestId("assembly-error").textContent).toMatch(
+        /not in the available list/i,
+      );
+    });
+    expect(fetchPreview).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("assembly-preview-frame")).toBeNull();
+    expect(screen.getByTestId("assembly-requested-template").textContent).toContain(
+      "99",
+    );
+  });
+
   it("AppRoutes mounts assembly outside AppLayout", () => {
     render(
       <MemoryRouter initialEntries={["/assembly"]}>

--- a/WebUI/src/test/ts/assembly/AssemblyHost.test.tsx
+++ b/WebUI/src/test/ts/assembly/AssemblyHost.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AssemblyHost } from "../../../main/ts/assembly/AssemblyHost";
+import { AppRoutes } from "../../../main/ts/app/routes";
+import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
+
+function renderHost(
+  search: string,
+  props: React.ComponentProps<typeof AssemblyHost> = {},
+): void {
+  render(
+    <MemoryRouter initialEntries={[`/assembly${search}`]}>
+      <Routes>
+        <Route path="/assembly" element={<AssemblyHost {...props} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AssemblyHost", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("asks for an item when contentId is missing", () => {
+    renderHost("");
+    expect(screen.getByTestId("assembly-overlay")).toBeTruthy();
+    expect(screen.getByTestId("assembly-error").textContent).toMatch(
+      /content item/i,
+    );
+    expect(screen.queryByTestId("assembly-preview-frame")).toBeNull();
+  });
+
+  it("loads the assembled preview for a page/snippet template", async () => {
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_contentid=42&sys_template=7",
+      contentId: 42,
+      templateId: 7,
+      revision: 1,
+    });
+    const loadTemplates = vi.fn().mockResolvedValue([
+      {
+        name: "rffPgGeneric",
+        label: "Generic Page",
+        url: "../assembler/render?sys_template=7",
+        sortRank: 0,
+        menuType: "MENUITEM",
+      } satisfies MenuAction,
+    ]);
+    renderHost("?contentId=42&templateId=7", { fetchPreview, loadTemplates });
+    await waitFor(() => {
+      expect(screen.getByTestId("assembly-preview-frame")).toBeTruthy();
+    });
+    expect(fetchPreview).toHaveBeenCalledWith(42, 7);
+    expect(screen.getByTestId("assembly-content-id").textContent).toContain("42");
+    const frame = screen.getByTestId("assembly-preview-frame");
+    expect(frame.getAttribute("src")).toContain("/assembler/render");
+    expect(frame.getAttribute("src")).toContain("sys_template=7");
+  });
+
+  it("picks the first AA template when the query omits templateId", async () => {
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_contentid=9&sys_template=3",
+      contentId: 9,
+      templateId: 3,
+      revision: 1,
+    });
+    const loadTemplates = vi.fn().mockResolvedValue([
+      {
+        name: "rffSnTitle",
+        label: "Title snippet",
+        sortRank: 0,
+        menuType: "MENUITEM",
+        parameters: [{ name: "sys_template", value: "3" }],
+      } satisfies MenuAction,
+    ]);
+    renderHost("?contentId=9", { fetchPreview, loadTemplates });
+    await waitFor(() => {
+      expect(fetchPreview).toHaveBeenCalledWith(9, 3);
+    });
+    expect(screen.getByTestId("assembly-template-select")).toBeTruthy();
+  });
+
+  it("AppRoutes mounts assembly outside AppLayout", () => {
+    render(
+      <MemoryRouter initialEntries={["/assembly"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("assembly-host")).toBeTruthy();
+    expect(screen.queryByTestId("perc-spa-app")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/assembly/assemblyHostUrl.test.ts
+++ b/WebUI/src/test/ts/assembly/assemblyHostUrl.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  assemblyWindowName,
+  buildAssemblyHostUrl,
+  parsePositiveInt,
+  withCmsContextPrefix,
+} from "../../../main/ts/assembly/assemblyHostUrl";
+
+describe("assemblyHostUrl", () => {
+  it("builds the spa.jsp query contract with optional template", () => {
+    expect(buildAssemblyHostUrl(42)).toBe(
+      "/cm/app/spa.jsp?entry=assembly&contentId=42",
+    );
+    expect(buildAssemblyHostUrl(42, 7)).toBe(
+      "/cm/app/spa.jsp?entry=assembly&contentId=42&templateId=7",
+    );
+    expect(buildAssemblyHostUrl(42, 0)).toBe(
+      "/cm/app/spa.jsp?entry=assembly&contentId=42",
+    );
+  });
+
+  it("names the popup per content id", () => {
+    expect(assemblyWindowName(42)).toBe("percAssembly_42");
+  });
+
+  it("parses positive ints only", () => {
+    expect(parsePositiveInt("7")).toBe(7);
+    expect(parsePositiveInt("0")).toBeNull();
+    expect(parsePositiveInt("-1")).toBeNull();
+    expect(parsePositiveInt("x")).toBeNull();
+    expect(parsePositiveInt(null)).toBeNull();
+  });
+
+  it("prefixes /Rhythmyx when the SPA is under that context", () => {
+    expect(withCmsContextPrefix("/cm/app/spa.jsp?entry=assembly")).toBe(
+      "/cm/app/spa.jsp?entry=assembly",
+    );
+  });
+});

--- a/WebUI/src/test/ts/assembly/assemblyHostUrl.test.ts
+++ b/WebUI/src/test/ts/assembly/assemblyHostUrl.test.ts
@@ -48,9 +48,21 @@ describe("assemblyHostUrl", () => {
     expect(parsePositiveInt(null)).toBeNull();
   });
 
-  it("prefixes /Rhythmyx when the SPA is under that context", () => {
+  it("leaves the path unchanged when the SPA is not under /Rhythmyx", () => {
     expect(withCmsContextPrefix("/cm/app/spa.jsp?entry=assembly")).toBe(
       "/cm/app/spa.jsp?entry=assembly",
     );
+  });
+
+  it("prefixes /Rhythmyx when the SPA is under that context", () => {
+    const original = window.location.pathname;
+    window.history.replaceState({}, "", "/Rhythmyx/cm/app/home");
+    try {
+      expect(withCmsContextPrefix("/cm/app/spa.jsp?entry=assembly")).toBe(
+        "/Rhythmyx/cm/app/spa.jsp?entry=assembly",
+      );
+    } finally {
+      window.history.replaceState({}, "", original || "/");
+    }
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
@@ -106,7 +106,7 @@ describe("ActionToolbar", () => {
     fireEvent.click(screen.getByTestId("action-toolbar-item-new-folder"));
     expect(onInvoke).toHaveBeenCalledWith(
       "new-folder",
-      expect.objectContaining({ name: "new-folder" }),
+      expect.objectContaining({ name: "new-folder", parentName: "new" }),
     );
   });
 

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -20,6 +20,7 @@ import type { MenuAction, PSPathItem } from "../../../main/ts/api/contentExplore
 import {
   classifyAction,
   dispatchAction,
+  findMenuParentName,
   isContentEditorActionUrl,
   isDataFlowActionUrl,
   parseTemplateIdFromAction,
@@ -101,7 +102,7 @@ describe("actionDispatch", () => {
     const openWindow = vi.fn();
     const result = await dispatchAction(
       action({
-        name: "Item_Assembly",
+        name: "Slot_Add",
         url: "../sys_cxSupport/aadocactions.html",
       }),
       { item: item(), openWindow },
@@ -370,6 +371,102 @@ describe("actionDispatch", () => {
     );
     expect(createPromotable).not.toHaveBeenCalled();
     expect(result.refresh).toBeUndefined();
+  });
+
+  it("classifies Active Assembly parents as rest and slot arrange as unavailable", () => {
+    expect(classifyAction(action({ name: "Item_ActiveAssembly" }))).toBe("rest");
+    expect(
+      classifyAction(action({ name: "EnterpriseItem_ActiveAssembly" })),
+    ).toBe("rest");
+    expect(classifyAction(action({ name: "Item_Assembly" }))).toBe("rest");
+    expect(classifyAction(action({ name: "Arrange_Remove" }))).toBe(
+      "unavailable",
+    );
+    expect(classifyAction(action({ name: "Slot_Add" }))).toBe("unavailable");
+  });
+
+  it("finds the parent menu name for a nested template child", () => {
+    expect(
+      findMenuParentName(
+        [
+          action({
+            name: "Item_ActiveAssembly",
+            children: [action({ name: "rffPgGeneric" })],
+          }),
+        ],
+        "rffPgGeneric",
+      ),
+    ).toBe("Item_ActiveAssembly");
+  });
+
+  it("opens the assembly host for Active Assembly without fetching preview", async () => {
+    const openWindow = vi.fn();
+    const fetchPreview = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "Item_ActiveAssembly" }),
+      { item: item(), openWindow, fetchPreview },
+    );
+    expect(result.kind).toBe("rest");
+    expect(fetchPreview).not.toHaveBeenCalled();
+    expect(openWindow).toHaveBeenCalledTimes(1);
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("entry=assembly");
+    expect(href).toContain("contentId=42");
+    expect(href).not.toContain("templateId=");
+    expect(openWindow.mock.calls[0]?.[1]).toBe("percAssembly_42");
+  });
+
+  it("opens the assembly host with a template when the AA child is invoked", async () => {
+    const openWindow = vi.fn();
+    const fetchPreview = vi.fn();
+    const result = await dispatchAction(
+      action({
+        name: "rffPgGeneric",
+        url: "../assembler/render?sys_template=7",
+      }),
+      {
+        item: item(),
+        parentName: "Item_ActiveAssembly",
+        openWindow,
+        fetchPreview,
+      },
+    );
+    expect(result.kind).toBe("rest");
+    expect(fetchPreview).not.toHaveBeenCalled();
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("entry=assembly");
+    expect(href).toContain("contentId=42");
+    expect(href).toContain("templateId=7");
+  });
+
+  it("still opens raw assembler preview for Preview template children", async () => {
+    const openWindow = vi.fn();
+    const fetchPreview = vi.fn().mockResolvedValue({
+      previewUrl: "/assembler/render?sys_contentid=42&sys_template=7",
+      contentId: 42,
+      templateId: 7,
+      revision: 1,
+    });
+    const result = await dispatchAction(
+      action({
+        name: "rffPgGeneric",
+        url: "../assembler/render?sys_template=7",
+      }),
+      {
+        item: item(),
+        parentName: "Item_Preview",
+        openWindow,
+        fetchPreview,
+      },
+    );
+    expect(result.kind).toBe("rest");
+    expect(fetchPreview).toHaveBeenCalledWith(42, 7);
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain(
+      "/assembler/render",
+    );
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).not.toContain(
+      "entry=assembly",
+    );
   });
 
   it("publish_now is unavailable without navigation", async () => {

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
 import {
   loadExplorerMenuCatalog,
+  mergeAaTemplateMenusIntoCatalog,
   mergeContentTypeMenusIntoCatalog,
   mergeTemplateMenusIntoCatalog,
   NEW_ITEM_HOST_PREFERRED_KEYS,
@@ -171,6 +172,40 @@ describe("mergeTemplateMenusIntoCatalog", () => {
   });
 });
 
+describe("mergeAaTemplateMenusIntoCatalog", () => {
+  it("nests AA templates under Item_ActiveAssembly even if Preview already has them", () => {
+    const tree: MenuAction[] = [
+      action({
+        name: "Item_Preview",
+        label: "Preview",
+        menuType: "MENU",
+        children: [
+          action({
+            name: "rffPgGeneric",
+            url: "../assembler/render?sys_template=7",
+          }),
+        ],
+      }),
+      action({
+        name: "Item_ActiveAssembly",
+        label: "Active Assembly",
+        menuType: "MENU",
+        children: [],
+      }),
+    ];
+    const merged = mergeAaTemplateMenusIntoCatalog(tree, [
+      action({
+        name: "rffPgGeneric",
+        url: "../assembler/render?sys_template=7",
+      }),
+    ]);
+    const aa = merged.find((a) => a.name === "Item_ActiveAssembly");
+    expect(aa?.children?.map((c) => c.name)).toEqual(["rffPgGeneric"]);
+    const preview = merged.find((a) => a.name === "Item_Preview");
+    expect(preview?.children?.map((c) => c.name)).toEqual(["rffPgGeneric"]);
+  });
+});
+
 describe("loadExplorerMenuCatalog", () => {
   it("always loads find() and keeps MENU children when types are also returned", async () => {
     const findPayload = {
@@ -210,6 +245,12 @@ describe("loadExplorerMenuCatalog", () => {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
       );
 
     const actions = await loadExplorerMenuCatalog({
@@ -224,7 +265,7 @@ describe("loadExplorerMenuCatalog", () => {
     expect(actions.map((a) => a.name)).toEqual(["file"]);
     expect(actions[0]?.children?.map((c) => c.name)).toContain("open");
     expect(actions[0]?.children?.map((c) => c.name)).toContain("new-page");
-    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(global.fetch).toHaveBeenCalledTimes(4);
   });
 
   it("uses only find() for folder-only selection", async () => {

--- a/docs/ai-generated/code-reviews/explorer-active-assembly-preview-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-active-assembly-preview-erlang.md
@@ -1,0 +1,58 @@
+# Erlang review — feat/explorer-active-assembly-preview
+
+**Date**: 2026-08-15  
+**Scope**: uncommitted vs `origin/main` on `feat/explorer-active-assembly-preview`  
+**Reviewer**: Erlang (independent of implementer)  
+**Memory patterns hit**: change-class completeness (WebUI screen + Playwright + product-docs + dual `spa.jsp` + Java `SPA_ENTRIES`); behavioral tests for dispatcher; URL `/` paths are URL not filesystem (false-positive guard)
+
+## Summary
+
+Preview-first Active Assembly: Explorer **Active Assembly** (and template children under those parents) opens a named window on `spa.jsp?entry=assembly&contentId=&templateId=`. The host loads `isAA` page/snippet templates, resolves `GET /services/assembly/preview-location`, and iframes `/assembler/render` under a light overlay. Slot add/create/arrange stay unavailable. Contenteditable is deferred to the Content Editor spec.
+
+Chrome is omitted for `/assembly` inside `AppLayout` so the catch-all `*` cannot swallow the route.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| SPA entry allowlist (TS + both `spa.jsp` + `PSWebUiSpaFallbackFilter`) | Present |
+| Chrome-less `/assembly` route + host | Present |
+| Dispatcher + parent stamping (Preview vs AA same template name) | Present |
+| AA template merge under Item_ActiveAssembly | Present |
+| Vitest (dispatch, host, URL, catalog, parseEntry, toolbar parentName) | Present |
+| Playwright (`explorer-active-assembly.spec.js` + dispatch blocklist) | Present |
+| product-docs `8.2/admin/content-explorer.md` + `developer/rest.md` | Present |
+| Spec 996 + action-execution update | Present |
+| New files Intersoft 2026 Apache headers | Present |
+
+## Issues
+
+None blocking.
+
+### Suggestion
+
+- `AssemblyHost` imports `parseTemplateIdFromAction` from `actionDispatch`, which pulls Explorer dispatch into the assembly chunk. A later slice can move the parser to a tiny shared module. Not a bug.
+
+### Nits
+
+- Overlay copy is TMX-key fallback (`perc.ui.assembly@…`) until a locale pack lands. Same pattern as Explorer dispatcher keys.
+- Live Playwright against QA mode was not run in this review (surface spec is present).
+
+## Cross-platform path checklist
+
+- No new filesystem path joins.
+- Assembly / preview hrefs are URL/query paths (`/cm/app/spa.jsp`, `/assembler/render`) — `/` is correct.
+- Tests do not assert OS file-separator strings.
+
+## Tests run (implementer)
+
+- Focused Vitest: assembly, actionDispatch, menuCatalogLoad, parseEntryQuery, ActionToolbar, ContextMenu, App — pass
+- WebUI standalone `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 2487, Failures: 0. Javadoc/dependency-analyze warnings are baseline (`PSDefaultLandingView`, unused declared deps), not from this change.

--- a/docs/ai-generated/code-reviews/explorer-active-assembly-preview-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-active-assembly-preview-erlang.md
@@ -46,6 +46,17 @@ None blocking.
 - Overlay copy is TMX-key fallback (`perc.ui.assembly@…`) until a locale pack lands. Same pattern as Explorer dispatcher keys.
 - Live Playwright against QA mode was not run in this review (surface spec is present).
 
+## Re-review (2026-08-15, PR #3448 kilo threads)
+
+**Scope:** catalog-load catch no longer seeds `templateId` (no masked preview). Unmatched `requestedTemplateId` shows `TEMPLATE_MISMATCH` instead of `options[0]`. `templateId` starts null so preview waits for catalog. URL test renamed + `/Rhythmyx` case. Host tests cover reject + mismatch.
+
+**Recommendation:** approve  
+**May commit/push:** yes
+
+**Cross-platform path checklist:** URL/CMS paths only. **Outcome: clean.**
+
+**Issues:** none blocking.
+
 ## Cross-platform path checklist
 
 - No new filesystem path joins.

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
@@ -49,7 +49,9 @@ test.describe("modern React Content Explorer — action dispatch", () => {
           u.includes("checkoutedit.xml") ||
           u.includes("contenteditorurls.html") ||
           u.includes("flushcache.html") ||
-          u.includes("navreset.html")
+          u.includes("navreset.html") ||
+          u.includes("sys_cxItemAssembly") ||
+          u.includes("itemassembly.html")
         ) {
           blocked.push(u);
         }

--- a/modules/perc-qa-automation/frontend/tests/explorer-active-assembly.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-active-assembly.spec.js
@@ -81,6 +81,45 @@ test.describe("modern React Active Assembly — preview host", () => {
   );
 
   test(
+    "unmatched templateId shows an error instead of silently using another template",
+    { tag: ["@explorer-active-assembly", "@explorer"] },
+    async ({ page }) => {
+      await page.route("**/services/actions/find/templates/**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ActionMenuList: [
+              {
+                name: "rffSnTitle",
+                label: "Title snippet",
+                url: "../assembler/render?sys_template=3",
+                sortRank: 0,
+                type: "MENUITEM",
+              },
+            ],
+          }),
+        });
+      });
+
+      await page.goto(assemblySpaUrl(BASE_URL, "contentId=42&templateId=99"));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="assembly-host"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.locator('[data-testid="assembly-error"]')).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page.locator('[data-testid="assembly-error"]')).toContainText(
+        /not in the available list|No page or snippet template/i,
+      );
+      await expect(page.locator('[data-testid="assembly-preview-frame"]')).toHaveCount(
+        0,
+      );
+    },
+  );
+
+  test(
     "Explorer Active Assembly does not navigate leftover AA HTML",
     { tag: ["@explorer-active-assembly", "@explorer"] },
     async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-active-assembly.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-active-assembly.spec.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Preview-first Active Assembly host — chrome-less assembled preview.
+ *
+ * <p>Tags: {@code @explorer-active-assembly} {@code @explorer}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-active-assembly.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { explorerSpaUrl } = require("./helpers/explorer-menu-bar");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+function assemblySpaUrl(baseUrl, query = "") {
+  const root = String(baseUrl || "").replace(/\/$/, "");
+  const q = query.startsWith("?") ? query : query ? `?${query}` : "";
+  const params = new URLSearchParams(q.startsWith("?") ? q.slice(1) : q);
+  params.set("entry", "assembly");
+  return `${root}/Rhythmyx/cm/app/spa.jsp?${params.toString()}`;
+}
+
+test.describe("modern React Active Assembly — preview host", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "assembly entry is chrome-less and does not request Data Flow AA HTML",
+    { tag: ["@explorer-active-assembly", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (
+          u.includes("sys_cxItemAssembly") ||
+          u.includes("itemassembly.html") ||
+          u.includes("variantlistwithslots.html") ||
+          u.includes("sys_cxSupport/")
+        ) {
+          blocked.push(u);
+        }
+      });
+
+      await page.goto(assemblySpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="assembly-host"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.locator('[data-testid="assembly-overlay"]')).toBeVisible();
+      await expect(page.locator('[data-testid="perc-spa-app"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="assembly-error"]')).toBeVisible();
+
+      expect(blocked, `Data Flow AA HTML must not be requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="assembly-host"]',
+      });
+    },
+  );
+
+  test(
+    "Explorer Active Assembly does not navigate leftover AA HTML",
+    { tag: ["@explorer-active-assembly", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (u.includes("sys_cxItemAssembly") || u.includes("itemassembly.html")) {
+          blocked.push(u);
+        }
+      });
+
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const aa = page.locator('[data-testid="action-toolbar-item-Item_ActiveAssembly"]');
+      if (await aa.isVisible()) {
+        await aa.click();
+      }
+
+      expect(blocked, `Data Flow AA HTML must not be requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -131,7 +131,8 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Promotable Version** | Confirm, then create a promotable version in the current folder. |
 | **Flush Cache** (Refresh Item) | Confirms, then flushes **all** assembler pages (not only the selected item). |
 | **Nav Reset** | Same goal as classic Nav Reset. On 8.2 this is typically a no-op once managed navigation is loaded (FastForward 6.0+ variants unused). |
-| **Publish Now** / Active Assembly / slot arrange | Still unavailable in this Explorer slice. |
+| **Publish Now** / slot arrange | Still unavailable in this Explorer slice. Slot add/create/arrange need relationship context from the assembly canvas. |
+| **Active Assembly** | Opens a new window that assembles the selected item with its **page** or **snippet template** (`GET /services/assembly/preview-location` in an iframe). A light overlay shows the content id and template. Field editing and slot arrange come later with the Content Editor. Does not open leftover Active Assembly HTML. |
 
 Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer
 menus — they are not Explorer pages.

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -132,7 +132,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Flush Cache** (Refresh Item) | Confirms, then flushes **all** assembler pages (not only the selected item). |
 | **Nav Reset** | Same goal as classic Nav Reset. On 8.2 this is typically a no-op once managed navigation is loaded (FastForward 6.0+ variants unused). |
 | **Publish Now** / slot arrange | Still unavailable in this Explorer slice. Slot add/create/arrange need relationship context from the assembly canvas. |
-| **Active Assembly** | Opens a new window that assembles the selected item with its **page** or **snippet template** (`GET /services/assembly/preview-location` in an iframe). A light overlay shows the content id and template. Field editing and slot arrange come later with the Content Editor. Does not open leftover Active Assembly HTML. |
+| **Active Assembly** | Opens a new window that assembles the selected item with its **page** or **snippet template** (`GET /services/assembly/preview-location` in an iframe). A light overlay shows the content id and template. If the requested template is missing from the item's available list, Explorer shows that mismatch instead of silently using another template. A failed template catalog load is an error, not a hidden preview retry. Field editing and slot arrange come later with the Content Editor. Does not open leftover Active Assembly HTML. |
 
 Do not bookmark or paste `../sys_cxSupport/…html` URLs from older Desktop Content Explorer
 menus — they are not Explorer pages.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -512,7 +512,7 @@ Response JSON (`PreviewLocation`):
 | `revision` | Revision used (current revision when the query omits `revision`) |
 
 `400` if `contentId` or `templateId` is missing or not positive. `404` if the item has no
-summary/revision. Template **menus** remain `GET /services/actions/find/templates/{id}`.
+summary/revision. Template **menus** remain `GET /services/actions/find/templates/{id}`. Explorer **Active Assembly** uses the same location with `isAA=true` template menus and opens the chrome-less SPA entry `spa.jsp?entry=assembly&contentId=&templateId=` (client path `/cm/app/assembly`).
 
 See [Content Explorer](id:admin-content-explorer) server actions.
 

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -23,7 +23,7 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 | `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
 | `rest` | Public REST (preview-location, types, transitions, purge, publish) |
 | `editor` | P3 — do **not** open CM1 `?view=editor`; TMX “editor not available” |
-| `unavailable` | P2 AA/slot or not-yet P1 — TMX not available |
+| `unavailable` | Slot arrange / New Item (P3 editor). Active Assembly parents are `rest` (996 preview host) |
 | `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
 
 Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.
@@ -41,7 +41,8 @@ Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It n
 | Promotable Version | Confirm, then promotable version in current folder |
 | Flush Cache (Refresh Item) | Confirm, then flush **all** assembler pages (not only the selected item) |
 | Nav Reset | Same as classic `PSNavReset`; on 8.2 typically a no-op once nav is loaded (FastForward variants unused) |
-| Publish Now / AA / slot arrange | Still unavailable (P2) |
+| Publish Now / slot arrange | Still unavailable (P2 leftover / slot context) |
+| Active Assembly | New window: assembled page/snippet preview + light overlay (`specs/996-react-active-assembly`) |
 
 ## P1 REST
 

--- a/specs/996-react-active-assembly/spec.md
+++ b/specs/996-react-active-assembly/spec.md
@@ -1,0 +1,47 @@
+# Spec: React Active Assembly
+
+**Status**: Preview-first host implemented (Explorer open + assembled iframe). Slot arrange and contenteditable editing are later slices.  
+**Split from**: Explorer server actions (`specs/992-react-content-explorer/contracts/action-execution.md`)
+
+## Host decision
+
+**New window** with assembler preview + light overlay (classic AA shape). Not an in-place Explorer chrome route.
+
+- Deep link: `spa.jsp?entry=assembly&contentId=&templateId=` → `/cm/app/assembly?…`
+- Named window `percAssembly_{contentId}`
+- **No** BrandBar / TopNav — chrome-less so the assembled page is the canvas
+
+## Preview first (this slice)
+
+When Explorer **Active Assembly** runs we already know the content id and the page or snippet **template**. This slice:
+
+1. Opens the assembly window
+2. Resolves templates via `GET /actions/find/templates/{id}?isAA=true` (falls back to preview templates)
+3. Loads `GET /services/assembly/preview-location`
+4. Renders `/assembler/render` in an iframe
+5. Shows a light overlay (title, content id, template select, note)
+
+Field editing is **not** invented here. When the Content Editor (`specs/995-react-content-editor`) is wired, the overlay can use **contenteditable** against known content ids / types on the assembled output. Slot add / create / arrange stay unavailable until relationship ids exist on that canvas.
+
+## In scope (later)
+
+- Contenteditable / content-type overlay (depends on 995)
+- Slot Add (Content Browser + relationship REST)
+- Slot Create (types + templates; creating an item still needs the Content Editor spec)
+- Arrange move / change template-slot / remove (relationship REST; relationship id from AA)
+- Compare (`sys_Compare`) may follow as a small add-on
+
+## Out of scope here
+
+- Explorer browse, Publish Now, revisions, translations, purge
+- Implementing Arrange_* from folder browse with no slot selected
+- Content Editor forms (`aa_table_editor` stays `specs/995-react-content-editor`)
+- Dual-shipping leftover Dojo AA JSPs or Data Flow HTML
+
+## Explorer behavior
+
+| Action | Behavior |
+|--------|----------|
+| Item_ActiveAssembly / Enterprise / Corporate / Item_Assembly (and template children under those parents) | Open the assembly window |
+| Slot add / create / arrange / change template / paste-as-link / move-to-slot | Still `unavailable` |
+| Item_Preview template children | Unchanged: raw assembler preview window |


### PR DESCRIPTION
## Summary

Explorer **Active Assembly** now opens a new window that renders the assembled **page or snippet template** for the selected item. The host uses `GET /services/assembly/preview-location` in an iframe, with a light overlay (content id, template select, preview badge). Field editing is left for the Content Editor slice — when we assemble we already know content ids and types.

Slot add / create / arrange stay unavailable (they need relationship ids on the canvas). Preview template children still open raw assembler preview.

Follows the Explorer action-execution train after #3437 / #3440. Spec: `specs/996-react-active-assembly/spec.md`.

## Test plan

1. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2487, Failures: 0.
2. In Explorer, select a page/asset and choose **Active Assembly** (or a template under it). A named window should open `spa.jsp?entry=assembly&contentId=…` and show the assembled preview, not Data Flow `itemassembly.html`.
3. **Preview** template children still open `/assembler/render` only.
4. Direct `/cm/app/spa.jsp?entry=assembly` (no ids) shows the overlay and a select-an-item message, without BrandBar/TopNav.
5. Playwright (QA mode after `perc-devctl qa-up`): `npm run test:surface -- --path tests/explorer-active-assembly.spec.js`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — dispatcher, host, catalog merge, SPA entry, Java fallback; WebUI standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-active-assembly.spec.js` plus dispatch blocklist
- [x] **Build gates** — `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS
- [x] **Cross-platform** — N/A (URL/query paths only; no filesystem I/O)

Erlang: `docs/ai-generated/code-reviews/explorer-active-assembly-preview-erlang.md` (approve).

> Co-Authored by Grok Build TUI using grok-4.6 with agent Grok 4.6