### PR TITLE
fix(explorer): Inbox catalog + execute results on H2 (#3446)

### DIFF
--- a/docs/ai-generated/code-reviews/3446-inbox-execute-results-h2-erlang.md
+++ b/docs/ai-generated/code-reviews/3446-inbox-execute-results-h2-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review: #3446 Inbox execute + results on H2
+
+**Branch:** `fix/issue-3446-inbox-execute-results-h2`  
+**Date:** 2026-08-15  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** no blocking bugs; behavioral unit + hardened Playwright present.
+
+## Summary
+
+H2 QA `GET /services/views` listed seven remapped `View_All` rows and omitted Inbox even though `PSX_SEARCHES` seeds Inbox. Explorer injected a stub leaf; click POSTed execute and 404'd; `explorer-inbox.spec.js` soft-skipped. This slice reconciles `findViews` names with `loadViews` results, synthesizes a runnable Inbox design (`../sys_cxViews/inbox.xml`) when missing, hardens Playwright to skip only when the catalog truly omits Inbox, and updates operator/integrator docs. Gap-matrix stays not Present.
+
+## Cross-platform path checklist
+
+- No new filesystem path construction.
+- Inbox URL/DCE path use `/` only (`../sys_cxViews/inbox.xml`, `//Views//MyContent/Inbox`).
+- Playwright helpers join CMS origin + URL paths (not OS file I/O).
+
+## Issues
+
+None blocking.
+
+## Tests
+
+- `ViewAdaptorExecuteTest` — list/execute Inbox when `loadViews` remaps to `View_All`; empty-catalog Inbox; reconcile/well-known URL.
+- `explorer-inbox.test.js` — skip only for missing catalog; expand-if-collapsed; execute URL + wrap.
+- Live H2: `GET /services/views` includes Inbox; `POST .../Inbox/execute` 200 empty; `npm run test:surface -- --path tests/explorer-inbox.spec.js` 2 passed (no skip).
+
+## Memory patterns hit
+
+- Change-class companions: sitemanage adaptor + unit tests + perc-qa-automation spec/helpers + product-docs.
+- Do not rewrite C1 `runCustomUrlView` from scratch; restore catalog/execute resolution.
+- Playwright must not toggle an already-expanded Views group (hides Inbox).

--- a/modules/perc-qa-automation/frontend/tests/explorer-inbox.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-inbox.spec.js
@@ -16,14 +16,15 @@
  */
 
 /**
- * Explorer Inbox surface (#3241 / parent #3118 / reality-check #3102).
+ * Explorer Inbox surface (#3446 / parent #3118 / reality-check #3102).
  *
  * <p>Inbox is <strong>Views → My Content → Inbox</strong>
  * ({@code //Views//MyContent/Inbox}), not a CE root. This spec is the
  * surface-filtered Playwright HARD GATE for the operator Inbox leaf.</p>
  *
- * <p>Soft-skip when the QA H2 cell has no Views catalog / Inbox leaf
- * (#3240 not deployed) or no assignment rows after a successful run.</p>
+ * <p>Soft-skip <strong>only</strong> when GET /services/views has no Inbox
+ * design view. A visible Inbox leaf, empty assignment list, or execute
+ * error must not skip (#3446).</p>
  *
  * <h3>Unattended surface (QA mode)</h3>
  * <pre>
@@ -54,8 +55,10 @@ const {
   inboxLeafSelector,
   inboxResultsSelector,
   isViewExecuteJaxbError,
+  isViewsExecuteUrl,
+  shouldSkipMissingInboxCatalog,
+  shouldExpandViewsGroup,
   missingInboxSkipMessage,
-  noAssignmentsSkipMessage,
 } = require("./helpers/explorer-inbox");
 
 /**
@@ -69,19 +72,90 @@ function attachPageErrors(page) {
   page.on("pageerror", (err) => {
     pageErrors.push(String(err && err.message ? err.message : err));
   });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = String(msg.text() || "");
+    if (/Failed to load resource: the server responded with a status of (404|400)/i.test(text)) {
+      return;
+    }
+    pageErrors.push(text);
+  });
   return pageErrors;
 }
 
-test.describe("Explorer Inbox (#3241 / #3118)", () => {
+/**
+ * Expand Views → My Content only when the group is collapsed.
+ * Clicking an already-open row hides the Inbox leaf (#3446).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+async function expandMyContentIfCollapsed(page) {
+  const groupRow = page.locator(`[data-testid="${TEST_IDS.myContentGroupRow}"]`);
+  if ((await groupRow.count()) === 0) {
+    return;
+  }
+  const expanded = await groupRow.first().getAttribute("aria-expanded");
+  if (shouldExpandViewsGroup(expanded)) {
+    await groupRow.first().click();
+  }
+}
+
+/**
+ * GET /services/views using the logged-in page session (plus Basic).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{ restStatus: number, restBody: unknown }>}
+ */
+async function fetchViewsCatalog(page) {
+  const headers = {
+    ...adminBasicAuthHeaders(),
+    Accept: "application/json",
+  };
+  try {
+    const res = await page.request.get(viewsCatalogUrl(BASE_URL), { headers });
+    let restBody = null;
+    if (res.ok()) {
+      restBody = await res.json().catch(() => null);
+    }
+    return { restStatus: res.status(), restBody };
+  } catch {
+    return { restStatus: 0, restBody: null };
+  }
+}
+
+test.describe("Explorer Inbox (#3446 / #3118)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
     await loginAsAdmin(page);
   });
 
-  test("Explorer shell a11y; Inbox leaf under Views My Content or soft-skip @explorer-inbox @inbox @explorer @a11y", async ({
+  test("Explorer shell a11y; Inbox leaf under Views My Content @explorer-inbox @inbox @explorer @a11y", async ({
     page,
   }) => {
     const pageErrors = attachPageErrors(page);
+    const { restStatus, restBody } = await fetchViewsCatalog(page);
+    const inboxDef = findInboxView(restBody);
+    const defs = unwrapViewDefs(restBody);
+
+    if (
+      shouldSkipMissingInboxCatalog({
+        inboxDef,
+        catalogEmpty: !inboxDef,
+      })
+    ) {
+      test.skip(
+        true,
+        missingInboxSkipMessage({
+          restStatus,
+          catalogEmpty: defs.length === 0,
+        }),
+      );
+      return;
+    }
+
     const url = explorerEntryUrl(BASE_URL);
     await page.goto(url, { waitUntil: "networkidle" });
 
@@ -93,66 +167,39 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
     });
 
     const viewsTree = page.locator(`[data-testid="${TEST_IDS.viewsTree}"]`);
+    await expect(viewsTree).toBeVisible({ timeout: 20_000 });
+    await expandMyContentIfCollapsed(page);
+
     const inboxLeaf = page.locator(inboxLeafSelector());
-
-    const hasTree = (await viewsTree.count()) > 0 && (await viewsTree.isVisible());
-    const hasLeaf = (await inboxLeaf.count()) > 0;
-
-    if (!hasTree && !hasLeaf) {
-      expect(pageErrors, "uncaught pageerror on Explorer Inbox chrome").toEqual(
-        [],
-      );
-      test.skip(true, missingInboxSkipMessage({ catalogEmpty: true }));
-      return;
-    }
-
-    if (hasTree) {
-      await expect(viewsTree).toBeVisible();
-    }
-
-    const groupRow = page.locator(
-      `[data-testid="${TEST_IDS.myContentGroupRow}"]`,
-    );
-    if ((await groupRow.count()) > 0) {
-      await groupRow.click();
-    }
-
-    if ((await inboxLeaf.count()) === 0) {
-      expect(pageErrors, "uncaught pageerror on Explorer Inbox chrome").toEqual(
-        [],
-      );
-      test.skip(true, missingInboxSkipMessage());
-      return;
-    }
-
     await expect(inboxLeaf.first()).toBeVisible({ timeout: 10_000 });
     expect(pageErrors, "uncaught pageerror on Explorer Inbox chrome").toEqual(
       [],
     );
   });
 
-  test("run Inbox lists assignments, empty, or soft-skip @explorer-inbox @inbox @explorer", async ({
+  test("run Inbox lists assignments or honest empty @explorer-inbox @inbox @explorer", async ({
     page,
-    request,
   }) => {
     const pageErrors = attachPageErrors(page);
-    const headers = adminBasicAuthHeaders();
-    let restStatus = 0;
-    let restBody = null;
-    try {
-      const res = await request.get(viewsCatalogUrl(BASE_URL), {
-        headers: { ...headers, Accept: "application/json" },
-      });
-      restStatus = res.status();
-      if (res.ok()) {
-        restBody = await res.json().catch(() => null);
-      }
-    } catch {
-      restBody = null;
-    }
-
+    const { restStatus, restBody } = await fetchViewsCatalog(page);
     const inboxDef = findInboxView(restBody);
     const defs = unwrapViewDefs(restBody);
+
+    if (
+      shouldSkipMissingInboxCatalog({
+        inboxDef,
+        catalogEmpty: !inboxDef,
+      })
+    ) {
+      test.skip(
+        true,
+        missingInboxSkipMessage({
+          restStatus,
+          catalogEmpty: defs.length === 0,
+        }),
+      );
+      return;
+    }
 
     const url = explorerEntryUrl(BASE_URL);
     await page.goto(url, { waitUntil: "networkidle" });
@@ -160,73 +207,59 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
       page.locator(`[data-testid="${TEST_IDS.shell}"]`),
     ).toBeVisible({ timeout: 20_000 });
 
-    const groupRow = page.locator(
-      `[data-testid="${TEST_IDS.myContentGroupRow}"]`,
-    );
-    if ((await groupRow.count()) > 0) {
-      await groupRow.click();
-    }
+    await expandMyContentIfCollapsed(page);
 
     const inboxLeaf = page.locator(inboxLeafSelector());
-    if ((await inboxLeaf.count()) === 0) {
-      expect(pageErrors, "uncaught pageerror before Inbox skip").toEqual([]);
-      test.skip(
-        true,
-        missingInboxSkipMessage({
-          restStatus,
-          catalogEmpty: !inboxDef && defs.length === 0,
-        }),
-      );
-      return;
-    }
+    await expect(
+      inboxLeaf.first(),
+      "Inbox catalog row must have a visible Explorer leaf (#3446)",
+    ).toBeVisible({ timeout: 15_000 });
 
     const executeBodies = [];
+    const executeStatuses = [];
     page.on("request", (req) => {
       if (req.method() !== "POST") return;
-      const reqUrl = req.url();
-      if (!/\/services\/views\/[^/]+\/execute(?:\?|$)/i.test(reqUrl)) return;
+      if (!isViewsExecuteUrl(req.url())) return;
       executeBodies.push(req.postData() || "");
+    });
+    page.on("response", (res) => {
+      if (res.request().method() !== "POST") return;
+      if (!isViewsExecuteUrl(res.url())) return;
+      executeStatuses.push(res.status());
     });
 
     await inboxLeaf.first().click();
 
     const results = page.locator(inboxResultsSelector());
-    const appeared = await results
-      .first()
-      .waitFor({ state: "visible", timeout: 20_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    if (!appeared) {
-      expect(pageErrors, "uncaught pageerror when Inbox execute missing").toEqual(
-        [],
-      );
-      test.skip(
-        true,
-        missingInboxSkipMessage({ restStatus }) +
-          " Inbox leaf present but no results region (execute not wired).",
-      );
-      return;
-    }
+    await expect(
+      results.first(),
+      "Inbox results region must mount after click (rows, empty, or error)",
+    ).toBeVisible({ timeout: 20_000 });
 
     const loading = page.locator(`[data-testid="${TEST_IDS.resultsLoading}"]`);
     if (await loading.isVisible().catch(() => false)) {
       await expect(loading).toBeHidden({ timeout: 30_000 });
     }
 
-    if (executeBodies.length > 0) {
-      for (const raw of executeBodies) {
-        const parsed = JSON.parse(raw);
-        expect(
-          parsed.ViewExecuteRequest,
-          "JAXB root ViewExecuteRequest required (#3323)",
-        ).toBeTruthy();
-        expect(
-          parsed.startIndex,
-          "bare startIndex must not be the JSON root",
-        ).toBeUndefined();
-      }
+    expect(
+      executeBodies.length,
+      "Inbox leaf must POST /services/views/{id}/execute",
+    ).toBeGreaterThan(0);
+    for (const raw of executeBodies) {
+      const parsed = JSON.parse(raw);
+      expect(
+        parsed.ViewExecuteRequest,
+        "JAXB root ViewExecuteRequest required (#3323)",
+      ).toBeTruthy();
+      expect(
+        parsed.startIndex,
+        "bare startIndex must not be the JSON root",
+      ).toBeUndefined();
     }
+    expect(
+      executeStatuses.some((s) => s === 200),
+      `Inbox execute must return 200 (statuses=${executeStatuses.join(",")})`,
+    ).toBe(true);
 
     const err = page.locator(`[data-testid="${TEST_IDS.resultsError}"]`);
     if (await err.isVisible().catch(() => false)) {
@@ -235,15 +268,9 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
         isViewExecuteJaxbError(errText),
         `Inbox must not fail JAXB startIndex / ViewExecuteRequest (#3323): ${errText}`,
       ).toBe(false);
-      expect(pageErrors, "uncaught pageerror on Inbox execute error").toEqual(
-        [],
+      throw new Error(
+        `Inbox execute showed an error region (must be 200 + rows or empty): ${errText}`,
       );
-      test.skip(
-        true,
-        missingInboxSkipMessage({ restStatus }) +
-          " Inbox execute error region (custom-URL C1 not on this cell).",
-      );
-      return;
     }
 
     const empty = page.locator(`[data-testid="${TEST_IDS.resultsEmpty}"]`);
@@ -252,7 +279,6 @@ test.describe("Explorer Inbox (#3241 / #3118)", () => {
     if (await empty.isVisible().catch(() => false)) {
       await expect(empty).toBeVisible();
       expect(pageErrors, "uncaught pageerror on empty Inbox").toEqual([]);
-      test.skip(true, noAssignmentsSkipMessage({ restStatus }));
       return;
     }
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-inbox.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-inbox.js
@@ -193,15 +193,30 @@ function inboxResultsSelector() {
 }
 
 /**
- * Soft-skip when Explorer has no Inbox leaf / Views catalog on this cell.
+ * True when GET /services/views has no Inbox design view.
+ * Soft-skip is allowed only in this case (#3446). A visible Inbox leaf
+ * or a catalog that already lists Inbox must not skip.
+ *
+ * @param {{ inboxDef?: unknown, catalogEmpty?: boolean }} [detail]
+ * @returns {boolean}
+ */
+function shouldSkipMissingInboxCatalog(detail = {}) {
+  if (detail.inboxDef) {
+    return false;
+  }
+  return detail.catalogEmpty === true;
+}
+
+/**
+ * Soft-skip message when GET /services/views has no Inbox design view.
  *
  * @param {{ restStatus?: number, catalogEmpty?: boolean }} [detail]
  * @returns {string}
  */
 function missingInboxSkipMessage(detail = {}) {
   const parts = [
-    "Inbox leaf not on Explorer product route (Views → My Content → Inbox).",
-    "Soft-skip until #3240 leaf + #3239 execute are deployed on this cell (#3241).",
+    "GET /services/views has no Inbox design view on this cell.",
+    "Soft-skip only when the Views catalog omits Inbox (#3446 / #3118).",
   ];
   if (detail.catalogEmpty) {
     parts.push("GET /services/views returned no Inbox view.");
@@ -210,6 +225,67 @@ function missingInboxSkipMessage(detail = {}) {
     parts.push(`REST status=${detail.restStatus}.`);
   }
   return parts.join(" ");
+}
+
+/**
+ * True when a Views group row should be clicked to expand (not already open).
+ * Clicking an expanded My Content row would collapse it and hide Inbox (#3446).
+ *
+ * @param {string | null | undefined} ariaExpanded
+ * @returns {boolean}
+ */
+function shouldExpandViewsGroup(ariaExpanded) {
+  return String(ariaExpanded ?? "").trim().toLowerCase() !== "true";
+}
+
+/**
+ * True when {@code url} is POST /services/views/{id}/execute.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isViewsExecuteUrl(url) {
+  return /\/services\/views\/[^/]+\/execute(?:\?|$)/i.test(String(url ?? ""));
+}
+
+/**
+ * JAXB / Jackson root envelope for POST /views/{id}/execute (#3323).
+ *
+ * @param {Record<string, unknown> | null | undefined} request
+ * @returns {{ ViewExecuteRequest: Record<string, unknown> }}
+ */
+function wrapViewExecuteRequest(request) {
+  if (
+    request != null &&
+    typeof request === "object" &&
+    request.ViewExecuteRequest != null &&
+    typeof request.ViewExecuteRequest === "object"
+  ) {
+    return { ViewExecuteRequest: request.ViewExecuteRequest };
+  }
+  return {
+    ViewExecuteRequest: request && typeof request === "object" ? request : {},
+  };
+}
+
+/**
+ * Catalog key for execute (name, then id).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {string}
+ */
+function inboxExecuteKey(def) {
+  if (def == null || typeof def !== "object") {
+    return INBOX_VIEW_NAME;
+  }
+  const name = String(def.name ?? "").trim();
+  if (name) {
+    return name;
+  }
+  if (def.id != null && String(def.id).trim()) {
+    return String(def.id).trim();
+  }
+  return INBOX_VIEW_NAME;
 }
 
 /**
@@ -260,6 +336,11 @@ module.exports = {
   inboxLeafSelector,
   inboxResultsSelector,
   isViewExecuteJaxbError,
+  shouldSkipMissingInboxCatalog,
   missingInboxSkipMessage,
+  shouldExpandViewsGroup,
+  isViewsExecuteUrl,
+  wrapViewExecuteRequest,
+  inboxExecuteKey,
   noAssignmentsSkipMessage,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-inbox.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-inbox.test.js
@@ -40,6 +40,11 @@ const {
   inboxLeafSelector,
   inboxResultsSelector,
   isViewExecuteJaxbError,
+  shouldSkipMissingInboxCatalog,
+  shouldExpandViewsGroup,
+  isViewsExecuteUrl,
+  wrapViewExecuteRequest,
+  inboxExecuteKey,
   missingInboxSkipMessage,
   noAssignmentsSkipMessage,
 } = require("../helpers/explorer-inbox");
@@ -156,16 +161,49 @@ describe("explorer-inbox helpers (#3241)", () => {
     );
   });
 
-  it("skip messages mention leaf vs empty assignments", () => {
+  it("skip messages mention catalog omit only", () => {
     const missing = missingInboxSkipMessage({
       catalogEmpty: true,
       restStatus: 404,
     });
-    assert.match(missing, /Inbox leaf not on Explorer/);
+    assert.match(missing, /no Inbox design view/);
     assert.match(missing, /REST status=404/);
     assert.match(missing, /no Inbox view/);
     const empty = noAssignmentsSkipMessage({ restStatus: 200 });
     assert.match(empty, /no assignment rows/);
     assert.match(empty, /REST status=200/);
+  });
+
+  it("shouldSkipMissingInboxCatalog only when catalog has no Inbox", () => {
+    assert.equal(shouldSkipMissingInboxCatalog({ inboxDef: { name: "Inbox" } }), false);
+    assert.equal(shouldSkipMissingInboxCatalog({ catalogEmpty: true }), true);
+    assert.equal(shouldSkipMissingInboxCatalog({ catalogEmpty: false }), false);
+  });
+
+  it("shouldExpandViewsGroup is false when already expanded", () => {
+    assert.equal(shouldExpandViewsGroup("true"), false);
+    assert.equal(shouldExpandViewsGroup("TRUE"), false);
+    assert.equal(shouldExpandViewsGroup("false"), true);
+    assert.equal(shouldExpandViewsGroup(null), true);
+  });
+
+  it("isViewsExecuteUrl and wrapViewExecuteRequest", () => {
+    assert.equal(
+      isViewsExecuteUrl("http://cms/Rhythmyx/services/views/Inbox/execute"),
+      true,
+    );
+    assert.equal(
+      isViewsExecuteUrl("http://cms/Rhythmyx/services/views/Inbox"),
+      false,
+    );
+    assert.deepEqual(wrapViewExecuteRequest({ startIndex: 1 }), {
+      ViewExecuteRequest: { startIndex: 1 },
+    });
+    assert.deepEqual(
+      wrapViewExecuteRequest({ ViewExecuteRequest: { maxResults: 5 } }),
+      { ViewExecuteRequest: { maxResults: 5 } },
+    );
+    assert.equal(inboxExecuteKey({ name: "Inbox", id: 1 }), "Inbox");
+    assert.equal(inboxExecuteKey({ id: 9 }), "9");
   });
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -183,8 +183,8 @@ Explorer result rows when the leaf is wired.
 |--------|---------|
 | Rows in the Inbox results list | You have current assignments |
 | Empty list (`children: []`) | No current assignments — this is success, not an error |
-| Views category or Inbox leaf missing | This build does not yet show the operator Inbox leaf; use DCE **Views → My Content → Inbox**, or wait for the Inbox leaf on the Explorer route |
-| Error instead of a list | Custom-URL execute is not available on this server, or the view is not in the Inbox family allow-list |
+| Views category or Inbox leaf missing | The Views catalog on this server does not include Inbox; use Desktop Content Explorer **Views → My Content → Inbox** or check that the Inbox design view is installed |
+| Error instead of a list | Custom-URL execute failed (unsupported URL, missing `sys_cxViews`, or a server error). An empty list is success, not an error |
 
 Do **not** look for a top-level **Inbox** tree root. Do **not** treat **Developer → Views**
 (design catalog) as the operator Inbox. Outbox / Recent / Session peers live in the same
@@ -197,8 +197,9 @@ Automated QA rerun (after `perc-devctl qa-up`, from `modules/perc-qa-automation/
 npm run test:surface -- --path tests/explorer-inbox.spec.js
 ```
 
-The spec soft-skips with a clear reason when the Inbox leaf or assignment execute path is
-missing on a minimal H2 cell.
+The spec soft-skips only when `GET /services/views` has no Inbox design view. If Inbox is
+in the catalog, the Explorer leaf must run execute (`200`) and show rows or an empty
+state — a missing results region is a product defect, not a skip.
 
 ## Search panel
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -270,7 +270,9 @@ and read `guid.stringValue` or synthesize from `id` when the Guid is omitted.
 
 Operators open Inbox from Explorer **Views → My Content → Inbox** (see
 [Content Explorer](id:admin-content-explorer)). Integrators run the same assignment list
-with the execute call below.
+with the execute call below. `GET /services/views` includes the Inbox design view (name
+`Inbox`, custom URL `../sys_cxViews/inbox.xml`) even when the design-WS load path
+collapses sibling CX views to `View_All`.
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -4,6 +4,7 @@
 
 package com.percussion.apibridge;
 
+import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSSFields;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
@@ -38,8 +39,10 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -71,6 +74,15 @@ public class ViewAdaptor implements IViewAdaptor {
    */
   static final Set<String> SUPPORTED_CX_VIEW_PAGES =
       Set.of("inbox", "outbox", "recent", "session", "checkedoutbyme", "duplicatefolderpaths");
+
+  /** Seed / DCE internal name for the operator Inbox view. */
+  static final String INBOX_VIEW_NAME = "Inbox";
+
+  /** Classic custom-URL stored on the Inbox design row. */
+  static final String INBOX_CUSTOM_URL = "../sys_cxViews/inbox.xml";
+
+  /** DCE path form operators may use as a catalog key. */
+  static final String INBOX_DCE_PATH = "//Views//MyContent/Inbox";
 
   /** Explicit 400 when a custom-view URL is blank or not a supported {@code sys_cxViews} page. */
   static final String CUSTOM_VIEW_URL_UNSUPPORTED =
@@ -487,7 +499,7 @@ public class ViewAdaptor implements IViewAdaptor {
   private List<PSSearch> loadAllViews() throws Exception {
     List<IPSCatalogSummary> summaries = designWs.findViews(null, null);
     if (summaries == null || summaries.isEmpty()) {
-      return List.of();
+      return ensureInboxFamilyDesigns(new ArrayList<>());
     }
     List<IPSGuid> guids = new ArrayList<>();
     for (IPSCatalogSummary sum : summaries) {
@@ -495,13 +507,108 @@ public class ViewAdaptor implements IViewAdaptor {
         guids.add(sum.getGUID());
       }
     }
-    if (guids.isEmpty()) {
-      return List.of();
+    List<PSSearch> loaded = List.of();
+    if (!guids.isEmpty()) {
+      String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+      String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+      List<PSSearch> fromWs = designWs.loadViews(guids, false, false, currentSession, currentUser);
+      if (fromWs != null) {
+        loaded = fromWs;
+      }
     }
-    String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
-    String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
-    List<PSSearch> loaded = designWs.loadViews(guids, false, false, currentSession, currentUser);
-    return loaded != null ? loaded : List.of();
+    return reconcileLoadedViews(summaries, loaded);
+  }
+
+  /**
+   * Collapse duplicate loadViews rows and restore Inbox-family designs that {@code
+   * findViews} named but {@code loadViews} remapped (H2 QA returns seven {@code
+   * View_All} copies for the seven seeded views). Always keep a runnable Inbox.
+   */
+  List<PSSearch> reconcileLoadedViews(
+      List<IPSCatalogSummary> summaries, List<PSSearch> loaded) {
+    Map<String, PSSearch> byName = new LinkedHashMap<>();
+    if (loaded != null) {
+      for (PSSearch s : loaded) {
+        if (s == null || StringUtils.isBlank(s.getName())) {
+          continue;
+        }
+        byName.putIfAbsent(s.getName().trim().toLowerCase(Locale.ROOT), s);
+      }
+    }
+    if (summaries != null) {
+      for (IPSCatalogSummary sum : summaries) {
+        if (sum == null || StringUtils.isBlank(sum.getName())) {
+          continue;
+        }
+        String name = sum.getName().trim();
+        String key = name.toLowerCase(Locale.ROOT);
+        if (byName.containsKey(key)) {
+          continue;
+        }
+        String url = wellKnownCustomViewUrl(name);
+        if (url != null) {
+          PSSearch synthetic = trySyntheticCustomView(name, url);
+          if (synthetic != null) {
+            byName.put(key, synthetic);
+          }
+        }
+      }
+    }
+    return ensureInboxFamilyDesigns(new ArrayList<>(byName.values()));
+  }
+
+  static List<PSSearch> ensureInboxFamilyDesigns(List<PSSearch> designs) {
+    List<PSSearch> out = designs != null ? designs : new ArrayList<>();
+    for (PSSearch s : out) {
+      if (s != null && isInboxKey(s.getName())) {
+        return out;
+      }
+    }
+    PSSearch inbox = trySyntheticCustomView(INBOX_VIEW_NAME, INBOX_CUSTOM_URL);
+    if (inbox != null) {
+      out.add(inbox);
+    }
+    return out;
+  }
+
+  /**
+   * Classic URL for Inbox-family names. Other catalog names stay {@code null} so
+   * we never invent a custom URL for a standard field-criteria view.
+   */
+  static String wellKnownCustomViewUrl(String name) {
+    if (isInboxKey(name)) {
+      return INBOX_CUSTOM_URL;
+    }
+    return null;
+  }
+
+  static boolean isInboxKey(String key) {
+    if (StringUtils.isBlank(key)) {
+      return false;
+    }
+    String n = key.trim().replace('\\', '/');
+    if (INBOX_VIEW_NAME.equalsIgnoreCase(n)) {
+      return true;
+    }
+    return INBOX_DCE_PATH.equalsIgnoreCase(n);
+  }
+
+  static PSSearch trySyntheticCustomView(String name, String url) {
+    try {
+      return syntheticCustomView(name, url);
+    } catch (Exception e) {
+      log.warn("Could not synthesize custom view {}: {}", name, e.toString());
+      return null;
+    }
+  }
+
+  static PSSearch syntheticCustomView(String name, String url) throws PSCmsException {
+    PSSearch s = new PSSearch(name, true);
+    s.setType(PSSearch.TYPE_VIEW);
+    s.setUrl(url);
+    s.setParentCategory(1);
+    s.setMaximumNumber(-1);
+    return s;
   }
 
   /** Resolve design view by name, GUID string, or numeric id. */
@@ -515,12 +622,13 @@ public class ViewAdaptor implements IViewAdaptor {
         if (key.equalsIgnoreCase(s.getName())) {
           return s;
         }
-        if (s.getGUID() != null) {
-          String gsv = s.getGUID().toString();
+        IPSGuid guid = safeGuid(s);
+        if (guid != null) {
+          String gsv = guid.toString();
           if (StringUtils.isNotBlank(gsv) && key.equalsIgnoreCase(gsv)) {
             return s;
           }
-          String untyped = s.getGUID().toStringUntyped();
+          String untyped = guid.toStringUntyped();
           if (StringUtils.isNotBlank(untyped) && key.equalsIgnoreCase(untyped)) {
             return s;
           }
@@ -546,8 +654,9 @@ public class ViewAdaptor implements IViewAdaptor {
    */
   static ViewDef toDef(PSSearch s, boolean includeDesignGaps) {
     ViewDef d = new ViewDef();
-    if (s.getGUID() != null) {
-      d.setGuid(copyGuid(s.getGUID()));
+    IPSGuid guid = safeGuid(s);
+    if (guid != null) {
+      d.setGuid(copyGuid(guid));
     }
     d.setId(s.getId());
     d.setName(s.getName());
@@ -597,6 +706,21 @@ public class ViewAdaptor implements IViewAdaptor {
       out.add(row);
     }
     return out;
+  }
+
+  /**
+   * Unsaved synthetic views have locator id 0; {@link PSSearch#getGUID()} then
+   * throws {@code Type does not match}. Treat that as no guid.
+   */
+  static IPSGuid safeGuid(PSSearch s) {
+    if (s == null) {
+      return null;
+    }
+    try {
+      return s.getGUID();
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   private static Guid copyGuid(IPSGuid guid) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorExecuteTest.java
@@ -156,6 +156,82 @@ class ViewAdaptorExecuteTest {
   }
 
   @Test
+  void listViews_includesInboxWhenLoadViewsRemapsToViewAll() throws Exception {
+    PSSearch remapped = mockView("View_All", false, true);
+    IPSCatalogSummary inboxSum = mock(IPSCatalogSummary.class);
+    when(inboxSum.getName()).thenReturn("Inbox");
+    IPSGuid g = mock(IPSGuid.class);
+    when(g.toString()).thenReturn("0-18-1");
+    when(inboxSum.getGUID()).thenReturn(g);
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of(inboxSum));
+    when(designWs.loadViews(anyList(), eq(false), eq(false), isNull(), isNull()))
+        .thenReturn(List.of(remapped));
+
+    List<com.percussion.rest.views.ViewDef> listed = adaptor.listViews();
+    assertTrue(
+        listed.stream().anyMatch(d -> "Inbox".equalsIgnoreCase(d.getName())),
+        "catalog must include Inbox even when loadViews remaps rows to View_All");
+    com.percussion.rest.views.ViewDef inbox =
+        listed.stream()
+            .filter(d -> "Inbox".equalsIgnoreCase(d.getName()))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(inbox.isCustomView());
+    assertEquals("../sys_cxViews/inbox.xml", inbox.getUrl());
+    assertEquals(1, inbox.getParentCategory());
+  }
+
+  @Test
+  void listViews_includesInboxWhenCatalogEmpty() throws Exception {
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    List<com.percussion.rest.views.ViewDef> listed = adaptor.listViews();
+    assertTrue(listed.stream().anyMatch(d -> "Inbox".equalsIgnoreCase(d.getName())));
+  }
+
+  @Test
+  void executeView_inboxRunsWhenLoadViewsLostTheDesign() throws Exception {
+    PSSearch remapped = mockView("View_All", false, true);
+    IPSCatalogSummary inboxSum = mock(IPSCatalogSummary.class);
+    when(inboxSum.getName()).thenReturn("Inbox");
+    IPSGuid g = mock(IPSGuid.class);
+    when(g.toString()).thenReturn("0-18-1");
+    when(inboxSum.getGUID()).thenReturn(g);
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of(inboxSum));
+    when(designWs.loadViews(anyList(), eq(false), eq(false), isNull(), isNull()))
+        .thenReturn(List.of(remapped));
+
+    ViewResultItem row = item("guid-1", "Assignment");
+    doReturn(List.of(row)).when(adaptor).runCustomUrlView(any(PSSearch.class), any());
+
+    ViewExecuteResult result = adaptor.executeView("Inbox", new ViewExecuteRequest());
+    assertNotNull(result);
+    assertEquals("Inbox", result.getViewName());
+    assertEquals(1, result.getChildren().size());
+    verify(adaptor).runCustomUrlView(any(PSSearch.class), any());
+    verify(adaptor, never()).runDesignView(any());
+  }
+
+  @Test
+  void wellKnownInboxUrlAndReconcile() {
+    assertEquals("../sys_cxViews/inbox.xml", ViewAdaptor.wellKnownCustomViewUrl("Inbox"));
+    assertEquals(
+        "../sys_cxViews/inbox.xml",
+        ViewAdaptor.wellKnownCustomViewUrl("//Views//MyContent/Inbox"));
+    assertNull(ViewAdaptor.wellKnownCustomViewUrl("View_All"));
+    assertTrue(ViewAdaptor.isInboxKey("inbox"));
+    assertFalse(ViewAdaptor.isInboxKey("Outbox"));
+
+    PSSearch remapped = mockView("View_All", false, true);
+    IPSCatalogSummary inboxSum = mock(IPSCatalogSummary.class);
+    when(inboxSum.getName()).thenReturn("Inbox");
+    List<PSSearch> out =
+        adaptor.reconcileLoadedViews(List.of(inboxSum), List.of(remapped));
+    assertEquals(2, out.size());
+    assertTrue(out.stream().anyMatch(s -> "Inbox".equalsIgnoreCase(s.getName())));
+    assertTrue(out.stream().anyMatch(s -> "View_All".equalsIgnoreCase(s.getName())));
+  }
+
+  @Test
   void executeView_inboxCustomUrlRunsAndMaps() throws Exception {
     PSSearch custom = mockView("Inbox", true, false);
     when(custom.getUrl()).thenReturn("../sys_cxViews/inbox.xml");


### PR DESCRIPTION
## Summary

H2 QA `GET /services/views` listed seven remapped `View_All` rows and omitted **Inbox** even though `PSX_SEARCHES` seeds Inbox (`../sys_cxViews/inbox.xml`). Explorer injected a stub leaf; click POSTed execute and 404'd; `explorer-inbox.spec.js` soft-skipped when the leaf existed or results were empty.

This slice restores a runnable Inbox on the operator path without rewriting C1 `runCustomUrlView` or leaf chrome:

- `ViewAdaptor` reconciles `findViews` names with `loadViews` results, dedupes remapped `View_All` copies, and synthesizes Inbox when the design-WS load loses it.
- Playwright `explorer-inbox.spec.js` expands My Content only when collapsed (no toggle-hide), skips **only** if the catalog has no Inbox, requires execute `200` + `ViewExecuteRequest` wrap, and treats empty results as success.
- Product-docs 8.2 Explorer + REST notes match that contract. Gap-matrix stays **not Present**.

Fixes #3446
Parent: #3118 (Inbox I1) / #3102 / #2400

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; `ViewAdaptorExecuteTest` 31/31.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci).
3. `python docker/scripts/perc-devctl.py qa-up` (this run: `TEST_CMS_URL=http://127.0.0.1:9993`). Hot-deploy `sitemanage` + matching `rest` SNAPSHOTs into `perc-matrix-cms-h2` WAR `WEB-INF/lib`, restart Jetty **inside** the cell.
4. Live REST (Admin + `RX_USEBASICAUTH`): `GET /Rhythmyx/services/views` includes `Inbox` (`customView=true`, `url=../sys_cxViews/inbox.xml`); `POST /Rhythmyx/services/views/Inbox/execute` with `{"ViewExecuteRequest":{"startIndex":1,"maxResults":50}}` returns **200** empty envelope.
5. `cd modules/perc-qa-automation/frontend` then `npm run test:surface -- --path tests/explorer-inbox.spec.js` — **2 passed**, no skip.
6. Confirm no Inbox-related ERROR/FATAL in `server.log` for the execute path (login-time `PSRuntimeExceptionMapper` null-object noise is pre-existing, not Inbox execute).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — `ViewAdaptorExecuteTest` + explorer-inbox helper unit tests
- [x] **WebUI + Playwright** — hardened `explorer-inbox.spec.js` (no WebUI chrome rewrite)
- [x] **Build gates** — standalone clean install on `projects/sitemanage` and `modules/perc-qa-automation`
- [x] **Cross-platform** — N/A (no filesystem path I/O; URL/DCE paths use `/`)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `modules/perc-qa-automation` (also reinstalled `rest` from this worktree to align SNAPSHOT Optional `Guid.getStringValue()` for sitemanage compile; rest sources unchanged)
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1254, Failures: 0; ViewAdaptorExecuteTest 31). `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS. Helper `npm run test:unit` explorer-inbox: pass.
- **downstream_checked:** none (no public type made final/sealed; no rest adaptor signature change). sitemanage implements rest `IViewAdaptor` as before.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build`; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2` Health=healthy after Jetty in-cell restart
- Deploy: `docker cp` `sitemanage-8.2.0-SNAPSHOT.jar` + matching `rest-8.2.0-SNAPSHOT.jar` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/WEB-INF/lib/`; `StopJetty.sh` / `StartJetty.sh` (not `docker restart`)
- Playwright: `npm run test:surface -- --path tests/explorer-inbox.spec.js` → **2 passed (5.3s)**
- console-clean=yes (pageerror + console error collectors; 404/400 resource noise ignored)
- server.log-clean=yes for Inbox execute (200 empty). Pre-existing FastForward import ERROR and login-time mapper null-object lines are not Inbox execute.

## Erlang

Approve. Report: `docs/ai-generated/code-reviews/3446-inbox-execute-results-h2-erlang.md`

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.