### PR TITLE
feat(explorer): first React Content Editor slice

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -66,6 +66,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
           "explorer",
           "profile",
           "assembly",
+          "editor",
           "unavailable");
 
   private static final String APP_PREFIX = "/cm/app";

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -445,6 +445,10 @@ export const PATHS = {
   get ITEM_PROMOTABLE_VERSION() {
     return `${SERVICES_ROOT}/itemmanagement/item/promotableVersion`;
   },
+  /** GET/PUT scalar content-editor fields. Append {@code /{id}}. */
+  get ITEM_EDITOR_FIELDS() {
+    return `${SERVICES_ROOT}/itemmanagement/item/fields`;
+  },
   /**
    * Public REST content type catalog ({@code rest} module ContentTypesResource).
    * List only — design-time field editor APIs are a P0 gap survey.

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -28,6 +28,7 @@ export const SPA_ENTRIES = [
   "explorer",
   "profile",
   "assembly",
+  "editor",
   "unavailable",
 ] as const;
 

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -48,6 +48,8 @@ export interface ParsedSpaEntry {
   contentId?: string;
   /** Active Assembly page/snippet template id (query contract). */
   templateId?: string;
+  /** Content Editor mode ({@code edit} or {@code view}). */
+  mode?: string;
 }
 
 /**
@@ -165,6 +167,20 @@ export function parseEntryQuery(
         clientPath: qstr ? `/assembly?${qstr}` : "/assembly",
       };
     }
+    case "editor": {
+      const contentId = normalizeId(params.get("contentId"));
+      const mode = normalizeId(params.get("mode"));
+      const qs = new URLSearchParams();
+      if (contentId) qs.set("contentId", contentId);
+      if (mode) qs.set("mode", mode);
+      const qstr = qs.toString();
+      return {
+        entry,
+        contentId,
+        mode,
+        clientPath: qstr ? `/editor?${qstr}` : "/editor",
+      };
+    }
     case "unavailable":
       return { entry, clientPath: "/unavailable" };
     default:
@@ -187,6 +203,7 @@ export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
   if (parsed.site) params.set("site", parsed.site);
   if (parsed.contentId) params.set("contentId", parsed.contentId);
   if (parsed.templateId) params.set("templateId", parsed.templateId);
+  if (parsed.mode) params.set("mode", parsed.mode);
   return `/cm/app/spa.jsp?${params.toString()}`;
 }
 
@@ -324,6 +341,20 @@ export function parseClientPath(
         contentId,
         templateId,
         clientPath: qstr ? `/assembly?${qstr}` : "/assembly",
+      };
+    }
+    case "editor": {
+      const contentId = normalizeId(params.get("contentId"));
+      const mode = normalizeId(params.get("mode"));
+      const qs = new URLSearchParams();
+      if (contentId) qs.set("contentId", contentId);
+      if (mode) qs.set("mode", mode);
+      const qstr = qs.toString();
+      return {
+        entry,
+        contentId,
+        mode,
+        clientPath: qstr ? `/editor?${qstr}` : "/editor",
       };
     }
     case "unavailable":

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -21,9 +21,12 @@ import { BrandBar, BrandFooter } from "../../ui-themes/components";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";
 
-function isBareAssemblyPath(pathname: string): boolean {
+function isChromeLessPath(pathname: string): boolean {
   const segments = pathname.split("/").filter(Boolean);
-  return segments.length === 1 && segments[0] === "assembly";
+  return (
+    segments.length === 1 &&
+    (segments[0] === "assembly" || segments[0] === "editor")
+  );
 }
 
 /**
@@ -33,7 +36,7 @@ function isBareAssemblyPath(pathname: string): boolean {
  */
 export function AppLayout(): React.ReactElement {
   const { pathname } = useLocation();
-  if (isBareAssemblyPath(pathname)) {
+  if (isChromeLessPath(pathname)) {
     return <Outlet />;
   }
   return (

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -22,6 +22,7 @@ import { AppLayout } from "./layout/AppLayout";
 import { AdminRoute } from "./routes/AdminRoute";
 import { ArchitectureRoute } from "./routes/ArchitectureRoute";
 import { AssemblyRoute } from "./routes/AssemblyRoute";
+import { EditorRoute } from "./routes/EditorRoute";
 import { DesignRoute } from "./routes/DesignRoute";
 import { DeveloperRoute } from "./routes/DeveloperRoute";
 import { ExplorerRoute } from "./routes/ExplorerRoute";
@@ -41,6 +42,7 @@ export function AppRoutes(): React.ReactElement {
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="assembly" element={<AssemblyRoute />} />
+        <Route path="editor" element={<EditorRoute />} />
         <Route index element={<Navigate to="/home" replace />} />
         <Route path="home" element={<HomeRoute />} />
         <Route path="home/:section" element={<HomeRoute />} />

--- a/WebUI/src/main/ts/app/routes/EditorRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/EditorRoute.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { EditorHost } from "../../editor/EditorHost";
+
+/** Chrome-less Content Editor window (spec 995 first slice). */
+export function EditorRoute(): React.ReactElement {
+  return <EditorHost />;
+}

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -41,6 +41,11 @@ import {
   assemblyWindowName,
   buildAssemblyHostUrl,
 } from "../assembly/assemblyHostUrl";
+import {
+  EDITOR_WINDOW_FEATURES,
+  buildEditorHostUrl,
+  editorWindowName,
+} from "../editor/editorHostUrl";
 import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
 import {
@@ -382,7 +387,23 @@ export async function dispatchAction(
   }
 
   if (kind === "editor") {
-    return { kind, messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+    const editorName = normalizeActionName(action.name);
+    if (!EDITOR_NAMES.has(editorName)) {
+      return { kind, messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+    }
+    if (!item || isFolder(item)) {
+      return { kind, messageKey: EXPLORER_MSG.ACTION_NEEDS_ITEM };
+    }
+    const contentId = parseExplorerContentId(item.id);
+    if (contentId == null) {
+      return { kind, messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+    }
+    const view =
+      editorName.startsWith("view_") || editorName.startsWith("revision_view");
+    const href = buildEditorHostUrl(contentId, view ? "view" : "edit");
+    const open = ctx.openWindow ?? defaultOpenWindow;
+    open(href, editorWindowName(contentId), EDITOR_WINDOW_FEATURES);
+    return { kind };
   }
 
   if (kind === "unavailable") {

--- a/WebUI/src/main/ts/contentExplorer/openInEditor.ts
+++ b/WebUI/src/main/ts/contentExplorer/openInEditor.ts
@@ -22,25 +22,33 @@
  */
 
 import type { PSPathItem } from "../api/contentExplorer/types";
+import {
+  EDITOR_WINDOW_FEATURES,
+  buildEditorHostUrl,
+  editorWindowName,
+} from "../editor/editorHostUrl";
+import { parseExplorerContentId } from "./menuCatalogLoad";
 import { isFolder } from "./selection";
 
-const EDITOR_BASE = "/cm/app/?view=editor";
-
 /**
- * Open a content item in the product editor. Folders stay in Explorer
- * browse — they are not workflowed pages (#3330).
+ * Open a content item in the React content editor. Folders stay in Explorer
+ * browse — they are not workflowed pages (#3330). Does not open CM1
+ * {@code ?view=editor}.
  */
 export function openInEditor(item: PSPathItem): void {
   if (isFolder(item)) {
     return;
   }
-  const path = (item.path ?? "").trim();
-  const id = (item.id ?? "").trim();
-  if (path) {
-    window.location.href = `${EDITOR_BASE}&path=${encodeURIComponent(path)}`;
+  const contentId = parseExplorerContentId(item.id);
+  if (contentId == null) {
     return;
   }
-  if (id) {
-    window.location.href = `${EDITOR_BASE}&id=${encodeURIComponent(id)}`;
+  if (typeof window === "undefined") {
+    return;
   }
+  window.open(
+    buildEditorHostUrl(contentId, "edit"),
+    editorWindowName(contentId),
+    EDITOR_WINDOW_FEATURES,
+  );
 }

--- a/WebUI/src/main/ts/editor/EditorHost.module.css
+++ b/WebUI/src/main/ts/editor/EditorHost.module.css
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: system-ui, sans-serif;
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  padding: 8px 12px;
+  border-bottom: 1px solid #334155;
+  font-size: 13px;
+}
+
+.title {
+  font-weight: 650;
+}
+
+.badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #1e3a5f;
+  color: #93c5fd;
+}
+
+.meta {
+  color: #94a3b8;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+.button {
+  padding: 4px 10px;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  background: #1e293b;
+  color: #e2e8f0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.buttonPrimary {
+  background: #2563eb;
+  border-color: #1d4ed8;
+}
+
+.stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 1.25rem 1.5rem 2rem;
+}
+
+.status {
+  padding: 1rem 0;
+  color: #334155;
+}
+
+.form {
+  display: grid;
+  gap: 0.9rem;
+  max-width: 48rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  font: inherit;
+  background: #fff;
+}
+
+.textarea {
+  min-height: 6rem;
+  resize: vertical;
+}
+
+.readonly {
+  background: #e2e8f0;
+}

--- a/WebUI/src/main/ts/editor/EditorHost.tsx
+++ b/WebUI/src/main/ts/editor/EditorHost.tsx
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * First Content Editor slice (995): checkout + content-type field form.
+ * Rich controls / TinyMCE / New Item remain later slices.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+import { getContentTypeDetail } from "../api/developer/contentTypesApi";
+import type { ContentTypeFieldSummary } from "../api/developer/types";
+import { parsePositiveInt } from "../assembly/assemblyHostUrl";
+import { message } from "../i18n/message";
+import {
+  checkinEditorItem,
+  checkoutEditorItem,
+  fetchItemEditorFields,
+  saveItemEditorFields,
+  type ItemEditorField,
+  type ItemEditorFields,
+} from "./itemFieldsApi";
+import styles from "./EditorHost.module.css";
+import { normalizeEditorMode, type EditorHostMode } from "./editorHostUrl";
+import { EDITOR_MSG } from "./messages";
+
+export interface EditorHostProps {
+  loadFields?: (itemId: string) => Promise<ItemEditorFields>;
+  saveFields?: (
+    itemId: string,
+    payload: ItemEditorFields,
+  ) => Promise<ItemEditorFields>;
+  checkout?: (itemId: string) => Promise<void>;
+  checkin?: (itemId: string) => Promise<void>;
+  loadType?: (typeName: string) => Promise<{ fields?: ContentTypeFieldSummary[] }>;
+}
+
+function isLongField(schema: ContentTypeFieldSummary | undefined, value: string): boolean {
+  const control = (schema?.control ?? "").toLowerCase();
+  const dataType = (schema?.dataType ?? "").toLowerCase();
+  if (control.includes("textarea") || control.includes("tinymce") || control.includes("html")) {
+    return true;
+  }
+  if (dataType.includes("text") && value.length > 80) {
+    return true;
+  }
+  return value.includes("\n") || value.length > 160;
+}
+
+export function mergeEditorRows(
+  payload: ItemEditorFields,
+  schemaFields: ContentTypeFieldSummary[],
+): Array<ItemEditorField & { label: string; readOnly: boolean; long: boolean }> {
+  const byName = new Map(schemaFields.map((f) => [f.name ?? "", f]));
+  return payload.fields.map((field) => {
+    const schema = byName.get(field.name);
+    const readOnly = schema?.readOnly === true;
+    return {
+      ...field,
+      label: schema?.label || field.name,
+      readOnly,
+      long: isLongField(schema, field.value),
+    };
+  });
+}
+
+export function EditorHost({
+  loadFields = fetchItemEditorFields,
+  saveFields = saveItemEditorFields,
+  checkout = checkoutEditorItem,
+  checkin = checkinEditorItem,
+  loadType = getContentTypeDetail,
+}: EditorHostProps = {}): React.ReactElement {
+  const [params] = useSearchParams();
+  const contentId = parsePositiveInt(params.get("contentId"));
+  const mode: EditorHostMode = normalizeEditorMode(params.get("mode"));
+  const readOnly = mode === "view";
+
+  const [payload, setPayload] = useState<ItemEditorFields | null>(null);
+  const [schema, setSchema] = useState<ContentTypeFieldSummary[]>([]);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [errorKey, setErrorKey] = useState<string | null>(
+    contentId == null ? EDITOR_MSG.MISSING_ITEM : null,
+  );
+  const [errorDetail, setErrorDetail] = useState<string>("");
+  const [loading, setLoading] = useState(contentId != null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    document.title = message(EDITOR_MSG.TITLE);
+  }, []);
+
+  useEffect(() => {
+    if (contentId == null) {
+      return;
+    }
+    const itemId = String(contentId);
+    let cancelled = false;
+    setLoading(true);
+    setErrorKey(null);
+    void (async () => {
+      try {
+        if (!readOnly) {
+          await checkout(itemId);
+        }
+        const fields = await loadFields(itemId);
+        if (cancelled) {
+          return;
+        }
+        setPayload(fields);
+        setDraft(
+          Object.fromEntries(fields.fields.map((f) => [f.name, f.value])),
+        );
+        if (fields.contentType) {
+          try {
+            const detail = await loadType(fields.contentType);
+            if (!cancelled) {
+              setSchema(detail.fields ?? []);
+            }
+          } catch {
+            if (!cancelled) {
+              setSchema([]);
+            }
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setErrorKey(EDITOR_MSG.LOAD_FAILED);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, readOnly, checkout, loadFields, loadType]);
+
+  const rows = useMemo(() => {
+    if (!payload) {
+      return [];
+    }
+    return mergeEditorRows(
+      {
+        ...payload,
+        fields: payload.fields.map((f) => ({
+          name: f.name,
+          value: draft[f.name] ?? f.value,
+        })),
+      },
+      schema,
+    );
+  }, [payload, draft, schema]);
+
+  async function handleSave(): Promise<void> {
+    if (contentId == null || payload == null) {
+      return;
+    }
+    setSaving(true);
+    setSaved(false);
+    setErrorKey(null);
+    try {
+      const next: ItemEditorFields = {
+        ...payload,
+        fields: payload.fields.map((f) => ({
+          name: f.name,
+          value: draft[f.name] ?? f.value,
+        })),
+      };
+      const savedPayload = await saveFields(String(contentId), next);
+      setPayload(savedPayload);
+      setDraft(
+        Object.fromEntries(savedPayload.fields.map((f) => [f.name, f.value])),
+      );
+      setSaved(true);
+    } catch {
+      setErrorKey(EDITOR_MSG.SAVE_FAILED);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleCheckin(): Promise<void> {
+    if (contentId == null) {
+      return;
+    }
+    try {
+      await checkin(String(contentId));
+      if (typeof window !== "undefined") {
+        window.close();
+      }
+    } catch (err) {
+      setErrorDetail(err instanceof Error ? err.message : String(err));
+      setErrorKey(EDITOR_MSG.SAVE_FAILED);
+    }
+  }
+
+  return (
+    <div className={styles.root} data-testid="editor-host">
+      <header className={styles.bar} data-testid="editor-overlay">
+        <span className={styles.title}>{message(EDITOR_MSG.TITLE)}</span>
+        <span className={styles.badge}>
+          {message(readOnly ? EDITOR_MSG.BADGE_VIEW : EDITOR_MSG.BADGE_EDIT)}
+        </span>
+        {contentId != null ? (
+          <span className={styles.meta} data-testid="editor-content-id">
+            {message(EDITOR_MSG.CONTENT_ID)} {contentId}
+          </span>
+        ) : null}
+        {payload?.contentType ? (
+          <span className={styles.meta} data-testid="editor-content-type">
+            {message(EDITOR_MSG.TYPE_LABEL)} {payload.contentType}
+          </span>
+        ) : null}
+        {payload?.checkoutUser ? (
+          <span className={styles.meta} data-testid="editor-checkout-user">
+            {message(EDITOR_MSG.CHECKOUT)} {payload.checkoutUser}
+          </span>
+        ) : null}
+        <div className={styles.actions}>
+          {saved ? <span className={styles.meta}>{message(EDITOR_MSG.SAVED)}</span> : null}
+          {!readOnly ? (
+            <button
+              type="button"
+              className={`${styles.button} ${styles.buttonPrimary}`}
+              data-testid="editor-save"
+              disabled={saving || loading || payload == null}
+              onClick={() => void handleSave()}
+            >
+              {message(saving ? EDITOR_MSG.SAVING : EDITOR_MSG.SAVE)}
+            </button>
+          ) : null}
+          {!readOnly ? (
+            <button
+              type="button"
+              className={styles.button}
+              data-testid="editor-checkin"
+              onClick={() => void handleCheckin()}
+            >
+              {message(EDITOR_MSG.CHECKIN)}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={styles.button}
+            data-testid="editor-close"
+            onClick={() => {
+              if (typeof window !== "undefined") {
+                window.close();
+              }
+            }}
+          >
+            {message(EDITOR_MSG.CLOSE)}
+          </button>
+        </div>
+      </header>
+      <div className={styles.stage} data-testid="editor-stage">
+        {errorKey ? (
+          <div className={styles.status} role="alert" data-testid="editor-error">
+            {message(errorKey)}
+            {errorDetail ? ` ${errorDetail}` : ""}
+          </div>
+        ) : loading ? (
+          <div className={styles.status} role="status" data-testid="editor-loading">
+            {message(EDITOR_MSG.LOADING)}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className={styles.status} data-testid="editor-empty">
+            {message(EDITOR_MSG.EMPTY)}
+          </div>
+        ) : (
+          <form
+            className={styles.form}
+            data-testid="editor-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!readOnly) {
+                void handleSave();
+              }
+            }}
+          >
+            {rows.map((row) => (
+              <label key={row.name} className={styles.field}>
+                <span className={styles.label}>{row.label}</span>
+                {row.long ? (
+                  <textarea
+                    className={`${styles.textarea} ${readOnly || row.readOnly ? styles.readonly : ""}`}
+                    data-testid={`editor-field-${row.name}`}
+                    name={row.name}
+                    value={row.value}
+                    readOnly={readOnly || row.readOnly}
+                    onChange={(e) =>
+                      setDraft((prev) => ({ ...prev, [row.name]: e.target.value }))
+                    }
+                  />
+                ) : (
+                  <input
+                    className={`${styles.input} ${readOnly || row.readOnly ? styles.readonly : ""}`}
+                    data-testid={`editor-field-${row.name}`}
+                    name={row.name}
+                    value={row.value}
+                    readOnly={readOnly || row.readOnly}
+                    onChange={(e) =>
+                      setDraft((prev) => ({ ...prev, [row.name]: e.target.value }))
+                    }
+                  />
+                )}
+              </label>
+            ))}
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/editor/editorHostUrl.ts
+++ b/WebUI/src/main/ts/editor/editorHostUrl.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { withCmsContextPrefix } from "../assembly/assemblyHostUrl";
+
+export const EDITOR_WINDOW_FEATURES =
+  "popup=yes,width=960,height=800,scrollbars=yes,resizable=yes";
+
+export type EditorHostMode = "edit" | "view";
+
+export function normalizeEditorMode(
+  raw: string | null | undefined,
+): EditorHostMode {
+  return raw?.trim().toLowerCase() === "view" ? "view" : "edit";
+}
+
+export function buildEditorHostUrl(
+  contentId: number,
+  mode: EditorHostMode = "edit",
+): string {
+  const q = new URLSearchParams();
+  q.set("entry", "editor");
+  q.set("contentId", String(contentId));
+  q.set("mode", mode);
+  return withCmsContextPrefix(`/cm/app/spa.jsp?${q.toString()}`);
+}
+
+export function editorWindowName(contentId: number): string {
+  return `percEditor_${contentId}`;
+}

--- a/WebUI/src/main/ts/editor/itemFieldsApi.ts
+++ b/WebUI/src/main/ts/editor/itemFieldsApi.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get, put } from "../api/client";
+import { PATHS } from "../api/paths";
+
+export interface ItemEditorField {
+  name: string;
+  value: string;
+}
+
+export interface ItemEditorFields {
+  contentId: string;
+  contentType: string;
+  name: string;
+  checkoutUser: string;
+  fields: ItemEditorField[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function unwrapFields(payload: unknown): ItemEditorFields {
+  const root = asRecord(payload);
+  const body =
+    asRecord(root?.ItemEditorFields ?? root?.itemEditorFields) ?? root ?? {};
+  const rawFields = body.fields ?? body.Fields;
+  const list = Array.isArray(rawFields) ? rawFields : [];
+  return {
+    contentId: String(body.contentId ?? body.ContentId ?? ""),
+    contentType: String(body.contentType ?? body.ContentType ?? ""),
+    name: String(body.name ?? body.Name ?? ""),
+    checkoutUser: String(body.checkoutUser ?? body.CheckoutUser ?? ""),
+    fields: list
+      .map((row) => {
+        const rec = asRecord(row);
+        if (!rec) {
+          return null;
+        }
+        const name = String(rec.name ?? rec.Name ?? "").trim();
+        if (!name) {
+          return null;
+        }
+        return {
+          name,
+          value: String(rec.value ?? rec.Value ?? ""),
+        };
+      })
+      .filter((row): row is ItemEditorField => row != null),
+  };
+}
+
+export async function fetchItemEditorFields(
+  itemId: string,
+): Promise<ItemEditorFields> {
+  const res = await get<unknown>(
+    `${PATHS.ITEM_EDITOR_FIELDS}/${encodeURIComponent(itemId)}`,
+  );
+  return unwrapFields(res);
+}
+
+export async function saveItemEditorFields(
+  itemId: string,
+  payload: ItemEditorFields,
+): Promise<ItemEditorFields> {
+  const res = await put<unknown>(
+    `${PATHS.ITEM_EDITOR_FIELDS}/${encodeURIComponent(itemId)}`,
+    payload,
+  );
+  return unwrapFields(res);
+}
+
+export async function checkoutEditorItem(itemId: string): Promise<void> {
+  await get(`${PATHS.ITEM_WORKFLOW_CHECKOUT}${encodeURIComponent(itemId)}`);
+}
+
+export async function checkinEditorItem(itemId: string): Promise<void> {
+  await get(`${PATHS.ITEM_WORKFLOW_CHECKIN}${encodeURIComponent(itemId)}`);
+}

--- a/WebUI/src/main/ts/editor/messages.ts
+++ b/WebUI/src/main/ts/editor/messages.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EDITOR_MSG = {
+  TITLE: "perc.ui.editor@Content Editor",
+  BADGE_EDIT: "perc.ui.editor@Edit",
+  BADGE_VIEW: "perc.ui.editor@View",
+  CONTENT_ID: "perc.ui.editor@Content",
+  TYPE_LABEL: "perc.ui.editor@Type",
+  CHECKOUT: "perc.ui.editor@Checked out to",
+  MISSING_ITEM: "perc.ui.editor@Open Edit from Explorer with a content item selected.",
+  LOADING: "perc.ui.editor@Loading item fields…",
+  LOAD_FAILED: "perc.ui.editor@Could not load this item for editing.",
+  SAVE: "perc.ui.editor@Save",
+  SAVING: "perc.ui.editor@Saving…",
+  SAVE_FAILED: "perc.ui.editor@Could not save the item.",
+  SAVED: "perc.ui.editor@Saved",
+  CHECKIN: "perc.ui.editor@Check In",
+  CLOSE: "perc.ui.editor@Close",
+  EMPTY: "perc.ui.editor@This content type has no editable text fields.",
+  LOCKED: "perc.ui.editor@This item is checked out to another user.",
+};

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -60,6 +60,7 @@
                 || "explorer".equals(n) || "developer".equals(n)
                 || "design".equals(n) || "architecture".equals(n)
                 || "profile".equals(n) || "assembly".equals(n)
+                || "editor".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -60,6 +60,7 @@
                 || "explorer".equals(n) || "developer".equals(n)
                 || "design".equals(n) || "architecture".equals(n)
                 || "profile".equals(n) || "assembly".equals(n)
+                || "editor".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -65,6 +65,14 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void forwardsEditorEntry() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=editor&contentId=42&mode=edit",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath(
+            "/cm/app/editor", "contentId=42&mode=edit"));
+  }
+
+  @Test
   public void forwardsAssemblyEntry() {
     assertEquals(
         "/cm/app/spa.jsp?entry=assembly&contentId=42&templateId=7",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -117,6 +117,17 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/profile").clientPath).toBe("/profile");
   });
 
+  it("maps editor entry to chrome-less /editor with mode", () => {
+    const p = parseEntryQuery("?entry=editor&contentId=42&mode=view");
+    expect(p.entry).toBe("editor");
+    expect(p.contentId).toBe("42");
+    expect(p.mode).toBe("view");
+    expect(p.clientPath).toBe("/editor?contentId=42&mode=view");
+    expect(parseClientPath("/editor", "?contentId=42&mode=edit").entry).toBe(
+      "editor",
+    );
+  });
+
   it("maps assembly entry to chrome-less /assembly with ids", () => {
     const p = parseEntryQuery(
       "?entry=assembly&contentId=42&templateId=7",

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -90,12 +90,29 @@ describe("actionDispatch", () => {
     ).toBe(11);
   });
 
-  it("dispatch Edit returns editor unavailable key", async () => {
+  it("dispatch Edit opens the React editor host", async () => {
+    const openWindow = vi.fn();
     const result = await dispatchAction(action({ name: "Edit" }), {
       item: item(),
+      openWindow,
     });
     expect(result.kind).toBe("editor");
-    expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE);
+    expect(result.messageKey).toBeUndefined();
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("entry=editor");
+    expect(href).toContain("contentId=42");
+    expect(href).toContain("mode=edit");
+    expect(href).not.toContain("view=editor");
+  });
+
+  it("dispatch View_Content opens the editor in view mode", async () => {
+    const openWindow = vi.fn();
+    const result = await dispatchAction(action({ name: "View_Content" }), {
+      item: item(),
+      openWindow,
+    });
+    expect(result.kind).toBe("editor");
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain("mode=view");
   });
 
   it("dispatch Data Flow HTML does not navigate", async () => {

--- a/WebUI/src/test/ts/contentExplorer/openInEditor.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/openInEditor.test.ts
@@ -47,22 +47,19 @@ describe("openInEditor (#3330)", () => {
     expect(hrefSpy).not.toHaveBeenCalled();
   });
 
-  it("navigates to the editor for a page path", () => {
-    const hrefSpy = vi.fn();
-    Object.defineProperty(window.location, "href", {
-      configurable: true,
-      get: () => originalHref,
-      set: hrefSpy,
-    });
+  it("opens the React editor host for a page path", () => {
+    const openSpy = vi.fn();
+    vi.spyOn(window, "open").mockImplementation(openSpy);
     openInEditor({
       id: "55",
       name: "Home",
       path: "/Sites/Demo/Home",
       type: "page",
     });
-    expect(hrefSpy).toHaveBeenCalled();
-    const dest = String(hrefSpy.mock.calls[0][0]);
-    expect(dest).toContain("view=editor");
-    expect(dest).toContain(encodeURIComponent("/Sites/Demo/Home"));
+    expect(openSpy).toHaveBeenCalled();
+    const dest = String(openSpy.mock.calls[0]?.[0] ?? "");
+    expect(dest).toContain("entry=editor");
+    expect(dest).toContain("contentId=55");
+    expect(dest).not.toContain("view=editor");
   });
 });

--- a/WebUI/src/test/ts/editor/EditorHost.test.tsx
+++ b/WebUI/src/test/ts/editor/EditorHost.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppRoutes } from "../../../main/ts/app/routes";
+import { EditorHost, mergeEditorRows } from "../../../main/ts/editor/EditorHost";
+import type { ItemEditorFields } from "../../../main/ts/editor/itemFieldsApi";
+
+const fields: ItemEditorFields = {
+  contentId: "42",
+  contentType: "percPage",
+  name: "Home",
+  checkoutUser: "admin",
+  fields: [
+    { name: "sys_title", value: "Home" },
+    { name: "displaytitle", value: "Welcome" },
+  ],
+};
+
+describe("EditorHost", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("asks for an item when contentId is missing", () => {
+    render(
+      <MemoryRouter initialEntries={["/editor"]}>
+        <Routes>
+          <Route path="/editor" element={<EditorHost />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("editor-overlay")).toBeTruthy();
+    expect(screen.getByTestId("editor-error").textContent).toMatch(/content item/i);
+  });
+
+  it("loads fields after checkout and saves edits", async () => {
+    const checkout = vi.fn().mockResolvedValue(undefined);
+    const loadFields = vi.fn().mockResolvedValue(fields);
+    const saveFields = vi.fn().mockResolvedValue({
+      ...fields,
+      fields: [
+        { name: "sys_title", value: "Home" },
+        { name: "displaytitle", value: "Updated" },
+      ],
+    });
+    const loadType = vi.fn().mockResolvedValue({
+      fields: [{ name: "displaytitle", label: "Display title", readOnly: false }],
+    });
+    render(
+      <MemoryRouter initialEntries={["/editor?contentId=42&mode=edit"]}>
+        <Routes>
+          <Route
+            path="/editor"
+            element={
+              <EditorHost
+                checkout={checkout}
+                loadFields={loadFields}
+                saveFields={saveFields}
+                loadType={loadType}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("editor-form")).toBeTruthy();
+    });
+    expect(checkout).toHaveBeenCalledWith("42");
+    expect(screen.getByTestId("editor-content-type").textContent).toContain("percPage");
+    fireEvent.change(screen.getByTestId("editor-field-displaytitle"), {
+      target: { value: "Updated" },
+    });
+    fireEvent.click(screen.getByTestId("editor-save"));
+    await waitFor(() => {
+      expect(saveFields).toHaveBeenCalled();
+    });
+    const saved = saveFields.mock.calls[0]?.[1] as ItemEditorFields;
+    expect(saved.fields.find((f) => f.name === "displaytitle")?.value).toBe("Updated");
+  });
+
+  it("does not checkout in view mode", async () => {
+    const checkout = vi.fn();
+    const loadFields = vi.fn().mockResolvedValue(fields);
+    render(
+      <MemoryRouter initialEntries={["/editor?contentId=42&mode=view"]}>
+        <Routes>
+          <Route
+            path="/editor"
+            element={
+              <EditorHost
+                checkout={checkout}
+                loadFields={loadFields}
+                loadType={async () => ({ fields: [] })}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("editor-form")).toBeTruthy();
+    });
+    expect(checkout).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("editor-save")).toBeNull();
+  });
+
+  it("AppRoutes mounts editor outside BrandBar chrome", () => {
+    render(
+      <MemoryRouter initialEntries={["/editor"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("editor-host")).toBeTruthy();
+    expect(screen.queryByTestId("perc-spa-app")).toBeNull();
+  });
+});
+
+describe("mergeEditorRows", () => {
+  it("uses content-type labels", () => {
+    const rows = mergeEditorRows(fields, [
+      { name: "displaytitle", label: "Display title", readOnly: false },
+    ]);
+    expect(rows.find((r) => r.name === "displaytitle")?.label).toBe("Display title");
+    expect(rows.find((r) => r.name === "sys_title")?.label).toBe("sys_title");
+  });
+});

--- a/WebUI/src/test/ts/editor/editorHostUrl.test.ts
+++ b/WebUI/src/test/ts/editor/editorHostUrl.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildEditorHostUrl,
+  editorWindowName,
+  normalizeEditorMode,
+} from "../../../main/ts/editor/editorHostUrl";
+
+describe("editorHostUrl", () => {
+  it("builds spa.jsp query contract", () => {
+    expect(buildEditorHostUrl(42)).toBe(
+      "/cm/app/spa.jsp?entry=editor&contentId=42&mode=edit",
+    );
+    expect(buildEditorHostUrl(42, "view")).toBe(
+      "/cm/app/spa.jsp?entry=editor&contentId=42&mode=view",
+    );
+    expect(editorWindowName(42)).toBe("percEditor_42");
+  });
+
+  it("defaults unknown mode to edit", () => {
+    expect(normalizeEditorMode("view")).toBe("view");
+    expect(normalizeEditorMode("VIEW")).toBe("view");
+    expect(normalizeEditorMode("edit")).toBe("edit");
+    expect(normalizeEditorMode(null)).toBe("edit");
+  });
+});

--- a/docs/ai-generated/code-reviews/explorer-content-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-content-editor-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review — feat/explorer-content-editor
+
+**Date**: 2026-08-15  
+**Scope**: uncommitted vs `origin/main`  
+**Reviewer**: Erlang  
+**Memory patterns hit**: change-class completeness (WebUI screen + Playwright + product-docs + dual spa.jsp + Java SPA_ENTRIES + sitemanage REST + mapper unit tests); behavioral tests for field filter/stringify; no filesystem path I/O
+
+## Summary
+
+First Content Editor slice (995). Explorer Edit/View opens a chrome-less `/editor` window. Edit checkouts via existing itemmanagement workflow REST. Fields load/save through `GET`/`PUT /services/itemmanagement/item/fields/{id}` (scalar `PSContentItem` map; `sys_*` except `sys_title` omitted; binary omitted). Labels from content-type catalog. New Item, TinyMCE, and AA contenteditable stay later.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| sitemanage GET/PUT fields + mapper | Present |
+| SPA entry (TS + both spa.jsp + Java filter) | Present |
+| Chrome-less editor route | Present |
+| Dispatcher + openInEditor (no `?view=editor`) | Present |
+| Vitest (host, dispatch, URL, mapper) | Present |
+| Playwright `explorer-content-editor.spec.js` | Present |
+| product-docs 8.2 admin + developer rest | Present |
+| Spec 995 | Present |
+
+## Issues
+
+None blocking.
+
+### Suggestion
+
+Home / TopNav still navigate to leftover `?view=editor`. Out of this Explorer slice; switch those shells when Home create/open is next.
+
+## Cross-platform path checklist
+
+URL/query paths only (`/cm/app/spa.jsp`, `/services/itemmanagement/...`). No filesystem joins.
+
+## Tests run
+
+- `cd rest && ../mvnw.cmd clean install` — SNAPSHOT restore only (unchanged sources); BUILD SUCCESS
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1258, Failures: 0, Skipped: 125
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire 61/0; Vitest 333 files, 2525 tests

--- a/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Preview-first Content Editor host — chrome-less field form.
+ *
+ * <p>Tags: {@code @explorer-content-editor} {@code @explorer}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-content-editor.spec.js}</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { explorerSpaUrl } = require("./helpers/explorer-menu-bar");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+function editorSpaUrl(baseUrl, query = "") {
+  const root = String(baseUrl || "").replace(/\/$/, "");
+  const params = new URLSearchParams(query.startsWith("?") ? query.slice(1) : query);
+  params.set("entry", "editor");
+  return `${root}/Rhythmyx/cm/app/spa.jsp?${params.toString()}`;
+}
+
+test.describe("modern React Content Editor — first slice", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "editor entry is chrome-less and does not open CM1 editor",
+    { tag: ["@explorer-content-editor", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (
+          u.includes("checkoutedit.xml") ||
+          u.includes("contenteditorurls.html") ||
+          u.includes("sys_ceSupport") ||
+          /view=editor/.test(u)
+        ) {
+          blocked.push(u);
+        }
+      });
+
+      await page.goto(editorSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="editor-host"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.locator('[data-testid="editor-overlay"]')).toBeVisible();
+      await expect(page.locator('[data-testid="perc-spa-app"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="editor-error"]')).toBeVisible();
+      expect(blocked, `CM1 / Data Flow editor must not be requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="editor-host"]',
+      });
+    },
+  );
+
+  test(
+    "Explorer Edit does not open CM1 ?view=editor",
+    { tag: ["@explorer-content-editor", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        if (/view=editor/.test(req.url()) || req.url().includes("checkoutedit.xml")) {
+          blocked.push(req.url());
+        }
+      });
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      const edit = page.locator('[data-testid="action-toolbar-item-Edit"]');
+      if (await edit.isVisible()) {
+        await edit.click();
+      }
+      expect(blocked, `CM1 editor must not be requested: ${blocked.join(" ")}`).toEqual([]);
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -121,7 +121,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **New Item** | Type menus list from `POST /services/actions/find/types`. Creating an item still requires the Content Editor (not in this Explorer slice) — choosing a type shows that the editor is not available. |
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
-| **Edit / Quick Edit / View content** | Not the CM1 editor (`?view=editor`). Explorer shows that the content editor is not available in this slice. |
+| **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows its content-type text fields. Save writes `PUT /services/itemmanagement/item/fields/{id}`. Does not open the CM1 editor (`?view=editor`). **New Item** and rich controls (TinyMCE, binary) are not in this slice. |
 | **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -519,6 +519,17 @@ summary/revision. Template **menus** remain `GET /services/actions/find/template
 
 See [Content Explorer](id:admin-content-explorer) server actions.
 
+## Content editor fields (Explorer)
+
+Explorer **Edit** uses itemmanagement field maps (same `PSContentItem` store as dates / copy), not Data Flow Content Editor HTML.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/itemmanagement/item/fields/{id}` | Scalar fields for the React editor (`sys_*` except `sys_title` omitted; binary omitted) |
+| `PUT` | `/services/itemmanagement/item/fields/{id}` | Save scalar field updates. Item must be checked out to the current user. |
+
+Checkout / check-in remain `GET /services/itemmanagement/workflow/checkOut/{id}` and `…/checkIn/{id}`. Content-type labels come from `GET /services/contenttypes/{type}`.
+
 ## Assembly cache and navigation
 
 Explorer **Flush Cache** (catalog display name **Refresh Item**) and **Nav Reset** use public

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemEditorField.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemEditorField.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.data;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** One scalar content-editor field for the React editor (995). */
+@XmlRootElement(name = "ItemEditorField")
+public class PSItemEditorField {
+
+  private String name;
+  private String value;
+
+  public PSItemEditorField() {}
+
+  public PSItemEditorField(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemEditorFields.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemEditorFields.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.data;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Item field payload for the React content editor (995). */
+@XmlRootElement(name = "ItemEditorFields")
+public class PSItemEditorFields {
+
+  private String contentId;
+  private String contentType;
+  private String name;
+  private String checkoutUser;
+  private List<PSItemEditorField> fields = new ArrayList<>();
+
+  public String getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(String contentId) {
+    this.contentId = contentId;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getCheckoutUser() {
+    return checkoutUser;
+  }
+
+  public void setCheckoutUser(String checkoutUser) {
+    this.checkoutUser = checkoutUser;
+  }
+
+  public List<PSItemEditorField> getFields() {
+    return fields;
+  }
+
+  public void setFields(List<PSItemEditorField> fields) {
+    this.fields = fields == null ? new ArrayList<>() : fields;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
@@ -19,6 +19,7 @@ package com.percussion.itemmanagement.service;
 import com.percussion.itemmanagement.data.PSAssetSiteImpact;
 import com.percussion.itemmanagement.data.PSItemCopyResult;
 import com.percussion.itemmanagement.data.PSItemDates;
+import com.percussion.itemmanagement.data.PSItemEditorFields;
 import com.percussion.itemmanagement.data.PSRevisionsSummary;
 import com.percussion.itemmanagement.data.PSSoProMetadata;
 import com.percussion.services.useritems.data.PSUserItem;
@@ -38,6 +39,21 @@ import java.util.Map;
  * @author Jose Annunziato
  */
 public interface IPSItemService {
+
+  /**
+   * Scalar content-editor fields for the React editor (995). Omits system fields
+   * except {@code sys_title} and omits binary values.
+   *
+   * @param id item id or GUID, must not be blank
+   */
+  PSItemEditorFields getEditorFields(String id) throws PSItemServiceException;
+
+  /**
+   * Saves scalar content-editor fields. Caller must have the item checked out.
+   * Only names present in {@code req} are updated.
+   */
+  PSItemEditorFields saveEditorFields(String id, PSItemEditorFields req)
+      throws PSItemServiceException;
 
   /**
    * Retrieves the revisions for a given page or asset.

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemEditorFieldsMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemEditorFieldsMapper.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import com.percussion.itemmanagement.data.PSItemEditorField;
+import com.percussion.itemmanagement.data.PSItemEditorFields;
+import com.percussion.share.dao.impl.PSContentItem;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Maps {@link PSContentItem} field maps to the React editor payload. Binary / object values are
+ * omitted. System fields except {@code sys_title} are omitted from both read and write.
+ */
+public final class PSItemEditorFieldsMapper {
+
+  private PSItemEditorFieldsMapper() {}
+
+  public static boolean isEditableFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    if ("sys_title".equals(name)) {
+      return true;
+    }
+    return !name.startsWith("sys_");
+  }
+
+  public static String stringifyFieldValue(Object raw) {
+    if (raw == null) {
+      return "";
+    }
+    if (raw instanceof byte[]) {
+      return null;
+    }
+    if (raw instanceof Collection<?> col) {
+      if (col.isEmpty()) {
+        return "";
+      }
+      Object first = col.iterator().next();
+      return stringifyFieldValue(first);
+    }
+    if (raw instanceof Date date) {
+      return Instant.ofEpochMilli(date.getTime()).toString();
+    }
+    if (raw instanceof Number || raw instanceof Boolean || raw instanceof CharSequence) {
+      return String.valueOf(raw);
+    }
+    return null;
+  }
+
+  public static PSItemEditorFields fromContentItem(PSContentItem item, String checkoutUser) {
+    PSItemEditorFields out = new PSItemEditorFields();
+    if (item == null) {
+      return out;
+    }
+    out.setContentId(item.getId());
+    out.setContentType(item.getType());
+    out.setName(item.getName());
+    out.setCheckoutUser(checkoutUser);
+    Map<String, Object> fields = item.getFields();
+    if (fields == null || fields.isEmpty()) {
+      return out;
+    }
+    List<PSItemEditorField> rows = new ArrayList<>();
+    for (Map.Entry<String, Object> entry : new TreeMap<>(fields).entrySet()) {
+      String name = entry.getKey();
+      if (!isEditableFieldName(name)) {
+        continue;
+      }
+      String value = stringifyFieldValue(entry.getValue());
+      if (value == null) {
+        continue;
+      }
+      rows.add(new PSItemEditorField(name, value));
+    }
+    out.setFields(rows);
+    return out;
+  }
+
+  public static void applyUpdates(PSContentItem item, List<PSItemEditorField> updates) {
+    if (item == null || updates == null || updates.isEmpty()) {
+      return;
+    }
+    Map<String, Object> fields = item.getFields();
+    for (PSItemEditorField update : updates) {
+      if (update == null || !isEditableFieldName(update.getName())) {
+        continue;
+      }
+      fields.put(update.getName(), update.getValue() == null ? "" : update.getValue());
+    }
+    item.setFields(fields);
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -39,6 +39,7 @@ import com.percussion.itemmanagement.data.PSAssetSiteImpact;
 import com.percussion.itemmanagement.data.PSComment;
 import com.percussion.itemmanagement.data.PSItemCopyResult;
 import com.percussion.itemmanagement.data.PSItemDates;
+import com.percussion.itemmanagement.data.PSItemEditorFields;
 import com.percussion.itemmanagement.data.PSPageLinkedToItem;
 import com.percussion.itemmanagement.data.PSRevision;
 import com.percussion.itemmanagement.data.PSRevisionsSummary;
@@ -285,6 +286,86 @@ public class PSItemService implements IPSItemService {
       return revSummary;
     } catch (PSValidationException e) {
       throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
+  @Path("fields/{id}")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Override
+  public PSItemEditorFields getEditorFields(@PathParam("id") String id)
+      throws PSItemServiceException {
+    try {
+      rejectIfBlank("getEditorFields", "id", id);
+      String guid = PSLegacyExtensionUtils.getGUID(id);
+      PSContentItem item = contentItemDao.find(guid, false);
+      if (item == null) {
+        throw new PSItemServiceException("The item no longer exists in the system.");
+      }
+      String checkoutUser = "";
+      try {
+        PSComponentSummary sum = workflowHelper.getComponentSummary(guid);
+        if (sum != null && StringUtils.isNotBlank(sum.getCheckoutUserName())) {
+          checkoutUser = sum.getCheckoutUserName();
+        }
+      } catch (Exception e) {
+        log.debug("Could not resolve checkout user for {}", guid, e);
+      }
+      return PSItemEditorFieldsMapper.fromContentItem(item, checkoutUser);
+    } catch (PSValidationException e) {
+      throw new WebApplicationException(e);
+    } catch (PSDataServiceException e) {
+      throw new PSItemServiceException("Could not load item fields.", e);
+    }
+  }
+
+  @PUT
+  @Path("fields/{id}")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Override
+  public PSItemEditorFields saveEditorFields(
+      @PathParam("id") String id, PSItemEditorFields req) throws PSItemServiceException {
+    try {
+      rejectIfBlank("saveEditorFields", "id", id);
+      if (req == null) {
+        throw new PSItemServiceException("Field payload is required.");
+      }
+      String guid = PSLegacyExtensionUtils.getGUID(id);
+      PSComponentSummary sum = workflowHelper.getComponentSummary(guid);
+      if (sum != null
+          && StringUtils.isNotBlank(sum.getCheckoutUserName())
+          && !workflowHelper.isCheckedOutToCurrentUser(guid)) {
+        throw new PSItemServiceException(
+            "User " + sum.getCheckoutUserName() + " is editing this item.");
+      }
+      IPSGuid itemGuid = idMapper.getGuid(guid);
+      PSItemStatus status = contentWs.prepareForEdit(itemGuid);
+      if (status != null && status.isDidCheckout()) {
+        waRelService.updateLocalRelationshipAsset(guid);
+      }
+      PSContentItem item = contentItemDao.find(guid, false);
+      if (item == null) {
+        throw new PSItemServiceException("The item no longer exists in the system.");
+      }
+      PSItemEditorFieldsMapper.applyUpdates(item, req.getFields());
+      contentItemDao.save(item);
+      String checkoutUser = "";
+      try {
+        PSComponentSummary after = workflowHelper.getComponentSummary(guid);
+        if (after != null && StringUtils.isNotBlank(after.getCheckoutUserName())) {
+          checkoutUser = after.getCheckoutUserName();
+        }
+      } catch (Exception e) {
+        log.debug("Could not resolve checkout user after save for {}", guid, e);
+      }
+      return PSItemEditorFieldsMapper.fromContentItem(item, checkoutUser);
+    } catch (PSItemServiceException e) {
+      throw e;
+    } catch (PSValidationException e) {
+      throw new WebApplicationException(e);
+    } catch (Exception e) {
+      throw new PSItemServiceException("Could not save item fields.", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemEditorFieldsMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemEditorFieldsMapperTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.itemmanagement.data.PSItemEditorField;
+import com.percussion.itemmanagement.data.PSItemEditorFields;
+import com.percussion.share.dao.impl.PSContentItem;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class PSItemEditorFieldsMapperTest {
+
+  @Test
+  void omitsSystemFieldsExceptTitle() {
+    assertTrue(PSItemEditorFieldsMapper.isEditableFieldName("sys_title"));
+    assertTrue(PSItemEditorFieldsMapper.isEditableFieldName("displaytitle"));
+    assertFalse(PSItemEditorFieldsMapper.isEditableFieldName("sys_contentid"));
+    assertFalse(PSItemEditorFieldsMapper.isEditableFieldName("sys_workflowid"));
+    assertFalse(PSItemEditorFieldsMapper.isEditableFieldName(""));
+  }
+
+  @Test
+  void stringifiesScalarsAndSkipsBinary() {
+    assertEquals("", PSItemEditorFieldsMapper.stringifyFieldValue(null));
+    assertEquals("hello", PSItemEditorFieldsMapper.stringifyFieldValue("hello"));
+    assertEquals("7", PSItemEditorFieldsMapper.stringifyFieldValue(7));
+    assertEquals("true", PSItemEditorFieldsMapper.stringifyFieldValue(true));
+    assertNull(PSItemEditorFieldsMapper.stringifyFieldValue(new byte[] {1, 2}));
+    assertEquals("a", PSItemEditorFieldsMapper.stringifyFieldValue(List.of("a", "b")));
+  }
+
+  @Test
+  void fromContentItemMapsEditableScalars() {
+    PSContentItem item = new PSContentItem();
+    item.setId("42");
+    item.setType("percPage");
+    item.setName("Home");
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("sys_title", "Home");
+    fields.put("sys_contentid", "42");
+    fields.put("displaytitle", "Welcome");
+    fields.put("body", new byte[] {1});
+    item.setFields(fields);
+
+    PSItemEditorFields out = PSItemEditorFieldsMapper.fromContentItem(item, "admin");
+    assertEquals("42", out.getContentId());
+    assertEquals("percPage", out.getContentType());
+    assertEquals("Home", out.getName());
+    assertEquals("admin", out.getCheckoutUser());
+    assertEquals(2, out.getFields().size());
+    assertEquals("displaytitle", out.getFields().get(0).getName());
+    assertEquals("Welcome", out.getFields().get(0).getValue());
+    assertEquals("sys_title", out.getFields().get(1).getName());
+  }
+
+  @Test
+  void applyUpdatesIgnoresSystemExceptTitle() {
+    PSContentItem item = new PSContentItem();
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("sys_title", "Old");
+    fields.put("sys_contentid", "42");
+    fields.put("displaytitle", "A");
+    item.setFields(fields);
+
+    PSItemEditorFieldsMapper.applyUpdates(
+        item,
+        List.of(
+            new PSItemEditorField("sys_title", "New"),
+            new PSItemEditorField("sys_contentid", "99"),
+            new PSItemEditorField("displaytitle", "B")));
+
+    assertEquals("New", item.getFields().get("sys_title"));
+    assertEquals("42", item.getFields().get("sys_contentid"));
+    assertEquals("B", item.getFields().get("displaytitle"));
+  }
+}

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -22,7 +22,7 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 |------|----------|
 | `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
 | `rest` | Public REST (preview-location, types, transitions, purge, publish) |
-| `editor` | P3 — do **not** open CM1 `?view=editor`; TMX “editor not available” |
+| `editor` | Named actions (`Edit`, `View_Content`, …) open the React editor host (`specs/995-react-content-editor`). Leftover CE URLs stay unavailable. |
 | `unavailable` | Slot arrange / New Item (P3 editor). Active Assembly parents are `rest` (996 preview host) |
 | `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
 

--- a/specs/995-react-content-editor/spec.md
+++ b/specs/995-react-content-editor/spec.md
@@ -1,6 +1,6 @@
-# Spec stub: React Content Editor
+# Spec: React Content Editor
 
-**Status**: Stub — **not** implemented in the Explorer action-execution train.  
+**Status**: First slice implemented — chrome-less field form + checkout.  
 **Split from**: Explorer server actions (`specs/992-react-content-explorer/contracts/action-execution.md`)
 
 ## Why this is separate
@@ -9,19 +9,33 @@ Explorer **Edit / Quick Edit / View content / View properties / revision CE** ro
 
 Opening the legacy CM1 editor from Explorer is **not** an acceptable stand-in.
 
-## In scope (later)
+## Host
 
-- React editor route/shell (not `/cm/app/?view=editor`)
-- REST for item fields, checkout/checkin, views (`sys_All`, metadata, revisions **form**, audit **form**)
-- Control inventory (legacy CE controls → React)
-- Quick Edit = workflow transition + checkout + this editor
-- AA-doc checkout (`checkoutaadoc.xml`) when AA has a React host
+New window (peer of Active Assembly):
+
+- `spa.jsp?entry=editor&contentId=&mode=edit|view` → `/cm/app/editor?…`
+- Named window `percEditor_{contentId}`
+- No BrandBar / TopNav
+
+## This slice
+
+1. Explorer **Edit** / **Quick Edit** / **Edit content** / **Edit properties** open the host in **edit** mode
+2. **View content** / **View properties** / revision view open **view** mode (no checkout)
+3. Edit mode calls existing `GET /services/itemmanagement/workflow/checkOut/{id}`
+4. Fields: `GET` / `PUT /services/itemmanagement/item/fields/{id}` (scalar map from `PSContentItem`; `sys_*` except `sys_title` omitted; binary omitted)
+5. Labels from `GET /services/contenttypes/{type}`
+6. Save + Check In (existing checkIn REST)
+
+## Later
+
+- TinyMCE / file / image / keyword / community controls
+- New Item (create in folder + content type)
+- AA contenteditable overlay on the assembled preview
+- Revision promote form
+- Home / TopNav still use leftover `?view=editor` until those shells switch
 
 ## Out of scope here
 
-- Explorer browse, menus, preview-by-template, purge, workflow toolbar, folder ops
+- Explorer browse, preview-by-template, purge, folder ops
 - Data Flow Server as a UI renderer
-
-## Explorer behavior until this spec lands
-
-Dispatcher classifies `Edit`, `Edit_Content`, `Edit_Properties`, `Quick_Edit`, `View_Content`, `View_Properties`, `Revision_ViewContent`, `Revision_ViewProperties`, `Revision_Promote` as **`editor`**. The SPA shows a TMX message and does **not** navigate.
+- Slot add/arrange


### PR DESCRIPTION
## Summary

First **Content Editor** increment (spec 995). Explorer **Edit** / **Quick Edit** / **View content** open a chrome-less window (`spa.jsp?entry=editor&contentId=&mode=edit|view`) instead of CM1 `?view=editor`.

Edit mode checkouts via existing itemmanagement workflow REST, loads scalar fields from `GET /services/itemmanagement/item/fields/{id}`, labels them from the content-type catalog, and saves with `PUT` on the same path. System fields except `sys_title` and binary values are omitted. **New Item**, TinyMCE, and AA contenteditable stay later.

## Test plan

1. `cd projects/sitemanage` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1258, Failures: 0.
2. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2525 passed.
3. Explorer: select a page or asset → **Edit**. A named window should show the field form, not `?view=editor`.
4. Change a text field → **Save**. **View content** should not checkout.
5. Playwright (QA mode): `npm run test:surface -- --path tests/explorer-content-editor.spec.js`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` and `developer/rest.md`
- [x] **Unit / module tests** — mapper + host + dispatch; standalone clean installs green
- [x] **WebUI + Playwright** — `explorer-content-editor.spec.js`
- [x] **Build gates** — sitemanage and WebUI standalone `clean install` (rest SNAPSHOT restore only, unchanged sources)
- [x] **Cross-platform** — N/A (URL/query paths only)

Erlang: `docs/ai-generated/code-reviews/explorer-content-editor-erlang.md` (approve).

> Co-Authored by Grok Build TUI using grok-4.6 with agent Grok 4.6