### PR TITLE
feat(explorer): New Item creates in folder and opens editor

### DIFF
--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -449,6 +449,10 @@ export const PATHS = {
   get ITEM_EDITOR_FIELDS() {
     return `${SERVICES_ROOT}/itemmanagement/item/fields`;
   },
+  /** POST create a content item in a folder. */
+  get ITEM_CREATE() {
+    return `${SERVICES_ROOT}/itemmanagement/item/create`;
+  },
   /**
    * Public REST content type catalog ({@code rest} module ContentTypesResource).
    * List only — design-time field editor APIs are a P0 gap survey.

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -46,7 +46,12 @@ import {
   buildEditorHostUrl,
   editorWindowName,
 } from "../editor/editorHostUrl";
-import { parseExplorerContentId } from "./menuCatalogLoad";
+import { createEditorItem } from "../editor/itemCreateApi";
+import {
+  isNewItemHostName,
+  parseExplorerContentId,
+} from "./menuCatalogLoad";
+import { resolveFolderPathFromSelection } from "./folderPath";
 import { EXPLORER_MSG } from "./messages";
 import {
   buildSitePathPreviewUrl,
@@ -162,6 +167,7 @@ export interface ActionDispatchContext {
   resetNav?: () => Promise<void>;
   createCopy?: (itemId: string) => Promise<void>;
   createPromotable?: (itemId: string) => Promise<void>;
+  createItem?: typeof createEditorItem;
   onPublish?: (item: PSPathItem) => Promise<void>;
   /** Parent menu name when the user activated a child (AA vs Preview). */
   parentName?: string;
@@ -241,8 +247,8 @@ export function classifyAction(action: MenuAction): ActionKind {
   if (name === "purge" || name === "publish_now") {
     return "rest";
   }
-  if (name === "create_new_item") {
-    return "unavailable";
+  if (name === "create_new_item" || isNewItemHostName(action.parentName)) {
+    return "rest";
   }
   if (isDataFlowActionUrl(action.url)) {
     return "unavailable";
@@ -271,6 +277,17 @@ export function findMenuParentName(
     }
   }
   return undefined;
+}
+
+export function isNewItemAction(
+  action: MenuAction,
+  parentName?: string,
+): boolean {
+  const name = normalizeActionName(action.name);
+  if (name === "create_new_item") {
+    return true;
+  }
+  return isNewItemHostName(parentName) || isNewItemHostName(action.parentName);
 }
 
 export function isAaPreviewAction(
@@ -384,6 +401,37 @@ export async function dispatchAction(
       await ctx.runWorkflow(String(item.id), trigger);
     }
     return { kind, refresh: true };
+  }
+
+  if (isNewItemAction(action, ctx.parentName)) {
+    const typeName = normalizeActionName(action.name);
+    if (typeName === "create_new_item" || isNewItemHostName(action.name)) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_TYPE };
+    }
+    const folder = resolveFolderPathFromSelection(
+      ctx.folderPath,
+      item?.path,
+      item?.type,
+    );
+    if (!folder) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_FOLDER };
+    }
+    const create = ctx.createItem ?? createEditorItem;
+    const created = await create({
+      contentType: action.name,
+      folderPath: folder,
+    });
+    const contentId = parseExplorerContentId(created.itemId);
+    if (contentId == null) {
+      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_EDITOR_UNAVAILABLE };
+    }
+    const open = ctx.openWindow ?? defaultOpenWindow;
+    open(
+      buildEditorHostUrl(contentId, "edit"),
+      editorWindowName(contentId),
+      EDITOR_WINDOW_FEATURES,
+    );
+    return { kind: "rest", refresh: true };
   }
 
   if (kind === "editor") {
@@ -596,10 +644,6 @@ export async function dispatchAction(
       return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
     }
     return { kind: "rest", refresh: true };
-  }
-
-  if (name === "create_new_item") {
-    return { kind: "unavailable", messageKey: EXPLORER_MSG.ACTION_UNAVAILABLE };
   }
 
   if (isAaPreviewAction(action.name, ctx.parentName)) {

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -92,6 +92,11 @@ export const NEW_ITEM_HOST_PREFERRED_KEYS: readonly string[] = [
   "createnewitem",
 ];
 
+export function isNewItemHostName(name: string | undefined | null): boolean {
+  const key = (name ?? "").replace(/[\s_-]/g, "").toLowerCase();
+  return (NEW_ITEM_HOST_PREFERRED_KEYS as readonly string[]).includes(key);
+}
+
 /** Normalized names of Preview MENU parents that host template children. */
 export const PREVIEW_HOST_PREFERRED_KEYS: readonly string[] = [
   "itempreview",

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -333,6 +333,10 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@This action is not available in Content Explorer yet",
   ACTION_NEEDS_ITEM:
     "perc.ui.explorer@Select a content item first",
+  ACTION_NEEDS_FOLDER:
+    "perc.ui.explorer@Select a folder first",
+  ACTION_NEEDS_TYPE:
+    "perc.ui.explorer@Choose a content type from New Item",
   CONFIRM_PURGE_BODY:
     "perc.ui.explorer@Permanently delete this item from the system?",
   CONFIRM_PUBLISH_NOW:

--- a/WebUI/src/main/ts/editor/itemCreateApi.ts
+++ b/WebUI/src/main/ts/editor/itemCreateApi.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { post } from "../api/client";
+import { PATHS } from "../api/paths";
+
+export interface ItemCreateRequest {
+  contentType: string;
+  folderPath: string;
+  name?: string;
+}
+
+export interface ItemCreateResult {
+  itemId: string;
+  folderPath: string;
+  name: string;
+  contentType: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function unwrapItemCreateResult(payload: unknown): ItemCreateResult {
+  const root = asRecord(payload);
+  const body =
+    asRecord(root?.ItemCreateResult ?? root?.itemCreateResult) ?? root ?? {};
+  return {
+    itemId: String(body.itemId ?? body.ItemId ?? ""),
+    folderPath: String(body.folderPath ?? body.FolderPath ?? ""),
+    name: String(body.name ?? body.Name ?? ""),
+    contentType: String(body.contentType ?? body.ContentType ?? ""),
+  };
+}
+
+export async function createEditorItem(
+  req: ItemCreateRequest,
+): Promise<ItemCreateResult> {
+  const res = await post<unknown>(PATHS.ITEM_CREATE, req);
+  const out = unwrapItemCreateResult(res);
+  if (!out.itemId.trim()) {
+    throw new Error("Create returned no item id");
+  }
+  return out;
+}

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -151,6 +151,49 @@ describe("actionDispatch", () => {
     expect(href).not.toContain("sys_cxSupport");
   });
 
+  it("creates a New Item type and opens the editor", async () => {
+    const openWindow = vi.fn();
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "99",
+      folderPath: "//Sites/Demo",
+      name: "New-rffEvent",
+      contentType: "rffEvent",
+    });
+    const result = await dispatchAction(
+      action({
+        name: "rffEvent",
+        url: "../rx_ceEvent/event.html",
+        parentName: "New",
+      }),
+      {
+        item: item({ type: "folder", path: "/Sites/Demo", id: "1" }),
+        folderPath: "/Sites/Demo",
+        parentName: "New",
+        openWindow,
+        createItem,
+      },
+    );
+    expect(result.kind).toBe("rest");
+    expect(result.refresh).toBe(true);
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "rffEvent",
+      folderPath: "/Sites/Demo",
+    });
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain("entry=editor");
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain("contentId=99");
+  });
+
+  it("New Item parent without a type asks to choose a type", async () => {
+    const createItem = vi.fn();
+    const result = await dispatchAction(action({ name: "Create_New_Item" }), {
+      item: item({ type: "folder", path: "/Sites/Demo" }),
+      folderPath: "/Sites/Demo",
+      createItem,
+    });
+    expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_NEEDS_TYPE);
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
   it("does not navigate Content Editor New Item URLs", async () => {
     const openWindow = vi.fn();
     expect(isContentEditorActionUrl("../rx_cePage/page.html")).toBe(true);

--- a/WebUI/src/test/ts/editor/itemCreateApi.test.ts
+++ b/WebUI/src/test/ts/editor/itemCreateApi.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { unwrapItemCreateResult } from "../../../main/ts/editor/itemCreateApi";
+
+describe("unwrapItemCreateResult", () => {
+  it("unwraps Jackson root and PascalCase", () => {
+    expect(
+      unwrapItemCreateResult({
+        ItemCreateResult: { ItemId: "99", FolderPath: "//Sites/x", Name: "n", ContentType: "t" },
+      }),
+    ).toEqual({
+      itemId: "99",
+      folderPath: "//Sites/x",
+      name: "n",
+      contentType: "t",
+    });
+  });
+});

--- a/docs/ai-generated/code-reviews/explorer-new-item-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-new-item-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — feat/explorer-new-item
+
+**Date**: 2026-08-15  
+**Scope**: uncommitted vs `feat/explorer-content-editor` (#3452)  
+**Reviewer**: Erlang  
+**Memory patterns hit**: change-class completeness (sitemanage create REST + WebUI dispatch + Playwright + product-docs); behavioral tests for path/name sanitize; CMS paths use `/` (URL/repo, not OS I/O)
+
+## Summary
+
+Explorer New Item type children create an item in the current folder (`POST /itemmanagement/item/create`) and open the React editor. Parent New without a type asks to choose a type. Leftover CE HTML is not navigated.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None blocking.
+
+### Suggestion
+
+`percPage` create via `contentItemDao` may fail without a template. Documented; Home Create remains the templated-page path.
+
+## Tests run
+
+- sitemanage `clean install` — BUILD SUCCESS; Tests run: 1261, Failures: 0
+- WebUI `clean install` — BUILD SUCCESS; Vitest 2528 passed

--- a/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
@@ -98,4 +98,32 @@ test.describe("modern React Content Editor — first slice", () => {
       expect(blocked, `CM1 editor must not be requested: ${blocked.join(" ")}`).toEqual([]);
     },
   );
+
+  test(
+    "Explorer New Item does not open leftover Content Editor HTML",
+    { tag: ["@explorer-content-editor", "@explorer"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (
+          u.includes("rx_ce") ||
+          u.includes("contenteditorurls.html") ||
+          u.includes("checkoutedit.xml")
+        ) {
+          blocked.push(u);
+        }
+      });
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+        timeout: 20_000,
+      });
+      const neu = page.locator('[data-testid="action-toolbar-item-New"]');
+      if (await neu.isVisible()) {
+        await neu.click();
+      }
+      expect(blocked, `Data Flow CE HTML must not be requested: ${blocked.join(" ")}`).toEqual([]);
+    },
+  );
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -118,7 +118,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | Action | What happens |
 |--------|----------------|
 | **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. New language: **template**, not variant. |
-| **New Item** | Type menus list from `POST /services/actions/find/types`. Creating an item still requires the Content Editor (not in this Explorer slice) — choosing a type shows that the editor is not available. |
+| **New Item** | Choose a content type under **New**. Explorer creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. Does not open leftover Content Editor HTML. Pages without a template may fail create — use Home → Create for a templated page when that happens. |
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows its content-type text fields. Save writes `PUT /services/itemmanagement/item/fields/{id}`. Does not open the CM1 editor (`?view=editor`). **New Item** and rich controls (TinyMCE, binary) are not in this slice. |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -527,6 +527,7 @@ Explorer **Edit** uses itemmanagement field maps (same `PSContentItem` store as 
 |--------|------|---------|
 | `GET` | `/services/itemmanagement/item/fields/{id}` | Scalar fields for the React editor (`sys_*` except `sys_title` omitted; binary omitted) |
 | `PUT` | `/services/itemmanagement/item/fields/{id}` | Save scalar field updates. Item must be checked out to the current user. |
+| `POST` | `/services/itemmanagement/item/create` | Create an item in a folder (`contentType`, `folderPath`, optional `name`) for Explorer New Item |
 
 Checkout / check-in remain `GET /services/itemmanagement/workflow/checkOut/{id}` and `…/checkIn/{id}`. Content-type labels come from `GET /services/contenttypes/{type}`.
 

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.data;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Create a new content item in a folder (React editor New Item). */
+@XmlRootElement(name = "ItemCreateRequest")
+public class PSItemCreateRequest {
+
+  private String contentType;
+  private String folderPath;
+  private String name;
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateResult.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateResult.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.data;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Result of creating a content item for the React editor. */
+@XmlRootElement(name = "ItemCreateResult")
+public class PSItemCreateResult {
+
+  private String itemId;
+  private String folderPath;
+  private String name;
+  private String contentType;
+
+  public PSItemCreateResult() {}
+
+  public PSItemCreateResult(String itemId, String folderPath, String name, String contentType) {
+    this.itemId = itemId;
+    this.folderPath = folderPath;
+    this.name = name;
+    this.contentType = contentType;
+  }
+
+  public String getItemId() {
+    return itemId;
+  }
+
+  public void setItemId(String itemId) {
+    this.itemId = itemId;
+  }
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
@@ -19,6 +19,8 @@ package com.percussion.itemmanagement.service;
 import com.percussion.itemmanagement.data.PSAssetSiteImpact;
 import com.percussion.itemmanagement.data.PSItemCopyResult;
 import com.percussion.itemmanagement.data.PSItemDates;
+import com.percussion.itemmanagement.data.PSItemCreateRequest;
+import com.percussion.itemmanagement.data.PSItemCreateResult;
 import com.percussion.itemmanagement.data.PSItemEditorFields;
 import com.percussion.itemmanagement.data.PSRevisionsSummary;
 import com.percussion.itemmanagement.data.PSSoProMetadata;
@@ -54,6 +56,11 @@ public interface IPSItemService {
    */
   PSItemEditorFields saveEditorFields(String id, PSItemEditorFields req)
       throws PSItemServiceException;
+
+  /**
+   * Creates a new content item in {@code req.folderPath} for the React editor New Item flow.
+   */
+  PSItemCreateResult createEditorItem(PSItemCreateRequest req) throws PSItemServiceException;
 
   /**
    * Retrieves the revisions for a given page or asset.

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupport.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import org.apache.commons.lang3.StringUtils;
+
+/** Folder path and item name helpers for Explorer New Item. */
+public final class PSItemCreateSupport {
+
+  private static final DateTimeFormatter STAMP =
+      DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneOffset.UTC);
+
+  private PSItemCreateSupport() {}
+
+  /**
+   * Repository folder path ({@code //Sites/...}). CMS paths always use {@code /}, not OS
+   * separators.
+   */
+  public static String toRepositoryFolderPath(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return null;
+    }
+    String p = raw.trim().replace('\\', '/');
+    p = p.replaceAll("/{2,}", "/");
+    if (!p.startsWith("/")) {
+      p = "/" + p;
+    }
+    return "/" + p;
+  }
+
+  public static String sanitizeItemName(String raw, String contentType) {
+    String base = StringUtils.trimToEmpty(raw);
+    if (base.isEmpty()) {
+      String type = StringUtils.defaultIfBlank(contentType, "Item");
+      type = type.replaceAll("[^A-Za-z0-9._-]", "-");
+      base = "New-" + type + "-" + STAMP.format(Instant.now());
+    }
+    base = base.replace('\\', '/');
+    int slash = base.lastIndexOf('/');
+    if (slash >= 0) {
+      base = base.substring(slash + 1);
+    }
+    base = base.replaceAll("[^A-Za-z0-9._-]", "-");
+    base = base.replaceAll("-{2,}", "-");
+    base = StringUtils.strip(base, "-");
+    if (base.isEmpty()) {
+      base = "New-Item";
+    }
+    if (isPageType(contentType) && !base.contains(".")) {
+      base = base + ".html";
+    }
+    return base;
+  }
+
+  public static boolean isPageType(String contentType) {
+    if (StringUtils.isBlank(contentType)) {
+      return false;
+    }
+    String n = contentType.replaceAll("[\\s_-]", "").toLowerCase();
+    return n.equals("percpage") || n.equals("page");
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -39,6 +39,8 @@ import com.percussion.itemmanagement.data.PSAssetSiteImpact;
 import com.percussion.itemmanagement.data.PSComment;
 import com.percussion.itemmanagement.data.PSItemCopyResult;
 import com.percussion.itemmanagement.data.PSItemDates;
+import com.percussion.itemmanagement.data.PSItemCreateRequest;
+import com.percussion.itemmanagement.data.PSItemCreateResult;
 import com.percussion.itemmanagement.data.PSItemEditorFields;
 import com.percussion.itemmanagement.data.PSPageLinkedToItem;
 import com.percussion.itemmanagement.data.PSRevision;
@@ -366,6 +368,42 @@ public class PSItemService implements IPSItemService {
       throw new WebApplicationException(e);
     } catch (Exception e) {
       throw new PSItemServiceException("Could not save item fields.", e);
+    }
+  }
+
+  @POST
+  @Path("create")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Override
+  public PSItemCreateResult createEditorItem(PSItemCreateRequest req)
+      throws PSItemServiceException {
+    try {
+      if (req == null || StringUtils.isBlank(req.getContentType())) {
+        throw new PSItemServiceException("Content type is required.");
+      }
+      String folder = PSItemCreateSupport.toRepositoryFolderPath(req.getFolderPath());
+      if (folder == null) {
+        throw new PSItemServiceException("Select a folder before creating an item.");
+      }
+      String name = PSItemCreateSupport.sanitizeItemName(req.getName(), req.getContentType());
+      PSContentItem item = new PSContentItem();
+      item.setType(req.getContentType().trim());
+      item.setName(name);
+      item.setFolderPaths(Collections.singletonList(folder));
+      Map<String, Object> fields = new HashMap<>();
+      fields.put("sys_title", name);
+      item.setFields(fields);
+      PSContentItem saved = contentItemDao.save(item);
+      String id = saved.getId();
+      if (StringUtils.isBlank(id)) {
+        throw new PSItemServiceException("Create succeeded but no item id was returned.");
+      }
+      return new PSItemCreateResult(id, folder, name, req.getContentType().trim());
+    } catch (PSItemServiceException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSItemServiceException("Could not create the item.", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupportTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupportTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class PSItemCreateSupportTest {
+
+  @Test
+  void repositoryFolderPathUsesCmsSlashes() {
+    assertEquals("//Sites/Demo", PSItemCreateSupport.toRepositoryFolderPath("/Sites/Demo"));
+    assertEquals("//Sites/Demo", PSItemCreateSupport.toRepositoryFolderPath("//Sites/Demo"));
+    assertEquals("//Sites/Demo", PSItemCreateSupport.toRepositoryFolderPath("Sites/Demo"));
+    assertNull(PSItemCreateSupport.toRepositoryFolderPath("  "));
+  }
+
+  @Test
+  void sanitizeStripsPathAndAddsHtmlForPages() {
+    assertEquals("Hello", PSItemCreateSupport.sanitizeItemName("Hello", "rffEvent"));
+    assertEquals("Hello.html", PSItemCreateSupport.sanitizeItemName("Hello", "percPage"));
+    assertEquals("file", PSItemCreateSupport.sanitizeItemName("/Sites/x/file", "rffEvent"));
+    assertTrue(PSItemCreateSupport.sanitizeItemName(null, "rffEvent").startsWith("New-rffEvent-"));
+    assertFalse(PSItemCreateSupport.sanitizeItemName("a/b\\c", "t").contains("/"));
+  }
+
+  @Test
+  void detectsPageType() {
+    assertTrue(PSItemCreateSupport.isPageType("percPage"));
+    assertTrue(PSItemCreateSupport.isPageType("perc_page"));
+    assertFalse(PSItemCreateSupport.isPageType("rffEvent"));
+  }
+}

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -23,7 +23,7 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 | `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
 | `rest` | Public REST (preview-location, types, transitions, purge, publish) |
 | `editor` | Named actions (`Edit`, `View_Content`, …) open the React editor host (`specs/995-react-content-editor`). Leftover CE URLs stay unavailable. |
-| `unavailable` | Slot arrange / New Item (P3 editor). Active Assembly parents are `rest` (996 preview host) |
+| `unavailable` | Slot arrange. New Item type children are `rest` (create + editor). Active Assembly parents are `rest` (996 preview host) |
 | `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
 
 Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.

--- a/specs/995-react-content-editor/spec.md
+++ b/specs/995-react-content-editor/spec.md
@@ -25,11 +25,12 @@ New window (peer of Active Assembly):
 4. Fields: `GET` / `PUT /services/itemmanagement/item/fields/{id}` (scalar map from `PSContentItem`; `sys_*` except `sys_title` omitted; binary omitted)
 5. Labels from `GET /services/contenttypes/{type}`
 6. Save + Check In (existing checkIn REST)
+7. **New Item** — type under New creates in the current folder (`POST /item/create`) and opens this editor
 
 ## Later
 
 - TinyMCE / file / image / keyword / community controls
-- New Item (create in folder + content type)
+- Default template picker when creating `percPage`
 - AA contenteditable overlay on the assembled preview
 - Revision promote form
 - Home / TopNav still use leftover `?view=editor` until those shells switch


### PR DESCRIPTION
## Summary

Follow-on to [#3452](https://github.com/intersoftdatalabs-in/percussioncms/pull/3452). Explorer **New Item** type menus create an item in the current folder (`POST /services/itemmanagement/item/create`) and open the React Content Editor. Choosing the New parent without a type asks the user to pick a type. Leftover `rx_ce` / contenteditorurls HTML is not navigated.

`percPage` create may still fail without a template — Home → Create remains the templated-page path.

Depends on #3452.

## Test plan

1. `cd projects/sitemanage` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1261, Failures: 0.
2. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2528 passed.
3. Explorer: select a folder → New → a content type. A new item appears and the editor window opens.
4. Confirm no `rx_ce` / `contenteditorurls.html` request.

## Checklist

- [x] **Product documentation** — New Item row + REST create path
- [x] **Unit / module tests** — path/name sanitize + dispatch create
- [x] **WebUI + Playwright** — New Item blocklist on `explorer-content-editor.spec.js`
- [x] **Build gates** — sitemanage + WebUI standalone clean install
- [x] **Cross-platform** — CMS folder paths use `/` (not OS file I/O)

Erlang: `docs/ai-generated/code-reviews/explorer-new-item-erlang.md` (approve).

> Co-Authored by Grok Build TUI using grok-4.6 with agent Grok 4.6