### PR TITLE
feat(explorer): pick a page template when creating percPage

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -82,6 +82,11 @@ import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/mod
 import { ContextMenu } from "./ContextMenu";
 import { TemplatePickerDialog } from "./TemplatePickerDialog";
 import type { PageTemplateChoice } from "../editor/pageTemplates";
+import {
+  replaceTemplatePickerSession,
+  settleTemplatePickerSession,
+  type TemplatePickerSession,
+} from "./templatePickerSession";
 import { resolveCurrentUserIdentities } from "./currentUserIdentities";
 import { DetailList } from "./DetailList";
 import {
@@ -454,10 +459,9 @@ function ContentExplorerShellInner({
   /** Non-fatal catalog load failure — chrome stays mounted (#2972). */
   const [menuLoadError, setMenuLoadError] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
-  const [templatePicker, setTemplatePicker] = useState<{
-    templates: PageTemplateChoice[];
-    resolve: (id: string | null) => void;
-  } | null>(null);
+  const [templatePicker, setTemplatePicker] =
+    useState<TemplatePickerSession | null>(null);
+  const templatePickerRef = useRef<TemplatePickerSession | null>(null);
   /**
    * Monotonic generation for context-menu loads. Rapid right-clicks on
    * different rows race two async IIFEs; only the latest generation may
@@ -710,6 +714,32 @@ function ContentExplorerShellInner({
     [loadMenuActions, loadWorkflowMenuActions],
   );
 
+  const pickPageTemplate = useCallback((templates: PageTemplateChoice[]) => {
+    return new Promise<string | null>((resolve) => {
+      const session = { templates, resolve };
+      templatePickerRef.current = replaceTemplatePickerSession(
+        templatePickerRef.current,
+        session,
+      );
+      setTemplatePicker(session);
+    });
+  }, []);
+
+  const finishTemplatePicker = useCallback((id: string | null) => {
+    const current = templatePickerRef.current;
+    templatePickerRef.current = null;
+    setTemplatePicker(null);
+    settleTemplatePickerSession(current, id);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      const current = templatePickerRef.current;
+      templatePickerRef.current = null;
+      settleTemplatePickerSession(current, null);
+    };
+  }, []);
+
   /**
    * Route toolbar / context-menu activations through the action dispatcher.
    * Data Flow HTML URLs are never navigated (they 404 from the SPA).
@@ -743,10 +773,7 @@ function ContentExplorerShellInner({
               setRevisionsTab(tab);
               setShowRevisions(true);
             },
-            pickPageTemplate: (templates) =>
-              new Promise<string | null>((resolve) => {
-                setTemplatePicker({ templates, resolve });
-              }),
+            pickPageTemplate,
           });
           if (result.messageKey) {
             setError(message(result.messageKey));
@@ -769,6 +796,7 @@ function ContentExplorerShellInner({
       runWorkflowTransition,
       menuActions,
       contextMenu,
+      pickPageTemplate,
     ],
   );
 
@@ -1500,14 +1528,8 @@ function ContentExplorerShellInner({
       {templatePicker ? (
         <TemplatePickerDialog
           templates={templatePicker.templates}
-          onPick={(id) => {
-            templatePicker.resolve(id);
-            setTemplatePicker(null);
-          }}
-          onCancel={() => {
-            templatePicker.resolve(null);
-            setTemplatePicker(null);
-          }}
+          onPick={(id) => finishTemplatePicker(id)}
+          onCancel={() => finishTemplatePicker(null)}
         />
       ) : null}
     </div>

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -80,6 +80,8 @@ import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
 import { ContextMenu } from "./ContextMenu";
+import { TemplatePickerDialog } from "./TemplatePickerDialog";
+import type { PageTemplateChoice } from "../editor/pageTemplates";
 import { resolveCurrentUserIdentities } from "./currentUserIdentities";
 import { DetailList } from "./DetailList";
 import {
@@ -452,6 +454,10 @@ function ContentExplorerShellInner({
   /** Non-fatal catalog load failure — chrome stays mounted (#2972). */
   const [menuLoadError, setMenuLoadError] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  const [templatePicker, setTemplatePicker] = useState<{
+    templates: PageTemplateChoice[];
+    resolve: (id: string | null) => void;
+  } | null>(null);
   /**
    * Monotonic generation for context-menu loads. Rapid right-clicks on
    * different rows race two async IIFEs; only the latest generation may
@@ -737,6 +743,10 @@ function ContentExplorerShellInner({
               setRevisionsTab(tab);
               setShowRevisions(true);
             },
+            pickPageTemplate: (templates) =>
+              new Promise<string | null>((resolve) => {
+                setTemplatePicker({ templates, resolve });
+              }),
           });
           if (result.messageKey) {
             setError(message(result.messageKey));
@@ -1487,6 +1497,19 @@ function ContentExplorerShellInner({
           />
         </div>
       )}
+      {templatePicker ? (
+        <TemplatePickerDialog
+          templates={templatePicker.templates}
+          onPick={(id) => {
+            templatePicker.resolve(id);
+            setTemplatePicker(null);
+          }}
+          onCancel={() => {
+            templatePicker.resolve(null);
+            setTemplatePicker(null);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/WebUI/src/main/ts/contentExplorer/TemplatePickerDialog.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TemplatePickerDialog.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from "react";
+import type { PageTemplateChoice } from "../editor/pageTemplates";
+import { message } from "../i18n/message";
+import { EXPLORER_MSG } from "./messages";
+
+export interface TemplatePickerDialogProps {
+  templates: PageTemplateChoice[];
+  onPick: (templateId: string) => void;
+  onCancel: () => void;
+}
+
+export function TemplatePickerDialog({
+  templates,
+  onPick,
+  onCancel,
+}: TemplatePickerDialogProps): React.ReactElement {
+  const [value, setValue] = useState(templates[0]?.id ?? "");
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="explorer-template-picker-title"
+      data-testid="explorer-template-picker"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15,23,42,0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 40,
+      }}
+    >
+      <form
+        style={{
+          background: "#fff",
+          color: "#0f172a",
+          minWidth: 280,
+          maxWidth: 420,
+          padding: 16,
+          borderRadius: 8,
+          boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+        }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (value) {
+            onPick(value);
+          }
+        }}
+      >
+        <h2 id="explorer-template-picker-title" style={{ fontSize: 16, margin: "0 0 12px" }}>
+          {message(EXPLORER_MSG.TEMPLATE_PICKER_TITLE)}
+        </h2>
+        <label style={{ display: "block", fontSize: 13 }}>
+          {message(EXPLORER_MSG.TEMPLATE_PICKER_LABEL)}
+          <select
+            data-testid="explorer-template-picker-select"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            style={{ display: "block", width: "100%", marginTop: 6, padding: 6 }}
+          >
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+          <button type="button" data-testid="explorer-template-picker-cancel" onClick={onCancel}>
+            {message(EXPLORER_MSG.CONFIRM_CANCEL)}
+          </button>
+          <button type="submit" data-testid="explorer-template-picker-ok" disabled={!value}>
+            {message(EXPLORER_MSG.CONFIRM_OK)}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/contentExplorer/TemplatePickerDialog.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TemplatePickerDialog.tsx
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { useDialogEscape } from "../architecture/useDialogEscape";
 import type { PageTemplateChoice } from "../editor/pageTemplates";
 import { message } from "../i18n/message";
 import { EXPLORER_MSG } from "./messages";
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export interface TemplatePickerDialogProps {
   templates: PageTemplateChoice[];
@@ -32,8 +36,44 @@ export function TemplatePickerDialog({
   onCancel,
 }: TemplatePickerDialogProps): React.ReactElement {
   const [value, setValue] = useState(templates[0]?.id ?? "");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
+
+  useDialogEscape(true, false, onCancel);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    selectRef.current?.focus();
+    if (!root) {
+      return;
+    }
+    const focusables = (): HTMLElement[] =>
+      Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key !== "Tab") {
+        return;
+      }
+      const list = focusables();
+      if (list.length === 0) {
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => root.removeEventListener("keydown", onKey);
+  }, []);
+
   return (
     <div
+      ref={rootRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="explorer-template-picker-title"
@@ -71,6 +111,7 @@ export function TemplatePickerDialog({
         <label style={{ display: "block", fontSize: 13 }}>
           {message(EXPLORER_MSG.TEMPLATE_PICKER_LABEL)}
           <select
+            ref={selectRef}
             data-testid="explorer-template-picker-select"
             value={value}
             onChange={(e) => setValue(e.target.value)}

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -48,6 +48,11 @@ import {
 } from "../editor/editorHostUrl";
 import { createEditorItem } from "../editor/itemCreateApi";
 import {
+  isExplorerPageType,
+  loadPageTemplates,
+  type PageTemplateChoice,
+} from "../editor/pageTemplates";
+import {
   isNewItemHostName,
   parseExplorerContentId,
 } from "./menuCatalogLoad";
@@ -168,6 +173,10 @@ export interface ActionDispatchContext {
   createCopy?: (itemId: string) => Promise<void>;
   createPromotable?: (itemId: string) => Promise<void>;
   createItem?: typeof createEditorItem;
+  loadPageTemplates?: typeof loadPageTemplates;
+  pickPageTemplate?: (
+    templates: PageTemplateChoice[],
+  ) => Promise<string | null>;
   onPublish?: (item: PSPathItem) => Promise<void>;
   /** Parent menu name when the user activated a child (AA vs Preview). */
   parentName?: string;
@@ -416,10 +425,30 @@ export async function dispatchAction(
     if (!folder) {
       return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_FOLDER };
     }
+    let templateId: string | undefined;
+    if (isExplorerPageType(action.name)) {
+      const load = ctx.loadPageTemplates ?? loadPageTemplates;
+      const templates = await load(folder, action.name);
+      if (templates.length === 0) {
+        return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_TEMPLATE };
+      }
+      templateId = templates[0]?.id;
+      if (templates.length > 1) {
+        if (!ctx.pickPageTemplate) {
+          return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_TEMPLATE };
+        }
+        const picked = await ctx.pickPageTemplate(templates);
+        if (!picked) {
+          return { kind: "rest" };
+        }
+        templateId = picked;
+      }
+    }
     const create = ctx.createItem ?? createEditorItem;
     const created = await create({
       contentType: action.name,
       folderPath: folder,
+      templateId,
     });
     const contentId = parseExplorerContentId(created.itemId);
     if (contentId == null) {

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -337,6 +337,10 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Select a folder first",
   ACTION_NEEDS_TYPE:
     "perc.ui.explorer@Choose a content type from New Item",
+  ACTION_NEEDS_TEMPLATE:
+    "perc.ui.explorer@This page needs a template. Choose a site folder or use Home → Create.",
+  TEMPLATE_PICKER_TITLE: "perc.ui.explorer@Choose a page template",
+  TEMPLATE_PICKER_LABEL: "perc.ui.explorer@Template",
   CONFIRM_PURGE_BODY:
     "perc.ui.explorer@Permanently delete this item from the system?",
   CONFIRM_PUBLISH_NOW:

--- a/WebUI/src/main/ts/contentExplorer/templatePickerSession.ts
+++ b/WebUI/src/main/ts/contentExplorer/templatePickerSession.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PageTemplateChoice } from "../editor/pageTemplates";
+
+export interface TemplatePickerSession {
+  templates: PageTemplateChoice[];
+  resolve: (id: string | null) => void;
+}
+
+/**
+ * Open a new picker session. Cancels any previous waiter so
+ * {@code dispatchAction} does not hang if the user starts another create
+ * before the first picker settles.
+ */
+export function replaceTemplatePickerSession(
+  previous: TemplatePickerSession | null,
+  next: TemplatePickerSession,
+): TemplatePickerSession {
+  if (previous && previous !== next) {
+    previous.resolve(null);
+  }
+  return next;
+}
+
+/**
+ * Settle the current session (pick or cancel). Safe if {@code session} is
+ * already null. The caller should drop its ref after this returns.
+ */
+export function settleTemplatePickerSession(
+  session: TemplatePickerSession | null,
+  id: string | null,
+): null {
+  session?.resolve(id);
+  return null;
+}

--- a/WebUI/src/main/ts/editor/itemCreateApi.ts
+++ b/WebUI/src/main/ts/editor/itemCreateApi.ts
@@ -22,6 +22,7 @@ export interface ItemCreateRequest {
   contentType: string;
   folderPath: string;
   name?: string;
+  templateId?: string;
 }
 
 export interface ItemCreateResult {

--- a/WebUI/src/main/ts/editor/pageTemplates.ts
+++ b/WebUI/src/main/ts/editor/pageTemplates.ts
@@ -78,8 +78,12 @@ export async function loadPageTemplates(
     if (fromType.length > 0) {
       return fromType;
     }
-  } catch {
-    /* fall through to site templates */
+  } catch (err) {
+    console.warn(
+      "[pageTemplates] content-type templates unavailable; using site templates",
+      contentType,
+      err,
+    );
   }
   const site = siteNameFromFolderPath(folderPath);
   if (!site) {

--- a/WebUI/src/main/ts/editor/pageTemplates.ts
+++ b/WebUI/src/main/ts/editor/pageTemplates.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getContentTypeDetail } from "../api/developer/contentTypesApi";
+import type { NamedObjectRef } from "../api/developer/types";
+import { fetchTemplatesForSite } from "../api/home/homeApi";
+
+export interface PageTemplateChoice {
+  id: string;
+  name: string;
+}
+
+export function isExplorerPageType(name: string | undefined | null): boolean {
+  const n = (name ?? "").replace(/[\s_-]/g, "").toLowerCase();
+  return n === "percpage" || n === "page";
+}
+
+export function siteNameFromFolderPath(folderPath: string | undefined | null): string | null {
+  if (folderPath == null || !folderPath.trim()) {
+    return null;
+  }
+  const parts = folderPath.replace(/\\/g, "/").split("/");
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].toLowerCase() === "sites" && i + 1 < parts.length) {
+      const site = parts[i + 1].trim();
+      return site || null;
+    }
+  }
+  return null;
+}
+
+function refId(ref: NamedObjectRef): string {
+  return (
+    ref.guid?.stringValue ||
+    (ref.guid?.uuid != null ? String(ref.guid.uuid) : "") ||
+    ref.name ||
+    ""
+  ).trim();
+}
+
+export function templatesFromContentType(
+  allowed: NamedObjectRef[] | undefined,
+): PageTemplateChoice[] {
+  const out: PageTemplateChoice[] = [];
+  const seen = new Set<string>();
+  for (const ref of allowed ?? []) {
+    const id = refId(ref);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    out.push({ id, name: ref.label || ref.name || id });
+  }
+  return out;
+}
+
+export async function loadPageTemplates(
+  folderPath: string,
+  contentType: string,
+): Promise<PageTemplateChoice[]> {
+  try {
+    const detail = await getContentTypeDetail(contentType);
+    const fromType = templatesFromContentType(detail.allowedTemplates);
+    if (fromType.length > 0) {
+      return fromType;
+    }
+  } catch {
+    /* fall through to site templates */
+  }
+  const site = siteNameFromFolderPath(folderPath);
+  if (!site) {
+    return [];
+  }
+  const siteTemplates = await fetchTemplatesForSite(site);
+  return siteTemplates
+    .filter((t) => t.id)
+    .map((t) => ({ id: t.id, name: t.name || t.id }));
+}

--- a/WebUI/src/test/ts/contentExplorer/TemplatePickerDialog.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TemplatePickerDialog.test.tsx
@@ -58,6 +58,50 @@ describe("TemplatePickerDialog", () => {
     expect(onPick).not.toHaveBeenCalled();
   });
 
+  it("cancels on Escape", () => {
+    const onCancel = vi.fn();
+    render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves focus to the template select on mount", () => {
+    render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-template-picker-select"),
+    );
+  });
+
+  it("traps Tab inside the dialog", () => {
+    render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const ok = screen.getByTestId("explorer-template-picker-ok");
+    ok.focus();
+    fireEvent.keyDown(screen.getByTestId("explorer-template-picker"), {
+      key: "Tab",
+    });
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-template-picker-select"),
+    );
+  });
+
   it("has no serious a11y violations", async () => {
     const { container } = render(
       <TemplatePickerDialog

--- a/WebUI/src/test/ts/contentExplorer/TemplatePickerDialog.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TemplatePickerDialog.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TemplatePickerDialog } from "../../../main/ts/contentExplorer/TemplatePickerDialog";
+import { renderA11yGate } from "./a11y";
+
+const TEMPLATES = [
+  { id: "tpl-a", name: "Home" },
+  { id: "tpl-b", name: "Interior" },
+];
+
+describe("TemplatePickerDialog", () => {
+  it("picks the selected template", () => {
+    const onPick = vi.fn();
+    render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={onPick}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("explorer-template-picker")).toBeTruthy();
+    fireEvent.change(screen.getByTestId("explorer-template-picker-select"), {
+      target: { value: "tpl-b" },
+    });
+    fireEvent.click(screen.getByTestId("explorer-template-picker-ok"));
+    expect(onPick).toHaveBeenCalledWith("tpl-b");
+  });
+
+  it("cancels without picking", () => {
+    const onCancel = vi.fn();
+    const onPick = vi.fn();
+    render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={onPick}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("explorer-template-picker-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("has no serious a11y violations", async () => {
+    const { container } = render(
+      <TemplatePickerDialog
+        templates={TEMPLATES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await renderA11yGate(container);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -151,6 +151,101 @@ describe("actionDispatch", () => {
     expect(href).not.toContain("sys_cxSupport");
   });
 
+  it("creates a percPage with a picked template", async () => {
+    const openWindow = vi.fn();
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "77",
+      folderPath: "//Sites/Demo",
+      name: "New-percPage.html",
+      contentType: "percPage",
+    });
+    const loadPageTemplates = vi.fn().mockResolvedValue([
+      { id: "tpl-a", name: "A" },
+      { id: "tpl-b", name: "B" },
+    ]);
+    const pickPageTemplate = vi.fn().mockResolvedValue("tpl-b");
+    const result = await dispatchAction(
+      action({ name: "percPage", parentName: "New" }),
+      {
+        item: item({ type: "folder", path: "/Sites/Demo", id: "1" }),
+        folderPath: "/Sites/Demo",
+        parentName: "New",
+        openWindow,
+        createItem,
+        loadPageTemplates,
+        pickPageTemplate,
+      },
+    );
+    expect(result.refresh).toBe(true);
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "percPage",
+      folderPath: "/Sites/Demo",
+      templateId: "tpl-b",
+    });
+  });
+
+  it("does not create a percPage without templates", async () => {
+    const createItem = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "percPage", parentName: "New" }),
+      {
+        folderPath: "/Sites/Demo",
+        parentName: "New",
+        createItem,
+        loadPageTemplates: async () => [],
+      },
+    );
+    expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_NEEDS_TEMPLATE);
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
+  it("auto-selects a single percPage template", async () => {
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "78",
+      folderPath: "//Sites/Demo",
+      name: "New-percPage.html",
+      contentType: "percPage",
+    });
+    const pickPageTemplate = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "percPage", parentName: "New" }),
+      {
+        folderPath: "/Sites/Demo",
+        parentName: "New",
+        openWindow: vi.fn(),
+        createItem,
+        loadPageTemplates: async () => [{ id: "only", name: "Only" }],
+        pickPageTemplate,
+      },
+    );
+    expect(result.refresh).toBe(true);
+    expect(pickPageTemplate).not.toHaveBeenCalled();
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "percPage",
+      folderPath: "/Sites/Demo",
+      templateId: "only",
+    });
+  });
+
+  it("does not create a percPage when the template picker is cancelled", async () => {
+    const createItem = vi.fn();
+    const result = await dispatchAction(
+      action({ name: "percPage", parentName: "New" }),
+      {
+        folderPath: "/Sites/Demo",
+        parentName: "New",
+        createItem,
+        loadPageTemplates: async () => [
+          { id: "tpl-a", name: "A" },
+          { id: "tpl-b", name: "B" },
+        ],
+        pickPageTemplate: async () => null,
+      },
+    );
+    expect(result.messageKey).toBeUndefined();
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
   it("creates a New Item type and opens the editor", async () => {
     const openWindow = vi.fn();
     const createItem = vi.fn().mockResolvedValue({

--- a/WebUI/src/test/ts/contentExplorer/templatePickerSession.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/templatePickerSession.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  replaceTemplatePickerSession,
+  settleTemplatePickerSession,
+} from "../../../main/ts/contentExplorer/templatePickerSession";
+
+const T = [{ id: "a", name: "A" }];
+
+describe("templatePickerSession", () => {
+  it("cancels the previous waiter when a new session opens", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const previous = { templates: T, resolve: first };
+    const next = { templates: T, resolve: second };
+    const opened = replaceTemplatePickerSession(previous, next);
+    expect(opened).toBe(next);
+    expect(first).toHaveBeenCalledWith(null);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("settles the open session and is a no-op when already cleared", () => {
+    const resolve = vi.fn();
+    const session = { templates: T, resolve };
+    expect(settleTemplatePickerSession(session, "tpl-b")).toBeNull();
+    expect(resolve).toHaveBeenCalledWith("tpl-b");
+    expect(settleTemplatePickerSession(null, "tpl-b")).toBeNull();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/WebUI/src/test/ts/editor/pageTemplates.test.ts
+++ b/WebUI/src/test/ts/editor/pageTemplates.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getContentTypeDetail } from "../../../main/ts/api/developer/contentTypesApi";
+import { fetchTemplatesForSite } from "../../../main/ts/api/home/homeApi";
+import {
+  isExplorerPageType,
+  loadPageTemplates,
+  siteNameFromFolderPath,
+  templatesFromContentType,
+} from "../../../main/ts/editor/pageTemplates";
+
+vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
+  getContentTypeDetail: vi.fn(),
+}));
+
+vi.mock("../../../main/ts/api/home/homeApi", () => ({
+  fetchTemplatesForSite: vi.fn(),
+}));
+
+describe("pageTemplates", () => {
+  beforeEach(() => {
+    vi.mocked(getContentTypeDetail).mockReset();
+    vi.mocked(fetchTemplatesForSite).mockReset();
+  });
+
+  it("detects percPage", () => {
+    expect(isExplorerPageType("percPage")).toBe(true);
+    expect(isExplorerPageType("perc_page")).toBe(true);
+    expect(isExplorerPageType("rffEvent")).toBe(false);
+  });
+
+  it("reads site name from CMS folder paths", () => {
+    expect(siteNameFromFolderPath("/Sites/Demo/Home")).toBe("Demo");
+    expect(siteNameFromFolderPath("//Sites/Demo")).toBe("Demo");
+    expect(siteNameFromFolderPath("/Folders/Assets")).toBeNull();
+  });
+
+  it("maps allowed template refs", () => {
+    const rows = templatesFromContentType([
+      { name: "t1", label: "Home", guid: { stringValue: "1-101-7" } },
+      { name: "t1", guid: { stringValue: "1-101-7" } },
+    ]);
+    expect(rows).toEqual([{ id: "1-101-7", name: "Home" }]);
+  });
+
+  it("prefers content-type allowed templates", async () => {
+    vi.mocked(getContentTypeDetail).mockResolvedValue({
+      allowedTemplates: [{ name: "t1", label: "Home", guid: { stringValue: "1-101-7" } }],
+    });
+    const rows = await loadPageTemplates("/Sites/Demo", "percPage");
+    expect(rows).toEqual([{ id: "1-101-7", name: "Home" }]);
+    expect(fetchTemplatesForSite).not.toHaveBeenCalled();
+  });
+
+  it("falls back to site templates when the type has none", async () => {
+    vi.mocked(getContentTypeDetail).mockResolvedValue({ allowedTemplates: [] });
+    vi.mocked(fetchTemplatesForSite).mockResolvedValue([
+      { id: "site-1", name: "Base" },
+    ]);
+    const rows = await loadPageTemplates("/Sites/Demo/Home", "percPage");
+    expect(rows).toEqual([{ id: "site-1", name: "Base" }]);
+    expect(fetchTemplatesForSite).toHaveBeenCalledWith("Demo");
+  });
+});

--- a/WebUI/src/test/ts/editor/pageTemplates.test.ts
+++ b/WebUI/src/test/ts/editor/pageTemplates.test.ts
@@ -77,4 +77,17 @@ describe("pageTemplates", () => {
     expect(rows).toEqual([{ id: "site-1", name: "Base" }]);
     expect(fetchTemplatesForSite).toHaveBeenCalledWith("Demo");
   });
+
+  it("falls back to site templates when the type catalog throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.mocked(getContentTypeDetail).mockRejectedValue(new Error("down"));
+    vi.mocked(fetchTemplatesForSite).mockResolvedValue([
+      { id: "site-1", name: "Base" },
+    ]);
+    const rows = await loadPageTemplates("/Sites/Demo/Home", "percPage");
+    expect(rows).toEqual([{ id: "site-1", name: "Base" }]);
+    expect(fetchTemplatesForSite).toHaveBeenCalledWith("Demo");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
 });

--- a/docs/ai-generated/code-reviews/explorer-new-item-page-template-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-new-item-page-template-erlang.md
@@ -51,3 +51,22 @@ Playwright skips when **New** has no `percPage` child. Acceptable for catalog va
 - `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS; Tests run: 1266, Failures: 0, Skipped: 125
 - `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; Vitest 2540 passed
 - Playwright live QA stack not started this increment
+
+## Re-review (PR #3455 kilo threads)
+
+**Date**: 2026-08-15  
+**Scope**: review-fix pack vs `347fb964b8`
+
+Kilo CRITICAL/WARNING/SUGGESTION on orphaned picker Promise, dialog keyboard, Playwright happy path, catalog-error fallback, silent catch, initial focus.
+
+### Recommendation
+
+`approve`
+
+### Gate
+
+May commit/push: **yes**
+
+### Issues
+
+None remaining. Prior suggestion (silent catch) now `console.warn`s and has a throw → site-template unit test. Picker session replace/settle is unit-tested so a second open or unmount cancels the waiter. Dialog uses `useDialogEscape` + Tab trap + select focus. Playwright posts `templateId` on OK.

--- a/docs/ai-generated/code-reviews/explorer-new-item-page-template-erlang.md
+++ b/docs/ai-generated/code-reviews/explorer-new-item-page-template-erlang.md
@@ -1,0 +1,53 @@
+# Erlang review — feat/explorer-new-item-page-template
+
+**Date**: 2026-08-15  
+**Scope**: uncommitted vs `origin/main` (`9927d427c3` New Item #3453)  
+**Reviewer**: Erlang  
+**Prior report**: `docs/ai-generated/code-reviews/explorer-new-item-erlang.md` (suggestion: percPage via `contentItemDao` may fail without a template — this increment addresses that)  
+**Memory patterns hit**: change-class completeness (sitemanage page create + WebUI picker/dispatch + Playwright + product-docs); behavioral tests for template pick / no-template / page-service save; CMS repository paths use `/` (not OS I/O)
+
+## Summary
+
+Explorer New Item for `percPage` loads allowed templates (content type, then site), auto-selects a single template, or opens **Choose a page template**. Create POSTs `templateId` and `PSItemService` saves through `IPSPageService` instead of a bare `contentItemDao` item.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+CMS folder helpers (`toRepositoryFolderPath`, `siteNameFromFolderPath` Java/TS) treat repository paths as `/` URLs and normalize `\`. No OS filesystem joins. Clean.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| sitemanage create + page save | yes |
+| WebUI picker + dispatch | yes |
+| Vitest / JUnit behavioral tests | yes |
+| Playwright (`explorer-content-editor.spec.js`) | yes |
+| product-docs 8.2 admin + REST | yes |
+
+## Issues
+
+None blocking.
+
+### Suggestion
+
+`loadPageTemplates` swallows content-type catalog errors and falls through to site templates. Intentional; a log would help operators when the type GET fails for a real reason.
+
+Playwright skips when **New** has no `percPage` child. Acceptable for catalog variance; live H2 with Demo should list it.
+
+`IPSPageService` is `@Autowired(required = false)` to avoid a setter cycle. Missing bean fails create with an explicit message (covered).
+
+## Tests run
+
+- Focused Vitest: 49 passed (`actionDispatch`, `TemplatePickerDialog`, `pageTemplates`)
+- Focused sitemanage: `PSItemCreateSupportTest` 5, `PSItemServiceCreatePageTest` 3
+- `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS; Tests run: 1266, Failures: 0, Skipped: 125
+- `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; Vitest 2540 passed
+- Playwright live QA stack not started this increment

--- a/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
@@ -127,87 +127,111 @@ test.describe("modern React Content Editor — first slice", () => {
     },
   );
 
+  async function openPercPageTemplatePicker(page, createBodies) {
+    await page.route("**/services/contenttypes/**", async (route) => {
+      const url = route.request().url();
+      if (!/percPage|\/Page(?:\?|$)/i.test(url)) {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ContentTypeDetail: {
+            name: "percPage",
+            allowedTemplates: [
+              { name: "t1", label: "Home", guid: { stringValue: "tpl-home" } },
+              { name: "t2", label: "Interior", guid: { stringValue: "tpl-in" } },
+            ],
+          },
+        }),
+      });
+    });
+    await page.route("**/services/itemmanagement/item/create**", async (route) => {
+      createBodies.push(route.request().postData() || "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ItemCreateResult: {
+            itemId: "1-101-1",
+            folderPath: "//Sites/Demo",
+            name: "New-percPage.html",
+            contentType: "percPage",
+          },
+        }),
+      });
+    });
+
+    await page.goto(explorerSpaUrl(BASE_URL));
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const tree = page.locator('[data-testid="explorer-tree"]');
+    if ((await tree.count()) > 0) {
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+      }
+    }
+
+    const neu = page.locator('[data-testid="action-toolbar-item-New"]');
+    if ((await neu.count()) === 0 || !(await neu.isVisible())) {
+      return { skipped: "New menu is not visible" };
+    }
+    await neu.click();
+    const percPage = page.locator(
+      '[data-testid="action-toolbar-item-percPage"], [data-testid="action-toolbar-item-Page"]',
+    );
+    if ((await percPage.count()) === 0) {
+      return { skipped: "percPage is not listed under New" };
+    }
+    await percPage.first().click();
+    const picker = page.locator('[data-testid="explorer-template-picker"]');
+    await expect(picker).toBeVisible({ timeout: 10_000 });
+    return { picker };
+  }
+
   test(
     "Explorer New percPage offers a template picker and does not create on cancel",
     { tag: ["@explorer-content-editor", "@explorer"] },
     async ({ page }) => {
       const createBodies = [];
-      await page.route("**/services/contenttypes/**", async (route) => {
-        const url = route.request().url();
-        if (!/percPage|\/Page(?:\?|$)/i.test(url)) {
-          await route.continue();
-          return;
-        }
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            ContentTypeDetail: {
-              name: "percPage",
-              allowedTemplates: [
-                { name: "t1", label: "Home", guid: { stringValue: "tpl-home" } },
-                { name: "t2", label: "Interior", guid: { stringValue: "tpl-in" } },
-              ],
-            },
-          }),
-        });
-      });
-      await page.route("**/services/itemmanagement/item/create**", async (route) => {
-        createBodies.push(route.request().postData() || "");
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            ItemCreateResult: {
-              itemId: "1-101-1",
-              folderPath: "//Sites/Demo",
-              name: "New-percPage.html",
-              contentType: "percPage",
-            },
-          }),
-        });
-      });
-
-      await page.goto(explorerSpaUrl(BASE_URL));
-      await page.waitForLoadState("networkidle");
-      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
-        timeout: 20_000,
-      });
-
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      if ((await tree.count()) > 0) {
-        const sitesNode = page
-          .locator(
-            '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-          )
-          .first();
-        if ((await sitesNode.count()) > 0) {
-          await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        }
-      }
-
-      const neu = page.locator('[data-testid="action-toolbar-item-New"]');
-      if ((await neu.count()) === 0 || !(await neu.isVisible())) {
-        test.skip(true, "New menu is not visible");
+      const opened = await openPercPageTemplatePicker(page, createBodies);
+      if (opened.skipped) {
+        test.skip(true, opened.skipped);
         return;
       }
-      await neu.click();
-      const percPage = page.locator(
-        '[data-testid="action-toolbar-item-percPage"], [data-testid="action-toolbar-item-Page"]',
-      );
-      if ((await percPage.count()) === 0) {
-        test.skip(true, "percPage is not listed under New");
-        return;
-      }
-      await percPage.first().click();
-      const picker = page.locator('[data-testid="explorer-template-picker"]');
-      await expect(picker).toBeVisible({ timeout: 10_000 });
       await expectNoSeriousA11yViolations(page, {
         scope: '[data-testid="explorer-template-picker"]',
       });
       await page.locator('[data-testid="explorer-template-picker-cancel"]').click();
-      await expect(picker).toHaveCount(0);
+      await expect(opened.picker).toHaveCount(0);
       expect(createBodies, "Cancel must not POST create").toEqual([]);
+    },
+  );
+
+  test(
+    "Explorer New percPage posts the picked templateId",
+    { tag: ["@explorer-content-editor", "@explorer"] },
+    async ({ page }) => {
+      const createBodies = [];
+      const opened = await openPercPageTemplatePicker(page, createBodies);
+      if (opened.skipped) {
+        test.skip(true, opened.skipped);
+        return;
+      }
+      await page.locator('[data-testid="explorer-template-picker-select"]').selectOption("tpl-in");
+      await page.locator('[data-testid="explorer-template-picker-ok"]').click();
+      await expect.poll(() => createBodies.length).toBe(1);
+      expect(createBodies[0]).toMatch(/"templateId"\s*:\s*"tpl-in"/);
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-content-editor.spec.js
@@ -126,4 +126,88 @@ test.describe("modern React Content Editor — first slice", () => {
       expect(blocked, `Data Flow CE HTML must not be requested: ${blocked.join(" ")}`).toEqual([]);
     },
   );
+
+  test(
+    "Explorer New percPage offers a template picker and does not create on cancel",
+    { tag: ["@explorer-content-editor", "@explorer"] },
+    async ({ page }) => {
+      const createBodies = [];
+      await page.route("**/services/contenttypes/**", async (route) => {
+        const url = route.request().url();
+        if (!/percPage|\/Page(?:\?|$)/i.test(url)) {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ContentTypeDetail: {
+              name: "percPage",
+              allowedTemplates: [
+                { name: "t1", label: "Home", guid: { stringValue: "tpl-home" } },
+                { name: "t2", label: "Interior", guid: { stringValue: "tpl-in" } },
+              ],
+            },
+          }),
+        });
+      });
+      await page.route("**/services/itemmanagement/item/create**", async (route) => {
+        createBodies.push(route.request().postData() || "");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ItemCreateResult: {
+              itemId: "1-101-1",
+              folderPath: "//Sites/Demo",
+              name: "New-percPage.html",
+              contentType: "percPage",
+            },
+          }),
+        });
+      });
+
+      await page.goto(explorerSpaUrl(BASE_URL));
+      await page.waitForLoadState("networkidle");
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      if ((await tree.count()) > 0) {
+        const sitesNode = page
+          .locator(
+            '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+          )
+          .first();
+        if ((await sitesNode.count()) > 0) {
+          await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        }
+      }
+
+      const neu = page.locator('[data-testid="action-toolbar-item-New"]');
+      if ((await neu.count()) === 0 || !(await neu.isVisible())) {
+        test.skip(true, "New menu is not visible");
+        return;
+      }
+      await neu.click();
+      const percPage = page.locator(
+        '[data-testid="action-toolbar-item-percPage"], [data-testid="action-toolbar-item-Page"]',
+      );
+      if ((await percPage.count()) === 0) {
+        test.skip(true, "percPage is not listed under New");
+        return;
+      }
+      await percPage.first().click();
+      const picker = page.locator('[data-testid="explorer-template-picker"]');
+      await expect(picker).toBeVisible({ timeout: 10_000 });
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="explorer-template-picker"]',
+      });
+      await page.locator('[data-testid="explorer-template-picker-cancel"]').click();
+      await expect(picker).toHaveCount(0);
+      expect(createBodies, "Cancel must not POST create").toEqual([]);
+    },
+  );
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -118,10 +118,10 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | Action | What happens |
 |--------|----------------|
 | **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. New language: **template**, not variant. |
-| **New Item** | Choose a content type under **New**. Explorer creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. Does not open leftover Content Editor HTML. Pages without a template may fail create — use Home → Create for a templated page when that happens. |
+| **New Item** | Choose a content type under **New**. Explorer creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. Does not open leftover Content Editor HTML. **Pages** (`percPage`) need a page template. Explorer loads allowed templates for the type, then the site's templates when the type has none. One template is used automatically; more than one opens **Choose a page template**. Cancel leaves the folder unchanged. If no template is available, Explorer asks you to pick a site folder or use Home → Create. |
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
-| **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows its content-type text fields. Save writes `PUT /services/itemmanagement/item/fields/{id}`. Does not open the CM1 editor (`?view=editor`). **New Item** and rich controls (TinyMCE, binary) are not in this slice. |
+| **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows its content-type text fields. Save writes `PUT /services/itemmanagement/item/fields/{id}`. Does not open the CM1 editor (`?view=editor`). Rich controls (TinyMCE, binary) are not in this slice. |
 | **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -527,7 +527,7 @@ Explorer **Edit** uses itemmanagement field maps (same `PSContentItem` store as 
 |--------|------|---------|
 | `GET` | `/services/itemmanagement/item/fields/{id}` | Scalar fields for the React editor (`sys_*` except `sys_title` omitted; binary omitted) |
 | `PUT` | `/services/itemmanagement/item/fields/{id}` | Save scalar field updates. Item must be checked out to the current user. |
-| `POST` | `/services/itemmanagement/item/create` | Create an item in a folder (`contentType`, `folderPath`, optional `name`) for Explorer New Item |
+| `POST` | `/services/itemmanagement/item/create` | Create an item in a folder (`contentType`, `folderPath`, optional `name`, optional `templateId`). Pages (`percPage`) require `templateId` and save through page management. |
 
 Checkout / check-in remain `GET /services/itemmanagement/workflow/checkOut/{id}` and `…/checkIn/{id}`. Content-type labels come from `GET /services/contenttypes/{type}`.
 

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemCreateRequest.java
@@ -25,6 +25,8 @@ public class PSItemCreateRequest {
   private String contentType;
   private String folderPath;
   private String name;
+  /** Required when {@code contentType} is a page ({@code percPage}). */
+  private String templateId;
 
   public String getContentType() {
     return contentType;
@@ -48,5 +50,13 @@ public class PSItemCreateRequest {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public String getTemplateId() {
+    return templateId;
+  }
+
+  public void setTemplateId(String templateId) {
+    this.templateId = templateId;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupport.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupport.java
@@ -76,4 +76,30 @@ public final class PSItemCreateSupport {
     String n = contentType.replaceAll("[\\s_-]", "").toLowerCase();
     return n.equals("percpage") || n.equals("page");
   }
+
+  /**
+   * Site name from a CMS folder ({@code /Sites/Demo/...} or {@code //Sites/Demo/...}).
+   */
+  public static String siteNameFromFolderPath(String folderPath) {
+    if (StringUtils.isBlank(folderPath)) {
+      return null;
+    }
+    String p = folderPath.replace('\\', '/');
+    String[] parts = p.split("/");
+    for (int i = 0; i < parts.length; i++) {
+      if ("Sites".equalsIgnoreCase(parts[i]) && i + 1 < parts.length) {
+        String site = parts[i + 1].trim();
+        return site.isEmpty() ? null : site;
+      }
+    }
+    return null;
+  }
+
+  public static String titleFromItemName(String name) {
+    String base = StringUtils.defaultIfBlank(name, "New Page");
+    if (base.toLowerCase().endsWith(".html")) {
+      return base.substring(0, base.length() - 5);
+    }
+    return base;
+  }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -49,7 +49,9 @@ import com.percussion.itemmanagement.data.PSSoProMetadata;
 import com.percussion.itemmanagement.service.IPSItemService;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
 import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.data.PSPage;
 import com.percussion.pagemanagement.data.PSTemplateSummary;
+import com.percussion.pagemanagement.service.IPSPageService;
 import com.percussion.pagemanagement.service.IPSTemplateService;
 import com.percussion.pathmanagement.data.PSFolderPermission;
 import com.percussion.recycle.service.IPSRecycleService;
@@ -175,6 +177,7 @@ public class PSItemService implements IPSItemService {
   IPSPublisherService pubService;
   IPSManagedLinkDao linkService;
   @Autowired IPSPublishingWs publishingWs;
+  IPSPageService pageService;
   @Autowired IPSContentChangeService changeService;
   @Autowired IPSRelationshipService relationshipService;
   @Autowired private IPSRecycleService recycleService;
@@ -182,6 +185,12 @@ public class PSItemService implements IPSItemService {
   /** Package-visible for unit tests. */
   void setRecycleService(IPSRecycleService recycleService) {
     this.recycleService = recycleService;
+  }
+
+  @Autowired(required = false)
+  @Qualifier("pageService")
+  public void setPageService(IPSPageService pageService) {
+    this.pageService = pageService;
   }
 
   private SecureKeyRotationListener secureKeyRotationListener;
@@ -387,6 +396,9 @@ public class PSItemService implements IPSItemService {
         throw new PSItemServiceException("Select a folder before creating an item.");
       }
       String name = PSItemCreateSupport.sanitizeItemName(req.getName(), req.getContentType());
+      if (PSItemCreateSupport.isPageType(req.getContentType())) {
+        return createPageItem(req.getContentType().trim(), folder, name, req.getTemplateId());
+      }
       PSContentItem item = new PSContentItem();
       item.setType(req.getContentType().trim());
       item.setName(name);
@@ -404,6 +416,36 @@ public class PSItemService implements IPSItemService {
       throw e;
     } catch (Exception e) {
       throw new PSItemServiceException("Could not create the item.", e);
+    }
+  }
+
+  private PSItemCreateResult createPageItem(
+      String contentType, String folder, String name, String templateId)
+      throws PSItemServiceException {
+    if (pageService == null) {
+      throw new PSItemServiceException("Page service is not available.");
+    }
+    if (StringUtils.isBlank(templateId)) {
+      throw new PSItemServiceException("A page template is required.");
+    }
+    try {
+      String title = PSItemCreateSupport.titleFromItemName(name);
+      PSPage page = new PSPage();
+      page.setName(name);
+      page.setTitle(title);
+      page.setLinkTitle(title);
+      page.setTemplateId(templateId.trim());
+      page.setFolderPath(folder);
+      page.setAddToRecent(true);
+      PSPage saved = pageService.save(page);
+      if (saved == null || StringUtils.isBlank(saved.getId())) {
+        throw new PSItemServiceException("Create succeeded but no page id was returned.");
+      }
+      return new PSItemCreateResult(saved.getId(), folder, name, contentType);
+    } catch (PSItemServiceException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSItemServiceException("Could not create the page.", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupportTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemCreateSupportTest.java
@@ -50,4 +50,18 @@ class PSItemCreateSupportTest {
     assertTrue(PSItemCreateSupport.isPageType("perc_page"));
     assertFalse(PSItemCreateSupport.isPageType("rffEvent"));
   }
+
+  @Test
+  void siteNameFromFolderPath() {
+    assertEquals("Demo", PSItemCreateSupport.siteNameFromFolderPath("/Sites/Demo/Home"));
+    assertEquals("Demo", PSItemCreateSupport.siteNameFromFolderPath("//Sites/Demo"));
+    assertNull(PSItemCreateSupport.siteNameFromFolderPath("/Folders/Assets"));
+  }
+
+  @Test
+  void titleFromItemNameStripsHtmlSuffix() {
+    assertEquals("New Page", PSItemCreateSupport.titleFromItemName("New Page.html"));
+    assertEquals("About", PSItemCreateSupport.titleFromItemName("About"));
+    assertEquals("New Page", PSItemCreateSupport.titleFromItemName(null));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemServiceCreatePageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemServiceCreatePageTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.data.PSItemCreateRequest;
+import com.percussion.itemmanagement.service.IPSItemService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.data.PSPage;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.services.linkmanagement.IPSManagedLinkDao;
+import com.percussion.services.notification.IPSNotificationService;
+import com.percussion.services.publisher.IPSPublisherService;
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.useritems.IPSUserItemsDao;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.webservices.content.IPSContentWs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class PSItemServiceCreatePageTest {
+
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSSystemService systemService;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSWidgetAssetRelationshipService waRelService;
+  @Mock private IPSItemWorkflowService itemWfService;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSContentItemDao contentItemDao;
+  @Mock private IPSAssetDao assetDao;
+  @Mock private IPSTemplateService templateService;
+  @Mock private IPSUserItemsDao userItemDao;
+  @Mock private IPSNotificationService notificationService;
+  @Mock private IPSPublisherService pubService;
+  @Mock private IPSManagedLinkDao linkService;
+  @Mock private IPSPageService pageService;
+
+  private PSItemService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSItemService(
+            idMapper,
+            systemService,
+            workflowHelper,
+            contentWs,
+            waRelService,
+            itemWfService,
+            folderHelper,
+            contentItemDao,
+            assetDao,
+            templateService,
+            userItemDao,
+            notificationService,
+            pubService,
+            linkService);
+    service.setPageService(pageService);
+  }
+
+  @Test
+  void createPageRequiresTemplate() {
+    PSItemCreateRequest req = new PSItemCreateRequest();
+    req.setContentType("percPage");
+    req.setFolderPath("/Sites/Demo");
+    IPSItemService.PSItemServiceException ex =
+        assertThrows(
+            IPSItemService.PSItemServiceException.class, () -> service.createEditorItem(req));
+    assertTrue(ex.getMessage().contains("template"));
+  }
+
+  @Test
+  void createPageUsesPageService() throws Exception {
+    PSPage saved = new PSPage();
+    saved.setId("1-101-88");
+    when(pageService.save(any(PSPage.class))).thenReturn(saved);
+
+    PSItemCreateRequest req = new PSItemCreateRequest();
+    req.setContentType("percPage");
+    req.setFolderPath("/Sites/Demo");
+    req.setTemplateId("tpl-1");
+    req.setName("About");
+
+    var result = service.createEditorItem(req);
+    assertEquals("1-101-88", result.getItemId());
+    assertEquals("percPage", result.getContentType());
+
+    ArgumentCaptor<PSPage> cap = ArgumentCaptor.forClass(PSPage.class);
+    verify(pageService).save(cap.capture());
+    assertEquals("About.html", cap.getValue().getName());
+    assertEquals("About", cap.getValue().getTitle());
+    assertEquals("About", cap.getValue().getLinkTitle());
+    assertEquals("tpl-1", cap.getValue().getTemplateId());
+    assertEquals("//Sites/Demo", cap.getValue().getFolderPath());
+  }
+
+  @Test
+  void createPageRequiresPageService() {
+    service.setPageService(null);
+    PSItemCreateRequest req = new PSItemCreateRequest();
+    req.setContentType("percPage");
+    req.setFolderPath("/Sites/Demo");
+    req.setTemplateId("tpl-1");
+    IPSItemService.PSItemServiceException ex =
+        assertThrows(
+            IPSItemService.PSItemServiceException.class, () -> service.createEditorItem(req));
+    assertTrue(ex.getMessage().contains("Page service"));
+  }
+}

--- a/specs/992-react-content-explorer/contracts/action-execution.md
+++ b/specs/992-react-content-explorer/contracts/action-execution.md
@@ -23,7 +23,7 @@ Desktop Content Explorer is **not** a 8.2 client. Do not dual-ship HTML for DCE.
 | `client` | Existing Explorer handlers (open, folder ops, workflow-transition, default preview) |
 | `rest` | Public REST (preview-location, types, transitions, purge, publish) |
 | `editor` | Named actions (`Edit`, `View_Content`, …) open the React editor host (`specs/995-react-content-editor`). Leftover CE URLs stay unavailable. |
-| `unavailable` | Slot arrange. New Item type children are `rest` (create + editor). Active Assembly parents are `rest` (996 preview host) |
+| `unavailable` | Slot arrange. New Item type children are `rest` (create + editor; `percPage` picks a template first). Active Assembly parents are `rest` (996 preview host) |
 | `legacy-file` | Non-app file (e.g. `.xls`) via same-origin `safeNavigate` |
 
 Presentation (`ActionToolbar` / `ContextMenu`) **always** calls `onInvoke`. It never `safeNavigate`s.

--- a/specs/995-react-content-editor/spec.md
+++ b/specs/995-react-content-editor/spec.md
@@ -26,11 +26,11 @@ New window (peer of Active Assembly):
 5. Labels from `GET /services/contenttypes/{type}`
 6. Save + Check In (existing checkIn REST)
 7. **New Item** — type under New creates in the current folder (`POST /item/create`) and opens this editor
+8. **percPage template** — load allowed templates (content type, then site); one template is used automatically; more than one opens a picker; `POST /item/create` includes `templateId`; server saves through `IPSPageService`
 
 ## Later
 
 - TinyMCE / file / image / keyword / community controls
-- Default template picker when creating `percPage`
 - AA contenteditable overlay on the assembled preview
 - Revision promote form
 - Home / TopNav still use leftover `?view=editor` until those shells switch


### PR DESCRIPTION
## Summary

Follow-on to [#3453](https://github.com/intersoftdatalabs-in/percussioncms/pull/3453). Explorer **New Item** for `percPage` loads allowed templates (content type, then the site's templates), uses one automatically, or opens **Choose a page template**. Create POSTs `templateId` and `PSItemService` saves through `IPSPageService` instead of a bare content item. Cancel leaves the folder unchanged. If no template is available, Explorer asks the user to pick a site folder or use Home → Create.

Does not open leftover Content Editor HTML or CM1 `?view=editor`.

Depends on #3453 (already on main).

## Test plan

1. `cd projects/sitemanage` then `..\..\mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1266, Failures: 0.
2. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2540 passed.
3. Explorer: select a site folder → New → percPage. If the type has more than one template, the picker appears; Cancel must not create. A single template creates and opens the editor.
4. Confirm no `rx_ce` / `contenteditorurls.html` request.

## Checklist

- [x] **Product documentation** — New Item row + REST `templateId` on create
- [x] **Unit / module tests** — page-service save, template load/pick/cancel, picker dialog
- [x] **WebUI + Playwright** — percPage picker cancel on `explorer-content-editor.spec.js`
- [x] **Build gates** — sitemanage + WebUI standalone clean install
- [x] **Cross-platform** — CMS folder paths use `/` (not OS file I/O)

Erlang: `docs/ai-generated/code-reviews/explorer-new-item-page-template-erlang.md` (approve).

> Co-Authored by Grok Build TUI using grok-4.6 with agent Grok 4.6