### PR TITLE
fix(explorer): Preview opens for a listed page (#3456)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/previewItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/previewItem.ts
@@ -132,6 +132,21 @@ function typeToken(item: PSPathItem): string {
   return `${item.type ?? ""} ${item.category ?? ""}`.toLowerCase();
 }
 
+/** Stock asset type names — not {@code category: ASSET} (see {@link resolvePreviewKind}). */
+const ASSET_PREVIEW_TYPE_KEYS = new Set([
+  "asset",
+  "percasset",
+  "rffimage",
+  "rfffile",
+]);
+
+function isAssetPreviewType(pathLower: string, typeOnly: string): boolean {
+  if (ASSET_PREVIEW_TYPE_KEYS.has(typeOnly)) {
+    return true;
+  }
+  return pathLower.startsWith("/assets/") || pathLower === "/assets";
+}
+
 /**
  * Classify whether Explorer can open a product preview for this selection.
  */
@@ -140,13 +155,16 @@ export function resolvePreviewKind(item: PSPathItem | null | undefined): Preview
     return "none";
   }
   const token = typeToken(item);
+  const typeOnly = (item.type ?? "").trim().toLowerCase();
   const path = normalizeCmsPath(item.path);
   const pathLower = path.toLowerCase();
   const hasId = Boolean((item.id ?? "").trim());
 
-  // Listed percPage / Page rows win over folder heuristics (#3456).
+  // Listed percPage / Page / customer items win over folder heuristics (#3456).
+  // Do not use category ASSET for kind: the server defaults every non-percPage
+  // item (including FastForward pages and customer types) to ASSET.
   if (isPageOrAssetContentType(item) && !token.includes("folder")) {
-    if (token.includes("asset")) {
+    if (isAssetPreviewType(pathLower, typeOnly)) {
       return hasId ? "asset" : "none";
     }
     if (hasId || pathLower.startsWith("/sites/")) {
@@ -158,11 +176,7 @@ export function resolvePreviewKind(item: PSPathItem | null | undefined): Preview
     return "none";
   }
 
-  if (
-    token.includes("asset") ||
-    pathLower.startsWith("/assets/") ||
-    pathLower.startsWith("/assets")
-  ) {
+  if (isAssetPreviewType(pathLower, typeOnly)) {
     // Need an id for the assetViewUrl service.
     return hasId ? "asset" : "none";
   }

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -44,14 +44,34 @@ export const EMPTY_SELECTION: Selection = {
 const FOLDER_TYPE_KEYS = new Set(["folder", "fsfolder", "site"]);
 
 /**
- * Exact {@code type} / {@code category} tokens that are previewable items.
- * Substring {@code includes("page")} would also match {@code pagination}
- * / {@code pagebreak} / {@code pagelet}; {@code includes("asset")} would
- * match {@code assetmanagement} (#3456 review). FastForward items are an
- * explicit allowlist — a prefix {@code rff*} would treat a future
- * folder-like type ({@code rffSection}, {@code rffCategory}) as previewable
- * (#3456 review). Nav types {@code rffNavon} / {@code rffNavTree} are
- * omitted on purpose.
+ * Server {@link IPSItemSummary.Category} values that are folders / nav.
+ * Stable across customer content-type names (#3456).
+ */
+const FOLDER_CATEGORY_KEYS = new Set([
+  "folder",
+  "site",
+  "section_folder",
+  "external_section_folder",
+  "system",
+]);
+
+/**
+ * Server categories that are workflowed items. {@code PSItemSummaryService}
+ * sets {@code PAGE} only for {@code percPage}, {@code LANDING_PAGE} for
+ * landing pages, and defaults every other non-folder / non-nav type
+ * (FastForward, customer types, assets) to {@code ASSET}.
+ */
+const ITEM_CATEGORY_KEYS = new Set([
+  "page",
+  "asset",
+  "landing_page",
+  "resource",
+]);
+
+/**
+ * Stock / FastForward {@code type} names used when {@code category} is
+ * omitted on a paginated row. Customer types are <em>not</em> listed —
+ * those names are not stable after upgrade (#3456).
  */
 const PAGE_OR_ASSET_TYPE_KEYS = new Set([
   "page",
@@ -73,33 +93,57 @@ const PAGE_OR_ASSET_TYPE_KEYS = new Set([
   "rffnavimage",
 ]);
 
+/** FastForward nav types are folder-like, not previewable items. */
+const RFF_NAV_TYPE_KEYS = new Set(["rffnavon", "rffnavtree"]);
+
+function folderTypeOrCategory(type: string, category: string): boolean {
+  return (
+    FOLDER_TYPE_KEYS.has(type) ||
+    FOLDER_CATEGORY_KEYS.has(category) ||
+    RFF_NAV_TYPE_KEYS.has(type) ||
+    RFF_NAV_TYPE_KEYS.has(category)
+  );
+}
+
 /**
- * Content types that are previewable items, not folders. Pathmanagement
- * lists FastForward pages as {@code percPage} / {@code Page}; those must
- * stay items even when {@code leaf} is omitted or {@code hasFolderChildren}
- * is set on a paginated row (#3456 / #2745).
+ * Content types that are previewable items, not folders.
+ *
+ * <p>Prefer {@code category} (object class) over {@code type} (content-type
+ * name). Customers define their own types and templates; those names are
+ * not consistent after upgrade outside FastForward (#3456). Pathmanagement
+ * lists {@code percPage} / {@code Page} / customer items even when
+ * {@code leaf} is omitted or {@code hasFolderChildren} is set (#2745).</p>
  */
 export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   if (!item) return false;
   const type = (item.type ?? "").trim().toLowerCase();
   const category = (item.category ?? "").trim().toLowerCase();
-  return PAGE_OR_ASSET_TYPE_KEYS.has(type) || PAGE_OR_ASSET_TYPE_KEYS.has(category);
+  if (folderTypeOrCategory(type, category)) {
+    return false;
+  }
+  if (ITEM_CATEGORY_KEYS.has(category)) {
+    return true;
+  }
+  if (PAGE_OR_ASSET_TYPE_KEYS.has(type) || PAGE_OR_ASSET_TYPE_KEYS.has(category)) {
+    return true;
+  }
+  // Customer / legacy type name: any non-folder type is an item.
+  return type.length > 0;
 }
 
 export function isFolder(item: PSPathItem | null): boolean {
   if (!item) return false;
   const type = (item.type ?? "").trim().toLowerCase();
-  if (FOLDER_TYPE_KEYS.has(type)) return true;
   const category = (item.category ?? "").trim().toLowerCase();
-  if (category === "folder") return true;
-  // Listed percPage / Page / rffHome / asset rows are never folders (#3456).
+  if (folderTypeOrCategory(type, category)) return true;
+  // Listed percPage / Page / rffHome / customer items are never folders (#3456).
   if (isPageOrAssetContentType(item)) return false;
   // Server PSPathItem.setPath appends '/' only for folders. $System$ and
   // similar under /Folders/ may omit type but still use a folder path (#3330).
   const path = (item.path ?? "").trim();
   if (path.endsWith("/")) return true;
-  // Do not treat every id'd /Sites/ path as an item — custom folder types
-  // with an id and no trailing slash stay folders via leaf / children.
+  // Untyped rows: leaf / children. Customer types with a name already
+  // returned above via {@link isPageOrAssetContentType}.
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
   return Boolean(item.hasFolderChildren);

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -47,7 +47,11 @@ const FOLDER_TYPE_KEYS = new Set(["folder", "fsfolder", "site"]);
  * Exact {@code type} / {@code category} tokens that are previewable items.
  * Substring {@code includes("page")} would also match {@code pagination}
  * / {@code pagebreak} / {@code pagelet}; {@code includes("asset")} would
- * match {@code assetmanagement} (#3456 review).
+ * match {@code assetmanagement} (#3456 review). FastForward items are an
+ * explicit allowlist — a prefix {@code rff*} would treat a future
+ * folder-like type ({@code rffSection}, {@code rffCategory}) as previewable
+ * (#3456 review). Nav types {@code rffNavon} / {@code rffNavTree} are
+ * omitted on purpose.
  */
 const PAGE_OR_ASSET_TYPE_KEYS = new Set([
   "page",
@@ -55,10 +59,19 @@ const PAGE_OR_ASSET_TYPE_KEYS = new Set([
   "percasset",
   "asset",
   "rffhome",
+  "rffevent",
+  "rffimage",
+  "rfffile",
+  "rffgeneric",
+  "rffgenericword",
+  "rffbrief",
+  "rffcalendar",
+  "rffcontacts",
+  "rffpressrelease",
+  "rffexternallink",
+  "rffautoindex",
+  "rffnavimage",
 ]);
-
-/** FastForward nav types are folder-like, not previewable items. */
-const RFF_NAV_TYPE_KEYS = new Set(["rffnavon", "rffnavtree"]);
 
 /**
  * Content types that are previewable items, not folders. Pathmanagement
@@ -70,13 +83,7 @@ export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   if (!item) return false;
   const type = (item.type ?? "").trim().toLowerCase();
   const category = (item.category ?? "").trim().toLowerCase();
-  if (PAGE_OR_ASSET_TYPE_KEYS.has(type) || PAGE_OR_ASSET_TYPE_KEYS.has(category)) {
-    return true;
-  }
-  // Other FastForward content items (rffEvent, rffImage, …) are items.
-  if (type.startsWith("rff") && !RFF_NAV_TYPE_KEYS.has(type)) return true;
-  if (category.startsWith("rff") && !RFF_NAV_TYPE_KEYS.has(category)) return true;
-  return false;
+  return PAGE_OR_ASSET_TYPE_KEYS.has(type) || PAGE_OR_ASSET_TYPE_KEYS.has(category);
 }
 
 export function isFolder(item: PSPathItem | null): boolean {

--- a/WebUI/src/test/ts/contentExplorer/previewItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/previewItem.test.ts
@@ -133,6 +133,17 @@ describe("previewItem pure helpers (#2733)", () => {
       }),
     ).toBe(true);
     expect(
+      resolvePreviewKind({
+        id: "16777215-101-88",
+        name: "Q3 Brief",
+        path: "/Sites/Demo/Pages/Q3 Brief",
+        type: "NewsArticle",
+        category: "ASSET",
+        leaf: false,
+        hasFolderChildren: true,
+      }),
+    ).toBe("page");
+    expect(
       resolvePreviewTarget(
         { name: "Home", path: "/Sites/Demo/Home", type: "Page" },
         "/services",

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -154,67 +154,61 @@ describe("isFolder (#3001 site nodes)", () => {
       isPageOrAssetContentType({
         name: "Section",
         path: "/Sites/Demo/Section",
-        type: "rffSection",
+        type: "rffNavon",
+        category: "SECTION_FOLDER",
       }),
     ).toBe(false);
+  });
+
+  it("treats customer-defined types as items without a name allowlist (#3456)", () => {
+    const custom: PSPathItem = {
+      id: "16777215-101-88",
+      name: "Q3 Brief",
+      path: "/Sites/Demo/Pages/Q3 Brief",
+      type: "NewsArticle",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    expect(isPageOrAssetContentType(custom)).toBe(true);
+    expect(isFolder(custom)).toBe(false);
     expect(
       isPageOrAssetContentType({
-        name: "Category",
-        path: "/Sites/Demo/Category",
-        type: "rffCategory",
+        id: "16777215-101-89",
+        name: "Widget",
+        path: "/Sites/Demo/Products/Widget",
+        type: "CI_products",
+        category: "ASSET",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
-      isFolder({
-        id: "16777215-101-30",
-        name: "Section",
-        path: "/Sites/Demo/Section",
-        type: "rffSection",
-        leaf: false,
+      isPageOrAssetContentType({
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "CustomLanding",
+        category: "LANDING_PAGE",
       }),
     ).toBe(true);
   });
 
-  it("rejects pagination/pagebreak/pagelet/assetmanagement as page or asset types", () => {
-    expect(
-      isPageOrAssetContentType({
-        name: "p",
-        path: "/Sites/Demo/pagination",
-        type: "pagination",
-      }),
-    ).toBe(false);
-    expect(
-      isPageOrAssetContentType({
-        name: "p",
-        path: "/Sites/Demo/pagebreak",
-        type: "pagebreak",
-      }),
-    ).toBe(false);
-    expect(
-      isPageOrAssetContentType({
-        name: "p",
-        path: "/Sites/Demo/pagelet",
-        type: "pagelet",
-      }),
-    ).toBe(false);
-    expect(
-      isPageOrAssetContentType({
-        name: "a",
-        path: "/Sites/Demo/assetmanagement",
-        type: "assetmanagement",
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps custom folder types under /Sites/ as folders when leaf is false", () => {
+  it("keeps server folder categories as folders even with a customer type name", () => {
     expect(
       isFolder({
         id: "16777215-101-20",
         name: "Campaigns",
         path: "/Sites/Demo/Campaigns",
         type: "CampaignFolder",
+        category: "FOLDER",
         leaf: false,
       }),
     ).toBe(true);
+    expect(
+      isPageOrAssetContentType({
+        id: "16777215-101-20",
+        name: "Campaigns",
+        path: "/Sites/Demo/Campaigns",
+        type: "CampaignFolder",
+        category: "FOLDER",
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -121,6 +121,60 @@ describe("isFolder (#3001 site nodes)", () => {
     ).toBe(false);
   });
 
+  it("allows known FastForward item types and rejects nav / folder-like rff types", () => {
+    expect(
+      isPageOrAssetContentType({
+        name: "Event",
+        path: "/Sites/Demo/Events/Open House",
+        type: "rffEvent",
+      }),
+    ).toBe(true);
+    expect(
+      isPageOrAssetContentType({
+        name: "Photo",
+        path: "/Sites/Demo/Assets/photo",
+        type: "rffImage",
+      }),
+    ).toBe(true);
+    expect(
+      isPageOrAssetContentType({
+        name: "Section",
+        path: "/Sites/Demo/Section",
+        type: "rffNavon",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "Nav",
+        path: "/Sites/Demo/Nav",
+        type: "rffNavTree",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "Section",
+        path: "/Sites/Demo/Section",
+        type: "rffSection",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "Category",
+        path: "/Sites/Demo/Category",
+        type: "rffCategory",
+      }),
+    ).toBe(false);
+    expect(
+      isFolder({
+        id: "16777215-101-30",
+        name: "Section",
+        path: "/Sites/Demo/Section",
+        type: "rffSection",
+        leaf: false,
+      }),
+    ).toBe(true);
+  });
+
   it("rejects pagination/pagebreak/pagelet/assetmanagement as page or asset types", () => {
     expect(
       isPageOrAssetContentType({

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -141,8 +141,21 @@ function isListedPageRow(row) {
   ) {
     return false;
   }
-  if (token.includes("page") || token.includes("rffhome")) return true;
+  if (token.includes("page") || token.includes("rffhome") || token.includes("landing_page")) {
+    return true;
+  }
   if (path.includes("/pages/") && Boolean(row.id)) return true;
+  // Customer types keep their own names after upgrade (#3456).
+  const type = String(row.type || "").trim().toLowerCase();
+  if (
+    Boolean(row.id) &&
+    path.includes("/sites/") &&
+    type.length > 0 &&
+    type !== "asset" &&
+    type !== "percasset"
+  ) {
+    return true;
+  }
   return false;
 }
 

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -113,6 +113,15 @@ describe("explorer-preview-view helpers (#2733)", () => {
       isListedPageRow({ type: "site", path: "/Sites/D/" }),
       false,
     );
+    assert.equal(
+      isListedPageRow({
+        type: "NewsArticle",
+        category: "ASSET",
+        path: "/Sites/Demo/Pages/Q3 Brief",
+        id: "16777215-101-88",
+      }),
+      true,
+    );
   });
 
   it("unwrapPathItems reads PathItem and PagedItemList children", () => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -117,7 +117,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 
 | Action | What happens |
 |--------|----------------|
-| **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. New language: **template**, not variant. |
+| **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. Applies to listed pages and assets, including customer-defined content types (type names are not a closed list; FastForward names stay stable). New language: **template**, not variant. |
 | **New Item** | Choose a content type under **New**. Explorer creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. Does not open leftover Content Editor HTML. **Pages** (`percPage`) need a page template. Explorer loads allowed templates for the type, then the site's templates when the type has none. One template is used automatically; more than one opens **Choose a page template**. Cancel leaves the folder unchanged. If no template is available, Explorer asks you to pick a site folder or use Home → Create. |
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |


### PR DESCRIPTION
## Summary

Parent **#2745** slice 2 (human QA never reached Preview because Pages was empty). After a page row exists, Explorer **Preview** (`action-preview`) must enable and open product preview.

This change treats listed FastForward/page content types (`percPage`, `Page`, `rffHome`) as previewable items even when paginated rows omit `leaf` or set `hasFolderChildren`. Folder / site types stay Preview-disabled. Detail rows expose `data-previewable` / `data-item-type`. Playwright walks Sites → site → Pages via REST `folderPath` and asserts Preview opens; it does **not** skip solely because the Sites-root list is folders.

Out of scope: listing seed (**#3457** / PR #3460) and console 404/400 (**#3458**).

Fixes #3456  
Parent: #2745

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd WebUI && ../mvnw clean install` — BUILD SUCCESS, Vitest Tests 2550 passed.
2. Standalone `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS; `npm run test:unit` 282 pass (includes explorer-preview-view helpers).
3. After a cell that lists at least one page (H2 with #3457 listing, or demo-sites Pages children): Explorer → Sites → sample site → Pages (or site-root listed page) → select page → **Preview** enabled → click opens preview (page render, site-path, or FastForward `sys_command=preview`).
4. Select a folder row (`data-row-kind=folder`, `data-previewable=false`) → Preview stays disabled.
5. Playwright: `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/explorer-preview-view.spec.js`

## Checklist

- [x] **Product documentation** — N/A (operator Preview steps unchanged; `product-docs/8.2/admin/content-explorer.md` already documents Preview)
- [x] **Unit / module tests** — Vitest enablement + URL (`previewItem`, `selection`, `ReducedActions`, `DetailList`, shell); Playwright helpers + surface spec
- [x] **WebUI + Playwright** — `tests/explorer-preview-view.spec.js` (2 passed, 0 skipped on H2 with listing available)
- [x] **Build gates** — WebUI + perc-qa-automation standalone `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — N/A (CMS `/` repository paths only; no OS file I/O)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS, Test Files 337 passed, Tests 2550 passed; Java Tests run: 61, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS; `npm run test:unit` 282 pass
- **downstream_checked:** none — no `final`/`sealed` or public signature break; additive `isPageOrAssetContentType` helper only

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2` published `http://127.0.0.1:9993` (HEALTH=healthy, HTTP 200). qa-up/qa-health `RESULT:FAIL DETAIL:server_log_errors` on **pre-existing** FastForward binary import / content type 315 (`CI_PS_products_on.gif` / `binarythumb.jpg`). Not `Failed startup of context`.
- Hot-copied `WebUI/target/generated-webui/cm/modern/assets/` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (no docker restart).
- Listing on the cell used a **temporary** in-cell sitemanage hot-deploy from sibling #3457 (not shipped in this PR). After StopJetty/StartJetty, HEALTH=healthy, HTTP 200; `GET …/paginatedFolder/Sites/CorporateInvestments/Pages` returned `rffHome` “Corporate Investments Home”.
- `TEST_CMS_URL=http://127.0.0.1:9993` `npm run test:surface -- --path tests/explorer-preview-view.spec.js` → **2 passed**, 0 skipped (chrome + Preview open + folder disabled).
- console-clean=yes (pageerror listeners empty)
- server.log-clean=no (pre-existing FastForward import / ctype 315 ERROR; no new feature-related ERROR)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
