### PR TITLE
feat(webui): Home and TopNav open the React editor

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -466,15 +466,52 @@ export async function createPage(req: CreatePageRequest): Promise<unknown> {
   return post(PATHS.PAGE_CREATE, body);
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/** Page id from {@code POST /pagemanagement/page} (Jackson Page root). */
+export function unwrapCreatedPageId(payload: unknown): string | null {
+  const root = asRecord(payload);
+  const page = asRecord(root?.Page ?? root?.page) ?? root;
+  if (!page) {
+    return null;
+  }
+  const id = page.id ?? page.Id;
+  const s = id != null ? String(id).trim() : "";
+  return s || null;
+}
+
+export interface CreatedPage {
+  path: string;
+  itemId: string | null;
+}
+
+/**
+ * Create a page and return folder path plus item id when the save response
+ * includes one.
+ */
+export async function createPageAndItem(
+  req: CreatePageRequest,
+): Promise<CreatedPage> {
+  const name = ensurePageFileName(req.name);
+  const payload = await createPage({ ...req, name });
+  return {
+    path: joinFolderAndName(req.folderPath, name),
+    itemId: unwrapCreatedPageId(payload),
+  };
+}
+
 /**
  * Create page then return full item path for open (classic openPage after create).
  */
 export async function createPageAndPath(
   req: CreatePageRequest,
 ): Promise<string> {
-  const name = ensurePageFileName(req.name);
-  await createPage({ ...req, name });
-  return joinFolderAndName(req.folderPath, name);
+  return (await createPageAndItem(req)).path;
 }
 
 /**

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -89,14 +89,14 @@ export function TopNav(): React.ReactElement {
             case "editor":
               return (
                 <li key={id}>
-                  <a
-                    className={styles.navLink}
-                    href="/cm/app/?view=editor"
+                  <NavLink
+                    to="/editor"
+                    className={linkClass}
                     data-testid="nav-editor"
                     {...i18nKeyAttr(MSG.NAV_EDITOR)}
                   >
                     {message(MSG.NAV_EDITOR)}
-                  </a>
+                  </NavLink>
                 </li>
               );
             case "architecture":

--- a/WebUI/src/main/ts/editor/messages.ts
+++ b/WebUI/src/main/ts/editor/messages.ts
@@ -22,7 +22,8 @@ export const EDITOR_MSG = {
   CONTENT_ID: "perc.ui.editor@Content",
   TYPE_LABEL: "perc.ui.editor@Type",
   CHECKOUT: "perc.ui.editor@Checked out to",
-  MISSING_ITEM: "perc.ui.editor@Open Edit from Explorer with a content item selected.",
+  MISSING_ITEM:
+    "perc.ui.editor@Open an item from Explorer or Home, or create one from Home → Create.",
   LOADING: "perc.ui.editor@Loading item fields…",
   LOAD_FAILED: "perc.ui.editor@Could not load this item for editing.",
   SAVE: "perc.ui.editor@Save",

--- a/WebUI/src/main/ts/editor/openEditorHost.ts
+++ b/WebUI/src/main/ts/editor/openEditorHost.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findItemByPath } from "../api/contentExplorer/pathApi";
+import { parseExplorerContentId } from "../contentExplorer/menuCatalogLoad";
+import {
+  EDITOR_WINDOW_FEATURES,
+  buildEditorHostUrl,
+  editorWindowName,
+  type EditorHostMode,
+} from "./editorHostUrl";
+
+export interface OpenEditorHostInput {
+  id?: string | number | null;
+  path?: string | null;
+  mode?: EditorHostMode;
+}
+
+export interface OpenEditorHostDeps {
+  openWindow?: (
+    url: string,
+    target?: string,
+    features?: string,
+  ) => Window | null;
+  findByPath?: (path: string) => Promise<{ id?: string | number }>;
+}
+
+function defaultOpenWindow(
+  url: string,
+  target?: string,
+  features?: string,
+): Window | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.open(url, target, features);
+}
+
+/**
+ * Open the React Content Editor host for an item id or CMS path.
+ * Does not navigate to leftover {@code ?view=editor}.
+ */
+export async function openEditorHost(
+  input: OpenEditorHostInput,
+  deps: OpenEditorHostDeps = {},
+): Promise<boolean> {
+  let contentId = parseExplorerContentId(input.id ?? undefined);
+  const path = input.path != null ? String(input.path).trim() : "";
+  if (contentId == null && path) {
+    const findByPath = deps.findByPath ?? findItemByPath;
+    try {
+      const item = await findByPath(path);
+      contentId = parseExplorerContentId(item?.id);
+    } catch {
+      return false;
+    }
+  }
+  if (contentId == null) {
+    return false;
+  }
+  const open = deps.openWindow ?? defaultOpenWindow;
+  open(
+    buildEditorHostUrl(contentId, input.mode ?? "edit"),
+    editorWindowName(contentId),
+    EDITOR_WINDOW_FEATURES,
+  );
+  return true;
+}

--- a/WebUI/src/main/ts/editor/openEditorHost.ts
+++ b/WebUI/src/main/ts/editor/openEditorHost.ts
@@ -72,11 +72,10 @@ export async function openEditorHost(
   if (contentId == null) {
     return false;
   }
-  const open = deps.openWindow ?? defaultOpenWindow;
-  open(
+  const opened = (deps.openWindow ?? defaultOpenWindow)(
     buildEditorHostUrl(contentId, input.mode ?? "edit"),
     editorWindowName(contentId),
     EDITOR_WINDOW_FEATURES,
   );
-  return true;
+  return opened != null;
 }

--- a/WebUI/src/main/ts/home/HomeShell.tsx
+++ b/WebUI/src/main/ts/home/HomeShell.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { contentItemId } from "../api/home/homeApi";
 import type { ContentListItem } from "../api/home/types";
+import { isFolder } from "../contentExplorer/selection";
+import { openEditorHost } from "../editor/openEditorHost";
 import { message, MSG } from "../i18n/message";
 import {
   mapInitialScreenToSection,
@@ -75,26 +78,31 @@ const SECTIONS: { id: HomeSection; key: string }[] = [
 ];
 
 /**
- * Open content using path-first navigation (classic openPathItem style).
- * Falls back to id when path is absent.
+ * Open content in the React editor host (id first, then CMS path).
+ * Folders stay on Home. Does not navigate to leftover {@code ?view=editor}.
  */
-function defaultOpenItem(item: ContentListItem): void {
-  const path = item.path != null ? String(item.path).trim() : "";
-  const id = item.id != null ? String(item.id) : "";
-  if (path) {
-    // Editor view accepts path; product navigation historically opened by path
-    window.location.href = `/cm/app/?view=editor&path=${encodeURIComponent(path)}`;
+export function openHomeItem(item: ContentListItem): void {
+  if (
+    item.folder === true ||
+    isFolder({
+      name: item.name ?? "",
+      path: item.path ?? "",
+      type: item.type,
+      id: item.id,
+    })
+  ) {
     return;
   }
-  if (id) {
-    window.location.href = `/cm/app/?view=editor&id=${encodeURIComponent(id)}`;
-  }
+  void openEditorHost({
+    id: contentItemId(item),
+    path: item.path != null ? String(item.path) : null,
+  });
 }
 
 function HomeShellBody({
   initialSection,
   isAdmin = false,
-  onOpenItem = defaultOpenItem,
+  onOpenItem = openHomeItem,
   onSectionChange,
 }: Omit<HomeShellProps, "embedded">): React.ReactElement {
   const start = useMemo(

--- a/WebUI/src/main/ts/home/create/BlogWizard.tsx
+++ b/WebUI/src/main/ts/home/create/BlogWizard.tsx
@@ -18,11 +18,12 @@
 import React, { useEffect, useState } from "react";
 import { isSessionRedirectError } from "../../api/client";
 import {
-  createPageAndPath,
+  createPageAndItem,
   fetchAllBlogs,
   formatApiError,
 } from "../../api/home/homeApi";
 import type { BlogSummary } from "../../api/home/types";
+import { openEditorHost } from "../../editor/openEditorHost";
 import { message, MSG } from "../../i18n/message";
 import {
   actionButtonStyle,
@@ -36,10 +37,14 @@ import {
 
 export interface BlogWizardProps {
   onBack: () => void;
+  openCreated?: typeof openEditorHost;
 }
 
 /** Classic blog post create = createPage with blog template + folder. */
-export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
+export function BlogWizard({
+  onBack,
+  openCreated = openEditorHost,
+}: BlogWizardProps): React.ReactElement {
   const [blogs, setBlogs] = useState<BlogSummary[]>([]);
   const [blogKey, setBlogKey] = useState("");
   const [title, setTitle] = useState("");
@@ -94,14 +99,20 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
     }
     setBusy(true);
     try {
-      const fullPath = await createPageAndPath({
+      const created = await createPageAndItem({
         name: fileName,
         title,
         linkTitle: title,
         templateId: selected.templateId,
         folderPath: selected.folderPath,
       });
-      window.location.href = `/cm/app/?view=editor&path=${encodeURIComponent(fullPath)}`;
+      const opened = await openCreated({
+        id: created.itemId,
+        path: created.path,
+      });
+      if (!opened) {
+        setError(message(MSG.CREATE_OPEN_EDITOR_FAILED));
+      }
     } catch (err) {
       if (isSessionRedirectError(err)) {
         return;

--- a/WebUI/src/main/ts/home/create/PageWizard.tsx
+++ b/WebUI/src/main/ts/home/create/PageWizard.tsx
@@ -17,13 +17,14 @@
 
 import React, { useEffect, useState } from "react";
 import {
-  createPageAndPath,
+  createPageAndItem,
   fetchFolderChildren,
   fetchSites,
   fetchTemplatesForSite,
   formatApiError,
 } from "../../api/home/homeApi";
 import type { SiteSummary, TemplateSummary } from "../../api/home/types";
+import { openEditorHost } from "../../editor/openEditorHost";
 import { message, MSG } from "../../i18n/message";
 import {
   actionButtonStyle,
@@ -38,9 +39,13 @@ import { isSessionRedirectError } from "../../api/client";
 
 export interface PageWizardProps {
   onBack: () => void;
+  openCreated?: typeof openEditorHost;
 }
 
-export function PageWizard({ onBack }: PageWizardProps): React.ReactElement {
+export function PageWizard({
+  onBack,
+  openCreated = openEditorHost,
+}: PageWizardProps): React.ReactElement {
   const [sites, setSites] = useState<SiteSummary[]>([]);
   const [site, setSite] = useState("");
   const [templates, setTemplates] = useState<TemplateSummary[]>([]);
@@ -127,14 +132,20 @@ export function PageWizard({ onBack }: PageWizardProps): React.ReactElement {
     }
     setBusy(true);
     try {
-      const fullPath = await createPageAndPath({
+      const created = await createPageAndItem({
         name: fileName,
         title,
         linkTitle: title,
         templateId,
         folderPath,
       });
-      window.location.href = `/cm/app/?view=editor&path=${encodeURIComponent(fullPath)}`;
+      const opened = await openCreated({
+        id: created.itemId,
+        path: created.path,
+      });
+      if (!opened) {
+        setError(message(MSG.CREATE_OPEN_EDITOR_FAILED));
+      }
     } catch (err) {
       if (isSessionRedirectError(err)) {
         return;

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -149,6 +149,8 @@ export const MSG = {
   CREATE_VALIDATION: "perc.ui.home.modern@Create Validation",
   CREATE_FILE_TOO_LONG: "perc.ui.home.modern@File Name Too Long",
   CREATE_NOT_AUTHORIZED: "perc.ui.home.modern@Create Not Authorized",
+  CREATE_OPEN_EDITOR_FAILED:
+    "perc.ui.home.modern@The page was created but the editor could not open.",
   CREATE_NO_BLOGS:
     "perc.ui.home.modern@No blogs are configured. Create a blog section on a site first.",
   CREATE_NO_ASSET_TYPES: "perc.ui.home.modern@No asset types available",

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -86,6 +86,14 @@ describe("TopNav (#2702)", () => {
     expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
   });
 
+  it("Editor is SPA NavLink to /editor and not leftover view=editor", () => {
+    renderNav();
+    const editor = screen.getByTestId("nav-editor");
+    const href = editor.getAttribute("href") || "";
+    expect(href === "/editor" || href.endsWith("/editor")).toBe(true);
+    expect(href).not.toMatch(/view=editor/);
+  });
+
   it("Architecture is SPA NavLink to /architecture (#3094)", () => {
     renderNav();
     const arch = screen.getByTestId("nav-architecture");

--- a/WebUI/src/test/ts/editor/EditorHost.test.tsx
+++ b/WebUI/src/test/ts/editor/EditorHost.test.tsx
@@ -49,7 +49,7 @@ describe("EditorHost", () => {
       </MemoryRouter>,
     );
     expect(screen.getByTestId("editor-overlay")).toBeTruthy();
-    expect(screen.getByTestId("editor-error").textContent).toMatch(/content item/i);
+    expect(screen.getByTestId("editor-error").textContent).toMatch(/Explorer or Home/i);
   });
 
   it("loads fields after checkout and saves edits", async () => {

--- a/WebUI/src/test/ts/editor/openEditorHost.test.ts
+++ b/WebUI/src/test/ts/editor/openEditorHost.test.ts
@@ -18,9 +18,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { openEditorHost } from "../../../main/ts/editor/openEditorHost";
 
+function popup(): Window {
+  return {} as Window;
+}
+
 describe("openEditorHost", () => {
   it("opens the React host from a numeric id", async () => {
-    const openWindow = vi.fn();
+    const openWindow = vi.fn().mockReturnValue(popup());
     const ok = await openEditorHost({ id: "55" }, { openWindow });
     expect(ok).toBe(true);
     expect(openWindow).toHaveBeenCalled();
@@ -31,7 +35,7 @@ describe("openEditorHost", () => {
   });
 
   it("resolves a CMS path when id is missing", async () => {
-    const openWindow = vi.fn();
+    const openWindow = vi.fn().mockReturnValue(popup());
     const findByPath = vi.fn().mockResolvedValue({ id: "1-101-88" });
     const ok = await openEditorHost(
       { path: "/Sites/Demo/About.html" },
@@ -52,5 +56,12 @@ describe("openEditorHost", () => {
     );
     expect(ok).toBe(false);
     expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the popup is blocked", async () => {
+    const openWindow = vi.fn().mockReturnValue(null);
+    const ok = await openEditorHost({ id: "55" }, { openWindow });
+    expect(ok).toBe(false);
+    expect(openWindow).toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/editor/openEditorHost.test.ts
+++ b/WebUI/src/test/ts/editor/openEditorHost.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { openEditorHost } from "../../../main/ts/editor/openEditorHost";
+
+describe("openEditorHost", () => {
+  it("opens the React host from a numeric id", async () => {
+    const openWindow = vi.fn();
+    const ok = await openEditorHost({ id: "55" }, { openWindow });
+    expect(ok).toBe(true);
+    expect(openWindow).toHaveBeenCalled();
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("entry=editor");
+    expect(href).toContain("contentId=55");
+    expect(href).not.toContain("view=editor");
+  });
+
+  it("resolves a CMS path when id is missing", async () => {
+    const openWindow = vi.fn();
+    const findByPath = vi.fn().mockResolvedValue({ id: "1-101-88" });
+    const ok = await openEditorHost(
+      { path: "/Sites/Demo/About.html" },
+      { openWindow, findByPath },
+    );
+    expect(ok).toBe(true);
+    expect(findByPath).toHaveBeenCalledWith("/Sites/Demo/About.html");
+    const href = String(openWindow.mock.calls[0]?.[0] ?? "");
+    expect(href).toContain("contentId=88");
+    expect(href).not.toContain("view=editor");
+  });
+
+  it("returns false when neither id nor path resolves", async () => {
+    const openWindow = vi.fn();
+    const ok = await openEditorHost(
+      { path: "/Sites/Missing" },
+      { openWindow, findByPath: async () => ({}) },
+    );
+    expect(ok).toBe(false);
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/home/CreateWizard.test.tsx
+++ b/WebUI/src/test/ts/home/CreateWizard.test.tsx
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { CreateWizard } from "@/home/create/CreateWizard";
+import { PageWizard } from "@/home/create/PageWizard";
 import * as homeApi from "@/api/home/homeApi";
 
 vi.mock("@/api/home/homeApi", async (importOriginal) => {
@@ -36,6 +37,10 @@ vi.mock("@/api/home/homeApi", async (importOriginal) => {
       { id: "percImage", name: "Image", label: "Image" },
     ]),
     createPageAndPath: vi.fn().mockResolvedValue("/Sites/Demo/page.html"),
+    createPageAndItem: vi.fn().mockResolvedValue({
+      path: "/Sites/Demo/page.html",
+      itemId: "55",
+    }),
     formatApiError: vi.fn((_e: unknown, fallback: string) => fallback),
   };
 });
@@ -87,6 +92,31 @@ describe("CreateWizard", () => {
       expect(screen.getByTestId("blog-wizard")).toBeDefined();
     });
     expect(homeApi.fetchAllBlogs).toHaveBeenCalled();
+  });
+
+  it("page create opens the React editor host instead of leftover view=editor", async () => {
+    const openCreated = vi.fn().mockResolvedValue(true);
+    render(<PageWizard onBack={() => undefined} openCreated={openCreated} />);
+    await waitFor(() => screen.getByTestId("page-wizard"));
+    await waitFor(() => {
+      const sel = document.getElementById("pw-template") as HTMLSelectElement;
+      expect(Array.from(sel.options).some((o) => o.value === "t1")).toBe(true);
+    });
+    fireEvent.change(document.getElementById("pw-template") as HTMLSelectElement, {
+      target: { value: "t1" },
+    });
+    fireEvent.change(document.getElementById("pw-title") as HTMLInputElement, {
+      target: { value: "About" },
+    });
+    fireEvent.click(screen.getByTestId("page-wizard-submit"));
+    await waitFor(() => {
+      expect(homeApi.createPageAndItem).toHaveBeenCalled();
+      expect(openCreated).toHaveBeenCalled();
+    });
+    expect(openCreated.mock.calls[0]?.[0]).toMatchObject({
+      id: "55",
+      path: "/Sites/Demo/page.html",
+    });
   });
 
   it("shows no-blogs empty state when none configured", async () => {

--- a/WebUI/src/test/ts/home/HomeShell.test.tsx
+++ b/WebUI/src/test/ts/home/HomeShell.test.tsx
@@ -17,7 +17,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { HomeShell } from "@/home/HomeShell";
+import { HomeShell, openHomeItem } from "@/home/HomeShell";
+import * as openEditor from "@/editor/openEditorHost";
 
 vi.mock("@/api/home/homeApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/home/homeApi")>();
@@ -120,6 +121,46 @@ describe("HomeShell", () => {
     );
     fireEvent.click(screen.getByTestId("home-nav-gadgets"));
     expect(onSectionChange).toHaveBeenCalledWith("gadgets");
+  });
+
+  it("openHomeItem uses the React editor host, not leftover view=editor", async () => {
+    const open = vi
+      .spyOn(openEditor, "openEditorHost")
+      .mockResolvedValue(true);
+    const hrefSpy = vi.fn();
+    const originalHref = window.location.href;
+    Object.defineProperty(window.location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: hrefSpy,
+    });
+    openHomeItem({
+      id: "55",
+      name: "Home",
+      path: "/Sites/Demo/Home",
+      type: "page",
+    });
+    expect(open).toHaveBeenCalledWith({
+      id: "55",
+      path: "/Sites/Demo/Home",
+    });
+    expect(hrefSpy).not.toHaveBeenCalled();
+    open.mockRestore();
+  });
+
+  it("openHomeItem does not open folders", () => {
+    const open = vi
+      .spyOn(openEditor, "openEditorHost")
+      .mockResolvedValue(true);
+    openHomeItem({
+      id: "1",
+      name: "Assets",
+      path: "/Assets/",
+      type: "Folder",
+      folder: true,
+    });
+    expect(open).not.toHaveBeenCalled();
+    open.mockRestore();
   });
 });
 

--- a/WebUI/src/test/ts/home/HomeShell.test.tsx
+++ b/WebUI/src/test/ts/home/HomeShell.test.tsx
@@ -127,13 +127,6 @@ describe("HomeShell", () => {
     const open = vi
       .spyOn(openEditor, "openEditorHost")
       .mockResolvedValue(true);
-    const hrefSpy = vi.fn();
-    const originalHref = window.location.href;
-    Object.defineProperty(window.location, "href", {
-      configurable: true,
-      get: () => originalHref,
-      set: hrefSpy,
-    });
     openHomeItem({
       id: "55",
       name: "Home",
@@ -144,7 +137,6 @@ describe("HomeShell", () => {
       id: "55",
       path: "/Sites/Demo/Home",
     });
-    expect(hrefSpy).not.toHaveBeenCalled();
     open.mockRestore();
   });
 

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -22,7 +22,9 @@ import {
   BLOG_POST_WIDGET_ID,
   contentItemId,
   createPage,
+  createPageAndItem,
   ensurePageFileName,
+  unwrapCreatedPageId,
   extractTemplateWidgetDefinitionIds,
   fetchAssetTypes,
   fetchMyContent,
@@ -195,6 +197,25 @@ describe("homeApi", () => {
       String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
     );
     expect(body.Page.name).toBe("about.html");
+  });
+
+  it("unwraps created page id and createPageAndItem returns path plus id", async () => {
+    expect(unwrapCreatedPageId({ Page: { id: "1-101-9", name: "p" } })).toBe(
+      "1-101-9",
+    );
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ Page: { id: "1-101-9", name: "about.html" } }),
+    );
+    const created = await createPageAndItem({
+      name: "about",
+      title: "About",
+      linkTitle: "About",
+      templateId: "t1",
+      folderPath: "/Sites/Demo",
+    });
+    expect(created.path).toMatch(/about\.html$/);
+    expect(created.itemId).toBe("1-101-9");
   });
 
   it("mapAssetType prefers widgetId over contentTypeId", () => {

--- a/docs/ai-generated/code-reviews/home-topnav-react-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/home-topnav-react-editor-erlang.md
@@ -40,3 +40,22 @@ None blocking.
 
 - Focused Vitest: 54 passed
 - `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; Vitest 2554 passed
+
+## Re-review (PR #3462 kilo threads)
+
+**Date**: 2026-08-15  
+**Scope**: review-fix pack
+
+Kilo WARNING: discarded `window.open` result / always-true return; Home test rewrote `location.href` without restore; missing blocked-popup test.
+
+### Recommendation
+
+`approve`
+
+### Gate
+
+May commit/push: **yes**
+
+### Issues
+
+None remaining. `openEditorHost` now returns `opened != null`. Home test no longer touches `location.href`. Blocked-popup unit test added.

--- a/docs/ai-generated/code-reviews/home-topnav-react-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/home-topnav-react-editor-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — feat/home-topnav-react-editor
+
+**Date**: 2026-08-15  
+**Scope**: uncommitted vs `origin/main` (`dc8f1a5100` #3455)  
+**Reviewer**: Erlang  
+**Memory patterns hit**: change-class completeness (WebUI + Playwright + product-docs); behavioral tests for open-by-id / open-by-path / no leftover `?view=editor`
+
+## Summary
+
+Home Recent/Bookmarks/Search/Library and Home → Create (page/blog) open the React Content Editor host (`spa.jsp?entry=editor`). TopNav **Editor** is an SPA `/editor` route. Leftover `?view=editor` is no longer requested from those shells.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+CMS folder paths stay `/` repository URLs. No OS filesystem I/O. Clean.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| WebUI Home + TopNav + create wizards | yes |
+| Vitest (openEditorHost, Home, wizard, TopNav) | yes |
+| Playwright (top-nav + home-react-editor) | yes |
+| product-docs 8.2 admin + getting-started | yes |
+
+Home **Create asset** still uses leftover `editAsset.jsp` (out of this slice; needs asset create on the React host). Residual `index.jsp?view=editor` is the leftover CM1 document, not the SPA shells.
+
+## Issues
+
+None blocking.
+
+## Tests run
+
+- Focused Vitest: 54 passed
+- `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; Vitest 2554 passed

--- a/modules/perc-qa-automation/frontend/tests/home-react-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/home-react-editor.spec.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Home Recent / Create open the React editor, not leftover {@code ?view=editor}.
+ *
+ * <p>Tags: {@code @home} {@code @editor}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/home-react-editor.spec.js}</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function homeDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+test.describe("Home React Content Editor", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "opening a Home recent item does not request leftover ?view=editor",
+    { tag: ["@home", "@editor"] },
+    async ({ page }) => {
+      const blocked = [];
+      page.on("request", (req) => {
+        if (/view=editor/.test(req.url())) {
+          blocked.push(req.url());
+        }
+      });
+      await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
+      await expect(page.getByTestId("home-shell")).toBeVisible({
+        timeout: 20_000,
+      });
+      const openBtn = page.locator('[data-testid="home-recent-open"]').first();
+      if ((await openBtn.count()) === 0 || !(await openBtn.isVisible())) {
+        test.skip(true, "No Home recent/open row available");
+        return;
+      }
+      const popupPromise = page.waitForEvent("popup", { timeout: 10_000 }).catch(() => null);
+      await openBtn.click();
+      const popup = await popupPromise;
+      if (popup) {
+        await expect(popup).toHaveURL(/entry=editor|\/editor/);
+        await expect(popup).not.toHaveURL(/view=editor/);
+      }
+      expect(blocked, `leftover editor requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -130,4 +130,27 @@ test.describe("Top nav restructure (#2702 / #3201)", () => {
       [],
     );
   });
+
+  test("Editor opens the React host, not leftover ?view=editor @smoke @ui", async ({
+    page,
+  }) => {
+    const blocked = [];
+    page.on("request", (req) => {
+      if (/view=editor/.test(req.url())) {
+        blocked.push(req.url());
+      }
+    });
+    await loginAsAdmin(page);
+    await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSpaTopNav(page);
+    await page.getByTestId("nav-editor").click();
+    await expect(page.locator('[data-testid="editor-host"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page).not.toHaveURL(/view=editor/);
+    await expect(page.locator('[data-testid="editor-error"]')).toBeVisible();
+    expect(blocked, `leftover editor requested: ${blocked.join(" ")}`).toEqual(
+      [],
+    );
+  });
 });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -18,7 +18,7 @@ For roles that can see the full chrome, the application top navigation is:
 
 1. **Home**
 2. **Explorer** (immediately after Home)
-3. Editor, Navigation, Design, Developer, Publish (role-gated)
+3. **Editor** (React Content Editor — `spa.jsp?entry=editor` / `/editor`. Does not open leftover `?view=editor`. Open an item from Explorer or Home, or create a page from **Home → Create**), Navigation, Design, Developer, Publish (role-gated)
 4. **Admin** (administrators only — one item)
 5. Widget Builder (when that feature is active)
 

--- a/product-docs/8.2/getting-started/index.md
+++ b/product-docs/8.2/getting-started/index.md
@@ -34,7 +34,7 @@ This section covers how to obtain, install, upgrade, and take first steps with P
    **Design** (Admin or Designer) opens the SPA template library — classic
    `?view=design` / `admin.jsp` bookmarks redirect there. See
    [Design templates](id:admin-design-templates).
-4. Create or open a **Site**, confirm Finder navigation, and open the Web UI editor.
+4. Create or open a **Site**, confirm Explorer navigation, and open the React Content Editor from Explorer **Edit**, **Home → Create** (page/blog), or the **Editor** top-nav item. Those surfaces do not open leftover `?view=editor`.
 5. Open **Design** to list assembly templates and edit source, JEXL bindings, assembler,
    and slots. See [Design templates](id:admin-design-templates).
 6. Review [Server operations](id:admin-server-ops) for ports, service control, and logs.

--- a/specs/995-react-content-editor/spec.md
+++ b/specs/995-react-content-editor/spec.md
@@ -27,13 +27,14 @@ New window (peer of Active Assembly):
 6. Save + Check In (existing checkIn REST)
 7. **New Item** — type under New creates in the current folder (`POST /item/create`) and opens this editor
 8. **percPage template** — load allowed templates (content type, then site); one template is used automatically; more than one opens a picker; `POST /item/create` includes `templateId`; server saves through `IPSPageService`
+9. **Home / TopNav** — Recent/Bookmarks/Search/Library open the React editor host; **Home → Create** page/blog opens the same host after create; TopNav **Editor** is `/editor` (not leftover `?view=editor`)
 
 ## Later
 
 - TinyMCE / file / image / keyword / community controls
 - AA contenteditable overlay on the assembled preview
 - Revision promote form
-- Home / TopNav still use leftover `?view=editor` until those shells switch
+- Home **Create asset** still uses leftover `editAsset.jsp` until asset create is on this host
 
 ## Out of scope here
 


### PR DESCRIPTION
## Summary

Follow-on to [#3455](https://github.com/intersoftdatalabs-in/percussioncms/pull/3455). **Home** Recent / Bookmarks / Search / Library and **Home → Create** page/blog open the React Content Editor host (`spa.jsp?entry=editor`) instead of leftover `?view=editor`. TopNav **Editor** is the SPA `/editor` route (chrome-less). Create uses the page-save id when present and otherwise resolves the CMS path.

Home **Create asset** still uses leftover `editAsset.jsp` (needs asset create on this host). Residual `index.jsp?view=editor` is unchanged.

## Test plan

1. `cd WebUI` then `..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2554 passed.
2. Home: open a Recent item — editor popup/window has `entry=editor`, not `view=editor`.
3. Home → Create → Page: after create, React editor opens; Home stays (no leftover editor navigation).
4. TopNav **Editor** opens `/editor` (empty-state asks for Explorer or Home Create).

## Checklist

- [x] **Product documentation** — Admin top-nav + getting-started editor path
- [x] **Unit / module tests** — openEditorHost, Home open, page create, TopNav href
- [x] **WebUI + Playwright** — `top-nav-restructure` Editor click + `home-react-editor.spec.js`
- [x] **Build gates** — WebUI standalone clean install
- [x] **Cross-platform** — CMS folder paths use `/` (not OS file I/O)

Erlang: `docs/ai-generated/code-reviews/home-topnav-react-editor-erlang.md` (approve).

> Co-Authored by Grok Build TUI using grok-4.6 with agent Grok 4.6