### PR TITLE
fix(qa): restore preview spec auth import and Pages nav (#3463)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -212,6 +212,7 @@ export function columnHeaderLabel(
   }
 }
 import { message } from "../i18n/message";
+import { isPreviewableItem } from "./previewItem";
 import { canRead, isFolder } from "./selection";
 import {
   emptyStateStyle,
@@ -530,6 +531,8 @@ export function DetailList({
                 key={idKey}
                 data-testid={`detail-row-${idKey}`}
                 data-row-kind={folderish ? "folder" : "item"}
+                data-item-type={item.type ?? ""}
+                data-previewable={isPreviewableItem(item) ? "true" : "false"}
                 data-selected={isChecked ? "true" : undefined}
                 style={rowStyle(selected)}
                 role="row"

--- a/WebUI/src/main/ts/contentExplorer/previewItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/previewItem.ts
@@ -35,7 +35,7 @@
 import { get } from "../api/client";
 import { PATHS, SERVICES_ROOT } from "../api/paths";
 import type { PSPathItem } from "../api/contentExplorer/types";
-import { isFolder } from "./selection";
+import { isFolder, isPageOrAssetContentType } from "./selection";
 
 /** Discriminator used by UI chrome and skip logic in Playwright. */
 export type PreviewKind = "page" | "asset" | "none";
@@ -136,12 +136,27 @@ function typeToken(item: PSPathItem): string {
  * Classify whether Explorer can open a product preview for this selection.
  */
 export function resolvePreviewKind(item: PSPathItem | null | undefined): PreviewKind {
-  if (!item || isFolder(item)) {
+  if (!item) {
     return "none";
   }
   const token = typeToken(item);
   const path = normalizeCmsPath(item.path);
   const pathLower = path.toLowerCase();
+  const hasId = Boolean((item.id ?? "").trim());
+
+  // Listed percPage / Page rows win over folder heuristics (#3456).
+  if (isPageOrAssetContentType(item) && !token.includes("folder")) {
+    if (token.includes("asset")) {
+      return hasId ? "asset" : "none";
+    }
+    if (hasId || pathLower.startsWith("/sites/")) {
+      return "page";
+    }
+  }
+
+  if (isFolder(item)) {
+    return "none";
+  }
 
   if (
     token.includes("asset") ||
@@ -149,7 +164,7 @@ export function resolvePreviewKind(item: PSPathItem | null | undefined): Preview
     pathLower.startsWith("/assets")
   ) {
     // Need an id for the assetViewUrl service.
-    return (item.id ?? "").trim() ? "asset" : "none";
+    return hasId ? "asset" : "none";
   }
 
   if (
@@ -158,14 +173,14 @@ export function resolvePreviewKind(item: PSPathItem | null | undefined): Preview
     pathLower === "/sites"
   ) {
     // Page: id (render) or Sites path (friendly URL).
-    if ((item.id ?? "").trim() || pathLower.startsWith("/sites/")) {
+    if (hasId || pathLower.startsWith("/sites/")) {
       return "page";
     }
     return "none";
   }
 
   // Unknown non-folder: try page render when id present (content items).
-  if ((item.id ?? "").trim()) {
+  if (hasId) {
     return "page";
   }
   return "none";

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -54,7 +54,10 @@ export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   const type = (item.type ?? "").trim().toLowerCase();
   const category = (item.category ?? "").trim().toLowerCase();
   const token = `${type} ${category}`;
-  return token.includes("page") || token.includes("asset");
+  if (token.includes("page") || token.includes("asset")) return true;
+  // FastForward landing pages (rffHome) are listed under /Pages (#3456).
+  if (token.includes("rffhome")) return true;
+  return false;
 }
 
 export function isFolder(item: PSPathItem | null): boolean {
@@ -63,12 +66,19 @@ export function isFolder(item: PSPathItem | null): boolean {
   if (FOLDER_TYPE_KEYS.has(type)) return true;
   const category = (item.category ?? "").trim().toLowerCase();
   if (category === "folder") return true;
-  // Listed percPage / Page / asset rows are never folders (#3456).
+  // Listed percPage / Page / rffHome / asset rows are never folders (#3456).
   if (isPageOrAssetContentType(item)) return false;
   // Server PSPathItem.setPath appends '/' only for folders. $System$ and
   // similar under /Folders/ may omit type but still use a folder path (#3330).
   const path = (item.path ?? "").trim();
   if (path.endsWith("/")) return true;
+  // Site-path content items with ids (listed pages) stay items even when
+  // leaf is omitted/false on paginated rows.
+  const hasId = Boolean((item.id ?? "").trim());
+  const pathLower = path.replace(/\\/g, "/").toLowerCase();
+  if (hasId && pathLower.includes("/sites/") && !pathLower.endsWith("/")) {
+    return false;
+  }
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
   return Boolean(item.hasFolderChildren);

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -44,6 +44,23 @@ export const EMPTY_SELECTION: Selection = {
 const FOLDER_TYPE_KEYS = new Set(["folder", "fsfolder", "site"]);
 
 /**
+ * Exact {@code type} / {@code category} tokens that are previewable items.
+ * Substring {@code includes("page")} would also match {@code pagination}
+ * / {@code pagebreak} / {@code pagelet}; {@code includes("asset")} would
+ * match {@code assetmanagement} (#3456 review).
+ */
+const PAGE_OR_ASSET_TYPE_KEYS = new Set([
+  "page",
+  "percpage",
+  "percasset",
+  "asset",
+  "rffhome",
+]);
+
+/** FastForward nav types are folder-like, not previewable items. */
+const RFF_NAV_TYPE_KEYS = new Set(["rffnavon", "rffnavtree"]);
+
+/**
  * Content types that are previewable items, not folders. Pathmanagement
  * lists FastForward pages as {@code percPage} / {@code Page}; those must
  * stay items even when {@code leaf} is omitted or {@code hasFolderChildren}
@@ -53,10 +70,12 @@ export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   if (!item) return false;
   const type = (item.type ?? "").trim().toLowerCase();
   const category = (item.category ?? "").trim().toLowerCase();
-  const token = `${type} ${category}`;
-  if (token.includes("page") || token.includes("asset")) return true;
-  // FastForward landing pages (rffHome) are listed under /Pages (#3456).
-  if (token.includes("rffhome")) return true;
+  if (PAGE_OR_ASSET_TYPE_KEYS.has(type) || PAGE_OR_ASSET_TYPE_KEYS.has(category)) {
+    return true;
+  }
+  // Other FastForward content items (rffEvent, rffImage, …) are items.
+  if (type.startsWith("rff") && !RFF_NAV_TYPE_KEYS.has(type)) return true;
+  if (category.startsWith("rff") && !RFF_NAV_TYPE_KEYS.has(category)) return true;
   return false;
 }
 
@@ -72,13 +91,8 @@ export function isFolder(item: PSPathItem | null): boolean {
   // similar under /Folders/ may omit type but still use a folder path (#3330).
   const path = (item.path ?? "").trim();
   if (path.endsWith("/")) return true;
-  // Site-path content items with ids (listed pages) stay items even when
-  // leaf is omitted/false on paginated rows.
-  const hasId = Boolean((item.id ?? "").trim());
-  const pathLower = path.replace(/\\/g, "/").toLowerCase();
-  if (hasId && pathLower.includes("/sites/") && !pathLower.endsWith("/")) {
-    return false;
-  }
+  // Do not treat every id'd /Sites/ path as an item — custom folder types
+  // with an id and no trailing slash stay folders via leaf / children.
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
   return Boolean(item.hasFolderChildren);

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -43,12 +43,28 @@ export const EMPTY_SELECTION: Selection = {
  */
 const FOLDER_TYPE_KEYS = new Set(["folder", "fsfolder", "site"]);
 
+/**
+ * Content types that are previewable items, not folders. Pathmanagement
+ * lists FastForward pages as {@code percPage} / {@code Page}; those must
+ * stay items even when {@code leaf} is omitted or {@code hasFolderChildren}
+ * is set on a paginated row (#3456 / #2745).
+ */
+export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
+  if (!item) return false;
+  const type = (item.type ?? "").trim().toLowerCase();
+  const category = (item.category ?? "").trim().toLowerCase();
+  const token = `${type} ${category}`;
+  return token.includes("page") || token.includes("asset");
+}
+
 export function isFolder(item: PSPathItem | null): boolean {
   if (!item) return false;
   const type = (item.type ?? "").trim().toLowerCase();
   if (FOLDER_TYPE_KEYS.has(type)) return true;
   const category = (item.category ?? "").trim().toLowerCase();
   if (category === "folder") return true;
+  // Listed percPage / Page / asset rows are never folders (#3456).
+  if (isPageOrAssetContentType(item)) return false;
   // Server PSPathItem.setPath appends '/' only for folders. $System$ and
   // similar under /Folders/ may omit type but still use a folder path (#3330).
   const path = (item.path ?? "").trim();

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -876,6 +876,63 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(arg.type).toBe("page");
   });
 
+  it("enables Preview for a listed percPage row (#3456)", async () => {
+    const onPreview = vi.fn(async () => undefined);
+    stubPathFetch();
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "16777215-101-9",
+                  name: "About",
+                  path: "/Sites/Demo/Pages/About",
+                  type: "percPage",
+                  leaf: false,
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        actionHandlers={{ onPreview }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-16777215-101-9")).toBeInTheDocument();
+    });
+    const row = screen.getByTestId("detail-row-16777215-101-9");
+    expect(row.getAttribute("data-previewable")).toBe("true");
+    fireEvent.click(row);
+    await waitFor(() => {
+      expect(screen.getByTestId("action-preview")).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId("action-preview"));
+    await waitFor(() => {
+      expect(onPreview).toHaveBeenCalled();
+    });
+  });
+
   it("passes the zero serious/critical axe-core gate (T082a / 508)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -84,6 +84,15 @@ describe("DetailList", () => {
       expect(screen.getByTestId("detail-row-p-1")).toBeInTheDocument(),
     );
     expect(screen.getByTestId("detail-row-p-2")).toBeInTheDocument();
+    expect(screen.getByTestId("detail-row-p-1").getAttribute("data-previewable")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("detail-row-p-1").getAttribute("data-item-type")).toBe(
+      "page",
+    );
+    expect(screen.getByTestId("detail-row-p-1").getAttribute("data-row-kind")).toBe(
+      "item",
+    );
     expect(screen.getByTestId("detail-pagination")).toHaveTextContent(
       /Page 1 of 1/,
     );
@@ -495,6 +504,18 @@ describe("DetailList folder row chrome (#3328)", () => {
     const systemIcon = screen.getByTestId("detail-folder-icon-sys-1");
     expect(systemIcon).toHaveAttribute("data-kind", "folder");
     expect(systemIcon).toHaveAttribute("data-folder-state", "closed");
+    expect(screen.getByTestId("detail-row-sys-1")).toHaveAttribute(
+      "data-previewable",
+      "false",
+    );
+    expect(screen.getByTestId("detail-row-uf-1")).toHaveAttribute(
+      "data-previewable",
+      "false",
+    );
+    expect(screen.getByTestId("detail-row-p-page")).toHaveAttribute(
+      "data-previewable",
+      "true",
+    );
     expect(screen.getByTestId("detail-row-sys-1")).toHaveAttribute(
       "data-row-kind",
       "folder",

--- a/WebUI/src/test/ts/contentExplorer/previewItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/previewItem.test.ts
@@ -109,6 +109,37 @@ describe("previewItem pure helpers (#2733)", () => {
     expect(isPreviewableItem(FOLDER)).toBe(false);
   });
 
+  it("enables preview for listed percPage rows even when leaf is false (#3456)", () => {
+    const listed: PSPathItem = {
+      id: "16777215-101-9",
+      name: "About",
+      path: "/Sites/Corporate_Investments/Pages/About",
+      type: "percPage",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    expect(resolvePreviewKind(listed)).toBe("page");
+    expect(isPreviewableItem(listed)).toBe(true);
+    const target = resolvePreviewTarget(listed, "/services");
+    expect(target.kind).toBe("page");
+    expect(target.url).toBe(
+      `/services/pagemanagement/render/page/${encodeURIComponent(listed.id!)}`,
+    );
+    expect(
+      isPreviewableItem({
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "Page",
+      }),
+    ).toBe(true);
+    expect(
+      resolvePreviewTarget(
+        { name: "Home", path: "/Sites/Demo/Home", type: "Page" },
+        "/services",
+      ).url,
+    ).toContain("/Sites/Demo/Home?");
+  });
+
   it("resolvePreviewTarget prefers page render id over site path", () => {
     const t = resolvePreviewTarget(PAGE, "/services");
     expect(t.kind).toBe("page");

--- a/WebUI/src/test/ts/contentExplorer/reducedActions.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/reducedActions.test.tsx
@@ -113,6 +113,32 @@ describe("ReducedActions", () => {
     expect(screen.getByTestId("action-preview")).toBeDisabled();
   });
 
+  it("enables Preview for listed percPage rows (#3456)", () => {
+    const { handlers, calls } = makeHandlers();
+    const listed: PSPathItem = {
+      id: "16777215-101-9",
+      name: "About",
+      path: "/Sites/Corporate_Investments/Pages/About",
+      type: "percPage",
+      leaf: false,
+      accessLevel: "READ",
+    };
+    render(
+      <ReducedActions
+        item={listed}
+        folder={FOLDER}
+        handlers={handlers}
+        hasPreviewHandler={true}
+        onError={() => undefined}
+      />,
+    );
+    const btn = screen.getByTestId("action-preview");
+    expect(btn).toBeEnabled();
+    fireEvent.click(btn);
+    expect(calls.onPreview).toHaveLength(1);
+    expect(calls.onPreview[0]).toMatchObject({ type: "percPage" });
+  });
+
   it("enables the Preview button for previewable pages when a handler is supplied (#2733)", () => {
     const { handlers, calls } = makeHandlers();
     render(

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -120,4 +120,47 @@ describe("isFolder (#3001 site nodes)", () => {
       }),
     ).toBe(false);
   });
+
+  it("rejects pagination/pagebreak/pagelet/assetmanagement as page or asset types", () => {
+    expect(
+      isPageOrAssetContentType({
+        name: "p",
+        path: "/Sites/Demo/pagination",
+        type: "pagination",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "p",
+        path: "/Sites/Demo/pagebreak",
+        type: "pagebreak",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "p",
+        path: "/Sites/Demo/pagelet",
+        type: "pagelet",
+      }),
+    ).toBe(false);
+    expect(
+      isPageOrAssetContentType({
+        name: "a",
+        path: "/Sites/Demo/assetmanagement",
+        type: "assetmanagement",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps custom folder types under /Sites/ as folders when leaf is false", () => {
+    expect(
+      isFolder({
+        id: "16777215-101-20",
+        name: "Campaigns",
+        path: "/Sites/Demo/Campaigns",
+        type: "CampaignFolder",
+        leaf: false,
+      }),
+    ).toBe(true);
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -110,5 +110,14 @@ describe("isFolder (#3001 site nodes)", () => {
         category: "PAGE",
       }),
     ).toBe(false);
+    expect(
+      isFolder({
+        id: "16777215-101-551",
+        name: "Corporate Investments Home",
+        path: "/Sites/CorporateInvestments/Pages/Corporate Investments Home",
+        type: "rffHome",
+        leaf: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -16,7 +16,10 @@
 
 import { describe, expect, it } from "vitest";
 import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
-import { isFolder } from "../../../main/ts/contentExplorer/selection";
+import {
+  isFolder,
+  isPageOrAssetContentType,
+} from "../../../main/ts/contentExplorer/selection";
 
 describe("isFolder (#3001 site nodes)", () => {
   it("treats type site as expandable folder", () => {
@@ -84,6 +87,27 @@ describe("isFolder (#3001 site nodes)", () => {
         path: "/Sites/1/index.html",
         type: "page",
         leaf: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat listed percPage rows as folders (#3456)", () => {
+    const listed: PSPathItem = {
+      id: "16777215-101-9",
+      name: "About",
+      path: "/Sites/Corporate_Investments/Pages/About",
+      type: "percPage",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    expect(isPageOrAssetContentType(listed)).toBe(true);
+    expect(isFolder(listed)).toBe(false);
+    expect(
+      isFolder({
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "Page",
+        category: "PAGE",
       }),
     ).toBe(false);
   });

--- a/docs/ai-generated/code-reviews/3456-explorer-preview-listed-page-erlang.md
+++ b/docs/ai-generated/code-reviews/3456-explorer-preview-listed-page-erlang.md
@@ -28,7 +28,7 @@ None.
 
 ## Notes (non-blocking)
 
-- `isFolder` now treats `percPage` / `Page` / asset content types as items even when `leaf` is false or `hasFolderChildren` is set. That is the right listed-row heuristic; folder types (`Folder` / `FSFolder` / `site`) still win first.
+- `isFolder` now treats `percPage` / `Page` / `rffHome` / asset content types as items even when `leaf` is false or `hasFolderChildren` is set. Folder types (`Folder` / `FSFolder` / `site`) still win first. Site-path items with ids and no trailing slash stay items.
 - Playwright skip is now gated on a REST walk of Sites/Pages, not “first 8 Sites-root rows.” If listing (#3457) is on the tip and a page row exists, skip is a defect.
 - Product-docs: operator Preview steps unchanged (`product-docs/8.2/admin/content-explorer.md` already documents Preview). N/A this PR.
 

--- a/docs/ai-generated/code-reviews/3456-explorer-preview-listed-page-erlang.md
+++ b/docs/ai-generated/code-reviews/3456-explorer-preview-listed-page-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review: #3456 Explorer Preview for a listed page
+
+**Branch:** `fix/issue-3456-explorer-preview-page`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Date:** 2026-08-15
+
+## Summary
+
+Parent #2745 slice 2: after a page row exists, Explorer Preview must enable and open product preview (page render or site-path URL). Folders stay disabled. Playwright must not soft-skip solely because the Sites-root list has no pages when `/Pages` listing is on the tip.
+
+**Memory patterns hit:** missing behavioral tests; WebUI Playwright companion; CMS `/` paths (not OS file I/O); change-class closure (Vitest + Playwright).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found after review
+- Behavioral tests: present (Vitest + Playwright helper/spec)
+- Cross-platform paths: N/A for filesystem — CMS logical `/` paths only
+- **May commit/push:** yes
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- `isFolder` now treats `percPage` / `Page` / asset content types as items even when `leaf` is false or `hasFolderChildren` is set. That is the right listed-row heuristic; folder types (`Folder` / `FSFolder` / `site`) still win first.
+- Playwright skip is now gated on a REST walk of Sites/Pages, not “first 8 Sites-root rows.” If listing (#3457) is on the tip and a page row exists, skip is a defect.
+- Product-docs: operator Preview steps unchanged (`product-docs/8.2/admin/content-explorer.md` already documents Preview). N/A this PR.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] CMS path helpers use `/` only (URL/repository form)
+- [x] Tests do not assert OS-only absolute path shapes

--- a/docs/ai-generated/code-reviews/3463-explorer-preview-auth-import-erlang.md
+++ b/docs/ai-generated/code-reviews/3463-explorer-preview-auth-import-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review: #3463 Explorer preview Playwright import + Pages nav
+
+**Branch:** `fix/issue-3463-preview-auth-import`  
+**Scope:** uncommitted vs `HEAD` / commits not in `origin/main`  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Date:** 2026-08-15
+
+## Summary
+
+Cycle Verify residual of PR #3461 (`fb68b7f511`): `fetchFolderChildren` called `adminBasicAuthHeaders()` without importing it. Tip `b19eabc` already restored the import. This branch rebases that tip onto `main` and keeps the import. Live H2 then failed because Playwright matched `Pages` with whole-row `/^Pages$/` (Type + Path cells), so the listed `rffHome` was never opened. Helpers now match the Name cell; folder-icon open is used (peer #3328).
+
+**Memory patterns hit:** missing behavioral tests; WebUI Playwright companion; CMS `/` paths (not OS file I/O); Cycle Verify import drift.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found after review
+- Behavioral tests: present (unit import + Name-cell match; Playwright 2 passed on H2)
+- Cross-platform paths: spec-source read uses `path.join`; CMS logical `/` paths only
+- **May commit/push:** yes
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Soft-skip remains gated on a successful REST listing with no page-type child. This H2 cell listed `Corporate Investments Home`; Preview opened; folders stayed `data-previewable=false`.
+- Product-docs: N/A (test/import residual; operator Preview steps unchanged).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Spec-file read uses `path.join(__dirname, "..", "explorer-preview-view.spec.js")`
+- [x] CMS path helpers use `/` only (URL/repository form)
+- [x] Tests do not assert OS-only absolute path shapes

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Playwright surface: #2733 / #3456 — Explorer preview for a listed page.
+ * Playwright surface: #2733 / #3456 / #3463 — Explorer preview for a listed page.
  *
  * <p>Verifies product shell chrome for Preview + Refresh, then opens
  * product preview for a listed page row. Folders stay Preview-disabled.
@@ -42,6 +42,8 @@ const {
   isProductPagePreviewUrl,
   listedPageSiteNames,
   foldSiteName,
+  detailRowHasExactName,
+  detailRowMatchesFoldedSite,
 } = require("./helpers/explorer-preview-view");
 
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -163,23 +165,11 @@ async function openSitesThenPages(page, listed) {
     }
     const row = siteRows.nth(i);
     const rowText = ((await row.innerText().catch(() => "")) || "").trim();
-    const foldedRow = foldSiteName(rowText);
     const nameMatch =
-      wanted.size === 0 || [...wanted].some((n) => n && foldedRow.includes(n));
+      wanted.size === 0 || detailRowMatchesFoldedSite(rowText, wanted);
     if (!nameMatch) continue;
-    await row.dblclick({ force: true });
-    await listWaitReady(page);
-    await page.waitForLoadState("networkidle").catch(() => {});
-
-    const pagesRow = list
-      .locator('tbody tr[data-testid^="detail-row-"]')
-      .filter({ hasText: /^Pages$/ })
-      .first();
-    if ((await pagesRow.count()) > 0) {
-      await pagesRow.dblclick({ force: true });
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
-    }
+    await openDetailFolderRow(row);
+    await openPagesFolderIfPresent(page, list);
 
     const previewable = list.locator(
       'tbody tr[data-testid^="detail-row-"][data-previewable="true"]',
@@ -201,18 +191,44 @@ async function openSitesThenPages(page, listed) {
     );
   }
   if (!opened) {
-    await siteRows.first().dblclick({ force: true });
-    await listWaitReady(page);
-    await page.waitForLoadState("networkidle").catch(() => {});
-    const pagesRow = list
-      .locator('tbody tr[data-testid^="detail-row-"]')
-      .filter({ hasText: /^Pages$/ })
-      .first();
-    if ((await pagesRow.count()) > 0) {
-      await pagesRow.dblclick({ force: true });
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
-    }
+    await openDetailFolderRow(siteRows.first());
+    await openPagesFolderIfPresent(page, list);
+  }
+}
+
+/**
+ * Prefer the folder-icon open control (peer #3328); fall back to dblclick.
+ * @param {import("@playwright/test").Locator} row
+ */
+async function openDetailFolderRow(row) {
+  const icon = row.locator('[data-testid^="detail-folder-icon-"]');
+  if ((await icon.count()) > 0) {
+    await icon.click();
+  } else {
+    await row.dblclick({ force: true });
+  }
+  const page = row.page();
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+}
+
+/**
+ * Open the Pages child when present. Match the Name cell, not the whole
+ * row text ({@code /^Pages$/} fails on Type+Path columns — #3463).
+ * @param {import("@playwright/test").Page} page
+ * @param {import("@playwright/test").Locator} list
+ */
+async function openPagesFolderIfPresent(page, list) {
+  const folderRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  const folderCount = await folderRows.count();
+  for (let i = 0; i < folderCount; i += 1) {
+    const folder = folderRows.nth(i);
+    const text = ((await folder.innerText().catch(() => "")) || "").trim();
+    if (!detailRowHasExactName(text, "Pages")) continue;
+    await openDetailFolderRow(folder);
+    return;
   }
 }
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -31,18 +31,14 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const {
-  loginAsAdmin,
-  BASE_URL,
-  adminBasicAuthHeaders,
-} = require("./helpers/auth");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
 const {
   TEST_IDS,
   explorerEntryUrl,
   noListedPageSkipMessage,
   isListedPageRow,
   unwrapPathItems,
-  parentFolderCmsPath,
+  resolveExplorerListPath,
   isProductPagePreviewUrl,
 } = require("./helpers/explorer-preview-view");
 
@@ -86,29 +82,41 @@ async function fetchFolderChildren(request, cmsPath) {
  */
 async function findListedPageViaRest(request) {
   const sites = await fetchFolderChildren(request, "Sites");
-  const siteNames = sites
-    .map((s) => (s && s.name ? String(s.name) : ""))
-    .filter(Boolean);
-
   const candidateFolders = [];
-  for (const name of siteNames) {
-    candidateFolders.push(`Sites/${name}`);
-    candidateFolders.push(`Sites/${name}/Pages`);
+  for (const site of sites) {
+    const listPath = resolveExplorerListPath(site);
+    if (listPath) {
+      candidateFolders.push(listPath.replace(/^\/+/, ""));
+      candidateFolders.push(`${listPath.replace(/^\/+/, "")}/Pages`);
+    }
+    const name = site && site.name ? String(site.name) : "";
+    if (name) {
+      candidateFolders.push(`Sites/${name}`);
+      candidateFolders.push(`Sites/${name}/Pages`);
+    }
   }
 
+  const seen = new Set();
   for (const folder of candidateFolders) {
+    if (!folder || seen.has(folder)) continue;
+    seen.add(folder);
     const kids = await fetchFolderChildren(request, folder);
     const page = kids.find((k) => isListedPageRow(k));
     if (page) return page;
     for (const kid of kids.slice(0, 12)) {
       const kidType = `${kid.type || ""} ${kid.category || ""}`.toLowerCase();
-      const kidName = String(kid.name || "");
       const looksFolder =
         kidType.includes("folder") ||
         kidType.includes("site") ||
         String(kid.path || "").endsWith("/");
-      if (!looksFolder || !kidName) continue;
-      const nested = await fetchFolderChildren(request, `${folder}/${kidName}`);
+      if (!looksFolder) continue;
+      const nestedPath = resolveExplorerListPath(kid);
+      const nestedRel = nestedPath
+        ? nestedPath.replace(/^\/+/, "")
+        : `${folder}/${kid.name || ""}`;
+      if (!nestedRel || seen.has(nestedRel)) continue;
+      seen.add(nestedRel);
+      const nested = await fetchFolderChildren(request, nestedRel);
       const nestedPage = nested.find((k) => isListedPageRow(k));
       if (nestedPage) return nestedPage;
     }
@@ -117,11 +125,11 @@ async function findListedPageViaRest(request) {
 }
 
 /**
- * Click Explorer tree/list down to {@code folderPath} under Sites.
+ * Open Sites → first sample site → Pages (when present).
+ * Finder site names use underscores; repository folderPath does not (#3326).
  * @param {import("@playwright/test").Page} page
- * @param {string} folderPath
  */
-async function openExplorerFolder(page, folderPath) {
+async function openSitesThenPages(page) {
   const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
   const sitesNode = tree
     .locator(
@@ -131,40 +139,25 @@ async function openExplorerFolder(page, folderPath) {
   await expect(sitesNode).toBeVisible({ timeout: 15_000 });
   await sitesNode.click({ force: true });
   await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
 
-  const segments = String(folderPath || "")
-    .replace(/^\/+/, "")
-    .split("/")
-    .filter((s) => s && s.toLowerCase() !== "sites");
+  const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
+  const siteRow = list
+    .locator('tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]')
+    .first();
+  await expect(siteRow).toBeVisible({ timeout: 15_000 });
+  await siteRow.dblclick({ force: true });
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
 
-  for (const segment of segments) {
-    const treeHit = tree
-      .locator(
-        `[data-testid="tree-node-/Sites/${segment}/"], [data-testid="tree-node-/Sites/${segment}"], [data-testid$="/${segment}/"], [data-testid$="/${segment}"]`,
-      )
-      .first();
-    if ((await treeHit.count()) > 0 && (await treeHit.isVisible().catch(() => false))) {
-      await treeHit.click({ force: true }).catch(() => {});
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
-      continue;
-    }
-    const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
-    const row = list
-      .locator(`tbody tr[data-testid^="detail-row-"]`)
-      .filter({ hasText: segment })
-      .first();
-    if ((await row.count()) > 0) {
-      await row.dblclick({ force: true }).catch(async () => {
-        await row.click({ force: true });
-        const openBtn = page.locator('[data-testid="action-open"]');
-        if (await openBtn.isEnabled().catch(() => false)) {
-          await openBtn.click();
-        }
-      });
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
-    }
+  const pagesRow = list
+    .locator('tbody tr[data-testid^="detail-row-"]')
+    .filter({ hasText: /^Pages$/ })
+    .first();
+  if ((await pagesRow.count()) > 0) {
+    await pagesRow.dblclick({ force: true });
+    await listWaitReady(page);
+    await page.waitForLoadState("networkidle").catch(() => {});
   }
 }
 
@@ -232,8 +225,7 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
       const shell = page.locator(`[data-testid="${TEST_IDS.shell}"]`);
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      const folderPath = parentFolderCmsPath(listed.path || "");
-      await openExplorerFolder(page, folderPath);
+      await openSitesThenPages(page);
 
       const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
       await expect(list).toBeVisible({ timeout: 15_000 });
@@ -282,13 +274,23 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
         await popup.close().catch(() => {});
       }
 
-      const folderRow = list
-        .locator('tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]')
-        .first();
-      if ((await folderRow.count()) > 0) {
-        await folderRow.click({ force: true });
-        await expect(preview).toBeDisabled();
-        await expect(preview).toHaveAttribute("title", /not available|Preview/i);
+      const folderRows = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+      );
+      if ((await folderRows.count()) > 0) {
+        await expect(folderRows.first()).toHaveAttribute(
+          "data-previewable",
+          "false",
+        );
+        const selectableFolder = list
+          .locator(
+            'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]:not([aria-disabled="true"])',
+          )
+          .first();
+        if ((await selectableFolder.count()) > 0) {
+          await selectableFolder.click({ force: true });
+          await expect(preview).toBeDisabled({ timeout: 10_000 });
+        }
       }
 
       expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -31,7 +31,7 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { loginAsAdmin, BASE_URL, adminBasicAuthHeaders } = require("./helpers/auth");
 const {
   TEST_IDS,
   explorerEntryUrl,
@@ -40,6 +40,8 @@ const {
   unwrapPathItems,
   resolveExplorerListPath,
   isProductPagePreviewUrl,
+  listedPageSiteNames,
+  foldSiteName,
 } = require("./helpers/explorer-preview-view");
 
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -125,11 +127,13 @@ async function findListedPageViaRest(request) {
 }
 
 /**
- * Open Sites → first sample site → Pages (when present).
- * Finder site names use underscores; repository folderPath does not (#3326).
+ * Open Sites → the site that owns {@code listed} (not merely the first
+ * folder row) → Pages when present. Finder names use underscores;
+ * repository folderPath does not (#3326).
  * @param {import("@playwright/test").Page} page
+ * @param {object} [listed]
  */
-async function openSitesThenPages(page) {
+async function openSitesThenPages(page, listed) {
   const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
   const sitesNode = tree
     .locator(
@@ -142,22 +146,73 @@ async function openSitesThenPages(page) {
   await page.waitForLoadState("networkidle").catch(() => {});
 
   const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
-  const siteRow = list
-    .locator('tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]')
-    .first();
-  await expect(siteRow).toBeVisible({ timeout: 15_000 });
-  await siteRow.dblclick({ force: true });
-  await listWaitReady(page);
-  await page.waitForLoadState("networkidle").catch(() => {});
+  const siteRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  await expect(siteRows.first()).toBeVisible({ timeout: 15_000 });
 
-  const pagesRow = list
-    .locator('tbody tr[data-testid^="detail-row-"]')
-    .filter({ hasText: /^Pages$/ })
-    .first();
-  if ((await pagesRow.count()) > 0) {
-    await pagesRow.dblclick({ force: true });
+  const wanted = new Set(listedPageSiteNames(listed).map((n) => foldSiteName(n)));
+  const listedName = listed && listed.name ? String(listed.name) : "";
+  const siteCount = await siteRows.count();
+  let opened = false;
+  for (let i = 0; i < siteCount; i += 1) {
+    if (i > 0) {
+      await sitesNode.click({ force: true });
+      await listWaitReady(page);
+      await page.waitForLoadState("networkidle").catch(() => {});
+    }
+    const row = siteRows.nth(i);
+    const rowText = ((await row.innerText().catch(() => "")) || "").trim();
+    const foldedRow = foldSiteName(rowText);
+    const nameMatch =
+      wanted.size === 0 || [...wanted].some((n) => n && foldedRow.includes(n));
+    if (!nameMatch) continue;
+    await row.dblclick({ force: true });
     await listWaitReady(page);
     await page.waitForLoadState("networkidle").catch(() => {});
+
+    const pagesRow = list
+      .locator('tbody tr[data-testid^="detail-row-"]')
+      .filter({ hasText: /^Pages$/ })
+      .first();
+    if ((await pagesRow.count()) > 0) {
+      await pagesRow.dblclick({ force: true });
+      await listWaitReady(page);
+      await page.waitForLoadState("networkidle").catch(() => {});
+    }
+
+    const previewable = list.locator(
+      'tbody tr[data-testid^="detail-row-"][data-previewable="true"]',
+    );
+    const byName = listedName
+      ? list
+          .locator('tbody tr[data-testid^="detail-row-"]')
+          .filter({ hasText: listedName })
+      : previewable;
+    if ((await previewable.count()) > 0 || (await byName.count()) > 0) {
+      opened = true;
+      break;
+    }
+  }
+  if (!opened && wanted.size > 0) {
+    throw new Error(
+      `REST listed page ${listedName || listed.id} but UI did not open a ` +
+        `matching site among ${[...wanted].join(", ")}`,
+    );
+  }
+  if (!opened) {
+    await siteRows.first().dblclick({ force: true });
+    await listWaitReady(page);
+    await page.waitForLoadState("networkidle").catch(() => {});
+    const pagesRow = list
+      .locator('tbody tr[data-testid^="detail-row-"]')
+      .filter({ hasText: /^Pages$/ })
+      .first();
+    if ((await pagesRow.count()) > 0) {
+      await pagesRow.dblclick({ force: true });
+      await listWaitReady(page);
+      await page.waitForLoadState("networkidle").catch(() => {});
+    }
   }
 }
 
@@ -225,7 +280,7 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
       const shell = page.locator(`[data-testid="${TEST_IDS.shell}"]`);
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      await openSitesThenPages(page);
+      await openSitesThenPages(page, listed);
 
       const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
       await expect(list).toBeVisible({ timeout: 15_000 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -15,11 +15,13 @@
  */
 
 /**
- * Playwright surface: #2733 — Explorer preview polish + View refresh residual.
+ * Playwright surface: #2733 / #3456 — Explorer preview for a listed page.
  *
- * <p>Verifies product shell chrome for Preview + Refresh. When H2 fixture
- * lacks a previewable content row, preview-open soft-skips (unit coverage
- * still applies).</p>
+ * <p>Verifies product shell chrome for Preview + Refresh, then opens
+ * product preview for a listed page row. Folders stay Preview-disabled.
+ * Soft-skip only when REST listing has no page-type child (listing not
+ * on the tip). Do not skip solely because the Sites root list is empty
+ * of pages when {@code /Pages} lists children (#3457 on tip).</p>
  *
  * <p>Tags: {@code @explorer-preview-view} {@code @preview} {@code @smoke}</p>
  *
@@ -29,12 +31,23 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
 const {
   TEST_IDS,
   explorerEntryUrl,
-  noPreviewableItemSkipMessage,
+  noListedPageSkipMessage,
+  isListedPageRow,
+  unwrapPathItems,
+  parentFolderCmsPath,
+  isProductPagePreviewUrl,
 } = require("./helpers/explorer-preview-view");
+
+const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
+const PATH_PAGED = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/paginatedFolder`;
 
 async function listWaitReady(page) {
   await page.locator(`[data-testid="${TEST_IDS.list}"]`).waitFor({
@@ -42,7 +55,120 @@ async function listWaitReady(page) {
   });
 }
 
-test.describe("modern React Content Explorer — preview + view residual (#2733)", () => {
+/**
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} cmsPath
+ * @returns {Promise<object[]>}
+ */
+async function fetchFolderChildren(request, cmsPath) {
+  const headers = adminBasicAuthHeaders();
+  const rel = String(cmsPath || "")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+  const paged = await request.get(
+    `${PATH_PAGED}/${rel}?startIndex=0&maxResults=50`,
+    { headers },
+  );
+  if (paged.status() === 200) {
+    return unwrapPathItems(await paged.json());
+  }
+  const folder = await request.get(`${PATH_FOLDER}/${rel}`, { headers });
+  if (folder.status() === 200) {
+    return unwrapPathItems(await folder.json());
+  }
+  return [];
+}
+
+/**
+ * Walk Sites → site → Pages (and one more folder level) for a listed page.
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @returns {Promise<object|null>}
+ */
+async function findListedPageViaRest(request) {
+  const sites = await fetchFolderChildren(request, "Sites");
+  const siteNames = sites
+    .map((s) => (s && s.name ? String(s.name) : ""))
+    .filter(Boolean);
+
+  const candidateFolders = [];
+  for (const name of siteNames) {
+    candidateFolders.push(`Sites/${name}`);
+    candidateFolders.push(`Sites/${name}/Pages`);
+  }
+
+  for (const folder of candidateFolders) {
+    const kids = await fetchFolderChildren(request, folder);
+    const page = kids.find((k) => isListedPageRow(k));
+    if (page) return page;
+    for (const kid of kids.slice(0, 12)) {
+      const kidType = `${kid.type || ""} ${kid.category || ""}`.toLowerCase();
+      const kidName = String(kid.name || "");
+      const looksFolder =
+        kidType.includes("folder") ||
+        kidType.includes("site") ||
+        String(kid.path || "").endsWith("/");
+      if (!looksFolder || !kidName) continue;
+      const nested = await fetchFolderChildren(request, `${folder}/${kidName}`);
+      const nestedPage = nested.find((k) => isListedPageRow(k));
+      if (nestedPage) return nestedPage;
+    }
+  }
+  return null;
+}
+
+/**
+ * Click Explorer tree/list down to {@code folderPath} under Sites.
+ * @param {import("@playwright/test").Page} page
+ * @param {string} folderPath
+ */
+async function openExplorerFolder(page, folderPath) {
+  const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
+  const sitesNode = tree
+    .locator(
+      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"]',
+    )
+    .first();
+  await expect(sitesNode).toBeVisible({ timeout: 15_000 });
+  await sitesNode.click({ force: true });
+  await listWaitReady(page);
+
+  const segments = String(folderPath || "")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((s) => s && s.toLowerCase() !== "sites");
+
+  for (const segment of segments) {
+    const treeHit = tree
+      .locator(
+        `[data-testid="tree-node-/Sites/${segment}/"], [data-testid="tree-node-/Sites/${segment}"], [data-testid$="/${segment}/"], [data-testid$="/${segment}"]`,
+      )
+      .first();
+    if ((await treeHit.count()) > 0 && (await treeHit.isVisible().catch(() => false))) {
+      await treeHit.click({ force: true }).catch(() => {});
+      await listWaitReady(page);
+      await page.waitForLoadState("networkidle").catch(() => {});
+      continue;
+    }
+    const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
+    const row = list
+      .locator(`tbody tr[data-testid^="detail-row-"]`)
+      .filter({ hasText: segment })
+      .first();
+    if ((await row.count()) > 0) {
+      await row.dblclick({ force: true }).catch(async () => {
+        await row.click({ force: true });
+        const openBtn = page.locator('[data-testid="action-open"]');
+        if (await openBtn.isEnabled().catch(() => false)) {
+          await openBtn.click();
+        }
+      });
+      await listWaitReady(page);
+      await page.waitForLoadState("networkidle").catch(() => {});
+    }
+  }
+}
+
+test.describe("modern React Content Explorer — preview + view residual (#2733 / #3456)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(45_000);
     await loginAsAdmin(page);
@@ -54,6 +180,9 @@ test.describe("modern React Content Explorer — preview + view residual (#2733)
     "shell mounts preview action and refresh view control",
     { tag: ["@explorer-preview-view", "@preview", "@smoke"] },
     async ({ page }) => {
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
       const shell = page.locator(`[data-testid="${TEST_IDS.shell}"]`);
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
@@ -78,63 +207,93 @@ test.describe("modern React Content Explorer — preview + view residual (#2733)
       await expect(
         page.locator(`[data-testid="${TEST_IDS.list}"]`),
       ).toBeVisible({ timeout: 15_000 });
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 
   test(
-    "preview enabled for a content row or soft-skip when H2 lacks item",
+    "preview opens for a listed page; folders stay disabled",
     { tag: ["@explorer-preview-view", "@preview"] },
     async ({ page }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+      // Use the logged-in page request (session cookies). Isolated
+      // APIRequestContext basic-auth is often redirected to login.
+      const listed = await findListedPageViaRest(page.request);
+      if (!listed) {
+        test.skip(true, noListedPageSkipMessage());
+        return;
+      }
+
       const shell = page.locator(`[data-testid="${TEST_IDS.shell}"]`);
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      const tree = page.locator(`[data-testid="${TEST_IDS.tree}"]`);
-      await expect(tree).toBeVisible({ timeout: 15_000 });
-      const sitesNode = page
-        .locator(
-          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-        )
-        .first();
-      if ((await sitesNode.count()) > 0) {
-        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        await listWaitReady(page);
-        await page.waitForLoadState("networkidle").catch(() => {});
-      }
+      const folderPath = parentFolderCmsPath(listed.path || "");
+      await openExplorerFolder(page, folderPath);
 
       const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
       await expect(list).toBeVisible({ timeout: 15_000 });
 
-      const rows = list.locator('tbody tr[data-testid^="detail-row-"]');
-      const rowCount = await rows.count();
-      if (rowCount === 0) {
-        test.skip(true, noPreviewableItemSkipMessage());
-        return;
+      const previewable = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-previewable="true"]',
+      );
+      const itemRows = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+      );
+      let pageRow = previewable.first();
+      if ((await previewable.count()) === 0) {
+        pageRow = itemRows.first();
       }
-
-      // Prefer non-folder rows: force-click first few until Preview enables.
-      let previewEnabled = false;
-      const maxProbe = Math.min(rowCount, 8);
-      for (let i = 0; i < maxProbe; i++) {
-        const row = rows.nth(i);
-        await row.click({ force: true, timeout: 10_000 }).catch(() => {});
-        const preview = page.locator(`[data-testid="${TEST_IDS.preview}"]`);
-        if (await preview.isEnabled().catch(() => false)) {
-          previewEnabled = true;
-          // Soft smoke: click opens a popup or navigates; do not assert body
-          // (fixture-dependent). Popup may be blocked in CI — just ensure no throw.
-          const popupPromise = page
-            .waitForEvent("popup", { timeout: 5_000 })
-            .catch(() => null);
-          await preview.click();
-          await popupPromise;
-          break;
+      if ((await pageRow.count()) === 0) {
+        const byName = list
+          .locator('tbody tr[data-testid^="detail-row-"]')
+          .filter({ hasText: String(listed.name || "") })
+          .first();
+        if ((await byName.count()) === 0) {
+          throw new Error(
+            `REST listed page ${listed.name || listed.id} at ${listed.path} ` +
+              `but Explorer detail list has no page/item row (listing on tip — do not skip)`,
+          );
         }
+        pageRow = byName;
       }
 
-      if (!previewEnabled) {
-        test.skip(true, noPreviewableItemSkipMessage());
+      await pageRow.click({ force: true });
+      const preview = page.locator(`[data-testid="${TEST_IDS.preview}"]`);
+      await expect(preview).toBeEnabled({ timeout: 10_000 });
+
+      const popupPromise = page.waitForEvent("popup", { timeout: 10_000 });
+      await preview.click();
+      const popup = await popupPromise;
+      let popupUrl = popup ? popup.url() : "";
+      if (popup && (!popupUrl || /about:blank/i.test(popupUrl))) {
+        await popup.waitForLoadState("domcontentloaded").catch(() => {});
+        popupUrl = popup.url();
       }
+      expect(
+        isProductPagePreviewUrl(popupUrl),
+        `Preview popup URL should be page render or site-path preview; got ${popupUrl}`,
+      ).toBe(true);
+      if (popup && !popup.isClosed()) {
+        await popup.close().catch(() => {});
+      }
+
+      const folderRow = list
+        .locator('tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]')
+        .first();
+      if ((await folderRow.count()) > 0) {
+        await folderRow.click({ force: true });
+        await expect(preview).toBeDisabled();
+        await expect(preview).toHaveAttribute("title", /not available|Preview/i);
+      }
+
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -210,10 +210,44 @@ function isProductPagePreviewUrl(url) {
   if (u.includes("/pagemanagement/render/page/")) return true;
   if (u.includes("/assembler/render")) return true;
   if (u.includes("percmobilepreview=")) return true;
-  // FastForward rff* types open classic CE preview (sys_command=preview).
+  // Classic CE preview requires the command — not any URL with "preview"
+  // near /psx_ce (e.g. /psx_ce/admin/preview-settings).
   if (u.includes("sys_command=preview")) return true;
-  if (u.includes("/psx_ce") && u.includes("preview")) return true;
   return false;
+}
+
+/**
+ * Fold finder / repository site names so spaces and underscores match.
+ * @param {string} name
+ * @returns {string}
+ */
+function foldSiteName(name) {
+  return String(name || "")
+    .toLowerCase()
+    .replace(/[_\s-]+/g, "");
+}
+
+/**
+ * Site folder names for a listed page (finder underscore + repository).
+ * @param {{ path?: string, folderPath?: string }} listed
+ * @returns {string[]}
+ */
+function listedPageSiteNames(listed) {
+  if (!listed) return [];
+  const names = [];
+  const seen = new Set();
+  for (const raw of [listed.folderPath, listed.path]) {
+    if (!raw) continue;
+    const p = resolveExplorerListPath({ path: String(raw) });
+    const parts = p.replace(/^\/+/, "").split("/").filter(Boolean);
+    if (parts.length < 2 || parts[0].toLowerCase() !== "sites") continue;
+    const name = parts[1];
+    const key = foldSiteName(name);
+    if (!name || seen.has(key)) continue;
+    seen.add(key);
+    names.push(name);
+  }
+  return names;
 }
 
 module.exports = {
@@ -229,4 +263,6 @@ module.exports = {
   resolveExplorerListPath,
   parentFolderCmsPath,
   isProductPagePreviewUrl,
+  listedPageSiteNames,
+  foldSiteName,
 };

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -93,6 +93,19 @@ function noPreviewableItemSkipMessage() {
 }
 
 /**
+ * Skip only when REST listing also has no page-type children (listing not on
+ * tip / #3457 not recovered). Do not use when Pages already lists a page.
+ * @returns {string}
+ */
+function noListedPageSkipMessage() {
+  return (
+    "No listed page-type child under Sites/Pages after REST walk; " +
+    "Preview open requires a page row (parent #2745 / slice #3456). " +
+    "If sample-site Pages listing is on the tip (#3457), this skip is a defect."
+  );
+}
+
+/**
  * Heuristic: row looks like a non-folder content item (page/asset).
  * @param {{ type?: string, category?: string, path?: string, id?: string }} row
  * @returns {boolean}
@@ -101,12 +114,86 @@ function isPreviewableRow(row) {
   if (!row) return false;
   const token = `${row.type || ""} ${row.category || ""}`.toLowerCase();
   const path = String(row.path || "").toLowerCase();
-  if (token.includes("folder") || path.endsWith("/")) return false;
+  if (token.includes("folder") || token.includes("site") || path.endsWith("/")) {
+    return false;
+  }
   if (token.includes("page") || path.includes("/sites/")) return true;
   if (token.includes("asset") || path.includes("/assets/")) {
     return Boolean(row.id);
   }
   return Boolean(row.id);
+}
+
+/**
+ * Listed Explorer page (percPage / Page) — folders stay false.
+ * @param {{ type?: string, category?: string, path?: string, id?: string, name?: string }} row
+ * @returns {boolean}
+ */
+function isListedPageRow(row) {
+  if (!row) return false;
+  const token = `${row.type || ""} ${row.category || ""}`.toLowerCase();
+  const path = String(row.path || "").replace(/\\/g, "/").toLowerCase();
+  if (
+    token.includes("folder") ||
+    token.includes("fsfolder") ||
+    token.includes("site") ||
+    path.endsWith("/")
+  ) {
+    return false;
+  }
+  if (token.includes("page")) return true;
+  if (path.includes("/pages/") && Boolean(row.id)) return true;
+  return false;
+}
+
+/**
+ * Unwrap pathmanagement folder or paginatedFolder JSON to item objects.
+ * @param {unknown} body
+ * @returns {object[]}
+ */
+function unwrapPathItems(body) {
+  if (body == null || typeof body !== "object") return [];
+  const root = /** @type {Record<string, unknown>} */ (body);
+  if (Array.isArray(root.PathItem)) return root.PathItem;
+  if (Array.isArray(body)) return body;
+  const paged =
+    root.PagedItemList && typeof root.PagedItemList === "object"
+      ? /** @type {Record<string, unknown>} */ (root.PagedItemList)
+      : root;
+  if (Array.isArray(paged.childrenInPage)) return paged.childrenInPage;
+  if (Array.isArray(paged.children)) return paged.children;
+  return [];
+}
+
+/**
+ * Parent CMS folder path for a listed item (logical `/` paths, not OS).
+ * @param {string} itemPath
+ * @returns {string}
+ */
+function parentFolderCmsPath(itemPath) {
+  let p = String(itemPath || "")
+    .trim()
+    .replace(/\\/g, "/");
+  while (p.startsWith("//")) p = p.slice(1);
+  if (p && !p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1 && p.endsWith("/")) p = p.replace(/\/+$/, "");
+  const idx = p.lastIndexOf("/");
+  if (idx <= 0) return p || "/";
+  return p.slice(0, idx) || "/";
+}
+
+/**
+ * Whether a popup URL is a product page preview (render or site-path).
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isProductPagePreviewUrl(url) {
+  const u = String(url || "").replace(/\\/g, "/").toLowerCase();
+  if (!u) return false;
+  if (u.includes("/pagemanagement/render/page/")) return true;
+  if (u.includes("/assembler/render")) return true;
+  if (u.includes("percmobilepreview=")) return true;
+  return false;
 }
 
 module.exports = {
@@ -115,5 +202,10 @@ module.exports = {
   pageRenderPreviewPath,
   sitePathPreviewUrl,
   noPreviewableItemSkipMessage,
+  noListedPageSkipMessage,
   isPreviewableRow,
+  isListedPageRow,
+  unwrapPathItems,
+  parentFolderCmsPath,
+  isProductPagePreviewUrl,
 };

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -141,7 +141,7 @@ function isListedPageRow(row) {
   ) {
     return false;
   }
-  if (token.includes("page")) return true;
+  if (token.includes("page") || token.includes("rffhome")) return true;
   if (path.includes("/pages/") && Boolean(row.id)) return true;
   return false;
 }
@@ -163,6 +163,23 @@ function unwrapPathItems(body) {
   if (Array.isArray(paged.childrenInPage)) return paged.childrenInPage;
   if (Array.isArray(paged.children)) return paged.children;
   return [];
+}
+
+/**
+ * Pathmanagement list path: prefer repository {@code folderPath}
+ * ({@code //Sites/CorporateInvestments}) over finder site-name path
+ * ({@code /Sites/Corporate_Investments/}) — peer of WebUI
+ * {@code resolveExplorerListPath} (#3326 / #3457).
+ * @param {{ path?: string, folderPath?: string }} item
+ * @returns {string}
+ */
+function resolveExplorerListPath(item) {
+  const raw = (item && (item.folderPath || item.path)) || "";
+  let p = String(raw).trim().replace(/\\/g, "/");
+  while (p.startsWith("//")) p = p.slice(1);
+  if (p && !p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1 && p.endsWith("/")) p = p.replace(/\/+$/, "");
+  return p;
 }
 
 /**
@@ -193,6 +210,9 @@ function isProductPagePreviewUrl(url) {
   if (u.includes("/pagemanagement/render/page/")) return true;
   if (u.includes("/assembler/render")) return true;
   if (u.includes("percmobilepreview=")) return true;
+  // FastForward rff* types open classic CE preview (sys_command=preview).
+  if (u.includes("sys_command=preview")) return true;
+  if (u.includes("/psx_ce") && u.includes("preview")) return true;
   return false;
 }
 
@@ -206,6 +226,7 @@ module.exports = {
   isPreviewableRow,
   isListedPageRow,
   unwrapPathItems,
+  resolveExplorerListPath,
   parentFolderCmsPath,
   isProductPagePreviewUrl,
 };

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -250,6 +250,37 @@ function listedPageSiteNames(listed) {
   return names;
 }
 
+/**
+ * True when any line of a detail-row {@code innerText} equals {@code name}.
+ * Whole-row regex {@code /^Pages$/} fails because rows also include Type
+ * and Path cells (#3463).
+ * @param {string} rowText
+ * @param {string} name
+ * @returns {boolean}
+ */
+function detailRowHasExactName(rowText, name) {
+  const want = String(name || "").trim();
+  if (!want) return false;
+  return String(rowText || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => line === want);
+}
+
+/**
+ * Folded site-name match against a detail-row's full text (finder
+ * underscores vs repository names).
+ * @param {string} rowText
+ * @param {Iterable<string>} wantedFolded
+ * @returns {boolean}
+ */
+function detailRowMatchesFoldedSite(rowText, wantedFolded) {
+  const folded = foldSiteName(rowText);
+  const wanted = [...(wantedFolded || [])].filter(Boolean);
+  if (wanted.length === 0) return false;
+  return wanted.some((n) => folded.includes(n));
+}
+
 module.exports = {
   TEST_IDS,
   explorerEntryUrl,
@@ -265,4 +296,6 @@ module.exports = {
   isProductPagePreviewUrl,
   listedPageSiteNames,
   foldSiteName,
+  detailRowHasExactName,
+  detailRowMatchesFoldedSite,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -22,6 +22,8 @@ const {
   resolveExplorerListPath,
   parentFolderCmsPath,
   isProductPagePreviewUrl,
+  listedPageSiteNames,
+  foldSiteName,
 } = require("../helpers/explorer-preview-view");
 
 describe("explorer-preview-view helpers (#2733)", () => {
@@ -169,6 +171,23 @@ describe("explorer-preview-view helpers (#2733)", () => {
       true,
     );
     assert.equal(isProductPagePreviewUrl("/Rhythmyx/cm/app/spa.jsp"), false);
+    assert.equal(
+      isProductPagePreviewUrl("/Rhythmyx/psx_ce/admin/preview-settings"),
+      false,
+    );
+  });
+
+  it("listedPageSiteNames reads finder and repository site folders", () => {
+    assert.deepEqual(
+      listedPageSiteNames({
+        path: "/Sites/Corporate_Investments/Pages/About",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+      ["CorporateInvestments"],
+    );
+    assert.deepEqual(listedPageSiteNames({ path: "/Assets/x" }), []);
+    assert.equal(foldSiteName("Corporate Investments"), "corporateinvestments");
+    assert.equal(foldSiteName("Corporate_Investments"), "corporateinvestments");
   });
 
   it("noPreviewableItemSkipMessage is stable and cites issue", () => {

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -19,6 +19,7 @@ const {
   isPreviewableRow,
   isListedPageRow,
   unwrapPathItems,
+  resolveExplorerListPath,
   parentFolderCmsPath,
   isProductPagePreviewUrl,
 } = require("../helpers/explorer-preview-view");
@@ -91,6 +92,14 @@ describe("explorer-preview-view helpers (#2733)", () => {
       true,
     );
     assert.equal(
+      isListedPageRow({
+        type: "rffHome",
+        path: "/Sites/CorporateInvestments/Pages/Home",
+        id: "16777215-101-551",
+      }),
+      true,
+    );
+    assert.equal(
       isListedPageRow({ type: "folder", path: "/Sites/D/Pages/" }),
       false,
     );
@@ -119,6 +128,20 @@ describe("explorer-preview-view helpers (#2733)", () => {
     assert.deepEqual(unwrapPathItems(null), []);
   });
 
+  it("resolveExplorerListPath prefers folderPath over site-name path", () => {
+    assert.equal(
+      resolveExplorerListPath({
+        path: "/Sites/Corporate_Investments/",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+      "/Sites/CorporateInvestments",
+    );
+    assert.equal(
+      resolveExplorerListPath({ path: "/Sites/Demo/" }),
+      "/Sites/Demo",
+    );
+  });
+
   it("parentFolderCmsPath is a logical CMS parent", () => {
     assert.equal(
       parentFolderCmsPath("/Sites/Demo/Pages/About"),
@@ -137,6 +160,12 @@ describe("explorer-preview-view helpers (#2733)", () => {
     );
     assert.equal(
       isProductPagePreviewUrl("/Sites/Demo/Home?percmobilepreview=false"),
+      true,
+    );
+    assert.equal(
+      isProductPagePreviewUrl(
+        "/Rhythmyx/psx_cerffHome/rffHome.html?sys_command=preview&sys_contentid=551",
+      ),
       true,
     );
     assert.equal(isProductPagePreviewUrl("/Rhythmyx/cm/app/spa.jsp"), false);

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -9,6 +9,8 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   TEST_IDS,
   explorerEntryUrl,
@@ -24,6 +26,8 @@ const {
   isProductPagePreviewUrl,
   listedPageSiteNames,
   foldSiteName,
+  detailRowHasExactName,
+  detailRowMatchesFoldedSite,
 } = require("../helpers/explorer-preview-view");
 
 describe("explorer-preview-view helpers (#2733)", () => {
@@ -197,5 +201,35 @@ describe("explorer-preview-view helpers (#2733)", () => {
   it("noListedPageSkipMessage cites listing slice", () => {
     assert.match(noListedPageSkipMessage(), /#3457/);
     assert.match(noListedPageSkipMessage(), /#3456/);
+  });
+
+  it("detailRowHasExactName matches a name cell, not whole-row /^Pages$/", () => {
+    const rowText = "Pages\nFolder\n/Sites/Corporate_Investments/Pages/";
+    assert.equal(detailRowHasExactName(rowText, "Pages"), true);
+    assert.equal(detailRowHasExactName(rowText, "Files"), false);
+    assert.equal(/^Pages$/.test(rowText), false);
+  });
+
+  it("detailRowMatchesFoldedSite matches finder underscore site rows", () => {
+    const rowText =
+      "Corporate_Investments\nsite\n/Sites/Corporate_Investments/";
+    assert.equal(
+      detailRowMatchesFoldedSite(rowText, ["corporateinvestments"]),
+      true,
+    );
+    assert.equal(
+      detailRowMatchesFoldedSite(rowText, ["enterpriseinvestments"]),
+      false,
+    );
+  });
+
+  it("preview spec imports adminBasicAuthHeaders for REST listing (#3463)", () => {
+    const specPath = path.join(__dirname, "..", "explorer-preview-view.spec.js");
+    const src = fs.readFileSync(specPath, "utf8");
+    assert.match(
+      src,
+      /const\s*\{[^}]*adminBasicAuthHeaders[^}]*\}\s*=\s*require\(["']\.\/helpers\/auth["']\)/,
+    );
+    assert.match(src, /adminBasicAuthHeaders\s*\(\s*\)/);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -15,7 +15,12 @@ const {
   pageRenderPreviewPath,
   sitePathPreviewUrl,
   noPreviewableItemSkipMessage,
+  noListedPageSkipMessage,
   isPreviewableRow,
+  isListedPageRow,
+  unwrapPathItems,
+  parentFolderCmsPath,
+  isProductPagePreviewUrl,
 } = require("../helpers/explorer-preview-view");
 
 describe("explorer-preview-view helpers (#2733)", () => {
@@ -72,7 +77,77 @@ describe("explorer-preview-view helpers (#2733)", () => {
     );
   });
 
+  it("isListedPageRow accepts percPage/Page and rejects folders (#3456)", () => {
+    assert.equal(
+      isListedPageRow({
+        type: "percPage",
+        path: "/Sites/Corporate_Investments/Pages/About",
+        id: "16777215-101-9",
+      }),
+      true,
+    );
+    assert.equal(
+      isListedPageRow({ type: "Page", path: "/Sites/D/Home", id: "1" }),
+      true,
+    );
+    assert.equal(
+      isListedPageRow({ type: "folder", path: "/Sites/D/Pages/" }),
+      false,
+    );
+    assert.equal(
+      isListedPageRow({ type: "site", path: "/Sites/D/" }),
+      false,
+    );
+  });
+
+  it("unwrapPathItems reads PathItem and PagedItemList children", () => {
+    assert.deepEqual(
+      unwrapPathItems({ PathItem: [{ name: "A" }, { name: "B" }] }).map(
+        (i) => i.name,
+      ),
+      ["A", "B"],
+    );
+    assert.deepEqual(
+      unwrapPathItems({
+        PagedItemList: {
+          childrenInPage: [{ name: "About", type: "percPage" }],
+          childrenCount: 1,
+        },
+      }).map((i) => i.name),
+      ["About"],
+    );
+    assert.deepEqual(unwrapPathItems(null), []);
+  });
+
+  it("parentFolderCmsPath is a logical CMS parent", () => {
+    assert.equal(
+      parentFolderCmsPath("/Sites/Demo/Pages/About"),
+      "/Sites/Demo/Pages",
+    );
+    assert.equal(parentFolderCmsPath("/Sites/Demo"), "/Sites");
+    assert.equal(parentFolderCmsPath("Sites/Demo/Home"), "/Sites/Demo");
+  });
+
+  it("isProductPagePreviewUrl matches render and site-path preview", () => {
+    assert.equal(
+      isProductPagePreviewUrl(
+        "/Rhythmyx/services/pagemanagement/render/page/16777215-101-9",
+      ),
+      true,
+    );
+    assert.equal(
+      isProductPagePreviewUrl("/Sites/Demo/Home?percmobilepreview=false"),
+      true,
+    );
+    assert.equal(isProductPagePreviewUrl("/Rhythmyx/cm/app/spa.jsp"), false);
+  });
+
   it("noPreviewableItemSkipMessage is stable and cites issue", () => {
     assert.match(noPreviewableItemSkipMessage(), /#2733/);
+  });
+
+  it("noListedPageSkipMessage cites listing slice", () => {
+    assert.match(noListedPageSkipMessage(), /#3457/);
+    assert.match(noListedPageSkipMessage(), /#3456/);
   });
 });


### PR DESCRIPTION
## Summary

Cycle Verify residual of PR #3461 (`fb68b7f511`): Playwright `explorer-preview-view.spec.js` threw `ReferenceError: adminBasicAuthHeaders is not defined` because `fetchFolderChildren` called the helper without importing it. Tip `b19eabc` already restored the import; this branch rebases that #3461 tip onto latest `main` and **keeps** `const { loginAsAdmin, BASE_URL, adminBasicAuthHeaders } = require("./helpers/auth")`.

Live H2 after the import restore still failed: `openSitesThenPages` matched `Pages` with whole-row `/^Pages$/`, which never hits because detail rows also include Type and Path cells. The spec now matches the Name cell (`detailRowHasExactName`) and opens folders via the folder-icon control (peer #3328). Preview opened for listed `rffHome` “Corporate Investments Home”; folders stayed `data-previewable=false`.

Fixes #3463  
Parent: #3456 / #2745  
Related: #3461 (same preview tip; this PR is the Cycle Verify land + Pages nav proof)

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS.
2. Standalone `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. `cd modules/perc-qa-automation/frontend && npm run test:unit` — includes import + Name-cell helpers.
4. After `perc-devctl qa-up` + `qa-health` (HTTP 200, HEALTH=healthy, no `Failed startup of context`):
   `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/explorer-preview-view.spec.js`
5. Confirm Preview opens for a listed page; folder rows stay `data-previewable=false`. Soft-skip only after a successful REST listing with no page child.

## Checklist

- [x] **Product documentation** — N/A (test/import residual; operator Preview steps unchanged in `product-docs/8.2/admin/content-explorer.md`)
- [x] **Unit / module tests** — import-regression + Name-cell helpers; WebUI Vitest + perc-qa-automation unit
- [x] **WebUI + Playwright** — `tests/explorer-preview-view.spec.js` 2 passed, 0 skipped on H2
- [x] **Build gates** — WebUI + perc-qa-automation standalone `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — spec-source read uses `path.join`; CMS `/` repository paths only

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Vitest Test Files 337 passed, Tests 2552 passed; Java Tests run: 61, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `npm run test:unit` → tests 286, pass 286
- **downstream_checked:** none — no `final`/`sealed` or public signature break; additive Playwright helpers only

### C5 UI proof

- Cell `perc-matrix-cms-h2` published `http://127.0.0.1:9993`. `qa-health` HTTP 200 HEALTH=healthy. `RESULT:FAIL DETAIL:server_log_errors` on **pre-existing** FastForward binary import (`CI_PM_about.gif` / `CI_PM_advice.gif`). Not `Failed startup of context`.
- Hot-copied `WebUI/target/generated-webui/cm/modern/assets/` + `spa.jsp`; in-cell StopJetty/StartJetty. qa-health again: HTTP 200 HEALTH=healthy.
- `TEST_CMS_URL=http://127.0.0.1:9993` `npm run test:surface -- --path tests/explorer-preview-view.spec.js` → **2 passed**, 0 skipped.
- console-clean=yes (pageerror listeners empty)
- server.log-clean=no (pre-existing FastForward import / search-index modifier / Assembly i18n secure-processing; no new Preview-specific ERROR)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.