### PR TITLE
fix(explorer): surface Publish Now HTTP 200 FORBIDDEN on server-actions error (#3451)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -458,6 +458,14 @@ function ContentExplorerShellInner({
   const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
   /** Non-fatal catalog load failure — chrome stays mounted (#2972). */
   const [menuLoadError, setMenuLoadError] = useState<string | null>(null);
+  /**
+   * Action-invoke failure (Publish Now HTTP 200 FORBIDDEN, etc.).
+   * Catalog load uses {@code menuLoadError}; invoke uses this so
+   * {@code explorer-server-actions-error} still mounts (#3451).
+   */
+  const [actionInvokeError, setActionInvokeError] = useState<string | null>(
+    null,
+  );
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [templatePicker, setTemplatePicker] =
     useState<TemplatePickerSession | null>(null);
@@ -506,6 +514,7 @@ function ContentExplorerShellInner({
   const handleRefreshList = useCallback(() => {
     setListEpoch((n) => n + 1);
     setError(null);
+    setActionInvokeError(null);
   }, []);
 
   useEffect(() => {
@@ -659,6 +668,7 @@ function ContentExplorerShellInner({
 
   const handleActionError = useCallback((msg: string) => {
     setError(msg);
+    setActionInvokeError(msg);
   }, []);
 
   const handleAddToClipboard = useCallback(() => {
@@ -776,15 +786,23 @@ function ContentExplorerShellInner({
             pickPageTemplate,
           });
           if (result.messageKey) {
-            setError(message(result.messageKey));
+            const msg = message(result.messageKey);
+            setError(msg);
+            setActionInvokeError(msg);
           } else {
             setError(null);
+            setActionInvokeError(null);
           }
           if (result.refresh) {
             setListEpoch((n) => n + 1);
           }
         } catch (err: unknown) {
-          setError(formatApiError(err, message(EXPLORER_MSG.ERROR_GENERIC)));
+          const msg = formatApiError(
+            err,
+            message(EXPLORER_MSG.ERROR_GENERIC),
+          );
+          setError(msg);
+          setActionInvokeError(msg);
         }
       })();
       void actionName;
@@ -1072,18 +1090,24 @@ function ContentExplorerShellInner({
               {message(EXPLORER_MSG.SERVER_ACTIONS_LABEL)}
             </span>
             <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-              {menuLoadError ? (
+              {menuLoadError || actionInvokeError ? (
                 <div
                   data-testid="explorer-server-actions-error"
                   role="status"
                   aria-live="polite"
                   style={{ color: "#b00020", fontSize: "0.85rem", padding: "4px 0" }}
                 >
-                  {message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)}
-                  {menuLoadError &&
-                  menuLoadError !== message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)
-                    ? `: ${menuLoadError}`
-                    : null}
+                  {menuLoadError ? (
+                    <>
+                      {message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)}
+                      {menuLoadError !==
+                      message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)
+                        ? `: ${menuLoadError}`
+                        : null}
+                    </>
+                  ) : (
+                    actionInvokeError
+                  )}
                 </div>
               ) : null}
               <ActionToolbar

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -277,6 +277,102 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("Publish Now HTTP 200 FORBIDDEN mounts server-actions error (#3451)", async () => {
+    const fetchSpy = mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("sitemanage/publish/")) {
+        return new Response(
+          JSON.stringify({
+            status: "FORBIDDEN",
+            warningMessage:
+              "Publication stopped because of licensing issues",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => [
+          {
+            name: "Publish_Now",
+            label: "Publish Now",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ]}
+        loadWorkflowMenuActions={async () => null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-42")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-toolbar-item-Publish_Now"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-42"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("action-toolbar-item-Publish_Now"),
+      ).toBeInTheDocument();
+    });
+
+    const folderLoadsBefore = fetchSpy.mock.calls.filter((call) => {
+      const url = String(call[0] ?? "");
+      return url.includes("paginatedFolder") || url.includes("/folder/");
+    }).length;
+
+    fireEvent.click(screen.getByTestId("action-toolbar-item-Publish_Now"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-server-actions-error"),
+      ).toHaveTextContent(/FORBIDDEN|licensing|Publication stopped/i);
+    });
+    expect(
+      fetchSpy.mock.calls.some((call) =>
+        String(call[0] ?? "").includes("sitemanage/publish/"),
+      ),
+    ).toBe(true);
+    const folderLoadsAfter = fetchSpy.mock.calls.filter((call) => {
+      const url = String(call[0] ?? "");
+      return url.includes("paginatedFolder") || url.includes("/folder/");
+    }).length;
+    // Throw must not refresh the list as if the item published.
+    expect(folderLoadsAfter).toBe(folderLoadsBefore);
+    await renderA11yGate(container);
+  });
+
   it("discards stale context-menu loads when right-clicking rows rapidly (#2732 race)", async () => {
     let releaseSlow: (() => void) | undefined;
     const slowGate = new Promise<void>((resolve) => {

--- a/docs/ai-generated/code-reviews/3451-explorer-publish-forbidden-error-erlang.md
+++ b/docs/ai-generated/code-reviews/3451-explorer-publish-forbidden-error-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review: Explorer Publish Now HTTP 200 FORBIDDEN error chrome (#3451)
+
+**Branch:** `fix/issue-3451-explorer-publish-forbidden-error`  
+**Base:** `origin/main`  
+**Date:** 2026-08-15  
+**Persona:** Erlang (independent of implementer)
+
+## Summary
+
+Explorer Publish Now already throws on HTTP 200 `{status:"FORBIDDEN"}` via
+`mapPublishResponse` / `publishSelectedItem`. The shell only mounted
+`[data-testid=explorer-server-actions-error]` for catalog `menuLoadError`.
+Invoke failures wrote the generic `error` alert instead, so Playwright
+`explorer-action-dispatch.spec.js` never saw the server-actions error region.
+
+This change adds `actionInvokeError` and mounts the same testid for
+`handleMenuInvoke` / `handleActionError` failures, showing the thrown
+FORBIDDEN/licensing text. Successful invoke still clears the region and
+does not refresh the list on throw.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral Vitest covers the FORBIDDEN 200 path on the
+shell (error region text + no extra folder refresh). Existing
+`itemPublish` throw tests remain. Playwright spec already asserts the
+testid; product-docs N/A (no new operator chrome copy).
+
+## Change-class closure
+
+Change class: **WebUI Explorer action-invoke error chrome**.
+
+| Companion | Status |
+|-----------|--------|
+| Shell `actionInvokeError` + testid | present |
+| Vitest (`ContentExplorerShell` FORBIDDEN 200) | present |
+| `itemPublish` throw tests | already present |
+| Playwright `explorer-action-dispatch.spec.js` | already present |
+| product-docs | N/A — server warning text only; no new chrome string |
+
+## Cross-platform path checklist
+
+No filesystem path I/O. Publish URLs use `/` (URL form). **Outcome: clean.**
+
+Memory patterns hit: missing behavioral test for changed logic (covered);
+WebUI Playwright companion (existing spec); incomplete change-class
+(Playwright + Vitest present).
+
+## Issues
+
+None.

--- a/docs/ai-generated/code-reviews/3451-explorer-publish-forbidden-error-erlang.md
+++ b/docs/ai-generated/code-reviews/3451-explorer-publish-forbidden-error-erlang.md
@@ -1,9 +1,13 @@
 # Erlang review: Explorer Publish Now HTTP 200 FORBIDDEN error chrome (#3451)
 
-**Branch:** `fix/issue-3451-explorer-publish-forbidden-error`  
-**Base:** `origin/main`  
+**Branch:** `fix/issue-3451-explorer-publish-forbidden-rebase`  
+**Base:** `origin/main` (`dc8f1a5100`, includes #3455 page-template picker)  
 **Date:** 2026-08-15  
 **Persona:** Erlang (independent of implementer)
+
+Rebase of #3459 (`2b3189b636`) onto latest main via cherry-pick. `handleMenuInvoke`
+kept `pickPageTemplate` in its dependency list; no conflict with the FORBIDDEN
+error-region wiring.
 
 ## Summary
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-dispatch.spec.js
@@ -85,8 +85,38 @@ test.describe("modern React Content Explorer — action dispatch", () => {
     "Publish Now HTTP 200 FORBIDDEN shows an error and does not treat it as published",
     { tag: ["@explorer-action-dispatch", "@explorer"] },
     async ({ page }) => {
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => {
+        pageErrors.push(String(err));
+      });
       page.on("dialog", (dialog) => {
         void dialog.accept();
+      });
+      // H2 QA sites often have no page rows. Inject one leaf so Publish Now
+      // can run and the 200 FORBIDDEN intercept can fire (#3451).
+      await page.route("**/pathmanagement/path/paginatedFolder**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "percPage",
+                  category: "page",
+                  accessLevel: "WRITE",
+                  leaf: true,
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+          }),
+        });
       });
       await page.route("**/services/sitemanage/publish/**", async (route) => {
         await route.fulfill({
@@ -105,34 +135,16 @@ test.describe("modern React Content Explorer — action dispatch", () => {
         timeout: 20_000,
       });
 
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      if ((await tree.count()) > 0) {
-        const sitesNode = page
-          .locator(
-            '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-          )
-          .first();
-        if ((await sitesNode.count()) > 0) {
-          await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        }
-      }
-
-      const list = page.locator('[data-testid="detail-list"]');
-      if ((await list.count()) > 0) {
-        const row = list.locator('tbody tr[data-testid^="detail-row-"]').first();
-        if ((await row.count()) > 0) {
-          await row.click({ force: true, timeout: 10_000 }).catch(() => {});
-        }
-      }
+      const itemRow = page.locator(
+        '[data-testid="detail-row-42"], tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+      );
+      await expect(itemRow.first()).toBeVisible({ timeout: 20_000 });
+      await itemRow.first().click({ force: true });
 
       const publishNow = page.locator(
         '[data-testid="action-toolbar-item-Publish_Now"], [data-testid="action-toolbar-item-publish_now"]',
       );
-      if ((await publishNow.count()) === 0 || !(await publishNow.first().isVisible())) {
-        test.skip(true, "Publish Now action not visible for the current selection");
-        return;
-      }
-
+      await expect(publishNow.first()).toBeVisible({ timeout: 15_000 });
       await publishNow.first().click();
       await expect(
         page.locator('[data-testid="explorer-server-actions-error"]'),
@@ -140,6 +152,9 @@ test.describe("modern React Content Explorer — action dispatch", () => {
       await expect(
         page.locator('[data-testid="explorer-server-actions-error"]'),
       ).toContainText(/FORBIDDEN|licensing|Publication stopped/i);
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary

Cycle Verify residual #3451: Publish Now HTTP 200 `{status:"FORBIDDEN", warningMessage:"Publication stopped because of licensing issues"}` never mounted `[data-testid=explorer-server-actions-error]`. Explorer already throws via `mapPublishResponse`; the shell only used that testid for catalog `menuLoadError`.

This is a rebase/absorb of #3459 onto latest `main` (`dc8f1a5100`, includes #3455 page-template picker). Cherry-pick was clean: `handleMenuInvoke` / `handleActionError` still write `actionInvokeError`, keep list refresh off on throw, and Playwright injects a page row so H2 can invoke Publish Now.

Parent tracker: #3451
Supersedes: #3459

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3451

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then docker-cp `WebUI/target/generated-webui/cm/modern` + `spa.jsp`; in-cell StopJetty/StartJetty.
4. `qa-health` → HTTP 200 HEALTH=healthy (pre-existing FastForward import ERROR only).
5. `cd modules/perc-qa-automation/frontend` with `TEST_CMS_URL` from qa-up:
   - `npm run test:surface -- --path tests/explorer-action-dispatch.spec.js` → 2 passed.
   - golden-unattended-smoke + login + explorer-active-assembly → 7 passed; explorer-inbox 2 skipped (no Inbox leaf on this H2 cell).
6. Vitest: `ContentExplorerShell` “Publish Now HTTP 200 FORBIDDEN mounts server-actions error (#3451)”.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing chrome copy): existing server warning text is shown in the existing server-actions error region; no new operator procedure or chrome string.
- [x] **Unit / module tests** — WebUI Vitest + standalone `mvnw clean install`.
- [x] **WebUI + Playwright** — `tests/explorer-action-dispatch.spec.js` (inject page row so H2 can invoke Publish Now).
- [x] **Build gates** — WebUI + perc-qa-automation standalone clean install (no skipTests).
- [x] **Cross-platform** — **N/A** (no filesystem path I/O).

## C3 evidence

- **modules_built:** WebUI, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-15T19:12:29-04:00). Surefire Tests run: 61, Failures: 0. Vitest Test Files 337 passed, Tests 2547 passed.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-15T19:10:57-04:00).
- **downstream_checked:** none (no `final`/public API shape change)

## C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`
- Deploy: docker-cp generated `cm/modern` + `spa.jsp`; in-cell StopJetty/StartJetty; qa-health HTTP 200 HEALTH=healthy
- Playwright: `npm run test:surface -- --path tests/explorer-action-dispatch.spec.js` → 2 passed (5.9s)
- Golden/login/AA: 7 passed; inbox 2 skipped (fixture, no Inbox leaf)
- console-clean=yes (spec asserts no uncaught pageerror on Publish Now path)
- server.log-clean=yes for this feature (publish intercept is client-side; remaining ERROR lines are pre-existing FastForward / search-index / content-type fixture noise)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
