### PR TITLE
fix(explorer): stop remaining gravatar 404 and path/item 400 (#3468)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -186,7 +186,26 @@ export async function paginatedFolder(
   };
 }
 
+/**
+ * Whether {@code path} has a non-empty pathmanagement {@code /path/item/{path}}
+ * suffix. CMS root {@code /} (and blank) encode to {@code …/path/item/} which
+ * the server rejects as HTTP 400 "Invalid path" (#3468 / #3458).
+ */
+export function isPathItemLookupPath(
+  path: string | null | undefined,
+): boolean {
+  if (path == null) {
+    return false;
+  }
+  return encodePath(String(path)) !== "";
+}
+
 export async function findItemByPath(path: string): Promise<PSPathItem> {
+  // Every caller (security folder-id, editor host, Refresh) must skip root —
+  // defaultResolveFolderId alone still left live H2 probing path/item/ (#3468).
+  if (!isPathItemLookupPath(path)) {
+    return {} as PSPathItem;
+  }
   const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
   return res?.PathItem ?? ({} as PSPathItem);
 }

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -223,7 +223,13 @@ export async function loadUserPreference(
   try {
     const data = await get<unknown>(`${PATHS.PREFERENCES}/${key}`);
     // Prefer wrapped wire; do not accept flat as a successful production parse.
-    return unwrapUserPreference(data, { acceptFlat: false });
+    const pref = unwrapUserPreference(data, { acceptFlat: false });
+    // PreferenceResource returns 200 + empty value when nothing is stored
+    // (#3458 / #3468). Treat blank as unset so callers do not keep a dummy.
+    if (pref == null || pref.value == null || String(pref.value).trim() === "") {
+      return null;
+    }
+    return pref;
   } catch (err: unknown) {
     if (isNotFound(err)) {
       return null;

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -39,9 +39,9 @@ export function UserMenu(): React.ReactElement {
       try {
         // Do not swallow SessionRedirectError on getCurrentUserBasic — let the
         // outer guard see it so login redirect is not silently skipped.
-        // Do not GET /preferences/{name} from chrome — unset prefs 404 and
-        // pollute Explorer console (#3458 / #2745). Profile AvatarSection
-        // still loads the override. Primary email is enough for the chip.
+        // Do not GET /preferences/{name} (or the list) from chrome — unset
+        // prefs 404 on both /services and /Rhythmyx/services and pollute
+        // Explorer (#3468 / #3458). Profile AvatarSection loads via list.
         const basic = await getCurrentUserBasic();
         if (cancelled) {
           return;

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1024,7 +1024,9 @@ function ContentExplorerShellInner({
         return;
       }
       const path = selection.folderPath;
-      if (!path) {
+      // Skip root / blank before calling any injector — custom resolveFolderId
+      // implementations (and default findItemByPath) must not GET path/item/ (#3468).
+      if (!path || !isFolderIdLookupPath(path)) {
         if (!cancelled) setSecurityFolderId(undefined);
         return;
       }

--- a/WebUI/src/main/ts/profile/avatarPrefs.ts
+++ b/WebUI/src/main/ts/profile/avatarPrefs.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  loadUserPreference,
+  getAllUserPreferences,
   saveUserPreference,
   PREF_CATEGORY_SYS,
   PREF_CONTEXT_PRIVATE,
@@ -28,16 +28,22 @@ import {
 import { GRAVATAR_EMAIL_PREF_NAME } from "./gravatar";
 
 /**
- * Load stored Gravatar email override for the current session user
- * ({@code loadUserPreference} is always session-scoped). Empty string when
- * unset (caller falls back to primary account email).
+ * Load stored Gravatar email override for the current session user.
+ *
+ * <p>Uses GET {@code /preferences/} (list) — not GET {@code /preferences/{name}}.
+ * Unset named prefs 404 on live H2 and pollute Explorer when chrome or Profile
+ * still probes the named path ({@code /services/…} and {@code /Rhythmyx/services/…}
+ * twins, #3468). Empty string when unset (caller falls back to primary email).
  */
 export async function loadGravatarEmailOverride(): Promise<string> {
-  const pref = await loadUserPreference(GRAVATAR_EMAIL_PREF_NAME);
-  if (pref == null || pref.value == null) {
+  const listed = await getAllUserPreferences();
+  const match = listed.find(
+    (p) => (p.name || "").trim() === GRAVATAR_EMAIL_PREF_NAME,
+  );
+  if (match == null || match.value == null) {
     return "";
   }
-  return String(pref.value).trim();
+  return String(match.value).trim();
 }
 
 /**

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -72,6 +72,18 @@ describe("preferencesApi (PreferenceResource)", () => {
     await expect(loadUserPreference("missing")).resolves.toBeNull();
   });
 
+  it("loadUserPreference treats 200 empty value as unset (#3468)", async () => {
+    vi.spyOn(client, "get").mockResolvedValueOnce({
+      UserPreference: {
+        name: "perc_profile_gravatar_email",
+        value: "",
+      },
+    });
+    await expect(
+      loadUserPreference("perc_profile_gravatar_email"),
+    ).resolves.toBeNull();
+  });
+
   it("loadUserPreference unwraps Jackson UserPreference root", async () => {
     vi.spyOn(client, "get").mockResolvedValueOnce({
       UserPreference: {

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1524,6 +1524,23 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("root initialPath does not call resolveFolderId (#3468)", async () => {
+    stubPathFetch();
+    const resolveFolderId = vi.fn(async () => "should-not-run");
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        resolveFolderId={resolveFolderId}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell")).toBeInTheDocument();
+    });
+    expect(resolveFolderId).not.toHaveBeenCalled();
+  });
+
   it("root initialPath does not GET path/item/ (#3458)", async () => {
     const seen: string[] = [];
     mockFetch(async (input) => {

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -23,6 +23,7 @@ import {
   encodePath,
   findChildren,
   findItemByPath,
+  isPathItemLookupPath,
   folderProperties,
   FOLDER_PROPERTIES_ROOT,
   joinPathUrl,
@@ -198,6 +199,30 @@ describe("pathmanagement URL shape (no double-slash)", () => {
     await findItemByPath("/Sites/Foo");
     expect(cap.lastUrl()).toContain("/path/item/Sites/Foo");
     expect(cap.lastUrl()).not.toContain("item//Sites");
+  });
+
+  it("isPathItemLookupPath skips root so path/item/ is not probed (#3468)", () => {
+    expect(isPathItemLookupPath(null)).toBe(false);
+    expect(isPathItemLookupPath(undefined)).toBe(false);
+    expect(isPathItemLookupPath("")).toBe(false);
+    expect(isPathItemLookupPath("/")).toBe(false);
+    expect(isPathItemLookupPath("///")).toBe(false);
+    expect(isPathItemLookupPath("/Sites")).toBe(true);
+    expect(isPathItemLookupPath("/Sites/Foo")).toBe(true);
+  });
+
+  it("findItemByPath does not GET path/item/ for CMS root (#3468)", async () => {
+    const fn = mockFetch(async () => {
+      return new Response(JSON.stringify({ PathItem: { name: "root" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const empty = await findItemByPath("/");
+    expect(empty).toEqual({});
+    expect(fn).not.toHaveBeenCalled();
+    await findItemByPath("");
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it("addNewFolder joins path and query without double slash", async () => {

--- a/WebUI/src/test/ts/profile/avatarPrefs.test.ts
+++ b/WebUI/src/test/ts/profile/avatarPrefs.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadGravatarEmailOverride,
+  saveGravatarEmailOverride,
+} from "../../../main/ts/profile/avatarPrefs";
+import { GRAVATAR_EMAIL_PREF_NAME } from "../../../main/ts/profile/gravatar";
+import * as prefs from "../../../main/ts/api/preferences/preferencesApi";
+
+describe("avatarPrefs (#3468)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loadGravatarEmailOverride uses the list endpoint, not named GET", async () => {
+    const listSpy = vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([
+      { name: GRAVATAR_EMAIL_PREF_NAME, value: "  avatar@example.com " },
+      { name: "other", value: "x" },
+    ]);
+    const namedSpy = vi.spyOn(prefs, "loadUserPreference");
+    await expect(loadGravatarEmailOverride()).resolves.toBe("avatar@example.com");
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(namedSpy).not.toHaveBeenCalled();
+  });
+
+  it("loadGravatarEmailOverride returns empty when list has no override", async () => {
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([]);
+    const namedSpy = vi.spyOn(prefs, "loadUserPreference");
+    await expect(loadGravatarEmailOverride()).resolves.toBe("");
+    expect(namedSpy).not.toHaveBeenCalled();
+  });
+
+  it("saveGravatarEmailOverride still PUTs the named preference", async () => {
+    const saveSpy = vi.spyOn(prefs, "saveUserPreference").mockResolvedValueOnce({
+      name: GRAVATAR_EMAIL_PREF_NAME,
+      value: "saved@example.com",
+    });
+    await expect(
+      saveGravatarEmailOverride("Admin", "saved@example.com"),
+    ).resolves.toBe("saved@example.com");
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: GRAVATAR_EMAIL_PREF_NAME,
+        value: "saved@example.com",
+        userName: "Admin",
+      }),
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
@@ -16,8 +16,9 @@
  */
 
 /**
- * Playwright surface: #3458 / parent #2745 — Explorer shell console-clean
- * of product-path 404/400 (login → Explorer → sample site folder → Refresh).
+ * Playwright surface: #3468 / #3458 / parent #2745 — Explorer shell
+ * console-clean of product-path 404/400 (login → Explorer → sample site
+ * folder → Refresh). Covers both /services and /Rhythmyx/services prefixes.
  *
  * Does not blanket-skip 404/400 resource errors.
  *
@@ -37,7 +38,7 @@ const {
   formatHits,
 } = require("./helpers/explorer-console-clean");
 
-test.describe("Explorer shell console-clean (#3458 / #2745)", () => {
+test.describe("Explorer shell console-clean (#3468 / #3458 / #2745)", () => {
   test(
     "login → Explorer → sample site → Refresh has no product 404/400",
     { tag: ["@explorer", "@console-clean", "@smoke"] },

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -101,6 +101,28 @@ Example create body:
 - The Developer SPA Keyword editor uses these endpoints; integrators can call the same surface
   without the UI.
 
+## User preferences
+
+Stored per-user preferences live under `/services/preferences` (same resource under the
+`/Rhythmyx/services` context-path prefix when the CMS is reached that way).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/preferences/` | All stored preferences for the current user |
+| `GET` | `/services/preferences/{name}` | One named preference (for example `perc_profile_gravatar_email`) |
+| `PUT` | `/services/preferences/` | Save one preference (`UserPreference` Jackson root) |
+
+An **unset** catalog or named preference is a successful empty result, not a missing resource:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | List (possibly empty) or named preference. When the name is not stored, the body is a `UserPreference` with that `name` and an empty `value` |
+| `500` | Unexpected server failure |
+
+Do **not** treat empty store as `404`. Product chrome (Explorer user menu, Profile avatar) treats a
+blank value as “use the account default.” Clients that still send `GET /preferences/{name}` for an
+unset Gravatar override should accept `200` + empty `value`.
+
 ## Sites (catalog)
 
 | Operation | Path | Notes |


### PR DESCRIPTION
## Summary

Cycle Verify residual of #3458 / #2745 (`explorer-console-clean.spec.js`). Open PR #3466 skipped UserMenu named-pref GET and `defaultResolveFolderId` for CMS root, and made `PreferenceResource` return **200 empty** — but live H2 still recorded:

- `GET /services/preferences/perc_profile_gravatar_email` **404**
- `GET /Rhythmyx/services/preferences/perc_profile_gravatar_email` **404**
- `GET /Rhythmyx/services/pathmanagement/path/item/` **400**

This PR includes #3466 and closes the remaining callers:

- **`findItemByPath`** no longer issues `GET …/path/item/` when the encoded suffix is empty (root `/`).
- **Explorer `resolveFolderId` effect** does not call any injector for root/blank paths.
- **`loadGravatarEmailOverride`** (AvatarSection / any missed chrome) uses **list** `GET /preferences/` — not named `GET /preferences/{name}` — so both `/services` and `/Rhythmyx/services` named 404s stop.
- **UserMenu** still does not probe preferences at all.
- **`loadUserPreference`** treats 200 + empty value as unset.
- **`PreferenceResource`** still returns 200 empty (list + named) instead of 404.
- Product-docs: `product-docs/8.2/developer/rest.md` documents the preference empty-store contract.

Fixes #3468  
Fixes #3458  
Parent: #2745 (QA Failed of #2733). Completes the remaining-caller residual after #3466.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health`. Use printed `TEST_CMS_URL` (freeport — do not hardcode `:9993`).
2. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into the cell WAR (`…/Rhythmyx/cm/modern/assets/`). Do **not** docker-restart the cell. Do **not** hot-copy a newer `rest-*-SNAPSHOT.jar` onto a stale matrix image (prior `IAssemblyAdaptor` Failed startup of context). After WebUI copy, `qa-health` again.
3. Login as Admin → Explorer → expand a sample site → **Refresh**.
4. DevTools Network: no 404/400 on `/services/preferences/perc_profile_gravatar_email`, `/Rhythmyx/services/preferences/perc_profile_gravatar_email`, or `/pathmanagement/path/item/`.
5. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/explorer-console-clean.spec.js` (expect exit 0, hits `[]`).
6. `npm run test:golden`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (User preferences: unset named/list prefs are **200 empty**, not 404)
- [x] **Unit / module tests** — `findItemByPath` root skip; `resolveFolderId` not called for `/`; avatarPrefs list-only load; PreferenceResource 200-empty; Playwright helper tests
- [x] **WebUI + Playwright** — `tests/explorer-console-clean.spec.js` (1 passed); `test:golden` (2 passed)
- [x] **Build gates** — standalone `mvnw clean install` on `rest`, `WebUI`, `modules/perc-qa-automation`
- [x] **Cross-platform** — N/A (CMS `/` repository paths only; no OS file I/O)

## C3 evidence

- **modules_built:** `rest`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **507**, Failures: 0 (`PreferenceResourceTest` 8 passed)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Java Tests run: **61**; Vitest Test Files **339** passed, Tests **2573** passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; `npm run test:unit` **292** passed / 0 failed
- **downstream_checked:** none (no `final`/`sealed` or public Java method/ctor signature change used by reverse-deps; TS `isPathItemLookupPath` is WebUI-local; PreferenceResource 200-empty + test ctor already in cherry-picked #3466)

## C5 UI live proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, **TEST_CMS_URL=`http://127.0.0.1:9993`**
- **qa-health:** HTTP 200 / **HEALTH=healthy** (RESULT:FAIL only on pre-existing FastForward `PSDbStorageService` import ERRORs — not `Failed startup of context` / not `rhythmyx_context_failed`)
- **deploy:** copied `WebUI/target/generated-webui/cm/modern/assets/*` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (JS-only; no docker restart; no rest SNAPSHOT copy)
- **Playwright:** `npm run test:surface -- --path tests/explorer-console-clean.spec.js` → **1 passed**; `npm run test:golden` → **2 passed**
- **console-clean=yes** (hits `[]`; no product 400/404)
- **server.log-clean=yes** for the feature (pre-existing FastForward import + search-index `PSSearchIndexFieldValueModifier` ERRORs at install time only)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
