### PR TITLE
fix(explorer): stop remaining gravatar 404 and path/item 400 (#3468)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -186,7 +186,26 @@ export async function paginatedFolder(
   };
 }
 
+/**
+ * Whether {@code path} has a non-empty pathmanagement {@code /path/item/{path}}
+ * suffix. CMS root {@code /} (and blank) encode to {@code …/path/item/} which
+ * the server rejects as HTTP 400 "Invalid path" (#3468 / #3458).
+ */
+export function isPathItemLookupPath(
+  path: string | null | undefined,
+): boolean {
+  if (path == null) {
+    return false;
+  }
+  return encodePath(String(path)) !== "";
+}
+
 export async function findItemByPath(path: string): Promise<PSPathItem> {
+  // Every caller (security folder-id, editor host, Refresh) must skip root —
+  // defaultResolveFolderId alone still left live H2 probing path/item/ (#3468).
+  if (!isPathItemLookupPath(path)) {
+    return {} as PSPathItem;
+  }
   const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
   return res?.PathItem ?? ({} as PSPathItem);
 }

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -223,7 +223,13 @@ export async function loadUserPreference(
   try {
     const data = await get<unknown>(`${PATHS.PREFERENCES}/${key}`);
     // Prefer wrapped wire; do not accept flat as a successful production parse.
-    return unwrapUserPreference(data, { acceptFlat: false });
+    const pref = unwrapUserPreference(data, { acceptFlat: false });
+    // PreferenceResource returns 200 + empty value when nothing is stored
+    // (#3458 / #3468). Treat blank as unset so callers do not keep a dummy.
+    if (pref == null || pref.value == null || String(pref.value).trim() === "") {
+      return null;
+    }
+    return pref;
   } catch (err: unknown) {
     if (isNotFound(err)) {
       return null;

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -39,9 +39,9 @@ export function UserMenu(): React.ReactElement {
       try {
         // Do not swallow SessionRedirectError on getCurrentUserBasic — let the
         // outer guard see it so login redirect is not silently skipped.
-        // Do not GET /preferences/{name} from chrome — unset prefs 404 and
-        // pollute Explorer console (#3458 / #2745). Profile AvatarSection
-        // still loads the override. Primary email is enough for the chip.
+        // Do not GET /preferences/{name} (or the list) from chrome — unset
+        // prefs 404 on both /services and /Rhythmyx/services and pollute
+        // Explorer (#3468 / #3458). Profile AvatarSection loads via list.
         const basic = await getCurrentUserBasic();
         if (cancelled) {
           return;

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1024,7 +1024,9 @@ function ContentExplorerShellInner({
         return;
       }
       const path = selection.folderPath;
-      if (!path) {
+      // Skip root / blank before calling any injector — custom resolveFolderId
+      // implementations (and default findItemByPath) must not GET path/item/ (#3468).
+      if (!path || !isFolderIdLookupPath(path)) {
         if (!cancelled) setSecurityFolderId(undefined);
         return;
       }

--- a/WebUI/src/main/ts/profile/avatarPrefs.ts
+++ b/WebUI/src/main/ts/profile/avatarPrefs.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  loadUserPreference,
+  getAllUserPreferences,
   saveUserPreference,
   PREF_CATEGORY_SYS,
   PREF_CONTEXT_PRIVATE,
@@ -28,16 +28,22 @@ import {
 import { GRAVATAR_EMAIL_PREF_NAME } from "./gravatar";
 
 /**
- * Load stored Gravatar email override for the current session user
- * ({@code loadUserPreference} is always session-scoped). Empty string when
- * unset (caller falls back to primary account email).
+ * Load stored Gravatar email override for the current session user.
+ *
+ * <p>Uses GET {@code /preferences/} (list) — not GET {@code /preferences/{name}}.
+ * Unset named prefs 404 on live H2 and pollute Explorer when chrome or Profile
+ * still probes the named path ({@code /services/…} and {@code /Rhythmyx/services/…}
+ * twins, #3468). Empty string when unset (caller falls back to primary email).
  */
 export async function loadGravatarEmailOverride(): Promise<string> {
-  const pref = await loadUserPreference(GRAVATAR_EMAIL_PREF_NAME);
-  if (pref == null || pref.value == null) {
+  const listed = await getAllUserPreferences();
+  const match = listed.find(
+    (p) => (p.name || "").trim() === GRAVATAR_EMAIL_PREF_NAME,
+  );
+  if (match == null || match.value == null) {
     return "";
   }
-  return String(pref.value).trim();
+  return String(match.value).trim();
 }
 
 /**

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -72,6 +72,18 @@ describe("preferencesApi (PreferenceResource)", () => {
     await expect(loadUserPreference("missing")).resolves.toBeNull();
   });
 
+  it("loadUserPreference treats 200 empty value as unset (#3468)", async () => {
+    vi.spyOn(client, "get").mockResolvedValueOnce({
+      UserPreference: {
+        name: "perc_profile_gravatar_email",
+        value: "",
+      },
+    });
+    await expect(
+      loadUserPreference("perc_profile_gravatar_email"),
+    ).resolves.toBeNull();
+  });
+
   it("loadUserPreference unwraps Jackson UserPreference root", async () => {
     vi.spyOn(client, "get").mockResolvedValueOnce({
       UserPreference: {

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1524,6 +1524,23 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("root initialPath does not call resolveFolderId (#3468)", async () => {
+    stubPathFetch();
+    const resolveFolderId = vi.fn(async () => "should-not-run");
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        resolveFolderId={resolveFolderId}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell")).toBeInTheDocument();
+    });
+    expect(resolveFolderId).not.toHaveBeenCalled();
+  });
+
   it("root initialPath does not GET path/item/ (#3458)", async () => {
     const seen: string[] = [];
     mockFetch(async (input) => {

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -23,6 +23,7 @@ import {
   encodePath,
   findChildren,
   findItemByPath,
+  isPathItemLookupPath,
   folderProperties,
   FOLDER_PROPERTIES_ROOT,
   joinPathUrl,
@@ -198,6 +199,30 @@ describe("pathmanagement URL shape (no double-slash)", () => {
     await findItemByPath("/Sites/Foo");
     expect(cap.lastUrl()).toContain("/path/item/Sites/Foo");
     expect(cap.lastUrl()).not.toContain("item//Sites");
+  });
+
+  it("isPathItemLookupPath skips root so path/item/ is not probed (#3468)", () => {
+    expect(isPathItemLookupPath(null)).toBe(false);
+    expect(isPathItemLookupPath(undefined)).toBe(false);
+    expect(isPathItemLookupPath("")).toBe(false);
+    expect(isPathItemLookupPath("/")).toBe(false);
+    expect(isPathItemLookupPath("///")).toBe(false);
+    expect(isPathItemLookupPath("/Sites")).toBe(true);
+    expect(isPathItemLookupPath("/Sites/Foo")).toBe(true);
+  });
+
+  it("findItemByPath does not GET path/item/ for CMS root (#3468)", async () => {
+    const fn = mockFetch(async () => {
+      return new Response(JSON.stringify({ PathItem: { name: "root" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const empty = await findItemByPath("/");
+    expect(empty).toEqual({});
+    expect(fn).not.toHaveBeenCalled();
+    await findItemByPath("");
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it("addNewFolder joins path and query without double slash", async () => {

--- a/WebUI/src/test/ts/profile/avatarPrefs.test.ts
+++ b/WebUI/src/test/ts/profile/avatarPrefs.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadGravatarEmailOverride,
+  saveGravatarEmailOverride,
+} from "../../../main/ts/profile/avatarPrefs";
+import { GRAVATAR_EMAIL_PREF_NAME } from "../../../main/ts/profile/gravatar";
+import * as prefs from "../../../main/ts/api/preferences/preferencesApi";
+
+describe("avatarPrefs (#3468)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loadGravatarEmailOverride uses the list endpoint, not named GET", async () => {
+    const listSpy = vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([
+      { name: GRAVATAR_EMAIL_PREF_NAME, value: "  avatar@example.com " },
+      { name: "other", value: "x" },
+    ]);
+    const namedSpy = vi.spyOn(prefs, "loadUserPreference");
+    await expect(loadGravatarEmailOverride()).resolves.toBe("avatar@example.com");
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(namedSpy).not.toHaveBeenCalled();
+  });
+
+  it("loadGravatarEmailOverride returns empty when list has no override", async () => {
+    vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([]);
+    const namedSpy = vi.spyOn(prefs, "loadUserPreference");
+    await expect(loadGravatarEmailOverride()).resolves.toBe("");
+    expect(namedSpy).not.toHaveBeenCalled();
+  });
+
+  it("saveGravatarEmailOverride still PUTs the named preference", async () => {
+    const saveSpy = vi.spyOn(prefs, "saveUserPreference").mockResolvedValueOnce({
+      name: GRAVATAR_EMAIL_PREF_NAME,
+      value: "saved@example.com",
+    });
+    await expect(
+      saveGravatarEmailOverride("Admin", "saved@example.com"),
+    ).resolves.toBe("saved@example.com");
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: GRAVATAR_EMAIL_PREF_NAME,
+        value: "saved@example.com",
+        userName: "Admin",
+      }),
+    );
+  });
+});

--- a/docs/ai-generated/code-reviews/3468-leftover-gravatar-path-item-erlang.md
+++ b/docs/ai-generated/code-reviews/3468-leftover-gravatar-path-item-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review — #3468 leftover gravatar named-GET 404 and empty path/item 400
+
+**Scope:** `fix/issue-3468-leftover-gravatar-path-item` vs `origin/main` (`d0838a584f`, includes merged #3466). Cherry-pick of `f7ee305977c8` plus product-docs prefs-note tweak.
+
+**Change class:** WebUI leftover callers after #3466 — Explorer still GETs named `perc_profile_gravatar_email` (404 on `/services` and `/Rhythmyx/services`) and `pathmanagement/path/item/` (400). Companions: Vitest on path/prefs/avatar, Playwright `explorer-console-clean.spec.js`, `product-docs/8.2/developer/rest.md`.
+
+**Memory patterns hit:** change-class completeness (WebUI + Playwright + product-docs); behavioral tests for new skip/list-load logic; URL `/` is not OS file I/O.
+
+## Summary
+
+#3466 skipped UserMenu named-pref GET and `defaultResolveFolderId` for CMS root. Live H2 still hit leftover callers: `findItemByPath("/")` (encodes to `…/path/item/`) and Profile/chrome named GET for an unset Gravatar pref.
+
+This slice:
+
+1. Adds `isPathItemLookupPath` and returns an empty `PSPathItem` from `findItemByPath` when the encoded suffix is empty (every caller, not only `defaultResolveFolderId`).
+2. Loads Gravatar override via `GET /preferences/` list; UserMenu does not probe prefs.
+3. Treats PreferenceResource `200` + empty `value` as unset (`loadUserPreference` → `null`).
+4. Does **not** change rest SNAPSHOT / PreferenceResource Java (already 200-empty on main).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none
+- Behavioral unit tests: present (`pathApi.test.ts`, `preferencesApi.test.ts`, `avatarPrefs.test.ts`, `ContentExplorerShell.test.tsx`)
+- Cross-platform path I/O: N/A (CMS URL `/` segments via `encodePath`; not filesystem)
+- Change-class companions: Playwright spec + product-docs prefs note present
+- May commit/push: **yes** (after standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation`)
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` filesystem joins
+- [x] CMS path encode uses `/` as repository URL segments (correct)
+- [x] Tests assert URL shapes (`/path/item/Sites/Foo`), not OS `Path.toString()`
+- [x] No Unix-only temp/absolute roots
+
+## Tests / docs
+
+- `findItemByPath("/")` and `""` do not call `fetch`
+- `isPathItemLookupPath` false for null/blank/`/`/`///`
+- `loadGravatarEmailOverride` uses `getAllUserPreferences`, never `loadUserPreference`
+- `loadUserPreference` 200-empty → `null`
+- Playwright: login → Explorer → sample site → Refresh, expect `hits []`
+- `product-docs/8.2/developer/rest.md`: list-first Gravatar; named GET 200-empty = unset

--- a/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
@@ -16,8 +16,9 @@
  */
 
 /**
- * Playwright surface: #3458 / parent #2745 — Explorer shell console-clean
- * of product-path 404/400 (login → Explorer → sample site folder → Refresh).
+ * Playwright surface: #3468 / #3458 / parent #2745 — Explorer shell
+ * console-clean of product-path 404/400 (login → Explorer → sample site
+ * folder → Refresh). Covers both /services and /Rhythmyx/services prefixes.
  *
  * Does not blanket-skip 404/400 resource errors.
  *
@@ -37,7 +38,7 @@ const {
   formatHits,
 } = require("./helpers/explorer-console-clean");
 
-test.describe("Explorer shell console-clean (#3458 / #2745)", () => {
+test.describe("Explorer shell console-clean (#3468 / #3458 / #2745)", () => {
   test(
     "login → Explorer → sample site → Refresh has no product 404/400",
     { tag: ["@explorer", "@console-clean", "@smoke"] },

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -119,9 +119,11 @@ An **unset** catalog or named preference is a successful empty result, not a mis
 | `200` | List (possibly empty) or named preference. When the name is not stored, the body is a `UserPreference` with that `name` and an empty `value` |
 | `500` | Unexpected server failure |
 
-Do **not** treat empty store as `404`. Product chrome (Explorer user menu, Profile avatar) treats a
-blank value as “use the account default.” Clients that still send `GET /preferences/{name}` for an
-unset Gravatar override should accept `200` + empty `value`.
+Do **not** treat empty store as `404`. Product Profile loads the Gravatar override from
+`GET /services/preferences/` (the list), not `GET /services/preferences/perc_profile_gravatar_email`.
+Explorer chrome does not probe the named preference. A blank list entry (or no entry) means
+“use the account default.” Clients that still send `GET /preferences/{name}` should accept
+`200` + empty `value` as unset — do not treat that 200 as a stored email.
 
 ## Sites (catalog)
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -101,6 +101,28 @@ Example create body:
 - The Developer SPA Keyword editor uses these endpoints; integrators can call the same surface
   without the UI.
 
+## User preferences
+
+Stored per-user preferences live under `/services/preferences` (same resource under the
+`/Rhythmyx/services` context-path prefix when the CMS is reached that way).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/preferences/` | All stored preferences for the current user |
+| `GET` | `/services/preferences/{name}` | One named preference (for example `perc_profile_gravatar_email`) |
+| `PUT` | `/services/preferences/` | Save one preference (`UserPreference` Jackson root) |
+
+An **unset** catalog or named preference is a successful empty result, not a missing resource:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | List (possibly empty) or named preference. When the name is not stored, the body is a `UserPreference` with that `name` and an empty `value` |
+| `500` | Unexpected server failure |
+
+Do **not** treat empty store as `404`. Product chrome (Explorer user menu, Profile avatar) treats a
+blank value as “use the account default.” Clients that still send `GET /preferences/{name}` for an
+unset Gravatar override should accept `200` + empty `value`.
+
 ## Sites (catalog)
 
 | Operation | Path | Notes |


### PR DESCRIPTION
## Summary

#3466 skipped UserMenu named-pref GET and `defaultResolveFolderId` for CMS root, but live H2 still issued leftover product 404/400s during Explorer login → sample site → Refresh:

- `GET /services/preferences/perc_profile_gravatar_email` (404, both `/services` and `/Rhythmyx/services`)
- `GET /Rhythmyx/services/pathmanagement/path/item/` (400)

This focused main PR (not a second cluster) cherry-picks the leftover-caller fix from closed #3485 (`f7ee305` / `6a477d7061`) onto current `main` (already includes merged #3466):

- Skip `findItemByPath` / `resolveFolderId` when the encoded path suffix is empty (CMS root `/`) so `path/item/` is never probed.
- Load Gravatar override via `GET /preferences/` list, not named GET `perc_profile_gravatar_email`. Explorer chrome does not probe prefs.
- Treat PreferenceResource `200` + empty `value` as unset in `loadUserPreference`.
- Do **not** copy a rest SNAPSHOT — `PreferenceResource` already returns 200-empty on main.

Fixes #3468  
Parent: #3458 / #2745

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 QA cell: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (Health=healthy; FastForward import `server_log_errors` are pre-existing).
2. Hot-copy `WebUI/target/generated-webui/cm/modern` + `cm/app/spa.jsp` into the cell WAR. Do not `docker restart` the cell.
3. From `modules/perc-qa-automation/frontend` with `TEST_CMS_URL` from qa-up:

   ```
   npm run test:surface -- --path tests/explorer-console-clean.spec.js
   npm run test:golden
   ```

4. Expect explorer-console-clean `hits []` (no product 404/400 on gravatar or `path/item/`).
5. Manual: Admin login → Explorer → sample site folder → Refresh. Browser network has no named Gravatar GET and no `path/item/` 400.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` User preferences note (list-first Gravatar; named GET 200-empty = unset)
- [x] **Unit / module tests** — Vitest for `isPathItemLookupPath` / root `findItemByPath` skip, list-first `loadGravatarEmailOverride`, 200-empty `loadUserPreference`; Playwright explorer-console-clean
- [x] **WebUI + Playwright** — `tests/explorer-console-clean.spec.js` + golden smoke
- [x] **Build gates** — standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (CMS URL `/` segments via `encodePath`, not filesystem I/O)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Surefire Tests run: 61, Failures: 0. Vitest: 2573 passed (339 files).
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. `npm run test:unit`: 292 passed.
- **downstream_checked:** none (no public Java API / `final` / signature change)

### C5 UI proof

- `qa-up --skip-image-build` started `perc-matrix-cms-h2` on `TEST_CMS_URL=http://127.0.0.1:9993`. Cell **Health=healthy**, HTTP 200. `qa-health` RESULT:FAIL only on pre-existing FastForward `PSDbStorageService` import `server_log_errors` (not `Failed startup of context` / not unhealthy).
- Deploy: `docker cp` `WebUI/target/generated-webui/cm/modern` + `spa.jsp` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/` (no Jetty restart, no `docker restart`).
- `npm run test:surface -- --path tests/explorer-console-clean.spec.js` → **1 passed** (1.4s), hits `[]`.
- `npm run test:golden` → **2 passed** (2.0s).
- **console-clean=yes** (spec asserts product 404/400 `hits []` and no unexpected pageerrors).
- **server.log-clean=yes** for the test window (no new feature-related ERROR/FATAL; FastForward import noise is pre-existing).

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
