### PR TITLE
fix(admin): keep remaining users available after first role member (#3504)

### DIFF
--- a/WebUI/src/main/ts/workflowAdmin/role/RoleEditor.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/role/RoleEditor.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from "react";
-import { post } from "../../api/client";
+import React, { useEffect, useMemo, useState } from "react";
+import { formatApiError, get, post } from "../../api/client";
+import { parseUserNameList } from "../../api/jsonList";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
 import { Role } from "./RolesSection";
+import { availableUsersMinusAssigned } from "./roleUsers";
 
 interface RoleEditorProps {
   role: Role | null; // null if creating
@@ -35,47 +37,55 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
   const [name, setName] = useState<string>(role?.name || "");
   const [description, setDescription] = useState<string>(role?.description || "");
   const [assignedUsers, setAssignedUsers] = useState<string[]>(role?.users || []);
-  const [availableUsers, setAvailableUsers] = useState<string[]>([]);
+  const [allUsers, setAllUsers] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
   useEffect(() => {
-    const fetchAvailableUsers = async () => {
+    let cancelled = false;
+    const loadAllUsers = async () => {
       try {
-        const payload = {
-          Role: {
-            name: role?.name || name || "TempRole",
-            description,
-            users: assignedUsers,
-          },
-        };
-        const res = await post<{ UserList: { users: string[] } }>(
-          PATHS.ROLE_AVAILABLE_USERS,
-          payload
-        );
-        setAvailableUsers(res?.UserList?.users || []);
-      } catch {
-        setAvailableUsers([]);
+        const res = await get<unknown>(PATHS.USERS);
+        if (!cancelled) {
+          setAllUsers(parseUserNameList(res));
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setAllUsers([]);
+          setError(formatApiError(err, message(WF_ADMIN_MSG.ERROR_GENERIC)));
+        }
       }
     };
-    fetchAvailableUsers();
-  }, [role, assignedUsers]);
+    void loadAllUsers();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const availableUsers = useMemo(
+    () => availableUsersMinusAssigned(allUsers, assignedUsers),
+    [allUsers, assignedUsers],
+  );
 
   const handleAddUser = (user: string) => {
     setError(null);
-    setAssignedUsers((prev) => [...prev, user].sort());
+    setAssignedUsers((prev) =>
+      prev.includes(user) ? prev : [...prev, user].sort(),
+    );
   };
 
   const handleRemoveUser = async (user: string) => {
     setError(null);
-    // Validate remove users if updating
+    // Validate remove users if updating a persisted role
     if (role) {
       try {
         await post(PATHS.ROLE_REMOVE_USERS_VALIDATE, {
           UserList: { users: [user] },
         });
-      } catch (err: any) {
-        setError(err?.message || "Cannot remove user from this role.");
+      } catch (err: unknown) {
+        setError(
+          formatApiError(err, "Cannot remove user from this role."),
+        );
         return;
       }
     }
@@ -108,8 +118,8 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
         await post(PATHS.ROLE_CREATE, payload);
       }
       onSave();
-    } catch (err: any) {
-      setError(err?.message || message(WF_ADMIN_MSG.ERROR_GENERIC));
+    } catch (err: unknown) {
+      setError(formatApiError(err, message(WF_ADMIN_MSG.ERROR_GENERIC)));
     } finally {
       setIsSaving(false);
     }
@@ -120,7 +130,7 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "20px" }}>
         <h3>{role ? message(WF_ADMIN_MSG.EDIT_ROLE) : message(WF_ADMIN_MSG.CREATE_ROLE)}</h3>
         <div style={{ display: "flex", gap: "8px" }}>
-          <button type="button" onClick={onCancel} disabled={isSaving}>
+          <button type="button" onClick={onCancel} disabled={isSaving} data-testid="cancel-role-button">
             {message(WF_ADMIN_MSG.CANCEL)}
           </button>
           <button type="submit" className="perc-button-primary" disabled={isSaving} data-testid="save-role-button">
@@ -131,6 +141,8 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
 
       {error && (
         <div
+          role="alert"
+          data-testid="role-editor-error"
           style={{
             color: "#d9534f",
             marginBottom: "16px",
@@ -174,7 +186,10 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px" }}>
         {/* Assigned Users list */}
         <div style={{ border: "1px solid #e2e8f0", borderRadius: "8px", background: "#fff", overflow: "hidden" }}>
-          <div style={{ background: "#f8fafc", padding: "10px 16px", borderBottom: "1px solid #e2e8f0", fontWeight: 600 }}>
+          <div
+            data-testid="assigned-users-heading"
+            style={{ background: "#f8fafc", padding: "10px 16px", borderBottom: "1px solid #e2e8f0", fontWeight: 600 }}
+          >
             {message(WF_ADMIN_MSG.ROLE_MEMBERS)} ({assignedUsers.length})
           </div>
           <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: "300px", overflowY: "auto" }} data-testid="assigned-users-list">
@@ -184,6 +199,7 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
               assignedUsers.map((user) => (
                 <li
                   key={user}
+                  data-testid={`assigned-user-row-${user}`}
                   style={{
                     padding: "10px 16px",
                     borderBottom: "1px solid #f1f5f9",
@@ -215,7 +231,10 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
 
         {/* Available Users list */}
         <div style={{ border: "1px solid #e2e8f0", borderRadius: "8px", background: "#fff", overflow: "hidden" }}>
-          <div style={{ background: "#f8fafc", padding: "10px 16px", borderBottom: "1px solid #e2e8f0", fontWeight: 600 }}>
+          <div
+            data-testid="available-users-heading"
+            style={{ background: "#f8fafc", padding: "10px 16px", borderBottom: "1px solid #e2e8f0", fontWeight: 600 }}
+          >
             {message(WF_ADMIN_MSG.AVAILABLE_USERS)} ({availableUsers.length})
           </div>
           <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: "300px", overflowY: "auto" }} data-testid="available-users-list">
@@ -225,6 +244,7 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
               availableUsers.map((user) => (
                 <li
                   key={user}
+                  data-testid={`available-user-row-${user}`}
                   style={{
                     padding: "10px 16px",
                     borderBottom: "1px solid #f1f5f9",

--- a/WebUI/src/main/ts/workflowAdmin/role/roleUsers.ts
+++ b/WebUI/src/main/ts/workflowAdmin/role/roleUsers.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dual-list membership for Admin → Roles (#3504).
+ *
+ * <p>The editor must not re-POST {@code /role/availableUsers} after every Add.
+ * That envelope bind/unwrap path cleared the available list after the first
+ * member. Filter GET-all-users minus assigned locally, matching the legacy
+ * create-role path in {@code PercRoleController.getAvailableUsers}.</p>
+ */
+
+/**
+ * Active users that are not already assigned to the role being edited.
+ * Comparison is exact (CMS user names are case-sensitive).
+ */
+export function availableUsersMinusAssigned(
+  allUsers: readonly string[],
+  assignedUsers: readonly string[],
+): string[] {
+  const assigned = new Set(assignedUsers);
+  return allUsers.filter((user) => user.length > 0 && !assigned.has(user));
+}

--- a/WebUI/src/test/ts/workflowAdmin/RoleEditor.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/RoleEditor.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoleEditor } from "../../../main/ts/workflowAdmin/role/RoleEditor";
+import * as client from "../../../main/ts/api/client";
+
+vi.mock("../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+  formatApiError: (err: unknown, fallback: string) =>
+    err && typeof err === "object" && "message" in err
+      ? String((err as { message: string }).message)
+      : fallback,
+}));
+
+const ALL_USERS = ["Admin", "Contributor", "Editor"];
+
+function mockUsersGet(): void {
+  vi.mocked(client.get).mockImplementation(async (url: string) => {
+    if (url.includes("/user/user/users")) {
+      return { UserList: { users: ALL_USERS } };
+    }
+    return {};
+  });
+}
+
+describe("RoleEditor membership dual-list (#3504)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockUsersGet();
+    vi.mocked(client.post).mockResolvedValue({});
+  });
+
+  it("loads available users from GET all-users, not availableUsers POST", async () => {
+    render(<RoleEditor role={null} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-user-Admin")).toBeTruthy();
+    });
+    expect(screen.getByTestId("add-user-Editor")).toBeTruthy();
+    expect(screen.getByTestId("add-user-Contributor")).toBeTruthy();
+    expect(screen.getByTestId("available-users-heading").textContent).toContain(
+      "(3)",
+    );
+
+    expect(client.get).toHaveBeenCalled();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it("keeps remaining users available after adding the first member", async () => {
+    render(<RoleEditor role={null} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-user-Admin")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("add-user-Admin"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assigned-user-row-Admin")).toBeTruthy();
+    });
+    expect(screen.getByTestId("add-user-Editor")).toBeTruthy();
+    expect(screen.getByTestId("add-user-Contributor")).toBeTruthy();
+    expect(screen.queryByTestId("add-user-Admin")).toBeNull();
+    expect(screen.getByTestId("available-users-heading").textContent).toContain(
+      "(2)",
+    );
+    expect(screen.getByTestId("assigned-users-heading").textContent).toContain(
+      "(1)",
+    );
+
+    fireEvent.click(screen.getByTestId("add-user-Editor"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assigned-user-row-Editor")).toBeTruthy();
+    });
+    expect(screen.getByTestId("add-user-Contributor")).toBeTruthy();
+    expect(screen.getByTestId("available-users-heading").textContent).toContain(
+      "(1)",
+    );
+    expect(screen.getByTestId("assigned-users-heading").textContent).toContain(
+      "(2)",
+    );
+
+    expect(
+      vi.mocked(client.post).mock.calls.some((call) =>
+        String(call[0]).includes("availableUsers"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns a removed user to Available Users", async () => {
+    render(
+      <RoleEditor
+        role={{ name: "Authors", description: "", users: [] }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-user-Contributor")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("add-user-Contributor"));
+    await waitFor(() => {
+      expect(screen.getByTestId("remove-user-Contributor")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("remove-user-Contributor"));
+    await waitFor(() => {
+      expect(screen.getByTestId("add-user-Contributor")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("assigned-user-row-Contributor")).toBeNull();
+    expect(screen.getByTestId("available-users-heading").textContent).toContain(
+      "(3)",
+    );
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/roleUsers.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/roleUsers.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { availableUsersMinusAssigned } from "../../../main/ts/workflowAdmin/role/roleUsers";
+
+describe("availableUsersMinusAssigned", () => {
+  it("returns all users when none are assigned", () => {
+    expect(
+      availableUsersMinusAssigned(["Admin", "Editor", "Contributor"], []),
+    ).toEqual(["Admin", "Editor", "Contributor"]);
+  });
+
+  it("drops assigned members and keeps remaining users (#3504)", () => {
+    expect(
+      availableUsersMinusAssigned(
+        ["Admin", "Editor", "Contributor"],
+        ["Editor"],
+      ),
+    ).toEqual(["Admin", "Contributor"]);
+  });
+
+  it("returns empty when every user is assigned", () => {
+    expect(
+      availableUsersMinusAssigned(["Admin", "Editor"], ["Editor", "Admin"]),
+    ).toEqual([]);
+  });
+
+  it("skips blank names and does not mutate inputs", () => {
+    const all = ["Admin", "", "Editor"];
+    const assigned = ["Admin"];
+    expect(availableUsersMinusAssigned(all, assigned)).toEqual(["Editor"]);
+    expect(all).toEqual(["Admin", "", "Editor"]);
+    expect(assigned).toEqual(["Admin"]);
+  });
+});

--- a/docs/ai-generated/code-reviews/3504-role-editor-available-users-erlang.md
+++ b/docs/ai-generated/code-reviews/3504-role-editor-available-users-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3504 Role editor available users
+
+- **Branch:** `fix/issue-3504-role-editor-available-users`
+- **Date:** 2026-08-17
+- **Reviewer:** Erlang (pre-commit, implementer session)
+- **Recommendation:** approve
+- **May commit/push:** yes
+- **Gate:** pass
+
+## Summary
+
+Admin Role editor cleared **Available Users** after the first Add because
+`RoleEditor` re-POSTed `/rolemanagement/role/availableUsers` on every
+`assignedUsers` change and treated any bind/unwrap/error as `[]`. The fix
+loads all users once via `GET /user/user/users` and filters locally
+(`availableUsersMinusAssigned`), matching the legacy create-role path.
+
+Change class: WebUI product screen (Admin → Roles membership dual-list).
+
+Companions present:
+
+- Behavioral Vitest for helper + RoleEditor add-two / remove-returns
+- Playwright `tests/bugs/bug-3504-role-editor-members.spec.js`
+- `product-docs/8.2/admin/users-roles.md` operator steps
+- No REST envelope change; sitemanage not required
+
+Memory patterns hit: missing behavioral tests (covered); change-class
+closure (Playwright + product-docs); empty catch (GET failure now surfaces
+`formatApiError`).
+
+Cross-platform path checklist: N/A — no filesystem path I/O in the diff
+(URL path `/user/user/users` is a REST path).
+
+## Issues
+
+None blocking.
+
+### nit
+
+- Role editor still has a few pre-existing hardcoded English strings
+  (`Description`, `Add`, `Remove`). Out of scope for this membership fix.
+
+## Test evidence (at review)
+
+- Focused Vitest: 10 passed (`RoleEditor`, `roleUsers`, `RolesSection`)
+- Standalone `cd WebUI && ../mvnw.cmd clean install`: BUILD SUCCESS,
+  Tests 2664 passed

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3504-role-editor-members.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3504-role-editor-members.spec.js
@@ -1,0 +1,115 @@
+/**
+ * Regression: Admin → Roles editor only allowed one member (#3504).
+ *
+ * After adding the first user, Available Users must still list remaining
+ * active users. Remove must return that user to Available. Membership is
+ * local until Save — this spec Cancels so it does not persist a role.
+ *
+ * Tags: @workflow-admin @administration @roles @bug-3504
+ *
+ * Surface filter:
+ *   npm run test:surface -- --path tests/bugs/bug-3504-role-editor-members.spec.js
+ *   npm run test:surface -- --tag bug-3504
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+function adminRolesEntry() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=admin&tab=roles&_=${Date.now()}`;
+}
+
+test.describe("Admin Role editor membership (#3504)", () => {
+  test(
+    "can add two users and remove one back to Available",
+    {
+      tag: [
+        "@workflow-admin",
+        "@administration",
+        "@roles",
+        "@bug-3504",
+      ],
+    },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      const consoleErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(adminRolesEntry(), { waitUntil: "domcontentloaded" });
+
+      const shell = page.getByTestId("perc-admin-shell");
+      await expect(shell).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId("route-error")).toHaveCount(0);
+
+      const rolesTab = page.getByTestId("tab-roles");
+      await expect(rolesTab).toBeVisible();
+      if ((await rolesTab.getAttribute("aria-selected")) !== "true") {
+        await rolesTab.click();
+      }
+      await expect(page.getByTestId("perc-roles-section")).toBeVisible({
+        timeout: 30_000,
+      });
+
+      await page.getByTestId("create-role-button").click();
+      const editor = page.getByTestId("perc-role-editor");
+      await expect(editor).toBeVisible({ timeout: 15_000 });
+
+      const availableList = page.getByTestId("available-users-list");
+      await expect(availableList).toBeVisible();
+
+      const addButtons = availableList.locator("button[data-testid^='add-user-']");
+      await expect(addButtons.first()).toBeVisible({ timeout: 15_000 });
+      const initialAvailable = await addButtons.count();
+      expect(initialAvailable).toBeGreaterThanOrEqual(2);
+
+      const firstTestId = await addButtons.nth(0).getAttribute("data-testid");
+      const secondTestId = await addButtons.nth(1).getAttribute("data-testid");
+      expect(firstTestId).toBeTruthy();
+      expect(secondTestId).toBeTruthy();
+      const firstUser = String(firstTestId).replace(/^add-user-/, "");
+      const secondUser = String(secondTestId).replace(/^add-user-/, "");
+
+      await page.getByTestId(`add-user-${firstUser}`).click();
+      await expect(page.getByTestId(`assigned-user-row-${firstUser}`)).toBeVisible();
+      await expect(page.getByTestId(`add-user-${firstUser}`)).toHaveCount(0);
+      await expect(page.getByTestId(`add-user-${secondUser}`)).toBeVisible();
+      await expect(addButtons).toHaveCount(initialAvailable - 1);
+      await expect(page.getByTestId("available-users-heading")).toContainText(
+        `(${initialAvailable - 1})`,
+      );
+
+      await page.getByTestId(`add-user-${secondUser}`).click();
+      await expect(page.getByTestId(`assigned-user-row-${secondUser}`)).toBeVisible();
+      await expect(addButtons).toHaveCount(initialAvailable - 2);
+
+      await page.getByTestId(`remove-user-${firstUser}`).click();
+      await expect(page.getByTestId(`add-user-${firstUser}`)).toBeVisible();
+      await expect(page.getByTestId(`assigned-user-row-${firstUser}`)).toHaveCount(0);
+      await expect(page.getByTestId(`assigned-user-row-${secondUser}`)).toBeVisible();
+      await expect(addButtons).toHaveCount(initialAvailable - 1);
+
+      await page.getByTestId("cancel-role-button").click();
+      await expect(page.getByTestId("perc-roles-section")).toBeVisible();
+
+      expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      const unexpectedConsole = consoleErrors.filter((text) => {
+        const t = String(text);
+        return (
+          !/favicon/i.test(t) &&
+          !/Download the React DevTools/i.test(t)
+        );
+      });
+      expect(
+        unexpectedConsole,
+        `console error: ${unexpectedConsole.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -32,6 +32,22 @@ Assign the minimum role set needed for each job function:
 
 Revisit role membership when Sites or departments reorganize.
 
+### Admin → Roles (membership)
+
+Open **Admin → Roles** (or deep link `spa.jsp?entry=admin&tab=roles`) to create or
+edit a role. The editor uses two lists:
+
+| List | What it shows |
+|------|----------------|
+| **Assigned Users** | Current members of this role (empty until you add someone). |
+| **Available Users** | Every active user who is **not** already a member. |
+
+Use **Add** next to any available user to move them to Assigned Users. You can add
+**more than one** member before you save — the available list keeps the remaining
+users after each Add. **Remove** returns that user to Available Users so you can
+re-assign them. Changes apply only when you **Submit**; **Cancel** discards the
+in-progress membership edits.
+
 ## Workflow
 
 Workflow states gate who can edit and publish. Common patterns:


### PR DESCRIPTION
## Summary

Admin → Roles membership dual-list cleared **Available Users** after the first Add (Available Users (0)), so operators could not add a second member. `RoleEditor` re-POSTed `/rolemanagement/role/availableUsers` on every `assignedUsers` change and treated any bind/unwrap/error as an empty list.

This PR loads all active users once via `GET /user/user/users` and filters assigned members locally (legacy create-role path). Add/Remove stay in-memory until Submit; Cancel discards membership edits.

Fixes #3504

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2664, Failures: 0
2. Vitest: `RoleEditor` add-two-users / remove-returns-to-available; `roleUsers` helper
3. QA H2: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (Health=healthy, HTTP=200)
4. Hot-copy `WebUI/target/generated-webui/cm/modern/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/` (no docker restart)
5. `npm run test:surface -- --path tests/bugs/bug-3504-role-editor-members.spec.js` — 1 passed (2.2s)
6. Manual: Admin → Roles → Create Role → Add user A → remaining users still listed → Add user B → Remove A → A returns to Available → Cancel

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (Admin → Roles membership dual-list)
- [x] **Unit / module tests** — Vitest RoleEditor + roleUsers; WebUI standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3504-role-editor-members.spec.js`
- [x] **Build gates** — standalone WebUI clean install (no skipTests); no Java API shape change
- [x] **Cross-platform** — N/A (no filesystem path I/O; REST URL only)

### C3 evidence

- **modules_built:** WebUI
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (01:29), Tests 2664 passed (2664). Focused Vitest: 10 passed (RoleEditor, roleUsers, RolesSection).
- **downstream_checked:** none (no public Java type/signature change; C2 did not apply)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build`; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`; docker Health=healthy; probe HTTP=200
- **qa-health:** RESULT:FAIL DETAIL:server_log_errors on pre-existing FastForward `PSDbStorageService Could not import item …gif` (startup, Health=healthy, not `Failed startup of context`). Not role-editor related.
- **deploy:** docker cp generated `cm/modern/` assets into Rhythmyx WAR (`perc-modern-ui.js` + `AdminShell-Cz6LAPPs.js`)
- **Playwright:** `npm run test:surface -- --path tests/bugs/bug-3504-role-editor-members.spec.js` → **1 passed** (2.2s)
- **console-clean:** yes (spec asserts no pageerror / unexpected console error)
- **server.log-clean:** yes for the feature window (login INFO at test time; startup FastForward/search-index ERRORs are pre-existing noise)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
