### PR TITLE
feat: top-nav community display and switch (#3506)

### DIFF
--- a/WebUI/src/main/ts/api/user/communitySwitchApi.ts
+++ b/WebUI/src/main/ts/api/user/communitySwitchApi.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Session community switch for top-nav chrome (#3506 / parent #3505).
+ *
+ * <p>POST {@code /services/communities/switch/{name}} — membership is
+ * enforced server-side. The UserMenu list must come from
+ * {@code GET /user/user/current} ({@code communities}), not the design
+ * catalog.</p>
+ */
+
+import { post } from "../client";
+import { PATHS } from "../paths";
+
+/** Builds POST /services/communities/switch/{name} with a path-safe name. */
+export function communitySwitchUrl(name: string): string {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) {
+    throw new Error("Community name is required");
+  }
+  return `${PATHS.COMMUNITIES}/switch/${encodeURIComponent(trimmed)}`;
+}
+
+/**
+ * Deduped membership names from the signed-in user payload.
+ * Does not add catalog communities.
+ */
+export function allowedSessionCommunities(
+  communities: readonly string[] | null | undefined,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of communities ?? []) {
+    const name =
+      typeof raw === "string" ? raw.trim() : String(raw ?? "").trim();
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+/** Switch the signed-in session to {@code name}. Throws {@link ApiError} on failure. */
+export async function switchSessionCommunity(name: string): Promise<void> {
+  await post(communitySwitchUrl(name));
+}

--- a/WebUI/src/main/ts/app/layout/AppLayout.module.css
+++ b/WebUI/src/main/ts/app/layout/AppLayout.module.css
@@ -68,6 +68,13 @@
   flex-direction: column;
 }
 
+.mainInner {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .userMenu {
   display: flex;
   align-items: center;
@@ -83,6 +90,95 @@
 .userName {
   font-weight: 600;
   color: var(--color-text, #181c2c);
+}
+
+.communityBlock {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  position: relative;
+}
+
+.communityLabel {
+  color: var(--color-text-muted, #5b6478);
+}
+
+.communityName {
+  font-weight: 600;
+  color: var(--color-text, #181c2c);
+}
+
+.communitySwitch {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary, #4a6aa3);
+  font-weight: 600;
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.communitySwitch:hover {
+  text-decoration: underline;
+}
+
+.communitySwitch:disabled {
+  opacity: 0.65;
+  cursor: wait;
+  text-decoration: none;
+}
+
+.communitySwitch:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.communityList {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  right: 0;
+  min-width: 12rem;
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(11, 34, 74, 0.12);
+  z-index: 40;
+}
+
+.communityOption {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  color: var(--color-text, #181c2c);
+  cursor: pointer;
+}
+
+.communityOption:hover,
+.communityOption:focus-visible {
+  background: var(--color-surface-alt, #eef2f8);
+}
+
+.communityOptionCurrent {
+  font-weight: 600;
+}
+
+.communityError {
+  color: var(--color-danger, #b42318);
+  font-size: 0.8rem;
+  width: 100%;
 }
 
 .profileLink,

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router";
 import { BrandBar, BrandFooter } from "../../ui-themes/components";
+import { SESSION_COMMUNITY_CHANGED_EVENT } from "./sessionCommunity";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";
 
@@ -36,6 +37,18 @@ function isChromeLessPath(pathname: string): boolean {
  */
 export function AppLayout(): React.ReactElement {
   const { pathname } = useLocation();
+  const [sessionCommunityEpoch, setSessionCommunityEpoch] = useState(0);
+
+  useEffect(() => {
+    const onChanged = (): void => {
+      setSessionCommunityEpoch((n) => n + 1);
+    };
+    window.addEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    return () => {
+      window.removeEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    };
+  }, []);
+
   if (isChromeLessPath(pathname)) {
     return <Outlet />;
   }
@@ -43,8 +56,14 @@ export function AppLayout(): React.ReactElement {
     <div className={styles.shell} data-testid="perc-spa-app">
       <BrandBar />
       <TopNav />
-      <main className={styles.main} data-testid="perc-spa-outlet">
-        <Outlet />
+      <main
+        className={styles.main}
+        data-testid="perc-spa-outlet"
+        data-session-community-epoch={sessionCommunityEpoch}
+      >
+        <div key={sessionCommunityEpoch} className={styles.mainInner}>
+          <Outlet />
+        </div>
       </main>
       <BrandFooter />
     </div>

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -15,10 +15,17 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router";
-import { getCurrentUserBasic } from "../../api/user/userCurrentApi";
-import { isSessionRedirectError } from "../../api/client";
+import {
+  formatApiError,
+  isSessionRedirectError,
+} from "../../api/client";
+import {
+  allowedSessionCommunities,
+  switchSessionCommunity,
+} from "../../api/user/communitySwitchApi";
+import { getCurrentUserProfile } from "../../api/user/userProfileApi";
 import { i18nKeyAttr } from "../../i18n/i18nDom";
 import { message, MSG } from "../../i18n/message";
 import { resolveAvatarPresentation } from "../../profile/gravatar";
@@ -26,30 +33,44 @@ import { PROFILE_MSG } from "../../profile/messages";
 import { UserAvatar } from "../../profile/UserAvatar";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import styles from "./AppLayout.module.css";
+import {
+  communityOptionTestId,
+  dispatchSessionCommunityChanged,
+} from "./sessionCommunity";
 
 export function UserMenu(): React.ReactElement {
   const bootstrap = useSpaBootstrap();
   const name = bootstrap.userName?.trim() || message(MSG.USER_DEFAULT_NAME);
   const allowExternal = bootstrap.allowExternalAvatarFetch !== false;
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [currentCommunity, setCurrentCommunity] = useState("");
+  const [allowedCommunities, setAllowedCommunities] = useState<string[]>([]);
+  const [switchOpen, setSwitchOpen] = useState(false);
+  const [switchError, setSwitchError] = useState<string | null>(null);
+  const [switchingTo, setSwitchingTo] = useState<string | null>(null);
+  const listId = useId();
+  const communityBlockRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        // Do not swallow SessionRedirectError on getCurrentUserBasic — let the
-        // outer guard see it so login redirect is not silently skipped.
+        // One GET /user/user/current for avatar email + membership communities.
+        // Do not swallow SessionRedirectError — let the outer guard redirect.
         // Do not GET /preferences/{name} (or the list) from chrome — unset
         // prefs 404 on both /services and /Rhythmyx/services and pollute
         // Explorer (#3468 / #3458). Profile AvatarSection loads via list.
-        const basic = await getCurrentUserBasic();
+        // Do not GET the communities catalog — list only session membership.
+        const profile = await getCurrentUserProfile();
         if (cancelled) {
           return;
         }
+        setAllowedCommunities(allowedSessionCommunities(profile.communities));
+        setCurrentCommunity((profile.currentCommunity ?? "").trim());
         const presentation = await resolveAvatarPresentation({
           displayName: name,
           overrideEmail: "",
-          primaryEmail: basic.email,
+          primaryEmail: profile.email,
           allowExternalAvatarFetch: allowExternal,
           size: 64,
         });
@@ -69,6 +90,62 @@ export function UserMenu(): React.ReactElement {
       cancelled = true;
     };
   }, [name, bootstrap.userName, allowExternal]);
+
+  useEffect(() => {
+    if (!switchOpen) {
+      return;
+    }
+    const onPointerDown = (event: MouseEvent): void => {
+      const root = communityBlockRef.current;
+      if (root && !root.contains(event.target as Node)) {
+        setSwitchOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setSwitchOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [switchOpen]);
+
+  async function handleSwitch(nextName: string): Promise<void> {
+    const trimmed = nextName.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (trimmed === currentCommunity) {
+      setSwitchOpen(false);
+      return;
+    }
+    setSwitchError(null);
+    setSwitchingTo(trimmed);
+    try {
+      await switchSessionCommunity(trimmed);
+      setCurrentCommunity(trimmed);
+      setSwitchOpen(false);
+      dispatchSessionCommunityChanged(trimmed);
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setSwitchError(
+        formatApiError(err, message(MSG.USER_COMMUNITY_SWITCH_ERROR)),
+      );
+    } finally {
+      setSwitchingTo(null);
+    }
+  }
+
+  const communityDisplay =
+    currentCommunity || message(MSG.USER_COMMUNITY_NONE);
+  const canSwitch = allowedCommunities.length > 0;
+  const switching = switchingTo != null;
 
   return (
     <div className={styles.userMenu} data-testid="perc-spa-user-menu">
@@ -92,6 +169,87 @@ export function UserMenu(): React.ReactElement {
           {name}
         </span>
       </span>
+      <div
+        className={styles.communityBlock}
+        ref={communityBlockRef}
+        data-testid="perc-spa-community"
+      >
+        <span className={styles.communityLabel} {...i18nKeyAttr(MSG.USER_COMMUNITY)}>
+          {message(MSG.USER_COMMUNITY)}
+        </span>
+        <span
+          className={styles.communityName}
+          data-testid="perc-spa-community-name"
+          data-mkd-lang-ignore="1"
+        >
+          {communityDisplay}
+        </span>
+        {canSwitch ? (
+          <button
+            type="button"
+            className={styles.communitySwitch}
+            data-testid="perc-spa-community-switch"
+            aria-expanded={switchOpen}
+            aria-controls={listId}
+            aria-haspopup="listbox"
+            aria-label={message(MSG.USER_COMMUNITY_SWITCH_ARIA)}
+            disabled={switching}
+            onClick={() => {
+              setSwitchError(null);
+              setSwitchOpen((open) => !open);
+            }}
+            {...i18nKeyAttr(MSG.USER_COMMUNITY_SWITCH)}
+          >
+            {switching
+              ? message(MSG.USER_COMMUNITY_SWITCHING)
+              : message(MSG.USER_COMMUNITY_SWITCH)}
+          </button>
+        ) : null}
+        {switchOpen ? (
+          <ul
+            id={listId}
+            className={styles.communityList}
+            role="listbox"
+            data-testid="perc-spa-community-list"
+            aria-label={message(MSG.USER_COMMUNITY_LIST_ARIA)}
+          >
+            {allowedCommunities.map((communityName) => {
+              const selected = communityName === currentCommunity;
+              return (
+                <li key={communityName} role="presentation">
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    className={
+                      selected
+                        ? `${styles.communityOption} ${styles.communityOptionCurrent}`
+                        : styles.communityOption
+                    }
+                    data-testid={communityOptionTestId(communityName)}
+                    data-community-name={communityName}
+                    disabled={switching}
+                    onClick={() => {
+                      void handleSwitch(communityName);
+                    }}
+                  >
+                    {communityName}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+        {switchError ? (
+          <div
+            className={styles.communityError}
+            role="alert"
+            data-testid="perc-spa-community-switch-error"
+          >
+            {switchError}
+          </div>
+        ) : null}
+      </div>
       <Link
         className={styles.profileLink}
         to="/profile"

--- a/WebUI/src/main/ts/app/layout/sessionCommunity.ts
+++ b/WebUI/src/main/ts/app/layout/sessionCommunity.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Session community change event so Explorer / Developer remount and
+ * refetch with the new community without a logout (#3506).
+ */
+
+export const SESSION_COMMUNITY_CHANGED_EVENT =
+  "perc:session-community-changed";
+
+export type SessionCommunityChangedDetail = {
+  community: string;
+};
+
+export function dispatchSessionCommunityChanged(community: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent<SessionCommunityChangedDetail>(
+      SESSION_COMMUNITY_CHANGED_EVENT,
+      { detail: { community } },
+    ),
+  );
+}
+
+/** Stable test id slug for a community option (spaces → hyphens). */
+export function communityOptionTestId(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `perc-spa-community-option-${slug || "unnamed"}`;
+}

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -236,6 +236,14 @@ export const MSG = {
   USER_SIGNED_IN_AS: "perc.ui.dashboard.modern@Signed in as",
   USER_DEFAULT_NAME: "perc.ui.dashboard.modern@user",
   USER_LOGOUT: "perc.ui.common.label@Log Out",
+  USER_COMMUNITY: "perc.ui.dashboard.modern@Community",
+  USER_COMMUNITY_NONE: "perc.ui.dashboard.modern@None",
+  USER_COMMUNITY_SWITCH: "perc.ui.dashboard.modern@Switch",
+  USER_COMMUNITY_SWITCH_ARIA: "perc.ui.dashboard.modern@Switch community",
+  USER_COMMUNITY_LIST_ARIA: "perc.ui.dashboard.modern@Available communities",
+  USER_COMMUNITY_SWITCH_ERROR:
+    "perc.ui.dashboard.modern@Could not switch community.",
+  USER_COMMUNITY_SWITCHING: "perc.ui.dashboard.modern@Switching community…",
   /** Profile hub menu entry (#2393) — prefer PROFILE_MSG in profile/messages.ts for new code */
   USER_MY_PROFILE: "perc.ui.profile.modern@My profile",
   // Dashboard / Gadgets chrome

--- a/WebUI/src/test/ts/api/communitySwitchApi.test.ts
+++ b/WebUI/src/test/ts/api/communitySwitchApi.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const post = vi.fn();
+
+vi.mock("../../../main/ts/api/client", () => ({
+  post: (...args: unknown[]) => post(...args),
+}));
+
+import {
+  allowedSessionCommunities,
+  communitySwitchUrl,
+  switchSessionCommunity,
+} from "../../../main/ts/api/user/communitySwitchApi";
+
+describe("communitySwitchApi", () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({ Status: { message: "OK", statusCode: 200 } });
+  });
+
+  it("builds a path-encoded switch URL", () => {
+    const url = communitySwitchUrl("Enterprise Investments");
+    expect(url).toContain("/communities/switch/");
+    expect(url).toContain(encodeURIComponent("Enterprise Investments"));
+    expect(url).not.toContain("Enterprise Investments");
+  });
+
+  it("rejects a blank community name", () => {
+    expect(() => communitySwitchUrl("  ")).toThrow(/required/i);
+  });
+
+  it("dedupes membership names and ignores blanks", () => {
+    expect(
+      allowedSessionCommunities(["Default", " Default ", "", "Corporate", "Default"]),
+    ).toEqual(["Default", "Corporate"]);
+    expect(allowedSessionCommunities(null)).toEqual([]);
+  });
+
+  it("POSTs switch without a body", async () => {
+    await switchSessionCommunity("Corporate");
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      expect.stringMatching(/\/communities\/switch\/Corporate$/),
+    );
+    expect(post.mock.calls[0]).toHaveLength(1);
+  });
+});

--- a/WebUI/src/test/ts/app/layout/AppLayout.community.test.tsx
+++ b/WebUI/src/test/ts/app/layout/AppLayout.community.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppLayout } from "../../../../main/ts/app/layout/AppLayout";
+import { dispatchSessionCommunityChanged } from "../../../../main/ts/app/layout/sessionCommunity";
+
+vi.mock("../../../../main/ts/ui-themes/components", () => ({
+  BrandBar: () => <div data-testid="brand-bar-stub" />,
+  BrandFooter: () => <div data-testid="brand-footer-stub" />,
+}));
+
+vi.mock("../../../../main/ts/app/layout/TopNav", () => ({
+  TopNav: () => <div data-testid="topnav-stub" />,
+}));
+
+let instanceSeq = 0;
+
+function OutletProbe(): React.ReactElement {
+  const [id] = useState(() => {
+    instanceSeq += 1;
+    return instanceSeq;
+  });
+  return <div data-testid="outlet-probe" data-instance={String(id)} />;
+}
+
+describe("AppLayout session community remount (#3506)", () => {
+  beforeEach(() => {
+    instanceSeq = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("remounts the main outlet after a session community change", () => {
+    render(
+      <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/home"]}>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="home" element={<OutletProbe />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+    const first = screen.getByTestId("outlet-probe");
+    expect(first.getAttribute("data-instance")).toBe("1");
+    expect(
+      screen.getByTestId("perc-spa-outlet").getAttribute(
+        "data-session-community-epoch",
+      ),
+    ).toBe("0");
+
+    act(() => {
+      dispatchSessionCommunityChanged("Corporate");
+    });
+
+    const remounted = screen.getByTestId("outlet-probe");
+    expect(remounted.getAttribute("data-instance")).toBe("2");
+    expect(
+      screen.getByTestId("perc-spa-outlet").getAttribute(
+        "data-session-community-epoch",
+      ),
+    ).toBe("1");
+    expect(screen.getByTestId("topnav-stub")).toBeTruthy();
+  });
+});

--- a/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
+++ b/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
@@ -16,21 +16,33 @@
  */
 
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BootstrapProvider } from "../../../../main/ts/app/bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "../../../../main/ts/app/bootstrap/types";
 import { UserMenu } from "../../../../main/ts/app/layout/UserMenu";
+import { SESSION_COMMUNITY_CHANGED_EVENT } from "../../../../main/ts/app/layout/sessionCommunity";
+import type { CurrentUserProfile } from "../../../../main/ts/api/user/userProfileApi";
 import * as prefs from "../../../../main/ts/api/preferences/preferencesApi";
 
-vi.mock("../../../../main/ts/api/user/userCurrentApi", () => ({
-  getCurrentUserBasic: vi.fn().mockResolvedValue({
-    name: "editor1",
-    email: "editor1@example.com",
-  }),
-  isValidEmailAddress: () => true,
+const getCurrentUserProfile = vi.fn();
+const switchSessionCommunity = vi.fn();
+
+vi.mock("../../../../main/ts/api/user/userProfileApi", () => ({
+  getCurrentUserProfile: (...args: unknown[]) => getCurrentUserProfile(...args),
 }));
+
+vi.mock("../../../../main/ts/api/user/communitySwitchApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../../main/ts/api/user/communitySwitchApi")
+  >();
+  return {
+    ...actual,
+    switchSessionCommunity: (...args: unknown[]) =>
+      switchSessionCommunity(...args),
+  };
+});
 
 vi.mock("../../../../main/ts/api/preferences/preferencesApi", () => ({
   loadUserPreference: vi.fn().mockResolvedValue(null),
@@ -50,6 +62,22 @@ const bootstrap: SpaBootstrap = {
   allowExternalAvatarFetch: true,
 };
 
+function profile(overrides: Partial<CurrentUserProfile> = {}): CurrentUserProfile {
+  return {
+    name: "editor1",
+    email: "editor1@example.com",
+    providerType: "INTERNAL",
+    roles: ["Editor"],
+    communities: ["Default", "Corporate"],
+    currentCommunity: "Default",
+    adminUser: false,
+    designerUser: false,
+    accessibilityUser: false,
+    emailEditable: true,
+    ...overrides,
+  };
+}
+
 function renderMenu(user?: Partial<SpaBootstrap>): void {
   render(
     <BootstrapProvider value={{ ...bootstrap, ...user }}>
@@ -68,6 +96,14 @@ describe("UserMenu", () => {
         return at >= 0 ? key.slice(at + 1) : key;
       },
     };
+    getCurrentUserProfile.mockReset();
+    getCurrentUserProfile.mockResolvedValue(profile());
+    switchSessionCommunity.mockReset();
+    switchSessionCommunity.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("shows signed-in name, My profile entry, logout, and avatar chip", async () => {
@@ -76,9 +112,9 @@ describe("UserMenu", () => {
     expect(screen.getByTestId("perc-spa-user-name").textContent).toContain(
       "editor1",
     );
-    const profile = screen.getByTestId("perc-spa-my-profile");
-    expect(profile.textContent).toBe("My profile");
-    expect(profile.getAttribute("href")).toBe("/cm/app/profile");
+    const profileLink = screen.getByTestId("perc-spa-my-profile");
+    expect(profileLink.textContent).toBe("My profile");
+    expect(profileLink.getAttribute("href")).toBe("/cm/app/profile");
     const logout = screen.getByTestId("perc-spa-logout");
     expect(logout.getAttribute("href")).toBe("/logout");
     await waitFor(() => {
@@ -114,5 +150,84 @@ describe("UserMenu", () => {
         "ED",
       );
     });
+  });
+
+  it("shows the session community next to signed-in user", async () => {
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Default",
+      );
+    });
+    expect(screen.getByTestId("perc-spa-community-switch").textContent).toBe(
+      "Switch",
+    );
+  });
+
+  it("lists only membership communities from current user, not the catalog", async () => {
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-switch")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-spa-community-switch"));
+    const list = screen.getByTestId("perc-spa-community-list");
+    const names = [...list.querySelectorAll("[data-community-name]")].map(
+      (el) => el.getAttribute("data-community-name"),
+    );
+    expect(names).toEqual(["Default", "Corporate"]);
+    expect(names).not.toContain("CatalogOnly");
+  });
+
+  it("switches community and updates chrome without logout", async () => {
+    const events: string[] = [];
+    const onChanged = (ev: Event): void => {
+      const detail = (ev as CustomEvent<{ community: string }>).detail;
+      events.push(detail.community);
+    };
+    window.addEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    try {
+      renderMenu();
+      await waitFor(() => {
+        expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+          "Default",
+        );
+      });
+      fireEvent.click(screen.getByTestId("perc-spa-community-switch"));
+      fireEvent.click(screen.getByTestId("perc-spa-community-option-corporate"));
+      await waitFor(() => {
+        expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+          "Corporate",
+        );
+      });
+      expect(switchSessionCommunity).toHaveBeenCalledWith("Corporate");
+      expect(events).toEqual(["Corporate"]);
+      expect(screen.getByTestId("perc-spa-logout").getAttribute("href")).toBe(
+        "/logout",
+      );
+    } finally {
+      window.removeEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    }
+  });
+
+  it("shows a clear error and keeps the current community when switch fails", async () => {
+    switchSessionCommunity.mockRejectedValueOnce({
+      status: 500,
+      statusText: "Error",
+      body: "User is not a member of community Corporate",
+    });
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-switch")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-spa-community-switch"));
+    fireEvent.click(screen.getByTestId("perc-spa-community-option-corporate"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-switch-error").textContent).toContain(
+        "User is not a member of community Corporate",
+      );
+    });
+    expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+      "Default",
+    );
   });
 });

--- a/WebUI/src/test/ts/app/layout/sessionCommunity.test.ts
+++ b/WebUI/src/test/ts/app/layout/sessionCommunity.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  communityOptionTestId,
+  dispatchSessionCommunityChanged,
+  SESSION_COMMUNITY_CHANGED_EVENT,
+} from "../../../../main/ts/app/layout/sessionCommunity";
+
+describe("sessionCommunity helpers", () => {
+  it("slugs option test ids", () => {
+    expect(communityOptionTestId("Enterprise Investments")).toBe(
+      "perc-spa-community-option-enterprise-investments",
+    );
+    expect(communityOptionTestId("  ")).toBe("perc-spa-community-option-unnamed");
+  });
+
+  it("dispatches the session community changed event", () => {
+    const seen: string[] = [];
+    const handler = (ev: Event): void => {
+      seen.push((ev as CustomEvent<{ community: string }>).detail.community);
+    };
+    window.addEventListener(SESSION_COMMUNITY_CHANGED_EVENT, handler);
+    try {
+      dispatchSessionCommunityChanged("Corporate");
+      expect(seen).toEqual(["Corporate"]);
+    } finally {
+      window.removeEventListener(SESSION_COMMUNITY_CHANGED_EVENT, handler);
+    }
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/user-menu-community-switch.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/user-menu-community-switch.spec.js
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Top-nav session community display + switch (#3506 / parent #3505).
+ *
+ * Surface-filtered only — not full suite:
+ *   npm run test:surface -- --path tests/user-menu-community-switch.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Lists only GET /user/user/current membership communities (not the catalog).
+ * Switch uses POST /services/communities/switch/{name}.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function homeUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+function unwrapCurrentUser(body) {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+  return body.CurrentUser || body.User || body;
+}
+
+function isIgnoredConsoleText(text) {
+  const raw = String(text || "");
+  return (
+    /gravatar\.com/i.test(raw) ||
+    /Failed to load resource/i.test(raw) ||
+    /net::ERR_/i.test(raw)
+  );
+}
+
+test.describe("Top-nav community display and switch (#3506) @community @ui", () => {
+  test("shows session community and switch list from current-user membership only", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    const consoleErrors = [];
+    const catalogFinds = [];
+    const switchPosts = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && !isIgnoredConsoleText(msg.text())) {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on("request", (req) => {
+      if (/\/communities\/find(?:\?|$)/.test(req.url())) {
+        catalogFinds.push(req.url());
+      }
+    });
+    page.on("response", (res) => {
+      if (res.request().method() === "POST" && /\/communities\/switch\//.test(res.url())) {
+        switchPosts.push({ url: res.url(), status: res.status() });
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-spa-community")).toBeVisible();
+    await expect(page.getByTestId("perc-spa-community-name")).toBeVisible();
+
+    const currentRes = await page.request.get(
+      `${BASE_URL}/Rhythmyx/services/user/user/current`,
+    );
+    expect(
+      currentRes.ok(),
+      `GET /user/user/current HTTP ${currentRes.status()}`,
+    ).toBe(true);
+    const payload = unwrapCurrentUser(await currentRes.json());
+    const allowed = Array.isArray(payload.communities)
+      ? payload.communities.map((n) => String(n).trim()).filter(Boolean)
+      : [];
+    const sessionCommunity = String(payload.currentCommunity || "").trim();
+
+    const chromeName = (
+      await page.getByTestId("perc-spa-community-name").textContent()
+    ).trim();
+    if (sessionCommunity) {
+      expect(chromeName).toBe(sessionCommunity);
+    } else {
+      expect(chromeName.length).toBeGreaterThan(0);
+    }
+
+    if (allowed.length === 0) {
+      await expect(page.getByTestId("perc-spa-community-switch")).toHaveCount(0);
+      expect(catalogFinds, "must not list the community catalog").toEqual([]);
+      expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
+        [],
+      );
+      return;
+    }
+
+    const switchBtn = page.getByTestId("perc-spa-community-switch");
+    await expect(switchBtn).toBeVisible();
+    await switchBtn.click();
+    const list = page.getByTestId("perc-spa-community-list");
+    await expect(list).toBeVisible();
+
+    const optionNames = await list
+      .locator("[data-community-name]")
+      .evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-community-name") || ""),
+      );
+    expect(optionNames.sort()).toEqual([...allowed].sort());
+
+    const other = allowed.find((name) => name !== sessionCommunity);
+    if (other) {
+      await list.getByRole("option", { name: other, exact: true }).click();
+      await expect
+        .poll(
+          async () => {
+            const chrome = (
+              await page.getByTestId("perc-spa-community-name").textContent()
+            ).trim();
+            const errCount = await page
+              .getByTestId("perc-spa-community-switch-error")
+              .count();
+            return { chrome, errCount, posts: switchPosts.length };
+          },
+          { timeout: 20_000 },
+        )
+        .toMatchObject({ posts: 1 });
+      expect(switchPosts[0].url).toContain("/communities/switch/");
+      const after = (
+        await page.getByTestId("perc-spa-community-name").textContent()
+      ).trim();
+      const err = page.getByTestId("perc-spa-community-switch-error");
+      if (switchPosts[0].status >= 400) {
+        await expect(err).toBeVisible();
+        expect(after).toBe(chromeName);
+      } else {
+        expect(after).toBe(other);
+        await expect(err).toHaveCount(0);
+      }
+      await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible();
+      await expect(page.getByTestId("perc-spa-logout")).toBeVisible();
+    }
+
+    expect(catalogFinds, "must not list the community catalog").toEqual([]);
+    expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -47,6 +47,22 @@ Workflow states gate who can edit and publish. Common patterns:
   documentation for your configured authenticator.
 - Protect the login endpoint behind TLS at the reverse proxy or edge.
 
+## Session community (top nav)
+
+After sign-in, the header user menu shows the **current community** next to **Signed in as**.
+Use **Switch** to change the session community **without signing out**.
+
+- The switch list contains **only** communities you can access through your user and role
+  membership (the same list as **My profile → Account**). It is not the full community catalog
+  from Developer.
+- After a successful switch, the header name updates immediately. Content Explorer and other
+  screens that filter by the active community then use the new community — you do not need to
+  log out and back in.
+- If the switch is not allowed (unknown community or you are not a member of a role in that
+  community), the header shows an error and keeps the previous community.
+- Setting a **default** community on the profile, or remembering the last community at the next
+  login, is not part of this header control.
+
 ## My profile — Security (password)
 
 Authenticated users open **My profile** from the header user menu (or deep link

--- a/system/src/test/java/com/percussion/webservices/system/impl/PSCommunityNameSelectorTest.java
+++ b/system/src/test/java/com/percussion/webservices/system/impl/PSCommunityNameSelectorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.webservices.system.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.percussion.services.security.data.PSCommunity;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PSCommunityNameSelectorTest {
+
+  @Test
+  void prefersExactNameWhenLikeAlsoHitsAdminSuffix() {
+    PSCommunity corp = named("Corporate_Investments");
+    PSCommunity admin = named("Corporate_Investments_Admin");
+    assertSame(
+        corp, PSCommunityNameSelector.select(List.of(corp, admin), "Corporate_Investments"));
+    assertSame(
+        admin,
+        PSCommunityNameSelector.select(List.of(corp, admin), "Corporate_Investments_Admin"));
+  }
+
+  @Test
+  void matchesExactNameIgnoringCase() {
+    PSCommunity def = named("Default");
+    assertSame(def, PSCommunityNameSelector.select(List.of(def), "default"));
+  }
+
+  @Test
+  void fallsBackToSoleLikeHitWhenNoExactName() {
+    PSCommunity only = named("Default");
+    assertSame(only, PSCommunityNameSelector.select(List.of(only), "Def"));
+  }
+
+  @Test
+  void returnsNullWhenAmbiguousAndNoExactMatch() {
+    PSCommunity a = named("Enterprise_Investments");
+    PSCommunity b = named("Enterprise_Investments_Admin");
+    assertNull(PSCommunityNameSelector.select(List.of(a, b), "Enterprise Investments"));
+    assertNull(PSCommunityNameSelector.select(List.of(), "Default"));
+    assertNull(PSCommunityNameSelector.select(null, "Default"));
+    assertNull(PSCommunityNameSelector.select(List.of(a), "  "));
+  }
+
+  @Test
+  void returnsNullWhenTwoExactNames() {
+    PSCommunity a = named("Default");
+    PSCommunity b = named("Default");
+    assertNull(PSCommunityNameSelector.select(List.of(a, b), "Default"));
+  }
+
+  @Test
+  void selectedNameIsTheRequestedCommunity() {
+    PSCommunity corp = named("Corporate_Investments");
+    PSCommunity admin = named("Corporate_Investments_Admin");
+    assertEquals(
+        "Corporate_Investments",
+        PSCommunityNameSelector.select(List.of(admin, corp), "Corporate_Investments")
+            .getName());
+  }
+
+  private static PSCommunity named(String name) {
+    PSCommunity community = new PSCommunity();
+    community.setName(name);
+    return community;
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSCommunityNameSelector.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSCommunityNameSelector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.webservices.system.impl;
+
+import com.percussion.services.security.data.PSCommunity;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Picks one community from a {@code findCommunitiesByName} result.
+ *
+ * <p>{@code findCommunitiesByName} uses SQL {@code LIKE %name%} where {@code _} is a
+ * single-character wildcard, so {@code Corporate_Investments} also matches
+ * {@code Corporate_Investments_Admin}. Session switch (#3506) must prefer an
+ * exact name match.
+ */
+public final class PSCommunityNameSelector {
+  private PSCommunityNameSelector() {}
+
+  /**
+   * @return the unique exact (case-insensitive) match; otherwise the sole LIKE
+   *     hit; otherwise {@code null}
+   */
+  public static PSCommunity select(List<PSCommunity> candidates, String name) {
+    if (candidates == null || candidates.isEmpty() || StringUtils.isBlank(name)) {
+      return null;
+    }
+    String wanted = name.trim();
+    List<PSCommunity> exact = new ArrayList<>();
+    for (PSCommunity community : candidates) {
+      if (community != null && wanted.equalsIgnoreCase(community.getName())) {
+        exact.add(community);
+      }
+    }
+    if (exact.size() == 1) {
+      return exact.get(0);
+    }
+    if (exact.isEmpty() && candidates.size() == 1) {
+      return candidates.get(0);
+    }
+    return null;
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSSystemWs.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSSystemWs.java
@@ -302,10 +302,10 @@ public class PSSystemWs extends PSSystemBaseWs implements IPSSystemWs
 
       IPSBackEndRoleMgr roleMgr = PSRoleMgrLocator.getBackEndRoleManager();
       List<PSCommunity> comms = roleMgr.findCommunitiesByName(name);
-      if (comms.isEmpty() || comms.size() > 1)
+      // LIKE %name% treats "_" as a wildcard — prefer exact name (#3506).
+      PSCommunity comm = PSCommunityNameSelector.select(comms, name);
+      if (comm == null)
          throw new IllegalArgumentException("Invalid community name");
-
-      PSCommunity comm = comms.get(0);
       String commid = String.valueOf(comm.getId());
 
       PSRequest psReq = (PSRequest) PSRequestInfo


### PR DESCRIPTION
## Summary

Slice 1 of parent **#3505** (Security: Community selection post login). Operators can see the **current session community** in the SPA header next to **Signed in as** and **Switch** to another membership community without signing out.

- `UserMenu` loads `GET /user/user/current` and lists **only** `communities` / `currentCommunity` (not the Developer catalog).
- Switch calls existing `POST /services/communities/switch/{name}`. Failures stay on the previous community and show a live-region error.
- After a successful switch, chrome updates and the main outlet remounts so Explorer / Developer refetch with the new session community (no logout).
- `PSSystemWs.switchCommunity` now prefers an **exact** community name. `findCommunitiesByName` uses SQL `LIKE %name%` where `_` is a wildcard, so `Corporate_Investments` previously also matched `Corporate_Investments_Admin` and threw `Invalid community name`.

Out of scope: profile default community (#3508), remember-last on next login (#3507).

Fixes #3506
Parent: #3505
Partial #3505

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Surefire 61, Vitest 356 files / 2668 tests).
2. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS including `PSCommunityNameSelectorTest` (6 tests).
3. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
4. QA H2: `python docker/scripts/perc-devctl.py qa-up` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`). `qa-health` reports `HEALTH:healthy` / HTTP 200; `DETAIL:server_log_errors` is pre-existing FastForward binary import noise (not `Failed startup of context`).
5. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/*` into the QA WAR; copy `perc-system-8.2.0-SNAPSHOT.jar` into `WEB-INF/lib`; restart Jetty **inside** the cell (`StopJetty.sh` / `StartJetty.sh`). Context started cleanly.
6. `npm run test:surface -- --path tests/user-menu-community-switch.spec.js` — 1 passed. Display + membership-only list + live switch.
7. `npm run test:golden` — 2 passed.
8. Console-clean on exercised path: yes (Gravatar resource noise ignored). server.log during test window: no new community/switch ERROR/FATAL.
9. `scripts/ci-smoke-product-docs.bat` — OK.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (Session community top nav)
- [x] **Unit / module tests** — UserMenu / switch API / AppLayout remount / `PSCommunityNameSelector`; standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/user-menu-community-switch.spec.js` + golden smoke
- [x] **Build gates** — standalone clean install on `WebUI`, `system`, `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** WebUI,system,modules/perc-qa-automation
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS (Surefire Tests run: 61; Vitest Test Files 356 / Tests 2668). `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2191, Failures: 0, Skipped: 241; `PSCommunityNameSelectorTest` Tests run: 6). `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS.
- **downstream_checked:** none — no existing public method/ctor made `final`/`sealed` or signature-changed. New helper `PSCommunityNameSelector` only; `CommunityAdaptor.switchCommunity(String)` unchanged.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up`; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`. Health=healthy after install; FastForward import ERROR lines pre-exist (not context-fail).
- Deploy: copied modern `cm/modern/assets` + `perc-system-8.2.0-SNAPSHOT.jar` into Rhythmyx WAR; in-cell Jetty restart (not `docker restart`).
- Playwright: `npm run test:surface -- --path tests/user-menu-community-switch.spec.js` (1 passed); `npm run test:golden` (2 passed).
- console-clean=yes (product JS pageerror none; Gravatar resource noise ignored)
- server.log-clean=yes for the test window (0 ERROR/FATAL matching community/switch)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.