### PR TITLE
feat(profile): persist default community as sys_defaultCommunity (#3508)

### DIFF
--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -605,6 +605,13 @@ export const PATHS = {
   get USER_PROFILE() {
     return `${SERVICES_ROOT}/user/user/profile`;
   },
+  /**
+   * Self-service default community (PUT text/plain) — current user only
+   * (issue #3508). Blank body clears {@code sys_defaultCommunity}.
+   */
+  get USER_DEFAULT_COMMUNITY() {
+    return `${SERVICES_ROOT}/user/user/defaultCommunity`;
+  },
   get USER_LDAP_FIND() {
     return `${SERVICES_ROOT}/user/user/external/find`;
   },

--- a/WebUI/src/main/ts/api/user/userProfileApi.ts
+++ b/WebUI/src/main/ts/api/user/userProfileApi.ts
@@ -22,7 +22,7 @@
  * on the path — no IDOR).</p>
  */
 
-import { get, put } from "../client";
+import { get, put, putPlainText } from "../client";
 import { PATHS } from "../paths";
 
 export type UserProviderType = "INTERNAL" | "DIRECTORY";
@@ -34,6 +34,8 @@ export interface CurrentUserProfile {
   roles: string[];
   communities: string[];
   currentCommunity: string;
+  /** Persisted {@code sys_defaultCommunity}; empty when unset. */
+  defaultCommunity: string;
   adminUser: boolean;
   designerUser: boolean;
   accessibilityUser: boolean;
@@ -109,6 +111,7 @@ export function normalizeCurrentUser(data: unknown): CurrentUserProfile {
     roles: asStringList(body.roles),
     communities: asStringList(body.communities),
     currentCommunity: asString(body.currentCommunity, "").trim(),
+    defaultCommunity: asString(body.defaultCommunity, "").trim(),
     adminUser: asBoolean(body.adminUser),
     designerUser: asBoolean(body.designerUser),
     accessibilityUser: asBoolean(body.accessibilityUser),
@@ -135,6 +138,20 @@ export async function updateMyAccountEmail(
     },
   };
   const data = await put<unknown>(PATHS.USER_PROFILE, body);
+  return normalizeCurrentUser(data);
+}
+
+/**
+ * PUT self-service default community. Server always targets the session user.
+ * Blank {@code communityName} clears the stored default.
+ */
+export async function updateMyDefaultCommunity(
+  communityName: string,
+): Promise<CurrentUserProfile> {
+  const data = await putPlainText<unknown>(
+    PATHS.USER_DEFAULT_COMMUNITY,
+    communityName == null ? "" : String(communityName).trim(),
+  );
   return normalizeCurrentUser(data);
 }
 

--- a/WebUI/src/main/ts/profile/AccountSection.module.css
+++ b/WebUI/src/main/ts/profile/AccountSection.module.css
@@ -76,6 +76,35 @@
   max-width: 28rem;
 }
 
+.select {
+  width: 100%;
+  max-width: 28rem;
+  box-sizing: border-box;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--color-text, #181c2c);
+  background: var(--color-surface, #fff);
+}
+
+.select:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.select[aria-invalid="true"] {
+  border-color: var(--color-danger, #b42318);
+}
+
+.communityForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: 28rem;
+}
+
 .emailInput {
   width: 100%;
   box-sizing: border-box;

--- a/WebUI/src/main/ts/profile/AccountSection.tsx
+++ b/WebUI/src/main/ts/profile/AccountSection.tsx
@@ -46,6 +46,23 @@ type LoadState =
   | { status: "ready"; profile: CurrentUserProfile };
 
 /**
+ * Select value for the stored default: membership spelling when still allowed,
+ * otherwise empty so the control never holds a stale unmatched option.
+ */
+export function allowedDefaultCommunityDraft(
+  profile: Pick<CurrentUserProfile, "communities" | "defaultCommunity">,
+): string {
+  const stored = (profile.defaultCommunity ?? "").trim();
+  if (!stored) {
+    return "";
+  }
+  const allowed = allowedSessionCommunities(profile.communities);
+  return (
+    allowed.find((name) => name.toLowerCase() === stored.toLowerCase()) ?? ""
+  );
+}
+
+/**
  * Account identity view/edit for the signed-in user (slice 2 / #2395).
  * Login id, provider, roles, and communities are read-only. Email is editable
  * only for internal accounts; directory-managed fields show localized hints.
@@ -86,7 +103,7 @@ export function AccountSection({
     try {
       const profile = await loadProfile();
       setEmailDraft(profile.email ?? "");
-      setDefaultCommunityDraft(profile.defaultCommunity ?? "");
+      setDefaultCommunityDraft(allowedDefaultCommunityDraft(profile));
       setCommunityFieldError(null);
       setLoadState({ status: "ready", profile });
     } catch (err) {
@@ -157,7 +174,7 @@ export function AccountSection({
     try {
       const updated = await saveDefaultCommunity(trimmed);
       setLoadState({ status: "ready", profile: updated });
-      setDefaultCommunityDraft(updated.defaultCommunity ?? "");
+      setDefaultCommunityDraft(allowedDefaultCommunityDraft(updated));
       setSuccessMessage(message(PROFILE_MSG.DEFAULT_COMMUNITY_SAVE_SUCCESS));
     } catch (err) {
       if (isSessionRedirectError(err)) {
@@ -483,7 +500,7 @@ export function AccountSection({
                       ? `${defaultCommunityHelpId} ${defaultCommunityErrorId}`
                       : defaultCommunityHelpId
                   }
-                  data-testid="perc-profile-account-default-community"
+                  data-testid="perc-profile-account-default-community-select"
                 >
                   <option
                     value=""
@@ -538,7 +555,7 @@ export function AccountSection({
               <>
                 <span
                   className={styles.readonlyValue}
-                  data-testid="perc-profile-account-default-community"
+                  data-testid="perc-profile-account-default-community-unavailable"
                 >
                   {message(PROFILE_MSG.DEFAULT_COMMUNITY_UNAVAILABLE)}
                 </span>

--- a/WebUI/src/main/ts/profile/AccountSection.tsx
+++ b/WebUI/src/main/ts/profile/AccountSection.tsx
@@ -20,11 +20,13 @@ import {
   formatApiError,
   isSessionRedirectError,
 } from "../api/client";
+import { allowedSessionCommunities } from "../api/user/communitySwitchApi";
 import {
   type CurrentUserProfile,
   getCurrentUserProfile,
   isValidEmailAddress,
   updateMyAccountEmail,
+  updateMyDefaultCommunity,
 } from "../api/user/userProfileApi";
 import { i18nKeyAttr } from "../i18n/i18nDom";
 import { message } from "../i18n/message";
@@ -35,6 +37,7 @@ export interface AccountSectionProps {
   /** Optional test double — defaults to live REST. */
   loadProfile?: () => Promise<CurrentUserProfile>;
   saveEmail?: (email: string) => Promise<CurrentUserProfile>;
+  saveDefaultCommunity?: (name: string) => Promise<CurrentUserProfile>;
 }
 
 type LoadState =
@@ -50,20 +53,30 @@ type LoadState =
 export function AccountSection({
   loadProfile = getCurrentUserProfile,
   saveEmail = updateMyAccountEmail,
+  saveDefaultCommunity = updateMyDefaultCommunity,
 }: AccountSectionProps = {}): React.ReactElement {
   const reactId = useId();
   const formId = `perc-profile-account-form-${reactId}`;
   const emailId = `perc-profile-account-email-${reactId}`;
   const emailErrorId = `perc-profile-account-email-error-${reactId}`;
   const emailHelpId = `perc-profile-account-email-help-${reactId}`;
+  const defaultCommunityId = `perc-profile-account-default-community-${reactId}`;
+  const defaultCommunityHelpId = `perc-profile-account-default-community-help-${reactId}`;
+  const defaultCommunityErrorId = `perc-profile-account-default-community-error-${reactId}`;
+  const defaultCommunityFormId = `perc-profile-account-default-community-form-${reactId}`;
   const statusId = `perc-profile-account-status-${reactId}`;
 
   const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
   const [emailDraft, setEmailDraft] = useState("");
+  const [defaultCommunityDraft, setDefaultCommunityDraft] = useState("");
   const [fieldError, setFieldError] = useState<string | null>(null);
+  const [communityFieldError, setCommunityFieldError] = useState<string | null>(
+    null,
+  );
   const [formError, setFormError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isSavingCommunity, setIsSavingCommunity] = useState(false);
 
   const load = useCallback(async () => {
     setLoadState({ status: "loading" });
@@ -73,6 +86,8 @@ export function AccountSection({
     try {
       const profile = await loadProfile();
       setEmailDraft(profile.email ?? "");
+      setDefaultCommunityDraft(profile.defaultCommunity ?? "");
+      setCommunityFieldError(null);
       setLoadState({ status: "ready", profile });
     } catch (err) {
       if (isSessionRedirectError(err)) {
@@ -116,6 +131,43 @@ export function AccountSection({
       setFormError(formatApiError(err, message(PROFILE_MSG.SAVE_ERROR)));
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const onSubmitDefaultCommunity = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (loadState.status !== "ready") {
+      return;
+    }
+    setCommunityFieldError(null);
+    setFormError(null);
+    setSuccessMessage(null);
+
+    const allowed = allowedSessionCommunities(loadState.profile.communities);
+    const trimmed = defaultCommunityDraft.trim();
+    if (
+      trimmed &&
+      !allowed.some((name) => name.toLowerCase() === trimmed.toLowerCase())
+    ) {
+      setCommunityFieldError(message(PROFILE_MSG.DEFAULT_COMMUNITY_INVALID));
+      return;
+    }
+
+    setIsSavingCommunity(true);
+    try {
+      const updated = await saveDefaultCommunity(trimmed);
+      setLoadState({ status: "ready", profile: updated });
+      setDefaultCommunityDraft(updated.defaultCommunity ?? "");
+      setSuccessMessage(message(PROFILE_MSG.DEFAULT_COMMUNITY_SAVE_SUCCESS));
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setFormError(
+        formatApiError(err, message(PROFILE_MSG.DEFAULT_COMMUNITY_SAVE_ERROR)),
+      );
+    } finally {
+      setIsSavingCommunity(false);
     }
   };
 
@@ -190,9 +242,12 @@ export function AccountSection({
     .filter(Boolean)
     .join(" ");
 
+  const allowedCommunities = allowedSessionCommunities(profile.communities);
   const dirty =
     profile.emailEditable &&
     emailDraft.trim() !== (profile.email ?? "").trim();
+  const communityDirty =
+    defaultCommunityDraft.trim() !== (profile.defaultCommunity ?? "").trim();
 
   return (
     <div className={styles.root} data-testid="perc-profile-account">
@@ -390,6 +445,111 @@ export function AccountSection({
             >
               {currentCommunityText}
             </span>
+          </dd>
+        </div>
+
+        <div className={styles.field}>
+          <dt>
+            <label
+              htmlFor={defaultCommunityId}
+              {...i18nKeyAttr(PROFILE_MSG.FIELD_DEFAULT_COMMUNITY)}
+            >
+              {message(PROFILE_MSG.FIELD_DEFAULT_COMMUNITY)}
+            </label>
+          </dt>
+          <dd>
+            {allowedCommunities.length > 0 ? (
+              <form
+                id={defaultCommunityFormId}
+                className={styles.communityForm}
+                onSubmit={(e) => void onSubmitDefaultCommunity(e)}
+                noValidate
+                data-testid="perc-profile-account-default-community-form"
+              >
+                <select
+                  id={defaultCommunityId}
+                  name="defaultCommunity"
+                  className={styles.select}
+                  value={defaultCommunityDraft}
+                  onChange={(e) => {
+                    setDefaultCommunityDraft(e.target.value);
+                    setCommunityFieldError(null);
+                    setSuccessMessage(null);
+                  }}
+                  disabled={isSavingCommunity}
+                  aria-invalid={communityFieldError ? true : undefined}
+                  aria-describedby={
+                    communityFieldError
+                      ? `${defaultCommunityHelpId} ${defaultCommunityErrorId}`
+                      : defaultCommunityHelpId
+                  }
+                  data-testid="perc-profile-account-default-community"
+                >
+                  <option
+                    value=""
+                    {...i18nKeyAttr(PROFILE_MSG.DEFAULT_COMMUNITY_NONE)}
+                  >
+                    {message(PROFILE_MSG.DEFAULT_COMMUNITY_NONE)}
+                  </option>
+                  {allowedCommunities.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+                <p
+                  id={defaultCommunityHelpId}
+                  className={styles.hint}
+                  {...i18nKeyAttr(PROFILE_MSG.DEFAULT_COMMUNITY_HINT)}
+                >
+                  {message(PROFILE_MSG.DEFAULT_COMMUNITY_HINT)}
+                </p>
+                {communityFieldError && (
+                  <p
+                    id={defaultCommunityErrorId}
+                    className={styles.fieldError}
+                    role="alert"
+                    data-testid="perc-profile-account-default-community-error"
+                  >
+                    {communityFieldError}
+                  </p>
+                )}
+                <div className={styles.actions}>
+                  <button
+                    type="submit"
+                    className={styles.primaryButton}
+                    disabled={isSavingCommunity || !communityDirty}
+                    data-testid="perc-profile-account-default-community-save"
+                    {...i18nKeyAttr(
+                      isSavingCommunity
+                        ? PROFILE_MSG.SAVING
+                        : PROFILE_MSG.SAVE_DEFAULT_COMMUNITY,
+                    )}
+                  >
+                    {message(
+                      isSavingCommunity
+                        ? PROFILE_MSG.SAVING
+                        : PROFILE_MSG.SAVE_DEFAULT_COMMUNITY,
+                    )}
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <>
+                <span
+                  className={styles.readonlyValue}
+                  data-testid="perc-profile-account-default-community"
+                >
+                  {message(PROFILE_MSG.DEFAULT_COMMUNITY_UNAVAILABLE)}
+                </span>
+                <p
+                  className={styles.hint}
+                  {...i18nKeyAttr(PROFILE_MSG.DEFAULT_COMMUNITY_HINT)}
+                >
+                  {message(PROFILE_MSG.DEFAULT_COMMUNITY_HINT)}
+                </p>
+              </>
+            )}
           </dd>
         </div>
       </dl>

--- a/WebUI/src/main/ts/profile/messages.ts
+++ b/WebUI/src/main/ts/profile/messages.ts
@@ -90,6 +90,20 @@ export const PROFILE_MSG = {
   FIELD_ROLES: "perc.ui.profile.modern@Roles",
   FIELD_COMMUNITIES: "perc.ui.profile.modern@Communities",
   FIELD_CURRENT_COMMUNITY: "perc.ui.profile.modern@Current community",
+  FIELD_DEFAULT_COMMUNITY: "perc.ui.profile.modern@Default community",
+  DEFAULT_COMMUNITY_HINT:
+    "perc.ui.profile.modern@Used at the next sign-in when Remember last community is not selected. Only communities you can access are listed.",
+  DEFAULT_COMMUNITY_NONE:
+    "perc.ui.profile.modern@Use role default",
+  DEFAULT_COMMUNITY_UNAVAILABLE:
+    "perc.ui.profile.modern@No communities are assigned to your account.",
+  SAVE_DEFAULT_COMMUNITY: "perc.ui.profile.modern@Save default community",
+  DEFAULT_COMMUNITY_SAVE_SUCCESS:
+    "perc.ui.profile.modern@Your default community was saved.",
+  DEFAULT_COMMUNITY_SAVE_ERROR:
+    "perc.ui.profile.modern@Unable to save your default community. Choose a community you can access.",
+  DEFAULT_COMMUNITY_INVALID:
+    "perc.ui.profile.modern@Choose a community from the list.",
   PROVIDER_INTERNAL: "perc.ui.profile.modern@Internal",
   PROVIDER_DIRECTORY: "perc.ui.profile.modern@Directory",
   READONLY_HINT:

--- a/WebUI/src/test/ts/api/userProfileApi.test.ts
+++ b/WebUI/src/test/ts/api/userProfileApi.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const putPlainText = vi.fn();
+
+vi.mock("../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  putPlainText: (...args: unknown[]) => putPlainText(...args),
+}));
+
+import { updateMyDefaultCommunity } from "../../../main/ts/api/user/userProfileApi";
+
+describe("userProfileApi default community (#3508)", () => {
+  beforeEach(() => {
+    putPlainText.mockReset();
+  });
+
+  it("PUTs text/plain to the current-user defaultCommunity path", async () => {
+    putPlainText.mockResolvedValue({
+      CurrentUser: {
+        name: "Admin",
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "Corporate",
+      },
+    });
+
+    const profile = await updateMyDefaultCommunity("Corporate");
+
+    expect(putPlainText).toHaveBeenCalledTimes(1);
+    expect(putPlainText.mock.calls[0][0]).toMatch(/\/user\/user\/defaultCommunity$/);
+    expect(putPlainText.mock.calls[0][1]).toBe("Corporate");
+    expect(profile.defaultCommunity).toBe("Corporate");
+    expect(profile.communities).toEqual(["Default", "Corporate"]);
+  });
+
+  it("trims the community name before PUT", async () => {
+    putPlainText.mockResolvedValue({
+      defaultCommunity: "",
+      name: "Admin",
+    });
+    await updateMyDefaultCommunity("  ");
+    expect(putPlainText.mock.calls[0][1]).toBe("");
+  });
+});

--- a/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
+++ b/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
@@ -70,6 +70,7 @@ function profile(overrides: Partial<CurrentUserProfile> = {}): CurrentUserProfil
     roles: ["Editor"],
     communities: ["Default", "Corporate"],
     currentCommunity: "Default",
+    defaultCommunity: "Default",
     adminUser: false,
     designerUser: false,
     accessibilityUser: false,

--- a/WebUI/src/test/ts/profile/AccountSection.test.tsx
+++ b/WebUI/src/test/ts/profile/AccountSection.test.tsx
@@ -18,7 +18,10 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { AccountSection } from "../../../main/ts/profile/AccountSection";
+import {
+  AccountSection,
+  allowedDefaultCommunityDraft,
+} from "../../../main/ts/profile/AccountSection";
 import type { CurrentUserProfile } from "../../../main/ts/api/user/userProfileApi";
 import {
   isValidEmailAddress,
@@ -228,17 +231,48 @@ describe("AccountSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("perc-profile-account-default-community"),
+        screen.getByTestId("perc-profile-account-default-community-select"),
       ).toBeTruthy();
     });
     const select = screen.getByTestId(
-      "perc-profile-account-default-community",
+      "perc-profile-account-default-community-select",
     ) as HTMLSelectElement;
     expect(select.tagName).toBe("SELECT");
     expect(select.value).toBe("Corporate");
     const options = Array.from(select.options).map((o) => o.value);
     expect(options).toEqual(["", "Default", "Corporate"]);
     expect(options).not.toContain("Unknown");
+  });
+
+  it("falls back to empty select when stored default is not in membership", async () => {
+    expect(
+      allowedDefaultCommunityDraft({
+        communities: ["Default"],
+        defaultCommunity: "Stale Community",
+      }),
+    ).toBe("");
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "RemovedFromRole",
+      }),
+    );
+    render(<AccountSection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-default-community-select"),
+      ).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-account-default-community-select",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("");
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      "",
+      "Default",
+      "Corporate",
+    ]);
   });
 
   it("saves allowed default community and reloads returned value", async () => {
@@ -263,11 +297,11 @@ describe("AccountSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("perc-profile-account-default-community"),
+        screen.getByTestId("perc-profile-account-default-community-select"),
       ).toBeTruthy();
     });
     const select = screen.getByTestId(
-      "perc-profile-account-default-community",
+      "perc-profile-account-default-community-select",
     ) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "Corporate" } });
     fireEvent.click(
@@ -294,7 +328,9 @@ describe("AccountSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("perc-profile-account-default-community").textContent,
+        screen.getByTestId(
+          "perc-profile-account-default-community-unavailable",
+        ).textContent,
       ).toMatch(/no communities/i);
     });
     expect(
@@ -324,11 +360,11 @@ describe("AccountSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("perc-profile-account-default-community"),
+        screen.getByTestId("perc-profile-account-default-community-select"),
       ).toBeTruthy();
     });
     const select = screen.getByTestId(
-      "perc-profile-account-default-community",
+      "perc-profile-account-default-community-select",
     ) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "" } });
     fireEvent.click(

--- a/WebUI/src/test/ts/profile/AccountSection.test.tsx
+++ b/WebUI/src/test/ts/profile/AccountSection.test.tsx
@@ -35,6 +35,7 @@ function internalProfile(
     roles: ["Admin", "Editor"],
     communities: ["Default"],
     currentCommunity: "Default",
+    defaultCommunity: "Default",
     adminUser: true,
     designerUser: false,
     accessibilityUser: false,
@@ -60,6 +61,19 @@ describe("normalizeCurrentUser / isValidEmailAddress", () => {
     expect(profile.email).toBe("e@example.com");
     expect(profile.emailEditable).toBe(true);
     expect(profile.communities).toEqual(["Default", "Corporate"]);
+    expect(profile.defaultCommunity).toBe("");
+  });
+
+  it("unwraps stored defaultCommunity from GET current user", () => {
+    const profile = normalizeCurrentUser({
+      CurrentUser: {
+        name: "Admin",
+        communities: ["Default", "Corporate"],
+        currentCommunity: "Corporate",
+        defaultCommunity: "Default",
+      },
+    });
+    expect(profile.defaultCommunity).toBe("Default");
   });
 
   it("marks DIRECTORY as not email-editable", () => {
@@ -201,5 +215,131 @@ describe("AccountSection", () => {
       );
     });
     expect(loadProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders default community from profile.communities only", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "Corporate",
+      }),
+    );
+    render(<AccountSection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-default-community"),
+      ).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-account-default-community",
+    ) as HTMLSelectElement;
+    expect(select.tagName).toBe("SELECT");
+    expect(select.value).toBe("Corporate");
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(["", "Default", "Corporate"]);
+    expect(options).not.toContain("Unknown");
+  });
+
+  it("saves allowed default community and reloads returned value", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "Default",
+      }),
+    );
+    const saveDefaultCommunity = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "Corporate",
+      }),
+    );
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        saveDefaultCommunity={saveDefaultCommunity}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-default-community"),
+      ).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-account-default-community",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "Corporate" } });
+    fireEvent.click(
+      screen.getByTestId("perc-profile-account-default-community-save"),
+    );
+
+    await waitFor(() => {
+      expect(saveDefaultCommunity).toHaveBeenCalledWith("Corporate");
+      expect(
+        screen.getByTestId("perc-profile-account-success").textContent,
+      ).toMatch(/default community was saved/i);
+    });
+    expect(select.value).toBe("Corporate");
+  });
+
+  it("shows an unavailable note when the user has no communities", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: [],
+        defaultCommunity: "",
+      }),
+    );
+    render(<AccountSection loadProfile={loadProfile} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-default-community").textContent,
+      ).toMatch(/no communities/i);
+    });
+    expect(
+      screen.queryByTestId("perc-profile-account-default-community-save"),
+    ).toBeNull();
+  });
+
+  it("clears the stored default when Use role default is saved", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "Default",
+      }),
+    );
+    const saveDefaultCommunity = vi.fn().mockResolvedValue(
+      internalProfile({
+        communities: ["Default", "Corporate"],
+        defaultCommunity: "",
+      }),
+    );
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        saveDefaultCommunity={saveDefaultCommunity}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-default-community"),
+      ).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-account-default-community",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "" } });
+    fireEvent.click(
+      screen.getByTestId("perc-profile-account-default-community-save"),
+    );
+
+    await waitFor(() => {
+      expect(saveDefaultCommunity).toHaveBeenCalledWith("");
+      expect(
+        screen.getByTestId("perc-profile-account-success").textContent,
+      ).toMatch(/default community was saved/i);
+    });
   });
 });

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -86,12 +86,14 @@ vi.mock("../../../main/ts/api/user/userProfileApi", () => ({
     roles: ["Admin"],
     communities: ["Default"],
     currentCommunity: "Default",
+    defaultCommunity: "Default",
     adminUser: true,
     designerUser: false,
     accessibilityUser: false,
     emailEditable: true,
   }),
   updateMyAccountEmail: vi.fn(),
+  updateMyDefaultCommunity: vi.fn(),
   // Mirror production isValidEmailAddress (userProfileApi) so shell tests do not mask shape bugs.
   isValidEmailAddress: (email: string) => {
     const value = (email ?? "").trim();

--- a/WebUI/src/test/ts/profile/SecuritySection.test.tsx
+++ b/WebUI/src/test/ts/profile/SecuritySection.test.tsx
@@ -35,6 +35,7 @@ function internalProfile(
     roles: ["Admin"],
     communities: ["Default"],
     currentCommunity: "Default",
+    defaultCommunity: "Default",
     adminUser: true,
     designerUser: false,
     accessibilityUser: false,

--- a/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
@@ -200,7 +200,9 @@ test.describe("Profile account @profile @account @smoke", () => {
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectAccountMounted(page);
 
-    const select = page.getByTestId("perc-profile-account-default-community");
+    const select = page.getByTestId(
+      "perc-profile-account-default-community-select",
+    );
     await expect(select).toBeVisible();
     await expect(select).toHaveJSProperty("tagName", "SELECT");
 
@@ -235,12 +237,12 @@ test.describe("Profile account @profile @account @smoke", () => {
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectAccountMounted(page);
     await expect(
-      page.getByTestId("perc-profile-account-default-community"),
+      page.getByTestId("perc-profile-account-default-community-select"),
     ).toHaveValue(target);
 
     if (original !== target) {
       await page
-        .getByTestId("perc-profile-account-default-community")
+        .getByTestId("perc-profile-account-default-community-select")
         .selectOption(original);
       await page
         .getByTestId("perc-profile-account-default-community-save")

--- a/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
@@ -170,4 +170,88 @@ test.describe("Profile account @profile @account @smoke", () => {
       ).toBeVisible({ timeout: 30_000 });
     }
   });
+
+  /**
+   * #3508 / parent #3505 slice 2 — default community save + reload from
+   * GET /user/user/current (sys_defaultCommunity). Options come from
+   * profile.communities only.
+   */
+  test("default community save and reload for Admin", async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        const text = msg.text();
+        if (
+          !/gravatar\.com/i.test(text) &&
+          !/Failed to load resource/i.test(text) &&
+          !/net::ERR_/i.test(text)
+        ) {
+          consoleErrors.push(text);
+        }
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+
+    const select = page.getByTestId("perc-profile-account-default-community");
+    await expect(select).toBeVisible();
+    await expect(select).toHaveJSProperty("tagName", "SELECT");
+
+    const membership = page.getByTestId("perc-profile-account-communities");
+    await expect(membership).toBeVisible();
+    const membershipText = ((await membership.textContent()) || "").trim();
+
+    const optionValues = await select.evaluate((el) =>
+      Array.from(el.options).map((o) => o.value).filter(Boolean),
+    );
+    expect(optionValues.length, "Admin must have at least one community").toBeGreaterThan(
+      0,
+    );
+    for (const name of optionValues) {
+      expect(
+        membershipText.toLowerCase().includes(name.toLowerCase()),
+        `option ${name} must appear in membership list`,
+      ).toBe(true);
+    }
+
+    const original = await select.inputValue();
+    const target =
+      optionValues.find((name) => name !== original) || optionValues[0];
+
+    await select.selectOption(target);
+    await page.getByTestId("perc-profile-account-default-community-save").click();
+    await expect(
+      page.getByTestId("perc-profile-account-success"),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(select).toHaveValue(target);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+    await expect(
+      page.getByTestId("perc-profile-account-default-community"),
+    ).toHaveValue(target);
+
+    if (original !== target) {
+      await page
+        .getByTestId("perc-profile-account-default-community")
+        .selectOption(original);
+      await page
+        .getByTestId("perc-profile-account-default-community-save")
+        .click();
+      await expect(
+        page.getByTestId("perc-profile-account-success"),
+      ).toBeVisible({ timeout: 30_000 });
+    }
+
+    expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
 });

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -79,6 +79,21 @@ Use **Switch** to change the session community **without signing out**.
 - Setting a **default** community on the profile, or remembering the last community at the next
   login, is not part of this header control.
 
+## My profile — Account (default community)
+
+On **My profile → Account** (deep link `spa.jsp?entry=profile`), signed-in users can set their
+**default community**. The list is the same membership list as the header switch (communities
+your roles grant — not the full catalog).
+
+| Control | What it does |
+|---------|----------------|
+| **Default community** | Community applied at the **next sign-in** when Remember last community is not selected. **Use role default** clears your personal override so the role attribute `sys_defaultCommunity` applies. |
+| **Save default community** | Writes the value for the signed-in user only (`sys_defaultCommunity` on your user subject). Reload the page to confirm the stored value. You cannot set a community you do not belong to. |
+
+This does **not** change the current session community. Use **Switch** in the header for that.
+Directory / SSO accounts can still set a default community here (it is a CMS attribute, not a
+directory field).
+
 ## My profile — Security (password)
 
 Authenticated users open **My profile** from the header user menu (or deep link

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
@@ -41,6 +41,12 @@ public class PSCurrentUser extends PSUser {
   /** Active community name for the current session, or empty when unknown. */
   private String currentCommunity = "";
 
+  /**
+   * Persisted default community ({@code sys_defaultCommunity} on the user subject). Empty when
+   * unset so login falls back to the role attribute.
+   */
+  private String defaultCommunity = "";
+
   public PSCurrentUser() {
     super();
   }
@@ -106,5 +112,13 @@ public class PSCurrentUser extends PSUser {
 
   public void setCurrentCommunity(String currentCommunity) {
     this.currentCommunity = currentCommunity == null ? "" : currentCommunity;
+  }
+
+  public String getDefaultCommunity() {
+    return defaultCommunity;
+  }
+
+  public void setDefaultCommunity(String defaultCommunity) {
+    this.defaultCommunity = defaultCommunity == null ? "" : defaultCommunity;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
@@ -146,6 +146,18 @@ public interface IPSUserService {
   public PSCurrentUser updateMyAccount(PSUserAccountUpdate update) throws PSDataServiceException;
 
   /**
+   * Self-service default community for the signed-in session user only (issue #3508). No user
+   * name on the path — no IDOR. Persists {@code sys_defaultCommunity} on the user subject.
+   * Blank name clears the stored default. The community must be in the user's allowed
+   * communities.
+   *
+   * @param communityName community name to store, may be blank (clears)
+   * @return refreshed {@link PSCurrentUser}, never {@code null}
+   * @throws PSDataServiceException when the name is not allowed or persist fails
+   */
+  public PSCurrentUser updateMyDefaultCommunity(String communityName) throws PSDataServiceException;
+
+  /**
    * Deletes the user with the given user name.
    *
    * @param name never <code>null</code> or empty.

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -33,6 +33,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.cms.PSAuthenticateUserUtils;
 import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSFolder;
@@ -981,6 +982,66 @@ public class PSUserService implements IPSUserService {
   }
 
   /**
+   * Self-service default community for the signed-in user only (issue #3508). Persists {@link
+   * PSAuthenticateUserUtils#SYS_DEFAULTCOMMUNITY} on the user subject. Blank body clears the
+   * stored default so role-level defaults apply at the next login.
+   */
+  @Override
+  @PUT
+  @Path("/defaultCommunity")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Consumes({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public PSCurrentUser updateMyDefaultCommunity(String communityName) throws PSDataServiceException {
+    PSCurrentUser current = getCurrentUser();
+    String canonical = canonicalizeAllowedCommunity(communityName, current.getCommunities());
+    if (canonical == null) {
+      PSParameterValidationUtils.validateParameters("updateMyDefaultCommunity")
+          .rejectField(
+              "defaultCommunity",
+              "Community is not in your allowed communities.",
+              communityName)
+          .throwIfInvalid();
+    }
+
+    try {
+      backEndRoleMgr.setSubjectAttribute(
+          current.getName(), PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, canonical);
+    } catch (RuntimeException e) {
+      logSelfServiceAccountUpdateAudit(AuditOutcome.FAILURE);
+      log.error(
+          "Self-service default community update failed for user {}: {}",
+          current.getName(),
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw e;
+    }
+
+    logSelfServiceAccountUpdateAudit(AuditOutcome.SUCCESS);
+    current.setDefaultCommunity(canonical);
+    return current;
+  }
+
+  /**
+   * Maps a requested community name onto the user's membership list. Blank request clears
+   * (returns empty string). Unknown / disallowed names return {@code null}.
+   */
+  static String canonicalizeAllowedCommunity(String requested, List<String> allowed) {
+    if (requested == null || requested.isBlank()) {
+      return "";
+    }
+    if (allowed == null) {
+      return null;
+    }
+    String trimmed = requested.trim();
+    for (String name : allowed) {
+      if (name != null && trimmed.equalsIgnoreCase(name.trim())) {
+        return name.trim();
+      }
+    }
+    return null;
+  }
+
+  /**
    * Best-effort audit for self-service account updates. Never throws — audit infrastructure must
    * not mask the primary operation outcome.
    */
@@ -1012,6 +1073,18 @@ public class PSUserService implements IPSUserService {
    * so account identity still returns.
    */
   private void enrichCurrentUserCommunities(PSCurrentUser currUser) {
+    try {
+      String storedDefault =
+          backEndRoleMgr.getSubjectAttribute(
+              currUser.getName(), PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY);
+      if (isNotBlank(storedDefault)) {
+        currUser.setDefaultCommunity(storedDefault);
+      }
+    } catch (Exception e) {
+      log.debug(
+          "Unable to load default community for current user: {}",
+          PSExceptionUtils.getMessageForLog(e));
+    }
     try {
       PSRequest req = PSSecurityFilter.getCurrentRequest();
       if (req == null || req.getUserSession() == null) {

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -1071,15 +1071,17 @@ public class PSUserService implements IPSUserService {
   /**
    * Best-effort session community summary for the profile hub. Failures are logged and left empty
    * so account identity still returns.
+   *
+   * <p>Stored {@code sys_defaultCommunity} is applied only after membership names are loaded, and
+   * only when it is still in that list — {@code GET /user/user/current} never returns a disallowed
+   * default.
    */
   private void enrichCurrentUserCommunities(PSCurrentUser currUser) {
+    String storedDefault = null;
     try {
-      String storedDefault =
+      storedDefault =
           backEndRoleMgr.getSubjectAttribute(
               currUser.getName(), PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY);
-      if (isNotBlank(storedDefault)) {
-        currUser.setDefaultCommunity(storedDefault);
-      }
     } catch (Exception e) {
       log.debug(
           "Unable to load default community for current user: {}",
@@ -1088,6 +1090,7 @@ public class PSUserService implements IPSUserService {
     try {
       PSRequest req = PSSecurityFilter.getCurrentRequest();
       if (req == null || req.getUserSession() == null) {
+        applyAllowedStoredDefault(currUser, storedDefault);
         return;
       }
       String currentCommunity = req.getUserSession().getUserCurrentCommunity();
@@ -1105,6 +1108,16 @@ public class PSUserService implements IPSUserService {
           "Unable to load community summary for current user: {}",
           PSExceptionUtils.getMessageForLog(e));
     }
+    applyAllowedStoredDefault(currUser, storedDefault);
+  }
+
+  /**
+   * Sets {@code defaultCommunity} only when {@code storedDefault} is still in the user's
+   * membership list. Unknown or disallowed names become empty.
+   */
+  static void applyAllowedStoredDefault(PSCurrentUser currUser, String storedDefault) {
+    String canonical = canonicalizeAllowedCommunity(storedDefault, currUser.getCommunities());
+    currUser.setDefaultCommunity(canonical == null ? "" : canonical);
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSBackEndRoleManagerFacade.java
+++ b/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSBackEndRoleManagerFacade.java
@@ -19,12 +19,15 @@ package com.percussion.utils.service.impl;
 
 import com.percussion.design.objectstore.PSSubject;
 import com.percussion.services.security.IPSBackEndRoleMgr;
+import com.percussion.services.security.PSJaasUtils;
 import com.percussion.services.security.data.PSBackEndRole;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.security.auth.Subject;
 
 /**
  * Simplifies the Back-end role manager while also making it thread safe.
@@ -104,6 +107,35 @@ public class PSBackEndRoleManagerFacade {
       backEndRoleMgr.setSubjectEmail(subjectName, subjectEmail);
     } finally {
       lock.writeLock().unlock();
+    }
+  }
+
+  /** See {@link IPSBackEndRoleMgr#setSubjectAttribute(String, String, String)}. */
+  public void setSubjectAttribute(String subjectName, String attributeName, String value) {
+    lock.writeLock().lock();
+    try {
+      backEndRoleMgr.setSubjectAttribute(subjectName, attributeName, value);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * First non-empty global subject attribute for {@code subjectName}. Empty when unset.
+   */
+  public String getSubjectAttribute(String subjectName, String attributeName) {
+    lock.readLock().lock();
+    try {
+      Set<Subject> subjects =
+          backEndRoleMgr.getGlobalSubjectAttributes(subjectName, attributeName, false);
+      if (subjects == null || subjects.isEmpty()) {
+        return "";
+      }
+      String value =
+          PSJaasUtils.getSubjectAttributeValue(subjects.iterator().next(), attributeName);
+      return value == null ? "" : value.trim();
+    } finally {
+      lock.readLock().unlock();
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserDefaultCommunityTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserDefaultCommunityTest.java
@@ -106,80 +106,95 @@ class PSUserDefaultCommunityTest {
 
   @Test
   void persistsAllowedCommunityOnUserSubject() throws Exception {
-      PSCurrentUser current = memberUser("Admin", List.of("Default", "Corporate"));
-      doReturn(current).when(userService).getCurrentUser();
+    PSCurrentUser current = memberUser("Admin", List.of("Default", "Corporate"));
+    doReturn(current).when(userService).getCurrentUser();
 
-      PSCurrentUser result = userService.updateMyDefaultCommunity("corporate");
+    PSCurrentUser result = userService.updateMyDefaultCommunity("corporate");
 
-      verify(backEndRoleMgr)
-          .setSubjectAttribute(
-              eq("Admin"),
-              eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY),
-              eq("Corporate"));
-      assertEquals("Corporate", result.getDefaultCommunity());
-    }
-
-    @Test
-    void blankClearsStoredDefault() throws Exception {
-      PSCurrentUser current = memberUser("Admin", List.of("Default"));
-      current.setDefaultCommunity("Default");
-      doReturn(current).when(userService).getCurrentUser();
-
-      PSCurrentUser result = userService.updateMyDefaultCommunity("  ");
-
-      verify(backEndRoleMgr)
-          .setSubjectAttribute(
-              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(""));
-      assertEquals("", result.getDefaultCommunity());
-    }
-
-    @Test
-    void rejectsCommunityNotInMembership() throws Exception {
-      PSCurrentUser current = memberUser("Editor1", List.of("Default"));
-      doReturn(current).when(userService).getCurrentUser();
-
-      assertThrows(
-          PSValidationException.class, () -> userService.updateMyDefaultCommunity("Unknown"));
-      verify(backEndRoleMgr, never())
-          .setSubjectAttribute(
-              org.mockito.ArgumentMatchers.anyString(),
-              org.mockito.ArgumentMatchers.anyString(),
-              org.mockito.ArgumentMatchers.anyString());
-    }
-
-    @Test
-    void propagatesBackendFailureWithoutApplying() throws Exception {
-      PSCurrentUser current = memberUser("Admin", List.of("Default"));
-      doReturn(current).when(userService).getCurrentUser();
-      doThrow(new RuntimeException("backend write failed"))
-          .when(backEndRoleMgr)
-          .setSubjectAttribute(
-              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq("Default"));
-
-      RuntimeException thrown =
-          assertThrows(
-              RuntimeException.class, () -> userService.updateMyDefaultCommunity("Default"));
-      assertEquals("backend write failed", thrown.getMessage());
-      assertEquals("", current.getDefaultCommunity());
-    }
+    verify(backEndRoleMgr)
+        .setSubjectAttribute(
+            eq("Admin"),
+            eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY),
+            eq("Corporate"));
+    assertEquals("Corporate", result.getDefaultCommunity());
+  }
 
   @Test
-  void returnsStoredSubjectAttribute() throws Exception {
-      PSUser internal = new PSUser();
-      internal.setName("Admin");
-      internal.setEmail("admin@example.com");
-      internal.setProviderType(PSUserProviderType.INTERNAL);
-      internal.setRoles(List.of("Admin"));
-      doReturn("Admin").when(userService).getCurrentUserName();
-      doReturn(internal).when(userService).find("Admin");
-      when(backEndRoleMgr.getGlobalSubjectAttributes(
-              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(false)))
-          .thenReturn(Set.of(subjectWithDefaultCommunity("Admin", "Corporate")));
+  void blankClearsStoredDefault() throws Exception {
+    PSCurrentUser current = memberUser("Admin", List.of("Default"));
+    current.setDefaultCommunity("Default");
+    doReturn(current).when(userService).getCurrentUser();
 
-      PSCurrentUser result = userService.getCurrentUser();
+    PSCurrentUser result = userService.updateMyDefaultCommunity("  ");
 
-      assertEquals("Corporate", result.getDefaultCommunity());
-    }
+    verify(backEndRoleMgr)
+        .setSubjectAttribute(
+            eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(""));
+    assertEquals("", result.getDefaultCommunity());
+  }
+
+  @Test
+  void rejectsCommunityNotInMembership() throws Exception {
+    PSCurrentUser current = memberUser("Editor1", List.of("Default"));
+    doReturn(current).when(userService).getCurrentUser();
+
+    assertThrows(
+        PSValidationException.class, () -> userService.updateMyDefaultCommunity("Unknown"));
+    verify(backEndRoleMgr, never())
+        .setSubjectAttribute(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void propagatesBackendFailureWithoutApplying() throws Exception {
+    PSCurrentUser current = memberUser("Admin", List.of("Default"));
+    doReturn(current).when(userService).getCurrentUser();
+    doThrow(new RuntimeException("backend write failed"))
+        .when(backEndRoleMgr)
+        .setSubjectAttribute(
+            eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq("Default"));
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class, () -> userService.updateMyDefaultCommunity("Default"));
+    assertEquals("backend write failed", thrown.getMessage());
+    assertEquals("", current.getDefaultCommunity());
+  }
+
+  @Test
+  void applyAllowedStoredDefaultKeepsMembershipSpelling() {
+    PSCurrentUser current = memberUser("Admin", List.of("Default", "Corporate"));
+    PSUserService.applyAllowedStoredDefault(current, "corporate");
+    assertEquals("Corporate", current.getDefaultCommunity());
+  }
+
+  @Test
+  void applyAllowedStoredDefaultClearsDisallowed() {
+    PSCurrentUser current = memberUser("Admin", List.of("Default"));
+    PSUserService.applyAllowedStoredDefault(current, "Corporate");
+    assertEquals("", current.getDefaultCommunity());
+  }
+
+  @Test
+  void getCurrentUserOmitsStoredDefaultWhenNotInSessionCommunities() throws Exception {
+    PSUser internal = new PSUser();
+    internal.setName("Admin");
+    internal.setEmail("admin@example.com");
+    internal.setProviderType(PSUserProviderType.INTERNAL);
+    internal.setRoles(List.of("Admin"));
+    doReturn("Admin").when(userService).getCurrentUserName();
+    doReturn(internal).when(userService).find("Admin");
+    when(backEndRoleMgr.getGlobalSubjectAttributes(
+            eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(false)))
+        .thenReturn(Set.of(subjectWithDefaultCommunity("Admin", "Corporate")));
+
+    PSCurrentUser result = userService.getCurrentUser();
+
+    // No session membership list in this unit fixture — do not return a stale default.
+    assertEquals("", result.getDefaultCommunity());
+  }
 
   private static PSCurrentUser memberUser(String name, List<String> communities) {
     PSCurrentUser user = new PSCurrentUser();

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserDefaultCommunityTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserDefaultCommunityTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.user.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.PSAuthenticateUserUtils;
+import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.design.objectstore.PSGlobalSubject;
+import com.percussion.design.objectstore.PSSubject;
+import com.percussion.metadata.service.IPSMetadataService;
+import com.percussion.security.IPSPasswordFilter;
+import com.percussion.services.security.IPSBackEndRoleMgr;
+import com.percussion.services.security.IPSRoleMgr;
+import com.percussion.services.security.PSJaasUtils;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.IPSSystemProperties;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.sitemanage.dao.IPSUserLoginDao;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.data.PSUser;
+import com.percussion.user.data.PSUserProviderType;
+import com.percussion.utils.service.IPSUtilityService;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.security.IPSSecurityWs;
+import java.util.List;
+import java.util.Set;
+import javax.security.auth.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Self-service default community persist/GET (issue #3508). Production types: {@link
+ * PSCurrentUser}, {@link IPSBackEndRoleMgr}, {@link PSAuthenticateUserUtils#SYS_DEFAULTCOMMUNITY}.
+ */
+class PSUserDefaultCommunityTest {
+
+  private IPSBackEndRoleMgr backEndRoleMgr;
+  private PSUserService userService;
+
+  @BeforeEach
+  void setUp() {
+    backEndRoleMgr = mock(IPSBackEndRoleMgr.class);
+    userService =
+        spy(
+            new PSUserService(
+                mock(IPSUserLoginDao.class),
+                mock(IPSPasswordFilter.class),
+                backEndRoleMgr,
+                mock(IPSRoleMgr.class),
+                /* notificationService */ null,
+                mock(IPSWorkflowService.class),
+                mock(IPSSecurityWs.class),
+                mock(IPSContentWs.class),
+                mock(IPSIdMapper.class),
+                mock(IPSUtilityService.class),
+                mock(IPSMetadataService.class)));
+    IPSSystemProperties systemProps = mock(IPSSystemProperties.class);
+    when(systemProps.getProperty("accessibilityRoles")).thenReturn("");
+    userService.setSystemProps(systemProps);
+  }
+
+  @Test
+  void blankClears() {
+    assertEquals("", PSUserService.canonicalizeAllowedCommunity("  ", List.of("Default")));
+    assertEquals("", PSUserService.canonicalizeAllowedCommunity(null, List.of("Default")));
+  }
+
+  @Test
+  void returnsCanonicalMembershipSpelling() {
+    assertEquals(
+        "Enterprise Investments",
+        PSUserService.canonicalizeAllowedCommunity(
+            "enterprise investments", List.of("Default", "Enterprise Investments")));
+  }
+
+  @Test
+  void rejectsUnknown() {
+    assertNull(PSUserService.canonicalizeAllowedCommunity("Unknown", List.of("Default")));
+  }
+
+  @Test
+  void persistsAllowedCommunityOnUserSubject() throws Exception {
+      PSCurrentUser current = memberUser("Admin", List.of("Default", "Corporate"));
+      doReturn(current).when(userService).getCurrentUser();
+
+      PSCurrentUser result = userService.updateMyDefaultCommunity("corporate");
+
+      verify(backEndRoleMgr)
+          .setSubjectAttribute(
+              eq("Admin"),
+              eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY),
+              eq("Corporate"));
+      assertEquals("Corporate", result.getDefaultCommunity());
+    }
+
+    @Test
+    void blankClearsStoredDefault() throws Exception {
+      PSCurrentUser current = memberUser("Admin", List.of("Default"));
+      current.setDefaultCommunity("Default");
+      doReturn(current).when(userService).getCurrentUser();
+
+      PSCurrentUser result = userService.updateMyDefaultCommunity("  ");
+
+      verify(backEndRoleMgr)
+          .setSubjectAttribute(
+              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(""));
+      assertEquals("", result.getDefaultCommunity());
+    }
+
+    @Test
+    void rejectsCommunityNotInMembership() throws Exception {
+      PSCurrentUser current = memberUser("Editor1", List.of("Default"));
+      doReturn(current).when(userService).getCurrentUser();
+
+      assertThrows(
+          PSValidationException.class, () -> userService.updateMyDefaultCommunity("Unknown"));
+      verify(backEndRoleMgr, never())
+          .setSubjectAttribute(
+              org.mockito.ArgumentMatchers.anyString(),
+              org.mockito.ArgumentMatchers.anyString(),
+              org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void propagatesBackendFailureWithoutApplying() throws Exception {
+      PSCurrentUser current = memberUser("Admin", List.of("Default"));
+      doReturn(current).when(userService).getCurrentUser();
+      doThrow(new RuntimeException("backend write failed"))
+          .when(backEndRoleMgr)
+          .setSubjectAttribute(
+              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq("Default"));
+
+      RuntimeException thrown =
+          assertThrows(
+              RuntimeException.class, () -> userService.updateMyDefaultCommunity("Default"));
+      assertEquals("backend write failed", thrown.getMessage());
+      assertEquals("", current.getDefaultCommunity());
+    }
+
+  @Test
+  void returnsStoredSubjectAttribute() throws Exception {
+      PSUser internal = new PSUser();
+      internal.setName("Admin");
+      internal.setEmail("admin@example.com");
+      internal.setProviderType(PSUserProviderType.INTERNAL);
+      internal.setRoles(List.of("Admin"));
+      doReturn("Admin").when(userService).getCurrentUserName();
+      doReturn(internal).when(userService).find("Admin");
+      when(backEndRoleMgr.getGlobalSubjectAttributes(
+              eq("Admin"), eq(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY), eq(false)))
+          .thenReturn(Set.of(subjectWithDefaultCommunity("Admin", "Corporate")));
+
+      PSCurrentUser result = userService.getCurrentUser();
+
+      assertEquals("Corporate", result.getDefaultCommunity());
+    }
+
+  private static PSCurrentUser memberUser(String name, List<String> communities) {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName(name);
+    user.setProviderType(PSUserProviderType.INTERNAL);
+    user.setRoles(List.of("Admin"));
+    user.setCommunities(communities);
+    return user;
+  }
+
+  private static Subject subjectWithDefaultCommunity(String name, String community) {
+    PSAttributeList attrs = new PSAttributeList();
+    attrs.setAttribute(
+        PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, List.of(community));
+    PSSubject psSubject = new PSGlobalSubject(name, PSSubject.SUBJECT_TYPE_USER, attrs);
+    return PSJaasUtils.convertSubject(psSubject);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/user/web/service/PSUserServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/web/service/PSUserServiceRestClient.java
@@ -107,6 +107,15 @@ public class PSUserServiceRestClient extends PSObjectRestClient implements IPSUs
   }
 
   @Override
+  public PSCurrentUser updateMyDefaultCommunity(final String communityName)
+      throws PSDataServiceException {
+    return putObjectToPath(
+        concatPath(getPath(), "defaultCommunity"),
+        communityName == null ? "" : communityName,
+        PSCurrentUser.class);
+  }
+
+  @Override
   public PSAccessLevel getAccessLevel(final PSAccessLevelRequest request) {
     return postObjectToPath(concatPath(getPath(), "accessLevel"), request, PSAccessLevel.class);
   }

--- a/system/services/src/com/percussion/services/security/IPSBackEndRoleMgr.java
+++ b/system/services/src/com/percussion/services/security/IPSBackEndRoleMgr.java
@@ -288,6 +288,20 @@ public interface IPSBackEndRoleMgr
     * @param subjectEmail subjectEmail never <code>null</code> might be empty.
     */
    public void setSubjectEmail(String subjectName, String subjectEmail);
+
+   /**
+    * Sets or clears a named global subject attribute (issue #3508).
+    *
+    * <p>Used for the signed-in user's {@code sys_defaultCommunity} (and other
+    * subject attributes). A blank {@code value} clears the stored attribute so
+    * role-level defaults apply again. Failures are thrown — callers must not
+    * treat a silent catch as success.
+    *
+    * @param subjectName never {@code null} or empty
+    * @param attributeName never {@code null} or empty
+    * @param value may be {@code null} or empty (clears the attribute)
+    */
+   public void setSubjectAttribute(String subjectName, String attributeName, String value);
    
    /**
     * Updates the description on the role for the provided roleName

--- a/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
+++ b/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
@@ -244,6 +244,69 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
         }
     }
 
+    // see IPSBackEndRoleMgr interface
+    public void setSubjectAttribute(String subjectName, String attributeName, String value) {
+        if (StringUtils.isBlank(subjectName)) {
+            throw new IllegalArgumentException("subjectName may not be null or empty");
+        }
+        if (StringUtils.isBlank(attributeName)) {
+            throw new IllegalArgumentException("attributeName may not be null or empty");
+        }
+        RoleConfig config = null;
+        try {
+            config = getRoleConfig();
+            applySubjectAttribute(config.roleCfg, subjectName, attributeName, value);
+            config.objectStore.saveRoleConfiguration(
+                config.roleCfg, config.lockId, config.securityToken);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            String msg =
+                "Failed to set attribute "
+                    + attributeName
+                    + " on user "
+                    + subjectName;
+            ms_log.error(msg, e);
+            throw new RuntimeException(msg, e);
+        } finally {
+            if (config != null) {
+                releaseConfigLock(config.objectStore, config.lockId);
+            }
+        }
+    }
+
+    /**
+     * Writes {@code attributeName} on the global subject in {@code roleCfg}.
+     * Blank {@code value} stores an empty value list (treated as unset by
+     * default-community readers).
+     */
+    public static void applySubjectAttribute(
+        PSRoleConfiguration roleCfg,
+        String subjectName,
+        String attributeName,
+        String value) {
+        if (roleCfg == null) {
+            throw new IllegalArgumentException("roleCfg may not be null");
+        }
+        if (StringUtils.isBlank(subjectName)) {
+            throw new IllegalArgumentException("subjectName may not be null or empty");
+        }
+        if (StringUtils.isBlank(attributeName)) {
+            throw new IllegalArgumentException("attributeName may not be null or empty");
+        }
+        PSRelativeSubject relativeSub =
+            new PSRelativeSubject(subjectName, PSSubject.SUBJECT_TYPE_USER, null);
+        PSSubject subject = roleCfg.getGlobalSubject(relativeSub, true);
+        if (subject == null) {
+            throw new IllegalStateException(
+                "Unable to create or load global subject for " + subjectName);
+        }
+        String stored = value == null ? "" : value.trim();
+        List<String> values =
+            stored.isEmpty() ? new ArrayList<>() : Arrays.asList(stored);
+        subject.getAttributes().setAttribute(attributeName, values);
+    }
+
     /**
      * See {@link IPSBackEndRoleMgr#update(String, String)}.
      */

--- a/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
+++ b/system/services/src/com/percussion/services/security/impl/PSBackEndRoleMgr.java
@@ -258,8 +258,6 @@ public class PSBackEndRoleMgr implements IPSBackEndRoleMgr {
             applySubjectAttribute(config.roleCfg, subjectName, attributeName, value);
             config.objectStore.saveRoleConfiguration(
                 config.roleCfg, config.lockId, config.securityToken);
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
             String msg =
                 "Failed to set attribute "

--- a/system/src/main/java/com/percussion/cms/PSAuthenticateUserUtils.java
+++ b/system/src/main/java/com/percussion/cms/PSAuthenticateUserUtils.java
@@ -18,6 +18,7 @@
 package com.percussion.cms;
 
 import com.percussion.design.objectstore.PSAttribute;
+import com.percussion.design.objectstore.PSSubject;
 import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
 import java.util.ArrayList;
@@ -165,5 +166,108 @@ public class PSAuthenticateUserUtils {
       }
     }
     return attrValue;
+  }
+
+  /**
+   * First non-empty global subject attribute for the current user (issue #3508).
+   *
+   * <p>Used for {@link #SYS_DEFAULTCOMMUNITY} stored on the user subject rather
+   * than a role. Failures return {@code null} so callers can fall back to the
+   * role attribute.
+   */
+  public static String getUserSubjectAttribute(IPSRequestContext request, String srcAttrName) {
+    if (request == null || srcAttrName == null || srcAttrName.isBlank()) {
+      return null;
+    }
+    try {
+      String userName = request.getUserName();
+      if (userName == null || userName.isBlank()) {
+        return null;
+      }
+      List<PSSubject> subjects =
+          request.getSubjectGlobalAttributes(
+              userName, PSSubject.SUBJECT_TYPE_USER, null, srcAttrName, false);
+      return firstSubjectAttributeValue(subjects, srcAttrName);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * First non-empty value of {@code attrName} on any supplied subject.
+   *
+   * @param subjects may be {@code null}
+   * @param attrName never {@code null} for a useful result
+   * @return trimmed value, or {@code null}
+   */
+  public static String firstSubjectAttributeValue(List<PSSubject> subjects, String attrName) {
+    if (subjects == null || attrName == null || attrName.isBlank()) {
+      return null;
+    }
+    for (PSSubject subject : subjects) {
+      if (subject == null || subject.getAttributes() == null) {
+        continue;
+      }
+      PSAttribute attr = subject.getAttributes().getAttribute(attrName);
+      if (attr == null) {
+        continue;
+      }
+      List<?> values = attr.getValues();
+      if (values == null || values.isEmpty() || values.get(0) == null) {
+        continue;
+      }
+      String value = values.get(0).toString().trim();
+      if (!value.isEmpty()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Default community name for login: user-subject {@link #SYS_DEFAULTCOMMUNITY}
+   * first, then the first non-empty role attribute (legacy).
+   */
+  public static String resolveDefaultCommunityName(IPSRequestContext request) throws Exception {
+    String subjectValue = getUserSubjectAttribute(request, SYS_DEFAULTCOMMUNITY);
+    if (subjectValue != null && !subjectValue.isBlank()) {
+      return subjectValue.trim();
+    }
+    String roleValue = getUserRoleAttribute(request, SYS_DEFAULTCOMMUNITY);
+    return roleValue == null ? null : roleValue.trim();
+  }
+
+  /**
+   * Pure resolver for tests and callers that already loaded both stores.
+   *
+   * @param subjectValue user-subject attribute, may be blank
+   * @param roleValue first role attribute, may be blank
+   * @return trimmed subject value when present, else trimmed role value, else {@code null}
+   */
+  public static String resolveDefaultCommunityName(String subjectValue, String roleValue) {
+    if (subjectValue != null && !subjectValue.isBlank()) {
+      return subjectValue.trim();
+    }
+    if (roleValue != null && !roleValue.isBlank()) {
+      return roleValue.trim();
+    }
+    return null;
+  }
+
+  /**
+   * True when {@code communityName} matches an allowed membership name
+   * (case-insensitive).
+   */
+  public static boolean isCommunityAllowed(String communityName, List<String> allowed) {
+    if (communityName == null || communityName.isBlank() || allowed == null) {
+      return false;
+    }
+    String wanted = communityName.trim();
+    for (String name : allowed) {
+      if (name != null && wanted.equalsIgnoreCase(name.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/system/src/main/java/com/percussion/server/PSServer.java
+++ b/system/src/main/java/com/percussion/server/PSServer.java
@@ -20,6 +20,7 @@ package com.percussion.server;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.cms.IPSConstants;
+import com.percussion.cms.PSAuthenticateUserUtils;
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.cms.objectstore.PSFolder;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
@@ -3214,9 +3215,14 @@ public class PSServer {
    */
   private static String getUserDefaultCommunity(PSRequest request)
       throws PSInternalRequestCallException {
-    return request
-        .getUserSession()
-        .getCommunityId(request, getUserRoleAttribute(request, SYS_DEFAULTCOMMUNITY));
+    PSRequestContext requestContext = new PSRequestContext(request);
+    String communityName;
+    try {
+      communityName = PSAuthenticateUserUtils.resolveDefaultCommunityName(requestContext);
+    } catch (Exception e) {
+      communityName = getUserRoleAttribute(request, SYS_DEFAULTCOMMUNITY);
+    }
+    return request.getUserSession().getCommunityId(request, communityName);
   }
 
   /**

--- a/system/src/main/java/com/percussion/servlets/PSSetCommunityFilter.java
+++ b/system/src/main/java/com/percussion/servlets/PSSetCommunityFilter.java
@@ -94,12 +94,30 @@ public class PSSetCommunityFilter implements Filter {
         return; // community ID has already been set on the session.
       }
 
-      String communityName =
-          PSAuthenticateUserUtils.getUserRoleAttribute(
-              reqCtx, PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY);
+      String communityName;
+      try {
+        communityName = PSAuthenticateUserUtils.resolveDefaultCommunityName(reqCtx);
+      } catch (Exception e) {
+        log.debug("Cannot resolve default community for user: {}", reqCtx.getUserName(), e);
+        return;
+      }
       if (StringUtils.isBlank(communityName)) {
         log.debug("Cannot find a default community for user: {}", reqCtx.getUserName());
         return; // do nothing if cannot find default community.
+      }
+
+      // Profile-stored default applies only while the user still has access.
+      if (psReq.getUserSession() != null) {
+        List<String> allowed = psReq.getUserSession().getUserCommunityNames(psReq);
+        if (allowed != null
+            && !allowed.isEmpty()
+            && !PSAuthenticateUserUtils.isCommunityAllowed(communityName, allowed)) {
+          log.debug(
+              "Stored default community {} is not allowed for user {}",
+              communityName,
+              reqCtx.getUserName());
+          return;
+        }
       }
 
       IPSBackEndRoleMgr mgr = PSRoleMgrLocator.getBackEndRoleManager();

--- a/system/src/test/java/com/percussion/cms/PSAuthenticateUserUtilsDefaultCommunityTest.java
+++ b/system/src/test/java/com/percussion/cms/PSAuthenticateUserUtilsDefaultCommunityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.design.objectstore.PSGlobalSubject;
+import com.percussion.design.objectstore.PSSubject;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Default-community resolution helpers used at login and profile persist (issue #3508).
+ */
+@Tag("UnitTest")
+class PSAuthenticateUserUtilsDefaultCommunityTest {
+
+  @Test
+  void subjectValueWinsOverRoleValue() {
+    assertEquals(
+        "Corporate",
+        PSAuthenticateUserUtils.resolveDefaultCommunityName("Corporate", "Default"));
+    assertEquals(
+        "Default", PSAuthenticateUserUtils.resolveDefaultCommunityName("  ", "Default"));
+    assertEquals(
+        "Default", PSAuthenticateUserUtils.resolveDefaultCommunityName(null, " Default "));
+    assertNull(PSAuthenticateUserUtils.resolveDefaultCommunityName("  ", "  "));
+    assertNull(PSAuthenticateUserUtils.resolveDefaultCommunityName(null, null));
+  }
+
+  @Test
+  void firstSubjectAttributeValueReadsSysDefaultCommunity() {
+    PSAttributeList attrs = new PSAttributeList();
+    attrs.setAttribute(
+        PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, Collections.singletonList("Engineering"));
+    PSSubject subject =
+        new PSGlobalSubject("Admin", PSSubject.SUBJECT_TYPE_USER, attrs);
+
+    assertEquals(
+        "Engineering",
+        PSAuthenticateUserUtils.firstSubjectAttributeValue(
+            List.of(subject), PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY));
+    assertNull(
+        PSAuthenticateUserUtils.firstSubjectAttributeValue(
+            List.of(subject), "sys_email"));
+    assertNull(PSAuthenticateUserUtils.firstSubjectAttributeValue(null, "sys_defaultCommunity"));
+    assertNull(
+        PSAuthenticateUserUtils.firstSubjectAttributeValue(List.of(), "sys_defaultCommunity"));
+  }
+
+  @Test
+  void firstSubjectAttributeValueSkipsEmptyShells() {
+    PSAttributeList empty = new PSAttributeList();
+    empty.setAttribute(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, List.of());
+    PSSubject blank =
+        new PSGlobalSubject("Admin", PSSubject.SUBJECT_TYPE_USER, empty);
+
+    assertNull(
+        PSAuthenticateUserUtils.firstSubjectAttributeValue(
+            List.of(blank), PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY));
+  }
+
+  @Test
+  void isCommunityAllowedIsCaseInsensitive() {
+    List<String> allowed = List.of("Default", "Enterprise Investments");
+    assertTrue(PSAuthenticateUserUtils.isCommunityAllowed("default", allowed));
+    assertTrue(PSAuthenticateUserUtils.isCommunityAllowed("Enterprise Investments", allowed));
+    assertFalse(PSAuthenticateUserUtils.isCommunityAllowed("Unknown", allowed));
+    assertFalse(PSAuthenticateUserUtils.isCommunityAllowed("Default", List.of()));
+    assertFalse(PSAuthenticateUserUtils.isCommunityAllowed("  ", allowed));
+    assertFalse(PSAuthenticateUserUtils.isCommunityAllowed("Default", null));
+  }
+}

--- a/system/src/test/java/com/percussion/services/security/impl/PSBackEndRoleMgrSubjectAttributeTest.java
+++ b/system/src/test/java/com/percussion/services/security/impl/PSBackEndRoleMgrSubjectAttributeTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.security.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.PSAuthenticateUserUtils;
+import com.percussion.design.objectstore.PSAttribute;
+import com.percussion.design.objectstore.PSRelativeSubject;
+import com.percussion.design.objectstore.PSRoleConfiguration;
+import com.percussion.design.objectstore.PSSubject;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Persist helper for user-subject attributes (sys_defaultCommunity, issue #3508).
+ *
+ * <p>Uses production {@link PSRoleConfiguration} / {@link PSSubject} types.
+ */
+@Tag("UnitTest")
+class PSBackEndRoleMgrSubjectAttributeTest {
+
+  @Test
+  void applySubjectAttributeWritesSysDefaultCommunity() {
+    PSRoleConfiguration cfg = new PSRoleConfiguration();
+    PSBackEndRoleMgr.applySubjectAttribute(
+        cfg, "Admin", PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, "Corporate");
+
+    PSSubject subject =
+        cfg.getGlobalSubject(
+            new PSRelativeSubject("Admin", PSSubject.SUBJECT_TYPE_USER, null), false);
+    assertNotNull(subject);
+    PSAttribute attr =
+        subject.getAttributes().getAttribute(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY);
+    assertNotNull(attr);
+    assertEquals("Corporate", attr.getValues().get(0));
+  }
+
+  @Test
+  void applySubjectAttributeBlankClearsStoredValue() {
+    PSRoleConfiguration cfg = new PSRoleConfiguration();
+    PSBackEndRoleMgr.applySubjectAttribute(
+        cfg, "Editor1", PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, "Default");
+    PSBackEndRoleMgr.applySubjectAttribute(
+        cfg, "Editor1", PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, "  ");
+
+    PSSubject subject =
+        cfg.getGlobalSubject(
+            new PSRelativeSubject("Editor1", PSSubject.SUBJECT_TYPE_USER, null), false);
+    assertNotNull(subject);
+    PSAttribute attr =
+        subject.getAttributes().getAttribute(PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY);
+    assertNotNull(attr);
+    List<?> values = attr.getValues();
+    assertTrue(values == null || values.isEmpty());
+  }
+
+  @Test
+  void applySubjectAttributeRejectsBlankNameOrAttribute() {
+    PSRoleConfiguration cfg = new PSRoleConfiguration();
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSBackEndRoleMgr.applySubjectAttribute(
+                cfg, "  ", PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, "Default"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSBackEndRoleMgr.applySubjectAttribute(cfg, "Admin", "  ", "Default"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSBackEndRoleMgr.applySubjectAttribute(
+                null, "Admin", PSAuthenticateUserUtils.SYS_DEFAULTCOMMUNITY, "Default"));
+  }
+}


### PR DESCRIPTION
## Summary

Parent tracker: #3505 (slice 2). Fixes #3508.

Signed-in users can set a **default community** on **My profile → Account**. The select lists only `GET /user/user/current` membership communities (same list as the top-nav switch from #3506). The value is persisted as the existing user-subject attribute `sys_defaultCommunity` (`PSAuthenticateUser.SYS_DEFAULTCOMMUNITY`) — no parallel preference store and no `GET /preferences/{name}` from chrome.

- Narrow current-user-only `PUT /user/user/defaultCommunity` (session user; no username on the path — no IDOR).
- `GET /user/user/current` returns `defaultCommunity` so the form reloads.
- Login (`PSSetCommunityFilter` / `PSServer`) prefers the stored user default over the role attribute when the user still has access.

Out of scope: top-nav switch (#3506) and remember-last (#3507).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `PSUserDefaultCommunityTest` persist/GET (exact production types); `PSAuthenticateUserUtilsDefaultCommunityTest`; `PSBackEndRoleMgrSubjectAttributeTest`.
2. Vitest: `AccountSection.test.tsx` + `userProfileApi.test.ts`.
3. H2 QA Playwright: `perc-devctl qa-up --skip-image-build` → deploy `perc-system` + `sitemanage` jars + full `cm/modern` assets → `qa-health` (HTTP 200, HEALTH=healthy; FastForward import ERROR lines are pre-existing install noise) → `npm run test:surface -- --path tests/profile-account.spec.js` (5 passed, including save/reload + axe).
4. Reload profile after save; only membership communities appear; disallowed names rejected server-side.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (My profile — Account default community)
- [x] **Unit / module tests** — behavioral tests; standalone `mvnw clean install` on `system`, `projects/sitemanage`, `WebUI`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/profile-account.spec.js` (save/reload)
- [x] **Build gates** — standalone clean install, tests on; no skipTests
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** `system`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (new tests: `PSAuthenticateUserUtilsDefaultCommunityTest` 4, `PSBackEndRoleMgrSubjectAttributeTest` 3)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (`PSUserDefaultCommunityTest` Tests run: 8, Failures: 0)
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (Vitest Tests 2694 passed)
- **downstream_checked:** additive `IPSBackEndRoleMgr.setSubjectAttribute` / `IPSUserService.updateMyDefaultCommunity`. Grep: only `PSBackEndRoleMgr` implements `IPSBackEndRoleMgr`; only `PSUserService` + test `PSUserServiceRestClient` implement `IPSUserService` (client updated). No `final`/signature change on existing methods. No perc-toolkit reverse-dep rebuild required.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → container `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`
- Deploy: docker cp `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` into `WEB-INF/lib`; copy full `WebUI/target/generated-webui/cm/modern` to `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern`; `StopJetty.sh` then `StartJetty.sh` (no docker restart). ROOT context started.
- Playwright: `npm run test:surface -- --path tests/profile-account.spec.js` → **5 passed** (identity, axe form, axe email error, email save, **default community save and reload**)
- console-clean=yes (pageerror/console listeners on save/reload spec)
- server.log-clean=yes for the feature (no default-community / user-service ERROR in the test window). FastForward `PSDbStorageService` import ERRORs and search-index modifier ERRORs are pre-existing install noise, not this slice.

Fixes #3508

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
