### PR TITLE
feat(WebUI): remember last community on next login (#3507)

### DIFF
--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -18,6 +18,7 @@
 import React, { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router";
 import { BrandBar, BrandFooter } from "../../ui-themes/components";
+import { restoreLastCommunityIfNeeded } from "./restoreLastCommunity";
 import { SESSION_COMMUNITY_CHANGED_EVENT } from "./sessionCommunity";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";
@@ -47,6 +48,10 @@ export function AppLayout(): React.ReactElement {
     return () => {
       window.removeEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
     };
+  }, []);
+
+  useEffect(() => {
+    void restoreLastCommunityIfNeeded();
   }, []);
 
   if (isChromeLessPath(pathname)) {

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -148,8 +148,13 @@ export function UserMenu(): React.ReactElement {
       dispatchSessionCommunityChanged(trimmed);
       // Write-only persist so login restore has a name. Do not GET prefs
       // from chrome (#3468 / #3458). Persist failure must not undo switch.
+      // Require the real login id — never fall back to the localized display
+      // name used for chrome when bootstrap.userName is missing.
       try {
-        await saveLastCommunity(bootstrap.userName ?? name, trimmed);
+        const userName = (bootstrap.userName ?? "").trim();
+        if (userName) {
+          await saveLastCommunity(userName, trimmed);
+        }
       } catch {
         // last-community write is best-effort
       }

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -30,12 +30,14 @@ import { i18nKeyAttr } from "../../i18n/i18nDom";
 import { message, MSG } from "../../i18n/message";
 import { resolveAvatarPresentation } from "../../profile/gravatar";
 import { PROFILE_MSG } from "../../profile/messages";
+import { saveLastCommunity } from "../../profile/rememberLastCommunity";
 import { UserAvatar } from "../../profile/UserAvatar";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import styles from "./AppLayout.module.css";
 import {
   communityOptionTestId,
   dispatchSessionCommunityChanged,
+  SESSION_COMMUNITY_CHANGED_EVENT,
 } from "./sessionCommunity";
 
 export function UserMenu(): React.ReactElement {
@@ -92,6 +94,20 @@ export function UserMenu(): React.ReactElement {
   }, [name, bootstrap.userName, allowExternal]);
 
   useEffect(() => {
+    const onChanged = (event: Event): void => {
+      const detail = (event as CustomEvent<{ community?: string }>).detail;
+      const next = (detail?.community ?? "").trim();
+      if (next) {
+        setCurrentCommunity(next);
+      }
+    };
+    window.addEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    return () => {
+      window.removeEventListener(SESSION_COMMUNITY_CHANGED_EVENT, onChanged);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!switchOpen) {
       return;
     }
@@ -130,6 +146,13 @@ export function UserMenu(): React.ReactElement {
       setCurrentCommunity(trimmed);
       setSwitchOpen(false);
       dispatchSessionCommunityChanged(trimmed);
+      // Write-only persist so login restore has a name. Do not GET prefs
+      // from chrome (#3468 / #3458). Persist failure must not undo switch.
+      try {
+        await saveLastCommunity(bootstrap.userName ?? name, trimmed);
+      } catch {
+        // last-community write is best-effort
+      }
     } catch (err) {
       if (isSessionRedirectError(err)) {
         return;

--- a/WebUI/src/main/ts/app/layout/restoreLastCommunity.ts
+++ b/WebUI/src/main/ts/app/layout/restoreLastCommunity.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * One-shot session-start restore of the last community (#3507).
+ *
+ * <p>Uses GET {@code /preferences/} (list) + GET current user, then POST
+ * {@code /services/communities/switch/{name}} when the remember-last option
+ * is on and the stored name is still in the membership list. Failures are
+ * swallowed so login never fails — missing or revoked last community leaves
+ * the existing login default (#3508 profile default when present).</p>
+ *
+ * <p>This is not UserMenu chrome: do not move a named GET
+ * {@code /preferences/{name}} into the header (#3468 / #3458).</p>
+ */
+
+import {
+  allowedSessionCommunities,
+  switchSessionCommunity,
+} from "../../api/user/communitySwitchApi";
+import {
+  getCurrentUserProfile,
+  type CurrentUserProfile,
+} from "../../api/user/userProfileApi";
+import {
+  loadRememberLastCommunityPrefs,
+  shouldRestoreLastCommunity,
+  type RememberLastCommunityPrefs,
+} from "../../profile/rememberLastCommunity";
+import { dispatchSessionCommunityChanged } from "./sessionCommunity";
+
+export type RestoreLastCommunityDeps = {
+  loadPrefs?: () => Promise<RememberLastCommunityPrefs>;
+  loadProfile?: () => Promise<CurrentUserProfile>;
+  switchCommunity?: (name: string) => Promise<void>;
+  notifyChanged?: (name: string) => void;
+};
+
+/**
+ * Restore last community after login when the option is on and still allowed.
+ *
+ * @returns switched community name, or null when no switch was performed
+ */
+export async function restoreLastCommunityIfNeeded(
+  deps: RestoreLastCommunityDeps = {},
+): Promise<string | null> {
+  const loadPrefs = deps.loadPrefs ?? loadRememberLastCommunityPrefs;
+  const loadProfile = deps.loadProfile ?? getCurrentUserProfile;
+  const switchCommunity = deps.switchCommunity ?? switchSessionCommunity;
+  const notifyChanged = deps.notifyChanged ?? dispatchSessionCommunityChanged;
+
+  try {
+    const [prefs, profile] = await Promise.all([loadPrefs(), loadProfile()]);
+    const target = shouldRestoreLastCommunity({
+      remember: prefs.remember,
+      last: prefs.last,
+      current: profile.currentCommunity,
+      allowed: allowedSessionCommunities(profile.communities),
+    });
+    if (!target) {
+      return null;
+    }
+    await switchCommunity(target);
+    notifyChanged(target);
+    return target;
+  } catch {
+    return null;
+  }
+}

--- a/WebUI/src/main/ts/profile/AccountSection.module.css
+++ b/WebUI/src/main/ts/profile/AccountSection.module.css
@@ -210,6 +210,10 @@
   word-break: break-word;
 }
 
+.checkbox {
+  margin: 0.25rem 0 0;
+}
+
 .statusRegion {
   margin-top: 0.85rem;
   min-height: 1.25rem;

--- a/WebUI/src/main/ts/profile/AccountSection.tsx
+++ b/WebUI/src/main/ts/profile/AccountSection.tsx
@@ -31,6 +31,12 @@ import {
 import { i18nKeyAttr } from "../i18n/i18nDom";
 import { message } from "../i18n/message";
 import { PROFILE_MSG } from "./messages";
+import {
+  loadRememberLastCommunityPrefs,
+  saveLastCommunity,
+  saveRememberLastCommunityFlag,
+  type RememberLastCommunityPrefs,
+} from "./rememberLastCommunity";
 import styles from "./AccountSection.module.css";
 
 export interface AccountSectionProps {
@@ -38,6 +44,9 @@ export interface AccountSectionProps {
   loadProfile?: () => Promise<CurrentUserProfile>;
   saveEmail?: (email: string) => Promise<CurrentUserProfile>;
   saveDefaultCommunity?: (name: string) => Promise<CurrentUserProfile>;
+  loadRememberLast?: () => Promise<RememberLastCommunityPrefs>;
+  saveRememberLast?: (userName: string, remember: boolean) => Promise<boolean>;
+  persistLastCommunity?: (userName: string, community: string) => Promise<string>;
 }
 
 type LoadState =
@@ -66,11 +75,16 @@ export function allowedDefaultCommunityDraft(
  * Account identity view/edit for the signed-in user (slice 2 / #2395).
  * Login id, provider, roles, and communities are read-only. Email is editable
  * only for internal accounts; directory-managed fields show localized hints.
+ * Default community (#3508) and remember-last community (#3507) are self-service
+ * controls on this form.
  */
 export function AccountSection({
   loadProfile = getCurrentUserProfile,
   saveEmail = updateMyAccountEmail,
   saveDefaultCommunity = updateMyDefaultCommunity,
+  loadRememberLast = loadRememberLastCommunityPrefs,
+  saveRememberLast = saveRememberLastCommunityFlag,
+  persistLastCommunity = saveLastCommunity,
 }: AccountSectionProps = {}): React.ReactElement {
   const reactId = useId();
   const formId = `perc-profile-account-form-${reactId}`;
@@ -81,11 +95,14 @@ export function AccountSection({
   const defaultCommunityHelpId = `perc-profile-account-default-community-help-${reactId}`;
   const defaultCommunityErrorId = `perc-profile-account-default-community-error-${reactId}`;
   const defaultCommunityFormId = `perc-profile-account-default-community-form-${reactId}`;
+  const rememberId = `perc-profile-account-remember-last-${reactId}`;
+  const rememberHelpId = `perc-profile-account-remember-last-help-${reactId}`;
   const statusId = `perc-profile-account-status-${reactId}`;
 
   const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
   const [emailDraft, setEmailDraft] = useState("");
   const [defaultCommunityDraft, setDefaultCommunityDraft] = useState("");
+  const [rememberLast, setRememberLast] = useState(false);
   const [fieldError, setFieldError] = useState<string | null>(null);
   const [communityFieldError, setCommunityFieldError] = useState<string | null>(
     null,
@@ -94,6 +111,7 @@ export function AccountSection({
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isSavingCommunity, setIsSavingCommunity] = useState(false);
+  const [isSavingRemember, setIsSavingRemember] = useState(false);
 
   const load = useCallback(async () => {
     setLoadState({ status: "loading" });
@@ -101,10 +119,14 @@ export function AccountSection({
     setFormError(null);
     setSuccessMessage(null);
     try {
-      const profile = await loadProfile();
+      const [profile, rememberPrefs] = await Promise.all([
+        loadProfile(),
+        loadRememberLast().catch(() => ({ remember: false, last: "" })),
+      ]);
       setEmailDraft(profile.email ?? "");
       setDefaultCommunityDraft(allowedDefaultCommunityDraft(profile));
       setCommunityFieldError(null);
+      setRememberLast(rememberPrefs.remember);
       setLoadState({ status: "ready", profile });
     } catch (err) {
       if (isSessionRedirectError(err)) {
@@ -115,7 +137,7 @@ export function AccountSection({
         message: formatApiError(err, message(PROFILE_MSG.ACCOUNT_LOAD_ERROR)),
       });
     }
-  }, [loadProfile]);
+  }, [loadProfile, loadRememberLast]);
 
   useEffect(() => {
     void load();
@@ -185,6 +207,40 @@ export function AccountSection({
       );
     } finally {
       setIsSavingCommunity(false);
+    }
+  };
+
+  const onRememberLastChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    if (loadState.status !== "ready") {
+      return;
+    }
+    const next = event.target.checked;
+    const previous = rememberLast;
+    setRememberLast(next);
+    setFormError(null);
+    setSuccessMessage(null);
+    setIsSavingRemember(true);
+    try {
+      await saveRememberLast(loadState.profile.name, next);
+      if (next) {
+        const current = (loadState.profile.currentCommunity ?? "").trim();
+        if (current) {
+          await persistLastCommunity(loadState.profile.name, current);
+        }
+      }
+      setSuccessMessage(message(PROFILE_MSG.REMEMBER_LAST_SAVE_SUCCESS));
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setRememberLast(previous);
+      setFormError(
+        formatApiError(err, message(PROFILE_MSG.REMEMBER_LAST_SAVE_ERROR)),
+      );
+    } finally {
+      setIsSavingRemember(false);
     }
   };
 
@@ -567,6 +623,39 @@ export function AccountSection({
                 </p>
               </>
             )}
+          </dd>
+        </div>
+
+        <div className={styles.field}>
+          <dt>
+            <label
+              htmlFor={rememberId}
+              {...i18nKeyAttr(PROFILE_MSG.REMEMBER_LAST_LABEL)}
+            >
+              {message(PROFILE_MSG.REMEMBER_LAST_LABEL)}
+            </label>
+          </dt>
+          <dd>
+            <input
+              id={rememberId}
+              type="checkbox"
+              className={styles.checkbox}
+              checked={rememberLast}
+              disabled={isSavingRemember}
+              onChange={(e) => {
+                void onRememberLastChange(e);
+              }}
+              aria-describedby={rememberHelpId}
+              data-testid="perc-profile-account-remember-last"
+            />
+            <p
+              id={rememberHelpId}
+              className={styles.hint}
+              data-testid="perc-profile-account-remember-last-hint"
+              {...i18nKeyAttr(PROFILE_MSG.REMEMBER_LAST_HINT)}
+            >
+              {message(PROFILE_MSG.REMEMBER_LAST_HINT)}
+            </p>
           </dd>
         </div>
       </dl>

--- a/WebUI/src/main/ts/profile/AccountSection.tsx
+++ b/WebUI/src/main/ts/profile/AccountSection.tsx
@@ -223,22 +223,37 @@ export function AccountSection({
     setSuccessMessage(null);
     setIsSavingRemember(true);
     try {
-      await saveRememberLast(loadState.profile.name, next);
+      try {
+        await saveRememberLast(loadState.profile.name, next);
+      } catch (err) {
+        if (isSessionRedirectError(err)) {
+          return;
+        }
+        setRememberLast(previous);
+        setFormError(
+          formatApiError(err, message(PROFILE_MSG.REMEMBER_LAST_SAVE_ERROR)),
+        );
+        return;
+      }
+      // Flag is already on the server. Do not revert the checkbox when only
+      // last-community persist fails — reload would still show remember=true.
       if (next) {
         const current = (loadState.profile.currentCommunity ?? "").trim();
         if (current) {
-          await persistLastCommunity(loadState.profile.name, current);
+          try {
+            await persistLastCommunity(loadState.profile.name, current);
+          } catch (err) {
+            if (isSessionRedirectError(err)) {
+              return;
+            }
+            setFormError(
+              formatApiError(err, message(PROFILE_MSG.REMEMBER_LAST_SAVE_ERROR)),
+            );
+            return;
+          }
         }
       }
       setSuccessMessage(message(PROFILE_MSG.REMEMBER_LAST_SAVE_SUCCESS));
-    } catch (err) {
-      if (isSessionRedirectError(err)) {
-        return;
-      }
-      setRememberLast(previous);
-      setFormError(
-        formatApiError(err, message(PROFILE_MSG.REMEMBER_LAST_SAVE_ERROR)),
-      );
     } finally {
       setIsSavingRemember(false);
     }

--- a/WebUI/src/main/ts/profile/messages.ts
+++ b/WebUI/src/main/ts/profile/messages.ts
@@ -104,6 +104,14 @@ export const PROFILE_MSG = {
     "perc.ui.profile.modern@Unable to save your default community. Choose a community you can access.",
   DEFAULT_COMMUNITY_INVALID:
     "perc.ui.profile.modern@Choose a community from the list.",
+  REMEMBER_LAST_LABEL:
+    "perc.ui.profile.modern@Remember last community on next login",
+  REMEMBER_LAST_HINT:
+    "perc.ui.profile.modern@When enabled, the next sign-in selects the last community you switched to if you still have access. Otherwise your default community is used.",
+  REMEMBER_LAST_SAVE_SUCCESS:
+    "perc.ui.profile.modern@Remember-last community preference saved.",
+  REMEMBER_LAST_SAVE_ERROR:
+    "perc.ui.profile.modern@Could not save the remember-last community preference.",
   PROVIDER_INTERNAL: "perc.ui.profile.modern@Internal",
   PROVIDER_DIRECTORY: "perc.ui.profile.modern@Directory",
   READONLY_HINT:

--- a/WebUI/src/main/ts/profile/rememberLastCommunity.ts
+++ b/WebUI/src/main/ts/profile/rememberLastCommunity.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Remember-last-community prefs (#3507 / parent #3505 slice 3).
+ *
+ * <p>Uses GET {@code /preferences/} (list) — never GET {@code /preferences/{name}}.
+ * Unset named prefs 404 on live H2 and pollute Explorer when chrome probes
+ * the named path (#3468 / #3458).</p>
+ */
+
+import {
+  getAllUserPreferences,
+  saveUserPreference,
+  PREF_CATEGORY_SYS,
+  PREF_CONTEXT_PRIVATE,
+  type UserPreference,
+} from "../api/preferences/preferencesApi";
+
+/** Opt-in flag: restore last community on the next login. */
+export const REMEMBER_LAST_COMMUNITY_PREF_NAME =
+  "perc_profile_rememberLastCommunity";
+
+/** Last community the user switched to (name). */
+export const LAST_COMMUNITY_PREF_NAME = "perc_profile_lastCommunity";
+
+export type RememberLastCommunityPrefs = {
+  remember: boolean;
+  last: string;
+};
+
+export type RestoreLastCommunityInput = {
+  remember: boolean;
+  last: string;
+  current: string;
+  allowed: readonly string[];
+};
+
+/** True for stored "true" / "1" / "yes" (case-insensitive) or boolean true. */
+export function parseRememberLastCommunityFlag(
+  value: string | boolean | number | null | undefined,
+): boolean {
+  if (value === true || value === 1) {
+    return true;
+  }
+  if (value === false || value === 0 || value == null) {
+    return false;
+  }
+  const raw = String(value).trim().toLowerCase();
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+
+export function prefValueByName(
+  listed: readonly UserPreference[],
+  name: string,
+): string {
+  const match = listed.find((p) => (p.name || "").trim() === name);
+  if (match == null || match.value == null) {
+    return "";
+  }
+  return String(match.value).trim();
+}
+
+/**
+ * When remember-last is on and {@code last} is still in the membership list
+ * and differs from the current session community, return the name to switch
+ * to. Otherwise null — caller leaves the login default (profile default from
+ * #3508 or the existing product default) and must not fail login.
+ */
+export function shouldRestoreLastCommunity(
+  input: RestoreLastCommunityInput,
+): string | null {
+  if (!input.remember) {
+    return null;
+  }
+  const last = (input.last ?? "").trim();
+  if (!last) {
+    return null;
+  }
+  const current = (input.current ?? "").trim();
+  if (last === current) {
+    return null;
+  }
+  const allowed = new Set(
+    (input.allowed ?? []).map((n) => String(n ?? "").trim()).filter(Boolean),
+  );
+  if (!allowed.has(last)) {
+    return null;
+  }
+  return last;
+}
+
+export function prefsFromList(
+  listed: readonly UserPreference[],
+): RememberLastCommunityPrefs {
+  return {
+    remember: parseRememberLastCommunityFlag(
+      prefValueByName(listed, REMEMBER_LAST_COMMUNITY_PREF_NAME),
+    ),
+    last: prefValueByName(listed, LAST_COMMUNITY_PREF_NAME),
+  };
+}
+
+/** Load remember-last prefs via the list endpoint only. */
+export async function loadRememberLastCommunityPrefs(): Promise<RememberLastCommunityPrefs> {
+  const listed = await getAllUserPreferences();
+  return prefsFromList(listed);
+}
+
+export async function saveRememberLastCommunityFlag(
+  userName: string,
+  remember: boolean,
+): Promise<boolean> {
+  const saved = await saveUserPreference({
+    name: REMEMBER_LAST_COMMUNITY_PREF_NAME,
+    value: remember ? "true" : "false",
+    category: PREF_CATEGORY_SYS,
+    context: PREF_CONTEXT_PRIVATE,
+    userName: userName ?? "",
+  });
+  return parseRememberLastCommunityFlag(saved.value);
+}
+
+/**
+ * Persist the last switched community. Write-only — chrome may call this
+ * after a successful switch without reading preferences.
+ */
+export async function saveLastCommunity(
+  userName: string,
+  community: string,
+): Promise<string> {
+  const value = (community ?? "").trim();
+  const saved = await saveUserPreference({
+    name: LAST_COMMUNITY_PREF_NAME,
+    value,
+    category: PREF_CATEGORY_SYS,
+    context: PREF_CONTEXT_PRIVATE,
+    userName: userName ?? "",
+  });
+  return saved.value == null ? value : String(saved.value).trim();
+}

--- a/WebUI/src/test/ts/app/layout/AppLayout.community.test.tsx
+++ b/WebUI/src/test/ts/app/layout/AppLayout.community.test.tsx
@@ -20,7 +20,12 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppLayout } from "../../../../main/ts/app/layout/AppLayout";
+import { restoreLastCommunityIfNeeded } from "../../../../main/ts/app/layout/restoreLastCommunity";
 import { dispatchSessionCommunityChanged } from "../../../../main/ts/app/layout/sessionCommunity";
+
+vi.mock("../../../../main/ts/app/layout/restoreLastCommunity", () => ({
+  restoreLastCommunityIfNeeded: vi.fn().mockResolvedValue(null),
+}));
 
 vi.mock("../../../../main/ts/ui-themes/components", () => ({
   BrandBar: () => <div data-testid="brand-bar-stub" />,
@@ -44,6 +49,7 @@ function OutletProbe(): React.ReactElement {
 describe("AppLayout session community remount (#3506)", () => {
   beforeEach(() => {
     instanceSeq = 0;
+    vi.mocked(restoreLastCommunityIfNeeded).mockClear();
   });
 
   afterEach(() => {
@@ -80,5 +86,18 @@ describe("AppLayout session community remount (#3506)", () => {
       ),
     ).toBe("1");
     expect(screen.getByTestId("topnav-stub")).toBeTruthy();
+  });
+
+  it("restores last community once on session start", () => {
+    render(
+      <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/home"]}>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="home" element={<OutletProbe />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(restoreLastCommunityIfNeeded).toHaveBeenCalledTimes(1);
   });
 });

--- a/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
+++ b/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
@@ -249,6 +249,24 @@ describe("UserMenu", () => {
     );
   });
 
+  it("does not persist last community under the display-name fallback", async () => {
+    renderMenu({ userName: "  " });
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Default",
+      );
+    });
+    fireEvent.click(screen.getByTestId("perc-spa-community-switch"));
+    fireEvent.click(screen.getByTestId("perc-spa-community-option-corporate"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Corporate",
+      );
+    });
+    expect(switchSessionCommunity).toHaveBeenCalledWith("Corporate");
+    expect(prefs.saveUserPreference).not.toHaveBeenCalled();
+  });
+
   it("keeps the switched community when last-community persist fails", async () => {
     vi.mocked(prefs.saveUserPreference).mockRejectedValueOnce(
       new Error("prefs down"),

--- a/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
+++ b/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BootstrapProvider } from "../../../../main/ts/app/bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "../../../../main/ts/app/bootstrap/types";
 import { UserMenu } from "../../../../main/ts/app/layout/UserMenu";
@@ -46,7 +46,7 @@ vi.mock("../../../../main/ts/api/user/communitySwitchApi", async (importOriginal
 
 vi.mock("../../../../main/ts/api/preferences/preferencesApi", () => ({
   loadUserPreference: vi.fn().mockResolvedValue(null),
-  saveUserPreference: vi.fn(),
+  saveUserPreference: vi.fn().mockResolvedValue({ name: "", value: "" }),
   getAllUserPreferences: vi.fn().mockResolvedValue([]),
   PREF_CATEGORY_SYS: "sys_preferences",
   PREF_CONTEXT_PRIVATE: "private",
@@ -101,6 +101,13 @@ describe("UserMenu", () => {
     getCurrentUserProfile.mockResolvedValue(profile());
     switchSessionCommunity.mockReset();
     switchSessionCommunity.mockResolvedValue(undefined);
+    vi.mocked(prefs.saveUserPreference).mockReset();
+    vi.mocked(prefs.saveUserPreference).mockResolvedValue({
+      name: "",
+      value: "",
+    });
+    vi.mocked(prefs.getAllUserPreferences).mockClear();
+    vi.mocked(prefs.loadUserPreference).mockClear();
   });
 
   afterEach(() => {
@@ -202,6 +209,16 @@ describe("UserMenu", () => {
       });
       expect(switchSessionCommunity).toHaveBeenCalledWith("Corporate");
       expect(events).toEqual(["Corporate"]);
+      await waitFor(() => {
+        expect(prefs.saveUserPreference).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "perc_profile_lastCommunity",
+            value: "Corporate",
+            userName: "editor1",
+          }),
+        );
+      });
+      expect(prefs.getAllUserPreferences).not.toHaveBeenCalled();
       expect(screen.getByTestId("perc-spa-logout").getAttribute("href")).toBe(
         "/logout",
       );
@@ -230,5 +247,47 @@ describe("UserMenu", () => {
     expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
       "Default",
     );
+  });
+
+  it("keeps the switched community when last-community persist fails", async () => {
+    vi.mocked(prefs.saveUserPreference).mockRejectedValueOnce(
+      new Error("prefs down"),
+    );
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Default",
+      );
+    });
+    fireEvent.click(screen.getByTestId("perc-spa-community-switch"));
+    fireEvent.click(screen.getByTestId("perc-spa-community-option-corporate"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Corporate",
+      );
+    });
+    expect(switchSessionCommunity).toHaveBeenCalledWith("Corporate");
+    expect(screen.queryByTestId("perc-spa-community-switch-error")).toBeNull();
+  });
+
+  it("updates chrome when a session-start restore fires", async () => {
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Default",
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(SESSION_COMMUNITY_CHANGED_EVENT, {
+          detail: { community: "Corporate" },
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-spa-community-name").textContent).toBe(
+        "Corporate",
+      );
+    });
   });
 });

--- a/WebUI/src/test/ts/app/layout/restoreLastCommunity.test.ts
+++ b/WebUI/src/test/ts/app/layout/restoreLastCommunity.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { restoreLastCommunityIfNeeded } from "../../../../main/ts/app/layout/restoreLastCommunity";
+import type { CurrentUserProfile } from "../../../../main/ts/api/user/userProfileApi";
+
+function profile(
+  overrides: Partial<CurrentUserProfile> = {},
+): CurrentUserProfile {
+  return {
+    name: "Admin",
+    email: "admin@example.com",
+    providerType: "INTERNAL",
+    roles: ["Admin"],
+    communities: ["Default", "Corporate"],
+    currentCommunity: "Default",
+    adminUser: true,
+    designerUser: false,
+    accessibilityUser: false,
+    emailEditable: true,
+    ...overrides,
+  };
+}
+
+describe("restoreLastCommunityIfNeeded (#3507)", () => {
+  it("POSTs switch when remember-last is on and last is still allowed", async () => {
+    const switchCommunity = vi.fn().mockResolvedValue(undefined);
+    const notifyChanged = vi.fn();
+    const restored = await restoreLastCommunityIfNeeded({
+      loadPrefs: async () => ({ remember: true, last: "Corporate" }),
+      loadProfile: async () => profile(),
+      switchCommunity,
+      notifyChanged,
+    });
+    expect(restored).toBe("Corporate");
+    expect(switchCommunity).toHaveBeenCalledWith("Corporate");
+    expect(notifyChanged).toHaveBeenCalledWith("Corporate");
+  });
+
+  it("does not switch when the option is off", async () => {
+    const switchCommunity = vi.fn();
+    const restored = await restoreLastCommunityIfNeeded({
+      loadPrefs: async () => ({ remember: false, last: "Corporate" }),
+      loadProfile: async () => profile(),
+      switchCommunity,
+      notifyChanged: vi.fn(),
+    });
+    expect(restored).toBeNull();
+    expect(switchCommunity).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the login default when last community is revoked", async () => {
+    const switchCommunity = vi.fn();
+    const restored = await restoreLastCommunityIfNeeded({
+      loadPrefs: async () => ({ remember: true, last: "Gone" }),
+      loadProfile: async () => profile(),
+      switchCommunity,
+      notifyChanged: vi.fn(),
+    });
+    expect(restored).toBeNull();
+    expect(switchCommunity).not.toHaveBeenCalled();
+  });
+
+  it("does not fail login when switch throws", async () => {
+    const restored = await restoreLastCommunityIfNeeded({
+      loadPrefs: async () => ({ remember: true, last: "Corporate" }),
+      loadProfile: async () => profile(),
+      switchCommunity: async () => {
+        throw new Error("not allowed");
+      },
+      notifyChanged: vi.fn(),
+    });
+    expect(restored).toBeNull();
+  });
+
+  it("does not fail login when prefs list fails", async () => {
+    const switchCommunity = vi.fn();
+    const restored = await restoreLastCommunityIfNeeded({
+      loadPrefs: async () => {
+        throw new Error("prefs down");
+      },
+      loadProfile: async () => profile(),
+      switchCommunity,
+      notifyChanged: vi.fn(),
+    });
+    expect(restored).toBeNull();
+    expect(switchCommunity).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/profile/AccountSection.test.tsx
+++ b/WebUI/src/test/ts/profile/AccountSection.test.tsx
@@ -470,4 +470,42 @@ describe("AccountSection", () => {
     ) as HTMLInputElement;
     expect(box.checked).toBe(false);
   });
+
+  it("keeps remember-last checked when only last-community persist fails", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const loadRememberLast = vi
+      .fn()
+      .mockResolvedValue({ remember: false, last: "" });
+    const saveRememberLast = vi.fn().mockResolvedValue(true);
+    const persistLastCommunity = vi.fn().mockRejectedValue({
+      status: 500,
+      statusText: "Err",
+      body: null,
+    });
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        loadRememberLast={loadRememberLast}
+        saveRememberLast={saveRememberLast}
+        persistLastCommunity={persistLastCommunity}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-remember-last"),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-profile-account-remember-last"));
+    await waitFor(() => {
+      expect(saveRememberLast).toHaveBeenCalledWith("Admin", true);
+      expect(persistLastCommunity).toHaveBeenCalledWith("Admin", "Default");
+      expect(
+        screen.getByTestId("perc-profile-account-form-error"),
+      ).toBeTruthy();
+    });
+    const box = screen.getByTestId(
+      "perc-profile-account-remember-last",
+    ) as HTMLInputElement;
+    expect(box.checked).toBe(true);
+  });
 });

--- a/WebUI/src/test/ts/profile/AccountSection.test.tsx
+++ b/WebUI/src/test/ts/profile/AccountSection.test.tsx
@@ -28,6 +28,14 @@ import {
   normalizeCurrentUser,
 } from "../../../main/ts/api/user/userProfileApi";
 
+vi.mock("../../../main/ts/api/preferences/preferencesApi", () => ({
+  getAllUserPreferences: vi.fn().mockResolvedValue([]),
+  saveUserPreference: vi.fn().mockResolvedValue({ name: "", value: "" }),
+  loadUserPreference: vi.fn().mockResolvedValue(null),
+  PREF_CATEGORY_SYS: "sys_preferences",
+  PREF_CONTEXT_PRIVATE: "private",
+}));
+
 function internalProfile(
   overrides: Partial<CurrentUserProfile> = {},
 ): CurrentUserProfile {
@@ -377,5 +385,89 @@ describe("AccountSection", () => {
         screen.getByTestId("perc-profile-account-success").textContent,
       ).toMatch(/default community was saved/i);
     });
+  });
+
+  it("reloads the remember-last checkbox from stored prefs", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const loadRememberLast = vi
+      .fn()
+      .mockResolvedValue({ remember: true, last: "Default" });
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        loadRememberLast={loadRememberLast}
+      />,
+    );
+    await waitFor(() => {
+      const box = screen.getByTestId(
+        "perc-profile-account-remember-last",
+      ) as HTMLInputElement;
+      expect(box.checked).toBe(true);
+    });
+    expect(loadRememberLast).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists remember-last and current community when enabled", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const loadRememberLast = vi
+      .fn()
+      .mockResolvedValue({ remember: false, last: "" });
+    const saveRememberLast = vi.fn().mockResolvedValue(true);
+    const persistLastCommunity = vi.fn().mockResolvedValue("Default");
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        loadRememberLast={loadRememberLast}
+        saveRememberLast={saveRememberLast}
+        persistLastCommunity={persistLastCommunity}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-remember-last"),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-profile-account-remember-last"));
+    await waitFor(() => {
+      expect(saveRememberLast).toHaveBeenCalledWith("Admin", true);
+      expect(persistLastCommunity).toHaveBeenCalledWith("Admin", "Default");
+      expect(
+        screen.getByTestId("perc-profile-account-success").textContent,
+      ).toMatch(/remember-last/i);
+    });
+  });
+
+  it("reverts the checkbox when remember-last save fails", async () => {
+    const loadProfile = vi.fn().mockResolvedValue(internalProfile());
+    const loadRememberLast = vi
+      .fn()
+      .mockResolvedValue({ remember: false, last: "" });
+    const saveRememberLast = vi.fn().mockRejectedValue({
+      status: 500,
+      statusText: "Err",
+      body: null,
+    });
+    render(
+      <AccountSection
+        loadProfile={loadProfile}
+        loadRememberLast={loadRememberLast}
+        saveRememberLast={saveRememberLast}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-remember-last"),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-profile-account-remember-last"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-account-form-error"),
+      ).toBeTruthy();
+    });
+    const box = screen.getByTestId(
+      "perc-profile-account-remember-last",
+    ) as HTMLInputElement;
+    expect(box.checked).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/profile/rememberLastCommunity.test.ts
+++ b/WebUI/src/test/ts/profile/rememberLastCommunity.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  LAST_COMMUNITY_PREF_NAME,
+  REMEMBER_LAST_COMMUNITY_PREF_NAME,
+  loadRememberLastCommunityPrefs,
+  parseRememberLastCommunityFlag,
+  prefsFromList,
+  saveLastCommunity,
+  saveRememberLastCommunityFlag,
+  shouldRestoreLastCommunity,
+} from "../../../main/ts/profile/rememberLastCommunity";
+import * as prefs from "../../../main/ts/api/preferences/preferencesApi";
+
+describe("rememberLastCommunity (#3507)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses remember-last flag values", () => {
+    expect(parseRememberLastCommunityFlag("true")).toBe(true);
+    expect(parseRememberLastCommunityFlag(" YES ")).toBe(true);
+    expect(parseRememberLastCommunityFlag("1")).toBe(true);
+    expect(parseRememberLastCommunityFlag(true)).toBe(true);
+    expect(parseRememberLastCommunityFlag(1)).toBe(true);
+    expect(parseRememberLastCommunityFlag("false")).toBe(false);
+    expect(parseRememberLastCommunityFlag("")).toBe(false);
+    expect(parseRememberLastCommunityFlag(undefined)).toBe(false);
+    expect(parseRememberLastCommunityFlag(false)).toBe(false);
+  });
+
+  it("restores last community only when opted in and still allowed", () => {
+    expect(
+      shouldRestoreLastCommunity({
+        remember: true,
+        last: "Corporate",
+        current: "Default",
+        allowed: ["Default", "Corporate"],
+      }),
+    ).toBe("Corporate");
+    expect(
+      shouldRestoreLastCommunity({
+        remember: false,
+        last: "Corporate",
+        current: "Default",
+        allowed: ["Default", "Corporate"],
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastCommunity({
+        remember: true,
+        last: "Corporate",
+        current: "Corporate",
+        allowed: ["Default", "Corporate"],
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastCommunity({
+        remember: true,
+        last: "Revoked",
+        current: "Default",
+        allowed: ["Default", "Corporate"],
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastCommunity({
+        remember: true,
+        last: "",
+        current: "Default",
+        allowed: ["Default"],
+      }),
+    ).toBeNull();
+  });
+
+  it("loadRememberLastCommunityPrefs uses the list endpoint, not named GET", async () => {
+    const listSpy = vi.spyOn(prefs, "getAllUserPreferences").mockResolvedValueOnce([
+      { name: REMEMBER_LAST_COMMUNITY_PREF_NAME, value: "true" },
+      { name: LAST_COMMUNITY_PREF_NAME, value: "  Corporate " },
+    ]);
+    const namedSpy = vi.spyOn(prefs, "loadUserPreference");
+    await expect(loadRememberLastCommunityPrefs()).resolves.toEqual({
+      remember: true,
+      last: "Corporate",
+    });
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(namedSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefsFromList defaults when unset", () => {
+    expect(prefsFromList([])).toEqual({ remember: false, last: "" });
+  });
+
+  it("saveRememberLastCommunityFlag PUTs true/false", async () => {
+    const saveSpy = vi.spyOn(prefs, "saveUserPreference").mockResolvedValueOnce({
+      name: REMEMBER_LAST_COMMUNITY_PREF_NAME,
+      value: "true",
+    });
+    await expect(saveRememberLastCommunityFlag("Admin", true)).resolves.toBe(
+      true,
+    );
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: REMEMBER_LAST_COMMUNITY_PREF_NAME,
+        value: "true",
+        userName: "Admin",
+      }),
+    );
+  });
+
+  it("saveLastCommunity PUTs the community name", async () => {
+    const saveSpy = vi.spyOn(prefs, "saveUserPreference").mockResolvedValueOnce({
+      name: LAST_COMMUNITY_PREF_NAME,
+      value: "Corporate",
+    });
+    await expect(saveLastCommunity("Admin", "Corporate")).resolves.toBe(
+      "Corporate",
+    );
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: LAST_COMMUNITY_PREF_NAME,
+        value: "Corporate",
+        userName: "Admin",
+      }),
+    );
+  });
+});

--- a/docs/ai-generated/code-reviews/3507-remember-last-community-erlang.md
+++ b/docs/ai-generated/code-reviews/3507-remember-last-community-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3507 remember last community
+
+**Branch:** `fix/issue-3507-remember-last-community`  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Change class:** WebUI product screen (profile checkbox + login restore)
+
+## Summary
+
+Slice 3 of #3505 adds an opt-in **Remember last community on next login** checkbox on
+My profile → Account. Last community is persisted via PreferenceResource list/PUT
+(not named GET). Session start restores with POST `/services/communities/switch/{name}`
+when the stored name is still in membership; otherwise login default is left in place.
+
+## Scope
+
+Uncommitted work vs `origin/main` on this branch. Modules: `WebUI`,
+`product-docs/8.2/admin/users-roles.md`, `modules/perc-qa-automation` Playwright.
+
+## Gate
+
+No bugs, missing behavioral tests, or non-portable path I/O.
+
+Cross-platform path checklist: **N/A** — no new filesystem path construction.
+
+## Issues
+
+None remaining.
+
+Fixed during C5: `parseRememberLastCommunityFlag` threw when PreferenceResource
+returned a JSON boolean (`(e ?? "").trim is not a function`). Coerce with
+`String(value)` / boolean short-circuit. Covered by unit + profile Playwright.
+
+## Tests
+
+- `rememberLastCommunity.test.ts` — parse, restore decision, list vs named GET, PUT
+- `restoreLastCommunity.test.ts` — switch / skip / revoked / swallow errors
+- `AccountSection.test.tsx` — reload checkbox, persist on enable, revert on save fail
+- `UserMenu.test.tsx` — write-only last persist, persist fail does not undo switch
+- Playwright: profile checkbox persist/reload + login landing community spec
+
+## Memory patterns hit
+
+- Do not GET `/preferences/{name}` from chrome (#3468 / #3458) — list on profile
+  and one-shot session restore; chrome writes last community only.
+- Consume #3508 default community as fallback only (no re-implemented editor).

--- a/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
@@ -86,6 +86,9 @@ test.describe("Profile account @profile @account @smoke", () => {
     await expect(email).toBeVisible();
     await expect(email).toHaveAttribute("type", "email");
     await expect(page.getByTestId("perc-profile-account-save")).toBeVisible();
+    await expect(
+      page.getByTestId("perc-profile-account-remember-last"),
+    ).toBeVisible();
   });
 
   /**
@@ -255,5 +258,42 @@ test.describe("Profile account @profile @account @smoke", () => {
     expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
       [],
     );
+  });
+
+  test("remember-last community checkbox persists and reloads (#3507)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+
+    const box = page.getByTestId("perc-profile-account-remember-last");
+    await expect(box).toBeVisible({ timeout: 30_000 });
+    const originallyChecked = await box.isChecked();
+
+    await box.click();
+    await expect(box).toBeChecked({ checked: !originallyChecked });
+    await expect(
+      page.getByTestId("perc-profile-account-success"),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("perc-profile-account-form-error")).toHaveCount(
+      0,
+    );
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+    await expect(page.getByTestId("perc-profile-account-remember-last")).toBeChecked({
+      checked: !originallyChecked,
+    });
+
+    // Restore original so re-runs stay stable
+    const restored = page.getByTestId("perc-profile-account-remember-last");
+    await restored.click();
+    await expect(restored).toBeChecked({ checked: originallyChecked });
+    await expect(
+      page.getByTestId("perc-profile-account-success"),
+    ).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/remember-last-community.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/remember-last-community.spec.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Remember last community on login (#3507 / parent #3505 slice 3).
+ *
+ * Surface-filtered only — not full suite:
+ *   npm run test:surface -- --path tests/remember-last-community.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function homeUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+function profileUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
+}
+
+function unwrapCurrentUser(body) {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+  return body.CurrentUser || body.User || body;
+}
+
+function isIgnoredConsoleText(text) {
+  const raw = String(text || "");
+  return (
+    /gravatar\.com/i.test(raw) ||
+    /Failed to load resource/i.test(raw) ||
+    /net::ERR_/i.test(raw)
+  );
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+async function expectShell(page) {
+  await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-spa-community-name")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+async function enableRememberLast(page) {
+  await page.goto(profileUrl(), { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("perc-profile-account")).toBeVisible({
+    timeout: 30_000,
+  });
+  const box = page.getByTestId("perc-profile-account-remember-last");
+  await expect(box).toBeVisible({ timeout: 30_000 });
+  if (!(await box.isChecked())) {
+    await box.check();
+    await expect(
+      page.getByTestId("perc-profile-account-success"),
+    ).toBeVisible({ timeout: 30_000 });
+  }
+}
+
+test.describe("Remember last community on login (#3507) @community @profile @ui", () => {
+  test("next login lands on last switched community when still allowed", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && !isIgnoredConsoleText(msg.text())) {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await enableRememberLast(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expectShell(page);
+
+    const currentRes = await page.request.get(
+      `${BASE_URL}/Rhythmyx/services/user/user/current`,
+    );
+    expect(
+      currentRes.ok(),
+      `GET /user/user/current HTTP ${currentRes.status()}`,
+    ).toBe(true);
+    const payload = unwrapCurrentUser(await currentRes.json());
+    const allowed = Array.isArray(payload.communities)
+      ? payload.communities.map((n) => String(n).trim()).filter(Boolean)
+      : [];
+    const sessionCommunity = String(payload.currentCommunity || "").trim();
+    const other = allowed.find((name) => name !== sessionCommunity);
+
+    if (!other) {
+      test.info().annotations.push({
+        type: "note",
+        description:
+          "Admin has a single membership community — persist path covered; restore switch skipped",
+      });
+      expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
+        [],
+      );
+      return;
+    }
+
+    await page.getByTestId("perc-spa-community-switch").click();
+    const list = page.getByTestId("perc-spa-community-list");
+    await expect(list).toBeVisible();
+    await list.locator(`[data-community-name="${other}"]`).click();
+    await expect(page.getByTestId("perc-spa-community-switch-error")).toHaveCount(
+      0,
+    );
+    await expect
+      .poll(
+        async () =>
+          (await page.getByTestId("perc-spa-community-name").textContent()).trim(),
+        { timeout: 20_000 },
+      )
+      .toBe(other);
+
+    await page.getByTestId("perc-spa-logout").click();
+    await expect(
+      page.getByTestId("perc-logout-page").or(page.getByTestId("perc-login-page")),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await loginAsAdmin(page);
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expectShell(page);
+    await expect
+      .poll(
+        async () =>
+          (await page.getByTestId("perc-spa-community-name").textContent()).trim(),
+        { timeout: 30_000 },
+      )
+      .toBe(other);
+
+    expect(consoleErrors, `console-clean: ${consoleErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -76,8 +76,25 @@ Use **Switch** to change the session community **without signing out**.
   log out and back in.
 - If the switch is not allowed (unknown community or you are not a member of a role in that
   community), the header shows an error and keeps the previous community.
-- Setting a **default** community on the profile, or remembering the last community at the next
-  login, is not part of this header control.
+- Setting a **default** community on the profile is a separate **My profile → Account** control
+  (when available). Remembering the last community at the next login is the checkbox described
+  below — not this header **Switch** control.
+
+## My profile — Remember last community
+
+On **My profile → Account**, enable **Remember last community on next login** so the next
+sign-in automatically selects the last community you switched to.
+
+- The option is stored as a personal preference for the signed-in user. Reloading **Account**
+  shows the saved checkbox state.
+- After a successful header **Switch**, the product stores that community name for the next
+  login (when the option is on).
+- At the next sign-in, if the option is on **and** you still have access to that community,
+  the session switches to it. If the community is missing or no longer in your membership
+  list, sign-in continues with your default community (profile default when set, otherwise
+  the product role default). Login does not fail.
+- Turn the checkbox off to stop restoring the last community. The next login then uses the
+  default community only.
 
 ## My profile — Account (default community)
 


### PR DESCRIPTION
## Summary

Parent tracker: #3505 (slice 3). Fixes #3507.

Signed-in users can opt in to **Remember last community on next login** on **My profile → Account**. The option and last community name are stored as current-user preferences via `GET /preferences/` (list) and `PUT /preferences/` — **not** `GET /preferences/{name}` from chrome (#3468 / #3458). After a successful top-nav **Switch**, the last community name is written (write-only). On the next SPA session start, if the option is on and that community is still in `GET /user/user/current` membership, the client `POST`s `/services/communities/switch/{name}`. If the last community is missing or revoked, login continues with the existing product default (profile default from #3508 when that lands). Login does not fail.

Out of scope: top-nav switcher (#3506) and default-community editor (#3508).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit/Vitest: `rememberLastCommunity.test.ts`, `restoreLastCommunity.test.ts`, `AccountSection.test.tsx` persist/reload/revert, `UserMenu.test.tsx` write-only persist.
2. H2 QA Playwright: `perc-devctl qa-up --skip-image-build` → copy `WebUI` `cm/modern` into the Rhythmyx WAR (and `perc-system` so #3510 exact-name switch works on a stale skip-image-build cell) → `qa-health` (HTTP 200, HEALTH=healthy; FastForward import ERROR lines are pre-existing install noise) → `npm run test:surface -- --path tests/profile-account.spec.js` and `tests/remember-last-community.spec.js` → `npm run test:golden`.
3. Reload profile after toggling the checkbox; next login lands on the last switched community when still allowed.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (My profile — Remember last community)
- [x] **Unit / module tests** — behavioral tests; standalone `mvnw clean install` on `WebUI`
- [x] **WebUI + Playwright** — `profile-account.spec.js` (checkbox persist/reload) + `remember-last-community.spec.js` (login landing) + golden smoke
- [x] **Build gates** — standalone clean install, tests on; no skipTests
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (Vitest Tests 2704 passed; Java Tests run: 61, Failures: 0)
- **downstream_checked:** none — no Java public/protected signature or `final`/`sealed` change. Prefs and `CommunityResource.switchCommunity` are existing APIs.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → container `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`. Probe/qa-health reported `DETAIL:server_log_errors` for FastForward `PSDbStorageService` import lines with **HTTP 200** and **HEALTH=healthy** (same pre-existing install noise as #3516; not `Failed startup of context` / unhealthy).
- Deploy: docker cp full `WebUI/target/generated-webui/cm/modern` to `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern`. Copied m2 `perc-system-8.2.0-SNAPSHOT.jar` (contains #3510 `PSCommunityNameSelector`) into `WEB-INF/lib` so underscore community names switch on this stale skip-image-build cell. `StopJetty.sh` then `StartJetty.sh` (no docker restart). ROOT context started.
- Playwright:
  - `npm run test:surface -- --path tests/profile-account.spec.js` → **5 passed** (including remember-last checkbox persist/reload)
  - `npm run test:surface -- --path tests/remember-last-community.spec.js` → **1 passed** (next login lands on last switched community)
  - `npm run test:golden` → **2 passed**
- console-clean=yes (pageerror/console listeners on remember-last spec)
- server.log-clean=yes for the feature after perc-system deploy (no new remember/prefs ERROR in the passing test window). One `CommunityResource.switchCommunity` ERROR at 13:32:19 is from the first attempt **before** the #3510 jar was copied (underscore LIKE). FastForward import ERRORs are pre-existing install noise.

Fixes #3507

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
