### PR TITLE
fix(explorer): New Item content-type picker (#3513)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -104,12 +104,22 @@ import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
 import { ContextMenu } from "./ContextMenu";
 import { TemplatePickerDialog } from "./TemplatePickerDialog";
+import { ContentTypePickerDialog } from "./ContentTypePickerDialog";
 import type { PageTemplateChoice } from "../editor/pageTemplates";
 import {
   replaceTemplatePickerSession,
   settleTemplatePickerSession,
   type TemplatePickerSession,
 } from "./templatePickerSession";
+import {
+  loadAllowedContentTypes,
+  type ContentTypeChoice,
+} from "./contentTypeChoices";
+import {
+  replaceContentTypePickerSession,
+  settleContentTypePickerSession,
+  type ContentTypePickerSession,
+} from "./contentTypePickerSession";
 import { resolveCurrentUserIdentities } from "./currentUserIdentities";
 import { DetailList } from "./DetailList";
 import {
@@ -258,6 +268,8 @@ export interface ContentExplorerShellProps {
   loadSlotAllowedTemplates?: typeof fetchSlotAllowedTemplates;
   /** Test seam: allowed content types for slot create. */
   loadSlotAllowedTypes?: typeof fetchSlotAllowedTypes;
+  /** Test seam: allowed content types when New Item host has no children. */
+  loadContentTypes?: () => Promise<ContentTypeChoice[]>;
   /** Test seam: itemmanagement create before opening the React editor. */
   createItem?: typeof createEditorItem;
   /** Test seam: open spa.jsp?entry=editor after create. */
@@ -460,6 +472,7 @@ function ContentExplorerShellInner({
   addToSlot = addSlotRelationship,
   loadSlotAllowedTemplates = fetchSlotAllowedTemplates,
   loadSlotAllowedTypes = fetchSlotAllowedTypes,
+  loadContentTypes = loadAllowedContentTypes,
   createItem = createEditorItem,
   openWindow,
   bootstrap,
@@ -533,6 +546,9 @@ function ContentExplorerShellInner({
   const slotPickerRef = useRef<SlotDependentPickerSession | null>(null);
   const [slotCreatePickerOpen, setSlotCreatePickerOpen] = useState(false);
   const slotCreatePickerRef = useRef<SlotCreatePickerSession | null>(null);
+  const [contentTypePicker, setContentTypePicker] =
+    useState<ContentTypePickerSession | null>(null);
+  const contentTypePickerRef = useRef<ContentTypePickerSession | null>(null);
   const [templatePicker, setTemplatePicker] =
     useState<TemplatePickerSession | null>(null);
   const templatePickerRef = useRef<TemplatePickerSession | null>(null);
@@ -792,6 +808,24 @@ function ContentExplorerShellInner({
     [loadMenuActions, loadWorkflowMenuActions],
   );
 
+  const pickContentType = useCallback((types: ContentTypeChoice[]) => {
+    return new Promise<string | null>((resolve) => {
+      const session = { types, resolve };
+      contentTypePickerRef.current = replaceContentTypePickerSession(
+        contentTypePickerRef.current,
+        session,
+      );
+      setContentTypePicker(session);
+    });
+  }, []);
+
+  const finishContentTypePicker = useCallback((name: string | null) => {
+    const current = contentTypePickerRef.current;
+    contentTypePickerRef.current = null;
+    setContentTypePicker(null);
+    settleContentTypePickerSession(current, name);
+  }, []);
+
   const pickPageTemplate = useCallback((templates: PageTemplateChoice[]) => {
     return new Promise<string | null>((resolve) => {
       const session = { templates, resolve };
@@ -812,6 +846,9 @@ function ContentExplorerShellInner({
 
   useEffect(() => {
     return () => {
+      const typeCurrent = contentTypePickerRef.current;
+      contentTypePickerRef.current = null;
+      settleContentTypePickerSession(typeCurrent, null);
       const current = templatePickerRef.current;
       templatePickerRef.current = null;
       settleTemplatePickerSession(current, null);
@@ -893,6 +930,8 @@ function ContentExplorerShellInner({
               setShowRevisions(true);
             },
             pickPageTemplate,
+            pickContentType,
+            loadContentTypes,
             slot,
             addToSlot,
             createItem,
@@ -935,6 +974,8 @@ function ContentExplorerShellInner({
       menuActions,
       contextMenu,
       pickPageTemplate,
+      pickContentType,
+      loadContentTypes,
       slot,
       addToSlot,
       createItem,
@@ -1679,6 +1720,13 @@ function ContentExplorerShellInner({
           />
         </div>
       )}
+      {contentTypePicker ? (
+        <ContentTypePickerDialog
+          types={contentTypePicker.types}
+          onPick={(name) => finishContentTypePicker(name)}
+          onCancel={() => finishContentTypePicker(null)}
+        />
+      ) : null}
       {templatePicker ? (
         <TemplatePickerDialog
           templates={templatePicker.templates}

--- a/WebUI/src/main/ts/contentExplorer/ContentTypePickerDialog.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentTypePickerDialog.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { useDialogEscape } from "../architecture/useDialogEscape";
+import { message } from "../i18n/message";
+import type { ContentTypeChoice } from "./contentTypeChoices";
+import { EXPLORER_MSG } from "./messages";
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export interface ContentTypePickerDialogProps {
+  types: ContentTypeChoice[];
+  onPick: (contentType: string) => void;
+  onCancel: () => void;
+}
+
+export function ContentTypePickerDialog({
+  types,
+  onPick,
+  onCancel,
+}: ContentTypePickerDialogProps): React.ReactElement {
+  const [value, setValue] = useState(types[0]?.name ?? "");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
+
+  useDialogEscape(true, false, onCancel);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    selectRef.current?.focus();
+    if (!root) {
+      return;
+    }
+    const focusables = (): HTMLElement[] =>
+      Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key !== "Tab") {
+        return;
+      }
+      const list = focusables();
+      if (list.length === 0) {
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => root.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="explorer-type-picker-title"
+      data-testid="explorer-type-picker"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15,23,42,0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 40,
+      }}
+    >
+      <form
+        style={{
+          background: "#fff",
+          color: "#0f172a",
+          minWidth: 280,
+          maxWidth: 420,
+          padding: 16,
+          borderRadius: 8,
+          boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+        }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (value) {
+            onPick(value);
+          }
+        }}
+      >
+        <h2 id="explorer-type-picker-title" style={{ fontSize: 16, margin: "0 0 12px" }}>
+          {message(EXPLORER_MSG.TYPE_PICKER_TITLE)}
+        </h2>
+        <label style={{ display: "block", fontSize: 13 }}>
+          {message(EXPLORER_MSG.TYPE_PICKER_LABEL)}
+          <select
+            ref={selectRef}
+            data-testid="explorer-type-picker-select"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            style={{ display: "block", width: "100%", marginTop: 6, padding: 6 }}
+          >
+            {types.map((t) => (
+              <option key={t.name} value={t.name}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+          <button type="button" data-testid="explorer-type-picker-cancel" onClick={onCancel}>
+            {message(EXPLORER_MSG.CONFIRM_CANCEL)}
+          </button>
+          <button type="submit" data-testid="explorer-type-picker-ok" disabled={!value}>
+            {message(EXPLORER_MSG.CONFIRM_OK)}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionDispatch.ts
@@ -53,6 +53,12 @@ import {
   type PageTemplateChoice,
 } from "../editor/pageTemplates";
 import {
+  contentTypeChoicesFromActions,
+  isNewItemHostActionName,
+  loadAllowedContentTypes,
+  type ContentTypeChoice,
+} from "./contentTypeChoices";
+import {
   isNewItemHostName,
   parseExplorerContentId,
 } from "./menuCatalogLoad";
@@ -178,6 +184,10 @@ export interface ActionDispatchContext {
   pickPageTemplate?: (
     templates: PageTemplateChoice[],
   ) => Promise<string | null>;
+  loadContentTypes?: () => Promise<ContentTypeChoice[]>;
+  pickContentType?: (
+    types: ContentTypeChoice[],
+  ) => Promise<string | null>;
   onPublish?: (item: PSPathItem) => Promise<void>;
   /** Parent menu name when the user activated a child (AA vs Preview). */
   parentName?: string;
@@ -283,7 +293,11 @@ export function classifyAction(action: MenuAction): ActionKind {
   if (name === "purge" || name === "publish_now") {
     return "rest";
   }
-  if (name === "create_new_item" || isNewItemHostName(action.parentName)) {
+  if (
+    name === "create_new_item" ||
+    isNewItemHostActionName(action.name) ||
+    isNewItemHostName(action.parentName)
+  ) {
     return "rest";
   }
   if (isDataFlowActionUrl(action.url)) {
@@ -319,11 +333,37 @@ export function isNewItemAction(
   action: MenuAction,
   parentName?: string,
 ): boolean {
-  const name = normalizeActionName(action.name);
-  if (name === "create_new_item") {
+  if (isNewItemHostActionName(action.name)) {
     return true;
   }
   return isNewItemHostName(parentName) || isNewItemHostName(action.parentName);
+}
+
+async function resolveNewItemContentType(
+  action: MenuAction,
+  ctx: ActionDispatchContext,
+): Promise<{ contentType?: string; messageKey?: string; cancelled?: boolean }> {
+  if (!isNewItemHostActionName(action.name)) {
+    return { contentType: action.name };
+  }
+  const fromChildren = contentTypeChoicesFromActions(action.children);
+  const load = ctx.loadContentTypes ?? loadAllowedContentTypes;
+  const types =
+    fromChildren.length > 0 ? fromChildren : await load();
+  if (types.length === 0) {
+    return { messageKey: EXPLORER_MSG.ACTION_NEEDS_TYPE };
+  }
+  if (types.length === 1) {
+    return { contentType: types[0].name };
+  }
+  if (!ctx.pickContentType) {
+    return { messageKey: EXPLORER_MSG.ACTION_NEEDS_TYPE };
+  }
+  const picked = await ctx.pickContentType(types);
+  if (!picked) {
+    return { cancelled: true };
+  }
+  return { contentType: picked };
 }
 
 export function isAaPreviewAction(
@@ -440,10 +480,6 @@ export async function dispatchAction(
   }
 
   if (isNewItemAction(action, ctx.parentName)) {
-    const typeName = normalizeActionName(action.name);
-    if (typeName === "create_new_item" || isNewItemHostName(action.name)) {
-      return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_TYPE };
-    }
     const folder = resolveFolderPathFromSelection(
       ctx.folderPath,
       item?.path,
@@ -452,10 +488,21 @@ export async function dispatchAction(
     if (!folder) {
       return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_FOLDER };
     }
+    const resolved = await resolveNewItemContentType(action, ctx);
+    if (resolved.cancelled) {
+      return { kind: "rest" };
+    }
+    if (!resolved.contentType) {
+      return {
+        kind: "rest",
+        messageKey: resolved.messageKey ?? EXPLORER_MSG.ACTION_NEEDS_TYPE,
+      };
+    }
+    const contentType = resolved.contentType;
     let templateId: string | undefined;
-    if (isExplorerPageType(action.name)) {
+    if (isExplorerPageType(contentType)) {
       const load = ctx.loadPageTemplates ?? loadPageTemplates;
-      const templates = await load(folder, action.name);
+      const templates = await load(folder, contentType);
       if (templates.length === 0) {
         return { kind: "rest", messageKey: EXPLORER_MSG.ACTION_NEEDS_TEMPLATE };
       }
@@ -473,7 +520,7 @@ export async function dispatchAction(
     }
     const create = ctx.createItem ?? createEditorItem;
     const created = await create({
-      contentType: action.name,
+      contentType,
       folderPath: folder,
       templateId,
     });

--- a/WebUI/src/main/ts/contentExplorer/contentTypeChoices.ts
+++ b/WebUI/src/main/ts/contentExplorer/contentTypeChoices.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Allowed content types for Explorer New Item when the host is invoked
+ * without a type leaf (#3513). Prefers action-menu children, then
+ * {@code POST /actions/find/types}, then {@code GET /contenttypes}.
+ */
+
+import {
+  findAllowedContentTypeMenus,
+  mapActionMenusToMenuActions,
+} from "../api/contentExplorer/actionMenuApi";
+import type { MenuAction } from "../api/contentExplorer/types";
+import { listContentTypes } from "../api/developer/contentTypesApi";
+import { isNewItemHostName } from "./menuCatalogLoad";
+
+export interface ContentTypeChoice {
+  name: string;
+  label: string;
+}
+
+export function isNewItemHostActionName(name: string | undefined | null): boolean {
+  const n = (name ?? "").replace(/[\s-]/g, "_").toLowerCase();
+  return n === "create_new_item" || isNewItemHostName(name);
+}
+
+export function contentTypeChoicesFromActions(
+  actions: MenuAction[] | undefined | null,
+): ContentTypeChoice[] {
+  const out: ContentTypeChoice[] = [];
+  const seen = new Set<string>();
+  for (const action of actions ?? []) {
+    const name = (action?.name ?? "").trim();
+    if (!name || isNewItemHostActionName(name)) {
+      continue;
+    }
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    out.push({
+      name,
+      label: (action.label ?? "").trim() || name,
+    });
+  }
+  return out;
+}
+
+export async function loadAllowedContentTypes(): Promise<ContentTypeChoice[]> {
+  try {
+    const menus = await findAllowedContentTypeMenus([]);
+    const fromMenus = contentTypeChoicesFromActions(
+      mapActionMenusToMenuActions(menus),
+    );
+    if (fromMenus.length > 0) {
+      return fromMenus;
+    }
+  } catch {
+    /* fall through to the content-types catalog */
+  }
+  try {
+    const types = await listContentTypes();
+    const out: ContentTypeChoice[] = [];
+    const seen = new Set<string>();
+    for (const type of types) {
+      const name = (type.name ?? "").trim();
+      if (!name || seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      out.push({
+        name,
+        label: (type.label ?? "").trim() || name,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/WebUI/src/main/ts/contentExplorer/contentTypePickerSession.ts
+++ b/WebUI/src/main/ts/contentExplorer/contentTypePickerSession.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ContentTypeChoice } from "./contentTypeChoices";
+
+export interface ContentTypePickerSession {
+  types: ContentTypeChoice[];
+  resolve: (name: string | null) => void;
+}
+
+/**
+ * Open a new type-picker session. Cancels any previous waiter so
+ * {@code dispatchAction} does not hang if the user starts another create
+ * before the first picker settles.
+ */
+export function replaceContentTypePickerSession(
+  previous: ContentTypePickerSession | null,
+  next: ContentTypePickerSession,
+): ContentTypePickerSession {
+  if (previous && previous !== next) {
+    previous.resolve(null);
+  }
+  return next;
+}
+
+/**
+ * Settle the current session (pick or cancel). Safe if {@code session} is
+ * already null. The caller should drop its ref after this returns.
+ */
+export function settleContentTypePickerSession(
+  session: ContentTypePickerSession | null,
+  name: string | null,
+): null {
+  session?.resolve(name);
+  return null;
+}

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -337,6 +337,8 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Select a folder first",
   ACTION_NEEDS_TYPE:
     "perc.ui.explorer@Choose a content type from New Item",
+  TYPE_PICKER_TITLE: "perc.ui.explorer@Choose a content type",
+  TYPE_PICKER_LABEL: "perc.ui.explorer@Content type",
   ACTION_NEEDS_TEMPLATE:
     "perc.ui.explorer@This page needs a template. Choose a site folder or use Home → Create.",
   ACTION_NEEDS_SLOT:

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -2172,6 +2172,56 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       /Custom URL views cannot be run/i,
     );
   });
+
+  it("New Item host opens a content-type picker instead of an error toast (#3513)", async () => {
+    stubPathFetch();
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "101",
+      folderPath: "//Sites/Demo",
+      name: "New-rffEvent",
+      contentType: "rffEvent",
+    });
+    const openWindow = vi.fn();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => [
+          {
+            name: "New",
+            label: "New Item",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ]}
+        loadContentTypes={async () => [
+          { name: "percFile", label: "File" },
+          { name: "rffEvent", label: "Event" },
+        ]}
+        createItem={createItem}
+        openWindow={openWindow}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("action-toolbar-item-New")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("action-toolbar-item-New"));
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-type-picker")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Choose a content type from New Item/i)).toBeNull();
+    fireEvent.change(screen.getByTestId("explorer-type-picker-select"), {
+      target: { value: "rffEvent" },
+    });
+    fireEvent.click(screen.getByTestId("explorer-type-picker-ok"));
+    await waitFor(() => {
+      expect(createItem).toHaveBeenCalledWith({
+        contentType: "rffEvent",
+        folderPath: "/Sites/Demo",
+      });
+    });
+    expect(openWindow).toHaveBeenCalled();
+  });
 });
 
 describe("ContentExplorerShell missing BootstrapProvider (#3331)", () => {

--- a/WebUI/src/test/ts/contentExplorer/ContentTypePickerDialog.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentTypePickerDialog.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ContentTypePickerDialog } from "../../../main/ts/contentExplorer/ContentTypePickerDialog";
+import { renderA11yGate } from "./a11y";
+
+const TYPES = [
+  { name: "percFile", label: "File" },
+  { name: "rffEvent", label: "Event" },
+];
+
+describe("ContentTypePickerDialog", () => {
+  it("picks the selected content type", () => {
+    const onPick = vi.fn();
+    render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={onPick}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("explorer-type-picker")).toBeTruthy();
+    fireEvent.change(screen.getByTestId("explorer-type-picker-select"), {
+      target: { value: "rffEvent" },
+    });
+    fireEvent.click(screen.getByTestId("explorer-type-picker-ok"));
+    expect(onPick).toHaveBeenCalledWith("rffEvent");
+  });
+
+  it("cancels without picking", () => {
+    const onCancel = vi.fn();
+    const onPick = vi.fn();
+    render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={onPick}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("explorer-type-picker-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Escape", () => {
+    const onCancel = vi.fn();
+    render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves focus to the type select on mount", () => {
+    render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-type-picker-select"),
+    );
+  });
+
+  it("traps Tab inside the dialog", () => {
+    render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const ok = screen.getByTestId("explorer-type-picker-ok");
+    ok.focus();
+    fireEvent.keyDown(screen.getByTestId("explorer-type-picker"), {
+      key: "Tab",
+    });
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-type-picker-select"),
+    );
+  });
+
+  it("has no serious a11y violations", async () => {
+    const { container } = render(
+      <ContentTypePickerDialog
+        types={TYPES}
+        onPick={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await renderA11yGate(container);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionDispatch.test.ts
@@ -61,6 +61,11 @@ describe("actionDispatch", () => {
     expect(classifyAction(action({ name: "Quick_Edit" }))).toBe("editor");
   });
 
+  it("classifies New Item host as rest so the type picker can run", () => {
+    expect(classifyAction(action({ name: "New" }))).toBe("rest");
+    expect(classifyAction(action({ name: "Create_New_Item" }))).toBe("rest");
+  });
+
   it("classifies Item_Preview and assembler URLs as rest", () => {
     expect(classifyAction(action({ name: "Item_Preview" }))).toBe("rest");
     expect(
@@ -288,14 +293,115 @@ describe("actionDispatch", () => {
     expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain("contentId=99");
   });
 
-  it("New Item parent without a type asks to choose a type", async () => {
+  it("New Item host with no types still asks to choose a type", async () => {
     const createItem = vi.fn();
     const result = await dispatchAction(action({ name: "Create_New_Item" }), {
       item: item({ type: "folder", path: "/Sites/Demo" }),
       folderPath: "/Sites/Demo",
       createItem,
+      loadContentTypes: async () => [],
     });
     expect(result.messageKey).toBe(EXPLORER_MSG.ACTION_NEEDS_TYPE);
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
+  it("New Item host opens a type picker and creates the picked type", async () => {
+    const openWindow = vi.fn();
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "88",
+      folderPath: "//Sites/Demo",
+      name: "New-rffEvent",
+      contentType: "rffEvent",
+    });
+    const pickContentType = vi.fn().mockResolvedValue("rffEvent");
+    const result = await dispatchAction(action({ name: "New" }), {
+      item: item({ type: "folder", path: "/Sites/Demo", id: "1" }),
+      folderPath: "/Sites/Demo",
+      createItem,
+      openWindow,
+      pickContentType,
+      loadContentTypes: async () => [
+        { name: "percFile", label: "File" },
+        { name: "rffEvent", label: "Event" },
+      ],
+    });
+    expect(result.messageKey).toBeUndefined();
+    expect(result.refresh).toBe(true);
+    expect(pickContentType).toHaveBeenCalled();
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "rffEvent",
+      folderPath: "/Sites/Demo",
+    });
+    expect(String(openWindow.mock.calls[0]?.[0] ?? "")).toContain("contentId=88");
+  });
+
+  it("New Item host auto-selects a single allowed type", async () => {
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "89",
+      folderPath: "//Sites/Demo",
+      name: "New-percFile",
+      contentType: "percFile",
+    });
+    const pickContentType = vi.fn();
+    const result = await dispatchAction(action({ name: "Create_New_Item" }), {
+      folderPath: "/Sites/Demo",
+      createItem,
+      openWindow: vi.fn(),
+      pickContentType,
+      loadContentTypes: async () => [{ name: "percFile", label: "File" }],
+    });
+    expect(result.refresh).toBe(true);
+    expect(pickContentType).not.toHaveBeenCalled();
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "percFile",
+      folderPath: "/Sites/Demo",
+    });
+  });
+
+  it("New Item host uses type children without calling the catalog", async () => {
+    const createItem = vi.fn().mockResolvedValue({
+      itemId: "90",
+      folderPath: "//Sites/Demo",
+      name: "New-rffEvent",
+      contentType: "rffEvent",
+    });
+    const loadContentTypes = vi.fn();
+    const pickContentType = vi.fn().mockResolvedValue("rffEvent");
+    await dispatchAction(
+      action({
+        name: "New",
+        children: [
+          { name: "percFile", label: "File", sortRank: 1, menuType: "MENUITEM" },
+          { name: "rffEvent", label: "Event", sortRank: 2, menuType: "MENUITEM" },
+        ],
+      }),
+      {
+        folderPath: "/Sites/Demo",
+        createItem,
+        openWindow: vi.fn(),
+        pickContentType,
+        loadContentTypes,
+      },
+    );
+    expect(loadContentTypes).not.toHaveBeenCalled();
+    expect(createItem).toHaveBeenCalledWith({
+      contentType: "rffEvent",
+      folderPath: "/Sites/Demo",
+    });
+  });
+
+  it("does not create when the New Item type picker is cancelled", async () => {
+    const createItem = vi.fn();
+    const result = await dispatchAction(action({ name: "New" }), {
+      folderPath: "/Sites/Demo",
+      createItem,
+      pickContentType: async () => null,
+      loadContentTypes: async () => [
+        { name: "percFile", label: "File" },
+        { name: "rffEvent", label: "Event" },
+      ],
+    });
+    expect(result.messageKey).toBeUndefined();
     expect(createItem).not.toHaveBeenCalled();
   });
 

--- a/WebUI/src/test/ts/contentExplorer/contentTypeChoices.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/contentTypeChoices.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
+import {
+  contentTypeChoicesFromActions,
+  isNewItemHostActionName,
+  loadAllowedContentTypes,
+} from "../../../main/ts/contentExplorer/contentTypeChoices";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function action(
+  partial: Partial<MenuAction> & Pick<MenuAction, "name">,
+): MenuAction {
+  return {
+    label: partial.label ?? partial.name,
+    sortRank: partial.sortRank ?? 0,
+    menuType: partial.menuType ?? "MENUITEM",
+    ...partial,
+  };
+}
+
+describe("contentTypeChoices", () => {
+  it("treats New / Create_New_Item as host names", () => {
+    expect(isNewItemHostActionName("New")).toBe(true);
+    expect(isNewItemHostActionName("Create_New_Item")).toBe(true);
+    expect(isNewItemHostActionName("rffEvent")).toBe(false);
+  });
+
+  it("maps action-menu leaves and skips New Item hosts", () => {
+    const choices = contentTypeChoicesFromActions([
+      action({ name: "New", label: "New Item" }),
+      action({ name: "rffEvent", label: "Event" }),
+      action({ name: "rffEvent", label: "Event dup" }),
+      action({ name: "percFile", label: "File" }),
+    ]);
+    expect(choices).toEqual([
+      { name: "rffEvent", label: "Event" },
+      { name: "percFile", label: "File" },
+    ]);
+  });
+
+  it("prefers find/types menus over the content-types catalog", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ActionMenuList: [
+              { name: "percPage", label: "Page", sortRank: 0, menuType: "MENUITEM" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ContentType: [{ name: "ignored" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    const types = await loadAllowedContentTypes();
+    expect(types).toEqual([{ name: "percPage", label: "Page" }]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to GET /contenttypes when find/types is empty", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ContentType: [{ name: "percFile", label: "File" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    const types = await loadAllowedContentTypes();
+    expect(types).toEqual([{ name: "percFile", label: "File" }]);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/contentTypePickerSession.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/contentTypePickerSession.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  replaceContentTypePickerSession,
+  settleContentTypePickerSession,
+} from "../../../main/ts/contentExplorer/contentTypePickerSession";
+
+const T = [{ name: "percFile", label: "File" }];
+
+describe("contentTypePickerSession", () => {
+  it("cancels the previous waiter when a new session opens", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const previous = { types: T, resolve: first };
+    const next = { types: T, resolve: second };
+    const opened = replaceContentTypePickerSession(previous, next);
+    expect(opened).toBe(next);
+    expect(first).toHaveBeenCalledWith(null);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("settles the open session and is a no-op when already cleared", () => {
+    const resolve = vi.fn();
+    const session = { types: T, resolve };
+    expect(settleContentTypePickerSession(session, "rffEvent")).toBeNull();
+    expect(resolve).toHaveBeenCalledWith("rffEvent");
+    expect(settleContentTypePickerSession(null, "rffEvent")).toBeNull();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/ai-generated/code-reviews/issue-3513-explorer-new-item-type-picker-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3513-explorer-new-item-type-picker-erlang.md
@@ -1,0 +1,21 @@
+# Erlang review — issue #3513 Explorer New Item type picker
+
+**Date:** 2026-08-17  
+**Branch:** `fix/issue-3513-explorer-new-item-type-picker`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** action-dispatch toast vs picker; Explorer i18n/`data-testid`; Playwright surface filter
+
+## Summary
+
+New Item host (`New` / `Create_New_Item`) no longer returns `ACTION_NEEDS_TYPE` when clicked as a leaf. Dispatch loads allowed types (action children, then `POST /actions/find/types`, then `GET /contenttypes`), auto-selects a single type, or opens a picker peer to the page-template dialog, then uses the existing create + editor path.
+
+## Gate
+
+- **Bugs:** none found. Host cancel does not create. Empty catalog still uses `ACTION_NEEDS_TYPE`. Folder required first.
+- **Behavioral tests:** dispatch, choices loader, picker session/dialog (a11y), shell invoke, Playwright surface (picker + create intercept).
+- **Cross-platform paths:** no filesystem I/O. CMS URL/path strings use `/`.
+
+## Issues
+
+None blocking.

--- a/modules/perc-qa-automation/frontend/tests/explorer-new-item-type-picker.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-new-item-type-picker.spec.js
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer New Item content-type picker (#3513).
+ *
+ * <p>Tags: {@code @explorer-new-item} {@code @explorer}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-new-item-type-picker.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { explorerSpaUrl } = require("./helpers/explorer-menu-bar");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+function isFeatureUrl(url) {
+  const u = String(url || "");
+  return (
+    /\/actions\/find/i.test(u) ||
+    /\/itemmanagement\/item\/create/i.test(u) ||
+    /\/services\/contenttypes/i.test(u)
+  );
+}
+
+function collectFeatureErrors(page) {
+  const pageErrors = [];
+  const featureHttpErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("response", (res) => {
+    if (res.status() < 500) {
+      return;
+    }
+    const url = res.url();
+    if (isFeatureUrl(url)) {
+      featureHttpErrors.push(`${res.status()} ${res.request().method()} ${url}`);
+    }
+  });
+  return { pageErrors, featureHttpErrors };
+}
+
+async function stubNewItemHostLeaf(page, createBodies) {
+  await page.route("**/actions/find**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/actions/find/types")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ActionMenuList: [
+            { name: "percFile", label: "File", sortRank: 1, menuType: "MENUITEM" },
+            { name: "rffEvent", label: "Event", sortRank: 2, menuType: "MENUITEM" },
+          ],
+        }),
+      });
+      return;
+    }
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ActionMenu: [
+          {
+            name: "New",
+            label: "New Item",
+            sortRank: 0,
+            menuType: "MENUITEM",
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/services/contenttypes**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ContentType: [
+          { name: "percFile", label: "File" },
+          { name: "rffEvent", label: "Event" },
+        ],
+      }),
+    });
+  });
+  await page.route("**/itemmanagement/item/create**", async (route) => {
+    createBodies.push(route.request().postData() || "");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ItemCreateResult: {
+          itemId: "1-101-88",
+          folderPath: "//Sites/Demo",
+          name: "New-rffEvent",
+          contentType: "rffEvent",
+        },
+      }),
+    });
+  });
+}
+
+async function openExplorerOnSitesFolder(page) {
+  await page.goto(`${explorerSpaUrl(BASE_URL)}&path=/Sites`, {
+    waitUntil: "networkidle",
+  });
+  await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const tree = page.locator('[data-testid="explorer-tree"]');
+  if ((await tree.count()) > 0) {
+    const sitesNode = page
+      .locator(
+        '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+      )
+      .first();
+    if ((await sitesNode.count()) > 0) {
+      await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+    }
+  }
+}
+
+test.describe("Explorer New Item content-type picker (#3513)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(60_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "New Item host opens a type picker instead of an error toast",
+    { tag: ["@explorer-new-item", "@explorer"] },
+    async ({ page }) => {
+      const { pageErrors, featureHttpErrors } = collectFeatureErrors(page);
+      const createBodies = [];
+      await stubNewItemHostLeaf(page, createBodies);
+      await openExplorerOnSitesFolder(page);
+
+      const neu = page.locator('[data-testid="action-toolbar-item-New"]');
+      await expect(neu).toBeVisible({ timeout: 15_000 });
+      await neu.click();
+
+      const picker = page.locator('[data-testid="explorer-type-picker"]');
+      await expect(picker).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText("Choose a content type from New Item")).toHaveCount(0);
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="explorer-type-picker"]',
+      });
+      await page.locator('[data-testid="explorer-type-picker-cancel"]').click();
+      await expect(picker).toHaveCount(0);
+      expect(createBodies, "Cancel must not POST create").toEqual([]);
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      expect(
+        featureHttpErrors,
+        `feature HTTP 5xx: ${featureHttpErrors.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
+
+  test(
+    "New Item picker creates the selected type and does not open leftover CE HTML",
+    { tag: ["@explorer-new-item", "@explorer"] },
+    async ({ page }) => {
+      const { pageErrors, featureHttpErrors } = collectFeatureErrors(page);
+      const blocked = [];
+      page.on("request", (req) => {
+        const u = req.url();
+        if (
+          u.includes("rx_ce") ||
+          u.includes("contenteditorurls.html") ||
+          u.includes("checkoutedit.xml")
+        ) {
+          blocked.push(u);
+        }
+      });
+      const createBodies = [];
+      await stubNewItemHostLeaf(page, createBodies);
+      await openExplorerOnSitesFolder(page);
+
+      await page.locator('[data-testid="action-toolbar-item-New"]').click();
+      const picker = page.locator('[data-testid="explorer-type-picker"]');
+      await expect(picker).toBeVisible({ timeout: 10_000 });
+      await page.locator('[data-testid="explorer-type-picker-select"]').selectOption("rffEvent");
+      await page.locator('[data-testid="explorer-type-picker-ok"]').click();
+      await expect.poll(() => createBodies.length).toBe(1);
+      expect(createBodies[0]).toMatch(/"contentType"\s*:\s*"rffEvent"/);
+      expect(blocked, `Data Flow CE HTML must not be requested: ${blocked.join(" ")}`).toEqual([]);
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      expect(
+        featureHttpErrors,
+        `feature HTTP 5xx: ${featureHttpErrors.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -118,7 +118,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | Action | What happens |
 |--------|----------------|
 | **Preview** (and per-template children) | Opens assembly preview (`GET /services/assembly/preview-location`) or the default page/asset preview. Applies to listed pages and assets, including customer-defined content types (type names are not a closed list; FastForward names stay stable). New language: **template**, not variant. |
-| **New Item** | Choose a content type under **New**. Explorer creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. Does not open leftover Content Editor HTML. **Pages** (`percPage`) need a page template. Explorer loads allowed templates for the type, then the site's templates when the type has none. One template is used automatically; more than one opens **Choose a page template**. Cancel leaves the folder unchanged. If no template is available, Explorer asks you to pick a site folder or use Home → Create. Home → Create **Asset** uses the same create + React editor host (not leftover `editAsset.jsp`). |
+| **New Item** | Select a **site or folder** first, then choose **New Item**. When the catalog lists types under **New**, pick a type from that menu. When **New Item** is a single action (no type children), Explorer opens **Choose a content type** — pick a type and **OK**, or **Cancel** to leave the folder unchanged. Explorer then creates the item in the current folder (`POST /services/itemmanagement/item/create`) and opens the React Content Editor. It does **not** show *Choose a content type from New Item* as an error toast instead of the picker, and it does not open leftover Content Editor HTML. **Pages** (`percPage`) need a page template. Explorer loads allowed templates for the type, then the site's templates when the type has none. One template is used automatically; more than one opens **Choose a page template**. Cancel leaves the folder unchanged. If no template is available, Explorer asks you to pick a site folder or use Home → Create. Home → Create **Asset** uses the same create + React editor host (not leftover `editAsset.jsp`). |
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open the CM1 editor (`?view=editor`). |
@@ -272,6 +272,9 @@ Menus and toolbar buttons come from the server action catalog used by Content Ex
   content-type **New** commands under an existing menu. It does not replace the tree with
   a flat list of every allowed command.
 - When only a folder is active, the shell loads the same cascading action tree.
+  **New Item** without type children opens **Choose a content type** (same create
+  path as a type under **New**). It does not fail with a toast that says to
+  choose a type from a menu that is not there.
 - **Desktop-only** actions (for example custom application protocols that only DCE can run)
   are **hidden** in the web shell so operators are not offered controls that cannot succeed
   in the browser.


### PR DESCRIPTION
## Summary

Explorer **New Item** on a selected site folder no longer fails with the toast *Something went wrong: Choose a content type from New Item*.

`GET /actions/find` returns the New Item host as a leaf (type children come from `POST /actions/find/types`, which Explorer only merged for workflow-eligible items). Clicking that host now:

1. Resolves the current folder
2. Loads allowed types from action-menu children, then `/actions/find/types`, then `GET /contenttypes`
3. Auto-selects a single type, or opens **Choose a content type** (peer to the page-template picker)
4. Creates the item (`POST /services/itemmanagement/item/create`) and opens the React editor

Cancel leaves the folder unchanged. Pages still go through the existing template picker.

Fixes #3513

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Log in as Admin on QA H2 (`perc-devctl qa-up`).
2. Open Explorer → expand **Sites** → select a site folder.
3. Click **New Item** when it is a single toolbar action (no type dropdown).
4. Confirm **Choose a content type** opens; **Cancel** does not create an item and does not show the ACTION_NEEDS_TYPE toast.
5. Click **New Item** again, pick a type, **OK**. Confirm create + editor window (not leftover `rx_ce` HTML).
6. If **New** already has type children, pick a type from the dropdown — existing typed path still works.

Automated:

- `cd WebUI && ../mvnw clean install` — BUILD SUCCESS, Tests run: 2705, Failures: 0
- Playwright (QA H2 `TEST_CMS_URL=http://127.0.0.1:9993`): `npm run test:surface -- --path tests/explorer-new-item-type-picker.spec.js` — 2 passed
- Golden: `npm run test:golden` — 2 passed

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` New Item + server-actions notes
- [x] **Unit / module tests** — dispatch, type-choice loader, picker session/dialog, shell invoke
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-new-item-type-picker.spec.js`
- [x] **Build gates** — standalone WebUI `mvnw clean install` (no skipTests)
- [x] **Cross-platform** — no filesystem I/O; CMS URL paths use `/`

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-17). Vitest: Tests run: 2705, Failures: 0. Surefire/frontend included. No new compiler warnings attributable to this change (existing javadoc/dependency-analyze baseline only).
- **downstream_checked:** none (no Java public/protected API or `final`/`sealed` type-shape change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` — cell `perc-matrix-cms-h2` HEALTH=healthy HTTP:200 `TEST_CMS_URL=http://127.0.0.1:9993` (qa-health RESULT:FAIL on pre-existing FastForward GIF import `PSDbStorageService Could not import item … CI_PS_products_on.gif` / `navEI_advice_on.gif` — not Failed startup / not unhealthy)
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern` (SPA JS/CSS; no Jetty restart)
- Playwright: `npm run test:surface -- --path tests/explorer-new-item-type-picker.spec.js` — **2 passed**; `npm run test:golden` — **2 passed**
- **console-clean=yes** (no uncaught `pageerror`; no feature HTTP 5xx on `/actions/find`, `/contenttypes`, `/item/create`)
- **server.log-clean=yes** for this feature (no New Item / create / type-picker ERROR). Pre-existing noise: FastForward import + search-index last-modifier + occasional transaction rollback-only (not this slice)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
