### PR TITLE
feat(WebUI): Create Site type picker + Traditional path (#3522)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -100,8 +100,9 @@ export const EXPLORER_MSG = {
   SITE_COPY_SELECT_SITE:
     "perc.ui.explorer@Open a site under Sites to copy it.",
 
-  // Create Site (#3002 / parent #2989) — traditional repository default
+  // Create Site (#3002 / parent #2989 / type picker #3522)
   SITE_CREATE_TITLE: "perc.ui.explorer@Create Site",
+  SITE_CREATE_STEP_TYPE: "perc.ui.explorer@Site type",
   SITE_CREATE_STEP_DETAILS: "perc.ui.explorer@Site details",
   SITE_CREATE_STEP_TEMPLATE: "perc.ui.explorer@Base template",
   SITE_CREATE_STEP_CONFIRM: "perc.ui.explorer@Confirm",
@@ -113,9 +114,14 @@ export const EXPLORER_MSG = {
   SITE_CREATE_TEMPLATE_NAME_LABEL: "perc.ui.explorer@Template name",
   SITE_CREATE_BASE_TEMPLATE_LABEL: "perc.ui.explorer@Base template",
   SITE_CREATE_TRADITIONAL_NOTE:
-    "perc.ui.explorer@Creates a traditional repository site (default).",
+    "perc.ui.explorer@Creates a traditional repository site. Managed navigation is optional. A page template is not required.",
   SITE_CREATE_REPOSITORY_KIND: "perc.ui.explorer@Repository",
+  SITE_CREATE_TYPE_LABEL: "perc.ui.explorer@Site type",
   SITE_CREATE_TRADITIONAL: "perc.ui.explorer@Traditional",
+  SITE_CREATE_TYPE_PAGE: "perc.ui.explorer@Page",
+  SITE_CREATE_TYPE_VIRTUAL: "perc.ui.explorer@Virtual",
+  SITE_CREATE_TYPE_UNAVAILABLE:
+    "perc.ui.explorer@This site type is not available yet. Choose Traditional to continue.",
   SITE_CREATE_MANAGED_NAV_LABEL: "perc.ui.explorer@Include managed navigation",
   SITE_CREATE_MANAGED_NAV_HELP:
     "perc.ui.explorer@When unchecked, the site folder is created without a NavTree or homepage. You can add navigation later in Explorer. Virtual Sites do not use this option.",
@@ -123,8 +129,7 @@ export const EXPLORER_MSG = {
   SITE_CREATE_MANAGED_NAV_NO: "perc.ui.explorer@No",
   SITE_CREATE_TEMPLATES_LOADING: "perc.ui.explorer@Loading base templates…",
   SITE_CREATE_TEMPLATES_ERROR: "perc.ui.explorer@Could not load base templates",
-  SITE_CREATE_VALIDATION:
-    "perc.ui.explorer@Enter a valid site name, template name, and base template",
+  SITE_CREATE_VALIDATION: "perc.ui.explorer@Enter a valid site name",
   SITE_CREATE_SUBMIT: "perc.ui.explorer@Create site",
   SITE_CREATE_SUBMITTING: "perc.ui.explorer@Creating site…",
   SITE_CREATE_SUCCESS: "perc.ui.explorer@Site {name} created",

--- a/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
+++ b/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
@@ -15,22 +15,26 @@
  */
 
 /**
- * Create Site wizard for modern Explorer (#3002 / parent #2989).
+ * Create Site wizard for Explorer Content → Create Site and Navigation
+ * New Site (#3522 / parent #3512).
  *
- * <p>Four-step flow: details → template → confirm → progress.
- * Creates a traditional (repository) site via sitemanage
- * {@code POST /site/} — no Virtual Site options. Success navigates the
- * host to {@code /Sites/&lt;name&gt;} via {@link SiteCreateWizardProps.onCreated}.</p>
+ * <p>First step is a site-type picker (Traditional / Page / Virtual).
+ * Slice 1 ships a complete Traditional path: type → details (name,
+ * description, optional managed nav) → confirm → progress. Traditional
+ * does not prompt for a page or base template. Page and Virtual radios
+ * are visible; Next stays on the type step with a clear message so those
+ * kinds cannot silently create a traditional site.</p>
+ *
+ * <p>Traditional create still uses {@code POST /sitemanage/site/} via
+ * {@link createTraditionalSite}. Template name and base template are
+ * generated (not shown) so the existing Site body stays valid.</p>
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   createTraditionalSite,
-  listBaseTemplates,
-  pickDefaultBaseTemplate,
   PLAIN_BASE_TEMPLATE_NAME,
   siteFolderPath,
-  type BaseTemplateSummary,
   type CreateSiteRequest,
   type CreatedSiteSummary,
 } from "../../api/contentExplorer/siteCreateApi";
@@ -40,6 +44,7 @@ import {
   advance,
   back,
   createWizard,
+  currentStepId,
   finishWizard,
   isFinalStep,
   resetWizard,
@@ -50,16 +55,14 @@ import {
   clampSiteDescription,
   defaultTemplateNameForSite,
   filterSiteNameInput,
-  filterTemplateNameInput,
+  isSiteCreateKindEnabled,
   validateSiteName,
-  validateTemplateName,
+  type SiteCreateKind,
 } from "./siteCreateValidation";
 
 export interface SiteCreateWizardProps {
   /** Optional submit override (default: POST /sitemanage/site/). */
   submit?: (request: CreateSiteRequest) => Promise<CreatedSiteSummary>;
-  /** Optional base-template loader (default: GET readonly base templates). */
-  loadBaseTemplates?: () => Promise<BaseTemplateSummary[]>;
   /** Optional seed site name. */
   initialSiteName?: string;
   /** Fired after successful create with site name + folder path. */
@@ -73,14 +76,31 @@ export interface SiteCreateWizardProps {
   className?: string;
 }
 
-const STEPS = ["details", "template", "confirm", "progress"];
+/** Traditional flow: type picker, details, confirm, progress. */
+const STEPS = ["type", "details", "confirm", "progress"] as const;
+
+const TYPE_TEST_IDS: Record<SiteCreateKind, string> = {
+  traditional: "site-create-type-traditional",
+  page: "site-create-type-page",
+  virtual: "site-create-type-virtual",
+};
+
+function typeLabel(kind: SiteCreateKind): string {
+  switch (kind) {
+    case "page":
+      return message(EXPLORER_MSG.SITE_CREATE_TYPE_PAGE);
+    case "virtual":
+      return message(EXPLORER_MSG.SITE_CREATE_TYPE_VIRTUAL);
+    default:
+      return message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL);
+  }
+}
 
 export function SiteCreateWizard(
   props: SiteCreateWizardProps,
 ): React.JSX.Element {
   const {
     submit: submitOverride,
-    loadBaseTemplates = listBaseTemplates,
     initialSiteName = "",
     onCreated,
     onSettled,
@@ -89,58 +109,18 @@ export function SiteCreateWizard(
   } = props;
 
   const [wizard, setWizard] = useState<WizardState>(() => createWizard(STEPS));
+  const [siteType, setSiteType] = useState<SiteCreateKind>("traditional");
   const [siteName, setSiteName] = useState(() =>
     filterSiteNameInput(initialSiteName),
   );
   const [description, setDescription] = useState("");
-  const [templateName, setTemplateName] = useState(() =>
-    defaultTemplateNameForSite(initialSiteName),
-  );
-  /** When true, site-name edits keep regenerating the default template name. */
-  const [templateNameFollowsSite, setTemplateNameFollowsSite] = useState(true);
-  const [baseTemplateName, setBaseTemplateName] = useState(
-    PLAIN_BASE_TEMPLATE_NAME,
-  );
   /** Traditional sites only. Virtual Sites do not use this flag. */
   const [managedNavigation, setManagedNavigation] = useState(true);
-  const [templates, setTemplates] = useState<BaseTemplateSummary[]>([]);
-  const [templatesError, setTemplatesError] = useState<string | null>(null);
-  const [templatesLoading, setTemplatesLoading] = useState(true);
   const [createdName, setCreatedName] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setTemplatesLoading(true);
-    loadBaseTemplates()
-      .then((list) => {
-        if (cancelled) return;
-        const rows = list ?? [];
-        setTemplates(rows);
-        setBaseTemplateName(pickDefaultBaseTemplate(rows));
-        setTemplatesError(null);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setTemplates([]);
-        setBaseTemplateName(PLAIN_BASE_TEMPLATE_NAME);
-        setTemplatesError(
-          err instanceof Error && err.message
-            ? err.message
-            : message(EXPLORER_MSG.SITE_CREATE_TEMPLATES_ERROR),
-        );
-      })
-      .finally(() => {
-        if (!cancelled) setTemplatesLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [loadBaseTemplates]);
 
   async function handleRun(): Promise<void> {
     const site = validateSiteName(siteName);
-    const tmpl = validateTemplateName(templateName);
-    if (!site.ok || !tmpl.ok || !baseTemplateName.trim()) {
+    if (!site.ok || !isSiteCreateKindEnabled(siteType)) {
       setWizard((w) =>
         finishWizard(w, {
           kind: "error",
@@ -155,8 +135,8 @@ export function SiteCreateWizard(
       name: site.name,
       label: site.name,
       description: clampSiteDescription(description),
-      baseTemplateName: baseTemplateName.trim(),
-      templateName: tmpl.name,
+      baseTemplateName: PLAIN_BASE_TEMPLATE_NAME,
+      templateName: defaultTemplateNameForSite(site.name),
       managedNavigation,
     };
     try {
@@ -175,45 +155,92 @@ export function SiteCreateWizard(
   }
 
   function handleSiteNameChange(value: string): void {
-    const next = filterSiteNameInput(value);
-    setSiteName(next);
-    if (templateNameFollowsSite) {
-      setTemplateName(defaultTemplateNameForSite(next));
-    }
-  }
-
-  function handleTemplateNameChange(value: string): void {
-    setTemplateNameFollowsSite(false);
-    setTemplateName(filterTemplateNameInput(value));
+    setSiteName(filterSiteNameInput(value));
   }
 
   function handleReset(): void {
     setWizard((w) => resetWizard(w));
     setCreatedName(null);
+    setSiteType("traditional");
     setManagedNavigation(true);
   }
 
-  const detailsReady =
-    validateSiteName(siteName).ok && validateTemplateName(templateName).ok;
-  const templateReady = baseTemplateName.trim().length > 0;
+  const typeReady = isSiteCreateKindEnabled(siteType);
+  const detailsReady = validateSiteName(siteName).ok;
   const canSubmit = canSubmitCreateSite({
     siteName,
-    templateName,
-    baseTemplateName,
+    siteType,
+    templateName: defaultTemplateNameForSite(siteName),
+    baseTemplateName: PLAIN_BASE_TEMPLATE_NAME,
   });
+  const stepId = currentStepId(wizard);
 
   function renderStep(): React.JSX.Element {
-    switch (wizard.current) {
-      case 0:
+    switch (stepId) {
+      case "type":
+        return (
+          <fieldset data-testid="site-create-step-type">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_TYPE)}</legend>
+            <p
+              style={{ color: "#555", fontSize: "0.9em", margin: "0 0 8px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_TYPE_LABEL)}
+            </p>
+            {(
+              [
+                "traditional",
+                "page",
+                "virtual",
+              ] as const satisfies readonly SiteCreateKind[]
+            ).map((kind) => (
+              <label
+                key={kind}
+                htmlFor={TYPE_TEST_IDS[kind]}
+                style={{ display: "block", margin: "6px 0" }}
+              >
+                <input
+                  id={TYPE_TEST_IDS[kind]}
+                  type="radio"
+                  name="site-create-type"
+                  data-testid={TYPE_TEST_IDS[kind]}
+                  value={kind}
+                  checked={siteType === kind}
+                  onChange={() => setSiteType(kind)}
+                  style={{ marginRight: 8 }}
+                />
+                {typeLabel(kind)}
+              </label>
+            ))}
+            {siteType === "traditional" ? (
+              <p
+                style={{
+                  color: "#555",
+                  fontSize: "0.85em",
+                  margin: "8px 0 0 24px",
+                }}
+                data-testid="site-create-traditional-note"
+              >
+                {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL_NOTE)}
+              </p>
+            ) : (
+              <p
+                role="status"
+                style={{
+                  color: "#8a4b08",
+                  fontSize: "0.9em",
+                  margin: "8px 0 0 0",
+                }}
+                data-testid="site-create-type-unavailable"
+              >
+                {message(EXPLORER_MSG.SITE_CREATE_TYPE_UNAVAILABLE)}
+              </p>
+            )}
+          </fieldset>
+        );
+      case "details":
         return (
           <fieldset data-testid="site-create-step-details">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_DETAILS)}</legend>
-            <p
-              style={{ color: "#555", fontSize: "0.9em", margin: "0 0 8px 0" }}
-              data-testid="site-create-traditional-note"
-            >
-              {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL_NOTE)}
-            </p>
             <label
               htmlFor="site-create-name"
               style={{ display: "block", margin: "4px 0" }}
@@ -248,21 +275,6 @@ export function SiteCreateWizard(
               />
             </label>
             <label
-              htmlFor="site-create-template-name"
-              style={{ display: "block", margin: "4px 0" }}
-            >
-              {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}
-              <input
-                id="site-create-template-name"
-                type="text"
-                data-testid="site-create-template-name"
-                value={templateName}
-                maxLength={100}
-                onChange={(e) => handleTemplateNameChange(e.target.value)}
-                style={{ marginLeft: 8, width: 240 }}
-              />
-            </label>
-            <label
               htmlFor="site-create-managed-nav"
               style={{ display: "block", margin: "8px 0 4px 0" }}
             >
@@ -277,64 +289,18 @@ export function SiteCreateWizard(
               {message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_LABEL)}
             </label>
             <p
-              style={{ color: "#555", fontSize: "0.85em", margin: "0 0 8px 24px" }}
+              style={{
+                color: "#555",
+                fontSize: "0.85em",
+                margin: "0 0 8px 24px",
+              }}
               data-testid="site-create-managed-nav-help"
             >
               {message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_HELP)}
             </p>
           </fieldset>
         );
-      case 1:
-        return (
-          <fieldset data-testid="site-create-step-template">
-            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_TEMPLATE)}</legend>
-            {templatesLoading ? (
-              <p role="status" data-testid="site-create-templates-loading">
-                {message(EXPLORER_MSG.SITE_CREATE_TEMPLATES_LOADING)}
-              </p>
-            ) : null}
-            {templatesError ? (
-              <p
-                role="alert"
-                data-testid="site-create-templates-error"
-                style={{ color: "#b00020" }}
-              >
-                {templatesError}
-              </p>
-            ) : null}
-            <label
-              htmlFor="site-create-base-template"
-              style={{ display: "block", margin: "4px 0" }}
-            >
-              {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}
-              {templates.length > 0 ? (
-                <select
-                  id="site-create-base-template"
-                  data-testid="site-create-base-template"
-                  value={baseTemplateName}
-                  onChange={(e) => setBaseTemplateName(e.target.value)}
-                  style={{ marginLeft: 8, minWidth: 240 }}
-                >
-                  {templates.map((t) => (
-                    <option key={t.id ?? t.name} value={t.name}>
-                      {t.label || t.name}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  id="site-create-base-template"
-                  type="text"
-                  data-testid="site-create-base-template"
-                  value={baseTemplateName}
-                  onChange={(e) => setBaseTemplateName(e.target.value)}
-                  style={{ marginLeft: 8, width: 240 }}
-                />
-              )}
-            </label>
-          </fieldset>
-        );
-      case 2:
+      case "confirm":
         return (
           <fieldset data-testid="site-create-step-confirm">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_CONFIRM)}</legend>
@@ -342,27 +308,13 @@ export function SiteCreateWizard(
               style={{ listStyle: "none", padding: 0 }}
               data-testid="site-create-confirm-summary"
             >
+              <li data-testid="site-create-confirm-type">
+                <strong>{message(EXPLORER_MSG.SITE_CREATE_TYPE_LABEL)}:</strong>{" "}
+                {typeLabel(siteType)}
+              </li>
               <li>
                 <strong>{message(EXPLORER_MSG.SITE_CREATE_NAME_LABEL)}:</strong>{" "}
                 <code>{siteName}</code>
-              </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}:
-                </strong>{" "}
-                <code>{templateName}</code>
-              </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}:
-                </strong>{" "}
-                <code>{baseTemplateName}</code>
-              </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_REPOSITORY_KIND)}:
-                </strong>{" "}
-                {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL)}
               </li>
               <li data-testid="site-create-confirm-managed-nav">
                 <strong>
@@ -375,7 +327,7 @@ export function SiteCreateWizard(
             </ul>
           </fieldset>
         );
-      case 3:
+      case "progress":
         return (
           <fieldset data-testid="site-create-step-progress">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_PROGRESS)}</legend>
@@ -404,6 +356,10 @@ export function SiteCreateWizard(
 
   const finalStep = isFinalStep(wizard);
   const result = wizard.result;
+  const nextDisabled =
+    wizard.submitting ||
+    (stepId === "type" && !typeReady) ||
+    (stepId === "details" && !detailsReady);
 
   return (
     <section
@@ -441,11 +397,7 @@ export function SiteCreateWizard(
           <button
             type="button"
             data-testid="site-create-next"
-            disabled={
-              wizard.submitting ||
-              (wizard.current === 0 && !detailsReady) ||
-              (wizard.current === 1 && !templateReady)
-            }
+            disabled={nextDisabled}
             onClick={() => setWizard((w) => advance(w))}
           >
             {message(EXPLORER_MSG.WIZARD_NEXT)}

--- a/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
+++ b/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
@@ -111,15 +111,54 @@ export function clampSiteDescription(raw: string): string {
 }
 
 /**
+ * Site kinds shown on the Create Site type picker (#3522 / parent #3512).
+ * Slice 1 ships Traditional only; Page and Virtual stay blocked until
+ * later slices.
+ */
+export type SiteCreateKind = "traditional" | "page" | "virtual";
+
+export const SITE_CREATE_KINDS: readonly SiteCreateKind[] = [
+  "traditional",
+  "page",
+  "virtual",
+];
+
+/**
+ * True when the chosen kind may leave the type-picker step. Slice 1:
+ * Traditional only.
+ */
+export function isSiteCreateKindEnabled(kind: SiteCreateKind): boolean {
+  return kind === "traditional";
+}
+
+/**
  * True when the create form has enough fields to submit (client-side only).
+ *
+ * <p>Traditional (#3522) does not prompt for template/base — those values
+ * are generated. When {@code siteType} is Traditional (default) and
+ * template/base are omitted, only the site name is required. Page and
+ * Virtual cannot submit from this slice.</p>
  */
 export function canSubmitCreateSite(fields: {
   siteName: string;
-  templateName: string;
-  baseTemplateName: string;
+  templateName?: string;
+  baseTemplateName?: string;
+  siteType?: SiteCreateKind;
 }): boolean {
+  const kind = fields.siteType ?? "traditional";
+  if (!isSiteCreateKindEnabled(kind)) {
+    return false;
+  }
   const site = validateSiteName(fields.siteName);
-  const tmpl = validateTemplateName(fields.templateName);
+  if (!site.ok) {
+    return false;
+  }
+  const hasTemplateFields =
+    fields.templateName != null || fields.baseTemplateName != null;
+  if (!hasTemplateFields) {
+    return true;
+  }
+  const tmpl = validateTemplateName(fields.templateName ?? "");
   const base = (fields.baseTemplateName ?? "").trim();
-  return site.ok && tmpl.ok && base.length > 0;
+  return tmpl.ok && base.length > 0;
 }

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -737,7 +737,11 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     expect(screen.getByTestId("architecture-new-site-title").textContent).toMatch(
       /New Site/i,
     );
-    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    expect(
+      (screen.getByTestId("site-create-type-traditional") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
     expect(screen.getByTestId("architecture-new-site-panel").getAttribute("role")).toBe(
       "dialog",
     );
@@ -773,16 +777,17 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     fireEvent.click(screen.getByTestId("architecture-action-new-site"));
     await waitFor(() => {
+      expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
       expect(screen.getByTestId("site-create-name")).toBeTruthy();
     });
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Acme" },
     });
     fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
+    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
     fireEvent.click(screen.getByTestId("site-create-next"));
     fetchSites.mockRejectedValue(new Error("catalog down"));
     fireEvent.click(screen.getByTestId("site-create-run"));

--- a/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
@@ -15,59 +15,107 @@ import type { CreateSiteRequest } from "../../../main/ts/api/contentExplorer/sit
 import { SiteCreateWizard } from "../../../main/ts/contentExplorer/wizards/SiteCreateWizard";
 import { renderA11yGate } from "./a11y";
 
-const baseTemplates = [
-  { name: "perc.base.plain", id: "1", label: "Plain" },
-  { name: "perc.base.other", id: "2", label: "Other" },
-];
-
 function renderWizard(
   overrides: Partial<ComponentProps<typeof SiteCreateWizard>> = {},
 ) {
-  return render(
-    <SiteCreateWizard
-      loadBaseTemplates={async () => baseTemplates}
-      {...overrides}
-    />,
-  );
+  return render(<SiteCreateWizard {...overrides} />);
 }
 
-describe("SiteCreateWizard (#3002)", () => {
-  it("renders the 4-step wizard at details", async () => {
+function chooseTraditionalAndOpenDetails(siteName = "Acme"): void {
+  expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+  expect(
+    (screen.getByTestId("site-create-type-traditional") as HTMLInputElement)
+      .checked,
+  ).toBe(true);
+  fireEvent.click(screen.getByTestId("site-create-next"));
+  expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+  fireEvent.change(screen.getByTestId("site-create-name"), {
+    target: { value: siteName },
+  });
+}
+
+describe("SiteCreateWizard (#3522 / #3002)", () => {
+  it("renders the type picker first with Traditional selected", () => {
     renderWizard();
     expect(screen.getByTestId("site-create-wizard")).toBeTruthy();
-    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    expect(screen.getByTestId("site-create-type-traditional")).toBeTruthy();
+    expect(screen.getByTestId("site-create-type-page")).toBeTruthy();
+    expect(screen.getByTestId("site-create-type-virtual")).toBeTruthy();
+    expect(
+      (screen.getByTestId("site-create-type-traditional") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(screen.getByTestId("site-create-traditional-note")).toBeTruthy();
     expect(screen.getByTestId("site-create-step-count").textContent).toMatch(
       /Step 1.*of 4/,
     );
-    expect(screen.getByTestId("site-create-traditional-note")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
+    expect(screen.queryByTestId("site-create-step-details")).toBeNull();
+    expect(screen.queryByTestId("site-create-template-name")).toBeNull();
   });
 
-  it("Next is disabled until site name and template name are valid", async () => {
+  it("blocks Next on Page and Virtual with a clear message", () => {
     renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
+    const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(false);
+
+    fireEvent.click(screen.getByTestId("site-create-type-page"));
+    expect(
+      (screen.getByTestId("site-create-type-page") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(screen.getByTestId("site-create-type-unavailable")).toBeTruthy();
+    expect(next.disabled).toBe(true);
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    expect(screen.queryByTestId("site-create-step-details")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("site-create-type-virtual"));
+    expect(
+      (screen.getByTestId("site-create-type-virtual") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+    expect(screen.getByTestId("site-create-type-unavailable")).toBeTruthy();
+    expect(next.disabled).toBe(true);
+
+    fireEvent.click(screen.getByTestId("site-create-type-traditional"));
+    expect(next.disabled).toBe(false);
+    expect(screen.queryByTestId("site-create-type-unavailable")).toBeNull();
+  });
+
+  it("Traditional skips template-name and base-template steps", () => {
+    renderWizard();
+    chooseTraditionalAndOpenDetails("Acme");
+    expect(screen.queryByTestId("site-create-template-name")).toBeNull();
+    expect(screen.queryByTestId("site-create-base-template")).toBeNull();
+
+    const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(false);
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
+    expect(screen.getByTestId("site-create-confirm-type").textContent).toMatch(
+      /Traditional/i,
+    );
+    expect(screen.getByTestId("site-create-confirm-summary").textContent).toContain(
+      "Acme",
+    );
+    expect(screen.queryByTestId("site-create-template-name")).toBeNull();
+    expect(screen.queryByTestId("site-create-base-template")).toBeNull();
+  });
+
+  it("Next on details is disabled until site name is valid", () => {
+    renderWizard();
+    fireEvent.click(screen.getByTestId("site-create-next"));
     const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
     expect(next.disabled).toBe(true);
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Acme" },
     });
-    // Template name auto-seeds from site name.
-    expect(
-      (screen.getByTestId("site-create-template-name") as HTMLInputElement)
-        .value,
-    ).toBe("AcmeTemplate");
     expect(next.disabled).toBe(false);
   });
 
-  it("filters invalid site name characters on input", async () => {
+  it("filters invalid site name characters on input", () => {
     renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Bad Name!" },
     });
@@ -76,42 +124,16 @@ describe("SiteCreateWizard (#3002)", () => {
     ).toBe("BadName");
   });
 
-  it("advances through template and confirm steps", async () => {
-    renderWizard();
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(screen.getByTestId("site-create-step-template")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
-    expect(screen.getByTestId("site-create-confirm-summary").textContent).toContain(
-      "Acme",
-    );
-    expect(
-      screen.getByTestId("site-create-confirm-managed-nav").textContent,
-    ).toMatch(/Yes/i);
-  });
-
   it("can opt out of managed navigation on a traditional site", async () => {
     const submit = vi.fn().mockResolvedValue({ name: "Bare" });
     renderWizard({ submit });
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Bare" },
-    });
+    chooseTraditionalAndOpenDetails("Bare");
     const checkbox = screen.getByTestId(
       "site-create-managed-nav",
     ) as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
     fireEvent.click(checkbox);
     expect(checkbox.checked).toBe(false);
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
     fireEvent.click(screen.getByTestId("site-create-next"));
     expect(
       screen.getByTestId("site-create-confirm-managed-nav").textContent,
@@ -123,19 +145,15 @@ describe("SiteCreateWizard (#3002)", () => {
     });
     const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
     expect(req.managedNavigation).toBe(false);
+    expect(req.baseTemplateName).toBe("perc.base.plain");
+    expect(req.templateName).toBe("BareTemplate");
   });
 
   it("Run invokes submit and fires onCreated with /Sites path", async () => {
     const submit = vi.fn().mockResolvedValue({ name: "Acme", id: "9" });
     const onCreated = vi.fn();
     renderWizard({ submit, onCreated });
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
+    chooseTraditionalAndOpenDetails("Acme");
     fireEvent.click(screen.getByTestId("site-create-next"));
     fireEvent.click(screen.getByTestId("site-create-next"));
     expect(screen.getByTestId("site-create-step-progress")).toBeTruthy();
@@ -162,13 +180,7 @@ describe("SiteCreateWizard (#3002)", () => {
   it("Run surfaces submit errors", async () => {
     const submit = vi.fn().mockRejectedValue(new Error("duplicate site"));
     renderWizard({ submit });
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
+    chooseTraditionalAndOpenDetails("Acme");
     fireEvent.click(screen.getByTestId("site-create-next"));
     fireEvent.click(screen.getByTestId("site-create-next"));
     fireEvent.click(screen.getByTestId("site-create-run"));
@@ -180,11 +192,8 @@ describe("SiteCreateWizard (#3002)", () => {
     );
   });
 
-  it("passes the zero serious/critical axe-core gate (step 0)", async () => {
+  it("passes the zero serious/critical axe-core gate (type step)", async () => {
     const { container } = renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
     await renderA11yGate(container);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
@@ -15,6 +15,7 @@ import {
   defaultTemplateNameForSite,
   filterSiteNameInput,
   filterTemplateNameInput,
+  isSiteCreateKindEnabled,
   SITE_DESCRIPTION_MAX_LENGTH,
   SITE_NAME_MAX_LENGTH,
   validateSiteName,
@@ -63,7 +64,8 @@ describe("siteCreateValidation (#3002)", () => {
     expect(clampSiteDescription(long).length).toBe(SITE_DESCRIPTION_MAX_LENGTH);
   });
 
-  it("canSubmitCreateSite requires site, template, and base template", () => {
+  it("canSubmitCreateSite requires site name; template/base optional for Traditional", () => {
+    expect(canSubmitCreateSite({ siteName: "A" })).toBe(true);
     expect(
       canSubmitCreateSite({
         siteName: "A",
@@ -85,5 +87,17 @@ describe("siteCreateValidation (#3002)", () => {
         baseTemplateName: "  ",
       }),
     ).toBe(false);
+    expect(canSubmitCreateSite({ siteName: "A", siteType: "page" })).toBe(
+      false,
+    );
+    expect(canSubmitCreateSite({ siteName: "A", siteType: "virtual" })).toBe(
+      false,
+    );
+  });
+
+  it("isSiteCreateKindEnabled is Traditional-only in slice 1", () => {
+    expect(isSiteCreateKindEnabled("traditional")).toBe(true);
+    expect(isSiteCreateKindEnabled("page")).toBe(false);
+    expect(isSiteCreateKindEnabled("virtual")).toBe(false);
   });
 });

--- a/docs/ai-generated/code-reviews/3522-site-type-picker-erlang.md
+++ b/docs/ai-generated/code-reviews/3522-site-type-picker-erlang.md
@@ -1,0 +1,53 @@
+# Erlang review — #3522 SiteCreateWizard type picker + Traditional path
+
+**Branch:** `feat/issue-3522-site-type-picker`  
+**Scope:** uncommitted vs `origin/main`  
+**Date:** 2026-08-17  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Slice 1 of parent #3512 adds a first **Site type** step (Traditional / Page / Virtual) on the shared `SiteCreateWizard` used by Explorer **Content → Create Site** and Navigation **New Site**. Traditional create skips the page/base template prompt; Page and Virtual stay on the type step with a blocking message. Traditional still `POST`s `/services/sitemanage/site/` via `createTraditionalSite` with generated template name + `perc.base.plain`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (Vitest wizard + validation; Playwright surface + ArchitectureShell)
+- Cross-platform path I/O: N/A (no filesystem path construction)
+- **May commit/push:** yes
+
+## Issues
+
+None (gate).
+
+### Notes (non-blocking)
+
+- `loadBaseTemplates` was dropped from wizard props because Traditional no longer catalogs templates. Callers did not pass it in production; ArchitectureShell tests still spy `listBaseTemplates` harmlessly.
+- Page/Virtual radios are selectable (not `disabled`) so operators see the kinds and the unavailable message; Next is disabled so those kinds cannot silently create Traditional sites.
+- Confirm no longer lists template/base for Traditional. API body still includes generated values so the existing Site contract stays valid.
+
+## Change-class companions
+
+| Kind | Status |
+|------|--------|
+| WebUI product screen | `SiteCreateWizard.tsx` + hosts unchanged |
+| Vitest | picker + Traditional skip-template + ArchitectureShell first-step |
+| Playwright | helper TEST_IDS, explorer chrome/happy path, new type-picker spec, architecture smoke |
+| product-docs | `sites.md`, `architecture-navigation.md`, `content-explorer.md` |
+| i18n | few `EXPLORER_MSG` keys only |
+
+## Cross-platform path checklist
+
+N/A — no new file I/O or path assertions.
+
+## Memory patterns hit
+
+- WebUI screen change requires Playwright companion
+- Product-facing change requires `product-docs/8.2`
+- Shared wizard used by two hosts — update both test surfaces
+
+> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -109,7 +109,10 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(newSite).toContainText(/New Site/i);
     await newSite.click();
     await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();
-    await expect(page.getByTestId("site-create-step-details")).toBeVisible();
+    await expect(page.getByTestId("site-create-step-type")).toBeVisible();
+    await expect(page.getByTestId("site-create-type-traditional")).toBeChecked();
+    await expect(page.getByTestId("site-create-type-page")).toBeVisible();
+    await expect(page.getByTestId("site-create-type-virtual")).toBeVisible();
     await page.getByTestId("architecture-new-site-close").click();
     await expect(page.getByTestId("architecture-new-site-panel")).toHaveCount(0);
     expect(pageErrors, pageErrors.join("\n")).toEqual([]);

--- a/modules/perc-qa-automation/frontend/tests/explorer-site-create-type-picker.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-site-create-type-picker.spec.js
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Playwright surface: #3522 / parent #3512 — Create Site type picker +
+ * Traditional path (no page / base template prompt).
+ *
+ * <p>Covers Explorer Content → Create Site and Navigation New Site:</p>
+ * <ul>
+ *   <li>Type picker first (Traditional / Page / Virtual); Traditional default</li>
+ *   <li>Page and Virtual stay on the type step with a clear message</li>
+ *   <li>Traditional: details → confirm with no template-name / base-template</li>
+ * </ul>
+ *
+ * <p>Tags: {@code @explorer-site-create-type-picker} {@code @explorer}
+ * {@code @sites} {@code @architecture}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-site-create-type-picker.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  TEST_IDS,
+  explorerSpaUrl,
+  openContentMenu,
+  uniqueQaSiteName,
+  createSiteMissingSkipReason,
+  isKnownExplorerSitesConsoleNoise,
+  advanceTraditionalTypeStep,
+} = require("./helpers/explorer-sites-list-create");
+
+function architectureUrl() {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<boolean>}
+ */
+async function openExplorerCreateSiteOrSkip(page) {
+  await loginAsAdmin(page);
+  await page.goto(explorerSpaUrl(BASE_URL), { waitUntil: "networkidle" });
+  await expect(
+    page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+  ).toBeVisible({ timeout: 20_000 });
+  await openContentMenu(page);
+  const menuItem = page.locator(`[data-testid="${TEST_IDS.createSiteMenu}"]`);
+  if ((await menuItem.count()) === 0) {
+    test.skip(createSiteMissingSkipReason());
+    return false;
+  }
+  await menuItem.click();
+  await expect(
+    page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
+  ).toBeVisible({ timeout: 10_000 });
+  return true;
+}
+
+test.describe("Create Site type picker (#3522 / #3512)", () => {
+  test(
+    "Explorer: type picker defaults Traditional; Page/Virtual block Next",
+    {
+      tag: [
+        "@explorer-site-create-type-picker",
+        "@explorer",
+        "@sites",
+      ],
+    },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      const consoleErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() !== "error") {
+          return;
+        }
+        const text = msg.text();
+        if (!isKnownExplorerSitesConsoleNoise(text)) {
+          consoleErrors.push(text);
+        }
+      });
+
+      const present = await openExplorerCreateSiteOrSkip(page);
+      if (!present) {
+        return;
+      }
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`),
+      ).toBeChecked();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typePage}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`),
+      ).toBeVisible();
+
+      const next = page.locator(`[data-testid="${TEST_IDS.next}"]`);
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+      ).toBeVisible();
+      await expect(next).toBeDisabled();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepDetails}"]`),
+      ).toHaveCount(0);
+
+      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).check();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+      ).toBeVisible();
+      await expect(next).toBeDisabled();
+
+      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
+      await expect(next).toBeEnabled();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+      ).toHaveCount(0);
+
+      expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+      expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+    },
+  );
+
+  test(
+    "Explorer: Traditional skips page/base template and reaches confirm",
+    {
+      tag: [
+        "@explorer-site-create-type-picker",
+        "@explorer",
+        "@sites",
+      ],
+    },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const present = await openExplorerCreateSiteOrSkip(page);
+      if (!present) {
+        return;
+      }
+
+      await advanceTraditionalTypeStep(page);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.templateName}"]`),
+      ).toHaveCount(0);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
+      ).toHaveCount(0);
+
+      const siteName = uniqueQaSiteName("QaType");
+      await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
+      ).toHaveCount(0);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmType}"]`),
+      ).toContainText(/Traditional/i);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmSummary}"]`),
+      ).toContainText(siteName);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmManagedNav}"]`),
+      ).toContainText(/Yes/i);
+    },
+  );
+
+  test(
+    "Navigation New Site opens the same type picker",
+    {
+      tag: [
+        "@explorer-site-create-type-picker",
+        "@architecture",
+        "@sites",
+      ],
+    },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+      await loginAsAdmin(page);
+      await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+      await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+        timeout: 20_000,
+      });
+      const newSite = page.getByTestId("architecture-action-new-site");
+      if ((await newSite.count()) === 0) {
+        test.skip("BUG: Navigation New Site affordance not present in image.");
+        return;
+      }
+      await expect(newSite).toBeEnabled();
+      await newSite.click();
+      await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();
+      await expect(page.getByTestId(TEST_IDS.stepType)).toBeVisible();
+      await expect(page.getByTestId(TEST_IDS.typeTraditional)).toBeChecked();
+      await expect(page.getByTestId(TEST_IDS.typePage)).toBeVisible();
+      await expect(page.getByTestId(TEST_IDS.typeVirtual)).toBeVisible();
+      expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
@@ -23,8 +23,8 @@
  *   <li>REST: expanding a sample site (folderPath / sitename) lists children (#3326)</li>
  *   <li>UI: Sites tree expands to child site nodes when list is non-empty</li>
  *   <li>UI: selecting a sample site shows folder children, not LIST_EMPTY (#3326)</li>
- *   <li>Create Site: Content menu always exposes Create Site; wizard details →
- *       template → confirm chrome; optional live submit when affordance present</li>
+ *   <li>Create Site: Content menu always exposes Create Site; wizard type →
+ *       details → confirm chrome (no page template); optional live submit</li>
  * </ul>
  *
  * <p><strong>Soft-skip policy (acceptance #3003):</strong> empty Sites list may
@@ -70,6 +70,7 @@ const {
   createSiteMissingSkipReason,
   emptySitesSoftSkipNote,
   isKnownExplorerSitesConsoleNoise,
+  advanceTraditionalTypeStep,
 } = require("./helpers/explorer-sites-list-create");
 
 const SITES_URL = sitesFolderUrl(BASE_URL);
@@ -348,7 +349,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
   );
 
   test(
-    "Create Site wizard: details → template → confirm chrome",
+    "Create Site wizard: type → details → confirm chrome (no page template)",
     { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
     async ({ page }) => {
       test.setTimeout(90_000);
@@ -373,11 +374,23 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       await expect(wizard).toBeVisible({ timeout: 10_000 });
 
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.stepDetails}"]`),
+        page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`),
+      ).toBeChecked();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typePage}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`),
       ).toBeVisible();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
       ).toBeVisible();
+
+      await advanceTraditionalTypeStep(page);
+
       const managedNav = page.locator(
         `[data-testid="${TEST_IDS.managedNav}"]`,
       );
@@ -389,7 +402,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.templateName}"]`),
-      ).not.toHaveValue("");
+      ).toHaveCount(0);
 
       const next = page.locator(`[data-testid="${TEST_IDS.next}"]`);
       await expect(next).toBeEnabled({ timeout: 5_000 });
@@ -397,12 +410,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
 
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
-      ).toBeVisible({ timeout: 10_000 });
-      await expect(
-        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
-      ).toBeVisible({ timeout: 15_000 });
-
-      await next.click();
+      ).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
       ).toBeVisible({ timeout: 10_000 });
@@ -411,6 +419,9 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       );
       await expect(summary).toBeVisible();
       await expect(summary).toContainText(siteName);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmType}"]`),
+      ).toContainText(/Traditional/i);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.confirmManagedNav}"]`),
       ).toContainText(/No/i);
@@ -442,6 +453,8 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
         page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
+      await advanceTraditionalTypeStep(page);
+
       const siteName = uniqueQaSiteName("QaCreate");
       await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
 
@@ -450,12 +463,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       await next.click();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
-      ).toBeVisible({ timeout: 10_000 });
-      // Wait for base template control (list load or fallback input).
-      await expect(
-        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
-      ).toBeVisible({ timeout: 20_000 });
-      await next.click();
+      ).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
       ).toBeVisible({ timeout: 10_000 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
@@ -21,6 +21,12 @@ const TEST_IDS = Object.freeze({
   createSiteMenu: "explorer-content-create-site",
   createSitePanel: "explorer-site-create-panel",
   wizard: "site-create-wizard",
+  stepType: "site-create-step-type",
+  typeTraditional: "site-create-type-traditional",
+  typePage: "site-create-type-page",
+  typeVirtual: "site-create-type-virtual",
+  typeUnavailable: "site-create-type-unavailable",
+  confirmType: "site-create-confirm-type",
   stepDetails: "site-create-step-details",
   stepTemplate: "site-create-step-template",
   stepConfirm: "site-create-step-confirm",
@@ -171,6 +177,20 @@ function folderChildrenUrl(baseUrl, cmsPath) {
 }
 
 /**
+ * Advance the Create Site wizard from the type picker (Traditional default).
+ * @param {import('@playwright/test').Page} page
+ */
+async function advanceTraditionalTypeStep(page) {
+  const typeStep = page.locator(`[data-testid="${TEST_IDS.stepType}"]`);
+  await typeStep.waitFor({ state: "visible", timeout: 10_000 });
+  await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
+  await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+  await page
+    .locator(`[data-testid="${TEST_IDS.stepDetails}"]`)
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+/**
  * Open Content menu dropdown.
  * @param {import('@playwright/test').Page} page
  */
@@ -298,6 +318,7 @@ module.exports = {
   siteChildListCandidates,
   folderChildrenUrl,
   openContentMenu,
+  advanceTraditionalTypeStep,
   sitesTreeRootLocator,
   expandExplorerTreeNode,
   sitesTreeDescendantsLocator,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -46,6 +46,10 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(TEST_IDS.createSiteMenu, "explorer-content-create-site");
     assert.equal(TEST_IDS.createSitePanel, "explorer-site-create-panel");
     assert.equal(TEST_IDS.wizard, "site-create-wizard");
+    assert.equal(TEST_IDS.stepType, "site-create-step-type");
+    assert.equal(TEST_IDS.typeTraditional, "site-create-type-traditional");
+    assert.equal(TEST_IDS.typePage, "site-create-type-page");
+    assert.equal(TEST_IDS.typeVirtual, "site-create-type-virtual");
     assert.equal(TEST_IDS.siteName, "site-create-name");
     assert.equal(TEST_IDS.run, "site-create-run");
     assert.equal(TEST_IDS.managedNav, "site-create-managed-nav");

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -39,9 +39,15 @@ dispatcher applies that preference and opens the Navigation SPA — not Home.
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
 4. Expand and collapse nodes with the mouse or keyboard (Enter/Space, Arrow Left/Right).
 5. Use **Refresh** to reload the tree after external changes.
-6. Use **New Site** (Admin or Designer) to open the same traditional-site wizard
-   used in Content Explorer. After a successful create, the new site is selected
-   in this shell.
+6. Use **New Site** (Admin or Designer) to open the same Create Site wizard
+   used in Content Explorer. The first step is **Site type**
+   (**Traditional** / **Page** / **Virtual**; **Traditional** is the default).
+   Traditional create continues to site name, optional **Include managed
+   navigation**, and confirm — it does **not** prompt for a page or base
+   template. **Page** and **Virtual** stay on the type step with a message
+   until those kinds ship (they do not silently create a Traditional site).
+   After a successful Traditional create, the new site is selected in this
+   shell.
 7. Use **Copy Site** (Admin or Designer) with a site selected to open the
    existing site-copy wizard (same sitemanage copy service as Explorer). The
    source is prefilled from the current site. A copy already in progress blocks
@@ -232,7 +238,7 @@ Home / the Blogs gadget — Navigation will not grow a second blog editor.
 | SPA route + top-nav entry under product chrome | **Available** |
 | Role gate (Admin / Designer) | **Available** |
 | Site picker | **Available** |
-| New Site (Explorer create-site wizard) | **Available** |
+| New Site (type picker + Traditional path) | **Available** (Page / Virtual kinds listed, not yet creatable) |
 | Copy Site (existing sitemanage copy wizard) | **Available** |
 | Delete Site (confirm + picker refresh) | **Available** |
 | Site navigation tree browse (navons / sections) | **Available** |

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -166,10 +166,13 @@ and the site NavTree).
 To create a new **traditional** repository Site from Explorer:
 
 1. Choose **Content → Create Site** (available without selecting an existing site).
-2. Complete the wizard: site name → base template → confirm → create.
+2. Complete the wizard: **Site type** (default **Traditional**) → site name and
+   optional managed navigation → confirm → create. Traditional does not prompt
+   for a page or base template. **Page** and **Virtual** are visible but not
+   creatable yet.
 3. On success, Explorer navigates to `/Sites/<new-site-name>`.
 
-This wizard creates repository Sites only. Configure **Virtual Site** source properties
+This Traditional path creates repository Sites only. Configure **Virtual Site** source properties
 (Git/filesystem) from **Developer → Sites** / Site detail — see
 [Sites & content structure](id:admin-sites) and [Virtual Sites](id:developer-virtual-sites).
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -33,16 +33,16 @@ After a standard install with **sample sites** (installer **Install sample sites
 
 ### Create a traditional Site from Explorer
 
-Use **Content Explorer** when you need a new traditional (repository) Site without leaving the product shell:
+Use **Content Explorer** when you need a new traditional (repository) Site without leaving the product shell. The same wizard opens from **Navigation → New Site**.
 
 1. Open **Content Explorer**.
 2. Choose **Content → Create Site**.
-3. On **Details**, enter a unique **Site name**, optional description, and the site **template name** (defaults from the site name). Traditional sites include **Include managed navigation** (checked by default). Leave it checked to create a NavTree and homepage. Uncheck it to create the site folder only — no NavTree and no homepage. You can add navigation later from Explorer. Virtual Sites do not use this option (`virtual.sourceKind` is their discriminator).
-4. On **Base template**, pick a base template from the catalog (or accept the default when the catalog is empty).
-5. On **Confirm**, review the summary (repository kind is **Traditional** — this flow does not create Virtual Sites) and whether managed navigation is **Yes** or **No**.
+3. On **Site type**, choose **Traditional**, **Page**, or **Virtual**. **Traditional** is selected by default. **Page** and **Virtual** are listed so you can see the kinds, but they are not available yet — **Next** stays on this step with a message until those kinds ship. Choosing **Page** or **Virtual** does **not** create a Traditional site.
+4. On **Site details**, enter a unique **Site name** and optional description. Traditional sites include **Include managed navigation** (checked by default). Leave it checked to create a NavTree and homepage. Uncheck it to create the site folder only — no NavTree and no homepage. You can add navigation later from Explorer. Traditional create does **not** ask for a page template or a base template.
+5. On **Confirm**, review the summary (site type is **Traditional**) and whether managed navigation is **Yes** or **No**.
 6. Choose **Create** and wait for progress to complete. Explorer opens the new site under `/Sites/<name>`. With **Include managed navigation** checked, the server seeds a NavTree, a site template, and the homepage (`index.html`) in that folder in one operation. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
 
-Virtual Site source settings (Git/filesystem) are configured later on the Site properties / Developer Sites surface — not in this Create Site wizard. See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
+**Page** site create (managed navigation required plus a page template) and **Virtual** site create (no navigation option, no page template) are later steps. Virtual Site source settings (Git/filesystem) are configured on the Site properties / Developer Sites surface — not in this Traditional path. See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
 
 ## Virtual Sites (8.2)
 


### PR DESCRIPTION
## Summary

Slice 1 of parent #3512. Adds a **Site type** first step (Traditional / Page / Virtual) on the shared `SiteCreateWizard` used by Explorer **Content → Create Site** and Navigation **New Site**.

- Default is **Traditional**.
- Traditional continues to name, optional **Include managed navigation**, confirm, and create. It does **not** prompt for a page or base template. Create still uses `POST /services/sitemanage/site/` via `createTraditionalSite` (generated template name + `perc.base.plain`).
- **Page** and **Virtual** are visible. Choosing them keeps **Next** on the type step with a clear message — they do not silently create a Traditional site.

Parent: #3512  
Partial #3512  
Fixes #3522

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. QA H2: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (Docker Health=healthy / HTTP 200).
2. Hot-copy `WebUI/target/generated-webui/cm/modern/assets` into the QA WAR `cm/modern/assets`.
3. Explorer: Content → Create Site. Confirm type picker; Traditional default; Page/Virtual show the unavailable message and block Next.
4. Traditional: details (name + managed nav) → confirm (no template fields) → Create. Site opens under `/Sites/<name>`.
5. Navigation → New Site: same type picker.
6. Surface-filtered Playwright as below.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `architecture-navigation.md`, and `content-explorer.md`
- [x] **Unit / module tests** — Vitest wizard + validation; ArchitectureShell first-step; helper unit tests
- [x] **WebUI + Playwright** — `explorer-site-create-type-picker.spec.js` plus updated explorer create + architecture smoke
- [x] **Build gates** — standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2689, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `npm run test:unit` (perc-qa-automation/frontend) → 303 passed
- **downstream_checked:** none (C2 did not apply — no Java `final`/signature/API shape change)

## C5 UI proof

- `perc-devctl qa-up --skip-image-build` cell `perc-matrix-cms-h2` **TEST_CMS_URL=http://127.0.0.1:9993** (Docker Health=healthy, HTTP 200). `qa-health` reported `DETAIL:server_log_errors` for pre-existing FastForward `PSDbStorageService` import noise (`CI_PS_products_on.gif`) — not `Failed startup of context`.
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets` → `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets` (verified `SiteCreateWizard-*.js` contains `site-create-type-traditional`).
- Playwright (`ADMIN_USERNAME=Admin`, `TEST_DB_TYPE=h2`, `TEST_PRODUCT=cms`):
  - `npm run test:surface -- --path tests/explorer-site-create-type-picker.spec.js` → 3 passed
  - `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js` → 7 passed (includes live Traditional create)
  - `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` → 2 passed
  - `npm run test:golden` → 2 passed
- **console-clean=yes** (pageerror + console error listeners on type-picker spec)
- **server.log-clean=yes** for this feature (no site-create ERROR/FATAL). Remaining ERROR lines are known seed/index/type-315 noise.
- Tear-down: `perc-devctl qa-down`

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
