### PR TITLE
feat(WebUI): Page site create from type picker (#3520)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
@@ -47,6 +47,12 @@ export interface CreateSiteRequest {
    * without a CMS NavTree / homepage. Virtual Sites do not send this flag.
    */
   managedNavigation?: boolean;
+  /**
+   * CM1 page-based site ({@code pageBased} / {@code IS_PAGE_BASED} on
+   * POST /sitemanage/site/). Send {@code true} for Page type. Traditional
+   * omits this field.
+   */
+  pageBased?: boolean;
 }
 
 /** Minimal site summary returned after create (name is required for navigation). */
@@ -74,18 +80,20 @@ export function buildCreateSiteBody(req: CreateSiteRequest): {
   const home = (req.homePageTitle ?? DEFAULT_HOME_PAGE_TITLE).trim() || DEFAULT_HOME_PAGE_TITLE;
   const nav = (req.navigationTitle ?? home).trim() || home;
   const managedNavigation = req.managedNavigation !== false;
-  return {
-    Site: {
-      name,
-      label: (req.label ?? name).trim() || name,
-      description: (req.description ?? "").trim(),
-      homePageTitle: home,
-      navigationTitle: nav,
-      baseTemplateName: req.baseTemplateName.trim(),
-      templateName: req.templateName.trim(),
-      managedNavigation,
-    },
+  const site: Record<string, string | boolean> = {
+    name,
+    label: (req.label ?? name).trim() || name,
+    description: (req.description ?? "").trim(),
+    homePageTitle: home,
+    navigationTitle: nav,
+    baseTemplateName: req.baseTemplateName.trim(),
+    templateName: req.templateName.trim(),
+    managedNavigation,
   };
+  if (req.pageBased === true) {
+    site.pageBased = true;
+  }
+  return { Site: site };
 }
 
 /**

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -100,8 +100,9 @@ export const EXPLORER_MSG = {
   SITE_COPY_SELECT_SITE:
     "perc.ui.explorer@Open a site under Sites to copy it.",
 
-  // Create Site (#3002 / parent #2989) — traditional repository default
+  // Create Site (#3002 / parent #2989 / type picker #3512)
   SITE_CREATE_TITLE: "perc.ui.explorer@Create Site",
+  SITE_CREATE_STEP_TYPE: "perc.ui.explorer@Site type",
   SITE_CREATE_STEP_DETAILS: "perc.ui.explorer@Site details",
   SITE_CREATE_STEP_TEMPLATE: "perc.ui.explorer@Base template",
   SITE_CREATE_STEP_CONFIRM: "perc.ui.explorer@Confirm",
@@ -113,17 +114,27 @@ export const EXPLORER_MSG = {
   SITE_CREATE_TEMPLATE_NAME_LABEL: "perc.ui.explorer@Template name",
   SITE_CREATE_BASE_TEMPLATE_LABEL: "perc.ui.explorer@Base template",
   SITE_CREATE_TRADITIONAL_NOTE:
-    "perc.ui.explorer@Creates a traditional repository site (default).",
+    "perc.ui.explorer@Creates a traditional repository site. Managed navigation is optional. A page template is not required.",
+  SITE_CREATE_PAGE_NOTE:
+    "perc.ui.explorer@Creates a page-based site. Managed navigation is required. Choose a page template on the next step.",
   SITE_CREATE_REPOSITORY_KIND: "perc.ui.explorer@Repository",
+  SITE_CREATE_TYPE_LABEL: "perc.ui.explorer@Site type",
   SITE_CREATE_TRADITIONAL: "perc.ui.explorer@Traditional",
+  SITE_CREATE_TYPE_PAGE: "perc.ui.explorer@Page",
+  SITE_CREATE_TYPE_VIRTUAL: "perc.ui.explorer@Virtual",
+  SITE_CREATE_TYPE_UNAVAILABLE:
+    "perc.ui.explorer@This site type is not available yet. Choose Traditional or Page to continue.",
   SITE_CREATE_MANAGED_NAV_LABEL: "perc.ui.explorer@Include managed navigation",
   SITE_CREATE_MANAGED_NAV_HELP:
     "perc.ui.explorer@When unchecked, the site folder is created without a NavTree or homepage. You can add navigation later in Explorer. Virtual Sites do not use this option.",
+  SITE_CREATE_MANAGED_NAV_REQUIRED:
+    "perc.ui.explorer@Page sites always include managed navigation.",
   SITE_CREATE_MANAGED_NAV_YES: "perc.ui.explorer@Yes",
   SITE_CREATE_MANAGED_NAV_NO: "perc.ui.explorer@No",
   SITE_CREATE_TEMPLATES_LOADING: "perc.ui.explorer@Loading base templates…",
   SITE_CREATE_TEMPLATES_ERROR: "perc.ui.explorer@Could not load base templates",
-  SITE_CREATE_VALIDATION:
+  SITE_CREATE_VALIDATION: "perc.ui.explorer@Enter a valid site name",
+  SITE_CREATE_VALIDATION_PAGE:
     "perc.ui.explorer@Enter a valid site name, template name, and base template",
   SITE_CREATE_SUBMIT: "perc.ui.explorer@Create site",
   SITE_CREATE_SUBMITTING: "perc.ui.explorer@Creating site…",

--- a/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
+++ b/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
@@ -10,17 +10,22 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
 /**
- * Create Site wizard for modern Explorer (#3002 / parent #2989).
+ * Create Site wizard for Explorer Content → Create Site and Navigation
+ * New Site (#3520 / parent #3512).
  *
- * <p>Four-step flow: details → template → confirm → progress.
- * Creates a traditional (repository) site via sitemanage
- * {@code POST /site/} — no Virtual Site options. Success navigates the
- * host to {@code /Sites/&lt;name&gt;} via {@link SiteCreateWizardProps.onCreated}.</p>
+ * <p>First step is a site-type picker (Traditional / Page / Virtual).
+ * Traditional: type → details (name, description, optional managed nav)
+ * → confirm → progress. No page-template prompt.
+ * Page: type → details (name, description, managed nav locked on)
+ * → page/base template → confirm → progress. Create sends
+ * {@code pageBased: true} on the existing {@code POST /sitemanage/site/}
+ * contract. Virtual stays blocked until slice 3.</p>
  */
 
 import React, { useEffect, useState } from "react";
@@ -40,6 +45,7 @@ import {
   advance,
   back,
   createWizard,
+  currentStepId,
   finishWizard,
   isFinalStep,
   resetWizard,
@@ -51,8 +57,13 @@ import {
   defaultTemplateNameForSite,
   filterSiteNameInput,
   filterTemplateNameInput,
+  isSiteCreateKindEnabled,
+  managedNavigationForcedOn,
+  requiresPageTemplate,
   validateSiteName,
   validateTemplateName,
+  wizardStepsForKind,
+  type SiteCreateKind,
 } from "./siteCreateValidation";
 
 export interface SiteCreateWizardProps {
@@ -73,7 +84,22 @@ export interface SiteCreateWizardProps {
   className?: string;
 }
 
-const STEPS = ["details", "template", "confirm", "progress"];
+const TYPE_TEST_IDS: Record<SiteCreateKind, string> = {
+  traditional: "site-create-type-traditional",
+  page: "site-create-type-page",
+  virtual: "site-create-type-virtual",
+};
+
+function typeLabel(kind: SiteCreateKind): string {
+  switch (kind) {
+    case "page":
+      return message(EXPLORER_MSG.SITE_CREATE_TYPE_PAGE);
+    case "virtual":
+      return message(EXPLORER_MSG.SITE_CREATE_TYPE_VIRTUAL);
+    default:
+      return message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL);
+  }
+}
 
 export function SiteCreateWizard(
   props: SiteCreateWizardProps,
@@ -88,7 +114,10 @@ export function SiteCreateWizard(
     className,
   } = props;
 
-  const [wizard, setWizard] = useState<WizardState>(() => createWizard(STEPS));
+  const [wizard, setWizard] = useState<WizardState>(() =>
+    createWizard(wizardStepsForKind("traditional")),
+  );
+  const [siteType, setSiteType] = useState<SiteCreateKind>("traditional");
   const [siteName, setSiteName] = useState(() =>
     filterSiteNameInput(initialSiteName),
   );
@@ -96,19 +125,20 @@ export function SiteCreateWizard(
   const [templateName, setTemplateName] = useState(() =>
     defaultTemplateNameForSite(initialSiteName),
   );
-  /** When true, site-name edits keep regenerating the default template name. */
   const [templateNameFollowsSite, setTemplateNameFollowsSite] = useState(true);
   const [baseTemplateName, setBaseTemplateName] = useState(
     PLAIN_BASE_TEMPLATE_NAME,
   );
-  /** Traditional sites only. Virtual Sites do not use this flag. */
   const [managedNavigation, setManagedNavigation] = useState(true);
   const [templates, setTemplates] = useState<BaseTemplateSummary[]>([]);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
-  const [templatesLoading, setTemplatesLoading] = useState(true);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
   const [createdName, setCreatedName] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!requiresPageTemplate(siteType)) {
+      return;
+    }
     let cancelled = false;
     setTemplatesLoading(true);
     loadBaseTemplates()
@@ -135,12 +165,25 @@ export function SiteCreateWizard(
     return () => {
       cancelled = true;
     };
-  }, [loadBaseTemplates]);
+  }, [loadBaseTemplates, siteType]);
+
+  function handleSiteTypeChange(kind: SiteCreateKind): void {
+    setSiteType(kind);
+    if (managedNavigationForcedOn(kind)) {
+      setManagedNavigation(true);
+    }
+    setWizard((w) => ({
+      ...w,
+      steps: wizardStepsForKind(kind),
+    }));
+  }
 
   async function handleRun(): Promise<void> {
     const site = validateSiteName(siteName);
+    const pageFlow = requiresPageTemplate(siteType);
     const tmpl = validateTemplateName(templateName);
-    if (!site.ok || !tmpl.ok || !baseTemplateName.trim()) {
+    const base = baseTemplateName.trim();
+    if (!site.ok || !isSiteCreateKindEnabled(siteType)) {
       setWizard((w) =>
         finishWizard(w, {
           kind: "error",
@@ -150,15 +193,34 @@ export function SiteCreateWizard(
       onSettled?.(false);
       return;
     }
+    let resolvedTemplate = defaultTemplateNameForSite(site.name);
+    let resolvedBase = PLAIN_BASE_TEMPLATE_NAME;
+    if (pageFlow) {
+      if (!tmpl.ok || !base) {
+        setWizard((w) =>
+          finishWizard(w, {
+            kind: "error",
+            message: message(EXPLORER_MSG.SITE_CREATE_VALIDATION_PAGE),
+          }),
+        );
+        onSettled?.(false);
+        return;
+      }
+      resolvedTemplate = tmpl.name;
+      resolvedBase = base;
+    }
     setWizard((w) => ({ ...w, submitting: true }));
     const req: CreateSiteRequest = {
       name: site.name,
       label: site.name,
       description: clampSiteDescription(description),
-      baseTemplateName: baseTemplateName.trim(),
-      templateName: tmpl.name,
-      managedNavigation,
+      baseTemplateName: resolvedBase,
+      templateName: resolvedTemplate,
+      managedNavigation: pageFlow ? true : managedNavigation,
     };
+    if (pageFlow) {
+      req.pageBased = true;
+    }
     try {
       const fn = submitOverride ?? createTraditionalSite;
       const created = await fn(req);
@@ -188,32 +250,105 @@ export function SiteCreateWizard(
   }
 
   function handleReset(): void {
-    setWizard((w) => resetWizard(w));
+    setWizard(() => createWizard(wizardStepsForKind("traditional")));
     setCreatedName(null);
+    setSiteType("traditional");
     setManagedNavigation(true);
+    setTemplateName(defaultTemplateNameForSite(siteName));
+    setTemplateNameFollowsSite(true);
   }
 
-  const detailsReady =
-    validateSiteName(siteName).ok && validateTemplateName(templateName).ok;
+  const typeReady = isSiteCreateKindEnabled(siteType);
+  const detailsReady = validateSiteName(siteName).ok;
   const templateReady = baseTemplateName.trim().length > 0;
   const canSubmit = canSubmitCreateSite({
     siteName,
+    siteType,
     templateName,
     baseTemplateName,
   });
+  const stepId = currentStepId(wizard);
+  const navLocked = managedNavigationForcedOn(siteType);
 
   function renderStep(): React.JSX.Element {
-    switch (wizard.current) {
-      case 0:
+    switch (stepId) {
+      case "type":
+        return (
+          <fieldset data-testid="site-create-step-type">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_TYPE)}</legend>
+            <p
+              style={{ color: "#555", fontSize: "0.9em", margin: "0 0 8px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_TYPE_LABEL)}
+            </p>
+            {(
+              [
+                "traditional",
+                "page",
+                "virtual",
+              ] as const satisfies readonly SiteCreateKind[]
+            ).map((kind) => (
+              <label
+                key={kind}
+                htmlFor={TYPE_TEST_IDS[kind]}
+                style={{ display: "block", margin: "6px 0" }}
+              >
+                <input
+                  id={TYPE_TEST_IDS[kind]}
+                  type="radio"
+                  name="site-create-type"
+                  data-testid={TYPE_TEST_IDS[kind]}
+                  value={kind}
+                  checked={siteType === kind}
+                  onChange={() => handleSiteTypeChange(kind)}
+                  style={{ marginRight: 8 }}
+                />
+                {typeLabel(kind)}
+              </label>
+            ))}
+            {siteType === "traditional" ? (
+              <p
+                style={{
+                  color: "#555",
+                  fontSize: "0.85em",
+                  margin: "8px 0 0 24px",
+                }}
+                data-testid="site-create-traditional-note"
+              >
+                {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL_NOTE)}
+              </p>
+            ) : null}
+            {siteType === "page" ? (
+              <p
+                style={{
+                  color: "#555",
+                  fontSize: "0.85em",
+                  margin: "8px 0 0 24px",
+                }}
+                data-testid="site-create-page-note"
+              >
+                {message(EXPLORER_MSG.SITE_CREATE_PAGE_NOTE)}
+              </p>
+            ) : null}
+            {siteType === "virtual" ? (
+              <p
+                role="status"
+                style={{
+                  color: "#8a4b08",
+                  fontSize: "0.9em",
+                  margin: "8px 0 0 0",
+                }}
+                data-testid="site-create-type-unavailable"
+              >
+                {message(EXPLORER_MSG.SITE_CREATE_TYPE_UNAVAILABLE)}
+              </p>
+            ) : null}
+          </fieldset>
+        );
+      case "details":
         return (
           <fieldset data-testid="site-create-step-details">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_DETAILS)}</legend>
-            <p
-              style={{ color: "#555", fontSize: "0.9em", margin: "0 0 8px 0" }}
-              data-testid="site-create-traditional-note"
-            >
-              {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL_NOTE)}
-            </p>
             <label
               htmlFor="site-create-name"
               style={{ display: "block", margin: "4px 0" }}
@@ -248,21 +383,6 @@ export function SiteCreateWizard(
               />
             </label>
             <label
-              htmlFor="site-create-template-name"
-              style={{ display: "block", margin: "4px 0" }}
-            >
-              {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}
-              <input
-                id="site-create-template-name"
-                type="text"
-                data-testid="site-create-template-name"
-                value={templateName}
-                maxLength={100}
-                onChange={(e) => handleTemplateNameChange(e.target.value)}
-                style={{ marginLeft: 8, width: 240 }}
-              />
-            </label>
-            <label
               htmlFor="site-create-managed-nav"
               style={{ display: "block", margin: "8px 0 4px 0" }}
             >
@@ -270,21 +390,32 @@ export function SiteCreateWizard(
                 id="site-create-managed-nav"
                 type="checkbox"
                 data-testid="site-create-managed-nav"
-                checked={managedNavigation}
-                onChange={(e) => setManagedNavigation(e.target.checked)}
+                checked={navLocked ? true : managedNavigation}
+                disabled={navLocked}
+                onChange={(e) => {
+                  if (!navLocked) {
+                    setManagedNavigation(e.target.checked);
+                  }
+                }}
                 style={{ marginRight: 8 }}
               />
               {message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_LABEL)}
             </label>
             <p
-              style={{ color: "#555", fontSize: "0.85em", margin: "0 0 8px 24px" }}
+              style={{
+                color: "#555",
+                fontSize: "0.85em",
+                margin: "0 0 8px 24px",
+              }}
               data-testid="site-create-managed-nav-help"
             >
-              {message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_HELP)}
+              {navLocked
+                ? message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_REQUIRED)
+                : message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_HELP)}
             </p>
           </fieldset>
         );
-      case 1:
+      case "template":
         return (
           <fieldset data-testid="site-create-step-template">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_TEMPLATE)}</legend>
@@ -302,6 +433,21 @@ export function SiteCreateWizard(
                 {templatesError}
               </p>
             ) : null}
+            <label
+              htmlFor="site-create-template-name"
+              style={{ display: "block", margin: "4px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}
+              <input
+                id="site-create-template-name"
+                type="text"
+                data-testid="site-create-template-name"
+                value={templateName}
+                maxLength={100}
+                onChange={(e) => handleTemplateNameChange(e.target.value)}
+                style={{ marginLeft: 8, width: 240 }}
+              />
+            </label>
             <label
               htmlFor="site-create-base-template"
               style={{ display: "block", margin: "4px 0" }}
@@ -334,7 +480,7 @@ export function SiteCreateWizard(
             </label>
           </fieldset>
         );
-      case 2:
+      case "confirm":
         return (
           <fieldset data-testid="site-create-step-confirm">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_CONFIRM)}</legend>
@@ -342,40 +488,42 @@ export function SiteCreateWizard(
               style={{ listStyle: "none", padding: 0 }}
               data-testid="site-create-confirm-summary"
             >
+              <li data-testid="site-create-confirm-type">
+                <strong>{message(EXPLORER_MSG.SITE_CREATE_TYPE_LABEL)}:</strong>{" "}
+                {typeLabel(siteType)}
+              </li>
               <li>
                 <strong>{message(EXPLORER_MSG.SITE_CREATE_NAME_LABEL)}:</strong>{" "}
                 <code>{siteName}</code>
               </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}:
-                </strong>{" "}
-                <code>{templateName}</code>
-              </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}:
-                </strong>{" "}
-                <code>{baseTemplateName}</code>
-              </li>
-              <li>
-                <strong>
-                  {message(EXPLORER_MSG.SITE_CREATE_REPOSITORY_KIND)}:
-                </strong>{" "}
-                {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL)}
-              </li>
+              {requiresPageTemplate(siteType) ? (
+                <>
+                  <li data-testid="site-create-confirm-template-name">
+                    <strong>
+                      {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}:
+                    </strong>{" "}
+                    <code>{templateName}</code>
+                  </li>
+                  <li data-testid="site-create-confirm-base-template">
+                    <strong>
+                      {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}:
+                    </strong>{" "}
+                    <code>{baseTemplateName}</code>
+                  </li>
+                </>
+              ) : null}
               <li data-testid="site-create-confirm-managed-nav">
                 <strong>
                   {message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_LABEL)}:
                 </strong>{" "}
-                {managedNavigation
+                {navLocked || managedNavigation
                   ? message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_YES)
                   : message(EXPLORER_MSG.SITE_CREATE_MANAGED_NAV_NO)}
               </li>
             </ul>
           </fieldset>
         );
-      case 3:
+      case "progress":
         return (
           <fieldset data-testid="site-create-step-progress">
             <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_PROGRESS)}</legend>
@@ -404,6 +552,11 @@ export function SiteCreateWizard(
 
   const finalStep = isFinalStep(wizard);
   const result = wizard.result;
+  const nextDisabled =
+    wizard.submitting ||
+    (stepId === "type" && !typeReady) ||
+    (stepId === "details" && !detailsReady) ||
+    (stepId === "template" && !templateReady);
 
   return (
     <section
@@ -423,7 +576,7 @@ export function SiteCreateWizard(
         style={{ color: "#888", margin: "0 0 8px 0" }}
       >
         {message(EXPLORER_MSG.WIZARD_STEP)} {wizard.current + 1}{" "}
-        {message(EXPLORER_MSG.WIZARD_OF)} {STEPS.length}
+        {message(EXPLORER_MSG.WIZARD_OF)} {wizard.steps.length}
       </p>
       {renderStep()}
       <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
@@ -441,11 +594,7 @@ export function SiteCreateWizard(
           <button
             type="button"
             data-testid="site-create-next"
-            disabled={
-              wizard.submitting ||
-              (wizard.current === 0 && !detailsReady) ||
-              (wizard.current === 1 && !templateReady)
-            }
+            disabled={nextDisabled}
             onClick={() => setWizard((w) => advance(w))}
           >
             {message(EXPLORER_MSG.WIZARD_NEXT)}

--- a/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
+++ b/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
@@ -111,15 +111,73 @@ export function clampSiteDescription(raw: string): string {
 }
 
 /**
+ * Site kinds on the Create Site type picker (#3512).
+ * Slice 2 enables Traditional and Page; Virtual stays blocked.
+ */
+export type SiteCreateKind = "traditional" | "page" | "virtual";
+
+export const SITE_CREATE_KINDS: readonly SiteCreateKind[] = [
+  "traditional",
+  "page",
+  "virtual",
+];
+
+/**
+ * True when the chosen kind may leave the type-picker step.
+ */
+export function isSiteCreateKindEnabled(kind: SiteCreateKind): boolean {
+  return kind === "traditional" || kind === "page";
+}
+
+/**
+ * Page sites require a page / base template step. Traditional does not.
+ */
+export function requiresPageTemplate(kind: SiteCreateKind): boolean {
+  return kind === "page";
+}
+
+/**
+ * Page sites force managed navigation on. Traditional may opt out.
+ */
+export function managedNavigationForcedOn(kind: SiteCreateKind): boolean {
+  return kind === "page";
+}
+
+/**
+ * Wizard step ids for the chosen kind. Page inserts a template step.
+ */
+export function wizardStepsForKind(kind: SiteCreateKind): readonly string[] {
+  if (kind === "page") {
+    return ["type", "details", "template", "confirm", "progress"];
+  }
+  return ["type", "details", "confirm", "progress"];
+}
+
+/**
  * True when the create form has enough fields to submit (client-side only).
+ *
+ * <p>Traditional does not prompt for template/base — those values are
+ * generated. Page requires a template name and base template. Virtual
+ * cannot submit from this slice.</p>
  */
 export function canSubmitCreateSite(fields: {
   siteName: string;
-  templateName: string;
-  baseTemplateName: string;
+  templateName?: string;
+  baseTemplateName?: string;
+  siteType?: SiteCreateKind;
 }): boolean {
+  const kind = fields.siteType ?? "traditional";
+  if (!isSiteCreateKindEnabled(kind)) {
+    return false;
+  }
   const site = validateSiteName(fields.siteName);
-  const tmpl = validateTemplateName(fields.templateName);
+  if (!site.ok) {
+    return false;
+  }
+  if (!requiresPageTemplate(kind)) {
+    return true;
+  }
+  const tmpl = validateTemplateName(fields.templateName ?? "");
   const base = (fields.baseTemplateName ?? "").trim();
-  return site.ok && tmpl.ok && base.length > 0;
+  return tmpl.ok && base.length > 0;
 }

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -737,7 +737,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     expect(screen.getByTestId("architecture-new-site-title").textContent).toMatch(
       /New Site/i,
     );
-    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
     expect(screen.getByTestId("architecture-new-site-panel").getAttribute("role")).toBe(
       "dialog",
     );
@@ -773,14 +773,14 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
     fireEvent.click(screen.getByTestId("architecture-action-new-site"));
     await waitFor(() => {
+      expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
       expect(screen.getByTestId("site-create-name")).toBeTruthy();
     });
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("site-create-next"));
     fireEvent.click(screen.getByTestId("site-create-next"));

--- a/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
@@ -31,43 +31,163 @@ function renderWizard(
   );
 }
 
-describe("SiteCreateWizard (#3002)", () => {
-  it("renders the 4-step wizard at details", async () => {
+function choosePageType(): void {
+  fireEvent.click(screen.getByTestId("site-create-type-page"));
+}
+
+function advanceFromType(): void {
+  fireEvent.click(screen.getByTestId("site-create-next"));
+}
+
+describe("SiteCreateWizard (#3520 / parent #3512)", () => {
+  it("starts on the type picker with Traditional selected", () => {
     renderWizard();
     expect(screen.getByTestId("site-create-wizard")).toBeTruthy();
-    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
     expect(screen.getByTestId("site-create-step-count").textContent).toMatch(
       /Step 1.*of 4/,
     );
+    expect(
+      (screen.getByTestId("site-create-type-traditional") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
     expect(screen.getByTestId("site-create-traditional-note")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
+    expect(screen.queryByTestId("site-create-step-details")).toBeNull();
   });
 
-  it("Next is disabled until site name and template name are valid", async () => {
+  it("blocks Next on Virtual and does not open details", () => {
     renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
+    fireEvent.click(screen.getByTestId("site-create-type-virtual"));
+    expect(screen.getByTestId("site-create-type-unavailable")).toBeTruthy();
+    const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-type")).toBeTruthy();
+    expect(screen.queryByTestId("site-create-step-details")).toBeNull();
+  });
+
+  it("Traditional: Next on name only; no template step; nav optional", async () => {
+    const submit = vi.fn().mockResolvedValue({ name: "Bare" });
+    renderWizard({ submit });
+    advanceFromType();
+    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.queryByTestId("site-create-template-name")).toBeNull();
     const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
     expect(next.disabled).toBe(true);
     fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Bare" },
+    });
+    expect(next.disabled).toBe(false);
+    const checkbox = screen.getByTestId(
+      "site-create-managed-nav",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(false);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
+    expect(screen.queryByTestId("site-create-step-template")).toBeNull();
+    expect(screen.queryByTestId("site-create-confirm-template-name")).toBeNull();
+    expect(
+      screen.getByTestId("site-create-confirm-managed-nav").textContent,
+    ).toMatch(/No/i);
+    fireEvent.click(next);
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+    const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
+    expect(req.name).toBe("Bare");
+    expect(req.managedNavigation).toBe(false);
+    expect(req.pageBased).toBeUndefined();
+    expect(req.templateName).toBe("BareTemplate");
+    expect(req.baseTemplateName).toBe("perc.base.plain");
+  });
+
+  it("Page: enables Next, locks managed nav, requires template", async () => {
+    renderWizard();
+    choosePageType();
+    expect(screen.getByTestId("site-create-page-note")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-count").textContent).toMatch(
+      /Step 1.*of 5/,
+    );
+    const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(false);
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    const checkbox = screen.getByTestId(
+      "site-create-managed-nav",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(true);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Acme" },
     });
-    // Template name auto-seeds from site name.
+    fireEvent.click(next);
+    expect(screen.getByTestId("site-create-step-template")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
     expect(
       (screen.getByTestId("site-create-template-name") as HTMLInputElement)
         .value,
     ).toBe("AcmeTemplate");
-    expect(next.disabled).toBe(false);
   });
 
-  it("filters invalid site name characters on input", async () => {
-    renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
+  it("Page submit sends pageBased and forced managed nav", async () => {
+    const submit = vi.fn().mockResolvedValue({ name: "Acme", id: "9" });
+    const onCreated = vi.fn();
+    renderWizard({ submit, onCreated });
+    choosePageType();
+    advanceFromType();
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
     });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("site-create-template-name"), {
+      target: { value: "AcmePageTmpl" },
+    });
+    fireEvent.change(screen.getByTestId("site-create-base-template"), {
+      target: { value: "perc.base.other" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    expect(
+      screen.getByTestId("site-create-confirm-template-name").textContent,
+    ).toContain("AcmePageTmpl");
+    expect(
+      screen.getByTestId("site-create-confirm-base-template").textContent,
+    ).toContain("perc.base.other");
+    expect(
+      screen.getByTestId("site-create-confirm-managed-nav").textContent,
+    ).toMatch(/Yes/i);
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+    const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
+    expect(req.name).toBe("Acme");
+    expect(req.pageBased).toBe(true);
+    expect(req.managedNavigation).toBe(true);
+    expect(req.templateName).toBe("AcmePageTmpl");
+    expect(req.baseTemplateName).toBe("perc.base.other");
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteName: "Acme",
+        folderPath: "/Sites/Acme",
+      }),
+    );
+  });
+
+  it("filters invalid site name characters on input", () => {
+    renderWizard();
+    advanceFromType();
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Bad Name!" },
     });
@@ -76,92 +196,11 @@ describe("SiteCreateWizard (#3002)", () => {
     ).toBe("BadName");
   });
 
-  it("advances through template and confirm steps", async () => {
-    renderWizard();
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(screen.getByTestId("site-create-step-template")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
-    expect(screen.getByTestId("site-create-confirm-summary").textContent).toContain(
-      "Acme",
-    );
-    expect(
-      screen.getByTestId("site-create-confirm-managed-nav").textContent,
-    ).toMatch(/Yes/i);
-  });
-
-  it("can opt out of managed navigation on a traditional site", async () => {
-    const submit = vi.fn().mockResolvedValue({ name: "Bare" });
-    renderWizard({ submit });
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Bare" },
-    });
-    const checkbox = screen.getByTestId(
-      "site-create-managed-nav",
-    ) as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
-    fireEvent.click(checkbox);
-    expect(checkbox.checked).toBe(false);
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(
-      screen.getByTestId("site-create-confirm-managed-nav").textContent,
-    ).toMatch(/No/i);
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    fireEvent.click(screen.getByTestId("site-create-run"));
-    await waitFor(() => {
-      expect(submit).toHaveBeenCalledTimes(1);
-    });
-    const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
-    expect(req.managedNavigation).toBe(false);
-  });
-
-  it("Run invokes submit and fires onCreated with /Sites path", async () => {
-    const submit = vi.fn().mockResolvedValue({ name: "Acme", id: "9" });
-    const onCreated = vi.fn();
-    renderWizard({ submit, onCreated });
-    fireEvent.change(screen.getByTestId("site-create-name"), {
-      target: { value: "Acme" },
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    await waitFor(() => {
-      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    fireEvent.click(screen.getByTestId("site-create-next"));
-    expect(screen.getByTestId("site-create-step-progress")).toBeTruthy();
-    fireEvent.click(screen.getByTestId("site-create-run"));
-    await waitFor(() => {
-      expect(submit).toHaveBeenCalledTimes(1);
-    });
-    const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
-    expect(req.name).toBe("Acme");
-    expect(req.baseTemplateName).toBe("perc.base.plain");
-    expect(req.templateName).toBe("AcmeTemplate");
-    expect(req.managedNavigation).toBe(true);
-    expect(onCreated).toHaveBeenCalledWith(
-      expect.objectContaining({
-        siteName: "Acme",
-        folderPath: "/Sites/Acme",
-      }),
-    );
-    expect(screen.getByTestId("site-create-progress").textContent).toMatch(
-      /Acme/,
-    );
-  });
-
-  it("Run surfaces submit errors", async () => {
+  it("Page Run surfaces submit errors", async () => {
     const submit = vi.fn().mockRejectedValue(new Error("duplicate site"));
     renderWizard({ submit });
+    choosePageType();
+    advanceFromType();
     fireEvent.change(screen.getByTestId("site-create-name"), {
       target: { value: "Acme" },
     });
@@ -180,11 +219,8 @@ describe("SiteCreateWizard (#3002)", () => {
     );
   });
 
-  it("passes the zero serious/critical axe-core gate (step 0)", async () => {
+  it("passes the zero serious/critical axe-core gate (type step)", async () => {
     const { container } = renderWizard();
-    await waitFor(() => {
-      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
-    });
     await renderA11yGate(container);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
@@ -35,6 +35,24 @@ describe("siteCreateApi helpers (#3002)", () => {
     expect(body.Site.baseTemplateName).toBe("perc.base.plain");
     expect(body.Site.templateName).toBe("QA-SiteTemplate");
     expect(body.Site.managedNavigation).toBe(true);
+    expect(body.Site.pageBased).toBeUndefined();
+  });
+
+  it("buildCreateSiteBody sends pageBased only for Page sites", () => {
+    const page = buildCreateSiteBody({
+      name: "PageSite",
+      baseTemplateName: "perc.base.other",
+      templateName: "PageSiteTmpl",
+      pageBased: true,
+    });
+    expect(page.Site.pageBased).toBe(true);
+    expect(page.Site.managedNavigation).toBe(true);
+    const traditional = buildCreateSiteBody({
+      name: "Trad",
+      baseTemplateName: "perc.base.plain",
+      templateName: "TradTemplate",
+    });
+    expect(traditional.Site.pageBased).toBeUndefined();
   });
 
   it("buildCreateSiteBody sends managedNavigation false when opted out", () => {

--- a/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
@@ -15,10 +15,14 @@ import {
   defaultTemplateNameForSite,
   filterSiteNameInput,
   filterTemplateNameInput,
+  isSiteCreateKindEnabled,
+  managedNavigationForcedOn,
+  requiresPageTemplate,
   SITE_DESCRIPTION_MAX_LENGTH,
   SITE_NAME_MAX_LENGTH,
   validateSiteName,
   validateTemplateName,
+  wizardStepsForKind,
 } from "../../../main/ts/contentExplorer/wizards/siteCreateValidation";
 
 describe("siteCreateValidation (#3002)", () => {
@@ -63,27 +67,74 @@ describe("siteCreateValidation (#3002)", () => {
     expect(clampSiteDescription(long).length).toBe(SITE_DESCRIPTION_MAX_LENGTH);
   });
 
-  it("canSubmitCreateSite requires site, template, and base template", () => {
+  it("canSubmitCreateSite Traditional requires only a site name", () => {
     expect(
       canSubmitCreateSite({
         siteName: "A",
+        siteType: "traditional",
+      }),
+    ).toBe(true);
+    expect(
+      canSubmitCreateSite({
+        siteName: "",
+        siteType: "traditional",
+      }),
+    ).toBe(false);
+  });
+
+  it("canSubmitCreateSite Page requires template name and base template", () => {
+    expect(
+      canSubmitCreateSite({
+        siteName: "A",
+        siteType: "page",
         templateName: "ATemplate",
         baseTemplateName: "perc.base.plain",
       }),
     ).toBe(true);
     expect(
       canSubmitCreateSite({
-        siteName: "",
-        templateName: "ATemplate",
-        baseTemplateName: "perc.base.plain",
+        siteName: "A",
+        siteType: "page",
       }),
     ).toBe(false);
     expect(
       canSubmitCreateSite({
         siteName: "A",
+        siteType: "page",
         templateName: "ATemplate",
         baseTemplateName: "  ",
       }),
     ).toBe(false);
+    expect(
+      canSubmitCreateSite({
+        siteName: "A",
+        siteType: "virtual",
+        templateName: "ATemplate",
+        baseTemplateName: "perc.base.plain",
+      }),
+    ).toBe(false);
+  });
+
+  it("kind helpers enable Traditional and Page only", () => {
+    expect(isSiteCreateKindEnabled("traditional")).toBe(true);
+    expect(isSiteCreateKindEnabled("page")).toBe(true);
+    expect(isSiteCreateKindEnabled("virtual")).toBe(false);
+    expect(requiresPageTemplate("page")).toBe(true);
+    expect(requiresPageTemplate("traditional")).toBe(false);
+    expect(managedNavigationForcedOn("page")).toBe(true);
+    expect(managedNavigationForcedOn("traditional")).toBe(false);
+    expect(wizardStepsForKind("page")).toEqual([
+      "type",
+      "details",
+      "template",
+      "confirm",
+      "progress",
+    ]);
+    expect(wizardStepsForKind("traditional")).toEqual([
+      "type",
+      "details",
+      "confirm",
+      "progress",
+    ]);
   });
 });

--- a/docs/ai-generated/code-reviews/3520-page-site-create-erlang.md
+++ b/docs/ai-generated/code-reviews/3520-page-site-create-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3520 Page site create
+
+**Branch:** `feat/issue-3520-page-site-create`  
+**Scope:** uncommitted vs `origin/main` (WebUI wizard, validation, site create body, Playwright, product-docs)  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class companions (Vitest + Playwright + product-docs); do not invent REST resources; Traditional must not regress.
+
+## Summary
+
+Slice 2 of #3512. Adds a Create Site type picker on main (slice 1 #3523 not merged) and enables **Page**: managed navigation locked on, page/base template step restored, `pageBased: true` on existing `POST /sitemanage/site/`. Traditional skips the template step and omits `pageBased`. Virtual remains blocked.
+
+No Java API shape change. `PSSitePublishDao.saveSite` still hardcodes `setPageBased(true)` for all sitemanage creates (including classic `perc_newsitedialog`). Sending `pageBased: true` documents the Page contract without regressing Traditional persistence.
+
+## Issues
+
+None that block.
+
+### Notes (non-blocking)
+
+- Server still persists every sitemanage create as page-based. Traditional vs Page is UX + request field until a later slice honors `pageBased=false` without breaking classic CM1 create (which omits the field).
+- Type picker is included because slice 1 is not merged. Expect merge conflict with #3523 (same files; Page is additive).
+
+## Tests
+
+- Vitest: type picker, Traditional skip-template + nav opt-out, Page lock-nav + template required + `pageBased` body, Virtual blocked, a11y gate.
+- Playwright: Traditional chrome/happy path updated; new `explorer-site-create-page.spec.js` (picker + live Page create).
+- product-docs 8.2 admin Create Site + Navigation + reference site-config.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path I/O. URL paths use `/` (REST/SPA). Playwright uses `path.join` only in existing helpers.
+
+## Change-class companions
+
+WebUI screen: Vitest + Playwright + product-docs present.

--- a/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-shell-smoke.spec.js
@@ -109,7 +109,8 @@ test.describe("Architecture SPA shell (#3094)", () => {
     await expect(newSite).toContainText(/New Site/i);
     await newSite.click();
     await expect(page.getByTestId("architecture-new-site-panel")).toBeVisible();
-    await expect(page.getByTestId("site-create-step-details")).toBeVisible();
+    await expect(page.getByTestId("site-create-step-type")).toBeVisible();
+    await expect(page.getByTestId("site-create-type-page")).toBeVisible();
     await page.getByTestId("architecture-new-site-close").click();
     await expect(page.getByTestId("architecture-new-site-panel")).toHaveCount(0);
     expect(pageErrors, pageErrors.join("\n")).toEqual([]);

--- a/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Playwright surface: #3520 / parent #3512 — Page site create from type picker.
+ *
+ * <p>Coverage:</p>
+ * <ul>
+ *   <li>Type picker: Page is selectable; Virtual stays blocked</li>
+ *   <li>Page flow: details (managed nav locked) → page/base template → confirm</li>
+ *   <li>Traditional still skips the template step</li>
+ *   <li>Live Page create persists on POST /sitemanage/site/ and lists under Sites</li>
+ * </ul>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-site-create-page.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const {
+  TEST_IDS,
+  explorerSpaUrl,
+  sitesFolderUrl,
+  uniqueQaSiteName,
+  createSiteMissingSkipReason,
+  isKnownExplorerSitesConsoleNoise,
+} = require("./helpers/explorer-sites-list-create");
+const { pathItemNames } = require("./helpers/demo-sites");
+
+const SITES_URL = sitesFolderUrl(BASE_URL);
+
+/**
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @returns {Promise<string[]>}
+ */
+async function fetchSitesChildNames(request) {
+  const headers = adminBasicAuthHeaders();
+  const res = await request.get(SITES_URL, { headers });
+  expect(res.status(), `GET ${SITES_URL} must be 200`).toBe(200);
+  return pathItemNames(await res.json());
+}
+
+/**
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} siteName
+ * @returns {Promise<{ pageBased?: boolean } | null>}
+ */
+async function fetchSiteSummary(request, siteName) {
+  const headers = adminBasicAuthHeaders();
+  const url = `${BASE_URL.replace(/\/$/, "")}/Rhythmyx/services/sitemanage/site/${encodeURIComponent(siteName)}`;
+  const res = await request.get(url, { headers });
+  if (res.status() !== 200) {
+    return null;
+  }
+  const body = await res.json();
+  const site = body.Site || body.site || body;
+  return site && typeof site === "object" ? site : null;
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<boolean>}
+ */
+async function ensureCreateSiteMenuOrSkip(page) {
+  await page.locator(`[data-testid="${TEST_IDS.menuContent}"]`).click();
+  const menuItem = page.locator(`[data-testid="${TEST_IDS.createSiteMenu}"]`);
+  if ((await menuItem.count()) === 0) {
+    test.skip(createSiteMissingSkipReason());
+    return false;
+  }
+  await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  return true;
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+function attachConsoleGate(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => pageErrors.push(String(err)));
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = msg.text();
+    if (!isKnownExplorerSitesConsoleNoise(text)) {
+      consoleErrors.push(text);
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+test.describe("Explorer Page site create (#3520 / #3512)", () => {
+  test(
+    "type picker: Page selectable, Virtual blocked, Traditional skips template",
+    { tag: ["@explorer-site-create-page", "@explorer", "@sites"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const { pageErrors, consoleErrors } = attachConsoleGate(page);
+      await loginAsAdmin(page);
+      await page.goto(explorerSpaUrl(BASE_URL), { waitUntil: "networkidle" });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const present = await ensureCreateSiteMenuOrSkip(page);
+      if (!present) {
+        return;
+      }
+      await page.locator(`[data-testid="${TEST_IDS.createSiteMenu}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+
+      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.next}"]`),
+      ).toBeDisabled();
+
+      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
+      ).toBeVisible();
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepDetails}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
+      ).toBeEnabled();
+      await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill("TradChk");
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
+      ).toHaveCount(0);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmTemplateName}"]`),
+      ).toHaveCount(0);
+
+      await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.pageNote}"]`),
+      ).toBeVisible();
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
+      ).toBeDisabled();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
+      ).toBeChecked();
+      await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill("PageChk");
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.templateName}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+
+      expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      expect(consoleErrors, `console error: ${consoleErrors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
+    "Create Site happy path: Page type with template and managed nav",
+    { tag: ["@explorer-site-create-page", "@explorer", "@sites"] },
+    async ({ page }) => {
+      test.setTimeout(120_000);
+      const { pageErrors, consoleErrors } = attachConsoleGate(page);
+      await loginAsAdmin(page);
+      await page.goto(explorerSpaUrl(BASE_URL), { waitUntil: "networkidle" });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const present = await ensureCreateSiteMenuOrSkip(page);
+      if (!present) {
+        return;
+      }
+      await page.locator(`[data-testid="${TEST_IDS.createSiteMenu}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+
+      const siteName = uniqueQaSiteName("QaPage");
+      await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
+      ).toBeDisabled();
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.templateName}"]`),
+      ).not.toHaveValue("");
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmSummary}"]`),
+      ).toContainText(siteName);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmType}"]`),
+      ).toContainText(/Page/i);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmManagedNav}"]`),
+      ).toContainText(/Yes/i);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.confirmTemplateName}"]`),
+      ).toBeVisible();
+
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepProgress}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+      const run = page.locator(`[data-testid="${TEST_IDS.run}"]`);
+      await expect(run).toBeEnabled({ timeout: 5_000 });
+      await run.click();
+
+      await expect
+        .poll(
+          async () => {
+            const errText = await page
+              .locator(`[data-testid="${TEST_IDS.wizard}"] [role="status"]`)
+              .allInnerTexts()
+              .catch(() => []);
+            const failed = errText.some((t) =>
+              /error|failed|invalid|500|rolled back/i.test(String(t || "")),
+            );
+            if (failed) {
+              return "error";
+            }
+            const names = await fetchSitesChildNames(page.request);
+            const hit = names.some(
+              (n) => String(n).toLowerCase() === siteName.toLowerCase(),
+            );
+            return hit ? "ok" : "pending";
+          },
+          { timeout: 60_000 },
+        )
+        .toBe("ok");
+
+      const summary = await fetchSiteSummary(page.request, siteName);
+      expect(summary, `GET sitemanage/site/${siteName}`).toBeTruthy();
+      if (summary && typeof summary.pageBased !== "undefined") {
+        expect(
+          summary.pageBased === true || summary.pageBased === "true",
+          `pageBased on created site: ${JSON.stringify(summary)}`,
+        ).toBe(true);
+      }
+
+      expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      expect(consoleErrors, `console error: ${consoleErrors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-sites-list-create.spec.js
@@ -24,7 +24,7 @@
  *   <li>UI: Sites tree expands to child site nodes when list is non-empty</li>
  *   <li>UI: selecting a sample site shows folder children, not LIST_EMPTY (#3326)</li>
  *   <li>Create Site: Content menu always exposes Create Site; wizard details →
- *       template → confirm chrome; optional live submit when affordance present</li>
+ *       confirm chrome (no page-template prompt); optional live submit</li>
  * </ul>
  *
  * <p><strong>Soft-skip policy (acceptance #3003):</strong> empty Sites list may
@@ -66,6 +66,7 @@ const {
   expandExplorerTreeNode,
   sitesTreeDescendantsLocator,
   siteChildNamesFromTreeTestIds,
+  advanceTraditionalTypeStep,
   uniqueQaSiteName,
   createSiteMissingSkipReason,
   emptySitesSoftSkipNote,
@@ -348,7 +349,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
   );
 
   test(
-    "Create Site wizard: details → template → confirm chrome",
+    "Create Site wizard: type → details → confirm chrome (Traditional)",
     { tag: ["@explorer-sites-list-create", "@explorer", "@sites"] },
     async ({ page }) => {
       test.setTimeout(90_000);
@@ -373,23 +374,33 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       await expect(wizard).toBeVisible({ timeout: 10_000 });
 
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.stepDetails}"]`),
+        page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
       ).toBeVisible();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
       ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typePage}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`),
+      ).toBeVisible();
+
+      await advanceTraditionalTypeStep(page);
+
       const managedNav = page.locator(
         `[data-testid="${TEST_IDS.managedNav}"]`,
       );
       await expect(managedNav).toBeVisible();
       await expect(managedNav).toBeChecked();
+      await expect(managedNav).toBeEnabled();
       await managedNav.uncheck();
 
       const siteName = uniqueQaSiteName("QaListCreate");
       await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.templateName}"]`),
-      ).not.toHaveValue("");
+      ).toHaveCount(0);
 
       const next = page.locator(`[data-testid="${TEST_IDS.next}"]`);
       await expect(next).toBeEnabled({ timeout: 5_000 });
@@ -397,12 +408,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
 
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
-      ).toBeVisible({ timeout: 10_000 });
-      await expect(
-        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
-      ).toBeVisible({ timeout: 15_000 });
-
-      await next.click();
+      ).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
       ).toBeVisible({ timeout: 10_000 });
@@ -442,6 +448,8 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
         page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
+      await advanceTraditionalTypeStep(page);
+
       const siteName = uniqueQaSiteName("QaCreate");
       await page.locator(`[data-testid="${TEST_IDS.siteName}"]`).fill(siteName);
 
@@ -450,12 +458,7 @@ test.describe("Explorer Sites list + Create Site (#3003 / #2989)", () => {
       await next.click();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepTemplate}"]`),
-      ).toBeVisible({ timeout: 10_000 });
-      // Wait for base template control (list load or fallback input).
-      await expect(
-        page.locator(`[data-testid="${TEST_IDS.baseTemplate}"]`),
-      ).toBeVisible({ timeout: 20_000 });
-      await next.click();
+      ).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepConfirm}"]`),
       ).toBeVisible({ timeout: 10_000 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
@@ -21,15 +21,24 @@ const TEST_IDS = Object.freeze({
   createSiteMenu: "explorer-content-create-site",
   createSitePanel: "explorer-site-create-panel",
   wizard: "site-create-wizard",
+  stepType: "site-create-step-type",
   stepDetails: "site-create-step-details",
   stepTemplate: "site-create-step-template",
   stepConfirm: "site-create-step-confirm",
   stepProgress: "site-create-step-progress",
+  typeTraditional: "site-create-type-traditional",
+  typePage: "site-create-type-page",
+  typeVirtual: "site-create-type-virtual",
+  typeUnavailable: "site-create-type-unavailable",
+  pageNote: "site-create-page-note",
   siteName: "site-create-name",
   description: "site-create-description",
   templateName: "site-create-template-name",
   baseTemplate: "site-create-base-template",
   confirmSummary: "site-create-confirm-summary",
+  confirmType: "site-create-confirm-type",
+  confirmTemplateName: "site-create-confirm-template-name",
+  confirmBaseTemplate: "site-create-confirm-base-template",
   next: "site-create-next",
   back: "site-create-back",
   run: "site-create-run",
@@ -241,6 +250,20 @@ function siteChildNamesFromTreeTestIds(nodeTestIds) {
  * @param {string} [prefix]
  * @returns {string}
  */
+/**
+ * Advance past the type-picker step (Traditional is the default).
+ * @param {import('@playwright/test').Page} page
+ */
+async function advanceTraditionalTypeStep(page) {
+  await page
+    .locator(`[data-testid="${TEST_IDS.stepType}"]`)
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+  await page
+    .locator(`[data-testid="${TEST_IDS.stepDetails}"]`)
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
 function uniqueQaSiteName(prefix = "QaSite") {
   const safe = String(prefix || "QaSite").replace(/[^A-Za-z0-9]/g, "");
   const stamp = Date.now().toString(36).slice(-6);
@@ -302,6 +325,7 @@ module.exports = {
   expandExplorerTreeNode,
   sitesTreeDescendantsLocator,
   siteChildNamesFromTreeTestIds,
+  advanceTraditionalTypeStep,
   uniqueQaSiteName,
   createSiteMissingSkipReason,
   emptySitesSoftSkipNote,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -46,6 +46,8 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(TEST_IDS.createSiteMenu, "explorer-content-create-site");
     assert.equal(TEST_IDS.createSitePanel, "explorer-site-create-panel");
     assert.equal(TEST_IDS.wizard, "site-create-wizard");
+    assert.equal(TEST_IDS.stepType, "site-create-step-type");
+    assert.equal(TEST_IDS.typePage, "site-create-type-page");
     assert.equal(TEST_IDS.siteName, "site-create-name");
     assert.equal(TEST_IDS.run, "site-create-run");
     assert.equal(TEST_IDS.managedNav, "site-create-managed-nav");

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -39,8 +39,10 @@ dispatcher applies that preference and opens the Navigation SPA — not Home.
 3. The **Navigation tree** panel loads the site’s sections (navons) from the server.
 4. Expand and collapse nodes with the mouse or keyboard (Enter/Space, Arrow Left/Right).
 5. Use **Refresh** to reload the tree after external changes.
-6. Use **New Site** (Admin or Designer) to open the same traditional-site wizard
-   used in Content Explorer. After a successful create, the new site is selected
+6. Use **New Site** (Admin or Designer) to open the same Create Site wizard
+   used in Content Explorer. Choose **Traditional** (managed navigation optional,
+   no page-template prompt) or **Page** (managed navigation required, choose a
+   page/base template). After a successful create, the new site is selected
    in this shell.
 7. Use **Copy Site** (Admin or Designer) with a site selected to open the
    existing site-copy wizard (same sitemanage copy service as Explorer). The

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -163,19 +163,21 @@ Under the tree root **Sites** you see traditional site folders available to your
 select a sample site to browse FastForward folders and pages (About…, Files, Images,
 and the site NavTree).
 
-To create a new **traditional** repository Site from Explorer:
+To create a new Site from Explorer:
 
 1. Choose **Content → Create Site** (available without selecting an existing site).
-2. Complete the wizard: site name → base template → confirm → create.
-3. On success, Explorer navigates to `/Sites/<new-site-name>`.
+2. On **Site type**, choose **Traditional** or **Page** (Virtual is listed but not available yet).
+3. **Traditional:** site name and optional managed navigation → confirm → create. There is no page-template prompt.
+4. **Page:** site name (managed navigation locked on) → template name and base template → confirm → create. The site is persisted as a CM1 page-based site.
+5. On success, Explorer navigates to `/Sites/<new-site-name>`.
 
-This wizard creates repository Sites only. Configure **Virtual Site** source properties
-(Git/filesystem) from **Developer → Sites** / Site detail — see
-[Sites & content structure](id:admin-sites) and [Virtual Sites](id:developer-virtual-sites).
+Configure **Virtual Site** source properties (Git/filesystem) from **Developer → Sites** /
+Site detail — see [Sites & content structure](id:admin-sites) and
+[Virtual Sites](id:developer-virtual-sites).
 
 Related Content menu commands:
 
-- **Create Site** — new traditional Site (no site context required)
+- **Create Site** — new Traditional or Page Site (no site context required)
 - **Site Copy** / **Subfolder Copy** — copy workflows when a site or folder is in context
 - **Search** — same Search panel as **View → Search**
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -31,16 +31,25 @@ Traditional Sites store pages and assets in the Percussion **content repository*
 
 After a standard install with **sample sites** (installer **Install sample sites** / silent `--demo-sites`), the Sites tree typically includes stock demo sites such as **Corporate Investments** and **Enterprise Investments**. Those FastForward sample sites are traditional **Rhythmyx** sites (not CM1 page-based). The installer loads the FastForward type/template seed, the **ObjectStore** editors for those types (`psx_cerffGeneric.xml`, `psx_cerffPressRelease.xml`, and the other rff editors — CM1 `perc*` types still come from packages), the **sample content** graph (site folders, Files/Images, About sections, navons, and pages), plus hashed sample binaries under `rxconfig/FastForward/importFiles` (imported on first server start). If sample items exist but the server log shows `Invalid content type id (311)` (or other 301–316 ids), those ObjectStore editors were not copied — reinstall with `--demo-sites` from an installer that includes this step. FastForward **navigation** types stay at ids 313–315 (`rffNavImage` / `rffNavon` / `rffNavTree`). The `perc.nav` package installs `percNav*` under separate ids; the sample seed must not rename 313–315 to those package names (that unique-name clash aborts the rest of the type table and drops **Press Release** id 316). Site **names** may use underscores (`Corporate_Investments`) while the repository folder is `//Sites/CorporateInvestments` — Explorer binds expand/list to the site folder root. The Sites list includes **all** sites — Rhythmyx and CM1 page-based, with or without a publishing server or navigation tree. Opening **Navigation** for a demo site that already has an `rffNavTree` / `percNavTree` shows that tree; if a site has a folder root but no NavTree, first open creates one — see [Navigation & site structure](id:admin-architecture-navigation). Fresh evaluation or H2 QA stacks without sample seed may show an empty Sites list until you create a site or reinstall with sample data. A running install that was seeded before this content pass is **not** backfilled — reinstall with `--demo-sites` (or a new H2 `qa-up`) to get FastForward pages and navons.
 
-### Create a traditional Site from Explorer
+### Create a Site from Explorer
 
-Use **Content Explorer** when you need a new traditional (repository) Site without leaving the product shell:
+Use **Content Explorer** (or **Navigation → New Site**) when you need a new Site without leaving the product shell. The first wizard step is **Site type**:
+
+| Type | Managed navigation | Page / base template | Persist |
+|------|--------------------|----------------------|---------|
+| **Traditional** | Optional (checked by default) | Not prompted — a generated template name and `perc.base.plain` are sent | Repository site |
+| **Page** | Required (locked on) | Required — choose a **template name** and **base template** | CM1 page-based site (`pageBased` / `IS_PAGE_BASED` on `POST /sitemanage/site/`) |
+| **Virtual** | Not used | Not used | Not available in this wizard yet — configure Virtual source on Developer → Sites |
 
 1. Open **Content Explorer**.
 2. Choose **Content → Create Site**.
-3. On **Details**, enter a unique **Site name**, optional description, and the site **template name** (defaults from the site name). Traditional sites include **Include managed navigation** (checked by default). Leave it checked to create a NavTree and homepage. Uncheck it to create the site folder only — no NavTree and no homepage. You can add navigation later from Explorer. Virtual Sites do not use this option (`virtual.sourceKind` is their discriminator).
-4. On **Base template**, pick a base template from the catalog (or accept the default when the catalog is empty).
-5. On **Confirm**, review the summary (repository kind is **Traditional** — this flow does not create Virtual Sites) and whether managed navigation is **Yes** or **No**.
-6. Choose **Create** and wait for progress to complete. Explorer opens the new site under `/Sites/<name>`. With **Include managed navigation** checked, the server seeds a NavTree, a site template, and the homepage (`index.html`) in that folder in one operation. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
+3. On **Site type**, choose **Traditional** or **Page**. **Virtual** is listed but cannot continue until that path is implemented.
+4. On **Details**, enter a unique **Site name** and optional description.
+   - **Traditional:** **Include managed navigation** is checked by default. Leave it checked to create a NavTree and homepage. Uncheck it to create the site folder only — no NavTree and no homepage. You can add navigation later from Explorer.
+   - **Page:** managed navigation is required and cannot be turned off.
+5. **Page** only: on **Base template**, enter a **template name** (defaults from the site name) and pick a base template from the catalog (or accept the default when the catalog is empty). Traditional does not show this step.
+6. On **Confirm**, review the type, name, managed-navigation choice, and (Page only) the template fields.
+7. Choose **Create** and wait for progress to complete. Explorer opens the new site under `/Sites/<name>`. With managed navigation on, the server seeds a NavTree, a site template, and the homepage (`index.html`) in that folder in one operation. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
 
 Virtual Site source settings (Git/filesystem) are configured later on the Site properties / Developer Sites surface — not in this Create Site wizard. See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -66,7 +66,7 @@ Traditional (repository) sites may store:
 |---------------|----------|---------|---------|
 | `navigation.managed` | No | `false` | When `false`, the site is created and treated as **without** a CMS NavTree/homepage. Absent or `true` is the default (include managed navigation). **Not used for Virtual Sites** — omit this flag when `virtual.sourceKind` is set; Virtual nav comes from the Git/Markdown tree. |
 
-Create Site (`POST /Rhythmyx/sitemanage/site/`) accepts `managedNavigation` on the `Site` body (`true` default). Public Site detail (`GET /sites/{nameOrId}`) returns `managedNavigation` for traditional sites only (`null`/omitted when Virtual).
+Create Site (`POST /Rhythmyx/sitemanage/site/`) accepts `managedNavigation` on the `Site` body (`true` default). Page-type create also sends `pageBased: true` (persisted as `IS_PAGE_BASED` / CM1 page-based). Traditional create omits `pageBased` and does not prompt for a page template. Public Site detail (`GET /sites/{nameOrId}`) returns `managedNavigation` for traditional sites only (`null`/omitted when Virtual) and `pageBasedSite` when the site is page-based.
 
 Cross-platform notes: prefer absolute paths (`C:\…` on Windows, `/opt/…` on Linux/macOS). Operators
 should not hardcode OS path separators in scripts — use the repo `scripts/build-cms-docs.*` wrappers


### PR DESCRIPTION
## Summary

Slice 2 of parent #3512. Enables **Page** site create from the shared `SiteCreateWizard` (Explorer **Content → Create Site** and Navigation **New Site**).

Slice 1 (#3522 / PR #3523) is not merged, so this PR includes a **minimal type picker** (Traditional / Page / Virtual) plus the Page path:

- **Traditional** (default): type → details (name, optional managed nav) → confirm → create. No page-template prompt. `POST /services/sitemanage/site/` without `pageBased`.
- **Page**: type → details (managed nav locked on) → template name + base template → confirm → create. Sends `pageBased: true` on the existing Site body (`IS_PAGE_BASED` / CM1 page-based). Does not invent a new REST resource.
- **Virtual** stays blocked with a clear message (slice 3 / #3521).

Parent: #3512  
Partial #3512  
Fixes #3520

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. QA H2: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (HTTP 200 / Docker Health=healthy).
2. Hot-copy `WebUI/target/generated-webui/cm/modern` into the QA WAR `cm/modern`.
3. Explorer: Content → Create Site. Confirm type picker. Traditional skips template and allows unchecking managed nav. Page locks nav and requires a template.
4. Page create: site appears under `/Sites/<name>`; GET `/sitemanage/site/<name>` has `pageBased` when the payload includes it.
5. Navigation → New Site: same type picker (Page radio visible).
6. Surface-filtered Playwright as below.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `architecture-navigation.md`, `content-explorer.md`, and `reference/site-config.md`
- [x] **Unit / module tests** — Vitest wizard + validation (Page vs Traditional); ArchitectureShell first-step
- [x] **WebUI + Playwright** — `explorer-site-create-page.spec.js` plus updated Traditional create + architecture smoke
- [x] **Build gates** — standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2690, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `npm run test:unit` (perc-qa-automation/frontend) → 303 passed
- **downstream_checked:** none (C2 did not apply — no Java `final`/signature/API shape change)

## C5 UI proof

- `perc-devctl qa-up --skip-image-build` cell `perc-matrix-cms-h2` **TEST_CMS_URL=http://127.0.0.1:9993** (Docker Health=healthy, HTTP 200). `qa-health` reported `DETAIL:server_log_errors` for pre-existing FastForward `PSDbStorageService` import noise (`CI_PS_products_on.gif`) — not `Failed startup of context`.
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern` → `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern` (verified `SiteCreateWizard-COmHutGr.js` contains `site-create-type-page`).
- Playwright (`ADMIN_USERNAME=Admin`, `TEST_DB_TYPE=h2`, `TEST_PRODUCT=cms`):
  - `npm run test:surface -- --path tests/explorer-site-create-page.spec.js` → 2 passed
  - `npm run test:surface -- --path tests/explorer-sites-list-create.spec.js` → 7 passed (includes live Traditional create)
  - `npm run test:surface -- --path tests/architecture-shell-smoke.spec.js` → 2 passed
  - `npm run test:golden` → 2 passed
- **console-clean=yes** (pageerror + console error listeners on Page spec)
- **server.log-clean=yes** for this feature (no site-create ERROR/FATAL). Remaining ERROR lines are known seed/index/type-315 noise.
- Tear-down: `perc-devctl qa-down`

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.