### PR TITLE
test(qa): restore type-picker helper export + typeUnavailable (#3528)

### DIFF
--- a/docs/ai-generated/code-reviews/3527-page-spec-test-ids-erlang.md
+++ b/docs/ai-generated/code-reviews/3527-page-spec-test-ids-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — #3527 page-spec TEST_IDS + Virtual-enabled assertions
+
+**Branch:** `fix/issue-3527-page-spec-test-ids` (stacks on `fix/issue-3528-type-picker-helper` / PR #3530)  
+**Scope:** uncommitted page spec + helper unit vs stacked #3528 tip  
+**Date:** 2026-08-17  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Cycle-verify residual for parent #3512 / cluster PR #3526. After #3530 restored `TEST_IDS.typeUnavailable`, `confirmType`, `confirmTemplateName`, and `pageNote`, `explorer-site-create-page.spec.js` still asserted **Virtual blocked** (`typeUnavailable` visible, Next disabled). The union wizard enables Page and Virtual and does not render `site-create-type-unavailable`. This change aligns the page spec with the shipped union (same IDs as `SiteCreateWizard` / type-picker spec) and adds a unit list of every key the page spec interpolates so another cluster absorb cannot go green with `undefined` locators.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (`TEST_IDS` key-closure unit; Playwright spec asserts enabled Virtual/Page + Traditional skip-template + Page happy path)
+- Cross-platform path I/O: N/A (no filesystem path construction; URL helpers already use `/`)
+- Change-class companions: Playwright page spec + helper unit (product-docs N/A — test-only)
+- **May commit/push:** yes
+
+## Issues
+
+None (gate).
+
+### Notes (non-blocking)
+
+- Helper IDs were **not** rewritten; #3530 already aligned them to wizard `data-testid`s. This slice only consumes those IDs.
+- `site-create-type-unavailable` remains a TEST_IDS string; union wizard does not render it while all kinds are enabled. Spec asserts `toHaveCount(0)`.
+- Happy-path Page create is unchanged except radio `.check()` (same control as type-picker).
+
+## Change-class companions
+
+| Kind | Status |
+|------|--------|
+| Helper | unchanged (stacked #3530 IDs) |
+| Unit | `explorer-sites-list-create.test.js` page-spec key closure |
+| Playwright | `explorer-site-create-page.spec.js` union-enabled assertions |
+| product-docs | N/A (Playwright/test-only) |
+
+## Memory patterns hit
+
+- Incomplete change-class closure — specs interpolating helper IDs the union dropped
+- Tests that only grep source strings — avoided; unit asserts exported string values

--- a/docs/ai-generated/code-reviews/3528-type-picker-helper-erlang.md
+++ b/docs/ai-generated/code-reviews/3528-type-picker-helper-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — #3528 type-picker helper export + typeUnavailable testid
+
+**Branch:** `fix/issue-3528-type-picker-helper` (stacks on `cluster/night-issue-20260817-site-create-wizard` @ `95ac375abf`)  
+**Scope:** uncommitted helper/spec/unit vs cluster tip  
+**Date:** 2026-08-17  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Cycle-verify residual for parent #3512 / cluster PR #3526. The cluster union left `explorer-site-create-type-picker.spec.js` importing `advanceTraditionalTypeStep` and `TEST_IDS.typeUnavailable` (and `confirmType`) that the helper no longer exported, so locators became `[data-testid=undefined]` and the Traditional confirm test threw `TypeError`. This change restores the helper IDs and export, adds a mock-page unit test for the helper, and updates the type-picker spec to assert the **shipped union** (Page/Virtual enabled, no force-disable).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (`advanceTraditionalTypeStep` mock-page unit test; TEST_IDS assertions; Playwright spec aligned to product)
+- Cross-platform path I/O: N/A (no filesystem path construction; URLs use `/`)
+- Change-class companions: Playwright helper + unit + surface spec (product-docs N/A — test helper only)
+- **May commit/push:** yes
+
+## Issues
+
+None (gate).
+
+### Notes (non-blocking)
+
+- Wizard was **not** rewritten. `site-create-type-unavailable` is restored as a TEST_IDS string for specs; the union wizard does not render that node while all kinds are enabled. Spec asserts `toHaveCount(0)` rather than inventing a blocking banner.
+- Extra IDs (`confirmType`, `confirmTemplateName`, `confirmBaseTemplate`, `pageNote`) match existing wizard `data-testid`s so sibling #3527 can stack without `undefined` interpolation.
+- Page spec (#3527) still asserts Virtual blocked; that is out of scope here.
+
+## Change-class companions
+
+| Kind | Status |
+|------|--------|
+| Helper | `TEST_IDS` + `advanceTraditionalTypeStep` export |
+| Unit | `explorer-sites-list-create.test.js` (IDs + mock-page helper) |
+| Playwright | type-picker spec asserts enabled Page/Virtual |
+| product-docs | N/A (test helper) |
+
+## Memory patterns hit
+
+- Missing behavioral tests for new/changed non-trivial logic — addressed with mock-page unit test
+- Incomplete change-class closure — helper IDs the specs interpolate

--- a/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
@@ -20,7 +20,8 @@
  *
  * <p>Coverage:</p>
  * <ul>
- *   <li>Type picker: Page is selectable; Virtual stays blocked</li>
+ *   <li>Type picker: Page is selectable; Virtual stays enabled on the cluster
+ *       union (no typeUnavailable banner; Next remains enabled)</li>
  *   <li>Page flow: details (managed nav locked) → page/base template → confirm</li>
  *   <li>Traditional still skips the template step</li>
  *   <li>Live Page create persists on POST /sitemanage/site/ and lists under Sites</li>
@@ -113,7 +114,7 @@ function attachConsoleGate(page) {
 
 test.describe("Explorer Page site create (#3520 / #3512)", () => {
   test(
-    "type picker: Page selectable, Virtual blocked, Traditional skips template",
+    "type picker: Page selectable, Virtual enabled, Traditional skips template",
     { tag: ["@explorer-site-create-page", "@explorer", "@sites"] },
     async ({ page }) => {
       test.setTimeout(90_000);
@@ -133,15 +134,19 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
         page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
-      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).click();
+      const unavailable = page.locator(
+        `[data-testid="${TEST_IDS.typeUnavailable}"]`,
+      );
+      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).check();
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+        page.locator(`[data-testid="${TEST_IDS.virtualNote}"]`),
       ).toBeVisible();
+      await expect(unavailable).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.next}"]`),
-      ).toBeDisabled();
+      ).toBeEnabled();
 
-      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
       ).toBeVisible();
@@ -166,10 +171,14 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
 
       await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
       await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
-      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.pageNote}"]`),
       ).toBeVisible();
+      await expect(unavailable).toHaveCount(0);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.next}"]`),
+      ).toBeEnabled();
       await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
@@ -217,7 +226,7 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
         page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
-      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
       await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
 
       const siteName = uniqueQaSiteName("QaPage");

--- a/modules/perc-qa-automation/frontend/tests/explorer-site-create-type-picker.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-site-create-type-picker.spec.js
@@ -21,7 +21,7 @@
  * <p>Covers Explorer Content → Create Site and Navigation New Site:</p>
  * <ul>
  *   <li>Type picker first (Traditional / Page / Virtual); Traditional default</li>
- *   <li>Page and Virtual stay on the type step with a clear message</li>
+ *   <li>Page and Virtual are enabled on the cluster union (do not block Next)</li>
  *   <li>Traditional: details → confirm with no template-name / base-template</li>
  * </ul>
  *
@@ -78,7 +78,7 @@ async function openExplorerCreateSiteOrSkip(page) {
 
 test.describe("Create Site type picker (#3522 / #3512)", () => {
   test(
-    "Explorer: type picker defaults Traditional; Page/Virtual block Next",
+    "Explorer: type picker defaults Traditional; Page/Virtual stay enabled",
     {
       tag: [
         "@explorer-site-create-type-picker",
@@ -120,26 +120,32 @@ test.describe("Create Site type picker (#3522 / #3512)", () => {
       ).toBeVisible();
 
       const next = page.locator(`[data-testid="${TEST_IDS.next}"]`);
+      const unavailable = page.locator(
+        `[data-testid="${TEST_IDS.typeUnavailable}"]`,
+      );
       await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+        page.locator(`[data-testid="${TEST_IDS.pageNote}"]`),
       ).toBeVisible();
-      await expect(next).toBeDisabled();
+      await expect(unavailable).toHaveCount(0);
+      await expect(next).toBeEnabled();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.stepDetails}"]`),
       ).toHaveCount(0);
 
       await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).check();
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+        page.locator(`[data-testid="${TEST_IDS.virtualNote}"]`),
       ).toBeVisible();
-      await expect(next).toBeDisabled();
+      await expect(unavailable).toHaveCount(0);
+      await expect(next).toBeEnabled();
 
       await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
-      await expect(next).toBeEnabled();
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
-      ).toHaveCount(0);
+        page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
+      ).toBeVisible();
+      await expect(next).toBeEnabled();
+      await expect(unavailable).toHaveCount(0);
 
       expect(pageErrors, pageErrors.join("\n")).toEqual([]);
       expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-sites-list-create.js
@@ -29,11 +29,17 @@ const TEST_IDS = Object.freeze({
   typeTraditional: "site-create-type-traditional",
   typePage: "site-create-type-page",
   typeVirtual: "site-create-type-virtual",
+  /** Shown only when the selected kind is not enabled in the product. */
+  typeUnavailable: "site-create-type-unavailable",
+  pageNote: "site-create-page-note",
   siteName: "site-create-name",
   description: "site-create-description",
   templateName: "site-create-template-name",
   baseTemplate: "site-create-base-template",
   confirmSummary: "site-create-confirm-summary",
+  confirmType: "site-create-confirm-type",
+  confirmTemplateName: "site-create-confirm-template-name",
+  confirmBaseTemplate: "site-create-confirm-base-template",
   next: "site-create-next",
   back: "site-create-back",
   run: "site-create-run",
@@ -178,6 +184,20 @@ function folderChildrenUrl(baseUrl, cmsPath) {
 }
 
 /**
+ * Select Traditional on the type picker and advance to the details step.
+ * @param {import('@playwright/test').Page} page
+ */
+async function advanceTraditionalTypeStep(page) {
+  const typeStep = page.locator(`[data-testid="${TEST_IDS.stepType}"]`);
+  await typeStep.waitFor({ state: "visible", timeout: 10_000 });
+  await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
+  await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+  await page
+    .locator(`[data-testid="${TEST_IDS.stepDetails}"]`)
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+/**
  * Open Content menu dropdown.
  * @param {import('@playwright/test').Page} page
  */
@@ -305,6 +325,7 @@ module.exports = {
   siteChildListCandidates,
   folderChildrenUrl,
   openContentMenu,
+  advanceTraditionalTypeStep,
   sitesTreeRootLocator,
   expandExplorerTreeNode,
   sitesTreeDescendantsLocator,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -37,6 +37,7 @@ const {
   createSiteMissingSkipReason,
   emptySitesSoftSkipNote,
   isKnownExplorerSitesConsoleNoise,
+  advanceTraditionalTypeStep,
 } = require("../helpers/explorer-sites-list-create");
 
 describe("explorer-sites-list-create helpers (#3003)", () => {
@@ -50,11 +51,55 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(TEST_IDS.typeTraditional, "site-create-type-traditional");
     assert.equal(TEST_IDS.typePage, "site-create-type-page");
     assert.equal(TEST_IDS.typeVirtual, "site-create-type-virtual");
+    assert.equal(TEST_IDS.typeUnavailable, "site-create-type-unavailable");
+    assert.equal(TEST_IDS.pageNote, "site-create-page-note");
+    assert.equal(TEST_IDS.confirmType, "site-create-confirm-type");
+    assert.equal(TEST_IDS.confirmTemplateName, "site-create-confirm-template-name");
+    assert.equal(TEST_IDS.confirmBaseTemplate, "site-create-confirm-base-template");
     assert.equal(TEST_IDS.siteName, "site-create-name");
     assert.equal(TEST_IDS.run, "site-create-run");
     assert.equal(TEST_IDS.managedNav, "site-create-managed-nav");
     assert.equal(TEST_IDS.confirmManagedNav, "site-create-confirm-managed-nav");
     assert.equal(TEST_IDS.virtualRoot, "site-create-virtual-root");
+  });
+
+  it("advanceTraditionalTypeStep selects Traditional and clicks Next", async () => {
+    assert.equal(typeof advanceTraditionalTypeStep, "function");
+    const checks = [];
+    const clicks = [];
+    const waits = [];
+    const page = {
+      locator(sel) {
+        return {
+          async waitFor(opts) {
+            waits.push({ sel, opts });
+          },
+          async check() {
+            checks.push(sel);
+          },
+          async click() {
+            clicks.push(sel);
+          },
+        };
+      },
+    };
+    await advanceTraditionalTypeStep(page);
+    assert.ok(
+      checks.some((s) => s.includes(TEST_IDS.typeTraditional)),
+      `Traditional radio checked: ${checks.join(",")}`,
+    );
+    assert.ok(
+      clicks.some((s) => s.includes(TEST_IDS.next)),
+      `Next clicked: ${clicks.join(",")}`,
+    );
+    assert.ok(
+      waits.some((w) => w.sel.includes(TEST_IDS.stepType)),
+      "waits for type step",
+    );
+    assert.ok(
+      waits.some((w) => w.sel.includes(TEST_IDS.stepDetails)),
+      "waits for details step",
+    );
   });
 
   it("tracks parent epic and slice issue numbers", () => {

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -63,6 +63,48 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(TEST_IDS.virtualRoot, "site-create-virtual-root");
   });
 
+  it("exports every TEST_IDS key explorer-site-create-page.spec interpolates (#3527)", () => {
+    const required = [
+      "shell",
+      "menuContent",
+      "createSiteMenu",
+      "wizard",
+      "stepType",
+      "stepDetails",
+      "stepTemplate",
+      "stepConfirm",
+      "stepProgress",
+      "typeTraditional",
+      "typePage",
+      "typeVirtual",
+      "typeUnavailable",
+      "pageNote",
+      "virtualNote",
+      "traditionalNote",
+      "siteName",
+      "templateName",
+      "baseTemplate",
+      "confirmSummary",
+      "confirmType",
+      "confirmTemplateName",
+      "confirmManagedNav",
+      "managedNav",
+      "next",
+      "back",
+      "run",
+    ];
+    for (const key of required) {
+      const value = TEST_IDS[key];
+      assert.equal(typeof value, "string", key);
+      assert.ok(value.length > 0, key);
+      assert.notEqual(value, "undefined", key);
+    }
+    assert.equal(TEST_IDS.typeUnavailable, "site-create-type-unavailable");
+    assert.equal(TEST_IDS.confirmType, "site-create-confirm-type");
+    assert.equal(TEST_IDS.confirmTemplateName, "site-create-confirm-template-name");
+    assert.equal(TEST_IDS.pageNote, "site-create-page-note");
+  });
+
   it("advanceTraditionalTypeStep selects Traditional and clicks Next", async () => {
     assert.equal(typeof advanceTraditionalTypeStep, "function");
     const checks = [];


### PR DESCRIPTION
## Summary

Cycle-verify residual for parent **#3512** / cluster **#3526** (`cluster/night-issue-20260817-site-create-wizard` @ `95ac375abf`).

On the cluster union, `tests/explorer-site-create-type-picker.spec.js` imported `advanceTraditionalTypeStep` and `TEST_IDS.typeUnavailable` (and used `confirmType`) from `tests/helpers/explorer-sites-list-create.js`, but the helper exported neither. Locators became `[data-testid="undefined"]`; Traditional confirm threw `TypeError: advanceTraditionalTypeStep is not a function`.

This PR does **not** rewrite the Create Site wizard. It:

- Restores `TEST_IDS.typeUnavailable` plus matching wizard IDs already on the union (`confirmType`, `confirmTemplateName`, `confirmBaseTemplate`, `pageNote`) so sibling **#3527** can stack.
- Exports `advanceTraditionalTypeStep` (select Traditional, click Next onto details).
- Updates the type-picker spec to assert **shipped** product behavior: Page/Virtual stay enabled on the union (no force-disable).

**Stacks on #3526** (`--base cluster/night-issue-20260817-site-create-wizard`). Do not merge independently of the cluster.

Fixes #3528  
Parent: #3512

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-qa-automation/frontend && npm run test:unit` — helper unit tests include new TEST_IDS + mock-page `advanceTraditionalTypeStep`.
2. `perc-devctl qa-up --skip-image-build` → `qa-health` HTTP 200 HEALTH=healthy (known FastForward `PSDbStorageService` seed ERROR is #2423).
3. Hot-copy cluster `WebUI/target/generated-webui/cm/modern/assets` into `perc-matrix-cms-h2` WAR `cm/modern/assets`.
4. `cd modules/perc-qa-automation/frontend` with `TEST_CMS_URL` from qa-health, `ADMIN_USERNAME=Admin`, `ADMIN_PASSWORD` from cell `var/config/generated/passwords`, `TEST_DB_TYPE=h2`, `TEST_PRODUCT=cms`:
   `npm run test:surface -- --path tests/explorer-site-create-type-picker.spec.js`
5. Expect 3 passed (Traditional default + enabled Page/Virtual; Traditional skips template to confirm; Navigation New Site same picker).

## Checklist

- [x] **Product documentation** — **N/A** (test helper / Playwright spec only; no operator-facing product change)
- [x] **Unit / module tests** — mock-page helper test + TEST_IDS assertions; `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` **BUILD SUCCESS**
- [x] **WebUI + Playwright** — updated `explorer-site-create-type-picker.spec.js`; C5 surface 3 passed
- [x] **Build gates** — standalone clean install of `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — **N/A** (no filesystem path I/O; URL joins use `/`)

## C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-17). Companion `frontend npm run test:unit` → 304 passed, 0 failed.
- **downstream_checked:** none (no Java public API / `final` / signature change)

## C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build`
- **TEST_CMS_URL:** `http://127.0.0.1:9993` (container `perc-matrix-cms-h2`)
- **qa-health:** HTTP 200 HEALTH=healthy (RESULT:FAIL only on known #2423 FastForward `PSDbStorageService` seed ERROR)
- **hot-deploy:** copied cluster `WebUI/target/generated-webui/cm/modern/assets` into WAR `cm/modern/assets` (entry `perc-modern-ui.js` → `SiteCreateWizard-BwQgseNf`); no Jetty restart (static assets only; no product jar change)
- **Playwright:** `npm run test:surface -- --path tests/explorer-site-create-type-picker.spec.js` → **3 passed** (5.7s)
- **console-clean:** yes (spec pageerror/console error listeners)
- **server.log-clean:** yes for this surface; post-run new ERROR lines are known missing FF nav type 315 (`BUG:#3326`); seed ERROR is `BUG:#2423`

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
