### PR TITLE
test(qa): align page-spec TEST_IDS with enabled Virtual (#3527)

### DIFF
--- a/docs/ai-generated/code-reviews/3527-page-spec-test-ids-erlang.md
+++ b/docs/ai-generated/code-reviews/3527-page-spec-test-ids-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — #3527 page-spec TEST_IDS + Virtual-enabled assertions
+
+**Branch:** `fix/issue-3527-page-spec-test-ids` (stacks on `fix/issue-3528-type-picker-helper` / PR #3530)  
+**Scope:** uncommitted page spec + helper unit vs stacked #3528 tip  
+**Date:** 2026-08-17  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Cycle-verify residual for parent #3512 / cluster PR #3526. After #3530 restored `TEST_IDS.typeUnavailable`, `confirmType`, `confirmTemplateName`, and `pageNote`, `explorer-site-create-page.spec.js` still asserted **Virtual blocked** (`typeUnavailable` visible, Next disabled). The union wizard enables Page and Virtual and does not render `site-create-type-unavailable`. This change aligns the page spec with the shipped union (same IDs as `SiteCreateWizard` / type-picker spec) and adds a unit list of every key the page spec interpolates so another cluster absorb cannot go green with `undefined` locators.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (`TEST_IDS` key-closure unit; Playwright spec asserts enabled Virtual/Page + Traditional skip-template + Page happy path)
+- Cross-platform path I/O: N/A (no filesystem path construction; URL helpers already use `/`)
+- Change-class companions: Playwright page spec + helper unit (product-docs N/A — test-only)
+- **May commit/push:** yes
+
+## Issues
+
+None (gate).
+
+### Notes (non-blocking)
+
+- Helper IDs were **not** rewritten; #3530 already aligned them to wizard `data-testid`s. This slice only consumes those IDs.
+- `site-create-type-unavailable` remains a TEST_IDS string; union wizard does not render it while all kinds are enabled. Spec asserts `toHaveCount(0)`.
+- Happy-path Page create is unchanged except radio `.check()` (same control as type-picker).
+
+## Change-class companions
+
+| Kind | Status |
+|------|--------|
+| Helper | unchanged (stacked #3530 IDs) |
+| Unit | `explorer-sites-list-create.test.js` page-spec key closure |
+| Playwright | `explorer-site-create-page.spec.js` union-enabled assertions |
+| product-docs | N/A (Playwright/test-only) |
+
+## Memory patterns hit
+
+- Incomplete change-class closure — specs interpolating helper IDs the union dropped
+- Tests that only grep source strings — avoided; unit asserts exported string values

--- a/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-site-create-page.spec.js
@@ -20,7 +20,8 @@
  *
  * <p>Coverage:</p>
  * <ul>
- *   <li>Type picker: Page is selectable; Virtual stays blocked</li>
+ *   <li>Type picker: Page is selectable; Virtual stays enabled on the cluster
+ *       union (no typeUnavailable banner; Next remains enabled)</li>
  *   <li>Page flow: details (managed nav locked) → page/base template → confirm</li>
  *   <li>Traditional still skips the template step</li>
  *   <li>Live Page create persists on POST /sitemanage/site/ and lists under Sites</li>
@@ -113,7 +114,7 @@ function attachConsoleGate(page) {
 
 test.describe("Explorer Page site create (#3520 / #3512)", () => {
   test(
-    "type picker: Page selectable, Virtual blocked, Traditional skips template",
+    "type picker: Page selectable, Virtual enabled, Traditional skips template",
     { tag: ["@explorer-site-create-page", "@explorer", "@sites"] },
     async ({ page }) => {
       test.setTimeout(90_000);
@@ -133,15 +134,19 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
         page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
-      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).click();
+      const unavailable = page.locator(
+        `[data-testid="${TEST_IDS.typeUnavailable}"]`,
+      );
+      await page.locator(`[data-testid="${TEST_IDS.typeVirtual}"]`).check();
       await expect(
-        page.locator(`[data-testid="${TEST_IDS.typeUnavailable}"]`),
+        page.locator(`[data-testid="${TEST_IDS.virtualNote}"]`),
       ).toBeVisible();
+      await expect(unavailable).toHaveCount(0);
       await expect(
         page.locator(`[data-testid="${TEST_IDS.next}"]`),
-      ).toBeDisabled();
+      ).toBeEnabled();
 
-      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typeTraditional}"]`).check();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.traditionalNote}"]`),
       ).toBeVisible();
@@ -166,10 +171,14 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
 
       await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
       await page.locator(`[data-testid="${TEST_IDS.back}"]`).click();
-      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.pageNote}"]`),
       ).toBeVisible();
+      await expect(unavailable).toHaveCount(0);
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.next}"]`),
+      ).toBeEnabled();
       await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
       await expect(
         page.locator(`[data-testid="${TEST_IDS.managedNav}"]`),
@@ -217,7 +226,7 @@ test.describe("Explorer Page site create (#3520 / #3512)", () => {
         page.locator(`[data-testid="${TEST_IDS.stepType}"]`),
       ).toBeVisible({ timeout: 10_000 });
 
-      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).click();
+      await page.locator(`[data-testid="${TEST_IDS.typePage}"]`).check();
       await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
 
       const siteName = uniqueQaSiteName("QaPage");

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-sites-list-create.test.js
@@ -63,6 +63,48 @@ describe("explorer-sites-list-create helpers (#3003)", () => {
     assert.equal(TEST_IDS.virtualRoot, "site-create-virtual-root");
   });
 
+  it("exports every TEST_IDS key explorer-site-create-page.spec interpolates (#3527)", () => {
+    const required = [
+      "shell",
+      "menuContent",
+      "createSiteMenu",
+      "wizard",
+      "stepType",
+      "stepDetails",
+      "stepTemplate",
+      "stepConfirm",
+      "stepProgress",
+      "typeTraditional",
+      "typePage",
+      "typeVirtual",
+      "typeUnavailable",
+      "pageNote",
+      "virtualNote",
+      "traditionalNote",
+      "siteName",
+      "templateName",
+      "baseTemplate",
+      "confirmSummary",
+      "confirmType",
+      "confirmTemplateName",
+      "confirmManagedNav",
+      "managedNav",
+      "next",
+      "back",
+      "run",
+    ];
+    for (const key of required) {
+      const value = TEST_IDS[key];
+      assert.equal(typeof value, "string", key);
+      assert.ok(value.length > 0, key);
+      assert.notEqual(value, "undefined", key);
+    }
+    assert.equal(TEST_IDS.typeUnavailable, "site-create-type-unavailable");
+    assert.equal(TEST_IDS.confirmType, "site-create-confirm-type");
+    assert.equal(TEST_IDS.confirmTemplateName, "site-create-confirm-template-name");
+    assert.equal(TEST_IDS.pageNote, "site-create-page-note");
+  });
+
   it("advanceTraditionalTypeStep selects Traditional and clicks Next", async () => {
     assert.equal(typeof advanceTraditionalTypeStep, "function");
     const checks = [];


### PR DESCRIPTION
## Summary

Cycle-verify residual for parent #3512 / cluster #3526. After #3530 restored helper `TEST_IDS.typeUnavailable`, `confirmType`, `confirmTemplateName`, and `pageNote`, `explorer-site-create-page.spec.js` still asserted **Virtual blocked** (`typeUnavailable` visible, Next disabled). The union wizard enables Page and Virtual and does not render `site-create-type-unavailable`, so locators either timed out or would fail once IDs were defined.

This slice (stacked on #3530 / `fix/issue-3528-type-picker-helper`) aligns the page spec with the shipped union — same `SiteCreateWizard` `data-testid`s, no second ID scheme — and unit-locks every `TEST_IDS` key the page spec interpolates.

Fixes #3527  
Parent #3512 / cluster #3526 / stacks on #3530 (#3528)

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit (no CMS): `cd modules/perc-qa-automation/frontend && npm run test:unit` — 305 passed (includes new #3527 key-closure test).
2. Standalone Maven: `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS**.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health` → HTTP 200 HEALTH=healthy (FastForward `PSDbStorageService` seed ERROR is known #2423 noise).
4. Hot-deploy cluster tip `sitemanage` + `perc-system` + `WebUI/target/generated-webui/cm/modern/assets` into `perc-matrix-cms-h2` WAR; in-cell `StopJetty.sh`/`StartJetty.sh`; `qa-health` again (same #2423 seed line only).
5. `TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2` `TEST_PRODUCT=cms` `ADMIN_USERNAME=Admin`  
   `npm run test:surface -- --path tests/explorer-site-create-page.spec.js` → **2 passed**.
6. Same env: `npm run test:surface -- --path tests/explorer-site-create-type-picker.spec.js` → **3 passed**.

## Checklist

- [x] **Product documentation** — N/A (Playwright/test-only; no operator/user-facing product change)
- [x] **Unit / module tests** — helper unit key-closure + Playwright page spec; `perc-qa-automation` standalone clean install green
- [x] **WebUI + Playwright** — updated `explorer-site-create-page.spec.js`; live H2 surface green (page + type-picker)
- [x] **Build gates** — standalone `modules/perc-qa-automation` `mvnw.cmd clean install` BUILD SUCCESS; no API-shape change
- [x] **Cross-platform** — N/A (no filesystem path I/O; URL helpers already use `/`)

### C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (frontend-maven `npm ci`; no Java tests in this module). `npm run test:unit` → 305 pass / 0 fail.
- **downstream_checked:** none (no public/protected Java API or `final`/`sealed` type change)

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2` on `TEST_CMS_URL=http://127.0.0.1:9993` (freeport publish 9993)
- qa-health: HTTP 200 HEALTH=healthy URL `/Rhythmyx/rest/mimetypes`; DETAIL:server_log_errors is FastForward `PSDbStorageService` seed only (BUG:#2423)
- deploy: docker cp cluster `sitemanage-8.2.0-SNAPSHOT.jar` + `perc-system-8.2.0-SNAPSHOT.jar` + `WebUI/target/generated-webui/cm/modern/assets` into WAR; in-cell Jetty stop/start; ROOT `ServletContextHandler] Started`
- Playwright: `npm run test:surface -- --path tests/explorer-site-create-page.spec.js` → 2 passed (6.3s); type-picker 3 passed (5.0s)
- console-clean=yes (spec pageerror/console error gate)
- server.log-clean=yes for the test window (no new site-create ERROR/FATAL; remaining seed/index noise is pre-test / BUG:#2423)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
