### PR TITLE
fix(WebUI): populate Home Create Page template dropdown (#3529)

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -165,6 +165,132 @@ export async function fetchFolderChildren(
   return normalizeList(data).map(normalizeContentItem) as FolderChild[];
 }
 
+/**
+ * Jackson list-wrapper keys used by sitemanage {@code PSTemplateSummaryList}
+ * and rest {@code TemplateSummaryList}.
+ */
+const TEMPLATE_LIST_KEYS = [
+  "TemplateSummary",
+  "templateSummary",
+  "TemplateSummaryList",
+  "templateSummaryList",
+  "Template",
+  "templates",
+  "entries",
+] as const;
+
+/**
+ * True when Jackson treated an {@code ArrayList} subclass as a bean
+ * ({@code {"empty":false}}) instead of a JSON array (#3368 / #3529).
+ */
+function isEmptyListBean(o: Record<string, unknown>): boolean {
+  if (!("empty" in o)) {
+    return false;
+  }
+  const hasId = o.id != null || o.Id != null || o.templateId != null;
+  const hasName =
+    o.name != null ||
+    o.Name != null ||
+    o.label != null ||
+    o.templateName != null ||
+    o.templateLabel != null;
+  return !hasId && !hasName;
+}
+
+function firstNonBlank(
+  o: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const v = o[key];
+    if (v != null && String(v).trim()) {
+      return String(v).trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Map one site/rest template summary row. Accepts {@code id}/{@code name}
+ * (sitemanage) and {@code templateId}/{@code templateName} (rest). Nested
+ * {@code TemplateSummary} wraps from WRAP_ROOT_VALUE are unwrapped.
+ */
+export function mapTemplateSummary(raw: unknown): TemplateSummary | null {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+  const rec = raw as Record<string, unknown>;
+  const nested = rec.TemplateSummary ?? rec.templateSummary ?? rec.Template;
+  const o =
+    nested && typeof nested === "object" && !Array.isArray(nested)
+      ? (nested as Record<string, unknown>)
+      : rec;
+  if (isEmptyListBean(o)) {
+    return null;
+  }
+  const id = firstNonBlank(o, "id", "Id", "templateId", "TemplateId");
+  if (!id) {
+    return null;
+  }
+  const name =
+    firstNonBlank(
+      o,
+      "name",
+      "Name",
+      "label",
+      "Label",
+      "templateName",
+      "templateLabel",
+      "TemplateName",
+    ) ?? id;
+  const thumb =
+    firstNonBlank(o, "imageThumbPath", "thumbPath", "imagePath") ?? undefined;
+  return { id, name, thumbPath: thumb };
+}
+
+/**
+ * Unwrap site-template GET payloads: Jackson {@code TemplateSummary} envelope,
+ * {@code TemplateSummaryList}, raw arrays, nested wraps, and the ArrayList
+ * {@code {empty:false}} bean (treated as empty). Rows without an id are
+ * dropped so the Create Page dropdown is not left on a blank “Select…”.
+ */
+export function unwrapTemplateSummaries(data: unknown): TemplateSummary[] {
+  if (data == null) {
+    return [];
+  }
+  if (Array.isArray(data)) {
+    return data
+      .map(mapTemplateSummary)
+      .filter((t): t is TemplateSummary => t != null);
+  }
+  const obj = asRecord(data);
+  if (!obj) {
+    return [];
+  }
+  if (isEmptyListBean(obj)) {
+    return [];
+  }
+  for (const key of TEMPLATE_LIST_KEYS) {
+    if (!(key in obj)) {
+      continue;
+    }
+    const list = obj[key];
+    if (Array.isArray(list)) {
+      return unwrapTemplateSummaries(list);
+    }
+    const nested = unwrapTemplateSummaries(list);
+    if (nested.length > 0) {
+      return nested;
+    }
+    const one = mapTemplateSummary(list);
+    if (one) {
+      return [one];
+    }
+  }
+  const one = mapTemplateSummary(obj);
+  return one ? [one] : [];
+}
+
 /** Templates for a site (classic getTemplates). */
 export async function fetchTemplatesForSite(
   siteName: string,
@@ -172,23 +298,7 @@ export async function fetchTemplatesForSite(
   const data = await get<unknown>(
     `${PATHS.TEMPLATES_BY_SITE}/${encodeURIComponent(siteName)}`,
   );
-  if (data && typeof data === "object" && "TemplateSummary" in data) {
-    const list = (data as { TemplateSummary: unknown }).TemplateSummary;
-    const arr = Array.isArray(list) ? list : list ? [list] : [];
-    return arr.map((t) => {
-      const o = t as Record<string, unknown>;
-      return {
-        id: String(o.id ?? ""),
-        name: String(o.name ?? o.label ?? o.id ?? ""),
-        thumbPath: o.imageThumbPath
-          ? String(o.imageThumbPath)
-          : o.thumbPath
-            ? String(o.thumbPath)
-            : undefined,
-      };
-    });
-  }
-  return [];
+  return unwrapTemplateSummaries(data);
 }
 
 /**

--- a/WebUI/src/main/ts/home/create/PageWizard.tsx
+++ b/WebUI/src/main/ts/home/create/PageWizard.tsx
@@ -24,6 +24,7 @@ import {
   formatApiError,
 } from "../../api/home/homeApi";
 import type { SiteSummary, TemplateSummary } from "../../api/home/types";
+import { loadPageTemplates } from "../../editor/pageTemplates";
 import { openEditorHost } from "../../editor/openEditorHost";
 import { message, MSG } from "../../i18n/message";
 import {
@@ -80,12 +81,28 @@ export function PageWizard({
       return;
     }
     setBusy(true);
+    setTemplateId("");
     Promise.all([
       fetchTemplatesForSite(site),
       fetchFolderChildren(`/Sites/${site}`),
     ])
-      .then(([tmpls, children]) => {
-        setTemplates(tmpls);
+      .then(async ([tmpls, children]) => {
+        let resolved = tmpls;
+        if (resolved.length === 0) {
+          try {
+            const fallback = await loadPageTemplates(`/Sites/${site}`, "percPage");
+            resolved = fallback
+              .filter((t) => t.id)
+              .map((t) => ({ id: t.id, name: t.name || t.id }));
+          } catch (err) {
+            console.warn(
+              "[PageWizard] content-type template fallback failed",
+              site,
+              err,
+            );
+          }
+        }
+        setTemplates(resolved);
         const folderPaths = children
           .filter(
             (c) =>
@@ -176,6 +193,7 @@ export function PageWizard({
           <label htmlFor="pw-site">{message(MSG.CREATE_SITE)}</label>
           <select
             id="pw-site"
+            data-testid="page-wizard-site"
             value={site}
             onChange={(e) => setSite(e.target.value)}
             required
@@ -194,6 +212,7 @@ export function PageWizard({
         <label htmlFor="pw-template">{message(MSG.CREATE_TEMPLATE)}</label>
         <select
           id="pw-template"
+          data-testid="page-wizard-template"
           value={templateId}
           onChange={(e) => setTemplateId(e.target.value)}
           required

--- a/WebUI/src/test/ts/home/PageWizard.test.tsx
+++ b/WebUI/src/test/ts/home/PageWizard.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PageWizard } from "@/home/create/PageWizard";
+
+function mockJsonResponse(body: unknown) {
+  const text = JSON.stringify(body);
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    text: async () => text,
+    json: async () => body,
+  };
+}
+
+describe("PageWizard templates", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k) => k,
+    };
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(handlers: {
+    sites: unknown;
+    templates: unknown;
+    folders?: unknown;
+    contentType?: unknown;
+  }) {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/sitemanage/site/")) {
+        return mockJsonResponse(handlers.sites);
+      }
+      if (url.includes("/sitetemplates/templates/")) {
+        return mockJsonResponse(handlers.templates);
+      }
+      if (url.includes("/contenttypes/")) {
+        return mockJsonResponse(
+          handlers.contentType ?? { ContentTypeDetail: { allowedTemplates: [] } },
+        );
+      }
+      if (url.includes("/pathmanagement/path/folder")) {
+        return mockJsonResponse(handlers.folders ?? []);
+      }
+      return mockJsonResponse([]);
+    });
+  }
+
+  it("selecting a site populates template options from the TemplateSummary envelope", async () => {
+    stubFetch({
+      sites: {
+        SiteSummary: [
+          { name: "OtherSite" },
+          { name: "QaSite3002" },
+        ],
+      },
+      templates: {
+        TemplateSummary: [
+          { id: "1-101-7", name: "Home" },
+          { templateId: "tmpl-article", templateName: "Article" },
+        ],
+      },
+    });
+
+    render(<PageWizard onBack={() => undefined} />);
+    await waitFor(() => screen.getByTestId("page-wizard"));
+
+    fireEvent.change(screen.getByTestId("page-wizard-site"), {
+      target: { value: "QaSite3002" },
+    });
+
+    await waitFor(() => {
+      const sel = screen.getByTestId("page-wizard-template") as HTMLSelectElement;
+      const values = Array.from(sel.options).map((o) => o.value);
+      expect(values).toContain("1-101-7");
+      expect(values).toContain("tmpl-article");
+    });
+    const sel = screen.getByTestId("page-wizard-template") as HTMLSelectElement;
+    expect(sel.options[Array.from(sel.options).findIndex((o) => o.value === "1-101-7")]?.text).toBe(
+      "Home",
+    );
+    expect(
+      sel.options[Array.from(sel.options).findIndex((o) => o.value === "tmpl-article")]?.text,
+    ).toBe("Article");
+  });
+
+  it("falls back to percPage allowedTemplates when the site catalog is an empty-bean", async () => {
+    stubFetch({
+      sites: {
+        SiteSummary: [{ name: "A" }, { name: "B" }],
+      },
+      templates: { TemplateSummary: { empty: false } },
+      contentType: {
+        ContentTypeDetail: {
+          allowedTemplates: [
+            { name: "t1", label: "Landing", guid: { stringValue: "1-101-9" } },
+          ],
+        },
+      },
+    });
+
+    render(<PageWizard onBack={() => undefined} />);
+    await waitFor(() => screen.getByTestId("page-wizard"));
+    fireEvent.change(screen.getByTestId("page-wizard-site"), {
+      target: { value: "B" },
+    });
+
+    await waitFor(() => {
+      const sel = screen.getByTestId("page-wizard-template") as HTMLSelectElement;
+      expect(Array.from(sel.options).some((o) => o.value === "1-101-9")).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -30,14 +30,17 @@ import {
   fetchMyContent,
   fetchRecentItems,
   fetchSites,
+  fetchTemplatesForSite,
   formatApiError,
   isBookmarkableItem,
   isMyPage,
   mapAssetType,
+  mapTemplateSummary,
   normalizeContentItem,
   removeFromMyPages,
   searchContent,
   templateHasWidget,
+  unwrapTemplateSummaries,
 } from "@/api/home/homeApi";
 import type { ApiError } from "@/api/client";
 
@@ -350,6 +353,82 @@ describe("homeApi", () => {
     expect(isBookmarkableItem({ id: "1", folder: true })).toBe(false);
     expect(isBookmarkableItem({ id: "1", type: "Folder" })).toBe(false);
     expect(isBookmarkableItem({ name: "no-id" })).toBe(false);
+  });
+
+  it("unwrapTemplateSummaries maps TemplateSummary envelope and field aliases", () => {
+    expect(
+      unwrapTemplateSummaries({
+        TemplateSummary: [
+          { id: "1-101-7", name: "Home", imageThumbPath: "/t.png" },
+          { templateId: 1037, templateName: "perc.page", templateLabel: "Page" },
+        ],
+      }),
+    ).toEqual([
+      { id: "1-101-7", name: "Home", thumbPath: "/t.png" },
+      { id: "1037", name: "perc.page" },
+    ]);
+  });
+
+  it("unwrapTemplateSummaries accepts raw arrays and nested WRAP_ROOT_VALUE rows", () => {
+    expect(
+      unwrapTemplateSummaries([
+        { TemplateSummary: { id: "a", label: "Alpha" } },
+        { Id: "b", Name: "Beta" },
+      ]),
+    ).toEqual([
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ]);
+  });
+
+  it("unwrapTemplateSummaries treats ArrayList empty-bean as no templates", () => {
+    expect(unwrapTemplateSummaries({ TemplateSummary: { empty: false } })).toEqual(
+      [],
+    );
+    expect(unwrapTemplateSummaries({ empty: true })).toEqual([]);
+  });
+
+  it("unwrapTemplateSummaries unwraps TemplateSummaryList envelope", () => {
+    expect(
+      unwrapTemplateSummaries({
+        TemplateSummaryList: {
+          TemplateSummary: [{ id: "t9", name: "Base" }],
+        },
+      }),
+    ).toEqual([{ id: "t9", name: "Base" }]);
+  });
+
+  it("mapTemplateSummary drops rows without an id", () => {
+    expect(mapTemplateSummary({ name: "orphan" })).toBeNull();
+    expect(mapTemplateSummary({ empty: false })).toBeNull();
+  });
+
+  it("fetchTemplatesForSite unwraps the live TemplateSummary envelope", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        TemplateSummary: [
+          { id: "1-101-7", name: "Home" },
+          { templateId: "tmpl-2", templateLabel: "Article" },
+        ],
+      }),
+    );
+    const list = await fetchTemplatesForSite("QaSite3002");
+    expect(list).toEqual([
+      { id: "1-101-7", name: "Home" },
+      { id: "tmpl-2", name: "Article" },
+    ]);
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/sitemanage/sitetemplates/templates/");
+    expect(url).toContain(encodeURIComponent("QaSite3002"));
+  });
+
+  it("fetchTemplatesForSite returns empty for the Jackson ArrayList bean", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ TemplateSummary: { empty: false } }),
+    );
+    await expect(fetchTemplatesForSite("Demo")).resolves.toEqual([]);
   });
 
   it("fetchSites surfaces API errors", async () => {

--- a/docs/ai-generated/code-reviews/3529-home-create-page-templates-erlang.md
+++ b/docs/ai-generated/code-reviews/3529-home-create-page-templates-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — #3529 Home Create Page template dropdown
+
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3529-create-page-template-dropdown`  
+**Persona:** independent pre-commit (Erlang)  
+**Memory patterns hit:** Jackson ArrayList `{empty:false}` bean (#3368); WebUI Playwright companion; product-docs for user-visible Home Create; unwrap envelope + field aliases.
+
+## Summary
+
+Home → Create Page left Template on “Select…” because `fetchTemplatesForSite` only accepted a `TemplateSummary` root and mapped empty `id`/`name` when Jackson 3 serialized `PSTemplateSummaryList` as an ArrayList bean. The change unwraps real envelopes (array, `TemplateSummary` / `TemplateSummaryList`, rest `templateId`/`templateName`), drops empty-bean rows, falls back to `loadPageTemplates` (`percPage` allowed templates), and marks the sitemanage list as `@JsonFormat(ARRAY)` (peer of `SiteList`).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+- Behavioral unit tests: `unwrapTemplateSummaries` / `fetchTemplatesForSite` envelopes; PageWizard selects a site and lists options from the live envelope; empty-bean falls back to allowed templates; `PSTemplateSummaryListJacksonTest` asserts array wire, not `{empty:false}`.
+- Playwright: `tests/bugs/bug-3529-home-create-page-templates.spec.js` (`@home` `@page-wizard`) passed on H2 QA after hot-deploy.
+- Product-docs: `product-docs/8.2/admin/index.md` Home → Create page template step.
+- Cross-platform path checklist: no new filesystem path construction (N/A). URLs use `/` correctly.
+
+## Issues
+
+None that block commit.
+
+### Notes (not gates)
+
+- `qa-health` still reports FastForward `PSDbStorageService` import ERRORs and search-index date parse noise on H2 silent install. Those predate this change; HTTP 200 / `HEALTH:healthy`; no `sitetemplates` / `TemplateSummary` ERRORs in the test window.
+- `perc-qa-automation` is spec-only (no Maven source change); Playwright is the required companion for this WebUI screen.

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3529-home-create-page-templates.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3529-home-create-page-templates.spec.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-3529: Home → Add New → Create Page Template dropdown must list
+ * templates after a site is selected (not stay on “Select…”).
+ *
+ * <p>Tags: {@code @home} {@code @page-wizard}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/bugs/bug-3529-home-create-page-templates.spec.js}</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+function homeDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+test.describe("GH-3529 Home Create Page templates", () => {
+  test(
+    "selecting a site populates the Create Page template dropdown",
+    { tag: ["@home", "@page-wizard"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const consoleErrors = [];
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await loginAsAdmin(page);
+      await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
+      await expect(page.getByTestId("home-shell")).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId("home-nav-create").click();
+      await expect(page.getByTestId("create-type-chooser")).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId("create-choose-page").click();
+      const empty = page.getByTestId("create-wizard-no-sites");
+      const wizard = page.getByTestId("page-wizard");
+      await expect(empty.or(wizard)).toBeVisible({ timeout: 20_000 });
+      if (await empty.isVisible()) {
+        test.skip(true, "No sites available for Home Create Page");
+        return;
+      }
+
+      const siteSelect = page.getByTestId("page-wizard-site");
+      if (await siteSelect.isVisible()) {
+        const firstSite = siteSelect.locator("option[value]:not([value=''])").first();
+        const siteValue = await firstSite.getAttribute("value");
+        if (!siteValue) {
+          test.skip(true, "No site options in Create Page wizard");
+          return;
+        }
+        await siteSelect.selectOption(siteValue);
+      }
+
+      const templateSelect = page.getByTestId("page-wizard-template");
+      await expect(templateSelect).toBeVisible({ timeout: 20_000 });
+      await expect
+        .poll(
+          async () =>
+            templateSelect.locator("option[value]:not([value=''])").count(),
+          { timeout: 20_000 },
+        )
+        .toBeGreaterThan(0);
+
+      const unexpected = consoleErrors.filter(
+        (t) =>
+          !/favicon|404|net::ERR|Failed to load resource|ResizeObserver/i.test(t) &&
+          !/Download the React DevTools/i.test(t),
+      );
+      expect(
+        unexpected,
+        `JS console errors: ${unexpected.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -37,6 +37,12 @@ for those kinds) and opens the React Content Editor
 use **Open** on the wizard to open the new asset. Home Create does **not**
 open leftover `editAsset.jsp` or `?view=editor`.
 
+**Create page:** choose a **Site**, then a **Template**. The Template list
+loads that site's page templates. If the site catalog is empty, the wizard
+falls back to templates allowed for the page content type. You cannot create
+the page until a template is selected. Then pick the destination folder,
+title, and file name.
+
 Rich file, image, and TinyMCE widget chrome in that editor is still a later
 slice — a new asset can still be created as a stub and opened on the field
 form.

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummaryList.java
@@ -18,17 +18,28 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.pagemanagement.data;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 
-/** List wrapper for PSTemplateSummary. */
+/**
+ * List wrapper for PSTemplateSummary.
+ *
+ * <p>{@link JsonFormat.Shape#ARRAY} keeps Jackson from treating this {@code ArrayList} subclass as
+ * a bean ({@code {"empty":false}}) under {@code JacksonContextResolver} WRAP_ROOT_VALUE. That bean
+ * shape is HTTP 200 with no template rows, so Home → Create Page leaves the Template dropdown on
+ * “Select…” (#3529). Peer: {@code SiteList} (#3368).
+ */
 @XmlRootElement(name = "TemplateSummary")
 @ArraySchema(schema = @Schema(implementation = PSTemplateSummary.class))
 @JsonRootName("TemplateSummary")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@XmlSeeAlso(PSTemplateSummary.class)
 public class PSTemplateSummaryList extends ArrayList<PSTemplateSummary> {
   private static final long serialVersionUID = 1L;
 

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/data/PSTemplateSummaryListJacksonTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/data/PSTemplateSummaryListJacksonTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.sitemanage.json.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire shape for GET {@code /sitemanage/sitetemplates/templates/{site}} must be a JSON array of
+ * template summaries, not an ArrayList bean ({@code {"empty":false}}) (#3529 / #3368).
+ */
+@Tag("UnitTest")
+class PSTemplateSummaryListJacksonTest {
+
+  private static PSTemplateSummary sample() {
+    PSTemplateSummary t = new PSTemplateSummary();
+    t.setId("1-101-7");
+    t.setName("perc.page");
+    t.setLabel("Page");
+    return t;
+  }
+
+  @Test
+  void productionMapperSerializesTemplateListAsArray() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(PSTemplateSummaryList.class);
+    PSTemplateSummaryList list = new PSTemplateSummaryList();
+    list.add(sample());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(
+        json.contains("TemplateSummary") || json.contains("["),
+        "expected list wire shape, got: " + json);
+    assertTrue(json.contains("["), "TemplateSummary list must be a JSON array: " + json);
+    assertTrue(json.contains("\"id\""), "template id property must be present: " + json);
+    assertTrue(json.contains("\"name\""), "template name property must be present: " + json);
+    assertTrue(json.contains("1-101-7"), json);
+    assertTrue(json.contains("perc.page"), json);
+    assertFalse(
+        json.contains("\"empty\""),
+        "ArrayList subclass must not serialize as {empty:false} bean (#3529): " + json);
+
+    PSTemplateSummaryList roundTrip = mapper.readValue(json, PSTemplateSummaryList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("1-101-7", roundTrip.get(0).getId());
+    assertEquals("perc.page", roundTrip.get(0).getName());
+  }
+
+  @Test
+  void productionMapperSerializesEmptyTemplateListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(PSTemplateSummaryList.class);
+    String json = mapper.writeValueAsString(new PSTemplateSummaryList());
+    assertTrue(json.contains("TemplateSummary") || json.contains("["), json);
+    assertFalse(json.contains("\"empty\""), json);
+  }
+}


### PR DESCRIPTION
## Summary

Home → Add New → Create page left the Template dropdown on “Select…” after a site was chosen. Two cooperating bugs:

1. **Wire:** sitemanage `PSTemplateSummaryList` (Jackson 3 + `WRAP_ROOT_VALUE`) serialized as an ArrayList bean (`{"empty":false}`) instead of a JSON array of `{id,name}` rows — the same class of defect as `SiteList` (#3368).
2. **Client:** `fetchTemplatesForSite` only unwrapped a `TemplateSummary` root and returned `[]` (or blank `id`/`name` options) for raw arrays, `TemplateSummaryList`, rest-style `templateId`/`templateName`, and the empty-bean shape.

This PR unwraps the real envelopes, maps sitemanage and rest field aliases, drops empty-bean rows, falls back to `loadPageTemplates` (`percPage` allowed templates) when the site catalog is empty, and marks `PSTemplateSummaryList` as `@JsonFormat(ARRAY)`.

Fixes #3529

Operator: Grok: night-issue-prs (model grok-4.6)

Parent tracker: #3529

## Test plan

1. Log in as Admin on a CMS with at least one site that has page templates (H2 QA sample sites work).
2. Home → Create → Create page.
3. Select a site (for example Corporate Investments / QaSite3002).
4. Open Template — options must list that site's page templates (not only “Select…”).
5. Select a template, folder, title, and file name; submit creates the page.

Automated:

- Vitest: `PageWizard.test.tsx` (real `TemplateSummary` envelope + empty-bean fallback); `homeApi.test.ts` unwrap/alias/bean cases.
- Playwright (H2 QA): `npm run test:surface -- --path tests/bugs/bug-3529-home-create-page-templates.spec.js` — 1 passed.
- `PSTemplateSummaryListJacksonTest` — array wire, not `{empty:false}`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/index.md` Home → Create page template step
- [x] **Unit / module tests** — unwrap + PageWizard + Jackson list tests; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3529-home-create-page-templates.spec.js`
- [x] **Build gates** — standalone clean install of `projects/sitemanage` and `WebUI` (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path/file I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (53.9s). Surefire: Tests run: 1218, Failures: 0, Errors: 0, Skipped: 125. `PSTemplateSummaryListJacksonTest` Tests run: 2, Failures: 0.
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (3:03). Vitest: Test Files 363 passed, Tests 2696 passed. Java Surefire unchanged.
- **downstream_checked:** grepped `extends PSTemplateSummaryList` and `new PSTemplateSummaryList() {` — no subclasses/anonymous types. No public method/ctor/`final` change; annotation-only list wire + WebUI unwrap.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993` (freeport). Docker health=healthy, HTTP 200 on `/Rhythmyx/rest/mimetypes`.
- `qa-health` RESULT:FAIL only on pre-existing FastForward `PSDbStorageService` import ERRORs (not `Failed startup of context` / unhealthy). Not feature-related.
- Deploy: `docker cp` `sitemanage-8.2.0-SNAPSHOT.jar` + `perc-system-8.2.0-SNAPSHOT.jar` into `WEB-INF/lib`; copy full `WebUI/target/generated-webui/cm/modern/assets/` into the WAR; Jetty stop/start **inside** the cell (not `docker restart`).
- Playwright: `TEST_CMS_URL=http://127.0.0.1:9993 TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/bugs/bug-3529-home-create-page-templates.spec.js` — **1 passed** (2.4s). console-clean=yes. server.log-clean=yes for this feature (no sitetemplates/TemplateSummary ERRORs). Known skip: FastForward import / search-index date parse noise from silent install.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
