### PR TITLE
fix(sitemgr): persist SITEID on Virtual Site Git-FS save

### DIFF
--- a/docs/ai-generated/code-reviews/3511-virtual-site-siteid-erlang.md
+++ b/docs/ai-generated/code-reviews/3511-virtual-site-siteid-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: #3511 Virtual Site SITEID persist
+
+- **Date:** 2026-08-17
+- **Branch:** `fix/issue-3511-virtual-site-siteid`
+- **Scope:** uncommitted vs `HEAD` (also vs `origin/main`)
+- **Change class:** Hibernate 6 bidirectional site-property FK (Developer Virtual Site save)
+- **Recommendation:** approve
+- **Gate:** May commit/push: yes
+- **Memory patterns hit:** change-class companions (mapping + adaptor persist assertions); exact field types in tests (`PSSite` / `PSSiteProperty`)
+
+## Summary
+
+Developer Git-FS save (`PUT /services/sites/{nameOrId}/virtual`) inserts `RXASSEMBLERPROPERTIES` rows. After #3521 the child `PSSiteProperty.site` JoinColumn is insertable, but the parent collection still owned `SITEID` via `@JoinColumn`. Hibernate 6 then omitted SITEID on INSERT (`NULL not allowed for column SITEID` on H2).
+
+This change makes `PSSite.properties` `mappedBy = "site"` so the child owns the FK, links `prop.setSite(this)` on `addProperty`, and adds mapping + adaptor tests that new `virtual.*` properties carry the parent `siteId`.
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Test values such as `C:/docs/product-docs` are stored property strings, not OS path joins.
+
+## Product documentation
+
+N/A — operator Save steps unchanged; backend persist only.
+
+## C5 UI live proof
+
+N/A — no WebUI / Playwright spec change. Existing `developer-site-virtual-source.spec.js` remains the live save surface.
+
+## Build evidence
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2150, Failures: 0; `PSSitePropertySiteIdMappingTest` 4/0/0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1226, Failures: 0; `SitesAdaptorTest` 36/0/0

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +44,7 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.sitemgr.IPSPublishingContext;
 import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.services.sitemgr.data.PSSite;
+import com.percussion.services.sitemgr.data.PSSiteProperty;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSManagedNavSiteHelper;
 import com.percussion.services.virtualsite.PSVirtualSiteHelper;
@@ -190,11 +192,18 @@ class SitesAdaptorTest {
 
     ArgumentCaptor<PSSite> saved = ArgumentCaptor.forClass(PSSite.class);
     verify(siteManager).saveSite(saved.capture());
-    assertTrue(PSVirtualSiteHelper.isVirtual(saved.getValue()));
+    PSSite persisted = saved.getValue();
+    assertTrue(PSVirtualSiteHelper.isVirtual(persisted));
     assertEquals(
         "product-docs",
-        PSVirtualSiteHelper.findProperty(saved.getValue(), PSVirtualSiteHelper.PROP_SITE_KEY)
+        PSVirtualSiteHelper.findProperty(persisted, PSVirtualSiteHelper.PROP_SITE_KEY)
             .orElse(null));
+    assertEquals(100L, persisted.getSiteId());
+    assertFalse(persisted.getProperties().isEmpty());
+    for (PSSiteProperty property : persisted.getProperties()) {
+      assertSame(persisted, property.getSite(), property.getName());
+      assertEquals(100L, ((PSSite) property.getSite()).getSiteId());
+    }
   }
 
   @Test

--- a/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
@@ -326,11 +326,14 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean pageBased;
 
+    // mappedBy: child PSSiteProperty.site owns RXASSEMBLERPROPERTIES.SITEID so
+    // Hibernate 6 includes SITEID on INSERT (NOT NULL). Dual @JoinColumn made
+    // the child insertable=false and H2 rejected Virtual Site property saves.
     @OneToMany(targetEntity = PSSiteProperty.class,
+            mappedBy = "site",
             cascade = {CascadeType.ALL},
             fetch = FetchType.EAGER,
             orphanRemoval = true)
-    @JoinColumn(name = "SITEID")
     @Fetch(FetchMode.SUBSELECT)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<PSSiteProperty> properties = new HashSet<>();
@@ -818,6 +821,9 @@ public class PSSite implements IPSSite, IPSCatalogItem {
         if (properties == null)
             properties = new HashSet<>();
 
+        if (prop.getSite() != this) {
+            prop.setSite(this);
+        }
         properties.add(prop);
     }
 

--- a/system/services/src/com/percussion/services/sitemgr/data/PSSiteProperty.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSSiteProperty.java
@@ -84,12 +84,12 @@ public class PSSiteProperty implements IPSCatalogItem, Serializable {
   Integer version;
 
   /**
-   * Parent site FK. Must be insertable so a new-site persist that also writes
-   * {@code RXASSEMBLERPROPERTIES} (managed-nav flag, Virtual source) includes
-   * {@code SITEID}. {@code insertable=false} produced H2 {@code NULL not
-   * allowed for column SITEID} on Create Site (#3511 / #3521).
+   * Owning {@code RXASSEMBLERPROPERTIES.SITEID} mapping. Must stay insertable so Hibernate 6 writes
+   * SITEID on INSERT (Create Site and Developer Virtual Site save). {@code insertable=false} plus a
+   * parent-side {@code @JoinColumn} omitted the column and H2 rejected {@code NULL SITEID} (#3511 /
+   * #3521). Parent {@link PSSite} properties use {@code mappedBy = "site"}.
    */
-  @ManyToOne(targetEntity = PSSite.class)
+  @ManyToOne(targetEntity = PSSite.class, optional = false)
   @JoinColumn(name = "SITEID", nullable = false)
   IPSSite site;
 

--- a/system/src/test/java/com/percussion/services/sitemgr/data/PSSitePropertySiteIdMappingTest.java
+++ b/system/src/test/java/com/percussion/services/sitemgr/data/PSSitePropertySiteIdMappingTest.java
@@ -17,18 +17,25 @@
 
 package com.percussion.services.sitemgr.data;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.virtualsite.PSVirtualSiteHelper;
+import com.percussion.utils.guid.IPSGuid;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 
 /**
- * New Site persist writes {@code RXASSEMBLERPROPERTIES} in the same session as
- * site create (managed-nav flag, Virtual source). SITEID must be insertable
- * (#3511 / #3521).
+ * {@code RXASSEMBLERPROPERTIES.SITEID} must be written on INSERT for Create Site and Developer
+ * Virtual Site save (#3511 / #3521). Child owns the FK; parent properties are {@code mappedBy}.
  */
 class PSSitePropertySiteIdMappingTest {
 
@@ -41,5 +48,50 @@ class PSSitePropertySiteIdMappingTest {
     assertTrue(join.updatable(), "SITEID must be writable on UPDATE");
     assertFalse(join.nullable(), "SITEID is NOT NULL");
     assertTrue("SITEID".equalsIgnoreCase(join.name()));
+  }
+
+  @Test
+  void parentPropertiesAreMappedBySite() throws Exception {
+    Field properties = PSSite.class.getDeclaredField("properties");
+    OneToMany otm = properties.getAnnotation(OneToMany.class);
+    assertNotNull(otm, "PSSite.properties OneToMany");
+    assertEquals("site", otm.mappedBy(), "child PSSiteProperty.site must own SITEID");
+    assertNull(
+        properties.getAnnotation(JoinColumn.class),
+        "parent must not also map SITEID (Hibernate 6 omits FK on INSERT)");
+  }
+
+  @Test
+  void putPropertyOnExistingSitePopulatesSiteId() {
+    PSSite site = new PSSite();
+    site.setGUID(new PSGuid(PSTypeEnum.SITE, 100L));
+    IPSGuid ctx = new PSGuid(PSTypeEnum.CONTEXT, 1L);
+
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    PSVirtualSiteHelper.putProperty(
+        site, ctx, PSVirtualSiteHelper.PROP_ROOT_PATH, "C:/docs/product-docs");
+
+    assertFalse(site.getProperties().isEmpty());
+    for (PSSiteProperty property : site.getProperties()) {
+      assertSame(site, property.getSite(), property.getName());
+      assertEquals(100L, ((PSSite) property.getSite()).getSiteId());
+    }
+  }
+
+  @Test
+  void addPropertyLinksSiteWhenMissing() {
+    PSSite site = new PSSite();
+    site.setSiteId(42L);
+    PSSiteProperty property = new PSSiteProperty();
+    property.setPropertyId(1L);
+    property.setName(PSVirtualSiteHelper.PROP_SOURCE_KIND);
+    property.setValue("git-filesystem");
+    property.setContextId(new PSGuid(PSTypeEnum.CONTEXT, 1L));
+
+    site.addProperty(property);
+
+    assertSame(site, property.getSite());
+    assertEquals(42L, ((PSSite) property.getSite()).getSiteId());
   }
 }


### PR DESCRIPTION
## Summary

Developer **Save Virtual Site source** (Git-FS) failed on H2 with `NULL not allowed for column SITEID` when inserting `RXASSEMBLERPROPERTIES`.

#3521 already made `PSSiteProperty.site` insertable. The parent collection still owned the same column via `@JoinColumn(name = SITEID)`. Hibernate 6 then omitted SITEID on INSERT for `PUT /services/sites/{nameOrId}/virtual` (`siteManager.saveSite` / merge of new `virtual.*` properties).

This PR makes `PSSite.properties` `mappedBy = "site" so the child owns the FK, and `addProperty` always links `prop.setSite(this)`. JAXB envelope work stays on #3365 / PR #3370; no source adapters reopened.

Fixes #3511
Parent tracker: #2678 (Virtual Sites epic). Related: #3030, #3365.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `PSSitePropertySiteIdMappingTest` — child JoinColumn insertable; parent `mappedBy=site`; `putProperty` / `addProperty` populate `siteId` on a real `PSSite`.
2. Unit: `SitesAdaptorTest.updateVirtualSiteProperties_persistsAndValidates` — saved properties have `getSite().getSiteId() == 100`.
3. Standalone `mvnw clean install` on `system` and `projects/sitemanage` (see C3).
4. Manual / later Human QA: Developer → Sites → existing site → Virtual source Git-FS → Save. Expect success (no SITEID NULL). Optional: existing Playwright `developer-site-virtual-source.spec.js` save path after qa-up → qa-health.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): operator Save steps unchanged; backend persist only
- [x] **Unit / module tests** — mapping + adaptor persist assertions; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); C2 N/A (no `final` / public signature change)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 build evidence

- **modules_built:** `system`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (01:20). Tests run: 2150, Failures: 0, Errors: 0. `PSSitePropertySiteIdMappingTest` Tests run: 4, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (42.5s). Tests run: 1226, Failures: 0, Errors: 0. `SitesAdaptorTest` Tests run: 36, Failures: 0.
- **downstream_checked:** none (C2 did not apply — no type made final/sealed; no public/protected method or ctor signature change)

## C5 UI proof

N/A — Java persistence only; no WebUI or Playwright spec change.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.