### PR TITLE
fix(explorer): All/View_All saved search no longer fails with java.io.IOException (#3517)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1399,6 +1399,7 @@ function ContentExplorerShellInner({
             listSavedSearches={listSavedSearches}
             executeSavedSearch={executeSavedSearch}
             initialCriteria={
+              isFolderIdLookupPath(selection.folderPath) &&
               selection.folderPath
                 ? { folderPath: selection.folderPath }
                 : undefined

--- a/WebUI/src/main/ts/contentExplorer/folderPath.ts
+++ b/WebUI/src/main/ts/contentExplorer/folderPath.ts
@@ -206,15 +206,9 @@ export function isFolderIdLookupPath(
 export function toRepositorySearchFolderPath(
   path: string | null | undefined,
 ): string | undefined {
-  if (path == null) return undefined;
-  let p = path.trim().replace(/\\/g, "/");
-  if (p.length === 0) return undefined;
-  p = p.replace(/^[A-Za-z]:/, "");
-  if (p.length === 0) return undefined;
-  // Collapse all slashes first so //Sites and /Sites share one form.
-  p = p.replace(/\/{2,}/g, "/");
-  if (!p.startsWith("/")) {
-    p = `/${p}`;
-  }
-  return `/${p}`;
+  // Root `/` / `//` is not a repository folder. Sending `//` to execute makes
+  // getIdByPath fail and the operator sees java.io.IOException (#3517).
+  const explorer = normalizeExplorerFolderPath(path);
+  if (explorer == null) return undefined;
+  return `/${explorer}`;
 }

--- a/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
@@ -431,6 +431,41 @@ describe("SearchPanel", () => {
       expect(onOpen).toHaveBeenCalledTimes(1);
     });
 
+    it("does not scope All / View_All to Explorer root folder (#3517)", async () => {
+      const executeSavedSearch = vi.fn().mockResolvedValue({
+        children: [],
+        totalCount: 0,
+        startIndex: 1,
+        searchName: "View_All",
+      });
+      render(
+        <SearchPanel
+          listSavedSearches={async () => [
+            { name: "View_All", label: "All", type: "View" },
+          ]}
+          executeSavedSearch={executeSavedSearch}
+          initialCriteria={{ folderPath: "/" }}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-select")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("search-panel-saved-select"), {
+        target: { value: "View_All" },
+      });
+      fireEvent.click(screen.getByTestId("search-panel-saved-run"));
+      await waitFor(() => {
+        expect(executeSavedSearch).toHaveBeenCalledTimes(1);
+      });
+      const req = executeSavedSearch.mock.calls[0]?.[1] as
+        | { folderPath?: string }
+        | undefined;
+      expect(req?.folderPath).toBeUndefined();
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-empty")).toBeTruthy();
+      });
+    });
+
     it("blocks custom URL searches with a clear error", async () => {
       const executeSavedSearch = vi.fn();
       render(

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -185,4 +185,10 @@ describe("toRepositorySearchFolderPath (#3438)", () => {
     expect(toRepositorySearchFolderPath("\\Sites\\Foo")).toBe("//Sites/Foo");
     expect(toRepositorySearchFolderPath("///Sites//Foo")).toBe("//Sites/Foo");
   });
+
+  it("drops Explorer root so All / View_All is unscoped (#3517)", () => {
+    expect(toRepositorySearchFolderPath("/")).toBeUndefined();
+    expect(toRepositorySearchFolderPath("//")).toBeUndefined();
+    expect(toRepositorySearchFolderPath("///")).toBeUndefined();
+  });
 });

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -135,6 +135,14 @@ describe("wrapSearchExecuteRequest", () => {
       SearchExecuteRequest: { folderPath: "//Sites", startIndex: 1 },
     });
   });
+
+  it("omits Explorer root folderPath so execute stays unscoped (#3517)", () => {
+    expect(
+      wrapSearchExecuteRequest({ folderPath: "/", startIndex: 1 }),
+    ).toEqual({
+      SearchExecuteRequest: { startIndex: 1 },
+    });
+  });
 });
 
 describe("executeSearch", () => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
@@ -64,6 +64,9 @@ const {
   postExecuteRegionSelector,
   catalogSettledSelector,
   isCustomUrlSearch,
+  isDefaultAllView,
+  searchDefKey,
+  searchesExecuteUrl,
 } = require("./helpers/explorer-saved-search");
 
 // Tags live on individual test() titles only — Playwright ignores @tags on describe names.
@@ -234,12 +237,77 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
     } else if (await emptyResults.isVisible()) {
       await expect(emptyResults).toBeVisible();
     } else {
-      // Execute may 500 on minimal H2 without search index — error region is
-      // valid wiring evidence (same contract as us5-search free-text path).
+      const errText = ((await errResults.textContent()) || "").trim();
+      // #3517: All / View_All (and other standard searches) must not surface
+      // the generic search-web-service IOException. Free-text FTS may still
+      // error without a Lucene index; design-search execute must not.
+      expect(
+        /java\.io\.IOException|search web service/i.test(errText),
+        `saved-search execute must not report I/O / search web service error: ${errText}`,
+      ).toBe(false);
+      if (runnable && /view_all|^all$/i.test(String(runnable.key))) {
+        throw new Error(
+          `All / View_All execute must show results or empty, not error: ${errText}`,
+        );
+      }
       await expect(errResults).toBeVisible();
       await expect(
         page.locator(`[data-testid="search-panel-retry"]`),
       ).toBeVisible();
+    }
+  });
+
+  test("REST: POST /services/searches/View_All/execute is 200 page not IOException @saved-search @explorer-saved-search", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    const catalogRes = await page.request.get(
+      searchesCatalogUrl(BASE_URL, { includeViews: true }),
+      { headers },
+    );
+    if (catalogRes.status() === 401 || catalogRes.status() === 403) {
+      test.skip(true, `catalog auth ${catalogRes.status()} — no execute probe`);
+      return;
+    }
+    expect(catalogRes.status(), `catalog status=${catalogRes.status()}`).toBeLessThan(
+      500,
+    );
+    const defs = unwrapSearchDefs(
+      catalogRes.ok() ? await catalogRes.json().catch(() => null) : null,
+    );
+    const allView = defs.find((d) => isDefaultAllView(d));
+    if (!allView) {
+      test.skip(
+        true,
+        "H2 catalog has no All / View_All — soft-skip execute REST (#3517).",
+      );
+      return;
+    }
+    const key = searchDefKey(allView);
+    const execUrl = searchesExecuteUrl(BASE_URL, key);
+    const body = JSON.stringify({
+      SearchExecuteRequest: { startIndex: 1, maxResults: 25 },
+    });
+    const res = await page.request.post(execUrl, { headers, data: body });
+    const text = await res.text();
+    expect(
+      res.status(),
+      `POST ${execUrl} must not 5xx (status=${res.status()} body=${text.slice(0, 400)})`,
+    ).toBeLessThan(500);
+    expect([200, 401, 403]).toContain(res.status());
+    expect(
+      /java\.io\.IOException|search web service/i.test(text),
+      `execute body must not be generic I/O error: ${text.slice(0, 400)}`,
+    ).toBe(false);
+    if (res.status() === 200) {
+      const parsed = JSON.parse(text);
+      const envelope = parsed.SearchExecuteResult || parsed.searchExecuteResult || parsed;
+      expect(Array.isArray(envelope.children || [])).toBe(true);
     }
   });
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -243,8 +243,11 @@ When the panel is open you can:
 2. Submit the search and open a hit or reveal it in its parent folder.
 3. Pick a **saved / design search** from the catalog (when the server exposes one) and run it.
    The picker includes CX **searches and views**. The default **All** view (`View_All`) is
-   listed when that design object exists on the server. Custom URL searches stay listed
-   but cannot be run from Explorer.
+   listed when that design object exists on the server. **Run saved search** on **All**
+   (or any other standard/user search) returns matching items or an empty results page —
+   not a generic I/O error. At Explorer **root** (`/`) the run is unscoped (all content the
+   search allows). When a real folder such as `/Sites` is selected, the run is scoped to
+   that folder. Custom URL searches stay listed but cannot be run from Explorer.
 
 Closing **Search** again (view-tools button, **View → Search**, or **Content → Search**)
 hides the panel. Revealing a result in its folder also closes the panel so the

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -455,6 +455,15 @@ Execute looks up the same combined catalog (searches first, then views). Keys ac
 internal name (`View_All`), display label (`All`), GUID string, or numeric id. Custom URL
 searches and custom views return **400**.
 
+POST body is the JAXB envelope `{ "SearchExecuteRequest": { … } }` (flat
+`startIndex` / `folderPath` is also accepted). Optional fields: `folderPath`,
+`startIndex` (≥ 1), `maxResults` (≥ 1), `sortColumn`, `sortOrder` (`asc` /
+`desc`). `folderPath` may be repository form (`//Sites/...`) or Explorer form
+(`/Sites/...`). Explorer **root** (`/` or `//`) is ignored so **All** /
+`View_All` runs unscoped instead of failing `getIdByPath`. A successful execute
+returns a paged `SearchExecuteResult` (`children[]`, `totalCount`,
+`startIndex`) — an empty `children` array is a valid page, not an error.
+
 ## Content Explorer folders (Rhythmyx path façade)
 
 Public REST for **Rhythmyx** folder operations used by Content Explorer integrators and (later)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -198,18 +198,54 @@ public class SearchAdaptor implements ISearchAdaptor {
     if (StringUtils.isNotBlank(out.getSortColumn())) {
       out.setSortColumn(out.getSortColumn().trim());
     }
-    if (StringUtils.isNotBlank(out.getFolderPath())) {
-      out.setFolderPath(out.getFolderPath().trim());
-    }
+    out.setFolderPath(normalizeFolderPath(out.getFolderPath()));
     return out;
+  }
+
+  /**
+   * Repository folder filter for execute ({@code //Sites/...}).
+   *
+   * <p>Explorer seeds {@code /} as the tree root. {@code getIdByPath("//")} is not a folder
+   * — {@code PSLocalExecutableSearch} wraps that as a nameless {@code IOException} and the
+   * operator sees {@code An error occurred while using search web service. Message:
+   * java.io.IOException} (#3517). Drop root / blank; convert a single leading slash to the
+   * {@code //} form {@code getIdByPath} requires.
+   *
+   * <p>CMS paths always use {@code /} (not OS file separators). Backslashes and a drive
+   * letter are stripped only so a pasted Windows-style string still becomes a repository
+   * path.
+   *
+   * @return {@code //Sites/...} form, or {@code null} when the path is empty or Explorer
+   *     root (unscoped execute)
+   */
+  static String normalizeFolderPath(String path) {
+    if (StringUtils.isBlank(path)) {
+      return null;
+    }
+    String p = path.trim().replace('\\', '/');
+    if (p.length() >= 2 && Character.isLetter(p.charAt(0)) && p.charAt(1) == ':') {
+      p = p.substring(2);
+    }
+    p = p.replaceAll("/{2,}", "/");
+    if (p.isEmpty() || "/".equals(p)) {
+      return null;
+    }
+    if (!p.startsWith("/")) {
+      p = "/" + p;
+    }
+    if ("/".equals(p)) {
+      return null;
+    }
+    return "/" + p;
   }
 
   static void applyExecuteOverrides(PSSearch search, SearchExecuteRequest req) {
     if (req == null || search == null) {
       return;
     }
-    if (StringUtils.isNotBlank(req.getFolderPath())) {
-      search.setProperty(PSSearch.PROP_FOLDER_PATH, req.getFolderPath().trim());
+    String folderPath = normalizeFolderPath(req.getFolderPath());
+    if (folderPath != null) {
+      search.setProperty(PSSearch.PROP_FOLDER_PATH, folderPath);
       // Default recurse when client scopes by folder (Explorer parity)
       if (StringUtils.isBlank(search.getProperty(PSSearch.PROP_FOLDER_PATH_RECURSE))) {
         search.setProperty(PSSearch.PROP_FOLDER_PATH_RECURSE, "true");

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -124,6 +124,8 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="runtimeExceptionMapper" />
             <!-- Inbox #3323: bind flat startIndex before jackson UNWRAP_ROOT_VALUE -->
             <ref bean="viewExecuteRequestJsonReader" />
+            <!-- #3517: Explorer saved-search execute envelope / flat startIndex+folderPath -->
+            <ref bean="searchExecuteRequestJsonReader" />
             <!-- #3378 / #3391: AclList ArrayList subclass must not ClassCast after UNWRAP.
                  Rest jar also has AclListDeserializer so a stale filesystem beans.xml
                  (hot-deploy jars only) still binds {"AclList":[…]} as AclList. -->

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -106,6 +106,39 @@ class SearchAdaptorExecuteTest {
   }
 
   @Test
+  void normalizeFolderPath_convertsExplorerSlashAndDropsRoot() {
+    assertEquals("//Sites/Demo", SearchAdaptor.normalizeFolderPath("/Sites/Demo"));
+    assertEquals("//Sites", SearchAdaptor.normalizeFolderPath("Sites"));
+    assertEquals("//Sites/Foo", SearchAdaptor.normalizeFolderPath("//Sites/Foo"));
+    assertNull(SearchAdaptor.normalizeFolderPath(null));
+    assertNull(SearchAdaptor.normalizeFolderPath("  "));
+    assertNull(SearchAdaptor.normalizeFolderPath("/"));
+    assertNull(SearchAdaptor.normalizeFolderPath("//"));
+    assertNull(SearchAdaptor.normalizeFolderPath("///"));
+  }
+
+  @Test
+  void normalizeRequest_dropsExplorerRootFolderPath() {
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setFolderPath("/");
+    r.setStartIndex(1);
+    SearchExecuteRequest n = SearchAdaptor.normalizeRequest(r);
+    assertNull(n.getFolderPath());
+    assertEquals(1, n.getStartIndex());
+  }
+
+  @Test
+  void applyExecuteOverrides_ignoresExplorerRootSoAllIsUnscoped() {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getMaximumResultSize()).thenReturn(25);
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setFolderPath("/");
+    SearchAdaptor.applyExecuteOverrides(s, r);
+    verify(s, org.mockito.Mockito.never())
+        .setProperty(eq(PSSearch.PROP_FOLDER_PATH), any());
+  }
+
+  @Test
   void applyExecuteOverrides_defaultsUnlimitedMax() {
     PSSearch s = mock(PSSearch.class);
     when(s.getMaximumResultSize()).thenReturn(0);

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -56,6 +56,9 @@ class CatalogRestJaxrsRegistrationTest {
   /** Inbox execute #3323 — must precede jacksonProvider on rest-jax-rs. */
   private static final String VIEW_EXECUTE_JSON_READER = "viewExecuteRequestJsonReader";
 
+  /** Explorer saved-search execute #3517 — must precede jacksonProvider on rest-jax-rs. */
+  private static final String SEARCH_EXECUTE_JSON_READER = "searchExecuteRequestJsonReader";
+
   /** Display Format Object ACL save #3378 — must precede jacksonProvider. */
   private static final String ACL_LIST_JSON_READER = "aclListJsonReader";
 
@@ -106,6 +109,7 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(providers >= 0 && providersEnd > providers, "rest-jax-rs providers block");
     String providerBlock = restBlock.substring(providers, providersEnd);
     int reader = providerBlock.indexOf("bean=\"" + VIEW_EXECUTE_JSON_READER + "\"");
+    int searchReader = providerBlock.indexOf("bean=\"" + SEARCH_EXECUTE_JSON_READER + "\"");
     int aclReader = providerBlock.indexOf("bean=\"" + ACL_LIST_JSON_READER + "\"");
     int addFolderReader = providerBlock.indexOf("bean=\"" + ADD_FOLDER_JSON_READER + "\"");
     int jackson = providerBlock.indexOf("bean=\"jacksonProvider\"");
@@ -114,6 +118,11 @@ class CatalogRestJaxrsRegistrationTest {
         "rest-jax-rs providers must ref "
             + VIEW_EXECUTE_JSON_READER
             + " (missing → Inbox flat startIndex 400)");
+    assertTrue(
+        searchReader >= 0,
+        "rest-jax-rs providers must ref "
+            + SEARCH_EXECUTE_JSON_READER
+            + " (missing → saved-search execute envelope/startIndex 400)");
     assertTrue(
         aclReader >= 0,
         "rest-jax-rs providers must ref "
@@ -128,6 +137,9 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         reader < jackson,
         VIEW_EXECUTE_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        searchReader < jackson,
+        SEARCH_EXECUTE_JSON_READER + " must be listed before jacksonProvider");
     assertTrue(
         aclReader < jackson,
         ACL_LIST_JSON_READER + " must be listed before jacksonProvider");

--- a/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequest.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequest.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.searches;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
@@ -27,6 +28,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * PSSearch}. Clients may only scope, page, and sort.
  */
 @XmlRootElement(name = "SearchExecuteRequest")
+@JsonRootName("SearchExecuteRequest")
 @Schema(description = "Optional overrides when executing a CX design search by id or name")
 public class SearchExecuteRequest {
 

--- a/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequestJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequestJsonReader.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for {@link SearchExecuteRequest} that accepts both the JAXB / Jackson root envelope
+ * and a flat paging object.
+ *
+ * <p>CXF {@code UNWRAP_ROOT_VALUE} / JAXB rejects a bare {@code startIndex} or {@code folderPath}
+ * field ({@code unexpected element startIndex}, expected {@code SearchExecuteRequest}). Explorer
+ * saved-search execute (#3517 / #2506) POSTs the wrapped envelope; residual clients may post
+ * flat paging. This reader binds either:
+ *
+ * <ul>
+ *   <li>{@code {"SearchExecuteRequest":{"folderPath":"//Sites","startIndex":1}}} (preferred)
+ *   <li>{@code {"startIndex":1,"maxResults":25}} (flat / QA residual)
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code
+ * jacksonProvider} so it wins over UNWRAP_ROOT_VALUE.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("searchExecuteRequestJsonReader")
+public class SearchExecuteRequestJsonReader implements MessageBodyReader<SearchExecuteRequest> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so a flat startIndex object is readable. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type != null && SearchExecuteRequest.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public SearchExecuteRequest readFrom(
+      Class<SearchExecuteRequest> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new SearchExecuteRequest();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new SearchExecuteRequest();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind execute JSON. Empty / whitespace is an empty request (design defaults).
+   *
+   * @param json request body; may be null
+   * @return non-null request
+   */
+  public static SearchExecuteRequest parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new SearchExecuteRequest();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid execute request", 400);
+    }
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new SearchExecuteRequest();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("Invalid execute request", 400);
+    }
+    JsonNode nested = firstObject(root, "SearchExecuteRequest", "searchExecuteRequest");
+    JsonNode fields = nested != null ? nested : root;
+    SearchExecuteRequest out = new SearchExecuteRequest();
+    out.setFolderPath(textField(fields, "folderPath"));
+    out.setStartIndex(intField(fields, "startIndex"));
+    out.setMaxResults(intField(fields, "maxResults"));
+    out.setSortColumn(textField(fields, "sortColumn"));
+    out.setSortOrder(textField(fields, "sortOrder"));
+    return out;
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  private static String textField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || !n.isString()) {
+      return null;
+    }
+    String v = n.asString();
+    return v != null && !v.isBlank() ? v : null;
+  }
+
+  private static Integer intField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || !n.isNumber()) {
+      return null;
+    }
+    return n.intValue();
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/MainTest.java
+++ b/rest/src/test/java/com/percussion/rest/MainTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.acls.AclListJsonReader;
 import com.percussion.rest.contentexplorer.folders.AddFolderRequestJsonReader;
+import com.percussion.rest.searches.SearchExecuteRequestJsonReader;
 import com.percussion.rest.errors.RestExceptionMapper;
 import com.percussion.rest.errors.WebApplicationExceptionMapper;
 import com.percussion.utils.testing.PSTestNetUtils;
@@ -163,6 +164,7 @@ public class MainTest {
               waeMapper,
               new AclListJsonReader(),
               new AddFolderRequestJsonReader(),
+              new SearchExecuteRequestJsonReader(),
               jacksonProvider,
               contextResolver));
       factory.setResourceProviders(resourceProviders);

--- a/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestCxfUnmarshallTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.errors.WebApplicationExceptionMapper;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
+
+/**
+ * CXF pipeline for POST {@code /searches/{id}/execute} (#3517).
+ *
+ * <p>Production JAXB / UNWRAP_ROOT_VALUE rejects a bare {@code startIndex} / {@code folderPath}
+ * root. When {@link SearchExecuteRequestJsonReader} is registered (rest-jax-rs providers), both
+ * the preferred wrap and a flat paging body bind.
+ */
+@Tag("UnitTest")
+public class SearchExecuteRequestCxfUnmarshallTest {
+
+  private static final String WRAPPED =
+      "{\"SearchExecuteRequest\":{\"folderPath\":\"//Sites\",\"startIndex\":1,\"maxResults\":25}}";
+  private static final String FLAT = "{\"startIndex\":2,\"maxResults\":10}";
+
+  private Server server;
+
+  @AfterEach
+  public void stopServer() {
+    if (server != null) {
+      server.stop();
+      server.destroy();
+      server = null;
+    }
+  }
+
+  @Test
+  public void cxfFactorySelectsSearchExecuteRequestJsonReader() throws Exception {
+    ServerProviderFactory factory = ServerProviderFactory.createInstance(null);
+    SearchExecuteRequestJsonReader custom = new SearchExecuteRequestJsonReader();
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(SearchExecuteRequest.class));
+    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+
+    MessageImpl message = new MessageImpl();
+    MessageBodyReader<SearchExecuteRequest> selected =
+        factory.createMessageBodyReader(
+            SearchExecuteRequest.class,
+            SearchExecuteRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            message);
+    assertNotNull(selected, "CXF must find a MessageBodyReader for SearchExecuteRequest");
+    assertTrue(
+        selected.isReadable(
+            SearchExecuteRequest.class,
+            SearchExecuteRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE),
+        selected.getClass().getName());
+
+    SearchExecuteRequest req =
+        selected.readFrom(
+            SearchExecuteRequest.class,
+            SearchExecuteRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(FLAT.getBytes(StandardCharsets.UTF_8)));
+    assertEquals(2, req.getStartIndex());
+    assertEquals(10, req.getMaxResults());
+    assertNull(req.getFolderPath());
+  }
+
+  @Test
+  public void cxfPostWrappedEnvelopeIsHttp200() throws Exception {
+    SearchExecuteRequest captured = assertPostBinds(WRAPPED, "local://issue-3517-search-exec-wrap");
+    assertEquals("//Sites", captured.getFolderPath());
+    assertEquals(1, captured.getStartIndex());
+    assertEquals(25, captured.getMaxResults());
+  }
+
+  @Test
+  public void cxfPostFlatStartIndexBodyIsHttp200() throws Exception {
+    SearchExecuteRequest captured = assertPostBinds(FLAT, "local://issue-3517-search-exec-flat");
+    assertNull(captured.getFolderPath());
+    assertEquals(2, captured.getStartIndex());
+    assertEquals(10, captured.getMaxResults());
+  }
+
+  private SearchExecuteRequest assertPostBinds(String json, String address) throws Exception {
+    AtomicReference<SearchExecuteRequest> captured = new AtomicReference<>();
+    ISearchAdaptor adaptor = mock(ISearchAdaptor.class);
+    doAnswer(
+            inv -> {
+              SearchExecuteRequest arg = inv.getArgument(1);
+              captured.set(arg);
+              SearchExecuteResult result = new SearchExecuteResult();
+              result.setSearchName("View_All");
+              result.setChildren(List.of());
+              result.setTotalCount(0);
+              result.setStartIndex(arg != null && arg.getStartIndex() != null ? arg.getStartIndex() : 1);
+              return result;
+            })
+        .when(adaptor)
+        .executeSearch(eq("View_All"), any());
+
+    SearchResource resource = new SearchResource(adaptor);
+
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(SearchExecuteRequest.class));
+
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setAddress(address);
+    sf.setServiceBean(resource);
+    sf.setProviders(
+        List.of(
+            new SearchExecuteRequestJsonReader(),
+            jackson,
+            new JacksonContextResolver(),
+            new WebApplicationExceptionMapper()));
+    server = sf.create();
+    assertNotNull(server, "CXF local server must start");
+
+    WebClient client =
+        WebClient.create(address)
+            .accept(MediaType.APPLICATION_JSON)
+            .type(MediaType.APPLICATION_JSON)
+            .path("/searches/View_All/execute");
+    Response response = client.post(json);
+    assertEquals(
+        200,
+        response.getStatus(),
+        "POST must be HTTP 200; body=" + response.readEntity(String.class));
+    SearchExecuteRequest saved = captured.get();
+    assertNotNull(saved, "adaptor.executeSearch must be invoked");
+    return saved;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestJsonReaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class SearchExecuteRequestJsonReaderTest {
+
+  private final SearchExecuteRequestJsonReader reader = new SearchExecuteRequestJsonReader();
+
+  @Test
+  public void parseAcceptsWrappedEnvelope() {
+    SearchExecuteRequest out =
+        SearchExecuteRequestJsonReader.parse(
+            "{\"SearchExecuteRequest\":{\"folderPath\":\"//Sites/Foo\","
+                + "\"startIndex\":1,\"maxResults\":50,\"sortColumn\":\"title\","
+                + "\"sortOrder\":\"desc\"}}");
+    assertEquals("//Sites/Foo", out.getFolderPath());
+    assertEquals(1, out.getStartIndex());
+    assertEquals(50, out.getMaxResults());
+    assertEquals("title", out.getSortColumn());
+    assertEquals("desc", out.getSortOrder());
+  }
+
+  @Test
+  public void parseAcceptsFlatStartIndexBody() {
+    SearchExecuteRequest out =
+        SearchExecuteRequestJsonReader.parse("{\"startIndex\":1,\"maxResults\":50}");
+    assertEquals(1, out.getStartIndex());
+    assertEquals(50, out.getMaxResults());
+    assertNull(out.getFolderPath());
+  }
+
+  @Test
+  public void parseAcceptsCamelCaseRootAlias() {
+    SearchExecuteRequest out =
+        SearchExecuteRequestJsonReader.parse(
+            "{\"searchExecuteRequest\":{\"startIndex\":2,\"maxResults\":10}}");
+    assertEquals(2, out.getStartIndex());
+    assertEquals(10, out.getMaxResults());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyRequest() {
+    SearchExecuteRequest empty = SearchExecuteRequestJsonReader.parse("  ");
+    assertNull(empty.getStartIndex());
+    assertNull(SearchExecuteRequestJsonReader.parse(null).getMaxResults());
+  }
+
+  @Test
+  public void parseRejectsNonObject() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> SearchExecuteRequestJsonReader.parse("[1,2]"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void parseRejectsInvalidJson() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> SearchExecuteRequestJsonReader.parse("{"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void readFromReadsUtf8Stream() throws Exception {
+    assertTrue(
+        reader.isReadable(
+            SearchExecuteRequest.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    byte[] raw = "{\"startIndex\":3}".getBytes(StandardCharsets.UTF_8);
+    SearchExecuteRequest out =
+        reader.readFrom(
+            SearchExecuteRequest.class,
+            SearchExecuteRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(raw));
+    assertEquals(3, out.getStartIndex());
+  }
+
+  @Test
+  public void readFromEmptyStreamIsEmptyRequest() throws Exception {
+    SearchExecuteRequest out =
+        reader.readFrom(
+            SearchExecuteRequest.class,
+            SearchExecuteRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(new byte[0]));
+    assertNull(out.getStartIndex());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchExecuteRequestSerialDeserialTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link SearchExecuteRequest} under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE.
+ *
+ * <p>SPA execute (#3517) sends {@code {"SearchExecuteRequest":{…}}}. Flat {@code startIndex} /
+ * {@code folderPath} is {@link SearchExecuteRequestJsonReader}, not this mapper.
+ */
+@Tag("UnitTest")
+public class SearchExecuteRequestSerialDeserialTest {
+
+  private final ObjectMapper mapper =
+      new JacksonContextResolver().getContext(SearchExecuteRequest.class);
+
+  @Test
+  public void serializesUnderSearchExecuteRequestRoot() {
+    SearchExecuteRequest req = new SearchExecuteRequest();
+    req.setStartIndex(1);
+    req.setMaxResults(50);
+    String json = mapper.writeValueAsString(req);
+    assertTrue(json.contains("\"SearchExecuteRequest\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"startIndex\""), json);
+  }
+
+  @Test
+  public void deserializesWrappedBody() {
+    String json =
+        "{\"SearchExecuteRequest\":{\"startIndex\":4,\"maxResults\":25,\"folderPath\":\"//Sites\"}}";
+    SearchExecuteRequest req = mapper.readValue(json, SearchExecuteRequest.class);
+    assertEquals(4, req.getStartIndex());
+    assertEquals(25, req.getMaxResults());
+    assertEquals("//Sites", req.getFolderPath());
+  }
+}


### PR DESCRIPTION
## Summary

Explorer **Search → saved search All → Run saved search** failed with:

`Search failed: An error occurred while using search web service. Message: java.io.IOException`

That operator string is `IPSCmsErrors.SEARCH_ERROR` wrapping a **nameless** `new IOException()` from `PSLocalExecutableSearch.getSearchResults`. The real cause was Explorer seeding `folderPath=/`, the client turning that into `//`, and `getIdByPath("//")` failing. **All** / `View_All` is unscoped at Explorer root; a real folder such as `/Sites` still scopes the run.

This PR keeps `POST /services/searches/{id}/execute` and:

- Drops Explorer root (`/`, `//`) on the WebUI client and in `SearchAdaptor.normalizeFolderPath`
- Adds `SearchExecuteRequestJsonReader` (peer of View execute) so the wrapped envelope and a flat `startIndex`/`folderPath` bind
- Updates product docs and Playwright so All/View_All must return a 200 results or empty page, not an I/O error

Fixes #3517  
Related (do not implement here): #2607, #2645, #2409

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 QA: `python docker/scripts/perc-devctl.py qa-up` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`). `qa-health` reported `HTTP:200 HEALTH:healthy` (pre-existing FastForward sample-binary import `ERROR` lines from install; not a context-failed startup).
2. Hot-deployed `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, `sitemanage-beans.xml`, and `cm/modern` into the Rhythmyx WAR; restarted Jetty **inside** the cell (`StopJetty`/`StartJetty`).
3. `npm run test:surface -- --path tests/explorer-saved-search.spec.js` — 4 passed (catalog chrome, run saved search, REST POST View_All/execute 200 page, GET catalog).
4. `npm run test:golden` — 2 passed (login + Explorer shell).
5. Log in as Admin → Explorer → Search → pick **All** → **Run saved search**. Expect results or empty, not `java.io.IOException`.
6. Select `/Sites` (or a site folder) and run All again — scoped results or empty, still no I/O error.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (All run at root is unscoped; no generic I/O error) and `product-docs/8.2/developer/rest.md` (execute envelope, `folderPath` forms, root ignored)
- [x] **Unit / module tests** — SearchExecuteRequest JSON/CXF tests; SearchAdaptor folder-path tests; WebUI folderPath / SearchPanel / wrap tests; perc-qa surface spec
- [x] **WebUI + Playwright** — `tests/explorer-saved-search.spec.js` (All/View_All execute must not report I/O)
- [x] **Build gates** — standalone `mvnw clean install` on `rest`, `projects/sitemanage`, `WebUI` (no skipTests)
- [x] **Cross-platform** — CMS repository paths use `/`; `\` / drive letter stripped only so a pasted Windows-style CMS path still becomes `//Sites/...` (not OS file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 535, Failures: 0 (including SearchExecuteRequest JsonReader 8, Cxf 3, Serial 2)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1229, Failures: 0, Errors: 0, Skipped: 125 (SearchAdaptorExecuteTest: 28)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest 2726 passed
- **downstream_checked:** sitemanage standalone install after rest (implements `ISearchAdaptor`; no `final`/signature break). No new public method removals. Grep not required for C2 API-shape (added `@JsonRootName` + static `normalizeFolderPath` only).

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993` (HTTP 200, Docker Health=healthy). FastForward sample import `ERROR` lines exist from silent install (BUG: pre-existing sample binaries, not this feature).
- **hot-deploy:** docker cp rest + sitemanage SNAPSHOT jars to `WEB-INF/lib`; beans.xml provider ref; `cm/modern` SPA assets; Jetty restart inside cell (not `docker restart`).
- **Playwright:** `TEST_CMS_URL=http://127.0.0.1:9993` `npm run test:surface -- --path tests/explorer-saved-search.spec.js` → **4 passed**; `npm run test:golden` → **2 passed**.
- **console-clean:** yes (surface + golden passed; no pageerror on exercised paths)
- **server.log-clean:** yes for the feature after Jetty restart (no new search/execute `ERROR`/`FATAL`). Pre-existing FastForward import errors remain from install.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
