### PR TITLE
fix(webui): drop Editor, Design, Widget Builder from top nav (#3514)

### DIFF
--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -33,16 +33,17 @@ import {
  * Product top navigation for the SPA shell.
  * SPA routes use client NavLink; unmigrated surfaces are full-page legacy exits.
  *
- * Order / labels: Home → Explorer → … → single Admin (issue #2702 / #3201).
- * Dashboard is not a top-nav item (gadgets remain under Home / deep link).
+ * Order / labels: Home → Explorer → Navigation → Developer → Publish →
+ * single Admin (issue #2702 / #3201 / #3514). Editor, Design, and Widget
+ * Builder are not top-nav items. Dashboard is not a top-nav item (gadgets
+ * remain under Home / deep link).
  */
 export function TopNav(): React.ReactElement {
-  const { isAdmin, isDesigner, isWidgetBuilderActive } = useSpaBootstrap();
+  const { isAdmin, isDesigner } = useSpaBootstrap();
   const location = useLocation();
   const itemIds = topNavItemIds({
     isAdmin,
     isDesigner,
-    isWidgetBuilderActive,
   });
 
   const linkClass = ({ isActive }: { isActive: boolean }): string =>
@@ -86,19 +87,6 @@ export function TopNav(): React.ReactElement {
                   </NavLink>
                 </li>
               );
-            case "editor":
-              return (
-                <li key={id}>
-                  <NavLink
-                    to="/editor"
-                    className={linkClass}
-                    data-testid="nav-editor"
-                    {...i18nKeyAttr(MSG.NAV_EDITOR)}
-                  >
-                    {message(MSG.NAV_EDITOR)}
-                  </NavLink>
-                </li>
-              );
             case "architecture":
               // SPA Navigation shell at /architecture (#3094 / #3217)
               return (
@@ -111,20 +99,6 @@ export function TopNav(): React.ReactElement {
                     {...i18nKeyAttr(MSG.NAV_ARCHITECTURE)}
                   >
                     {message(MSG.NAV_ARCHITECTURE)}
-                  </NavLink>
-                </li>
-              );
-            case "design":
-              return (
-                <li key={id}>
-                  <NavLink
-                    to="/design"
-                    className={linkClass}
-                    data-testid="nav-design"
-                    title={message(MSG.NAV_DESIGN_TITLE)}
-                    {...i18nKeyAttr(MSG.NAV_DESIGN)}
-                  >
-                    {message(MSG.NAV_DESIGN)}
                   </NavLink>
                 </li>
               );
@@ -174,19 +148,6 @@ export function TopNav(): React.ReactElement {
                     {...i18nKeyAttr(MSG.NAV_ADMIN)}
                   >
                     {adminTopNavLabel(message(MSG.NAV_ADMIN))}
-                  </NavLink>
-                </li>
-              );
-            case "widget-builder":
-              return (
-                <li key={id}>
-                  <NavLink
-                    to="/widget-builder"
-                    className={linkClass}
-                    data-testid="nav-widget-builder"
-                    {...i18nKeyAttr(MSG.NAV_WIDGET_BUILDER)}
-                  >
-                    {message(MSG.NAV_WIDGET_BUILDER)}
                   </NavLink>
                 </li>
               );

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -16,11 +16,15 @@
  */
 
 /**
- * Primary product top-nav order and role gates (issue #2702 / #2784 / #3088 / #3201).
+ * Primary product top-nav order and role gates (issue #2702 / #2784 / #3088 / #3201 / #3514).
  *
  * Dashboard is intentionally omitted from top chrome (gadgets remain on Home
  * via deep link {@code /home/gadgets}). Administration + Admin tools collapse
  * to a single {@code admin} item labeled <strong>Admin</strong>.
+ *
+ * <p>Editor, Design, and Widget Builder are not top-nav items (#3514). Editor
+ * opens from Explorer / Preview / Home Create. Design is the template library
+ * under Developer. Widget Builder is a Developer sub-entry when enabled.</p>
  *
  * <p>Landing is the unified <strong>Admin tools</strong> shell at {@code /admin}
  * (#2784 / #3088 / #3201) — not a Workflow-only hub. Workflow / roles / users /
@@ -31,17 +35,18 @@
 export type TopNavItemId =
   | "home"
   | "explorer"
-  | "editor"
   | "architecture"
-  | "design"
   | "developer"
   | "publish"
-  | "admin"
-  | "widget-builder";
+  | "admin";
 
 export interface TopNavGates {
   isAdmin?: boolean;
   isDesigner?: boolean;
+  /**
+   * Widget Builder enablement. Not a top-nav gate (#3514); used by Developer
+   * sub-entry chrome via {@link isWidgetBuilderDeveloperEntry}.
+   */
   isWidgetBuilderActive?: boolean;
 }
 
@@ -77,26 +82,33 @@ export const ARCHITECTURE_NAV_LANDING = "/architecture";
 
 /**
  * Ordered top-nav item ids for the given role / feature gates.
- * Explorer is always immediately after Home.
+ * Explorer is always immediately after Home. Editor / Design / Widget Builder
+ * are not top-nav items (#3514).
  */
 export function topNavItemIds(gates: TopNavGates = {}): TopNavItemId[] {
   const isAdmin = !!gates.isAdmin;
   const isDesigner = !!gates.isDesigner || isAdmin;
   const canPublish = isAdmin || isDesigner;
-  const canWb =
-    !!gates.isWidgetBuilderActive && (isAdmin || isDesigner);
 
-  const items: TopNavItemId[] = ["home", "explorer", "editor"];
+  const items: TopNavItemId[] = ["home", "explorer"];
   if (canPublish) {
-    items.push("architecture", "design", "developer", "publish");
+    items.push("architecture", "developer", "publish");
   }
   if (isAdmin) {
     items.push("admin");
   }
-  if (canWb) {
-    items.push("widget-builder");
-  }
   return items;
+}
+
+/**
+ * Whether Widget Builder should appear as a Developer sub-entry (not top nav).
+ */
+export function isWidgetBuilderDeveloperEntry(
+  gates: TopNavGates = {},
+): boolean {
+  const isAdmin = !!gates.isAdmin;
+  const isDesigner = !!gates.isDesigner || isAdmin;
+  return !!gates.isWidgetBuilderActive && (isAdmin || isDesigner);
 }
 
 /**

--- a/WebUI/src/main/ts/developer/DeveloperRelatedLinks.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperRelatedLinks.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Link, useInRouterContext } from "react-router";
+import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
+import { isWidgetBuilderDeveloperEntry } from "../app/layout/topNavConfig";
+import { i18nKeyAttr } from "../i18n/i18nDom";
+import { message, MSG } from "../i18n/message";
+import { catalogColors } from "./catalogStyles";
+
+/**
+ * Developer sub-entries that are not product top-nav items (#3514).
+ *
+ * <p>Design is the existing template-library SPA ({@code /design}). Widget
+ * Builder reuses {@code /widget-builder} when that feature is active. Neither
+ * link invents a new builder surface.</p>
+ */
+export function DeveloperRelatedLinks(): React.ReactElement {
+  const { isAdmin, isDesigner, isWidgetBuilderActive } = useSpaBootstrap();
+  const showWidgetBuilder = isWidgetBuilderDeveloperEntry({
+    isAdmin,
+    isDesigner,
+    isWidgetBuilderActive,
+  });
+
+  return (
+    <nav
+      className="perc-developer-related"
+      aria-label={message(MSG.NAV_DEVELOPER_TITLE)}
+      data-testid="developer-related-links"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "12px 20px",
+        marginTop: "10px",
+      }}
+    >
+      <DeveloperSpaLink
+        to="/design"
+        testId="developer-design-library-link"
+        title={message(MSG.NAV_DESIGN_TITLE)}
+        labelKey={MSG.NAV_DESIGN}
+      >
+        {message(MSG.NAV_DESIGN)}
+      </DeveloperSpaLink>
+      {showWidgetBuilder ? (
+        <DeveloperSpaLink
+          to="/widget-builder"
+          testId="developer-widget-builder-link"
+          labelKey={MSG.NAV_WIDGET_BUILDER}
+        >
+          {message(MSG.NAV_WIDGET_BUILDER)}
+        </DeveloperSpaLink>
+      ) : null}
+    </nav>
+  );
+}
+
+function DeveloperSpaLink({
+  to,
+  testId,
+  title,
+  labelKey,
+  children,
+}: {
+  to: string;
+  testId: string;
+  title?: string;
+  labelKey: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const inRouter = useInRouterContext();
+  const style: React.CSSProperties = {
+    color: catalogColors.accent,
+    fontWeight: 600,
+    textDecoration: "none",
+  };
+  if (inRouter) {
+    return (
+      <Link
+        to={to}
+        data-testid={testId}
+        title={title}
+        style={style}
+        {...i18nKeyAttr(labelKey)}
+      >
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a href={to} data-testid={testId} title={title} style={style} {...i18nKeyAttr(labelKey)}>
+      {children}
+    </a>
+  );
+}

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -45,6 +45,7 @@ import { TemplatesPanel } from "./TemplatesPanel";
 import { ViewsPanel } from "./ViewsPanel";
 import { WorkflowsPanel } from "./WorkflowsPanel";
 import { catalogColors } from "./catalogStyles";
+import { DeveloperRelatedLinks } from "./DeveloperRelatedLinks";
 import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 
 
@@ -128,6 +129,7 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
         <p style={{ margin: 0, color: catalogColors.muted, maxWidth: "48rem" }}>
           {DEV_MSG.INTRO}
         </p>
+        <DeveloperRelatedLinks />
       </header>
 
       <nav

--- a/WebUI/src/main/ts/developer/index.ts
+++ b/WebUI/src/main/ts/developer/index.ts
@@ -21,3 +21,4 @@ export {
   type DeveloperSection,
   type DeveloperShellProps,
 } from "./DeveloperShell";
+export { DeveloperRelatedLinks } from "./DeveloperRelatedLinks";

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -21,7 +21,9 @@
  * <p>Values are product homepage types (PascalCase) already accepted by
  * {@code PSUserService} / login landing resolve. Labels reuse nav menu keys.
  * Options are filtered from SPA bootstrap admin/designer flags (self-service
- * does not load full role lists).</p>
+ * does not load full role lists). Editor and Design are not offered as new
+ * choices after they left top nav (#3514); a stored override still lists so
+ * the user can clear it.</p>
  */
 
 import { HOMEPAGE_TYPES, type HomepageType } from "../api/user/userHomepageApi";
@@ -77,13 +79,16 @@ export function isProfileLandingAllowed(
   if (homepageType === "" || homepageType === HOMEPAGE_TYPES.HOME) {
     return true;
   }
-  if (homepageType === HOMEPAGE_TYPES.EDITOR) {
-    return true;
+  // Editor / Design left product top nav (#3514 / #3536). Not new choices.
+  if (
+    homepageType === HOMEPAGE_TYPES.EDITOR ||
+    homepageType === HOMEPAGE_TYPES.DESIGNER
+  ) {
+    return false;
   }
   const isAdmin = !!gates.isAdmin;
   const isDesigner = !!gates.isDesigner || isAdmin;
   switch (homepageType) {
-    case HOMEPAGE_TYPES.DESIGNER:
     case HOMEPAGE_TYPES.ARCHITECTURE:
     case HOMEPAGE_TYPES.PUBLISH:
     case HOMEPAGE_TYPES.WIDGET_BUILDER:

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -19,7 +19,8 @@
  *
  * <p>Labels use nav menu i18n keys. Values are slice-2 canonical homepage
  * types (or empty for clear → role resolve). Options are filtered to screens
- * the assigned roles may open (peer SPA TopNav gates).</p>
+ * the assigned roles may open (peer SPA TopNav gates). Editor and Design
+ * are not offered as new choices after they left top nav (#3514).</p>
  */
 
 import { HOMEPAGE_TYPES, type HomepageType } from "../../api/user/userHomepageApi";
@@ -89,14 +90,17 @@ export function isLandingAllowedForRoles(
   if (homepageType === "" || homepageType === HOMEPAGE_TYPES.HOME) {
     return true;
   }
-  if (homepageType === HOMEPAGE_TYPES.EDITOR) {
-    return true;
+  // Editor / Design left product top nav (#3514 / #3536). Not new choices.
+  if (
+    homepageType === HOMEPAGE_TYPES.EDITOR ||
+    homepageType === HOMEPAGE_TYPES.DESIGNER
+  ) {
+    return false;
   }
   const rs = roleSet(roles);
   const isAdmin = rs.has("admin");
   const isDesigner = rs.has("designer") || isAdmin;
   switch (homepageType) {
-    case HOMEPAGE_TYPES.DESIGNER:
     case HOMEPAGE_TYPES.ARCHITECTURE:
     case HOMEPAGE_TYPES.PUBLISH:
     case HOMEPAGE_TYPES.WIDGET_BUILDER:

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -86,12 +86,15 @@ describe("TopNav (#2702)", () => {
     expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
   });
 
-  it("Editor is SPA NavLink to /editor and not leftover view=editor", () => {
+  it("does not render Editor, Design, or Widget Builder top-nav items (#3514)", () => {
     renderNav();
-    const editor = screen.getByTestId("nav-editor");
-    const href = editor.getAttribute("href") || "";
-    expect(href === "/editor" || href.endsWith("/editor")).toBe(true);
-    expect(href).not.toMatch(/view=editor/);
+    const nav = screen.getByTestId("perc-spa-topnav");
+    expect(within(nav).queryByTestId("nav-editor")).toBeNull();
+    expect(within(nav).queryByTestId("nav-design")).toBeNull();
+    expect(within(nav).queryByTestId("nav-widget-builder")).toBeNull();
+    expect(screen.getByTestId("nav-developer")).toBeTruthy();
+    expect(screen.getByTestId("nav-architecture")).toBeTruthy();
+    expect(screen.getByTestId("nav-publish")).toBeTruthy();
   });
 
   it("Architecture is SPA NavLink to /architecture (#3094)", () => {

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -21,6 +21,7 @@ import {
   ARCHITECTURE_NAV_LANDING,
   adminTopNavLabel,
   isAdminNavPath,
+  isWidgetBuilderDeveloperEntry,
   topNavItemIds,
 } from "../../../../main/ts/app/layout/topNavConfig";
 
@@ -58,13 +59,10 @@ describe("topNavItemIds (#2702)", () => {
     expect(ids).toEqual([
       "home",
       "explorer",
-      "editor",
       "architecture",
-      "design",
       "developer",
       "publish",
       "admin",
-      "widget-builder",
     ]);
   });
 
@@ -74,12 +72,40 @@ describe("topNavItemIds (#2702)", () => {
     ).toEqual([
       "home",
       "explorer",
-      "editor",
       "architecture",
-      "design",
       "developer",
       "publish",
     ]);
+  });
+
+  it("does not expose Editor, Design, or Widget Builder as top-nav items (#3514)", () => {
+    const ids = topNavItemIds({
+      isAdmin: true,
+      isDesigner: true,
+      isWidgetBuilderActive: true,
+    });
+    expect(ids).not.toContain("editor" as never);
+    expect(ids).not.toContain("design" as never);
+    expect(ids).not.toContain("widget-builder" as never);
+    expect(isWidgetBuilderDeveloperEntry({
+      isAdmin: true,
+      isDesigner: true,
+      isWidgetBuilderActive: true,
+    })).toBe(true);
+    expect(
+      isWidgetBuilderDeveloperEntry({
+        isAdmin: false,
+        isDesigner: true,
+        isWidgetBuilderActive: false,
+      }),
+    ).toBe(false);
+    expect(
+      isWidgetBuilderDeveloperEntry({
+        isAdmin: false,
+        isDesigner: false,
+        isWidgetBuilderActive: true,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/WebUI/src/test/ts/developer/DeveloperRelatedLinks.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperRelatedLinks.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeveloperRelatedLinks } from "../../../main/ts/developer/DeveloperRelatedLinks";
+
+const bootstrapState = {
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: true,
+};
+
+vi.mock("../../../main/ts/app/bootstrap/BootstrapContext", () => ({
+  useSpaBootstrap: () => bootstrapState,
+}));
+
+describe("DeveloperRelatedLinks (#3514)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+    bootstrapState.isAdmin = true;
+    bootstrapState.isDesigner = true;
+    bootstrapState.isWidgetBuilderActive = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("links Design and Widget Builder as Developer sub-entries, not top-nav", () => {
+    render(
+      <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/developer"]}>
+        <DeveloperRelatedLinks />
+      </MemoryRouter>,
+    );
+    const design = screen.getByTestId("developer-design-library-link");
+    const wb = screen.getByTestId("developer-widget-builder-link");
+    expect(design.getAttribute("href") || "").toMatch(/\/design$/);
+    expect(wb.getAttribute("href") || "").toMatch(/\/widget-builder$/);
+    expect(design.textContent).toMatch(/Design/i);
+    expect(wb.textContent).toMatch(/Widget Builder/i);
+  });
+
+  it("hides Widget Builder when the feature is inactive", () => {
+    bootstrapState.isWidgetBuilderActive = false;
+    render(
+      <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/developer"]}>
+        <DeveloperRelatedLinks />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("developer-design-library-link")).toBeTruthy();
+    expect(screen.queryByTestId("developer-widget-builder-link")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -564,6 +564,8 @@ describe("DeveloperShell", () => {
   it("renders shell and loads content types by default", async () => {
     render(<DeveloperShell embedded />);
     expect(screen.getByTestId("perc-developer-shell")).toBeTruthy();
+    expect(screen.getByTestId("developer-related-links")).toBeTruthy();
+    expect(screen.getByTestId("developer-design-library-link")).toBeTruthy();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });

--- a/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
+++ b/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
@@ -75,8 +75,8 @@ describe("PreferencesSection", () => {
     const loadLanding = vi
       .fn()
       .mockResolvedValueOnce("")
-      .mockResolvedValue("Editor");
-    const saveLanding = vi.fn().mockResolvedValue("Editor");
+      .mockResolvedValue("Architecture");
+    const saveLanding = vi.fn().mockResolvedValue("Architecture");
     const loadPreferenceCount = vi.fn().mockResolvedValue(0);
     renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
 
@@ -87,17 +87,17 @@ describe("PreferencesSection", () => {
     const select = screen.getByTestId(
       "perc-profile-preferences-landing",
     ) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "Editor" } });
+    fireEvent.change(select, { target: { value: "Architecture" } });
 
     const save = screen.getByTestId("perc-profile-preferences-save");
     expect((save as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(save);
 
     await waitFor(() => {
-      expect(saveLanding).toHaveBeenCalledWith("Editor");
+      expect(saveLanding).toHaveBeenCalledWith("Architecture");
       expect(screen.getByTestId("perc-profile-preferences-success")).toBeTruthy();
     });
-    expect(select.value).toBe("Editor");
+    expect(select.value).toBe("Architecture");
     expect(loadLanding).toHaveBeenCalledTimes(2);
   });
 
@@ -125,7 +125,7 @@ describe("PreferencesSection", () => {
 
   it("shows save error when reload does not persist the landing (#3207)", async () => {
     const loadLanding = vi.fn().mockResolvedValue("");
-    const saveLanding = vi.fn().mockResolvedValue("Editor");
+    const saveLanding = vi.fn().mockResolvedValue("Architecture");
     const loadPreferenceCount = vi.fn().mockResolvedValue(0);
     renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
 
@@ -135,11 +135,11 @@ describe("PreferencesSection", () => {
     const select = screen.getByTestId(
       "perc-profile-preferences-landing",
     ) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "Editor" } });
+    fireEvent.change(select, { target: { value: "Architecture" } });
     fireEvent.click(screen.getByTestId("perc-profile-preferences-save"));
 
     await waitFor(() => {
-      expect(saveLanding).toHaveBeenCalledWith("Editor");
+      expect(saveLanding).toHaveBeenCalledWith("Architecture");
       expect(screen.getByTestId("perc-profile-preferences-error")).toBeTruthy();
     });
     expect(screen.queryByTestId("perc-profile-preferences-success")).toBeNull();

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -24,12 +24,15 @@ import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
 import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 
 describe("profileLandingOptions", () => {
-  it("allows Home and Editor for any user", () => {
+  it("allows Home for any user and does not offer Editor or Design (#3514)", () => {
     expect(isProfileLandingAllowed("", {})).toBe(true);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.HOME, {})).toBe(true);
-    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.EDITOR, {})).toBe(true);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.EDITOR, {})).toBe(false);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, {})).toBe(false);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, {})).toBe(false);
+    const opts = profileLandingOptions({ isAdmin: true, isDesigner: true });
+    expect(opts.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(false);
+    expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(false);
   });
 
   it("includes Architecture (Navigation) landing for designers", () => {
@@ -54,21 +57,25 @@ describe("profileLandingOptions", () => {
     ).toBe(false);
   });
 
-  it("opens Design for designers and Administration for admins", () => {
+  it("opens Administration for admins and keeps Design only as a stale current value", () => {
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, { isAdmin: true }),
     ).toBe(true);
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isAdmin: true }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps current value when no longer allowed", () => {
     const opts = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
     expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
+    const editorStale = profileLandingOptions({}, HOMEPAGE_TYPES.EDITOR);
+    expect(editorStale.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(
+      true,
+    );
   });
 
   it("labels the Architecture homepage type as Navigation (#3217)", () => {

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -23,32 +23,32 @@ import {
 } from "../../../main/ts/workflowAdmin/user/landingOptions";
 
 describe("landingOptionsForRoles", () => {
-  it("always includes role-default and Home/Editor for any roles", () => {
+  it("always includes role-default and Home; not Editor or Design (#3514)", () => {
     const opts = landingOptionsForRoles(["Contributor"]);
     const values = opts.map((o) => o.value);
     expect(values).toContain("");
     expect(values).toContain(HOMEPAGE_TYPES.HOME);
-    expect(values).toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).not.toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
   });
 
-  it("includes Design and Architecture for Designer role", () => {
+  it("includes Architecture for Designer role without Design as a new choice", () => {
     const opts = landingOptionsForRoles(["Designer"]);
     const values = opts.map((o) => o.value);
-    expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
     const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
     expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
   });
 
-  it("includes Administration (Workflow) for Admin role", () => {
+  it("includes Administration (Workflow) for Admin role without Design", () => {
     const opts = landingOptionsForRoles(["Admin"]);
     const values = opts.map((o) => o.value);
     expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
-    expect(values).toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
   });
 
@@ -58,6 +58,11 @@ describe("landingOptionsForRoles", () => {
       HOMEPAGE_TYPES.WORKFLOW,
     );
     expect(opts.map((o) => o.value)).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const editorStale = landingOptionsForRoles(
+      ["Contributor"],
+      HOMEPAGE_TYPES.EDITOR,
+    );
+    expect(editorStale.map((o) => o.value)).toContain(HOMEPAGE_TYPES.EDITOR);
   });
 });
 
@@ -65,7 +70,7 @@ describe("isLandingAllowedForRoles", () => {
   it("allows Home and empty for empty roles", () => {
     expect(isLandingAllowedForRoles("", [])).toBe(true);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.HOME, [])).toBe(true);
-    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.EDITOR, [])).toBe(true);
+    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.EDITOR, [])).toBe(false);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.WORKFLOW, [])).toBe(false);
   });
 });

--- a/docs/ai-generated/code-reviews/issue-3514-top-nav-remove-editor-design-widget-builder-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3514-top-nav-remove-editor-design-widget-builder-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — issue #3514 top-nav chrome
+
+**Branch:** `fix/issue-3514-top-nav-remove-editor-design-widget-builder`  
+**Base:** `origin/main`  
+**Scope:** uncommitted WebUI top-nav / Developer sub-entries, landing-select coordination, Playwright, product-docs 8.2  
+**Memory patterns hit:** change-class closure (WebUI + Playwright + product-docs); behavioral tests for nav gates; no non-portable path I/O
+
+## Summary
+
+Removes Editor, Design, and Widget Builder from product top nav. Editor remains reachable from Explorer / Preview / Home Create. Design and Widget Builder reuse existing SPA routes (`/design`, `/widget-builder`) as Developer sub-entries. Profile and Users landing selects no longer offer Editor/Design as new choices (stale stored values still list). Login / community switch untouched.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None blocking.
+
+### Tests
+
+- Vitest covers `topNavItemIds`, TopNav chrome absence, `isWidgetBuilderDeveloperEntry`, Developer related links, landing-option gates + stale current.
+- Playwright `top-nav-restructure.spec.js` asserts remaining chrome and Developer → Design (optional Widget Builder). Design library spec waits on `perc-spa-topnav` instead of `nav-design`.
+- Cross-platform path checklist: N/A (no filesystem I/O; SPA/URL paths correctly use `/`).
+
+### Change-class closure
+
+- Production: `topNavConfig.ts`, `TopNav.tsx`, `DeveloperRelatedLinks.tsx`
+- Tests: Vitest + Playwright surface + golden smoke (live H2 QA)
+- Product-docs 8.2 admin / getting-started / glossary / users-roles / design-templates
+
+### Suggestions (non-blocking)
+
+- `qa-health` reports pre-existing FastForward `PSDbStorageService` import ERRORs on first H2 cell start; HTTP 200 / Health=healthy; not feature-related.
+- #3536 still owns adding Explorer to the profile landing list.

--- a/modules/perc-qa-automation/frontend/tests/design-template-library.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-library.spec.js
@@ -51,9 +51,10 @@ test.describe("Design template library list shell (#2808)", () => {
   }) => {
     await page.goto(designTemplatesUrl(), { waitUntil: "networkidle" });
 
-    await expect(page.locator('[data-testid="nav-design"]')).toBeVisible({
+    await expect(page.locator('[data-testid="perc-spa-topnav"]')).toBeVisible({
       timeout: 20_000,
     });
+    await expect(page.locator('[data-testid="nav-design"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="perc-design-shell"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -30,7 +30,8 @@ const { softVisible } = require("./explorer-shell-chrome");
 
 /** Stable data-testid values on the Design SPA (WebUI design/*). */
 const TEST_IDS = Object.freeze({
-  nav: "nav-design",
+  /** Product chrome after #3514 (Design is no longer a top-nav item). */
+  nav: "perc-spa-topnav",
   shell: "perc-design-shell",
   tabTemplates: "tab-design-templates",
   panel: "design-tpl-panel",

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -15,13 +15,15 @@
  */
 
 /**
- * Top navigation restructure (#2702 / #2784 / #2953 / #3088 / #3201):
+ * Top navigation restructure (#2702 / #2784 / #2953 / #3088 / #3201 / #3514):
  * - Dashboard removed from SPA top chrome
  * - Explorer immediately after Home
  * - Single consolidated Admin labeled "Admin" (not "Administration")
  * - Admin lands on working Admin tools shell (/admin); workflow/roles/users/
  *   categories are in-shell tabs (sibling chrome removed in #3088).
  *   #3340 is not a revert: do not restore admin-sibling-workflow-link.
+ * - Editor, Design, and Widget Builder are not top-nav items (#3514).
+ *   Widget Builder is a Developer sub-entry when the feature is active.
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -77,6 +79,12 @@ test.describe("Top nav restructure (#2702 / #3201)", () => {
     await expect(admin).toHaveText(/^Admin$/);
     await expect(nav.getByTestId("nav-dashboard")).toHaveCount(0);
     await expect(nav.getByTestId("nav-workflow")).toHaveCount(0);
+    await expect(nav.getByTestId("nav-editor")).toHaveCount(0);
+    await expect(nav.getByTestId("nav-design")).toHaveCount(0);
+    await expect(nav.getByTestId("nav-widget-builder")).toHaveCount(0);
+    await expect(nav.getByTestId("nav-architecture")).toBeVisible();
+    await expect(nav.getByTestId("nav-developer")).toBeVisible();
+    await expect(nav.getByTestId("nav-publish")).toBeVisible();
     await expect(nav.getByRole("link", { name: "Dashboard", exact: true })).toHaveCount(
       0,
     );
@@ -131,25 +139,61 @@ test.describe("Top nav restructure (#2702 / #3201)", () => {
     );
   });
 
-  test("Editor opens the React host, not leftover ?view=editor @smoke @ui", async ({
+  test("Developer sub-entries open Design and optional Widget Builder (#3514) @smoke @ui", async ({
     page,
   }) => {
-    const blocked = [];
-    page.on("request", (req) => {
-      if (/view=editor/.test(req.url())) {
-        blocked.push(req.url());
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
       }
     });
+
     await loginAsAdmin(page);
     await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
     await expectSpaTopNav(page);
-    await page.getByTestId("nav-editor").click();
-    await expect(page.locator('[data-testid="editor-host"]')).toBeVisible({
+    await expect(page.getByTestId("nav-editor")).toHaveCount(0);
+    await expect(page.getByTestId("nav-design")).toHaveCount(0);
+    await expect(page.getByTestId("nav-widget-builder")).toHaveCount(0);
+
+    await page.getByTestId("nav-developer").click();
+    await expect(page.getByTestId("perc-developer-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("developer-related-links")).toBeVisible({
+      timeout: 15_000,
+    });
+    const designLink = page.getByTestId("developer-design-library-link");
+    await expect(designLink).toBeVisible();
+    await designLink.click();
+    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("nav-design")).toHaveCount(0);
+
+    await page.getByTestId("nav-developer").click();
+    await expect(page.getByTestId("perc-developer-shell")).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page).not.toHaveURL(/view=editor/);
-    await expect(page.locator('[data-testid="editor-error"]')).toBeVisible();
-    expect(blocked, `leftover editor requested: ${blocked.join(" ")}`).toEqual(
+    const wb = page.getByTestId("developer-widget-builder-link");
+    if ((await wb.count()) > 0) {
+      await expect(wb).toBeVisible();
+      await wb.click();
+      await expect(page.getByTestId("widget-builder-app")).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(page.getByTestId("nav-widget-builder")).toHaveCount(0);
+    }
+
+    const unexpected = consoleErrors.filter(
+      (t) =>
+        !/favicon|404|net::ERR|Failed to load resource/i.test(t) &&
+        !/Download the React DevTools/i.test(t),
+    );
+    expect(unexpected, `JS console errors: ${unexpected.join(" | ")}`).toEqual(
       [],
     );
   });

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -37,7 +37,7 @@ const {
 describe("design-spa-surface helpers (#3307)", () => {
   it("exports stable Design SPA test ids", () => {
     assert.equal(TEST_IDS.shell, "perc-design-shell");
-    assert.equal(TEST_IDS.nav, "nav-design");
+    assert.equal(TEST_IDS.nav, "perc-spa-topnav");
     assert.equal(TEST_IDS.tabTemplates, "tab-design-templates");
     assert.equal(TEST_IDS.panel, "design-tpl-panel");
     assert.equal(TEST_IDS.create, "design-tpl-create");

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -24,7 +24,7 @@ The product name is **Navigation**. The SPA route remains `/architecture` (and
    - Query contract: `spa.jsp?entry=architecture`
    - Path route: `/cm/app/architecture` (optional site segment or `?site=` for context)
    - Legacy bookmarks: `/cm/app/?view=arch` and `/cm/app/siteArchitecture.jsp` redirect here
-3. The shell loads under the same product top nav as Explorer, Design, Publish, and Admin.
+3. The shell loads under the same product top nav as Explorer, Developer, Publish, and Admin.
 
 Default landing can also be set to **Navigation** (stored homepage type
 `Architecture`, also accepted as `Navigation`) for a user or role. After sign-in

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -19,7 +19,8 @@ In Percussion CMS 8.2 the primary template-list entry is the SPA shell. The clas
 ## Open Design (SPA)
 
 1. Sign in as an **Admin** or **Designer**.
-2. Choose **Design** in the product top navigation, or open:
+2. Open **Developer** in the product top navigation and choose **Design** (template
+   library). Design is not a top-nav item. You can also open:
    - Query contract: `spa.jsp?entry=design&section=templates`
    - Path route: `/cm/app/design` or `/cm/app/design/templates`
    - Legacy bookmarks: `/cm/app/?view=design` and `/cm/app/admin.jsp` redirect here
@@ -28,11 +29,12 @@ In Percussion CMS 8.2 the primary template-list entry is the SPA shell. The clas
      Admin). Until that cutover is on the server, `admin.jsp` may still show the
      classic CM1 Design list.
 3. The **Templates** tab lists assembly templates (label, name, id, description).
-   The shell loads under the same product top nav as Explorer, Navigation, Publish, and Admin.
+   The shell loads under the same product top nav as Explorer, Navigation, Developer, Publish, and Admin.
 
-Default landing can also be set to **Design** for a user or role. After sign-in
-with no deep-link return URL, the dispatcher applies that preference and opens the
-Design SPA.
+A stored **Design** default landing (from before this chrome change) still opens
+the Design SPA after sign-in. New profile and role landing lists do not offer
+Design as a destination — pick **Developer** surfaces via the remaining top-nav
+apps, or clear the override.
 
 ## Template library
 

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -18,9 +18,10 @@ For roles that can see the full chrome, the application top navigation is:
 
 1. **Home**
 2. **Explorer** (immediately after Home)
-3. **Editor** (React Content Editor — `spa.jsp?entry=editor` / `/editor`. Does not open leftover `?view=editor` or `editAsset.jsp`. Open an item from Explorer or Home, or create a page, blog post, or asset from **Home → Create**), Navigation, Design, Developer, Publish (role-gated)
+3. **Navigation**, **Developer**, **Publish** (Admin or Designer)
 4. **Admin** (administrators only — one item)
-5. Widget Builder (when that feature is active)
+
+**Editor**, **Design**, and **Widget Builder** are not top-nav items. Open the React Content Editor from Explorer **Edit**, Preview, or **Home → Create** (`spa.jsp?entry=editor` / `/editor` — not leftover `?view=editor` or `editAsset.jsp`). Open the template library from **Developer → Design** (or the existing `/design` deep link). Open Widget Builder from **Developer** when that feature is active.
 
 **Dashboard** is not a top-nav item. Dashboard gadgets remain on Home
 (`/home/gadgets`) and via homepage preference; they are not a separate

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -138,7 +138,7 @@ landing from **Admin → Users**.
 
 | Control | What it does |
 |---------|----------------|
-| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open (Home, Editor, **Navigation**, and additional screens when your roles include Designer or Admin). **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Use role default** clears your personal override so the role homepage applies. |
+| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open (Home, **Navigation**, and additional screens when your roles include Designer or Admin). **Editor** and **Design** are not offered as new choices (they are not top-nav items). **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. A stored Editor or Design override still appears so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
 | **Save preferences** | Writes the landing override for the signed-in user only. The value is reloaded from the server after save so a failed persist is not shown as success. |
 
 The stored-preference count is informational (existing preference entries for your

--- a/product-docs/8.2/getting-started/index.md
+++ b/product-docs/8.2/getting-started/index.md
@@ -30,12 +30,13 @@ This section covers how to obtain, install, upgrade, and take first steps with P
 2. Sign in with the administrative account created at install time.
 3. Confirm the SPA top navigation starts with **Home**, then **Explorer** (adjacent).
    There is no **Dashboard** top-nav item. Administrators see a single **Admin**
-   item that opens **Admin tools** (`/admin`). See [Administration](id:admin).
-   **Design** (Admin or Designer) opens the SPA template library — classic
-   `?view=design` / `admin.jsp` bookmarks redirect there. See
+   item that opens **Admin tools** (`/admin`). **Editor**, **Design**, and
+   **Widget Builder** are not top-nav items. See [Administration](id:admin).
+   The template library is under **Developer → Design** — classic
+   `?view=design` / `admin.jsp` bookmarks still redirect there. See
    [Design templates](id:admin-design-templates).
-4. Create or open a **Site**, confirm Explorer navigation, and open the React Content Editor from Explorer **Edit**, **Home → Create** (page, blog, or asset), or the **Editor** top-nav item. Those surfaces do not open leftover `?view=editor` or `editAsset.jsp`.
-5. Open **Design** to list assembly templates and edit source, JEXL bindings, assembler,
+4. Create or open a **Site**, confirm Explorer navigation, and open the React Content Editor from Explorer **Edit** or **Home → Create** (page, blog, or asset). Those surfaces do not open leftover `?view=editor` or `editAsset.jsp`.
+5. Open **Developer → Design** to list assembly templates and edit source, JEXL bindings, assembler,
    and slots. See [Design templates](id:admin-design-templates).
 6. Review [Server operations](id:admin-server-ops) for ports, service control, and logs.
 

--- a/product-docs/8.2/reference/glossary.md
+++ b/product-docs/8.2/reference/glossary.md
@@ -15,7 +15,7 @@ tags: [reference]
 | **Asset** | Shared content fragment referenced by pages |
 | **CM1** | Marketing name historically used for the modern Percussion CMS product line |
 | **CMS** | Content Management System — this product |
-| **Design (SPA)** | Product top-nav surface for the modern assembly template library |
+| **Design (SPA)** | Assembly template library under **Developer** (not a top-nav item) |
 | **Content repository** | Traditional storage of CMS items (pages, assets, design objects) |
 | **DTS** | Delivery Tier Service — dynamic microservices for published sites |
 | **Edition / publish job** | Configured publishing unit of work |


### PR DESCRIPTION
## Summary

Removes **Editor**, **Design**, and **Widget Builder** from product top navigation (#3514). Remaining chrome is **Home**, **Explorer**, **Navigation**, **Developer**, **Publish**, **Admin**.

- Editor is still opened from Explorer / Preview / Home Create (`/editor` deep link unchanged).
- Design template library is a Developer sub-entry that uses the existing `/design` route (not a new builder).
- Widget Builder is a Developer sub-entry when the feature is active (`/widget-builder`).
- Profile and Users default-landing selects no longer offer Editor/Design as new choices; a stored override still lists so it can be cleared. Explorer landing addition remains #3536.
- Login and community switch are unchanged.

Operator: Grok: night-issue-prs (model grok-4.6)

Parent / tracker: #3514  
Coordinates with #3515 / #3536.

Fixes #3514

## Test plan

1. Sign in as Admin. Confirm top nav is Home, Explorer, Navigation, Developer, Publish, Admin. No Editor, Design, Widget Builder, Dashboard.
2. Open Developer. Confirm **Design** sub-link opens the template library. If Widget Builder is enabled, confirm that sub-link opens `/widget-builder`.
3. Open Explorer / Home Create and confirm the React editor still opens (not `?view=editor`).
4. Profile / Admin → Users landing select: Editor and Design are not new options; a stored Editor/Design value still appears so it can be cleared.
5. Community switch in the user menu still works.

H2 QA (this PR): `perc-devctl qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` → docker-cp `WebUI/target/generated-webui/cm/modern` into the cell → Playwright surface + golden.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (admin chrome, getting-started, design-templates, users-roles landing, glossary)
- [x] **Unit / module tests** — Vitest nav/landing/Developer links; standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **WebUI + Playwright** — `tests/top-nav-restructure.spec.js`, `tests/design-template-library.spec.js`, `npm run test:golden`
- [x] **Build gates** — standalone clean install on changed modules (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path I/O; SPA/URL paths use `/`)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2748, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **downstream_checked:** none (C2 did not apply — no Java `final`/public API shape change)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993` (HTTP 200, Docker Health=healthy). `qa-health` reported pre-existing FastForward `PSDbStorageService` import ERRORs during first start (not feature-related).
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/` (SPA JS/CSS hot copy; no docker restart)
- Playwright:
  - `npm run test:surface -- --path tests/top-nav-restructure.spec.js` → **2 passed**
  - `npm run test:surface -- --path tests/design-template-library.spec.js` → **1 passed**
  - `npm run test:golden` → **2 passed**
- console-clean=yes (surface specs listen for pageerror/console error)
- server.log-clean=yes for this feature (install-time FastForward/search-index ERROR noise only; no nav-related ERROR/FATAL during the test window)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
