### PR TITLE
fix(profile): include Explorer in default landing list (drop Editor/Design) (#3536)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/util/PSDefaultLandingView.java
+++ b/WebUI/src/main/java/com/percussion/webui/util/PSDefaultLandingView.java
@@ -43,6 +43,12 @@ public final class PSDefaultLandingView {
   public static final String VIEW_WORKFLOW = "workflow";
   public static final String VIEW_WIDGET_BUILDER = "widgetbuilder";
 
+  /** Content Explorer SPA ({@code spa.jsp?entry=explorer}). */
+  public static final String VIEW_EXPLORER = "explorer";
+
+  /** Developer / System Definition SPA ({@code spa.jsp?entry=developer}). */
+  public static final String VIEW_DEVELOPER = "developer";
+
   /** Canonical product homepage types (PascalCase), peer to role/user service constants. */
   public static final String TYPE_HOME = "Home";
 
@@ -53,6 +59,12 @@ public final class PSDefaultLandingView {
   public static final String TYPE_PUBLISH = "Publish";
   public static final String TYPE_WORKFLOW = "Workflow";
   public static final String TYPE_WIDGET_BUILDER = "WidgetBuilder";
+
+  /** Product homepage type: Content Explorer. */
+  public static final String TYPE_EXPLORER = "Explorer";
+
+  /** Product homepage type: Developer / System Definition. */
+  public static final String TYPE_DEVELOPER = "Developer";
 
   /**
    * Views that require Admin. Designer may open a subset ({@link #DESIGNER_ALLOWED_VIEWS});
@@ -65,32 +77,26 @@ public final class PSDefaultLandingView {
           VIEW_PUBLISH,
           VIEW_WORKFLOW,
           VIEW_WIDGET_BUILDER,
-          "developer",
+          VIEW_DEVELOPER,
           "admin");
 
   /** Subset of admin-gated views that Designers may open (matches index.jsp designerViews). */
   private static final Set<String> DESIGNER_ALLOWED_VIEWS =
-      Set.of(VIEW_DESIGN, VIEW_ARCH, VIEW_PUBLISH, VIEW_WIDGET_BUILDER, "developer");
+      Set.of(VIEW_DESIGN, VIEW_ARCH, VIEW_PUBLISH, VIEW_WIDGET_BUILDER, VIEW_DEVELOPER);
 
   /** Canonical type → view key. */
   private static final Map<String, String> TYPE_TO_VIEW =
-      Map.of(
-          TYPE_HOME,
-          VIEW_HOME,
-          TYPE_DASHBOARD,
-          VIEW_DASH,
-          TYPE_EDITOR,
-          VIEW_EDITOR,
-          TYPE_DESIGNER,
-          VIEW_DESIGN,
-          TYPE_ARCHITECTURE,
-          VIEW_ARCH,
-          TYPE_PUBLISH,
-          VIEW_PUBLISH,
-          TYPE_WORKFLOW,
-          VIEW_WORKFLOW,
-          TYPE_WIDGET_BUILDER,
-          VIEW_WIDGET_BUILDER);
+      Map.ofEntries(
+          Map.entry(TYPE_HOME, VIEW_HOME),
+          Map.entry(TYPE_DASHBOARD, VIEW_DASH),
+          Map.entry(TYPE_EDITOR, VIEW_EDITOR),
+          Map.entry(TYPE_DESIGNER, VIEW_DESIGN),
+          Map.entry(TYPE_ARCHITECTURE, VIEW_ARCH),
+          Map.entry(TYPE_PUBLISH, VIEW_PUBLISH),
+          Map.entry(TYPE_WORKFLOW, VIEW_WORKFLOW),
+          Map.entry(TYPE_WIDGET_BUILDER, VIEW_WIDGET_BUILDER),
+          Map.entry(TYPE_EXPLORER, VIEW_EXPLORER),
+          Map.entry(TYPE_DEVELOPER, VIEW_DEVELOPER));
 
   private PSDefaultLandingView() {}
 
@@ -144,6 +150,10 @@ public final class PSDefaultLandingView {
       case "widgetbuilder":
       case "widget-builder":
         return VIEW_WIDGET_BUILDER;
+      case "explorer":
+        return VIEW_EXPLORER;
+      case "developer":
+        return VIEW_DEVELOPER;
       default:
         return VIEW_HOME;
     }

--- a/WebUI/src/main/ts/api/user/userHomepageApi.ts
+++ b/WebUI/src/main/ts/api/user/userHomepageApi.ts
@@ -34,6 +34,8 @@ export const HOMEPAGE_TYPES = {
   PUBLISH: "Publish",
   WORKFLOW: "Workflow",
   WIDGET_BUILDER: "WidgetBuilder",
+  EXPLORER: "Explorer",
+  DEVELOPER: "Developer",
 } as const;
 
 export type HomepageType =
@@ -110,6 +112,8 @@ const HOMEPAGE_ALIAS: Record<string, HomepageType> = {
   widgetbuilder: HOMEPAGE_TYPES.WIDGET_BUILDER,
   "widget-builder": HOMEPAGE_TYPES.WIDGET_BUILDER,
   widget_builder: HOMEPAGE_TYPES.WIDGET_BUILDER,
+  explorer: HOMEPAGE_TYPES.EXPLORER,
+  developer: HOMEPAGE_TYPES.DEVELOPER,
 };
 
 /**

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * Default landing options for the profile Preferences section (#2396).
+ * Default landing options for the profile Preferences section (#2396 / #3536).
  *
  * <p>Values are product homepage types (PascalCase) already accepted by
  * {@code PSUserService} / login landing resolve. Labels reuse nav menu keys.
@@ -35,7 +35,11 @@ export interface ProfileLandingOption {
   labelKey: string;
 }
 
-/** Product options for the profile landing select. */
+/**
+ * Product options for the profile landing select (#3536 / parent #3515).
+ * Matches remaining top-nav apps (Home, Explorer, Navigation, Developer,
+ * Publish, Admin). Editor / Design are not offered as new choices.
+ */
 export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   {
     value: "",
@@ -46,12 +50,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
     labelKey: "perc.ui.navMenu.home@Home",
   },
   {
-    value: HOMEPAGE_TYPES.EDITOR,
-    labelKey: "perc.ui.navMenu.webmgt@Editor",
-  },
-  {
-    value: HOMEPAGE_TYPES.DESIGNER,
-    labelKey: "perc.ui.navMenu.design@Design",
+    value: HOMEPAGE_TYPES.EXPLORER,
+    labelKey: "perc.ui.dashboard.modern@Explorer",
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
@@ -59,8 +59,31 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
     labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
+    value: HOMEPAGE_TYPES.DEVELOPER,
+    labelKey: "perc.ui.dashboard.modern@Developer",
+  },
+  {
+    value: HOMEPAGE_TYPES.PUBLISH,
+    labelKey: "perc.ui.navMenu.publish@Publish",
+  },
+  {
     value: HOMEPAGE_TYPES.WORKFLOW,
     labelKey: "perc.ui.navMenu.admin@Administration",
+  },
+] as const;
+
+/**
+ * Stored Editor/Design overrides stay visible once so the user can clear them
+ * after those items leave top nav (#3514 / #3536).
+ */
+export const STALE_PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
+  {
+    value: HOMEPAGE_TYPES.EDITOR,
+    labelKey: "perc.ui.navMenu.webmgt@Editor",
+  },
+  {
+    value: HOMEPAGE_TYPES.DESIGNER,
+    labelKey: "perc.ui.navMenu.design@Design",
   },
 ] as const;
 
@@ -76,10 +99,15 @@ export function isProfileLandingAllowed(
   homepageType: HomepageType | "",
   gates: ProfileLandingGates,
 ): boolean {
-  if (homepageType === "" || homepageType === HOMEPAGE_TYPES.HOME) {
+  if (
+    homepageType === "" ||
+    homepageType === HOMEPAGE_TYPES.HOME ||
+    homepageType === HOMEPAGE_TYPES.EXPLORER
+  ) {
     return true;
   }
-  // Editor / Design left product top nav (#3514 / #3536). Not new choices.
+  // Editor / Design left product top nav (#3514 / #3536). Not new choices;
+  // stale stored values use {@link profileLandingOptions} extra-current.
   if (
     homepageType === HOMEPAGE_TYPES.EDITOR ||
     homepageType === HOMEPAGE_TYPES.DESIGNER
@@ -90,6 +118,7 @@ export function isProfileLandingAllowed(
   const isDesigner = !!gates.isDesigner || isAdmin;
   switch (homepageType) {
     case HOMEPAGE_TYPES.ARCHITECTURE:
+    case HOMEPAGE_TYPES.DEVELOPER:
     case HOMEPAGE_TYPES.PUBLISH:
     case HOMEPAGE_TYPES.WIDGET_BUILDER:
       return isDesigner;
@@ -114,12 +143,10 @@ export function profileLandingOptions(
     isProfileLandingAllowed(opt.value, gates),
   );
   const current = currentValue == null ? "" : String(currentValue).trim();
-  if (
-    current &&
-    !allowed.some((o) => o.value === current) &&
-    PROFILE_LANDING_OPTIONS.some((o) => o.value === current)
-  ) {
-    const extra = PROFILE_LANDING_OPTIONS.find((o) => o.value === current);
+  if (current && !allowed.some((o) => o.value === current)) {
+    const extra =
+      PROFILE_LANDING_OPTIONS.find((o) => o.value === current) ??
+      STALE_PROFILE_LANDING_OPTIONS.find((o) => o.value === current);
     if (extra) {
       return [...allowed, extra];
     }

--- a/WebUI/src/main/ts/profile/resolveLandingEntry.ts
+++ b/WebUI/src/main/ts/profile/resolveLandingEntry.ts
@@ -57,6 +57,10 @@ export function resolveHomepageToSpaEntry(
       return "admin";
     case HOMEPAGE_TYPES.WIDGET_BUILDER:
       return "widget-builder";
+    case HOMEPAGE_TYPES.EXPLORER:
+      return "explorer";
+    case HOMEPAGE_TYPES.DEVELOPER:
+      return "developer";
     default:
       break;
   }

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -87,7 +87,9 @@
             "dash"
     };
 
-    // List of views requiring admin role
+    // List of views requiring admin role.
+    // home / dash / explorer are ungated spaViews — they must stay off this list
+    // so Contributor and Designer stored landings are not reset (issue #3536).
     String[] adminViews = new String[]{
             "design",
             "arch",
@@ -100,7 +102,8 @@
             "admin"
     };
 
-    // List of views requiring designer role
+    // Subset of adminViews that Designer may open. Only consulted inside the
+    // isAdminView gate below — listing an ungated view (explorer) here is a no-op.
     String[] designerViews = new String[]{
             "design",
             "arch",

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -79,6 +79,7 @@
             "admin",
             "widgetbuilder",
             "developer",
+            "explorer",
             "arch",
             "architecture",
             "navigation",
@@ -249,7 +250,8 @@
             entry = "design";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
-                || "developer".equals(view))
+                || "developer".equals(view)
+                || "explorer".equals(view))
             entry = view;
         else
             entry = "home";

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -87,7 +87,9 @@
             "dash"
     };
 
-    // List of views requiring admin role
+    // List of views requiring admin role.
+    // home / dash / explorer are ungated spaViews — they must stay off this list
+    // so Contributor and Designer stored landings are not reset (issue #3536).
     String[] adminViews = new String[]{
             "design",
             "arch",
@@ -100,7 +102,8 @@
             "admin"
     };
 
-    // List of views requiring designer role
+    // Subset of adminViews that Designer may open. Only consulted inside the
+    // isAdminView gate below — listing an ungated view (explorer) here is a no-op.
     String[] designerViews = new String[]{
             "design",
             "arch",

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -79,6 +79,7 @@
             "admin",
             "widgetbuilder",
             "developer",
+            "explorer",
             "arch",
             "architecture",
             "navigation",
@@ -249,7 +250,8 @@
             entry = "design";
         else if ("home".equals(view) || "publish".equals(view)
                 || "admin".equals(view)
-                || "developer".equals(view))
+                || "developer".equals(view)
+                || "explorer".equals(view))
             entry = view;
         else
             entry = "home";

--- a/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
@@ -19,7 +19,9 @@ package com.percussion.webui.util;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_ARCHITECTURE;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_DASHBOARD;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_DESIGNER;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_DEVELOPER;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_EDITOR;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_EXPLORER;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_HOME;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_PUBLISH;
 import static com.percussion.webui.util.PSDefaultLandingView.TYPE_WIDGET_BUILDER;
@@ -27,7 +29,9 @@ import static com.percussion.webui.util.PSDefaultLandingView.TYPE_WORKFLOW;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_ARCH;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_DASH;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_DESIGN;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_DEVELOPER;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_EDITOR;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_EXPLORER;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_HOME;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_PUBLISH;
 import static com.percussion.webui.util.PSDefaultLandingView.VIEW_WIDGET_BUILDER;
@@ -59,6 +63,8 @@ public class PSDefaultLandingViewTest {
     assertEquals(VIEW_WORKFLOW, PSDefaultLandingView.homepageTypeToViewKey(TYPE_WORKFLOW));
     assertEquals(
         VIEW_WIDGET_BUILDER, PSDefaultLandingView.homepageTypeToViewKey(TYPE_WIDGET_BUILDER));
+    assertEquals(VIEW_EXPLORER, PSDefaultLandingView.homepageTypeToViewKey(TYPE_EXPLORER));
+    assertEquals(VIEW_DEVELOPER, PSDefaultLandingView.homepageTypeToViewKey(TYPE_DEVELOPER));
   }
 
   @Test
@@ -74,6 +80,8 @@ public class PSDefaultLandingViewTest {
     assertEquals(VIEW_PUBLISH, PSDefaultLandingView.homepageTypeToViewKey("publish"));
     assertEquals(VIEW_WORKFLOW, PSDefaultLandingView.homepageTypeToViewKey("workflow"));
     assertEquals(VIEW_WIDGET_BUILDER, PSDefaultLandingView.homepageTypeToViewKey("widgetbuilder"));
+    assertEquals(VIEW_EXPLORER, PSDefaultLandingView.homepageTypeToViewKey("explorer"));
+    assertEquals(VIEW_DEVELOPER, PSDefaultLandingView.homepageTypeToViewKey("developer"));
   }
 
   @Test
@@ -93,6 +101,8 @@ public class PSDefaultLandingViewTest {
         VIEW_DASH, PSDefaultLandingView.resolveAuthorizedView(TYPE_DASHBOARD, false, false));
     assertEquals(
         VIEW_EDITOR, PSDefaultLandingView.resolveAuthorizedView(TYPE_EDITOR, false, false));
+    assertEquals(
+        VIEW_EXPLORER, PSDefaultLandingView.resolveAuthorizedView(TYPE_EXPLORER, false, false));
   }
 
   @Test
@@ -105,6 +115,8 @@ public class PSDefaultLandingViewTest {
         VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_PUBLISH, false, false));
     assertEquals(
         VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, false, false));
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_DEVELOPER, false, false));
   }
 
   @Test
@@ -128,6 +140,8 @@ public class PSDefaultLandingViewTest {
     assertEquals(
         VIEW_WIDGET_BUILDER,
         PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, false, true));
+    assertEquals(
+        VIEW_DEVELOPER, PSDefaultLandingView.resolveAuthorizedView(TYPE_DEVELOPER, false, true));
   }
 
   @Test
@@ -143,6 +157,10 @@ public class PSDefaultLandingViewTest {
     assertEquals(
         VIEW_WIDGET_BUILDER,
         PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, true, false));
+    assertEquals(
+        VIEW_EXPLORER, PSDefaultLandingView.resolveAuthorizedView(TYPE_EXPLORER, true, false));
+    assertEquals(
+        VIEW_DEVELOPER, PSDefaultLandingView.resolveAuthorizedView(TYPE_DEVELOPER, true, false));
   }
 
   @Test

--- a/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
@@ -103,6 +103,9 @@ public class PSDefaultLandingViewTest {
         VIEW_EDITOR, PSDefaultLandingView.resolveAuthorizedView(TYPE_EDITOR, false, false));
     assertEquals(
         VIEW_EXPLORER, PSDefaultLandingView.resolveAuthorizedView(TYPE_EXPLORER, false, false));
+    // Explorer is not admin-gated; Designer stored landings must not fail closed (#3536).
+    assertEquals(
+        VIEW_EXPLORER, PSDefaultLandingView.resolveAuthorizedView(TYPE_EXPLORER, false, true));
   }
 
   @Test
@@ -142,6 +145,8 @@ public class PSDefaultLandingViewTest {
         PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, false, true));
     assertEquals(
         VIEW_DEVELOPER, PSDefaultLandingView.resolveAuthorizedView(TYPE_DEVELOPER, false, true));
+    assertEquals(
+        VIEW_EXPLORER, PSDefaultLandingView.resolveAuthorizedView(TYPE_EXPLORER, false, true));
   }
 
   @Test
@@ -168,6 +173,9 @@ public class PSDefaultLandingViewTest {
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_HOME, false, false));
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DASH, false, false));
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_EDITOR, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_EXPLORER, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_EXPLORER, false, true));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_EXPLORER, true, false));
     assertFalse(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, false, false));
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, false, true));
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, true, false));
@@ -179,6 +187,7 @@ public class PSDefaultLandingViewTest {
   public void roleGatedClassification() {
     assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_HOME));
     assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_DASH));
+    assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_EXPLORER));
     assertTrue(PSDefaultLandingView.isRoleGatedView(VIEW_DESIGN));
     assertTrue(PSDefaultLandingView.isAdminOnlyView(VIEW_WORKFLOW));
     assertFalse(PSDefaultLandingView.isAdminOnlyView(VIEW_DESIGN));

--- a/WebUI/src/test/ts/api/userHomepageApi.test.ts
+++ b/WebUI/src/test/ts/api/userHomepageApi.test.ts
@@ -47,6 +47,9 @@ describe("userHomepageApi", () => {
     expect(canonicalizeHomepageType("Editor")).toBe(HOMEPAGE_TYPES.EDITOR);
     expect(canonicalizeHomepageType("editor")).toBe(HOMEPAGE_TYPES.EDITOR);
     expect(canonicalizeHomepageType("arch")).toBe(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(canonicalizeHomepageType("explorer")).toBe(HOMEPAGE_TYPES.EXPLORER);
+    expect(canonicalizeHomepageType("Explorer")).toBe(HOMEPAGE_TYPES.EXPLORER);
+    expect(canonicalizeHomepageType("developer")).toBe(HOMEPAGE_TYPES.DEVELOPER);
     expect(canonicalizeHomepageType('"Home"')).toBe(HOMEPAGE_TYPES.HOME);
   });
 

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -28,6 +28,16 @@ function read(path: string): string {
   return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
 }
 
+/** Pull quoted entries from a JSP `String[] name = new String[]{ ... };` block. */
+function extractStringArray(text: string, name: string): string[] {
+  const re = new RegExp(
+    `String\\[\\]\\s+${name}\\s*=\\s*new String\\[\\]\\{([\\s\\S]*?)\\};`,
+  );
+  const match = text.match(re);
+  expect(match, `${name} array`).toBeTruthy();
+  return [...match![1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
 /** Product host JSPs deleted in PR-8 (SPA owns these surfaces). */
 const DELETED_PRODUCT_HOSTS = [
   "cm/app/homeModern.jsp",
@@ -179,6 +189,21 @@ describe("PR-5 aggressive index.jsp SPA cutover (retained)", () => {
 
   it("dual-tree index.jsp files stay aligned for SPA cutover", () => {
     expect(read(appIndex)).toBe(read(pagesIndex));
+  });
+
+  it("explorer is an ungated spaView (not adminViews) so Designer landings are not reset", () => {
+    for (const indexPath of [appIndex, pagesIndex]) {
+      const text = read(indexPath);
+      const spa = extractStringArray(text, "spaViews");
+      const admin = extractStringArray(text, "adminViews");
+      const designer = extractStringArray(text, "designerViews");
+      expect(spa).toContain("explorer");
+      // Gate at isAdminView && !admin: explorer must stay off adminViews.
+      // designerViews is only consulted inside that gate — listing explorer
+      // there would be a no-op and would not authorize Contributors.
+      expect(admin).not.toContain("explorer");
+      expect(designer).not.toContain("explorer");
+    }
   });
 });
 

--- a/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
+++ b/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
@@ -75,8 +75,8 @@ describe("PreferencesSection", () => {
     const loadLanding = vi
       .fn()
       .mockResolvedValueOnce("")
-      .mockResolvedValue("Architecture");
-    const saveLanding = vi.fn().mockResolvedValue("Architecture");
+      .mockResolvedValue("Explorer");
+    const saveLanding = vi.fn().mockResolvedValue("Explorer");
     const loadPreferenceCount = vi.fn().mockResolvedValue(0);
     renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
 
@@ -87,17 +87,17 @@ describe("PreferencesSection", () => {
     const select = screen.getByTestId(
       "perc-profile-preferences-landing",
     ) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "Architecture" } });
+    fireEvent.change(select, { target: { value: "Explorer" } });
 
     const save = screen.getByTestId("perc-profile-preferences-save");
     expect((save as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(save);
 
     await waitFor(() => {
-      expect(saveLanding).toHaveBeenCalledWith("Architecture");
+      expect(saveLanding).toHaveBeenCalledWith("Explorer");
       expect(screen.getByTestId("perc-profile-preferences-success")).toBeTruthy();
     });
-    expect(select.value).toBe("Architecture");
+    expect(select.value).toBe("Explorer");
     expect(loadLanding).toHaveBeenCalledTimes(2);
   });
 
@@ -125,7 +125,7 @@ describe("PreferencesSection", () => {
 
   it("shows save error when reload does not persist the landing (#3207)", async () => {
     const loadLanding = vi.fn().mockResolvedValue("");
-    const saveLanding = vi.fn().mockResolvedValue("Architecture");
+    const saveLanding = vi.fn().mockResolvedValue("Explorer");
     const loadPreferenceCount = vi.fn().mockResolvedValue(0);
     renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
 
@@ -135,11 +135,11 @@ describe("PreferencesSection", () => {
     const select = screen.getByTestId(
       "perc-profile-preferences-landing",
     ) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "Architecture" } });
+    fireEvent.change(select, { target: { value: "Explorer" } });
     fireEvent.click(screen.getByTestId("perc-profile-preferences-save"));
 
     await waitFor(() => {
-      expect(saveLanding).toHaveBeenCalledWith("Architecture");
+      expect(saveLanding).toHaveBeenCalledWith("Explorer");
       expect(screen.getByTestId("perc-profile-preferences-error")).toBeTruthy();
     });
     expect(screen.queryByTestId("perc-profile-preferences-success")).toBeNull();

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -34,6 +34,8 @@ vi.mock("../../../main/ts/api/user/userHomepageApi", () => ({
     PUBLISH: "Publish",
     WORKFLOW: "Workflow",
     WIDGET_BUILDER: "WidgetBuilder",
+    EXPLORER: "Explorer",
+    DEVELOPER: "Developer",
   },
 }));
 

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -24,15 +24,31 @@ import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
 import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
 
 describe("profileLandingOptions", () => {
-  it("allows Home for any user and does not offer Editor or Design (#3514)", () => {
+  it("allows Home and Explorer for any user and does not offer Editor or Design (#3514)", () => {
     expect(isProfileLandingAllowed("", {})).toBe(true);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.HOME, {})).toBe(true);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.EXPLORER, {})).toBe(true);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.EDITOR, {})).toBe(false);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, {})).toBe(false);
     expect(isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, {})).toBe(false);
     const opts = profileLandingOptions({ isAdmin: true, isDesigner: true });
     expect(opts.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(false);
     expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(false);
+  });
+
+  it("offers remaining top-nav apps and not Editor or Design (#3536)", () => {
+    const values = profileLandingOptions({ isAdmin: true, isDesigner: true }).map(
+      (o) => o.value,
+    );
+    expect(values).toContain("");
+    expect(values).toContain(HOMEPAGE_TYPES.HOME);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
   });
 
   it("includes Architecture (Navigation) landing for designers", () => {
@@ -55,9 +71,16 @@ describe("profileLandingOptions", () => {
     expect(
       opts.some((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE),
     ).toBe(false);
+    expect(opts.some((o) => o.value === HOMEPAGE_TYPES.EXPLORER)).toBe(true);
   });
 
-  it("opens Administration for admins and keeps Design only as a stale current value", () => {
+  it("opens Developer/Publish for designers and Administration for admins", () => {
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.DEVELOPER, { isDesigner: true }),
+    ).toBe(true);
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.PUBLISH, { isDesigner: true }),
+    ).toBe(true);
     expect(
       isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),
     ).toBe(false);
@@ -69,13 +92,11 @@ describe("profileLandingOptions", () => {
     ).toBe(false);
   });
 
-  it("keeps current value when no longer allowed", () => {
-    const opts = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
-    expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
-    const editorStale = profileLandingOptions({}, HOMEPAGE_TYPES.EDITOR);
-    expect(editorStale.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(
-      true,
-    );
+  it("keeps stale Editor/Design current values so the user can clear them", () => {
+    const design = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
+    expect(design.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
+    const editor = profileLandingOptions({}, HOMEPAGE_TYPES.EDITOR);
+    expect(editor.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(true);
   });
 
   it("labels the Architecture homepage type as Navigation (#3217)", () => {

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -66,6 +66,16 @@ describe("resolveHomepageToSpaEntry (#3219)", () => {
     expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
       "/widget-builder",
     );
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.EXPLORER)).toBe("explorer");
+    expect(resolveHomepageToSpaEntry(HOMEPAGE_TYPES.DEVELOPER)).toBe(
+      "developer",
+    );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.EXPLORER)).toBe(
+      "/explorer",
+    );
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DEVELOPER)).toBe(
+      "/developer",
+    );
     expect(resolveHomepageToClientPath("explorer")).toBe("/explorer");
     expect(resolveHomepageToClientPath("profile")).toBe("/profile");
     expect(resolveHomepageToClientPath("developer")).toBe("/developer");

--- a/WebUI/src/test/ts/workflowAdmin/UserEditor.landing.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/UserEditor.landing.test.tsx
@@ -46,6 +46,8 @@ vi.mock("../../../main/ts/api/user/userHomepageApi", () => ({
     PUBLISH: "Publish",
     WORKFLOW: "Workflow",
     WIDGET_BUILDER: "WidgetBuilder",
+    EXPLORER: "Explorer",
+    DEVELOPER: "Developer",
   },
 }));
 

--- a/docs/ai-generated/code-reviews/3536-pr-3540-designer-explorer-gate-erlang.md
+++ b/docs/ai-generated/code-reviews/3536-pr-3540-designer-explorer-gate-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — PR #3540 follow-up (Explorer ungated for Designer)
+
+**Date:** 2026-08-17  
+**Scope:** Uncommitted follow-up on `fix/issue-3536-profile-landing-explorer` (Kilo threads on PR #3540).  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Memory patterns hit:** dual-tree lockstep WebUI JSP hosts; behavioral tests for role-gated landing; do not treat source-string tests as sole proof (JSP parse is paired with `PSDefaultLandingView` role assertions).
+
+## Summary
+
+Kilo asked to add `"explorer"` to `designerViews` in both `index.jsp` hosts. That list is only consulted inside `if (isAdminView && !admin)`. Explorer is not in `adminViews`, so Designer stored landings are already not reset. Adding explorer to `designerViews` alone is a no-op; adding it to `adminViews` would fail-closed Contributor landings.
+
+This change documents that contract on both dual-tree JSPs and locks it with:
+
+- `PSDefaultLandingViewTest` — Designer + Contributor + Admin `resolveAuthorizedView` / `isViewAuthorized`; `isRoleGatedView(VIEW_EXPLORER) == false`
+- `spaCutover.test.ts` — both JSP hosts: explorer in `spaViews`, absent from `adminViews` and `designerViews`
+
+No production authorization change.
+
+## Gate
+
+- **Bugs:** none
+- **Behavioral tests:** present for Java role mapping; JSP allowlist contract covered via dual-tree parse + Java behavior
+- **Cross-platform paths:** no new filesystem joins; existing `read()` normalizes CRLF
+- **Change-class companions:** review-thread fix only (comments + tests). No new UI surface; Playwright N/A. Product-docs N/A (behavior unchanged).
+- **New warnings:** none attributable (WebUI `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS; Vitest 2747 passed; `PSDefaultLandingViewTest` 11/0)
+
+## Issues
+
+None.

--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -123,6 +123,22 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
 
     const landing = page.getByTestId("perc-profile-preferences-landing");
     await expect(landing).toBeEnabled();
+    const optionValues = await landing.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(optionValues).toContain("Home");
+    expect(optionValues).toContain("Explorer");
+    expect(optionValues).toContain("Architecture");
+    expect(optionValues).toContain("Developer");
+    expect(optionValues).toContain("Publish");
+    expect(optionValues).toContain("Workflow");
+    const current = await landing.inputValue();
+    if (current !== "Editor") {
+      expect(optionValues).not.toContain("Editor");
+    }
+    if (current !== "Designer") {
+      expect(optionValues).not.toContain("Designer");
+    }
     await expect(
       page.getByTestId("perc-profile-preferences-save"),
     ).toBeVisible();
@@ -187,8 +203,8 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     await expect(landing).toBeVisible();
 
     const original = await landing.inputValue();
-    // Prefer Home ↔ Editor so both are allowed for Admin and product-backed.
-    const next = original === "Editor" ? "Home" : "Editor";
+    // Prefer Home ↔ Explorer so both are allowed for Admin and product-backed (#3536).
+    const next = original === "Explorer" ? "Home" : "Explorer";
 
     await landing.selectOption(next);
     await page.getByTestId("perc-profile-preferences-save").click();

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -138,7 +138,7 @@ landing from **Admin → Users**.
 
 | Control | What it does |
 |---------|----------------|
-| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open (Home, **Navigation**, and additional screens when your roles include Designer or Admin). **Editor** and **Design** are not offered as new choices (they are not top-nav items). **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. A stored Editor or Design override still appears so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
+| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open — the same remaining top-nav apps as chrome: **Home**, **Explorer**, **Navigation**, and (when your roles include Designer or Admin) **Developer**, **Publish**, and **Admin**. **Explorer** is stored as homepage type `Explorer` and opens the Content Explorer SPA. **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Editor** and **Design** are no longer offered as new choices (they are not top-nav items); if you already stored one of those values, it still appears once so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
 | **Save preferences** | Writes the landing override for the signed-in user only. The value is reloaded from the server after save so a failed persist is not shown as success. |
 
 The stored-preference count is informational (existing preference entries for your

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
@@ -242,6 +242,12 @@ public interface IPSUserService {
   /** Product homepage type: Widget Builder. */
   String HOMEPAGE_TYPE_WIDGET_BUILDER = "WidgetBuilder";
 
+  /** Product homepage type: Content Explorer ({@code view=explorer}). */
+  String HOMEPAGE_TYPE_EXPLORER = "Explorer";
+
+  /** Product homepage type: Developer / System Definition ({@code view=developer}). */
+  String HOMEPAGE_TYPE_DEVELOPER = "Developer";
+
   /**
    * Returns the persisted default landing-page override for the named user, or empty string when
    * unset. Never {@code null}. Does not apply role resolve.

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -215,27 +215,23 @@ public class PSUserService implements IPSUserService {
                   HOMEPAGE_TYPE_ARCHITECTURE,
                   HOMEPAGE_TYPE_PUBLISH,
                   HOMEPAGE_TYPE_WORKFLOW,
-                  HOMEPAGE_TYPE_WIDGET_BUILDER)));
+                  HOMEPAGE_TYPE_WIDGET_BUILDER,
+                  HOMEPAGE_TYPE_EXPLORER,
+                  HOMEPAGE_TYPE_DEVELOPER)));
 
   /** Maps canonical homepage type → {@code index.jsp} {@code view} key. */
   private static final Map<String, String> HOMEPAGE_TYPE_TO_VIEW_KEY =
-      Map.of(
-          HOMEPAGE_TYPE_HOME,
-          "home",
-          HOMEPAGE_TYPE_DASHBOARD,
-          "dash",
-          HOMEPAGE_TYPE_EDITOR,
-          "editor",
-          HOMEPAGE_TYPE_DESIGNER,
-          "design",
-          HOMEPAGE_TYPE_ARCHITECTURE,
-          "arch",
-          HOMEPAGE_TYPE_PUBLISH,
-          "publish",
-          HOMEPAGE_TYPE_WORKFLOW,
-          "workflow",
-          HOMEPAGE_TYPE_WIDGET_BUILDER,
-          "widgetbuilder");
+      Map.ofEntries(
+          Map.entry(HOMEPAGE_TYPE_HOME, "home"),
+          Map.entry(HOMEPAGE_TYPE_DASHBOARD, "dash"),
+          Map.entry(HOMEPAGE_TYPE_EDITOR, "editor"),
+          Map.entry(HOMEPAGE_TYPE_DESIGNER, "design"),
+          Map.entry(HOMEPAGE_TYPE_ARCHITECTURE, "arch"),
+          Map.entry(HOMEPAGE_TYPE_PUBLISH, "publish"),
+          Map.entry(HOMEPAGE_TYPE_WORKFLOW, "workflow"),
+          Map.entry(HOMEPAGE_TYPE_WIDGET_BUILDER, "widgetbuilder"),
+          Map.entry(HOMEPAGE_TYPE_EXPLORER, "explorer"),
+          Map.entry(HOMEPAGE_TYPE_DEVELOPER, "developer"));
 
   public static final String PERCUSSION_ADMIN_NAME = "PercussionAdmin";
   public static final String ADMIN_NAME = "Admin";
@@ -1219,7 +1215,7 @@ public class PSUserService implements IPSUserService {
                   + homepage
                   + "'. Allowed: "
                   + ALLOWED_HOMEPAGE_TYPES
-                  + " (or view keys home/dash/editor/design/arch/publish/workflow/widgetbuilder).",
+                  + " (or view keys home/dash/editor/design/arch/publish/workflow/widgetbuilder/explorer/developer).",
               homepage)
           .throwIfInvalid();
     }
@@ -1313,6 +1309,10 @@ public class PSUserService implements IPSUserService {
       case "widget-builder":
       case "widget_builder":
         return HOMEPAGE_TYPE_WIDGET_BUILDER;
+      case "explorer":
+        return HOMEPAGE_TYPE_EXPLORER;
+      case "developer":
+        return HOMEPAGE_TYPE_DEVELOPER;
       default:
         return null;
     }

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
@@ -23,6 +23,8 @@ import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DESIGNER;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_PUBLISH;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DEVELOPER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_EXPLORER;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WIDGET_BUILDER;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WORKFLOW;
 import static com.percussion.user.service.IPSUserService.META_DATA_HOMEPAGE_PREFIX;
@@ -105,6 +107,8 @@ class PSUserHomepageTest {
       assertEquals(HOMEPAGE_TYPE_WORKFLOW, PSUserService.normalizeHomepageType("Workflow"));
       assertEquals(
           HOMEPAGE_TYPE_WIDGET_BUILDER, PSUserService.normalizeHomepageType("WidgetBuilder"));
+      assertEquals(HOMEPAGE_TYPE_EXPLORER, PSUserService.normalizeHomepageType("Explorer"));
+      assertEquals(HOMEPAGE_TYPE_DEVELOPER, PSUserService.normalizeHomepageType("Developer"));
     }
 
     @Test
@@ -120,6 +124,8 @@ class PSUserHomepageTest {
       assertEquals(HOMEPAGE_TYPE_WORKFLOW, PSUserService.normalizeHomepageType("workflow"));
       assertEquals(
           HOMEPAGE_TYPE_WIDGET_BUILDER, PSUserService.normalizeHomepageType("widgetbuilder"));
+      assertEquals(HOMEPAGE_TYPE_EXPLORER, PSUserService.normalizeHomepageType("explorer"));
+      assertEquals(HOMEPAGE_TYPE_DEVELOPER, PSUserService.normalizeHomepageType("developer"));
     }
 
     @Test
@@ -142,6 +148,8 @@ class PSUserHomepageTest {
       assertEquals("workflow", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_WORKFLOW));
       assertEquals(
           "widgetbuilder", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_WIDGET_BUILDER));
+      assertEquals("explorer", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_EXPLORER));
+      assertEquals("developer", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_DEVELOPER));
       assertEquals("home", PSUserService.homepageTypeToViewKey(null));
       assertEquals("home", PSUserService.homepageTypeToViewKey("bogus"));
     }


### PR DESCRIPTION
## Summary

Slice 1 of parent #3515 / residual of #2598: **My profile → Preferences → Default landing page** now lists the remaining top-nav apps (**Home**, **Explorer**, **Navigation**, **Developer**, **Publish**, **Admin**) instead of Editor/Design.

Explorer and Developer persist through the existing homepage REST (`GET`/`PUT` `/user/user/homepage`) by extending the allowed `HOMEPAGE_TYPES` tokens — no new REST resource. Stale stored Editor/Design values still appear once so the user can clear them.

Parent: #3515. Also coordinates with #3514 (Editor/Design leave chrome).

Fixes #3536
Partial #3515
Partial #2598

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
2. Standalone `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2746 passed
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993`
4. Hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar`, `PSDefaultLandingView.class`, full `cm/modern/assets/`, `cm/app/index.jsp`; restart Jetty inside cell (not `docker restart`)
5. `npm run test:surface -- --path tests/profile-preferences.spec.js` — 3 passed
6. Admin: open Preferences; confirm Explorer is listed and Editor/Design are not new choices; save Explorer, reload, value persists

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (My profile — Preferences default landing)
- [x] **Unit / module tests** — landing option set + gates, homepage token aliases, `PSUserHomepageTest` / `PSDefaultLandingViewTest`; standalone clean install
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js` (options + Home↔Explorer persist)
- [x] **Build gates** — standalone clean install on `WebUI` and `projects/sitemanage` (no skipTests); additive homepage constants only (no `final` / signature break)
- [x] **Cross-platform** — N/A (no new path/file I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (01:38)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (01:52); Vitest `Tests 2746 passed (2746)` / `Test Files 369 passed`
- **downstream_checked:** grepped `extends IPSUserService` / `extends PSUserService` / `new PSUserService(` — only existing sitemanage unit tests construct `PSUserService`; no `final`/signature change. Standalone sitemanage + WebUI installs green.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`)
- `qa-health` after start and after Jetty restart: HTTP 200, `HEALTH:healthy`; `RESULT:FAIL DETAIL:server_log_errors` is **pre-existing FastForward `PSDbStorageService` import noise** (not homepage/profile)
- Deploy: `sitemanage-8.2.0-SNAPSHOT.jar` → `WEB-INF/lib/`; `PSDefaultLandingView.class`; full Vite `cm/modern/assets/`; `cm/app/index.jsp` + `cm/pages/app/index.jsp`; in-cell `StopJetty.sh` + `StartJetty.sh`
- `npm run test:surface -- --path tests/profile-preferences.spec.js` → **3 passed** (4.2s)
- console-clean=yes (spec `pageerror`/`console error` collectors)
- server.log-clean=yes for this feature (no homepage/profile ERROR after Jetty restart; FastForward import + search-index last-modifier errors are install noise)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
