### PR TITLE
fix(admin): Users/Roles homepage lists match remaining top-nav apps (#3537)

### DIFF
--- a/WebUI/src/main/ts/workflowAdmin/messages.ts
+++ b/WebUI/src/main/ts/workflowAdmin/messages.ts
@@ -53,6 +53,9 @@ export const WF_ADMIN_MSG = {
   AVAILABLE_USERS: "perc.ui.role.view@Available Users",
   CONFIRM_DELETE_ROLE: "perc.ui.role.view@Are you sure you want to delete role \"{0}\"?",
   ROLE_NAME_REQUIRED: "perc.ui.role.view@Role name is required.",
+  ROLE_HOMEPAGE: "perc.ui.roles@Default homepage",
+  ROLE_HOMEPAGE_HELP:
+    "perc.ui.roles@Where members of this role land after sign-in when they have not set a personal default. Same remaining apps as User Profile and Admin Users (Home, Explorer, Navigation, Developer, Publish, Admin). Editor and Design are not new choices.",
 
   // Steps
   SECTION_STEPS: "perc.ui.workflow.steps.view@Workflow Steps",

--- a/WebUI/src/main/ts/workflowAdmin/role/RoleEditor.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/role/RoleEditor.tsx
@@ -21,6 +21,10 @@ import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
 import { Role } from "./RolesSection";
+import {
+  canonicalizeRoleHomepage,
+  roleLandingOptions,
+} from "./roleLandingOptions";
 import { availableUsersMinusAssigned } from "./roleUsers";
 
 interface RoleEditorProps {
@@ -37,9 +41,16 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
   const [name, setName] = useState<string>(role?.name || "");
   const [description, setDescription] = useState<string>(role?.description || "");
   const [assignedUsers, setAssignedUsers] = useState<string[]>(role?.users || []);
+  const [homepage, setHomepage] = useState<string>(
+    canonicalizeRoleHomepage(role?.homepage),
+  );
   const [allUsers, setAllUsers] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const homepageOptions = useMemo(
+    () => roleLandingOptions(homepage),
+    [homepage],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -106,7 +117,7 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
         name: name.trim(),
         description: description.trim(),
         users: assignedUsers,
-        homepage: "Home",
+        homepage: canonicalizeRoleHomepage(homepage),
         ...(role ? { oldName: role.name } : {}),
       },
     };
@@ -171,7 +182,7 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
           />
         </div>
 
-        <div>
+        <div style={{ marginBottom: "16px" }}>
           <label style={{ display: "block", fontWeight: 600, marginBottom: "6px" }}>Description</label>
           <textarea
             value={description}
@@ -180,6 +191,47 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
             style={{ width: "100%", maxWidth: "600px", padding: "8px", borderRadius: "4px", border: "1px solid #cbd5e1" }}
             data-testid="role-description-input"
           />
+        </div>
+
+        <div data-testid="role-default-homepage-block">
+          <label
+            htmlFor="perc-role-default-homepage"
+            style={{ display: "block", fontWeight: 600, marginBottom: "6px" }}
+          >
+            {message(WF_ADMIN_MSG.ROLE_HOMEPAGE)}
+          </label>
+          <select
+            id="perc-role-default-homepage"
+            value={homepage}
+            onChange={(e) => setHomepage(e.target.value)}
+            style={{
+              width: "100%",
+              maxWidth: "400px",
+              padding: "8px",
+              borderRadius: "4px",
+              border: "1px solid #cbd5e1",
+            }}
+            data-testid="role-default-homepage-select"
+            aria-describedby="perc-role-default-homepage-help"
+          >
+            {homepageOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {message(opt.labelKey)}
+              </option>
+            ))}
+          </select>
+          <p
+            id="perc-role-default-homepage-help"
+            style={{
+              margin: "8px 0 0 0",
+              fontSize: "13px",
+              color: "#64748b",
+              maxWidth: "640px",
+            }}
+            data-testid="role-default-homepage-help"
+          >
+            {message(WF_ADMIN_MSG.ROLE_HOMEPAGE_HELP)}
+          </p>
         </div>
       </div>
 

--- a/WebUI/src/main/ts/workflowAdmin/role/RolesSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/role/RolesSection.tsx
@@ -26,6 +26,8 @@ export interface Role {
   name: string;
   description: string;
   users: string[];
+  /** Canonical role homepage type (Home, Explorer, …). */
+  homepage?: string;
 }
 
 export const RolesSection: React.FC = () => {
@@ -53,9 +55,10 @@ export const RolesSection: React.FC = () => {
               name: role.name || name,
               description: role.description || "",
               users: asStringArray(role.users),
+              homepage: role.homepage || "Home",
             };
           } catch {
-            return { name, description: "", users: [] };
+            return { name, description: "", users: [], homepage: "Home" };
           }
         })
       );

--- a/WebUI/src/main/ts/workflowAdmin/role/roleLandingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/role/roleLandingOptions.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default homepage options for Admin → Roles editor (#3537 / parent #3515).
+ *
+ * <p>Same remaining top-nav apps as User Profile Preferences and Admin → Users
+ * (Explorer in; Editor/Design not new choices). Role homepage is a stored
+ * default, not a "use role default" empty value.</p>
+ */
+
+import { HOMEPAGE_TYPES, type HomepageType } from "../../api/user/userHomepageApi";
+
+export interface RoleLandingOption {
+  /** Canonical API value (never empty — roles always store a homepage). */
+  value: HomepageType;
+  /** TMX message key (nav-aligned). */
+  labelKey: string;
+}
+
+/**
+ * Remaining top-nav apps an admin can assign as a role default homepage.
+ */
+export const ROLE_LANDING_OPTIONS: readonly RoleLandingOption[] = [
+  {
+    value: HOMEPAGE_TYPES.HOME,
+    labelKey: "perc.ui.navMenu.home@Home",
+  },
+  {
+    value: HOMEPAGE_TYPES.EXPLORER,
+    labelKey: "perc.ui.dashboard.modern@Explorer",
+  },
+  {
+    value: HOMEPAGE_TYPES.ARCHITECTURE,
+    labelKey: "perc.ui.navMenu.architecture@Navigation",
+  },
+  {
+    value: HOMEPAGE_TYPES.DEVELOPER,
+    labelKey: "perc.ui.dashboard.modern@Developer",
+  },
+  {
+    value: HOMEPAGE_TYPES.PUBLISH,
+    labelKey: "perc.ui.navMenu.publish@Publish",
+  },
+  {
+    value: HOMEPAGE_TYPES.WORKFLOW,
+    labelKey: "perc.ui.navMenu.admin@Administration",
+  },
+] as const;
+
+/**
+ * Stale stored role values remain visible once so they can be cleared
+ * (Editor / Design / Dashboard were previously valid).
+ */
+export const STALE_ROLE_LANDING_OPTIONS: readonly RoleLandingOption[] = [
+  {
+    value: HOMEPAGE_TYPES.EDITOR,
+    labelKey: "perc.ui.navMenu.webmgt@Editor",
+  },
+  {
+    value: HOMEPAGE_TYPES.DESIGNER,
+    labelKey: "perc.ui.navMenu.design@Design",
+  },
+  {
+    value: HOMEPAGE_TYPES.DASHBOARD,
+    labelKey: "perc.ui.navMenu.dashboard@Dashboard",
+  },
+] as const;
+
+/** Canonical default when a role has no stored homepage. */
+export const DEFAULT_ROLE_HOMEPAGE: HomepageType = HOMEPAGE_TYPES.HOME;
+
+/**
+ * Normalize a stored role homepage to a product type, or Home when unset.
+ */
+export function canonicalizeRoleHomepage(raw?: string | null): HomepageType | string {
+  const current = raw == null ? "" : String(raw).trim();
+  return current || DEFAULT_ROLE_HOMEPAGE;
+}
+
+/**
+ * Options for the Role editor homepage select.
+ * Slice 3 (#3538) will tighten by permission; this slice lists remaining apps.
+ * Stale current values stay listed once so the admin can change them.
+ */
+export function roleLandingOptions(
+  currentValue?: string | null,
+): RoleLandingOption[] {
+  const allowed = [...ROLE_LANDING_OPTIONS];
+  const current = canonicalizeRoleHomepage(currentValue);
+  if (!allowed.some((o) => o.value === current)) {
+    const extra = STALE_ROLE_LANDING_OPTIONS.find((o) => o.value === current);
+    if (extra) {
+      return [...allowed, extra];
+    }
+  }
+  return allowed;
+}

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -15,12 +15,14 @@
  */
 
 /**
- * Default landing options for Admin → Users editor (#2211 / parent #959).
+ * Default landing options for Admin → Users editor (#2211 / #3537).
  *
  * <p>Labels use nav menu i18n keys. Values are slice-2 canonical homepage
- * types (or empty for clear → role resolve). Options are filtered to screens
- * the assigned roles may open (peer SPA TopNav gates). Editor and Design
- * are not offered as new choices after they left top nav (#3514).</p>
+ * types (or empty for clear → role resolve). The option set matches User
+ * Profile Preferences (parent #3515 / slice 1): Explorer in; Editor/Design
+ * not offered as new choices after they left top nav (#3514). Options are
+ * still filtered to screens the assigned roles may open (peer SPA TopNav
+ * gates). Permission tightening beyond those gates is slice 3 (#3538).</p>
  */
 
 import { HOMEPAGE_TYPES, type HomepageType } from "../../api/user/userHomepageApi";
@@ -33,9 +35,10 @@ export interface LandingOption {
 }
 
 /**
- * Product options exposed in the Users editor.
+ * Product options exposed in the Users editor (#3537 / parent #3515).
  * Empty value = no user override (role Homepage / Home fallback).
- * Role Homepage field is intentionally left alone — this is a user-level override.
+ * Matches remaining top-nav apps (Home, Explorer, Navigation, Developer,
+ * Publish, Admin). Editor / Design are not offered as new choices.
  */
 export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   {
@@ -47,12 +50,8 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
     labelKey: "perc.ui.navMenu.home@Home",
   },
   {
-    value: HOMEPAGE_TYPES.EDITOR,
-    labelKey: "perc.ui.navMenu.webmgt@Editor",
-  },
-  {
-    value: HOMEPAGE_TYPES.DESIGNER,
-    labelKey: "perc.ui.navMenu.design@Design",
+    value: HOMEPAGE_TYPES.EXPLORER,
+    labelKey: "perc.ui.dashboard.modern@Explorer",
   },
   {
     value: HOMEPAGE_TYPES.ARCHITECTURE,
@@ -60,9 +59,32 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
     labelKey: "perc.ui.navMenu.architecture@Navigation",
   },
   {
+    value: HOMEPAGE_TYPES.DEVELOPER,
+    labelKey: "perc.ui.dashboard.modern@Developer",
+  },
+  {
+    value: HOMEPAGE_TYPES.PUBLISH,
+    labelKey: "perc.ui.navMenu.publish@Publish",
+  },
+  {
     value: HOMEPAGE_TYPES.WORKFLOW,
     // Workflow admin SPA (still a valid homepage); top-nav Admin lands on tools (#2784)
     labelKey: "perc.ui.navMenu.admin@Administration",
+  },
+] as const;
+
+/**
+ * Stored Editor/Design overrides stay visible once so the admin can clear them
+ * after those items leave top nav (#3514 / #3537).
+ */
+export const STALE_LANDING_OPTIONS: readonly LandingOption[] = [
+  {
+    value: HOMEPAGE_TYPES.EDITOR,
+    labelKey: "perc.ui.navMenu.webmgt@Editor",
+  },
+  {
+    value: HOMEPAGE_TYPES.DESIGNER,
+    labelKey: "perc.ui.navMenu.design@Design",
   },
 ] as const;
 
@@ -87,10 +109,15 @@ export function isLandingAllowedForRoles(
   homepageType: HomepageType | "",
   roles: readonly string[] | null | undefined,
 ): boolean {
-  if (homepageType === "" || homepageType === HOMEPAGE_TYPES.HOME) {
+  if (
+    homepageType === "" ||
+    homepageType === HOMEPAGE_TYPES.HOME ||
+    homepageType === HOMEPAGE_TYPES.EXPLORER
+  ) {
     return true;
   }
-  // Editor / Design left product top nav (#3514 / #3536). Not new choices.
+  // Editor / Design left product top nav (#3514 / #3537). Not new choices;
+  // stale stored values use {@link landingOptionsForRoles} extra-current.
   if (
     homepageType === HOMEPAGE_TYPES.EDITOR ||
     homepageType === HOMEPAGE_TYPES.DESIGNER
@@ -102,13 +129,14 @@ export function isLandingAllowedForRoles(
   const isDesigner = rs.has("designer") || isAdmin;
   switch (homepageType) {
     case HOMEPAGE_TYPES.ARCHITECTURE:
+    case HOMEPAGE_TYPES.DEVELOPER:
     case HOMEPAGE_TYPES.PUBLISH:
     case HOMEPAGE_TYPES.WIDGET_BUILDER:
       return isDesigner;
     case HOMEPAGE_TYPES.WORKFLOW:
+      return isAdmin;
     case HOMEPAGE_TYPES.DASHBOARD:
-      // Administration tools / dashboard chrome: Admin (dashboard also open to all historically)
-      return homepageType === HOMEPAGE_TYPES.DASHBOARD ? true : isAdmin;
+      return true;
     default:
       return isAdmin;
   }
@@ -127,12 +155,10 @@ export function landingOptionsForRoles(
     isLandingAllowedForRoles(opt.value, roles),
   );
   const current = currentValue == null ? "" : String(currentValue).trim();
-  if (
-    current &&
-    !allowed.some((o) => o.value === current) &&
-    ALL_LANDING_OPTIONS.some((o) => o.value === current)
-  ) {
-    const extra = ALL_LANDING_OPTIONS.find((o) => o.value === current);
+  if (current && !allowed.some((o) => o.value === current)) {
+    const extra =
+      ALL_LANDING_OPTIONS.find((o) => o.value === current) ??
+      STALE_LANDING_OPTIONS.find((o) => o.value === current);
     if (extra) {
       return [...allowed, extra];
     }

--- a/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
@@ -181,6 +181,9 @@ public class PSDefaultLandingViewTest {
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, true, false));
     assertFalse(PSDefaultLandingView.isViewAuthorized(VIEW_WORKFLOW, false, true));
     assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_WORKFLOW, true, false));
+    assertFalse(PSDefaultLandingView.isViewAuthorized(VIEW_DEVELOPER, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DEVELOPER, false, true));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DEVELOPER, true, false));
   }
 
   @Test
@@ -189,7 +192,10 @@ public class PSDefaultLandingViewTest {
     assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_DASH));
     assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_EXPLORER));
     assertTrue(PSDefaultLandingView.isRoleGatedView(VIEW_DESIGN));
+    assertTrue(PSDefaultLandingView.isRoleGatedView(VIEW_DEVELOPER));
     assertTrue(PSDefaultLandingView.isAdminOnlyView(VIEW_WORKFLOW));
     assertFalse(PSDefaultLandingView.isAdminOnlyView(VIEW_DESIGN));
+    assertFalse(PSDefaultLandingView.isAdminOnlyView(VIEW_DEVELOPER));
+    assertFalse(PSDefaultLandingView.isAdminOnlyView(VIEW_EXPLORER));
   }
 }

--- a/WebUI/src/test/ts/api/userHomepageApi.test.ts
+++ b/WebUI/src/test/ts/api/userHomepageApi.test.ts
@@ -51,6 +51,8 @@ describe("userHomepageApi", () => {
     expect(canonicalizeHomepageType("Explorer")).toBe(HOMEPAGE_TYPES.EXPLORER);
     expect(canonicalizeHomepageType("developer")).toBe(HOMEPAGE_TYPES.DEVELOPER);
     expect(canonicalizeHomepageType('"Home"')).toBe(HOMEPAGE_TYPES.HOME);
+    expect(canonicalizeHomepageType("explorer")).toBe(HOMEPAGE_TYPES.EXPLORER);
+    expect(canonicalizeHomepageType("developer")).toBe(HOMEPAGE_TYPES.DEVELOPER);
   });
 
   it("getMyHomepageOverride treats 404 as empty override", async () => {

--- a/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
+++ b/WebUI/src/test/ts/profile/resolveLandingEntry.test.ts
@@ -77,7 +77,11 @@ describe("resolveHomepageToSpaEntry (#3219)", () => {
       "/developer",
     );
     expect(resolveHomepageToClientPath("explorer")).toBe("/explorer");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.EXPLORER)).toBe("/explorer");
     expect(resolveHomepageToClientPath("profile")).toBe("/profile");
     expect(resolveHomepageToClientPath("developer")).toBe("/developer");
+    expect(resolveHomepageToClientPath(HOMEPAGE_TYPES.DEVELOPER)).toBe(
+      "/developer",
+    );
   });
 });

--- a/WebUI/src/test/ts/workflowAdmin/RoleEditor.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/RoleEditor.test.tsx
@@ -17,6 +17,7 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
 import { RoleEditor } from "../../../main/ts/workflowAdmin/role/RoleEditor";
 import * as client from "../../../main/ts/api/client";
 
@@ -132,6 +133,73 @@ describe("RoleEditor membership dual-list (#3504)", () => {
     expect(screen.queryByTestId("assigned-user-row-Contributor")).toBeNull();
     expect(screen.getByTestId("available-users-heading").textContent).toContain(
       "(3)",
+    );
+  });
+
+  it("exposes remaining-app homepage select and persists Explorer (#3537)", async () => {
+    const onSave = vi.fn();
+    render(
+      <RoleEditor
+        role={{ name: "Authors", description: "", users: [], homepage: "Home" }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("role-default-homepage-select")).toBeTruthy();
+    });
+
+    const select = screen.getByTestId(
+      "role-default-homepage-select",
+    ) as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain(HOMEPAGE_TYPES.HOME);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+
+    fireEvent.change(select, { target: { value: HOMEPAGE_TYPES.EXPLORER } });
+    fireEvent.click(screen.getByTestId("save-role-button"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+    const updateCall = vi
+      .mocked(client.post)
+      .mock.calls.find((call) => String(call[0]).includes("update"));
+    expect(updateCall).toBeTruthy();
+    const payload = updateCall![1] as { Role?: { homepage?: string } };
+    expect(payload.Role?.homepage).toBe(HOMEPAGE_TYPES.EXPLORER);
+  });
+
+  it("keeps a stale Editor homepage visible so it can be cleared", async () => {
+    render(
+      <RoleEditor
+        role={{
+          name: "Editors",
+          description: "",
+          users: [],
+          homepage: HOMEPAGE_TYPES.EDITOR,
+        }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("role-default-homepage-select")).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "role-default-homepage-select",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe(HOMEPAGE_TYPES.EDITOR);
+    expect(Array.from(select.options).map((o) => o.value)).toContain(
+      HOMEPAGE_TYPES.EDITOR,
     );
   });
 });

--- a/WebUI/src/test/ts/workflowAdmin/UserEditor.landing.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/UserEditor.landing.test.tsx
@@ -93,6 +93,12 @@ describe("UserEditor default landing", () => {
     });
 
     expect(screen.getByTestId("user-default-landing-help")).toBeTruthy();
+
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("Home");
+    expect(values).toContain("Explorer");
+    expect(values).toContain("Editor");
+    expect(values).not.toContain("Designer");
   });
 
   it("saves landing override via setUserHomepageOverride on submit", async () => {

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -23,23 +23,39 @@ import {
 } from "../../../main/ts/workflowAdmin/user/landingOptions";
 
 describe("landingOptionsForRoles", () => {
-  it("always includes role-default and Home; not Editor or Design (#3514)", () => {
+  it("always includes role-default, Home, and Explorer; not Editor or Design (#3514)", () => {
     const opts = landingOptionsForRoles(["Contributor"]);
     const values = opts.map((o) => o.value);
     expect(values).toContain("");
     expect(values).toContain(HOMEPAGE_TYPES.HOME);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
     expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).not.toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
   });
 
-  it("includes Architecture for Designer role without Design as a new choice", () => {
+  it("offers remaining top-nav apps and not Editor or Design (#3537)", () => {
+    const values = landingOptionsForRoles(["Admin"]).map((o) => o.value);
+    expect(values).toContain("");
+    expect(values).toContain(HOMEPAGE_TYPES.HOME);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+  });
+
+  it("includes Architecture, Developer, and Publish for Designer role", () => {
     const opts = landingOptionsForRoles(["Designer"]);
     const values = opts.map((o) => o.value);
-    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
     expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
   });
@@ -48,29 +64,37 @@ describe("landingOptionsForRoles", () => {
     const opts = landingOptionsForRoles(["Admin"]);
     const values = opts.map((o) => o.value);
     expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
   });
 
   it("keeps a currently stored disallowed value so admin can clear it", () => {
-    const opts = landingOptionsForRoles(
+    const workflow = landingOptionsForRoles(
       ["Contributor"],
       HOMEPAGE_TYPES.WORKFLOW,
     );
-    expect(opts.map((o) => o.value)).toContain(HOMEPAGE_TYPES.WORKFLOW);
-    const editorStale = landingOptionsForRoles(
+    expect(workflow.map((o) => o.value)).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    const editor = landingOptionsForRoles(
       ["Contributor"],
       HOMEPAGE_TYPES.EDITOR,
     );
-    expect(editorStale.map((o) => o.value)).toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(editor.map((o) => o.value)).toContain(HOMEPAGE_TYPES.EDITOR);
+    const design = landingOptionsForRoles(
+      ["Contributor"],
+      HOMEPAGE_TYPES.DESIGNER,
+    );
+    expect(design.map((o) => o.value)).toContain(HOMEPAGE_TYPES.DESIGNER);
   });
 });
 
 describe("isLandingAllowedForRoles", () => {
-  it("allows Home and empty for empty roles", () => {
+  it("allows Home, Explorer, and empty for empty roles", () => {
     expect(isLandingAllowedForRoles("", [])).toBe(true);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.HOME, [])).toBe(true);
+    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.EXPLORER, [])).toBe(true);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.EDITOR, [])).toBe(false);
+    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.DESIGNER, [])).toBe(false);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.WORKFLOW, [])).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/workflowAdmin/roleLandingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/roleLandingOptions.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+import { fallbackLabelFromKey } from "../../../main/ts/i18n/message";
+import {
+  canonicalizeRoleHomepage,
+  DEFAULT_ROLE_HOMEPAGE,
+  roleLandingOptions,
+} from "../../../main/ts/workflowAdmin/role/roleLandingOptions";
+
+describe("roleLandingOptions", () => {
+  it("lists remaining top-nav apps and not Editor or Design (#3537)", () => {
+    const values = roleLandingOptions().map((o) => o.value);
+    expect(values).toContain(HOMEPAGE_TYPES.HOME);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain("");
+    expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DASHBOARD);
+  });
+
+  it("labels Architecture as Navigation", () => {
+    const arch = roleLandingOptions().find(
+      (o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE,
+    );
+    expect(arch).toBeTruthy();
+    expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
+  });
+
+  it("keeps stale Editor, Design, and Dashboard so they can be cleared", () => {
+    expect(
+      roleLandingOptions(HOMEPAGE_TYPES.EDITOR).map((o) => o.value),
+    ).toContain(HOMEPAGE_TYPES.EDITOR);
+    expect(
+      roleLandingOptions(HOMEPAGE_TYPES.DESIGNER).map((o) => o.value),
+    ).toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(
+      roleLandingOptions(HOMEPAGE_TYPES.DASHBOARD).map((o) => o.value),
+    ).toContain(HOMEPAGE_TYPES.DASHBOARD);
+  });
+
+  it("defaults blank stored homepage to Home", () => {
+    expect(canonicalizeRoleHomepage("")).toBe(DEFAULT_ROLE_HOMEPAGE);
+    expect(canonicalizeRoleHomepage(null)).toBe(DEFAULT_ROLE_HOMEPAGE);
+    expect(canonicalizeRoleHomepage(HOMEPAGE_TYPES.EXPLORER)).toBe(
+      HOMEPAGE_TYPES.EXPLORER,
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
@@ -51,7 +51,7 @@ test.describe("Admin Users default landing page (#2211)", () => {
     );
     await expect(landingSelect).toBeVisible();
 
-    // Role-default + Home + Editor at minimum (Admin also gets Design/Admin options)
+    // Remaining-app list (#3537): role-default + Home + Explorer; Editor/Design not new
     const options = landingSelect.locator("option");
     const optionCount = await options.count();
     expect(optionCount).toBeGreaterThanOrEqual(3);
@@ -59,17 +59,23 @@ test.describe("Admin Users default landing page (#2211)", () => {
     const help = page.locator("[data-testid='user-default-landing-help']");
     await expect(help).toBeVisible();
 
-    // Select Home if available, or leave role default — ensure control is interactive
     const values = await options.evaluateAll((els) =>
       els.map((o) => o.value),
     );
     expect(values).toContain("");
     expect(values).toContain("Home");
-    expect(values).toContain("Editor");
+    expect(values).toContain("Explorer");
+    const current = await landingSelect.inputValue();
+    if (current !== "Editor") {
+      expect(values).not.toContain("Editor");
+    }
+    if (current !== "Designer") {
+      expect(values).not.toContain("Designer");
+    }
 
-    if (values.includes("Editor")) {
-      await landingSelect.selectOption("Editor");
-      await expect(landingSelect).toHaveValue("Editor");
+    if (values.includes("Explorer")) {
+      await landingSelect.selectOption("Explorer");
+      await expect(landingSelect).toHaveValue("Explorer");
     }
 
     // Cancel without saving permanent fixture data
@@ -78,5 +84,74 @@ test.describe("Admin Users default landing page (#2211)", () => {
       await cancelBtn.click();
       await expect(usersSection).toBeVisible({ timeout: 15000 });
     }
+  });
+});
+
+test.describe("Admin Roles default homepage (#3537)", () => {
+  test("Roles editor lists remaining top-nav apps, not Editor/Design", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await loginAsAdmin(page);
+    await page.goto(
+      `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=admin&tab=roles&_=${Date.now()}`,
+      { waitUntil: "domcontentloaded" },
+    );
+
+    const shell = page.locator("[data-testid='perc-admin-shell']");
+    await expect(shell).toBeVisible({ timeout: 30000 });
+
+    const rolesTab = page.locator("[data-testid='tab-roles']");
+    await expect(rolesTab).toBeVisible();
+    if ((await rolesTab.getAttribute("aria-selected")) !== "true") {
+      await rolesTab.click();
+    }
+
+    const rolesSection = page.locator("[data-testid='perc-roles-section']");
+    await expect(rolesSection).toBeVisible({ timeout: 30000 });
+
+    const adminEdit = page.locator("[data-testid='edit-role-Admin']");
+    const anyEdit = page.locator("[data-testid^='edit-role-']").first();
+    if (await adminEdit.count()) {
+      await adminEdit.click();
+    } else {
+      await expect(anyEdit).toBeVisible({ timeout: 30000 });
+      await anyEdit.click();
+    }
+
+    const editor = page.locator("[data-testid='perc-role-editor']");
+    await expect(editor).toBeVisible({ timeout: 15000 });
+
+    const homepageSelect = page.locator(
+      "[data-testid='role-default-homepage-select']",
+    );
+    await expect(homepageSelect).toBeVisible();
+    await expect(
+      page.locator("[data-testid='role-default-homepage-help']"),
+    ).toBeVisible();
+
+    const values = await homepageSelect.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(values).toContain("Home");
+    expect(values).toContain("Explorer");
+    expect(values).toContain("Architecture");
+    expect(values).toContain("Developer");
+    expect(values).toContain("Publish");
+    expect(values).toContain("Workflow");
+    const current = await homepageSelect.inputValue();
+    if (current !== "Editor") {
+      expect(values).not.toContain("Editor");
+    }
+    if (current !== "Designer") {
+      expect(values).not.toContain("Designer");
+    }
+
+    const cancelBtn = page.locator("[data-testid='cancel-role-button']");
+    await cancelBtn.click();
+    await expect(rolesSection).toBeVisible({ timeout: 15000 });
+    expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -48,6 +48,21 @@ users after each Add. **Remove** returns that user to Available Users so you can
 re-assign them. Changes apply only when you **Submit**; **Cancel** discards the
 in-progress membership edits.
 
+The editor also has a **Default homepage** list. It is the same remaining top-nav
+apps as **My profile → Preferences** and **Admin → Users**: **Home**, **Explorer**,
+**Navigation**, **Developer**, **Publish**, and **Admin**. Members of the role land
+there after sign-in unless they set a personal override. **Editor** and **Design**
+are not new choices (they leave top nav); if the role already stored one of those
+values (or **Dashboard**), it still appears once so you can change it.
+
+### Admin → Users (default landing)
+
+Open **Admin → Users** (or deep link `spa.jsp?entry=admin&tab=users`) and edit a
+user. **Default landing page** lists the same remaining apps as profile Preferences
+(Explorer in; Editor/Design not offered as new choices). **Use role default**
+clears the user override so the role homepage applies. A stale stored Editor or
+Design value still appears once so you can clear it.
+
 ## Workflow
 
 Workflow states gate who can edit and publish. Common patterns:
@@ -138,7 +153,7 @@ landing from **Admin → Users**.
 
 | Control | What it does |
 |---------|----------------|
-| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open — the same remaining top-nav apps as chrome: **Home**, **Explorer**, **Navigation**, and (when your roles include Designer or Admin) **Developer**, **Publish**, and **Admin**. **Explorer** is stored as homepage type `Explorer` and opens the Content Explorer SPA. **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Editor** and **Design** are no longer offered as new choices (they are not top-nav items); if you already stored one of those values, it still appears once so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
+| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open — the same remaining top-nav apps as chrome and as **Admin → Users / Roles**: **Home**, **Explorer**, **Navigation**, and (when your roles include Designer or Admin) **Developer**, **Publish**, and **Admin**. **Explorer** is stored as homepage type `Explorer` and opens the Content Explorer SPA. **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Editor** and **Design** are no longer offered as new choices (they are not top-nav items); if you already stored one of those values, it still appears once so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
 | **Save preferences** | Writes the landing override for the signed-in user only. The value is reloaded from the server after save so a failed persist is not shown as success. |
 
 The stored-preference count is informational (existing preference entries for your

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
@@ -30,6 +30,8 @@ public interface IPSRoleService {
   String HOMEPAGE_TYPE_DASHBOARD = "Dashboard";
   String HOMEPAGE_TYPE_EDITOR = "Editor";
   String HOMEPAGE_TYPE_HOME = "Home";
+  String HOMEPAGE_TYPE_EXPLORER = "Explorer";
+  String HOMEPAGE_TYPE_DEVELOPER = "Developer";
 
   /**
    * Finds a role.

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
@@ -16,6 +16,10 @@
  */
 package com.percussion.role.service.impl;
 
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DESIGNER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_PUBLISH;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WORKFLOW;
 import static org.springframework.util.StringUtils.trimWhitespace;
 
 import com.percussion.itemmanagement.service.impl.PSWorkflowHelper;
@@ -411,12 +415,12 @@ public class PSRoleService implements IPSRoleService {
     if (StringUtils.isBlank(roleName)) {
       throw new IllegalArgumentException("roleName must not be blank");
     }
-    if (StringUtils.isBlank(homepage)
-        || !(homepage.equals(HOMEPAGE_TYPE_DASHBOARD)
-            || homepage.equals(HOMEPAGE_TYPE_EDITOR)
-            || homepage.equals(HOMEPAGE_TYPE_HOME))) {
+    String normalized = PSUserService.normalizeHomepageType(homepage);
+    if (normalized == null) {
       // SPA product default landing is Home (not Dashboard)
       homepage = HOMEPAGE_TYPE_HOME;
+    } else {
+      homepage = normalized;
     }
     var key = META_DATA_HOMEPAGE_PREFIX + roleName;
     var md = mdService.find(key);
@@ -547,13 +551,13 @@ public class PSRoleService implements IPSRoleService {
   /**
    * Resolve effective homepage from the set of role homepage values (role-only; no user override).
    *
-   * <p>Product priority (SPA-first): Home &gt; Dashboard &gt; Editor. Empty/unset → Home.
+   * <p>Product priority (SPA-first): Home &gt; Dashboard &gt; Editor, then remaining top-nav
+   * apps (Explorer, Architecture, Developer, Publish, Workflow). Empty/unset → Home.
    *
    * <p>User-level override is applied in {@link #getUserHomepage()} before this method.
    *
    * @param userHomePages role homepage types, never {@code null} (may be empty)
-   * @return one of {@link #HOMEPAGE_TYPE_HOME}, {@link #HOMEPAGE_TYPE_DASHBOARD}, {@link
-   *     #HOMEPAGE_TYPE_EDITOR}
+   * @return a canonical homepage type, never {@code null}
    */
   static String resolveUserHomepage(Set<String> userHomePages) {
     if (userHomePages == null || userHomePages.isEmpty()) {
@@ -567,6 +571,24 @@ public class PSRoleService implements IPSRoleService {
     }
     if (userHomePages.contains(HOMEPAGE_TYPE_EDITOR)) {
       return HOMEPAGE_TYPE_EDITOR;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_EXPLORER)) {
+      return HOMEPAGE_TYPE_EXPLORER;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_ARCHITECTURE)) {
+      return HOMEPAGE_TYPE_ARCHITECTURE;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_DEVELOPER)) {
+      return HOMEPAGE_TYPE_DEVELOPER;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_PUBLISH)) {
+      return HOMEPAGE_TYPE_PUBLISH;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_WORKFLOW)) {
+      return HOMEPAGE_TYPE_WORKFLOW;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_DESIGNER)) {
+      return HOMEPAGE_TYPE_DESIGNER;
     }
     return HOMEPAGE_TYPE_HOME;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
@@ -23,6 +23,9 @@ import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EDITOR;
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EXPLORER;
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DESIGNER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_PUBLISH;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WORKFLOW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -103,5 +106,101 @@ class PSRoleServiceHomepageTest {
     assertEquals(
         HOMEPAGE_TYPE_HOME,
         PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_EXPLORER)));
+  }
+
+  @Test
+  void remainingAppPriorityExplorerBeatsWorkflow() {
+    assertEquals(
+        HOMEPAGE_TYPE_EXPLORER,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_EXPLORER, HOMEPAGE_TYPE_WORKFLOW)));
+  }
+
+  @Test
+  void remainingAppPriorityExplorerBeatsArchitecture() {
+    assertEquals(
+        HOMEPAGE_TYPE_EXPLORER,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_EXPLORER, HOMEPAGE_TYPE_ARCHITECTURE)));
+  }
+
+  @Test
+  void remainingAppPriorityArchitectureBeatsDeveloper() {
+    assertEquals(
+        HOMEPAGE_TYPE_ARCHITECTURE,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_ARCHITECTURE, HOMEPAGE_TYPE_DEVELOPER)));
+  }
+
+  @Test
+  void remainingAppPriorityDeveloperBeatsDesigner() {
+    assertEquals(
+        HOMEPAGE_TYPE_DEVELOPER,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_DEVELOPER, HOMEPAGE_TYPE_DESIGNER)));
+  }
+
+  @Test
+  void remainingAppPriorityDeveloperBeatsPublishAndWorkflow() {
+    assertEquals(
+        HOMEPAGE_TYPE_DEVELOPER,
+        PSRoleService.resolveUserHomepage(
+            Set.of(
+                HOMEPAGE_TYPE_DEVELOPER,
+                HOMEPAGE_TYPE_PUBLISH,
+                HOMEPAGE_TYPE_WORKFLOW,
+                HOMEPAGE_TYPE_DESIGNER)));
+  }
+
+  @Test
+  void remainingAppPriorityPublishBeatsWorkflow() {
+    assertEquals(
+        HOMEPAGE_TYPE_PUBLISH,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_PUBLISH, HOMEPAGE_TYPE_WORKFLOW)));
+  }
+
+  @Test
+  void remainingAppPriorityWorkflowBeatsDesigner() {
+    assertEquals(
+        HOMEPAGE_TYPE_WORKFLOW,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_WORKFLOW, HOMEPAGE_TYPE_DESIGNER)));
+  }
+
+  @Test
+  void editorStillBeatsRemainingApps() {
+    assertEquals(
+        HOMEPAGE_TYPE_EDITOR,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_EDITOR, HOMEPAGE_TYPE_EXPLORER, HOMEPAGE_TYPE_DEVELOPER)));
+  }
+
+  @Test
+  void effectiveExplorerOverrideBeatsRoleResolve() {
+    assertEquals(
+        HOMEPAGE_TYPE_EXPLORER,
+        PSRoleService.resolveEffectiveHomepage(
+            HOMEPAGE_TYPE_EXPLORER, Set.of(HOMEPAGE_TYPE_WORKFLOW, HOMEPAGE_TYPE_DESIGNER)));
+  }
+
+  @Test
+  void effectiveDeveloperOverrideBeatsRoleResolve() {
+    assertEquals(
+        HOMEPAGE_TYPE_DEVELOPER,
+        PSRoleService.resolveEffectiveHomepage(HOMEPAGE_TYPE_DEVELOPER, Set.of(HOMEPAGE_TYPE_HOME)));
+  }
+
+  @Test
+  void effectiveNormalizesExplorerAndDeveloperAliases() {
+    assertEquals(
+        HOMEPAGE_TYPE_EXPLORER,
+        PSRoleService.resolveEffectiveHomepage("explorer", Set.of(HOMEPAGE_TYPE_HOME)));
+    assertEquals(
+        HOMEPAGE_TYPE_DEVELOPER,
+        PSRoleService.resolveEffectiveHomepage("developer", Set.of(HOMEPAGE_TYPE_HOME)));
+    assertEquals(
+        HOMEPAGE_TYPE_ARCHITECTURE,
+        PSRoleService.resolveEffectiveHomepage("navigation", Set.of(HOMEPAGE_TYPE_HOME)));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
@@ -18,8 +18,11 @@
 package com.percussion.role.service.impl;
 
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_DASHBOARD;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_DEVELOPER;
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EDITOR;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EXPLORER;
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -78,5 +81,27 @@ class PSRoleServiceHomepageTest {
         HOMEPAGE_TYPE_DASHBOARD,
         PSRoleService.resolveEffectiveHomepage(
             "", Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+  }
+
+  @Test
+  void explorerWhenOnlyExplorerRole() {
+    assertEquals(
+        HOMEPAGE_TYPE_EXPLORER, PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_EXPLORER)));
+  }
+
+  @Test
+  void remainingAppsResolveWhenHomeDashboardEditorAbsent() {
+    assertEquals(
+        HOMEPAGE_TYPE_ARCHITECTURE,
+        PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_ARCHITECTURE)));
+    assertEquals(
+        HOMEPAGE_TYPE_DEVELOPER, PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_DEVELOPER)));
+  }
+
+  @Test
+  void homeStillWinsOverExplorer() {
+    assertEquals(
+        HOMEPAGE_TYPE_HOME,
+        PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_EXPLORER)));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
@@ -22,6 +22,8 @@ import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EDITOR;
 import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DESIGNER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DEVELOPER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_EXPLORER;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_PUBLISH;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DEVELOPER;
 import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_EXPLORER;


### PR DESCRIPTION
## Summary

Slice 2 of parent #3515: **Admin → Users** and **Admin → Roles** default-homepage pickers now use the same remaining top-nav app list as User Profile Preferences (slice 1 / #3536): **Home**, **Explorer**, **Navigation**, **Developer**, **Publish**, **Admin**. Editor/Design are not offered as new choices; a stale stored Editor, Design, or Dashboard value still appears once so it can be cleared.

Admin Users `landingOptions.ts` is aligned with that option set. The Role editor now exposes a **Default homepage** select (it previously hardcoded `Home` on every save) and persists the chosen type on the existing role create/update payload. Explorer/Developer persist through the existing homepage REST by adding canonical tokens (same stacking as #3536).

Parent: #3515. Coordinates with #3536 (profile option set) and #3514 (Editor/Design leave chrome). Does **not** implement slice 3 permission tightening (#3538).

Fixes #3537
Partial #3515

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
2. Standalone `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2752 passed
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`
4. Hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar`, `PSDefaultLandingView.class`, full `cm/modern/assets/`, `cm/app/index.jsp` + `cm/pages/app/index.jsp`; in-cell `StopJetty.sh` + `StartJetty.sh` (not `docker restart`)
5. `npm run test:surface -- --path tests/bugs/bug-2211-user-default-landing.spec.js` — 2 passed
6. Admin: edit a user — Explorer is listed, Editor/Design are not new choices; edit a role — same remaining-app list; cancel without saving fixture data

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (Admin → Roles default homepage + Admin → Users default landing; Preferences note aligned)
- [x] **Unit / module tests** — admin/role landing helpers, RoleEditor persist, `PSRoleServiceHomepageTest`, homepage token aliases; standalone clean install
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js` (Users + Roles option lists)
- [x] **Build gates** — standalone clean install on `WebUI` and `projects/sitemanage` (no skipTests); additive homepage constants only (no `final` / signature break)
- [x] **Cross-platform** — N/A (no new path/file I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (18:04)
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (18:06); Vitest `Tests 2752 passed (2752)` / `Test Files 370 passed`
- **downstream_checked:** grepped `extends PSUserService` / `new PSUserService(` / `extends PSRoleService` / `new PSRoleService(` — only existing sitemanage unit tests construct `PSUserService`; no `final`/signature change. Standalone sitemanage + WebUI installs green.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`)
- `qa-health` after start and after Jetty restart: HTTP 200, `HEALTH:healthy`; `RESULT:FAIL DETAIL:server_log_errors` is **pre-existing FastForward `PSDbStorageService` import noise** (not homepage/admin)
- Deploy: `sitemanage-8.2.0-SNAPSHOT.jar` → `WEB-INF/lib/`; `PSDefaultLandingView.class`; full Vite `cm/modern/assets/`; `cm/app/index.jsp` + `cm/pages/app/index.jsp`; in-cell `StopJetty.sh` + `StartJetty.sh`
- `npm run test:surface -- --path tests/bugs/bug-2211-user-default-landing.spec.js` → **2 passed** (3.2s)
- console-clean=yes (roles spec `pageerror` collector)
- server.log-clean=yes for this feature (no homepage/admin ERROR after Jetty restart; FastForward import errors are install noise)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
