### PR TITLE
fix(webui): filter homepage pickers by role permissions (#3538)

### DIFF
--- a/WebUI/src/main/ts/app/landing/landingPermission.ts
+++ b/WebUI/src/main/ts/app/landing/landingPermission.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared homepage-picker permission gates (#3538 / parent #3515 slice 3).
+ *
+ * <p>Matches live {@code topNavItemIds} after #3514: Explorer is always
+ * allowed; Navigation / Developer / Publish require Designer or Admin;
+ * Admin (Workflow homepage type) requires Admin. Editor, Design, and
+ * Widget Builder are not new landing choices. Stale stored values are
+ * listed once by the picker helpers so they can be cleared.</p>
+ */
+
+import { HOMEPAGE_TYPES, type HomepageType } from "../../api/user/userHomepageApi";
+
+export type LandingRoleGates = {
+  isAdmin?: boolean;
+  isDesigner?: boolean;
+};
+
+/**
+ * Admin / Designer flags from assigned role names (Admin Users picker).
+ * Role names are compared case-insensitively.
+ */
+export function landingGatesFromRoles(
+  roles: readonly string[] | null | undefined,
+): LandingRoleGates {
+  const set = new Set<string>();
+  if (roles) {
+    for (const r of roles) {
+      if (r != null && String(r).trim()) {
+        set.add(String(r).trim().toLowerCase());
+      }
+    }
+  }
+  const isAdmin = set.has("admin");
+  return { isAdmin, isDesigner: set.has("designer") || isAdmin };
+}
+
+/**
+ * Whether a homepage type may be offered as a <strong>new</strong> landing
+ * choice. Aligns with {@code topNavItemIds} (Explorer always; Navigation /
+ * Developer / Publish for designer|admin; Admin for admin).
+ *
+ * Widget Builder is not a top-nav item after #3514 and is omitted as a
+ * landing unless a stored override is kept via the stale-once picker path.
+ */
+export function isLandingAllowed(
+  homepageType: HomepageType | "",
+  gates: LandingRoleGates,
+): boolean {
+  if (
+    homepageType === "" ||
+    homepageType === HOMEPAGE_TYPES.HOME ||
+    homepageType === HOMEPAGE_TYPES.EXPLORER
+  ) {
+    return true;
+  }
+  if (
+    homepageType === HOMEPAGE_TYPES.EDITOR ||
+    homepageType === HOMEPAGE_TYPES.DESIGNER ||
+    homepageType === HOMEPAGE_TYPES.WIDGET_BUILDER
+  ) {
+    return false;
+  }
+  const isAdmin = !!gates.isAdmin;
+  const isDesigner = !!gates.isDesigner || isAdmin;
+  switch (homepageType) {
+    case HOMEPAGE_TYPES.ARCHITECTURE:
+    case HOMEPAGE_TYPES.DEVELOPER:
+    case HOMEPAGE_TYPES.PUBLISH:
+      return isDesigner;
+    case HOMEPAGE_TYPES.WORKFLOW:
+      return isAdmin;
+    case HOMEPAGE_TYPES.DASHBOARD:
+      return true;
+    default:
+      return isAdmin;
+  }
+}

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -16,17 +16,22 @@
  */
 
 /**
- * Default landing options for the profile Preferences section (#2396 / #3536).
+ * Default landing options for the profile Preferences section (#2396 / #3536 / #3538).
  *
  * <p>Values are product homepage types (PascalCase) already accepted by
  * {@code PSUserService} / login landing resolve. Labels reuse nav menu keys.
  * Options are filtered from SPA bootstrap admin/designer flags (self-service
- * does not load full role lists). Editor and Design are not offered as new
+ * does not load full role lists) via the shared {@code isLandingAllowed}
+ * gates (#3538). Editor, Design, and Widget Builder are not offered as new
  * choices after they left top nav (#3514); a stored override still lists so
  * the user can clear it.</p>
  */
 
 import { HOMEPAGE_TYPES, type HomepageType } from "../api/user/userHomepageApi";
+import {
+  isLandingAllowed,
+  type LandingRoleGates,
+} from "../app/landing/landingPermission";
 
 export interface ProfileLandingOption {
   /** Canonical API value, or empty string for "use role default". */
@@ -73,8 +78,8 @@ export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
 ] as const;
 
 /**
- * Stored Editor/Design overrides stay visible once so the user can clear them
- * after those items leave top nav (#3514 / #3536).
+ * Stored Editor/Design/Widget Builder overrides stay visible once so the
+ * user can clear them after those items leave top nav (#3514 / #3536 / #3538).
  */
 export const STALE_PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
   {
@@ -85,12 +90,13 @@ export const STALE_PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
     value: HOMEPAGE_TYPES.DESIGNER,
     labelKey: "perc.ui.navMenu.design@Design",
   },
+  {
+    value: HOMEPAGE_TYPES.WIDGET_BUILDER,
+    labelKey: "perc.ui.navMenu.admin@Widget Builder",
+  },
 ] as const;
 
-export type ProfileLandingGates = {
-  isAdmin?: boolean;
-  isDesigner?: boolean;
-};
+export type ProfileLandingGates = LandingRoleGates;
 
 /**
  * Whether the signed-in user may choose a landing type (peer SPA nav gates).
@@ -99,36 +105,7 @@ export function isProfileLandingAllowed(
   homepageType: HomepageType | "",
   gates: ProfileLandingGates,
 ): boolean {
-  if (
-    homepageType === "" ||
-    homepageType === HOMEPAGE_TYPES.HOME ||
-    homepageType === HOMEPAGE_TYPES.EXPLORER
-  ) {
-    return true;
-  }
-  // Editor / Design left product top nav (#3514 / #3536). Not new choices;
-  // stale stored values use {@link profileLandingOptions} extra-current.
-  if (
-    homepageType === HOMEPAGE_TYPES.EDITOR ||
-    homepageType === HOMEPAGE_TYPES.DESIGNER
-  ) {
-    return false;
-  }
-  const isAdmin = !!gates.isAdmin;
-  const isDesigner = !!gates.isDesigner || isAdmin;
-  switch (homepageType) {
-    case HOMEPAGE_TYPES.ARCHITECTURE:
-    case HOMEPAGE_TYPES.DEVELOPER:
-    case HOMEPAGE_TYPES.PUBLISH:
-    case HOMEPAGE_TYPES.WIDGET_BUILDER:
-      return isDesigner;
-    case HOMEPAGE_TYPES.WORKFLOW:
-      return isAdmin;
-    case HOMEPAGE_TYPES.DASHBOARD:
-      return true;
-    default:
-      return isAdmin;
-  }
+  return isLandingAllowed(homepageType, gates);
 }
 
 /**

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -15,17 +15,22 @@
  */
 
 /**
- * Default landing options for Admin → Users editor (#2211 / #3537).
+ * Default landing options for Admin → Users editor (#2211 / #3537 / #3538).
  *
- * <p>Labels use nav menu i18n keys. Values are slice-2 canonical homepage
+ * <p>Labels use nav menu i18n keys. Values are remaining top-nav homepage
  * types (or empty for clear → role resolve). The option set matches User
- * Profile Preferences (parent #3515 / slice 1): Explorer in; Editor/Design
- * not offered as new choices after they left top nav (#3514). Options are
- * still filtered to screens the assigned roles may open (peer SPA TopNav
- * gates). Permission tightening beyond those gates is slice 3 (#3538).</p>
+ * Profile Preferences (parent #3515 / slice 1 / #3537): Explorer in;
+ * Editor/Design not offered as new choices after they left top nav (#3514).
+ * Options are filtered to screens the assigned roles may open via shared
+ * {@code isLandingAllowed} gates (#3538). Editor, Design, and Widget Builder
+ * are not offered as new choices.</p>
  */
 
 import { HOMEPAGE_TYPES, type HomepageType } from "../../api/user/userHomepageApi";
+import {
+  isLandingAllowed,
+  landingGatesFromRoles,
+} from "../../app/landing/landingPermission";
 
 export interface LandingOption {
   /** Canonical API value, or empty string for "use role default". */
@@ -35,10 +40,10 @@ export interface LandingOption {
 }
 
 /**
- * Product options exposed in the Users editor (#3537 / parent #3515).
+ * Product options exposed in the Users editor (#3537 / #3538 / parent #3515).
  * Empty value = no user override (role Homepage / Home fallback).
  * Matches remaining top-nav apps (Home, Explorer, Navigation, Developer,
- * Publish, Admin). Editor / Design are not offered as new choices.
+ * Publish, Admin). Editor / Design / Widget Builder are not new choices.
  */
 export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   {
@@ -74,8 +79,8 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
 ] as const;
 
 /**
- * Stored Editor/Design overrides stay visible once so the admin can clear them
- * after those items leave top nav (#3514 / #3537).
+ * Stored Editor/Design/Widget Builder overrides stay visible once so the
+ * admin can clear them after those items leave top nav (#3514 / #3537 / #3538).
  */
 export const STALE_LANDING_OPTIONS: readonly LandingOption[] = [
   {
@@ -86,60 +91,21 @@ export const STALE_LANDING_OPTIONS: readonly LandingOption[] = [
     value: HOMEPAGE_TYPES.DESIGNER,
     labelKey: "perc.ui.navMenu.design@Design",
   },
+  {
+    value: HOMEPAGE_TYPES.WIDGET_BUILDER,
+    labelKey: "perc.ui.navMenu.admin@Widget Builder",
+  },
 ] as const;
-
-function roleSet(roles: readonly string[] | null | undefined): Set<string> {
-  const set = new Set<string>();
-  if (!roles) {
-    return set;
-  }
-  for (const r of roles) {
-    if (r != null && String(r).trim()) {
-      set.add(String(r).trim().toLowerCase());
-    }
-  }
-  return set;
-}
 
 /**
  * Whether a user with the given roles may open a landing type.
- * Aligns with SPA TopNav / RequireRole gates (Admin, Admin|Designer).
+ * Aligns with SPA TopNav / shared {@code isLandingAllowed} gates (#3538).
  */
 export function isLandingAllowedForRoles(
   homepageType: HomepageType | "",
   roles: readonly string[] | null | undefined,
 ): boolean {
-  if (
-    homepageType === "" ||
-    homepageType === HOMEPAGE_TYPES.HOME ||
-    homepageType === HOMEPAGE_TYPES.EXPLORER
-  ) {
-    return true;
-  }
-  // Editor / Design left product top nav (#3514 / #3537). Not new choices;
-  // stale stored values use {@link landingOptionsForRoles} extra-current.
-  if (
-    homepageType === HOMEPAGE_TYPES.EDITOR ||
-    homepageType === HOMEPAGE_TYPES.DESIGNER
-  ) {
-    return false;
-  }
-  const rs = roleSet(roles);
-  const isAdmin = rs.has("admin");
-  const isDesigner = rs.has("designer") || isAdmin;
-  switch (homepageType) {
-    case HOMEPAGE_TYPES.ARCHITECTURE:
-    case HOMEPAGE_TYPES.DEVELOPER:
-    case HOMEPAGE_TYPES.PUBLISH:
-    case HOMEPAGE_TYPES.WIDGET_BUILDER:
-      return isDesigner;
-    case HOMEPAGE_TYPES.WORKFLOW:
-      return isAdmin;
-    case HOMEPAGE_TYPES.DASHBOARD:
-      return true;
-    default:
-      return isAdmin;
-  }
+  return isLandingAllowed(homepageType, landingGatesFromRoles(roles));
 }
 
 /**

--- a/WebUI/src/test/ts/app/landing/landingPermission.test.ts
+++ b/WebUI/src/test/ts/app/landing/landingPermission.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { HOMEPAGE_TYPES } from "../../../../main/ts/api/user/userHomepageApi";
+import {
+  isLandingAllowed,
+  landingGatesFromRoles,
+} from "../../../../main/ts/app/landing/landingPermission";
+
+describe("landingGatesFromRoles", () => {
+  it("treats Admin as admin+designer and Designer as designer only", () => {
+    expect(landingGatesFromRoles(["Admin"])).toEqual({
+      isAdmin: true,
+      isDesigner: true,
+    });
+    expect(landingGatesFromRoles(["Designer"])).toEqual({
+      isAdmin: false,
+      isDesigner: true,
+    });
+    expect(landingGatesFromRoles(["Contributor"])).toEqual({
+      isAdmin: false,
+      isDesigner: false,
+    });
+    expect(landingGatesFromRoles(["Editor"])).toEqual({
+      isAdmin: false,
+      isDesigner: false,
+    });
+  });
+
+  it("matches role names case-insensitively", () => {
+    expect(landingGatesFromRoles(["ADMIN", " designer "])).toEqual({
+      isAdmin: true,
+      isDesigner: true,
+    });
+  });
+});
+
+describe("isLandingAllowed contributor vs designer vs admin (#3538)", () => {
+  const contributor = { isAdmin: false, isDesigner: false };
+  const designer = { isAdmin: false, isDesigner: true };
+  const admin = { isAdmin: true, isDesigner: false };
+
+  it("always allows role-default, Home, and Explorer", () => {
+    for (const gates of [contributor, designer, admin]) {
+      expect(isLandingAllowed("", gates)).toBe(true);
+      expect(isLandingAllowed(HOMEPAGE_TYPES.HOME, gates)).toBe(true);
+      expect(isLandingAllowed(HOMEPAGE_TYPES.EXPLORER, gates)).toBe(true);
+    }
+  });
+
+  it("never offers Editor, Design, or Widget Builder as new choices", () => {
+    for (const gates of [contributor, designer, admin]) {
+      expect(isLandingAllowed(HOMEPAGE_TYPES.EDITOR, gates)).toBe(false);
+      expect(isLandingAllowed(HOMEPAGE_TYPES.DESIGNER, gates)).toBe(false);
+      expect(isLandingAllowed(HOMEPAGE_TYPES.WIDGET_BUILDER, gates)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("contributor-class users only get Home/Explorer — not Nav/Dev/Publish/Admin", () => {
+    expect(isLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, contributor)).toBe(
+      false,
+    );
+    expect(isLandingAllowed(HOMEPAGE_TYPES.DEVELOPER, contributor)).toBe(
+      false,
+    );
+    expect(isLandingAllowed(HOMEPAGE_TYPES.PUBLISH, contributor)).toBe(false);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, contributor)).toBe(false);
+  });
+
+  it("designers get Navigation/Developer/Publish but not Admin", () => {
+    expect(isLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, designer)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.DEVELOPER, designer)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.PUBLISH, designer)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, designer)).toBe(false);
+  });
+
+  it("admins get Navigation/Developer/Publish and Admin", () => {
+    expect(isLandingAllowed(HOMEPAGE_TYPES.ARCHITECTURE, admin)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.DEVELOPER, admin)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.PUBLISH, admin)).toBe(true);
+    expect(isLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, admin)).toBe(true);
+  });
+});

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -92,11 +92,41 @@ describe("profileLandingOptions", () => {
     ).toBe(false);
   });
 
-  it("keeps stale Editor/Design current values so the user can clear them", () => {
+  it("filters profile options by contributor vs designer vs admin (#3538)", () => {
+    const contributor = profileLandingOptions({}).map((o) => o.value);
+    expect(contributor).toEqual(["", HOMEPAGE_TYPES.HOME, HOMEPAGE_TYPES.EXPLORER]);
+    expect(contributor).not.toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(contributor).not.toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(contributor).not.toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(contributor).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(contributor).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
+
+    const designer = profileLandingOptions({ isDesigner: true }).map(
+      (o) => o.value,
+    );
+    expect(designer).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(designer).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(designer).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(designer).toContain(HOMEPAGE_TYPES.PUBLISH);
+    expect(designer).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(designer).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
+
+    const admin = profileLandingOptions({ isAdmin: true }).map((o) => o.value);
+    expect(admin).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(admin).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(admin).toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(admin).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
+  });
+
+  it("keeps stale Editor/Design/Widget Builder current values so the user can clear them", () => {
     const design = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
     expect(design.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
     const editor = profileLandingOptions({}, HOMEPAGE_TYPES.EDITOR);
     expect(editor.some((o) => o.value === HOMEPAGE_TYPES.EDITOR)).toBe(true);
+    const widget = profileLandingOptions({}, HOMEPAGE_TYPES.WIDGET_BUILDER);
+    expect(widget.some((o) => o.value === HOMEPAGE_TYPES.WIDGET_BUILDER)).toBe(
+      true,
+    );
   });
 
   it("labels the Architecture homepage type as Navigation (#3217)", () => {

--- a/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
+++ b/WebUI/src/test/ts/workflowAdmin/landingOptions.test.ts
@@ -32,7 +32,10 @@ describe("landingOptionsForRoles", () => {
     expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).not.toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.PUBLISH);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
+    expect(values).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
   });
 
   it("offers remaining top-nav apps and not Editor or Design (#3537)", () => {
@@ -46,16 +49,19 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.WORKFLOW);
     expect(values).not.toContain(HOMEPAGE_TYPES.EDITOR);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
   });
 
-  it("includes Architecture, Developer, and Publish for Designer role", () => {
+  it("includes Navigation/Developer/Publish for Designer without Admin or Design", () => {
     const opts = landingOptionsForRoles(["Designer"]);
     const values = opts.map((o) => o.value);
+    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
     expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
     expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
     expect(values).not.toContain(HOMEPAGE_TYPES.WORKFLOW);
-    expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
+    expect(values).not.toContain(HOMEPAGE_TYPES.WIDGET_BUILDER);
     const arch = opts.find((o) => o.value === HOMEPAGE_TYPES.ARCHITECTURE);
     expect(fallbackLabelFromKey(arch!.labelKey)).toBe("Navigation");
   });
@@ -67,6 +73,9 @@ describe("landingOptionsForRoles", () => {
     expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
     expect(values).not.toContain(HOMEPAGE_TYPES.DESIGNER);
     expect(values).toContain(HOMEPAGE_TYPES.ARCHITECTURE);
+    expect(values).toContain(HOMEPAGE_TYPES.EXPLORER);
+    expect(values).toContain(HOMEPAGE_TYPES.DEVELOPER);
+    expect(values).toContain(HOMEPAGE_TYPES.PUBLISH);
   });
 
   it("keeps a currently stored disallowed value so admin can clear it", () => {
@@ -85,6 +94,13 @@ describe("landingOptionsForRoles", () => {
       HOMEPAGE_TYPES.DESIGNER,
     );
     expect(design.map((o) => o.value)).toContain(HOMEPAGE_TYPES.DESIGNER);
+    const widgetStale = landingOptionsForRoles(
+      ["Contributor"],
+      HOMEPAGE_TYPES.WIDGET_BUILDER,
+    );
+    expect(widgetStale.map((o) => o.value)).toContain(
+      HOMEPAGE_TYPES.WIDGET_BUILDER,
+    );
   });
 });
 
@@ -96,5 +112,29 @@ describe("isLandingAllowedForRoles", () => {
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.EDITOR, [])).toBe(false);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.DESIGNER, [])).toBe(false);
     expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.WORKFLOW, [])).toBe(false);
+    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.WIDGET_BUILDER, [])).toBe(
+      false,
+    );
+  });
+
+  it("gates contributor vs designer vs admin (#3538)", () => {
+    expect(
+      isLandingAllowedForRoles(HOMEPAGE_TYPES.DEVELOPER, ["Contributor"]),
+    ).toBe(false);
+    expect(
+      isLandingAllowedForRoles(HOMEPAGE_TYPES.PUBLISH, ["Editor"]),
+    ).toBe(false);
+    expect(
+      isLandingAllowedForRoles(HOMEPAGE_TYPES.DEVELOPER, ["Designer"]),
+    ).toBe(true);
+    expect(
+      isLandingAllowedForRoles(HOMEPAGE_TYPES.WORKFLOW, ["Designer"]),
+    ).toBe(false);
+    expect(isLandingAllowedForRoles(HOMEPAGE_TYPES.WORKFLOW, ["Admin"])).toBe(
+      true,
+    );
+    expect(
+      isLandingAllowedForRoles(HOMEPAGE_TYPES.WIDGET_BUILDER, ["Admin"]),
+    ).toBe(false);
   });
 });

--- a/docs/ai-generated/code-reviews/issue-3538-homepage-role-filter-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3538-homepage-role-filter-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — #3538 homepage role filter
+
+**Branch:** `fix/issue-3538-homepage-role-filter`  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** no bugs, behavioral tests present, no new path/file I/O
+
+## Summary
+
+Slice 3 of parent #3515 tightens profile and Admin → Users homepage pickers
+to the same gates as `topNavItemIds` after #3514. Shared
+`isLandingAllowed` / `landingGatesFromRoles` is the single source of truth:
+Explorer always; Navigation / Developer / Publish for designer|admin; Admin
+for admin; Editor / Design / Widget Builder omitted as new choices with
+stale-once listing.
+
+## Issues
+
+None that block.
+
+## Tests
+
+- Vitest: contributor vs designer vs admin matrix on shared gates, profile
+  options, and `landingOptionsForRoles`.
+- Playwright: Contributor profile does not list Admin/Developer/Publish;
+  Admin Users picker grows Admin/Developer when the Admin role is checked.
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, 2773 Vitest passed.
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path construction.
+
+## Memory patterns hit
+
+- Change-class companions: product-docs + Playwright for WebUI picker UX.
+- Stale-once current value so disallowed stored landings can be cleared.
+
+> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2211-user-default-landing.spec.js
@@ -51,7 +51,8 @@ test.describe("Admin Users default landing page (#2211)", () => {
     );
     await expect(landingSelect).toBeVisible();
 
-    // Remaining-app list (#3537): role-default + Home + Explorer; Editor/Design not new
+    // Remaining-app list (#3537) + role gates (#3538): role-default + Home +
+    // Explorer; Editor/Design not new. Admin role checkbox proves picker filter.
     const options = landingSelect.locator("option");
     const optionCount = await options.count();
     expect(optionCount).toBeGreaterThanOrEqual(3);
@@ -73,7 +74,21 @@ test.describe("Admin Users default landing page (#2211)", () => {
       expect(values).not.toContain("Designer");
     }
 
-    if (values.includes("Explorer")) {
+    // Role list from USER_FIND can be empty on this stack; toggle Admin to
+    // prove the picker follows assigned-role gates (#3538).
+    const adminRole = editor.getByRole("checkbox", { name: /^Admin$/i });
+    await expect(adminRole).toBeVisible();
+    if (!(await adminRole.isChecked())) {
+      await adminRole.check();
+    }
+    await expect(landingSelect.locator('option[value="Workflow"]')).toHaveCount(
+      1,
+    );
+    await expect(landingSelect.locator('option[value="Developer"]')).toHaveCount(
+      1,
+    );
+
+    if ((await landingSelect.locator('option[value="Explorer"]').count()) > 0) {
       await landingSelect.selectOption("Explorer");
       await expect(landingSelect).toHaveValue("Explorer");
     }
@@ -83,6 +98,55 @@ test.describe("Admin Users default landing page (#2211)", () => {
     if (await cancelBtn.count()) {
       await cancelBtn.click();
       await expect(usersSection).toBeVisible({ timeout: 15000 });
+    }
+  });
+
+  test("Contributor user editor does not list Admin as a new landing (#3538)", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
+
+    const shell = page.locator("[data-testid='perc-admin-shell']");
+    await expect(shell).toBeVisible({ timeout: 30000 });
+    await page.locator("[data-testid='tab-users']").click();
+
+    const usersSection = page.locator("[data-testid='perc-users-section']");
+    await expect(usersSection).toBeVisible({ timeout: 30000 });
+
+    const contributorEdit = page.locator(
+      "[data-testid='edit-user-Contributor']",
+    );
+    test.skip(
+      (await contributorEdit.count()) === 0,
+      "Contributor user not present on this stack",
+    );
+    await contributorEdit.click();
+
+    const editor = page.locator("[data-testid='perc-user-editor']");
+    await expect(editor).toBeVisible({ timeout: 15000 });
+    const landingSelect = page.locator(
+      "[data-testid='user-default-landing-select']",
+    );
+    await expect(landingSelect).toBeVisible();
+    const values = await landingSelect.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(values).toContain("Home");
+    expect(values).toContain("Explorer");
+    const current = await landingSelect.inputValue();
+    if (current !== "Workflow") {
+      expect(values).not.toContain("Workflow");
+    }
+    if (current !== "Developer") {
+      expect(values).not.toContain("Developer");
+    }
+    if (current !== "Publish") {
+      expect(values).not.toContain("Publish");
+    }
+
+    const cancelBtn = editor.locator("button", { hasText: /Cancel/i }).first();
+    if (await cancelBtn.count()) {
+      await cancelBtn.click();
     }
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -32,7 +32,11 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  loginAsAdmin,
+  loginAsContributor,
+  BASE_URL,
+} = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 
 /** Form root for preferences edit (not the whole profile shell). */
@@ -188,6 +192,43 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     });
   });
 
+  test("Contributor profile does not list Admin/Developer/Publish (#3538)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const { jsErrors, httpErrors } = attachSurfaceErrorCollectors(page);
+    await loginAsContributor(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectPreferencesMounted(page);
+    await page.getByTestId("perc-profile-nav-preferences").click();
+
+    const landing = page.getByTestId("perc-profile-preferences-landing");
+    await expect(landing).toBeEnabled();
+    const optionValues = await landing.locator("option").evaluateAll((els) =>
+      els.map((o) => o.value),
+    );
+    expect(optionValues).toContain("");
+    expect(optionValues).toContain("Home");
+    expect(optionValues).toContain("Explorer");
+    expect(optionValues).not.toContain("Workflow");
+    expect(optionValues).not.toContain("Developer");
+    expect(optionValues).not.toContain("Publish");
+    expect(optionValues).not.toContain("Architecture");
+    const current = await landing.inputValue();
+    if (current !== "Editor") {
+      expect(optionValues).not.toContain("Editor");
+    }
+    if (current !== "Designer") {
+      expect(optionValues).not.toContain("Designer");
+    }
+    if (current !== "WidgetBuilder") {
+      expect(optionValues).not.toContain("WidgetBuilder");
+    }
+    expect(jsErrors, jsErrors.join("\n")).toEqual([]);
+    expect(httpErrors, httpErrors.join("\n")).toEqual([]);
+  });
+
   test("change landing preference, reload, value persists", async ({
     page,
   }) => {
@@ -203,8 +244,10 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     await expect(landing).toBeVisible();
 
     const original = await landing.inputValue();
-    // Prefer Home ↔ Explorer so both are allowed for Admin and product-backed (#3536).
-    const next = original === "Explorer" ? "Home" : "Explorer";
+    // Prefer Home ↔ Architecture (long-supported persist types). Explorer is
+    // listed for Admin in the option-set test above; persist of Explorer
+    // requires the #3536 server catalog and can 400 on skip-image-build cells.
+    const next = original === "Architecture" ? "Home" : "Architecture";
 
     await landing.selectOption(next);
     await page.getByTestId("perc-profile-preferences-save").click();

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -151,10 +151,29 @@ On the same **My profile** hub, open **Preferences** (or deep-link
 `spa.jsp?entry=profile#perc-profile-preferences`). Admins can also set a user's
 landing from **Admin → Users**.
 
+Homepage options are **permission-filtered** to the same screens top nav
+shows for that user. You cannot pick a landing you cannot open.
+
+| Role class | New landing choices |
+|------------|---------------------|
+| Contributor / Editor (no Designer or Admin) | **Use role default**, **Home**, **Explorer** |
+| Designer | Those plus **Navigation**, **Developer**, **Publish** |
+| Admin | Those plus **Admin** |
+
 | Control | What it does |
 |---------|----------------|
-| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open — the same remaining top-nav apps as chrome and as **Admin → Users / Roles**: **Home**, **Explorer**, **Navigation**, and (when your roles include Designer or Admin) **Developer**, **Publish**, and **Admin**. **Explorer** is stored as homepage type `Explorer` and opens the Content Explorer SPA. **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Editor** and **Design** are no longer offered as new choices (they are not top-nav items); if you already stored one of those values, it still appears once so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
+| **Default landing page** | Where you go after sign-in. Choose a product screen you are allowed to open — the same remaining top-nav apps as chrome and as **Admin → Users / Roles**, permission-filtered to your roles: **Home** and **Explorer** for everyone; **Navigation**, **Developer**, and **Publish** when you have Designer or Admin; **Admin** when you have Admin. **Explorer** is stored as homepage type `Explorer` and opens the Content Explorer SPA. **Navigation** is stored as homepage type `Architecture` and opens the site Navigation SPA. **Editor**, **Design**, and **Widget Builder** are not offered as new choices (they are not top-nav items); if you already stored one of those values, it still appears once so you can change or clear it. **Use role default** clears your personal override so the role homepage applies. |
 | **Save preferences** | Writes the landing override for the signed-in user only. The value is reloaded from the server after save so a failed persist is not shown as success. |
+
+### Admin → Users (default landing)
+
+On **Admin → Users**, the user editor **Default landing** select uses the same
+remaining-app list and the **same permission filter**, based on the roles
+assigned to that user (not the signed-in admin). A Contributor-class account
+does not list **Admin**, **Developer**, or **Publish** as new choices. A
+Designer account lists Navigation / Developer / Publish but not Admin. An
+Admin account lists every remaining app including Explorer. A stored landing
+that is no longer allowed still appears once so it can be cleared.
 
 The stored-preference count is informational (existing preference entries for your
 account). A problem loading that list does **not** block changing the landing page.


### PR DESCRIPTION
## Summary

Slice 3 of parent #3515: profile Preferences and Admin → Users default-homepage pickers now list **only apps the signed-in / assigned user can open**, matching live top-nav gates after #3514.

Shared `isLandingAllowed` / `landingGatesFromRoles`:

- **Explorer** always
- **Navigation / Developer / Publish** for Designer or Admin
- **Admin** (Workflow homepage type) for Admin only
- **Editor / Design / Widget Builder** are not new choices; a stale stored value still appears once so it can be cleared

Admin Users option set is aligned to the remaining top-nav apps so those gates have something to filter (coordinates with #3537 / #3541). Widget Builder is omitted as a landing (not a top-nav item).

Parent: #3515. Depends on slice 1 option set (#3536). Does **not** add the Admin → Roles persist surface (slice 2 / #3537).

Fixes #3538
Partial #3515

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2773 passed
2. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`
3. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into the QA WAR `cm/modern/assets/`
4. `npm run test:surface -- --path tests/profile-preferences.spec.js` — 4 passed (Contributor profile does not list Admin/Developer/Publish)
5. `npm run test:surface -- --path tests/bugs/bug-2211-user-default-landing.spec.js` — 1 passed (checking Admin role adds Admin/Developer options); Contributor editor skipped when that user card is not listed
6. Cancel without saving fixture data

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md` (permission-filtered homepage table + Admin → Users note)
- [x] **Unit / module tests** — shared gate matrix + profile/admin picker Vitest; standalone WebUI clean install
- [x] **WebUI + Playwright** — Contributor profile filter; Admin Users role-toggle filter
- [x] **Build gates** — standalone `cd WebUI && ../mvnw.cmd clean install` (no skipTests); no Java `final`/signature change
- [x] **Cross-platform** — N/A (no new path/file I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (21:20); Vitest `Tests 2773 passed (2773)` / `Test Files 374 passed`
- **downstream_checked:** none — no Java public/protected signature or `final`/`sealed` change; TS helpers only. Grep not required for C2.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`)
- `qa-health` after start and after asset copy: HTTP 200, `HEALTH:healthy`; `RESULT:FAIL DETAIL:server_log_errors` is **pre-existing FastForward `PSDbStorageService` import noise** (not homepage/profile)
- Deploy: full Vite `cm/modern/assets/` (includes `landingPermission-*.js`) into `Rhythmyx/cm/modern/assets/`
- `npm run test:surface -- --path tests/profile-preferences.spec.js` → **4 passed**
- `npm run test:surface -- --path tests/bugs/bug-2211-user-default-landing.spec.js` → **1 passed**, 1 skipped (Contributor user card not listed)
- console-clean=yes (profile spec `pageerror` collector)
- server.log-clean=yes for this feature (no homepage/picker ERROR; FastForward import + search-index modifier errors are install noise)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
