### PR TITLE
fix(webui): Translations GUID content id for variants + create-variant (#3545)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -39,6 +39,7 @@ import {
 } from "../api/contentExplorer/translationsApi";
 import { formatApiError } from "../api/client";
 import { message } from "../i18n/message";
+import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
 
 export interface TranslationsPanelProps {
@@ -84,9 +85,15 @@ async function defaultCreateVariants(body: {
   return createTranslations(body);
 }
 
-function parseNumericItemId(itemId: string): number | null {
-  const n = Number(itemId);
-  return Number.isFinite(n) && n > 0 ? n : null;
+/**
+ * Resolve Explorer row id to a legacy content id.
+ *
+ * <p>List rows are usually Percussion GUIDs ({@code 1-101-708}); {@link
+ * Number}({@code itemId}) is NaN for those and must not be used (#3545 /
+ * parent #2649). Folders/sites with no content id still return null.
+ */
+function resolveTranslationsContentId(itemId: string): number | null {
+  return parseExplorerContentId(itemId);
 }
 
 function roleLabel(role: string | null | undefined): string {
@@ -130,10 +137,15 @@ export function TranslationsPanel(
       setState({ kind: "auth" });
       return;
     }
+    const resolvedId = resolveTranslationsContentId(itemId);
+    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
+    // numeric string still loads. Folders with no content id stay null.
+    const variantsKey =
+      resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });
     setCreateError(null);
     setCreateSuccess(null);
-    loadVariants(itemId)
+    loadVariants(variantsKey)
       .then((data) => {
         if (!alive) return;
         setState({ kind: "ok", data });
@@ -197,7 +209,7 @@ export function TranslationsPanel(
   }, []);
 
   const handleCreate = useCallback(async () => {
-    const numericId = parseNumericItemId(itemId);
+    const numericId = resolveTranslationsContentId(itemId);
     if (numericId == null) {
       setCreateError(message(EXPLORER_MSG.TRANSLATIONS_INVALID_ITEM));
       return;

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -138,8 +138,9 @@ export function TranslationsPanel(
       return;
     }
     const resolvedId = resolveTranslationsContentId(itemId);
-    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
-    // numeric string still loads. Folders with no content id stay null.
+    // GUID last segment (1-101-708 → 708). Parse-null does not skip GET:
+    // loadVariants still receives the raw itemId (unit tests / direct mounts).
+    // The Explorer shell never mounts this panel for folders/sites.
     const variantsKey =
       resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1193,6 +1193,76 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("translations-panel")).toBeNull();
   });
 
+  it("GUID list row opens translations panel (not select-item hint) (#3545)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/content-explorer/translations/")) {
+        return new Response(
+          JSON.stringify({
+            itemId: 708,
+            locale: "en-us",
+            variants: [
+              { contentId: 708, locale: "en-us", role: "source", revision: 1 },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-translations"));
+    await waitFor(() => {
+      expect(screen.getByTestId("translations-panel")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-translations-hint")).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-708")).toBeTruthy();
+  });
+
   it("Content → Site Copy mounts wizard with source from /Sites/<name> (#2767)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -90,6 +90,30 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("resolves GUID Explorer row ids for variants GET (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        itemLabel="Home"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-335")).toBeTruthy();
+    expect(screen.getByTestId("translations-variant-row-900")).toBeTruthy();
+  });
+
   it("create-variant POSTs selected locales via injection seam", async () => {
     const createVariants = vi.fn(async () => ({
       created: [
@@ -127,6 +151,73 @@ describe("TranslationsPanel", () => {
       expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
     );
     expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("create-variant POSTs GUID last-segment content id (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    const createVariants = vi.fn(async () => ({
+      created: [
+        {
+          contentId: 901,
+          locale: "de-de",
+          role: "translation",
+          sourceContentId: 708,
+        },
+      ],
+    }));
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() => expect(createVariants).toHaveBeenCalledTimes(1));
+    expect(createVariants).toHaveBeenCalledWith({
+      itemIds: [708],
+      locales: ["de-de"],
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("translations-create-error"),
+    ).toBeNull();
+  });
+
+  it("keeps the no-id create message for folder-like ids without a content id", async () => {
+    const createVariants = vi.fn(async () => ({ created: [] }));
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={async () => SAMPLE_VARIANTS}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-error")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("translations-create-error")).toHaveTextContent(
+      /does not have a numeric content id/i,
+    );
+    expect(createVariants).not.toHaveBeenCalled();
   });
 
   it("maps create 403 to permission chrome", async () => {

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -194,6 +194,24 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("GET variants with the raw itemId when parse yields null", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("//Sites/Demo");
+  });
+
   it("keeps the no-id create message for folder-like ids without a content id", async () => {
     const createVariants = vi.fn(async () => ({ created: [] }));
     render(

--- a/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
+++ b/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review: Translations GUID content id for variants + create-variant (#3545)
+
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Base:** `origin/main`  
+**Date:** 2026-08-17  
+**Persona:** Erlang (independent of implementer)
+
+Parent QA #2649 (Failed of #2430): Explorer Translations used `Number(itemId)`
+only. List rows are Percussion GUIDs (`1-101-708`); create-variant then emitted
+`Selected item does not have a numeric content id`.
+
+## Summary
+
+`TranslationsPanel` now resolves Explorer row ids with `parseExplorerContentId`
+(GUID last segment) for variants GET (`708`) and create-variant POST
+`itemIds: [708]`. Folders/sites with no content id still return null and keep
+the existing no-id create message. Shell already gated the panel with
+`parseExplorerContentId`; a GUID-row shell test plus Vitest GUID create body
+and Playwright intercept cover the user-visible path. Product-docs note the
+GUID last-segment behavior.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests exercise GUID parse → GET key and POST body.
+Playwright companion updated. No public Java API shape change. No filesystem
+path I/O.
+
+## Change-class closure
+
+Change class: **WebUI Explorer product screen (Translations panel GUID id)**.
+
+| Companion | Status |
+|-----------|--------|
+| `TranslationsPanel` parse via `parseExplorerContentId` | present |
+| Vitest GUID GET + create body + no-id folder path | present |
+| Shell GUID row mounts panel | present |
+| Playwright `explorer-translations.spec.js` | present (create intercept) |
+| product-docs `8.2/admin/content-explorer.md` | present |
+| i18n / a11y | existing keys + axe gates; no new chrome strings |
+
+## Cross-platform path checklist
+
+No filesystem path construction. REST URLs and GUID tokens use `/` and `-`
+as protocol forms, not OS paths. **Outcome: clean.**
+
+Memory patterns hit: missing behavioral tests (covered); WebUI Playwright
+companion (updated); change-class product-docs (updated).
+
+## Issues
+
+None blocking.
+
+### nit
+
+`resolveTranslationsContentId` is a one-line alias of `parseExplorerContentId`.
+Acceptable as a named call-site comment; not required to inline.
+
+C5 live Playwright against H2 QA is a process gate after this review, not a
+code defect.

--- a/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — PR #3547 review follow-up (#3545)
+
+**Date:** 2026-08-18  
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Scope:** uncommitted review-response (comment accuracy + Playwright detach retry)
+
+## Summary
+
+Kilo threads on #3547: (1) `variantsKey` comment claimed folders stay null while
+code falls back to raw `itemId`; (2) item-row click lacked the detach retry used
+for folder rows. Comment rewritten, unit test asserts GET uses the raw token on
+parse-null, Playwright helper retries item (and folder fallback) clicks.
+
+## Recommendation
+
+**approve** — May commit/push: **yes**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: new Vitest case for parse-null GET fallback
+- Cross-platform path review: N/A (no filesystem I/O)
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Orphaned JSDoc above extracted helper — fixed before commit
+- Public helper comment contradicting implementation — addressed
+
+> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -44,6 +44,13 @@ async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
 }
 
+/** Click the first matching row; re-query if the locator detaches mid-click. */
+async function clickFirstRowWithDetachRetry(rows) {
+  await rows.first().click({ force: true, timeout: 10_000 }).catch(async () => {
+    await rows.first().click({ force: true, timeout: 10_000 }).catch(() => {});
+  });
+}
+
 /**
  * Open the first listed content row (page/asset), drilling one folder when
  * the current list is folders only. GUID-shaped {@code data-testid} values
@@ -55,7 +62,7 @@ async function selectFirstContentRow(page) {
     'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
   );
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   const folderRows = list.locator(
@@ -66,15 +73,13 @@ async function selectFirstContentRow(page) {
   }
   await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
     async () => {
-      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
-        () => {},
-      );
+      await clickFirstRowWithDetachRetry(folderRows);
     },
   );
   await listWaitReady(page);
   await page.waitForLoadState("networkidle").catch(() => {});
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   return false;

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -20,8 +20,11 @@
  * <p>Verifies the modern React Content Explorer shell exposes the Translations
  * panel chrome and loads item locale / variants from the public REST façade
  * ({@code GET /rest/content-explorer/translations/{itemId}}). Create-variant
- * is exercised only when a content row with a numeric id is selectable and
- * the CMS returns target locales; chrome visibility is the hard gate.</p>
+ * is exercised when a content row is selectable (GUID last-segment ids such as
+ * {@code 1-101-708} → {@code 708}, #3545 / parent #2649). The client must not
+ * emit {@code Selected item does not have a numeric content id} for a
+ * GUID-shaped row. Folders/sites keep the select-item hint. Chrome visibility
+ * is the hard gate when no content row is listed.</p>
  *
  * <p>Tags: {@code @explorer-translations} {@code @p-trans} {@code @smoke}</p>
  *
@@ -32,10 +35,49 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  expectNoSeriousA11yViolations,
+} = require("./helpers/a11y");
 
 /** Wait until the detail list region is present (folder navigation settled). */
 async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
+}
+
+/**
+ * Open the first listed content row (page/asset), drilling one folder when
+ * the current list is folders only. GUID-shaped {@code data-testid} values
+ * are valid (#3545).
+ */
+async function selectFirstContentRow(page) {
+  const list = page.locator('[data-testid="detail-list"]');
+  const itemRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  const folderRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  if ((await folderRows.count()) === 0) {
+    return false;
+  }
+  await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
+    async () => {
+      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
+        () => {},
+      );
+    },
+  );
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  return false;
 }
 
 test.describe("modern React Content Explorer — translations (P-Trans #2430)", () => {
@@ -114,19 +156,22 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
         return;
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
-      });
+      const selectedContent = await selectFirstContentRow(page);
+      if (!selectedContent) {
+        const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
+        await target.click({ force: true, timeout: 10_000 }).catch(async () => {
+          // Re-query after detach from folder refresh.
+          const again = list
+            .locator('tbody tr[data-testid^="detail-row-"]')
+            .first();
+          await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+        });
+      }
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
       await page.locator('[data-testid="explorer-toggle-translations"]').click();
 
-      // Either full panel (numeric content id) or select-item hint (folder / no id).
+      // Content row (including GUID 1-101-708) → panel; folder/site → hint.
       const panel = page.locator('[data-testid="translations-panel"]');
       const hint = page.locator('[data-testid="explorer-translations-hint"]');
       await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
@@ -150,8 +195,130 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
           await expect(
             page.locator('[data-testid="translations-inflight-note"]'),
           ).toBeVisible();
+          await expectNoSeriousA11yViolations(page, {
+            scope: '[data-testid="translations-panel"]',
+          });
         }
+      } else {
+        await expect(hint).toBeVisible();
       }
+    },
+  );
+
+  test(
+    "create-variant on a content row does not emit numeric-id client error (#3545)",
+    { tag: ["@explorer-translations", "@p-trans"] },
+    async ({ page }) => {
+      test.setTimeout(75_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const selectedContent = await selectFirstContentRow(page);
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      await page.locator('[data-testid="explorer-toggle-translations"]').click();
+
+      const panel = page.locator('[data-testid="translations-panel"]');
+      const hint = page.locator('[data-testid="explorer-translations-hint"]');
+      await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
+
+      if (!selectedContent || (await panel.count()) === 0) {
+        await expect(hint).toBeVisible();
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+        timeout: 20_000,
+      });
+      const state = await panel.getAttribute("data-testid-state");
+      if (state !== "ok") {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(
+        page.locator('[data-testid="translations-current-locale"]'),
+      ).toBeVisible();
+
+      const localeOptions = page.locator(
+        '[data-testid^="translations-locale-option-"]',
+      );
+      if ((await localeOptions.count()) === 0) {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      /** @type {{ itemIds?: number[] } | null} */
+      let posted = null;
+      await page.route("**/rest/content-explorer/translations", async (route) => {
+        if (route.request().method() !== "POST") {
+          await route.continue();
+          return;
+        }
+        try {
+          posted = route.request().postDataJSON();
+        } catch {
+          posted = {};
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            created: [
+              {
+                contentId: 901,
+                locale: "xx-test",
+                role: "translation",
+              },
+            ],
+          }),
+        });
+      });
+
+      await localeOptions.first().click();
+      await page.locator('[data-testid="translations-create-submit"]').click();
+
+      await expect(
+        page.locator('[data-testid="translations-create-success"]'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator('[data-testid="translations-create-error"]'),
+      ).toHaveCount(0);
+      await expect(
+        page.getByText(/does not have a numeric content id/i),
+      ).toHaveCount(0);
+
+      expect(posted, "create-variant POST should have been sent").not.toBeNull();
+      const ids = posted && Array.isArray(posted.itemIds) ? posted.itemIds : [];
+      expect(ids.length).toBeGreaterThan(0);
+      expect(Number(ids[0])).toBeGreaterThan(0);
+      expect(Number.isFinite(Number(ids[0]))).toBe(true);
+
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -122,7 +122,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open the CM1 editor (`?view=editor`). |
-| **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
+| **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`1-101-708`); the panel uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
 | **Revisions** | Opens the Revisions panel; restore is available when the selected revision is restorable. **Promote revision** opens the same chrome-less editor host (`mode=promote`) and restores the chosen revision through `GET /services/itemmanagement/item/restoreRevision/{revisionGuid}`. |
@@ -323,8 +323,25 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  suitable item is selected (see **Translations** below)
 - **Clipboard** — multi-select copy/cut staging when items are selected
+
+## Translations
+
+Open **View → Translations** after selecting a **page or asset** in the list (or use
+**Translate** on Server actions / the item context menu).
+
+The panel shows **this item’s current locale** and **related locale variants**, and lets
+an authorized user **Create variants** for catalog locales the item does not already
+have. Explorer list rows identify items with a Percussion content id. The id is often
+GUID-shaped (for example `1-101-708`); the panel uses the last segment (`708`) for
+both the variants request and create-variant. That GUID form must not fail with
+“Selected item does not have a numeric content id.”
+
+**Folders and sites** have no content id. With Translations open and only a folder or
+site selected, Explorer shows a select-item hint instead of the live panel.
+
+In-flight translation queue status is not available (product disposition).
 
 ## If Content Explorer cannot start
 


### PR DESCRIPTION
## Summary

Explorer Translations (`TranslationsPanel`) treated row ids with `Number(itemId)` only. Content Explorer list rows are Percussion GUIDs (`1-101-708`), so **Create variants** failed with the client message `Selected item does not have a numeric content id`, and variants GET used the raw token.

This PR resolves Explorer row ids with `parseExplorerContentId` (GUID last segment → `708`) for:

- variants GET (`loadVariants("708")`)
- create-variant POST `itemIds: [708]`

Folders and sites with no content id still keep the existing no-id message / select-item hint.

Fixes #3545. Residual of parent QA #2649 (do **not** close #2649). Do not reopen P-Trans in-flight/session OUT (#2829).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Log in as Admin. Open Explorer: `/Rhythmyx/cm/app/spa.jsp?entry=explorer`.
2. **View → Translations** with no item selected → select-item hint.
3. Select a **page/asset** list row (GUID-shaped id such as `1-101-708`) → panel shows **this item’s locale** and **locale variants**.
4. Pick a target locale and **Create variants** → success or a real API error. Must **not** show `Selected item does not have a numeric content id`.
5. Select a folder/site only → hint remains (no numeric-id client error for a missing content id).

Env: QA H2 docker (`perc-devctl qa-up`) or local install.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (Translate action + Translations section: GUID last-segment / folder hint)
- [x] **Unit / module tests** — Vitest GUID GET + create body + folder no-id; shell GUID row mounts panel
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js` (GUID/content-row + create intercept)
- [x] **Build gates** — standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **Cross-platform** — N/A (no filesystem path I/O; GUID tokens / REST URLs only)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Vitest `Tests 2775 passed / 374 files`; Java Surefire included; no new warnings from this change)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **downstream_checked:** none (no public Java/`final`/signature change; TS panel + tests + docs only)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2` **Health=healthy**, `TEST_CMS_URL=http://127.0.0.1:9993`. Host `qa-up`/`qa-health` RESULT:FAIL on pre-existing FastForward `PSDbStorageService` GIF import ERROR (HTTP 200; not `Failed startup of context`).
- Hot-deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- `npm run test:surface -- --path tests/explorer-translations.spec.js` → **3 passed**
- `npm run test:golden` → **2 passed**
- **console-clean=yes** (spec `pageerror` listener; no uncaught errors)
- **server.log-clean=no** — pre-existing FastForward import + search-index last-modifier ERROR noise; **no** translations/P-Trans feature ERROR in the test window

Erlang review: `docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md` — approve.

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
