### PR TITLE
fix(webui): View Clipboard toggle opens explorer-clipboard-panel (#3544)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1304,7 +1304,6 @@ function ContentExplorerShellInner({
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
-            clipboardItemCount={clipboard.items.length}
             hasSiteContext={hasSiteContext}
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -52,8 +52,6 @@ export interface ExplorerMenuBarProps {
   showSubfolderCopy?: boolean;
   /** Multi-select size for clipboard-add disable + status badge. */
   multiSelectedCount: number;
-  /** Clipboard size — enables View → Clipboard when non-empty. */
-  clipboardItemCount: number;
   /**
    * True when the current folder/selection is under {@code /Sites/&lt;name&gt;}.
    * Enables Content → Site Copy (#2767).
@@ -186,15 +184,11 @@ function menuItemTestId(item: ExplorerMenuBarItem): string {
 function isItemDisabled(
   item: ExplorerMenuBarItem,
   multiSelectedCount: number,
-  clipboardItemCount: number,
   hasSiteContext: boolean,
   hasFolderContext: boolean,
 ): boolean {
   if (item.disabledWhen === "noSelection") {
     return multiSelectedCount === 0;
-  }
-  if (item.disabledWhen === "noClipboardContext") {
-    return multiSelectedCount === 0 && clipboardItemCount === 0;
   }
   if (item.disabledWhen === "noSiteContext") {
     return !hasSiteContext;
@@ -218,7 +212,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showSiteCopy = false,
     showSubfolderCopy = false,
     multiSelectedCount,
-    clipboardItemCount,
     hasSiteContext = false,
     hasFolderContext = false,
     displayFormats,
@@ -269,7 +262,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
       isItemDisabled(
         item,
         multiSelectedCount,
-        clipboardItemCount,
         hasSiteContext,
         hasFolderContext,
       )
@@ -343,7 +335,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                     const disabled = isItemDisabled(
                       item,
                       multiSelectedCount,
-                      clipboardItemCount,
                       hasSiteContext,
                       hasFolderContext,
                     );

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -58,7 +58,6 @@ export interface ExplorerMenuBarItem {
   /** Optional disabled predicate flag name resolved by the host. */
   disabledWhen?:
     | "noSelection"
-    | "noClipboardContext"
     | "noSiteContext"
     | "noFolderContext";
 }
@@ -174,8 +173,8 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.CLIPBOARD_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_CLIPBOARD_ARIA,
           testId: "explorer-toggle-clipboard",
+          /** Always enabled so empty clipboard can still be viewed (#3544). */
           toggle: true,
-          disabledWhen: "noClipboardContext",
         },
       ],
     },

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1175,6 +1175,47 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("View → Clipboard opens the empty clipboard panel and toggles aria-checked (#3544)", async () => {
+    stubPathFetch();
+    const { container } = renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-view")).toBeInTheDocument(),
+    );
+    openViewMenu();
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-clipboard"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+    await renderA11yGate(container);
+  });
+
   it("translations toggle shows select-item hint without a content selection (#2430)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -34,7 +34,6 @@ function renderBar(
       showDependencies={false}
       showClipboard={false}
       multiSelectedCount={0}
-      clipboardItemCount={0}
       displayFormats={[]}
       selectedFormatKey=""
       onSelectFormat={onSelectFormat}
@@ -89,6 +88,37 @@ describe("ExplorerMenuBar (#2731)", () => {
     );
     fireEvent.click(contentSearch);
     expect(onCommand).toHaveBeenCalledWith("content-search");
+  });
+
+  it("View → Clipboard is enabled with empty clipboard and invokes view-clipboard (#3544)", () => {
+    const { onCommand } = renderBar({
+      multiSelectedCount: 0,
+      showClipboard: false,
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("role")).toBe("menuitemcheckbox");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
+    fireEvent.click(toggle);
+    expect(onCommand).toHaveBeenCalledWith("view-clipboard");
+  });
+
+  it("View → Clipboard reflects showClipboard on aria-checked (#3544)", () => {
+    renderBar({ showClipboard: true, multiSelectedCount: 0 });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const checked = screen.getByTestId("explorer-toggle-clipboard");
+    expect(checked.getAttribute("aria-checked")).toBe("true");
+    expect(checked.getAttribute("aria-expanded")).toBe("true");
+    expect(checked.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
   });
 
   it("View → Folder Security menu item invokes view-security (#3268)", () => {

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -53,6 +53,14 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(byId["view-clipboard"]).toBe("explorer-toggle-clipboard");
   });
 
+  it("View → Clipboard is an always-enabled toggle (#3544)", () => {
+    const view = buildExplorerMenuBarGroups().find((g) => g.id === "view");
+    const clipboard = view?.items.find((i) => i.id === "view-clipboard");
+    expect(clipboard?.toggle).toBe(true);
+    expect(clipboard?.disabledWhen).toBeUndefined();
+    expect(clipboard?.testId).toBe("explorer-toggle-clipboard");
+  });
+
   it("puts clipboard-add under Content with stable test id", () => {
     const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
     const add = content?.items.find((i) => i.id === "content-clipboard-add");

--- a/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
+++ b/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — #3544 View → Clipboard toggle
+
+**Branch:** `fix/issue-3544-view-clipboard-toggle`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure (WebUI screen + Playwright + product-docs); missing behavioral tests for new/changed logic.
+
+## Summary
+
+Parent QA #2741 failed because **View → Clipboard** (`explorer-toggle-clipboard`) stayed `aria-checked=false` and `explorer-clipboard-panel` never appeared. `ContentExplorerShell` already flipped `showClipboard` on `view-clipboard`; the menu item was gated with `disabledWhen: "noClipboardContext"` so `activateItem` returned without calling `onCommand` whenever multi-select and clipboard were both empty.
+
+This change removes that disable so the View toggle always works (empty clipboard panel is an accepted state). `Content → Add to clipboard` still uses `noSelection`. Companions: Vitest (model, menubar, shell + a11y), Playwright surface (`explorer-menu-bar.spec.js` + `explorer-multiselect.spec.js` aria-checked), product-docs `content-explorer.md`.
+
+## Issues
+
+None that are hard-gate bugs.
+
+### Suggestion (low)
+
+`clipboardItemCount` was removed from `ExplorerMenuBarProps` because it only fed the disable predicate. If a later badge needs the count, reintroduce it as display-only — do not re-gate the View toggle.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Menu model (`view-clipboard` always enabled) | Done |
+| Menu bar activate + `aria-checked` | Done |
+| Shell `setShowClipboard` + panel mount | Already present; shell test added |
+| Vitest (model, menubar, shell a11y) | Done |
+| Playwright explorer menu-bar + multiselect | Done |
+| Product-docs (`content-explorer.md` View tools) | Done |
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path joins; URL/`data-testid` strings only.
+
+## Tests
+
+- Focused Vitest: ExplorerMenuBar 18, menuBarModel 9, ContentExplorerShell 49 (clipboard toggle included)
+- WebUI standalone `cd WebUI && ../mvnw.cmd clean install`: BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2775 passed (374 files)
+- perc-qa-automation helper unit: explorer-menu-bar ids include clipboard toggle/panel
+- C5 Playwright on H2 QA (`TEST_CMS_URL=http://127.0.0.1:9993`, cell `perc-matrix-cms-h2`, Health=healthy, HTTP 200 after Jetty in-cell restart):
+  - `npm run test:surface -- --path tests/explorer-menu-bar.spec.js --path tests/explorer-multiselect.spec.js` — 7 passed (including View → Clipboard empty toggle `#3544`)
+  - `npm run test:golden` — 2 passed
+  - console-clean=yes (pageerror/console listener on `#3544` spec)
+  - server.log-clean=yes for the post-restart Playwright window (no new ERROR/FATAL after `2026-08-18 03:17:50`; remaining ERRORs are pre-existing FastForward import / search-index last-modifier noise from first cell start)

--- a/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
@@ -96,6 +96,49 @@ test.describe("modern React Content Explorer — DCE menu bar chrome (#2731)", (
   );
 
   test(
+    "View → Clipboard opens empty panel and sets aria-checked (#3544)",
+    { tag: ["@explorer-menu-bar", "@explorer", "@issue-3544"] },
+    async ({ page }) => {
+      const errors = [];
+      page.on("pageerror", (err) => errors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 15_000 });
+
+      await openViewMenu(page);
+      const toggle = page.locator(
+        `[data-testid="${TEST_IDS.toggleClipboard}"]`,
+      );
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toBeEnabled();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toBeVisible({ timeout: 5_000 });
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      expect(errors, `JS console/page errors: ${errors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
     "server action toolbar still mounts under menu bar",
     { tag: ["@explorer-menu-bar", "@explorer"] },
     async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
@@ -90,12 +90,15 @@ test.describe("modern React Content Explorer — multi-select + clipboard (#2408
     await rowCheckboxes.nth(0).check();
     await rowCheckboxes.nth(1).check();
 
-    // #2731: clipboard-add lives under Content menu; clipboard toggle under View.
+    // #2731 / #3544: Add lives under Content; it also opens the clipboard
+    // panel. View → Clipboard must already be checked — do not click it
+    // again here or the toggle would hide the panel.
     await page.locator('[data-testid="explorer-menu-content"]').click();
     await page.locator('[data-testid="explorer-clipboard-add"]').click();
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
-    await page.locator('[data-testid="explorer-toggle-clipboard"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-clipboard"]');
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
     const panel = page.locator('[data-testid="explorer-clipboard-panel"]');
     await expect(panel).toBeVisible();
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -17,6 +17,9 @@ const TEST_IDS = Object.freeze({
   viewDropdown: "explorer-menu-view-dropdown",
   helpDropdown: "explorer-menu-help-dropdown",
   toggleSearch: "explorer-toggle-search",
+  /** View → Clipboard (#3544) — panel toggle, enabled even when empty. */
+  toggleClipboard: "explorer-toggle-clipboard",
+  clipboardPanel: "explorer-clipboard-panel",
   /** Content → Search (#2850) — same panel as View → Search. */
   contentSearch: "explorer-menu-content-search",
   searchPanel: "explorer-search-panel",

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
@@ -34,6 +34,8 @@ describe("explorer-menu-bar helpers (#2731)", () => {
     assert.equal(TEST_IDS.menuView, "explorer-menu-view");
     assert.equal(TEST_IDS.menuHelp, "explorer-menu-help");
     assert.equal(TEST_IDS.toggleSearch, "explorer-toggle-search");
+    assert.equal(TEST_IDS.toggleClipboard, "explorer-toggle-clipboard");
+    assert.equal(TEST_IDS.clipboardPanel, "explorer-clipboard-panel");
     assert.equal(TEST_IDS.contentSearch, "explorer-menu-content-search");
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -324,7 +324,10 @@ From the **View** menu you can also toggle:
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
-- **Clipboard** — multi-select copy/cut staging when items are selected
+- **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
+  the panel (even when empty) and shows a check mark while it is visible.
+  Use **Content → Add to clipboard** after multi-select to put items on the
+  clipboard; paste from the panel when a destination folder is selected.
 
 ## If Content Explorer cannot start
 


### PR DESCRIPTION
## Summary

**View → Clipboard** (`explorer-toggle-clipboard`) was disabled whenever there was no multi-select **and** the clipboard was empty (`disabledWhen: "noClipboardContext"`). Clicks did nothing, so `aria-checked` stayed `false` and `explorer-clipboard-panel` never appeared — the #2741 QA fail (step 5 residual).

This PR removes that gate. **View → Clipboard** always toggles `showClipboard` (empty clipboard panel is OK). **Content → Add to clipboard** is unchanged (`noSelection`). Shell handler `setShowClipboard((v) => !v)` was already correct.

Parent tracker: #2741 (do **not** close). Epic: #2400. Implements #3544.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Open Explorer: `/Rhythmyx/cm/app/spa.jsp?entry=explorer`
2. Open **View → Clipboard** with nothing selected — panel appears (empty state), check mark / `aria-checked=true`
3. Toggle **View → Clipboard** again — panel hides, `aria-checked=false`
4. Multi-select two list rows — **Content → Add to clipboard** is enabled; after Add the panel is open and View → Clipboard is checked
5. Env: QA H2 docker (`perc-devctl qa-up`) or local install; user **Admin**

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (View → Clipboard always opens the panel, including empty)
- [x] **Unit / module tests** — Vitest menu model + ExplorerMenuBar + ContentExplorerShell toggle/a11y; standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **WebUI + Playwright** — `tests/explorer-menu-bar.spec.js` (#3544 empty toggle) and `tests/explorer-multiselect.spec.js` (Add keeps panel + `aria-checked`)
- [x] **Build gates** — standalone clean install on changed Maven modules (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Surefire Tests run: 61, Failures: 0; Vitest Tests 2775 passed (374 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (npm ci; no Java tests)
- **downstream_checked:** none (no Java `final`/public API shape change; `ExplorerMenuBarProps.clipboardItemCount` is WebUI-internal only)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2` **HEALTH:healthy** HTTP 200 `TEST_CMS_URL=http://127.0.0.1:9993` (qa-health RESULT:FAIL is pre-existing FastForward `PSDbStorageService` import ERRORs from first cell start, not `Failed startup of context` / unhealthy)
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` then in-cell `StopJetty.sh` + `StartJetty.sh` (not `docker restart`)
- Playwright (`TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2` `TEST_PRODUCT=cms`):
  - `npm run test:surface -- --path tests/explorer-menu-bar.spec.js --path tests/explorer-multiselect.spec.js` — **7 passed** (including View → Clipboard empty toggle)
  - `npm run test:golden` — **2 passed**
- **console-clean=yes** (`pageerror`/console listener on #3544 spec)
- **server.log-clean=yes** for the post-restart Playwright window (no new ERROR/FATAL after `2026-08-18 03:17:50`; leftover ERRORs are install-time FastForward import / search-index last-modifier noise)

Fixes #3544
Partial #2741

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
