### PR TITLE
fix(explorer): Relationships panel mounts for parseable content row (#3546)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -47,6 +47,7 @@
 
 import { get, post, type ApiError } from "../client";
 import { PATHS } from "../paths";
+import { bindExplorerPathItemId } from "./pathItemId";
 import type {
   PSPathItem,
   PSPagedResult,
@@ -136,7 +137,7 @@ export function unwrapPathItemList(res: PSPathItemListResponse | null | undefine
     };
     throw err;
   }
-  return list;
+  return list.map(bindExplorerPathItemId);
 }
 
 export async function findChildren(path: string): Promise<PSPathItem[]> {
@@ -180,7 +181,7 @@ export async function paginatedFolder(
     return { children: [], totalCount: 0, startIndex: params.startIndex };
   }
   return {
-    children: paged.childrenInPage ?? [],
+    children: (paged.childrenInPage ?? []).map(bindExplorerPathItemId),
     totalCount: paged.childrenCount ?? undefined,
     startIndex: paged.startIndex ?? params.startIndex,
   };
@@ -207,14 +208,16 @@ export async function findItemByPath(path: string): Promise<PSPathItem> {
     return {} as PSPathItem;
   }
   const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function findItemById(id: string): Promise<PSPathItem> {
   const res = await get<PSPathItemResponse>(
     `${PATHS.PATH_ITEM_ID}/${encodeURIComponent(id)}`,
   );
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function addNewFolder(

--- a/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer list / selection content-id bind (#3546 / parent #2778).
+ *
+ * <p>Sample-site and display-format rows sometimes omit {@code id}, send a
+ * slug, or wrap a GUID as {@code {stringValue}} / host-type-uuid parts.
+ * Relationships (and other item tools) only mount when
+ * {@link parseExplorerContentId} succeeds — bind a parseable id onto the
+ * path item before the list hands it to selection.</p>
+ */
+
+import type { PSPathItem } from "./types";
+
+/** Display-format / type-property keys that carry a CMS content id. */
+const CONTENT_ID_KEYS = [
+  "sys_contentid",
+  "sys_contentId",
+  "contentId",
+  "contentid",
+  "sys_id",
+] as const;
+
+/**
+ * Flatten a wire id (string, number, or Jackson GUID object) to a scalar.
+ */
+export function unwrapExplorerWireId(
+  raw: unknown,
+): string | number | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "number" || typeof raw === "string") {
+    return raw;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const rec = raw as Record<string, unknown>;
+  const stringValue = rec.stringValue ?? rec.string_value;
+  if (typeof stringValue === "string" && stringValue.trim()) {
+    return stringValue.trim();
+  }
+  if (typeof rec.id === "string" || typeof rec.id === "number") {
+    return rec.id;
+  }
+  const host = rec.hostId ?? rec.host_id;
+  const type = rec.type;
+  const uuid = rec.uuid;
+  if (host != null && type != null && uuid != null) {
+    return `${host}-${type}-${uuid}`;
+  }
+  return undefined;
+}
+
+/**
+ * Parse a content id from a numeric string, GUID {@code host-type-uuid}
+ * (last segment), or Jackson GUID object.
+ *
+ * @returns positive integer content id, or {@code null}
+ */
+export function parseExplorerContentId(
+  id: string | number | undefined | unknown,
+): number | null {
+  if (id == null || id === "") {
+    return null;
+  }
+  if (typeof id === "number") {
+    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
+  }
+  if (typeof id === "object") {
+    const unwrapped = unwrapExplorerWireId(id);
+    if (unwrapped == null) {
+      return null;
+    }
+    return parseExplorerContentId(unwrapped);
+  }
+  const s = String(id).trim();
+  if (!s) {
+    return null;
+  }
+  const whole = Number(s);
+  if (Number.isFinite(whole) && whole > 0) {
+    return Math.trunc(whole);
+  }
+  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
+  const last = s.split("-").pop();
+  if (!last) {
+    return null;
+  }
+  const n = Number(last);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+}
+
+function collectTypePropertyMap(
+  typeProperties: unknown,
+): Record<string, unknown> | null {
+  if (typeProperties == null || typeof typeProperties !== "object") {
+    return null;
+  }
+  const rec = typeProperties as Record<string, unknown>;
+  const entries = rec.entries;
+  if (entries != null && typeof entries === "object" && !Array.isArray(entries)) {
+    return entries as Record<string, unknown>;
+  }
+  return rec;
+}
+
+/**
+ * Copy of {@code item} with {@code id} set to a parseable content/GUID
+ * string when the wire omitted it or used a non-GUID shape that still
+ * carries {@code sys_contentid} / a GUID object.
+ *
+ * Folders keep their original id when nothing parseable is found (site
+ * name slugs stay slugs).
+ */
+export function bindExplorerPathItemId(item: PSPathItem): PSPathItem {
+  const extras = item as PSPathItem & {
+    typeProperties?: unknown;
+    guid?: unknown;
+    Guid?: unknown;
+  };
+  const candidates: unknown[] = [item.id, extras.guid, extras.Guid];
+  const dp = item.displayProperties;
+  if (dp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(dp[key]);
+    }
+  }
+  const tp = collectTypePropertyMap(extras.typeProperties);
+  if (tp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(tp[key]);
+    }
+  }
+
+  for (const raw of candidates) {
+    const unwrapped = unwrapExplorerWireId(raw);
+    if (unwrapped == null) {
+      continue;
+    }
+    if (parseExplorerContentId(unwrapped) == null) {
+      continue;
+    }
+    const nextId =
+      typeof unwrapped === "string" ? unwrapped.trim() : String(unwrapped);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+
+  const unwrappedId = unwrapExplorerWireId(item.id);
+  if (typeof unwrappedId === "string" && unwrappedId !== item.id) {
+    return { ...item, id: unwrappedId };
+  }
+  if (typeof unwrappedId === "number") {
+    const nextId = String(unwrappedId);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+  return item;
+}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -83,6 +83,7 @@ import {
   transitionItem,
 } from "../api/contentExplorer/itemWorkflowApi";
 import { findItemByPath } from "../api/contentExplorer/pathApi";
+import { bindExplorerPathItemId } from "../api/contentExplorer/pathItemId";
 import {
   executeView as executeViewApi,
   listViews as listViewsApi,
@@ -152,7 +153,12 @@ import {
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { resolvePublishKind } from "./itemPublish";
-import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import {
+  EMPTY_SELECTION,
+  isFolder,
+  sameExplorerItemId,
+  type Selection,
+} from "./selection";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 import {
   isFolderIdLookupPath,
@@ -605,7 +611,9 @@ function ContentExplorerShellInner({
     ...actionHandlers,
     onOpen: (item) => {
       if (isFolder(item)) {
-        setSelection({ folderPath: item.path, item: null });
+        const folderPath =
+          resolveExplorerListPath(item, item.path) ?? item.path;
+        setSelection({ folderPath, item: null });
         return;
       }
       onOpenItem(item);
@@ -748,7 +756,41 @@ function ContentExplorerShellInner({
   );
 
   const handleSelectItem = useCallback((item: PSPathItem) => {
-    setSelection((prev) => ({ ...prev, item }));
+    const bound = bindExplorerPathItemId(item);
+    setSelection((prev) => ({ ...prev, item: bound }));
+    // List rows that omit id / use a slug still resolve via path so
+    // View → Relationships can mount (#3546 / #2778).
+    if (
+      isFolder(bound) ||
+      parseExplorerContentId(bound.id) != null ||
+      !isFolderIdLookupPath(bound.path)
+    ) {
+      return;
+    }
+    void findItemByPath(bound.path)
+      .then((resolved) => {
+        const next = bindExplorerPathItemId({
+          ...bound,
+          ...resolved,
+          id: resolved.id ?? bound.id,
+          path: bound.path || resolved.path,
+        });
+        if (parseExplorerContentId(next.id) == null) {
+          return;
+        }
+        setSelection((prev) => {
+          if (prev.item == null) {
+            return prev;
+          }
+          const sameRow =
+            sameExplorerItemId(prev.item.id, bound.id) ||
+            (Boolean(prev.item.path) && prev.item.path === bound.path);
+          return sameRow ? { ...prev, item: next } : prev;
+        });
+      })
+      .catch(() => {
+        // Keep the list row; relationships stays hint if id never binds.
+      });
   }, []);
 
   const handleActivateItem = useCallback(
@@ -1152,6 +1194,10 @@ function ContentExplorerShellInner({
     !isFolder(selection.item) &&
     selection.item.id != null &&
     String(selection.item.id).trim().length > 0;
+  const hasRelationshipItem =
+    selection.item != null &&
+    !isFolder(selection.item) &&
+    parseExplorerContentId(selection.item.id) != null;
   const hasOpenSidePanel =
     showSearch ||
     showSecurity ||
@@ -1669,10 +1715,7 @@ function ContentExplorerShellInner({
           {message(EXPLORER_MSG.SUBFOLDER_COPY_SELECT_FOLDER)}
         </div>
       )}
-      {showRelationships &&
-        selection.item &&
-        selection.item.type !== "folder" &&
-        parseExplorerContentId(selection.item.id) != null && (
+      {showRelationships && hasRelationshipItem && (
           <section
             id="explorer-relationships-panel"
             style={sidePanelStyle}
@@ -1681,19 +1724,14 @@ function ContentExplorerShellInner({
           >
             <RelationshipsView
               item={{
-                id: String(selection.item.id),
-                path: selection.item.path,
+                id: String(selection.item!.id),
+                path: selection.item!.path,
                 folderPath: selection.folderPath || undefined,
               }}
             />
           </section>
         )}
-      {showRelationships &&
-        !(
-          selection.item &&
-          selection.item.type !== "folder" &&
-          parseExplorerContentId(selection.item.id) != null
-        ) && (
+      {showRelationships && !hasRelationshipItem && (
           <div
             id="explorer-relationships-panel"
             style={sidePanelStyle}

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -31,34 +31,13 @@ import {
   findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
 } from "../api/contentExplorer/actionMenuApi";
+import {
+  parseExplorerContentId,
+} from "../api/contentExplorer/pathItemId";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 
-export function parseExplorerContentId(
-  id: string | number | undefined,
-): number | null {
-  if (id == null || id === "") {
-    return null;
-  }
-  if (typeof id === "number") {
-    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
-  }
-  const s = String(id).trim();
-  if (!s) {
-    return null;
-  }
-  const whole = Number(s);
-  if (Number.isFinite(whole) && whole > 0) {
-    return Math.trunc(whole);
-  }
-  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
-  const last = s.split("-").pop();
-  if (!last) {
-    return null;
-  }
-  const n = Number(last);
-  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
-}
+export { parseExplorerContentId };
 
 function isCascadeParent(action: MenuAction): boolean {
   const type = (action.menuType ?? "").toUpperCase();

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1508,6 +1508,224 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
   });
 
+  it("relationships panel mounts for a GUID-shaped content row (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("relationships-view")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("relationships panel binds slug rows via sys_contentid (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "ci-home",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                  displayProperties: { sys_contentid: "708" },
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
+  it("relationships panel resolves omitted list id via path lookup (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/path/item/")) {
+        return new Response(
+          JSON.stringify({
+            PathItem: {
+              id: "1-101-708",
+              name: "Home",
+              path: "/Sites/Corporate_Investments/Pages/Home",
+              type: "rffHome",
+              category: "PAGE",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
   it("dependencies toggle shows select-item hint without a content selection (#2768)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -49,6 +49,7 @@ describe("parseExplorerContentId", () => {
     expect(parseExplorerContentId("")).toBeNull();
     expect(parseExplorerContentId("nope")).toBeNull();
     expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -87,6 +87,36 @@ describe("joinPathUrl", () => {
 });
 
 describe("paginatedFolder", () => {
+  it("binds parseable content ids onto childrenInPage rows (#3546)", async () => {
+    mockFetch(async () => {
+      return new Response(
+        JSON.stringify({
+          PagedItemList: {
+            childrenInPage: [
+              {
+                id: "ci-home",
+                name: "Home",
+                path: "/Sites/Corporate_Investments/Pages/Home",
+                type: "rffHome",
+                category: "PAGE",
+                displayProperties: { sys_contentid: "708" },
+              },
+            ],
+            childrenCount: 1,
+            startIndex: 0,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const res = await paginatedFolder("/Sites/Corporate_Investments/Pages", {
+      startIndex: 0,
+      maxResults: 50,
+    });
+    expect(res.children).toHaveLength(1);
+    expect(res.children[0]?.id).toBe("708");
+  });
+
   it("builds the paginated URL with required pagination params", async () => {
     const fn = mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  bindExplorerPathItemId,
+  parseExplorerContentId,
+  unwrapExplorerWireId,
+} from "../../../main/ts/api/contentExplorer/pathItemId";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+
+describe("parseExplorerContentId", () => {
+  it("parses finite numeric ids and rejects junk", () => {
+    expect(parseExplorerContentId("42")).toBe(42);
+    expect(parseExplorerContentId(7)).toBe(7);
+    expect(parseExplorerContentId("1-101-708")).toBe(708);
+    expect(parseExplorerContentId(undefined)).toBeNull();
+    expect(parseExplorerContentId("")).toBeNull();
+    expect(parseExplorerContentId("nope")).toBeNull();
+    expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId("ci-home")).toBeNull();
+  });
+
+  it("unwraps Jackson GUID objects (#3546)", () => {
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
+    expect(
+      parseExplorerContentId({ hostId: 1, type: 101, uuid: 708 }),
+    ).toBe(708);
+    expect(parseExplorerContentId({ id: 42 })).toBe(42);
+  });
+});
+
+describe("unwrapExplorerWireId", () => {
+  it("returns scalars and GUID object forms", () => {
+    expect(unwrapExplorerWireId("1-101-708")).toBe("1-101-708");
+    expect(unwrapExplorerWireId(42)).toBe(42);
+    expect(unwrapExplorerWireId({ stringValue: "1-101-9" })).toBe("1-101-9");
+    expect(unwrapExplorerWireId({ hostId: 0, type: 101, uuid: 3 })).toBe(
+      "0-101-3",
+    );
+    expect(unwrapExplorerWireId(null)).toBeUndefined();
+    expect(unwrapExplorerWireId({})).toBeUndefined();
+  });
+});
+
+describe("bindExplorerPathItemId (#3546)", () => {
+  const page = (over: Partial<PSPathItem>): PSPathItem => ({
+    name: "Home",
+    path: "/Sites/Corporate_Investments/Pages/Home",
+    type: "rffHome",
+    category: "PAGE",
+    ...over,
+  });
+
+  it("keeps a GUID-shaped id", () => {
+    const item = page({ id: "1-101-708" });
+    expect(bindExplorerPathItemId(item)).toBe(item);
+    expect(parseExplorerContentId(item.id)).toBe(708);
+  });
+
+  it("binds sys_contentid when id is omitted or a slug", () => {
+    const omitted = bindExplorerPathItemId(
+      page({
+        displayProperties: { sys_contentid: "708" },
+      }),
+    );
+    expect(omitted.id).toBe("708");
+    expect(parseExplorerContentId(omitted.id)).toBe(708);
+
+    const slug = bindExplorerPathItemId(
+      page({
+        id: "ci-home",
+        displayProperties: { sys_contentid: 708 },
+      }),
+    );
+    expect(slug.id).toBe("708");
+    expect(parseExplorerContentId(slug.id)).toBe(708);
+  });
+
+  it("unwraps a GUID object id", () => {
+    const bound = bindExplorerPathItemId(
+      page({
+        id: { stringValue: "1-101-708" } as unknown as string,
+      }),
+    );
+    expect(bound.id).toBe("1-101-708");
+    expect(parseExplorerContentId(bound.id)).toBe(708);
+  });
+
+  it("leaves a folder slug unchanged when nothing parseable is present", () => {
+    const folder: PSPathItem = {
+      id: "Corporate_Investments",
+      name: "Corporate_Investments",
+      path: "/Sites/Corporate_Investments/",
+      type: "site",
+    };
+    const bound = bindExplorerPathItemId(folder);
+    expect(bound.id).toBe("Corporate_Investments");
+    expect(parseExplorerContentId(bound.id)).toBeNull();
+  });
+});

--- a/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #3546 Relationships panel for content row
+
+**Branch:** `fix/issue-3546-relationships-content-row`  
+**Scope:** uncommitted vs `HEAD` (WebUI list/id bind, Explorer shell mount, Vitest, Playwright, product-docs)  
+**Date:** 2026-08-17  
+**Reviewer:** Erlang (pre-commit)
+
+## Summary
+
+Explorer Relationships stayed hint-only unless `selection.item.type !== "folder"` and `parseExplorerContentId(selection.item.id)` succeeded. Sample-site rows can omit `id`, use a slug (`ci-home`), or wrap a GUID object. This change binds a parseable content/GUID id onto path items at list unwrap (and path lookup on select), mounts the panel for any non-folder with a parseable id, and covers GUID + slug + omitted-id cases in Vitest plus a Playwright spec that requires a `data-row-kind="item"` row.
+
+Memory patterns hit: behavioral tests for new logic; WebUI Playwright companion; product-docs for operator-facing View → Relationships; CMS URL paths correctly use `/`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs, missing behavioral tests, or non-portable filesystem I/O. Change-class companions present (Vitest, Playwright, product-docs).
+
+## Cross-platform path checklist
+
+- No new OS filesystem joins (`"/"` / `"\\"` concatenation for files)
+- CMS Explorer paths remain URL-style `/` (correct)
+- Tests do not assert OS-specific absolute paths
+- N/A for installers / temp files
+
+## Issues
+
+None blocking.
+
+### nit
+
+- `handleSelectItem` path lookup is best-effort; a rapid second click is ignored via `sameRow`. Acceptable for this slice.
+
+## Tests / companions
+
+- `pathItemId.test.ts` — parse, unwrap, bind (GUID, slug+sys_contentid, folder slug)
+- `ContentExplorerShell.test.tsx` — GUID row → panel; slug bind → panel; omitted id + path lookup → panel; existing folder → hint
+- `pathApi.test.ts` — paginatedFolder binds `sys_contentid`
+- Playwright `explorer-relationships.spec.js` — content row must mount panel (not hint-only)
+- `product-docs/8.2/admin/content-explorer.md` — select page/asset; FastForward section folders

--- a/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Playwright surface: #2769 / parent #2400 — Explorer IA Relationships view.
+ * Playwright surface: #2769 / #3546 / parent #2400 — Explorer IA Relationships view.
  *
  * <p>Verifies the modern React Content Explorer shell exposes the Relationships
  * panel chrome (View → IA Relationships) and mounts {@code RelationshipsView}
@@ -83,55 +83,101 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
   );
 
   test(
-    "selecting a list row opens relationships panel or select-item hint",
+    "selecting a content row mounts the relationships panel (#3546)",
     { tag: ["@explorer-relationships", "@p-adv"] },
     async ({ page }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(90_000);
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      // Navigate into a structural root so the list has selectable children.
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      await expect(tree).toBeVisible({ timeout: 15_000 });
-      const sitesNode = page
-        .locator(
-          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-        )
-        .first();
-      if ((await sitesNode.count()) > 0) {
-        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        await listWaitReady(page);
-        await page.waitForLoadState("networkidle").catch(() => {});
+      async function fetchChildren(folderPath) {
+        const suffix = String(folderPath || "")
+          .replace(/^\/+/, "")
+          .replace(/\/+$/, "");
+        const url = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/paginatedFolder/${suffix}?startIndex=0&maxResults=50`;
+        const res = await page.request.get(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok()) {
+          return [];
+        }
+        const body = await res.json();
+        return body?.PagedItemList?.childrenInPage ?? [];
       }
+
+      function isContentChild(child) {
+        const type = String(child?.type ?? "").trim().toLowerCase();
+        const category = String(child?.category ?? "").trim().toLowerCase();
+        if (
+          type === "folder" ||
+          type === "fsfolder" ||
+          type === "site" ||
+          category === "folder" ||
+          category === "site" ||
+          category === "section_folder"
+        ) {
+          return false;
+        }
+        if (category === "page" || category === "asset" || category === "landing_page") {
+          return true;
+        }
+        return type.length > 0 && type !== "folder";
+      }
+
+      async function findFolderWithContent(startPath, depth) {
+        const children = await fetchChildren(startPath);
+        const items = children.filter(isContentChild);
+        if (items.length > 0) {
+          return { folderPath: startPath, items };
+        }
+        if (depth <= 0) {
+          return null;
+        }
+        for (const child of children) {
+          const next =
+            child.folderPath ||
+            child.path ||
+            (child.name ? `${startPath.replace(/\/+$/, "")}/${child.name}` : null);
+          if (!next) continue;
+          const found = await findFolderWithContent(next, depth - 1);
+          if (found) return found;
+        }
+        return null;
+      }
+
+      const found = await findFolderWithContent("/Sites", 4);
+      expect(
+        found,
+        "H2 sample sites should list at least one page/asset under Sites",
+      ).toBeTruthy();
+
+      const folderPath = found.folderPath.replace(/\/+$/, "") || "/Sites";
+      await page.goto(
+        `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&path=${encodeURIComponent(folderPath)}&_=${Date.now()}`,
+      );
+      await page.waitForLoadState("networkidle");
+      await listWaitReady(page);
 
       const list = page.locator('[data-testid="detail-list"]');
       await expect(list).toBeVisible({ timeout: 15_000 });
 
-      // Prefer an enabled row; force-click to survive list re-renders (H2 QA).
-      const enabledRows = list.locator(
-        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      const itemRow = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]:not([aria-disabled="true"])',
       );
-      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
-      const enabledCount = await enabledRows.count();
-      const anyCount = await anyRows.count();
-      if (enabledCount === 0 && anyCount === 0) {
-        await page.locator('[data-testid="explorer-menu-view"]').click();
-        await page
-          .locator('[data-testid="explorer-toggle-relationships"]')
-          .click();
-        await expect(
-          page.locator('[data-testid="explorer-relationships-hint"]'),
-        ).toBeVisible({ timeout: 5_000 });
-        return;
+
+      if ((await itemRow.count()) === 0) {
+        const first = found.items[0];
+        const idKey = first.id ?? first.path;
+        const byId = list.locator(`[data-testid="detail-row-${idKey}"]`);
+        if ((await byId.count()) > 0) {
+          await byId.first().click({ force: true, timeout: 10_000 });
+        }
+      } else {
+        await itemRow.first().click({ force: true, timeout: 10_000 });
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+      await expect(itemRow.first().or(list.locator('[data-selected="true"]'))).toBeVisible({
+        timeout: 10_000,
       });
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
@@ -139,37 +185,19 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
         .locator('[data-testid="explorer-toggle-relationships"]')
         .click();
 
-      // Either full panel (item with id) or select-item hint (folder / no id).
-      const panel = page.locator('[data-testid="relationships-view"]');
       const region = page.locator(
         '[data-testid="explorer-relationships-panel"]',
       );
-      const hint = page.locator(
-        '[data-testid="explorer-relationships-hint"]',
+      const panel = page.locator('[data-testid="relationships-view"]');
+      await expect(region).toBeVisible({ timeout: 15_000 });
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-relationships-hint"]'),
+      ).toHaveCount(0);
+      await expect(panel).toHaveAttribute(
+        "data-testid-state",
+        /ok|loading|auth|error/,
       );
-      await expect(panel.or(hint).or(region)).toBeVisible({ timeout: 15_000 });
-
-      if ((await panel.count()) > 0) {
-        await expect(panel).toHaveAttribute(
-          "data-testid-state",
-          /ok|loading|auth|error/,
-        );
-        await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
-          timeout: 20_000,
-        });
-        const state = await panel.getAttribute("data-testid-state");
-        if (state === "ok") {
-          await expect(
-            page.locator('[data-testid="relationships-primary"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-outgoing"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-incoming"]'),
-          ).toBeVisible();
-        }
-      }
     },
   );
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -323,7 +323,12 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  **page or asset** is selected (not a folder or site). On sample FastForward
+  sites, expand a site in the tree, open a section folder (for example
+  **AboutEnterpriseInvestments** — not only a `Pages` folder), and select a
+  content row. **View → Relationships** then mounts the relationships panel
+  (loading, results, empty, or an error). A folder-only or empty selection
+  keeps the select-item hint.
 - **Clipboard** — multi-select copy/cut staging when items are selected
 
 ## If Content Explorer cannot start


### PR DESCRIPTION
## Summary

Human QA on **#2778** could not open **View → Relationships** because the panel only mounted when `parseExplorerContentId(selection.item.id)` succeeded, and sample-site rows often omit `id`, use a slug (`ci-home`), or wrap a GUID object. Folder/site selection correctly stayed hint-only.

This slice binds a parseable content/GUID id onto path items at list unwrap (`sys_contentid`, Jackson `{stringValue}`, `host-type-uuid`) and, if still missing, resolves via `findItemByPath` on select. Relationships now use `!isFolder(item)` plus a parseable id. Folder/site selection still shows the hint.

Parent tracker / QA task: **#2778** (do **not** close). Epic: **#2400**.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3546
Partial #2778

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (cell `HEALTH:healthy`, HTTP 200; `qa-up`/`qa-health` also reported pre-existing FastForward `CI_PS_products_on.gif` import ERROR — not a `Failed startup of context`)
4. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
5. Playwright: `npm run test:surface -- --path tests/explorer-relationships.spec.js` — 2 passed
6. Golden: `npm run test:golden` — 2 passed
7. `python docker/scripts/perc-devctl.py qa-down`

Manual (later Human QA / #2778):
1. Login as Admin; open Explorer
2. Expand a sample site section folder (e.g. **AboutEnterpriseInvestments**, not only `Pages/`)
3. Select a **page/asset** row
4. **View → Relationships** — `explorer-relationships-panel` mounts (loading/ok/empty/error allowed)
5. Select a folder/site — hint remains

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (select page/asset; FastForward section folders)
- [x] **Unit / module tests** — `pathItemId.test.ts`, shell GUID/slug/path-lookup cases, `pathApi` bind; WebUI 2782 Vitest + 61 Surefire
- [x] **WebUI + Playwright** — `explorer-relationships.spec.js` requires a content row to mount the panel; golden smoke
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — CMS URL paths only (`/`); no OS filesystem joins

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2782 passed (375 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
- **downstream_checked:** none (no Java public API shape / `final` / signature change)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up` — cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`, Docker `Health=healthy`
- **qa-health:** HTTP 200 `/Rhythmyx/rest/mimetypes`; script `RESULT:FAIL DETAIL:server_log_errors` on pre-existing FastForward GIF import (known install noise, not `rhythmyx_context_failed`)
- **deploy:** docker cp generated `cm/modern/assets/` into Rhythmyx WAR (JS/CSS; no Jetty restart)
- **Playwright:** `npm run test:surface -- --path tests/explorer-relationships.spec.js` — 2 passed; `npm run test:golden` — 2 passed
- **console-clean:** yes (no test/pageerror failures on exercised paths)
- **server.log-clean:** yes for this feature; pre-existing FastForward `CI_PS_products_on.gif` import + search-index last-modifier noise at cell start (not Relationships)
- **qa-down:** RESULT:OK

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.