### PR TITLE
cluster: absorb Explorer Translations/Clipboard/Relationships thrash (#3547 #3548 #3549)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -47,6 +47,7 @@
 
 import { get, post, type ApiError } from "../client";
 import { PATHS } from "../paths";
+import { bindExplorerPathItemId } from "./pathItemId";
 import type {
   PSPathItem,
   PSPagedResult,
@@ -136,7 +137,7 @@ export function unwrapPathItemList(res: PSPathItemListResponse | null | undefine
     };
     throw err;
   }
-  return list;
+  return list.map(bindExplorerPathItemId);
 }
 
 export async function findChildren(path: string): Promise<PSPathItem[]> {
@@ -180,7 +181,7 @@ export async function paginatedFolder(
     return { children: [], totalCount: 0, startIndex: params.startIndex };
   }
   return {
-    children: paged.childrenInPage ?? [],
+    children: (paged.childrenInPage ?? []).map(bindExplorerPathItemId),
     totalCount: paged.childrenCount ?? undefined,
     startIndex: paged.startIndex ?? params.startIndex,
   };
@@ -207,14 +208,16 @@ export async function findItemByPath(path: string): Promise<PSPathItem> {
     return {} as PSPathItem;
   }
   const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function findItemById(id: string): Promise<PSPathItem> {
   const res = await get<PSPathItemResponse>(
     `${PATHS.PATH_ITEM_ID}/${encodeURIComponent(id)}`,
   );
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function addNewFolder(

--- a/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer list / selection content-id bind (#3546 / parent #2778).
+ *
+ * <p>Sample-site and display-format rows sometimes omit {@code id}, send a
+ * slug, or wrap a GUID as {@code {stringValue}} / host-type-uuid parts.
+ * Relationships (and other item tools) only mount when
+ * {@link parseExplorerContentId} succeeds — bind a parseable id onto the
+ * path item before the list hands it to selection.</p>
+ */
+
+import type { PSPathItem } from "./types";
+
+/** Display-format / type-property keys that carry a CMS content id. */
+const CONTENT_ID_KEYS = [
+  "sys_contentid",
+  "sys_contentId",
+  "contentId",
+  "contentid",
+  "sys_id",
+] as const;
+
+/**
+ * Flatten a wire id (string, number, or Jackson GUID object) to a scalar.
+ */
+export function unwrapExplorerWireId(
+  raw: unknown,
+): string | number | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "number" || typeof raw === "string") {
+    return raw;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const rec = raw as Record<string, unknown>;
+  const stringValue = rec.stringValue ?? rec.string_value;
+  if (typeof stringValue === "string" && stringValue.trim()) {
+    return stringValue.trim();
+  }
+  if (typeof rec.id === "string" || typeof rec.id === "number") {
+    return rec.id;
+  }
+  const host = rec.hostId ?? rec.host_id;
+  const type = rec.type;
+  const uuid = rec.uuid;
+  if (host != null && type != null && uuid != null) {
+    return `${host}-${type}-${uuid}`;
+  }
+  return undefined;
+}
+
+/**
+ * Parse a content id from a numeric string, GUID {@code host-type-uuid}
+ * (last segment), or Jackson GUID object.
+ *
+ * @returns positive integer content id, or {@code null}
+ */
+export function parseExplorerContentId(
+  id: string | number | undefined | unknown,
+): number | null {
+  if (id == null || id === "") {
+    return null;
+  }
+  if (typeof id === "number") {
+    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
+  }
+  if (typeof id === "object") {
+    const unwrapped = unwrapExplorerWireId(id);
+    if (unwrapped == null) {
+      return null;
+    }
+    return parseExplorerContentId(unwrapped);
+  }
+  const s = String(id).trim();
+  if (!s) {
+    return null;
+  }
+  const whole = Number(s);
+  if (Number.isFinite(whole) && whole > 0) {
+    return Math.trunc(whole);
+  }
+  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
+  const last = s.split("-").pop();
+  if (!last) {
+    return null;
+  }
+  const n = Number(last);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+}
+
+function collectTypePropertyMap(
+  typeProperties: unknown,
+): Record<string, unknown> | null {
+  if (typeProperties == null || typeof typeProperties !== "object") {
+    return null;
+  }
+  const rec = typeProperties as Record<string, unknown>;
+  const entries = rec.entries;
+  if (entries != null && typeof entries === "object" && !Array.isArray(entries)) {
+    return entries as Record<string, unknown>;
+  }
+  return rec;
+}
+
+/**
+ * Copy of {@code item} with {@code id} set to a parseable content/GUID
+ * string when the wire omitted it or used a non-GUID shape that still
+ * carries {@code sys_contentid} / a GUID object.
+ *
+ * Folders keep their original id when nothing parseable is found (site
+ * name slugs stay slugs).
+ */
+export function bindExplorerPathItemId(item: PSPathItem): PSPathItem {
+  const extras = item as PSPathItem & {
+    typeProperties?: unknown;
+    guid?: unknown;
+    Guid?: unknown;
+  };
+  const candidates: unknown[] = [item.id, extras.guid, extras.Guid];
+  const dp = item.displayProperties;
+  if (dp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(dp[key]);
+    }
+  }
+  const tp = collectTypePropertyMap(extras.typeProperties);
+  if (tp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(tp[key]);
+    }
+  }
+
+  for (const raw of candidates) {
+    const unwrapped = unwrapExplorerWireId(raw);
+    if (unwrapped == null) {
+      continue;
+    }
+    if (parseExplorerContentId(unwrapped) == null) {
+      continue;
+    }
+    const nextId =
+      typeof unwrapped === "string" ? unwrapped.trim() : String(unwrapped);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+
+  const unwrappedId = unwrapExplorerWireId(item.id);
+  if (typeof unwrappedId === "string" && unwrappedId !== item.id) {
+    return { ...item, id: unwrappedId };
+  }
+  if (typeof unwrappedId === "number") {
+    const nextId = String(unwrappedId);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+  return item;
+}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -83,6 +83,7 @@ import {
   transitionItem,
 } from "../api/contentExplorer/itemWorkflowApi";
 import { findItemByPath } from "../api/contentExplorer/pathApi";
+import { bindExplorerPathItemId } from "../api/contentExplorer/pathItemId";
 import {
   executeView as executeViewApi,
   listViews as listViewsApi,
@@ -152,7 +153,12 @@ import {
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { resolvePublishKind } from "./itemPublish";
-import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import {
+  EMPTY_SELECTION,
+  isFolder,
+  sameExplorerItemId,
+  type Selection,
+} from "./selection";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 import {
   isFolderIdLookupPath,
@@ -605,7 +611,9 @@ function ContentExplorerShellInner({
     ...actionHandlers,
     onOpen: (item) => {
       if (isFolder(item)) {
-        setSelection({ folderPath: item.path, item: null });
+        const folderPath =
+          resolveExplorerListPath(item, item.path) ?? item.path;
+        setSelection({ folderPath, item: null });
         return;
       }
       onOpenItem(item);
@@ -748,7 +756,41 @@ function ContentExplorerShellInner({
   );
 
   const handleSelectItem = useCallback((item: PSPathItem) => {
-    setSelection((prev) => ({ ...prev, item }));
+    const bound = bindExplorerPathItemId(item);
+    setSelection((prev) => ({ ...prev, item: bound }));
+    // List rows that omit id / use a slug still resolve via path so
+    // View → Relationships can mount (#3546 / #2778).
+    if (
+      isFolder(bound) ||
+      parseExplorerContentId(bound.id) != null ||
+      !isFolderIdLookupPath(bound.path)
+    ) {
+      return;
+    }
+    void findItemByPath(bound.path)
+      .then((resolved) => {
+        const next = bindExplorerPathItemId({
+          ...bound,
+          ...resolved,
+          id: resolved.id ?? bound.id,
+          path: bound.path || resolved.path,
+        });
+        if (parseExplorerContentId(next.id) == null) {
+          return;
+        }
+        setSelection((prev) => {
+          if (prev.item == null) {
+            return prev;
+          }
+          const sameRow =
+            sameExplorerItemId(prev.item.id, bound.id) ||
+            (Boolean(prev.item.path) && prev.item.path === bound.path);
+          return sameRow ? { ...prev, item: next } : prev;
+        });
+      })
+      .catch(() => {
+        // Keep the list row; relationships stays hint if id never binds.
+      });
   }, []);
 
   const handleActivateItem = useCallback(
@@ -1152,6 +1194,10 @@ function ContentExplorerShellInner({
     !isFolder(selection.item) &&
     selection.item.id != null &&
     String(selection.item.id).trim().length > 0;
+  const hasRelationshipItem =
+    selection.item != null &&
+    !isFolder(selection.item) &&
+    parseExplorerContentId(selection.item.id) != null;
   const hasOpenSidePanel =
     showSearch ||
     showSecurity ||
@@ -1669,10 +1715,7 @@ function ContentExplorerShellInner({
           {message(EXPLORER_MSG.SUBFOLDER_COPY_SELECT_FOLDER)}
         </div>
       )}
-      {showRelationships &&
-        selection.item &&
-        selection.item.type !== "folder" &&
-        parseExplorerContentId(selection.item.id) != null && (
+      {showRelationships && hasRelationshipItem && (
           <section
             id="explorer-relationships-panel"
             style={sidePanelStyle}
@@ -1681,19 +1724,14 @@ function ContentExplorerShellInner({
           >
             <RelationshipsView
               item={{
-                id: String(selection.item.id),
-                path: selection.item.path,
+                id: String(selection.item!.id),
+                path: selection.item!.path,
                 folderPath: selection.folderPath || undefined,
               }}
             />
           </section>
         )}
-      {showRelationships &&
-        !(
-          selection.item &&
-          selection.item.type !== "folder" &&
-          parseExplorerContentId(selection.item.id) != null
-        ) && (
+      {showRelationships && !hasRelationshipItem && (
           <div
             id="explorer-relationships-panel"
             style={sidePanelStyle}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1304,7 +1304,6 @@ function ContentExplorerShellInner({
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
-            clipboardItemCount={clipboard.items.length}
             hasSiteContext={hasSiteContext}
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -52,8 +52,6 @@ export interface ExplorerMenuBarProps {
   showSubfolderCopy?: boolean;
   /** Multi-select size for clipboard-add disable + status badge. */
   multiSelectedCount: number;
-  /** Clipboard size — enables View → Clipboard when non-empty. */
-  clipboardItemCount: number;
   /**
    * True when the current folder/selection is under {@code /Sites/&lt;name&gt;}.
    * Enables Content → Site Copy (#2767).
@@ -186,15 +184,11 @@ function menuItemTestId(item: ExplorerMenuBarItem): string {
 function isItemDisabled(
   item: ExplorerMenuBarItem,
   multiSelectedCount: number,
-  clipboardItemCount: number,
   hasSiteContext: boolean,
   hasFolderContext: boolean,
 ): boolean {
   if (item.disabledWhen === "noSelection") {
     return multiSelectedCount === 0;
-  }
-  if (item.disabledWhen === "noClipboardContext") {
-    return multiSelectedCount === 0 && clipboardItemCount === 0;
   }
   if (item.disabledWhen === "noSiteContext") {
     return !hasSiteContext;
@@ -218,7 +212,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showSiteCopy = false,
     showSubfolderCopy = false,
     multiSelectedCount,
-    clipboardItemCount,
     hasSiteContext = false,
     hasFolderContext = false,
     displayFormats,
@@ -269,7 +262,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
       isItemDisabled(
         item,
         multiSelectedCount,
-        clipboardItemCount,
         hasSiteContext,
         hasFolderContext,
       )
@@ -343,7 +335,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                     const disabled = isItemDisabled(
                       item,
                       multiSelectedCount,
-                      clipboardItemCount,
                       hasSiteContext,
                       hasFolderContext,
                     );

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -39,6 +39,7 @@ import {
 } from "../api/contentExplorer/translationsApi";
 import { formatApiError } from "../api/client";
 import { message } from "../i18n/message";
+import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
 
 export interface TranslationsPanelProps {
@@ -84,9 +85,15 @@ async function defaultCreateVariants(body: {
   return createTranslations(body);
 }
 
-function parseNumericItemId(itemId: string): number | null {
-  const n = Number(itemId);
-  return Number.isFinite(n) && n > 0 ? n : null;
+/**
+ * Resolve Explorer row id to a legacy content id.
+ *
+ * <p>List rows are usually Percussion GUIDs ({@code 1-101-708}); {@link
+ * Number}({@code itemId}) is NaN for those and must not be used (#3545 /
+ * parent #2649). Folders/sites with no content id still return null.
+ */
+function resolveTranslationsContentId(itemId: string): number | null {
+  return parseExplorerContentId(itemId);
 }
 
 function roleLabel(role: string | null | undefined): string {
@@ -130,10 +137,15 @@ export function TranslationsPanel(
       setState({ kind: "auth" });
       return;
     }
+    const resolvedId = resolveTranslationsContentId(itemId);
+    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
+    // numeric string still loads. Folders with no content id stay null.
+    const variantsKey =
+      resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });
     setCreateError(null);
     setCreateSuccess(null);
-    loadVariants(itemId)
+    loadVariants(variantsKey)
       .then((data) => {
         if (!alive) return;
         setState({ kind: "ok", data });
@@ -197,7 +209,7 @@ export function TranslationsPanel(
   }, []);
 
   const handleCreate = useCallback(async () => {
-    const numericId = parseNumericItemId(itemId);
+    const numericId = resolveTranslationsContentId(itemId);
     if (numericId == null) {
       setCreateError(message(EXPLORER_MSG.TRANSLATIONS_INVALID_ITEM));
       return;

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -138,8 +138,9 @@ export function TranslationsPanel(
       return;
     }
     const resolvedId = resolveTranslationsContentId(itemId);
-    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
-    // numeric string still loads. Folders with no content id stay null.
+    // GUID last segment (1-101-708 → 708). Parse-null does not skip GET:
+    // loadVariants still receives the raw itemId (unit tests / direct mounts).
+    // The Explorer shell never mounts this panel for folders/sites.
     const variantsKey =
       resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -58,7 +58,6 @@ export interface ExplorerMenuBarItem {
   /** Optional disabled predicate flag name resolved by the host. */
   disabledWhen?:
     | "noSelection"
-    | "noClipboardContext"
     | "noSiteContext"
     | "noFolderContext";
 }
@@ -174,8 +173,8 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.CLIPBOARD_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_CLIPBOARD_ARIA,
           testId: "explorer-toggle-clipboard",
+          /** Always enabled so empty clipboard can still be viewed (#3544). */
           toggle: true,
-          disabledWhen: "noClipboardContext",
         },
       ],
     },

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -31,34 +31,13 @@ import {
   findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
 } from "../api/contentExplorer/actionMenuApi";
+import {
+  parseExplorerContentId,
+} from "../api/contentExplorer/pathItemId";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 
-export function parseExplorerContentId(
-  id: string | number | undefined,
-): number | null {
-  if (id == null || id === "") {
-    return null;
-  }
-  if (typeof id === "number") {
-    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
-  }
-  const s = String(id).trim();
-  if (!s) {
-    return null;
-  }
-  const whole = Number(s);
-  if (Number.isFinite(whole) && whole > 0) {
-    return Math.trunc(whole);
-  }
-  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
-  const last = s.split("-").pop();
-  if (!last) {
-    return null;
-  }
-  const n = Number(last);
-  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
-}
+export { parseExplorerContentId };
 
 function isCascadeParent(action: MenuAction): boolean {
   const type = (action.menuType ?? "").toUpperCase();

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1175,6 +1175,47 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("View → Clipboard opens the empty clipboard panel and toggles aria-checked (#3544)", async () => {
+    stubPathFetch();
+    const { container } = renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-view")).toBeInTheDocument(),
+    );
+    openViewMenu();
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-clipboard"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+    await renderA11yGate(container);
+  });
+
   it("translations toggle shows select-item hint without a content selection (#2430)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1193,6 +1193,76 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("translations-panel")).toBeNull();
   });
 
+  it("GUID list row opens translations panel (not select-item hint) (#3545)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/content-explorer/translations/")) {
+        return new Response(
+          JSON.stringify({
+            itemId: 708,
+            locale: "en-us",
+            variants: [
+              { contentId: 708, locale: "en-us", role: "source", revision: 1 },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-translations"));
+    await waitFor(() => {
+      expect(screen.getByTestId("translations-panel")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-translations-hint")).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-708")).toBeTruthy();
+  });
+
   it("Content → Site Copy mounts wizard with source from /Sites/<name> (#2767)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1508,6 +1508,224 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
   });
 
+  it("relationships panel mounts for a GUID-shaped content row (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("relationships-view")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("relationships panel binds slug rows via sys_contentid (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "ci-home",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                  displayProperties: { sys_contentid: "708" },
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
+  it("relationships panel resolves omitted list id via path lookup (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/path/item/")) {
+        return new Response(
+          JSON.stringify({
+            PathItem: {
+              id: "1-101-708",
+              name: "Home",
+              path: "/Sites/Corporate_Investments/Pages/Home",
+              type: "rffHome",
+              category: "PAGE",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
   it("dependencies toggle shows select-item hint without a content selection (#2768)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -34,7 +34,6 @@ function renderBar(
       showDependencies={false}
       showClipboard={false}
       multiSelectedCount={0}
-      clipboardItemCount={0}
       displayFormats={[]}
       selectedFormatKey=""
       onSelectFormat={onSelectFormat}
@@ -89,6 +88,37 @@ describe("ExplorerMenuBar (#2731)", () => {
     );
     fireEvent.click(contentSearch);
     expect(onCommand).toHaveBeenCalledWith("content-search");
+  });
+
+  it("View → Clipboard is enabled with empty clipboard and invokes view-clipboard (#3544)", () => {
+    const { onCommand } = renderBar({
+      multiSelectedCount: 0,
+      showClipboard: false,
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("role")).toBe("menuitemcheckbox");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
+    fireEvent.click(toggle);
+    expect(onCommand).toHaveBeenCalledWith("view-clipboard");
+  });
+
+  it("View → Clipboard reflects showClipboard on aria-checked (#3544)", () => {
+    renderBar({ showClipboard: true, multiSelectedCount: 0 });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const checked = screen.getByTestId("explorer-toggle-clipboard");
+    expect(checked.getAttribute("aria-checked")).toBe("true");
+    expect(checked.getAttribute("aria-expanded")).toBe("true");
+    expect(checked.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
   });
 
   it("View → Folder Security menu item invokes view-security (#3268)", () => {

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -90,6 +90,30 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("resolves GUID Explorer row ids for variants GET (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        itemLabel="Home"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-335")).toBeTruthy();
+    expect(screen.getByTestId("translations-variant-row-900")).toBeTruthy();
+  });
+
   it("create-variant POSTs selected locales via injection seam", async () => {
     const createVariants = vi.fn(async () => ({
       created: [
@@ -127,6 +151,73 @@ describe("TranslationsPanel", () => {
       expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
     );
     expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("create-variant POSTs GUID last-segment content id (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    const createVariants = vi.fn(async () => ({
+      created: [
+        {
+          contentId: 901,
+          locale: "de-de",
+          role: "translation",
+          sourceContentId: 708,
+        },
+      ],
+    }));
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() => expect(createVariants).toHaveBeenCalledTimes(1));
+    expect(createVariants).toHaveBeenCalledWith({
+      itemIds: [708],
+      locales: ["de-de"],
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("translations-create-error"),
+    ).toBeNull();
+  });
+
+  it("keeps the no-id create message for folder-like ids without a content id", async () => {
+    const createVariants = vi.fn(async () => ({ created: [] }));
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={async () => SAMPLE_VARIANTS}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-error")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("translations-create-error")).toHaveTextContent(
+      /does not have a numeric content id/i,
+    );
+    expect(createVariants).not.toHaveBeenCalled();
   });
 
   it("maps create 403 to permission chrome", async () => {

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -194,6 +194,24 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("GET variants with the raw itemId when parse yields null", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("//Sites/Demo");
+  });
+
   it("keeps the no-id create message for folder-like ids without a content id", async () => {
     const createVariants = vi.fn(async () => ({ created: [] }));
     render(

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -53,6 +53,14 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(byId["view-clipboard"]).toBe("explorer-toggle-clipboard");
   });
 
+  it("View → Clipboard is an always-enabled toggle (#3544)", () => {
+    const view = buildExplorerMenuBarGroups().find((g) => g.id === "view");
+    const clipboard = view?.items.find((i) => i.id === "view-clipboard");
+    expect(clipboard?.toggle).toBe(true);
+    expect(clipboard?.disabledWhen).toBeUndefined();
+    expect(clipboard?.testId).toBe("explorer-toggle-clipboard");
+  });
+
   it("puts clipboard-add under Content with stable test id", () => {
     const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
     const add = content?.items.find((i) => i.id === "content-clipboard-add");

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -49,6 +49,7 @@ describe("parseExplorerContentId", () => {
     expect(parseExplorerContentId("")).toBeNull();
     expect(parseExplorerContentId("nope")).toBeNull();
     expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -87,6 +87,36 @@ describe("joinPathUrl", () => {
 });
 
 describe("paginatedFolder", () => {
+  it("binds parseable content ids onto childrenInPage rows (#3546)", async () => {
+    mockFetch(async () => {
+      return new Response(
+        JSON.stringify({
+          PagedItemList: {
+            childrenInPage: [
+              {
+                id: "ci-home",
+                name: "Home",
+                path: "/Sites/Corporate_Investments/Pages/Home",
+                type: "rffHome",
+                category: "PAGE",
+                displayProperties: { sys_contentid: "708" },
+              },
+            ],
+            childrenCount: 1,
+            startIndex: 0,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const res = await paginatedFolder("/Sites/Corporate_Investments/Pages", {
+      startIndex: 0,
+      maxResults: 50,
+    });
+    expect(res.children).toHaveLength(1);
+    expect(res.children[0]?.id).toBe("708");
+  });
+
   it("builds the paginated URL with required pagination params", async () => {
     const fn = mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  bindExplorerPathItemId,
+  parseExplorerContentId,
+  unwrapExplorerWireId,
+} from "../../../main/ts/api/contentExplorer/pathItemId";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+
+describe("parseExplorerContentId", () => {
+  it("parses finite numeric ids and rejects junk", () => {
+    expect(parseExplorerContentId("42")).toBe(42);
+    expect(parseExplorerContentId(7)).toBe(7);
+    expect(parseExplorerContentId("1-101-708")).toBe(708);
+    expect(parseExplorerContentId(undefined)).toBeNull();
+    expect(parseExplorerContentId("")).toBeNull();
+    expect(parseExplorerContentId("nope")).toBeNull();
+    expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId("ci-home")).toBeNull();
+  });
+
+  it("unwraps Jackson GUID objects (#3546)", () => {
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
+    expect(
+      parseExplorerContentId({ hostId: 1, type: 101, uuid: 708 }),
+    ).toBe(708);
+    expect(parseExplorerContentId({ id: 42 })).toBe(42);
+  });
+});
+
+describe("unwrapExplorerWireId", () => {
+  it("returns scalars and GUID object forms", () => {
+    expect(unwrapExplorerWireId("1-101-708")).toBe("1-101-708");
+    expect(unwrapExplorerWireId(42)).toBe(42);
+    expect(unwrapExplorerWireId({ stringValue: "1-101-9" })).toBe("1-101-9");
+    expect(unwrapExplorerWireId({ hostId: 0, type: 101, uuid: 3 })).toBe(
+      "0-101-3",
+    );
+    expect(unwrapExplorerWireId(null)).toBeUndefined();
+    expect(unwrapExplorerWireId({})).toBeUndefined();
+  });
+});
+
+describe("bindExplorerPathItemId (#3546)", () => {
+  const page = (over: Partial<PSPathItem>): PSPathItem => ({
+    name: "Home",
+    path: "/Sites/Corporate_Investments/Pages/Home",
+    type: "rffHome",
+    category: "PAGE",
+    ...over,
+  });
+
+  it("keeps a GUID-shaped id", () => {
+    const item = page({ id: "1-101-708" });
+    expect(bindExplorerPathItemId(item)).toBe(item);
+    expect(parseExplorerContentId(item.id)).toBe(708);
+  });
+
+  it("binds sys_contentid when id is omitted or a slug", () => {
+    const omitted = bindExplorerPathItemId(
+      page({
+        displayProperties: { sys_contentid: "708" },
+      }),
+    );
+    expect(omitted.id).toBe("708");
+    expect(parseExplorerContentId(omitted.id)).toBe(708);
+
+    const slug = bindExplorerPathItemId(
+      page({
+        id: "ci-home",
+        displayProperties: { sys_contentid: 708 },
+      }),
+    );
+    expect(slug.id).toBe("708");
+    expect(parseExplorerContentId(slug.id)).toBe(708);
+  });
+
+  it("unwraps a GUID object id", () => {
+    const bound = bindExplorerPathItemId(
+      page({
+        id: { stringValue: "1-101-708" } as unknown as string,
+      }),
+    );
+    expect(bound.id).toBe("1-101-708");
+    expect(parseExplorerContentId(bound.id)).toBe(708);
+  });
+
+  it("leaves a folder slug unchanged when nothing parseable is present", () => {
+    const folder: PSPathItem = {
+      id: "Corporate_Investments",
+      name: "Corporate_Investments",
+      path: "/Sites/Corporate_Investments/",
+      type: "site",
+    };
+    const bound = bindExplorerPathItemId(folder);
+    expect(bound.id).toBe("Corporate_Investments");
+    expect(parseExplorerContentId(bound.id)).toBeNull();
+  });
+});

--- a/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
+++ b/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — #3544 View → Clipboard toggle
+
+**Branch:** `fix/issue-3544-view-clipboard-toggle`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure (WebUI screen + Playwright + product-docs); missing behavioral tests for new/changed logic.
+
+## Summary
+
+Parent QA #2741 failed because **View → Clipboard** (`explorer-toggle-clipboard`) stayed `aria-checked=false` and `explorer-clipboard-panel` never appeared. `ContentExplorerShell` already flipped `showClipboard` on `view-clipboard`; the menu item was gated with `disabledWhen: "noClipboardContext"` so `activateItem` returned without calling `onCommand` whenever multi-select and clipboard were both empty.
+
+This change removes that disable so the View toggle always works (empty clipboard panel is an accepted state). `Content → Add to clipboard` still uses `noSelection`. Companions: Vitest (model, menubar, shell + a11y), Playwright surface (`explorer-menu-bar.spec.js` + `explorer-multiselect.spec.js` aria-checked), product-docs `content-explorer.md`.
+
+## Issues
+
+None that are hard-gate bugs.
+
+### Suggestion (low)
+
+`clipboardItemCount` was removed from `ExplorerMenuBarProps` because it only fed the disable predicate. If a later badge needs the count, reintroduce it as display-only — do not re-gate the View toggle.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Menu model (`view-clipboard` always enabled) | Done |
+| Menu bar activate + `aria-checked` | Done |
+| Shell `setShowClipboard` + panel mount | Already present; shell test added |
+| Vitest (model, menubar, shell a11y) | Done |
+| Playwright explorer menu-bar + multiselect | Done |
+| Product-docs (`content-explorer.md` View tools) | Done |
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path joins; URL/`data-testid` strings only.
+
+## Tests
+
+- Focused Vitest: ExplorerMenuBar 18, menuBarModel 9, ContentExplorerShell 49 (clipboard toggle included)
+- WebUI standalone `cd WebUI && ../mvnw.cmd clean install`: BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2775 passed (374 files)
+- perc-qa-automation helper unit: explorer-menu-bar ids include clipboard toggle/panel
+- C5 Playwright on H2 QA (`TEST_CMS_URL=http://127.0.0.1:9993`, cell `perc-matrix-cms-h2`, Health=healthy, HTTP 200 after Jetty in-cell restart):
+  - `npm run test:surface -- --path tests/explorer-menu-bar.spec.js --path tests/explorer-multiselect.spec.js` — 7 passed (including View → Clipboard empty toggle `#3544`)
+  - `npm run test:golden` — 2 passed
+  - console-clean=yes (pageerror/console listener on `#3544` spec)
+  - server.log-clean=yes for the post-restart Playwright window (no new ERROR/FATAL after `2026-08-18 03:17:50`; remaining ERRORs are pre-existing FastForward import / search-index last-modifier noise from first cell start)

--- a/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
+++ b/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review: Translations GUID content id for variants + create-variant (#3545)
+
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Base:** `origin/main`  
+**Date:** 2026-08-17  
+**Persona:** Erlang (independent of implementer)
+
+Parent QA #2649 (Failed of #2430): Explorer Translations used `Number(itemId)`
+only. List rows are Percussion GUIDs (`1-101-708`); create-variant then emitted
+`Selected item does not have a numeric content id`.
+
+## Summary
+
+`TranslationsPanel` now resolves Explorer row ids with `parseExplorerContentId`
+(GUID last segment) for variants GET (`708`) and create-variant POST
+`itemIds: [708]`. Folders/sites with no content id still return null and keep
+the existing no-id create message. Shell already gated the panel with
+`parseExplorerContentId`; a GUID-row shell test plus Vitest GUID create body
+and Playwright intercept cover the user-visible path. Product-docs note the
+GUID last-segment behavior.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests exercise GUID parse → GET key and POST body.
+Playwright companion updated. No public Java API shape change. No filesystem
+path I/O.
+
+## Change-class closure
+
+Change class: **WebUI Explorer product screen (Translations panel GUID id)**.
+
+| Companion | Status |
+|-----------|--------|
+| `TranslationsPanel` parse via `parseExplorerContentId` | present |
+| Vitest GUID GET + create body + no-id folder path | present |
+| Shell GUID row mounts panel | present |
+| Playwright `explorer-translations.spec.js` | present (create intercept) |
+| product-docs `8.2/admin/content-explorer.md` | present |
+| i18n / a11y | existing keys + axe gates; no new chrome strings |
+
+## Cross-platform path checklist
+
+No filesystem path construction. REST URLs and GUID tokens use `/` and `-`
+as protocol forms, not OS paths. **Outcome: clean.**
+
+Memory patterns hit: missing behavioral tests (covered); WebUI Playwright
+companion (updated); change-class product-docs (updated).
+
+## Issues
+
+None blocking.
+
+### nit
+
+`resolveTranslationsContentId` is a one-line alias of `parseExplorerContentId`.
+Acceptable as a named call-site comment; not required to inline.
+
+C5 live Playwright against H2 QA is a process gate after this review, not a
+code defect.

--- a/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — PR #3547 review follow-up (#3545)
+
+**Date:** 2026-08-18  
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Scope:** uncommitted review-response (comment accuracy + Playwright detach retry)
+
+## Summary
+
+Kilo threads on #3547: (1) `variantsKey` comment claimed folders stay null while
+code falls back to raw `itemId`; (2) item-row click lacked the detach retry used
+for folder rows. Comment rewritten, unit test asserts GET uses the raw token on
+parse-null, Playwright helper retries item (and folder fallback) clicks.
+
+## Recommendation
+
+**approve** — May commit/push: **yes**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: new Vitest case for parse-null GET fallback
+- Cross-platform path review: N/A (no filesystem I/O)
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Orphaned JSDoc above extracted helper — fixed before commit
+- Public helper comment contradicting implementation — addressed
+
+> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #3546 Relationships panel for content row
+
+**Branch:** `fix/issue-3546-relationships-content-row`  
+**Scope:** uncommitted vs `HEAD` (WebUI list/id bind, Explorer shell mount, Vitest, Playwright, product-docs)  
+**Date:** 2026-08-17  
+**Reviewer:** Erlang (pre-commit)
+
+## Summary
+
+Explorer Relationships stayed hint-only unless `selection.item.type !== "folder"` and `parseExplorerContentId(selection.item.id)` succeeded. Sample-site rows can omit `id`, use a slug (`ci-home`), or wrap a GUID object. This change binds a parseable content/GUID id onto path items at list unwrap (and path lookup on select), mounts the panel for any non-folder with a parseable id, and covers GUID + slug + omitted-id cases in Vitest plus a Playwright spec that requires a `data-row-kind="item"` row.
+
+Memory patterns hit: behavioral tests for new logic; WebUI Playwright companion; product-docs for operator-facing View → Relationships; CMS URL paths correctly use `/`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs, missing behavioral tests, or non-portable filesystem I/O. Change-class companions present (Vitest, Playwright, product-docs).
+
+## Cross-platform path checklist
+
+- No new OS filesystem joins (`"/"` / `"\\"` concatenation for files)
+- CMS Explorer paths remain URL-style `/` (correct)
+- Tests do not assert OS-specific absolute paths
+- N/A for installers / temp files
+
+## Issues
+
+None blocking.
+
+### nit
+
+- `handleSelectItem` path lookup is best-effort; a rapid second click is ignored via `sameRow`. Acceptable for this slice.
+
+## Tests / companions
+
+- `pathItemId.test.ts` — parse, unwrap, bind (GUID, slug+sys_contentid, folder slug)
+- `ContentExplorerShell.test.tsx` — GUID row → panel; slug bind → panel; omitted id + path lookup → panel; existing folder → hint
+- `pathApi.test.ts` — paginatedFolder binds `sys_contentid`
+- Playwright `explorer-relationships.spec.js` — content row must mount panel (not hint-only)
+- `product-docs/8.2/admin/content-explorer.md` — select page/asset; FastForward section folders

--- a/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
@@ -96,6 +96,49 @@ test.describe("modern React Content Explorer — DCE menu bar chrome (#2731)", (
   );
 
   test(
+    "View → Clipboard opens empty panel and sets aria-checked (#3544)",
+    { tag: ["@explorer-menu-bar", "@explorer", "@issue-3544"] },
+    async ({ page }) => {
+      const errors = [];
+      page.on("pageerror", (err) => errors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 15_000 });
+
+      await openViewMenu(page);
+      const toggle = page.locator(
+        `[data-testid="${TEST_IDS.toggleClipboard}"]`,
+      );
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toBeEnabled();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toBeVisible({ timeout: 5_000 });
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      expect(errors, `JS console/page errors: ${errors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
     "server action toolbar still mounts under menu bar",
     { tag: ["@explorer-menu-bar", "@explorer"] },
     async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
@@ -90,12 +90,15 @@ test.describe("modern React Content Explorer — multi-select + clipboard (#2408
     await rowCheckboxes.nth(0).check();
     await rowCheckboxes.nth(1).check();
 
-    // #2731: clipboard-add lives under Content menu; clipboard toggle under View.
+    // #2731 / #3544: Add lives under Content; it also opens the clipboard
+    // panel. View → Clipboard must already be checked — do not click it
+    // again here or the toggle would hide the panel.
     await page.locator('[data-testid="explorer-menu-content"]').click();
     await page.locator('[data-testid="explorer-clipboard-add"]').click();
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
-    await page.locator('[data-testid="explorer-toggle-clipboard"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-clipboard"]');
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
     const panel = page.locator('[data-testid="explorer-clipboard-panel"]');
     await expect(panel).toBeVisible();
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Playwright surface: #2769 / parent #2400 — Explorer IA Relationships view.
+ * Playwright surface: #2769 / #3546 / parent #2400 — Explorer IA Relationships view.
  *
  * <p>Verifies the modern React Content Explorer shell exposes the Relationships
  * panel chrome (View → IA Relationships) and mounts {@code RelationshipsView}
@@ -83,55 +83,101 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
   );
 
   test(
-    "selecting a list row opens relationships panel or select-item hint",
+    "selecting a content row mounts the relationships panel (#3546)",
     { tag: ["@explorer-relationships", "@p-adv"] },
     async ({ page }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(90_000);
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      // Navigate into a structural root so the list has selectable children.
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      await expect(tree).toBeVisible({ timeout: 15_000 });
-      const sitesNode = page
-        .locator(
-          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-        )
-        .first();
-      if ((await sitesNode.count()) > 0) {
-        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        await listWaitReady(page);
-        await page.waitForLoadState("networkidle").catch(() => {});
+      async function fetchChildren(folderPath) {
+        const suffix = String(folderPath || "")
+          .replace(/^\/+/, "")
+          .replace(/\/+$/, "");
+        const url = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/paginatedFolder/${suffix}?startIndex=0&maxResults=50`;
+        const res = await page.request.get(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok()) {
+          return [];
+        }
+        const body = await res.json();
+        return body?.PagedItemList?.childrenInPage ?? [];
       }
+
+      function isContentChild(child) {
+        const type = String(child?.type ?? "").trim().toLowerCase();
+        const category = String(child?.category ?? "").trim().toLowerCase();
+        if (
+          type === "folder" ||
+          type === "fsfolder" ||
+          type === "site" ||
+          category === "folder" ||
+          category === "site" ||
+          category === "section_folder"
+        ) {
+          return false;
+        }
+        if (category === "page" || category === "asset" || category === "landing_page") {
+          return true;
+        }
+        return type.length > 0 && type !== "folder";
+      }
+
+      async function findFolderWithContent(startPath, depth) {
+        const children = await fetchChildren(startPath);
+        const items = children.filter(isContentChild);
+        if (items.length > 0) {
+          return { folderPath: startPath, items };
+        }
+        if (depth <= 0) {
+          return null;
+        }
+        for (const child of children) {
+          const next =
+            child.folderPath ||
+            child.path ||
+            (child.name ? `${startPath.replace(/\/+$/, "")}/${child.name}` : null);
+          if (!next) continue;
+          const found = await findFolderWithContent(next, depth - 1);
+          if (found) return found;
+        }
+        return null;
+      }
+
+      const found = await findFolderWithContent("/Sites", 4);
+      expect(
+        found,
+        "H2 sample sites should list at least one page/asset under Sites",
+      ).toBeTruthy();
+
+      const folderPath = found.folderPath.replace(/\/+$/, "") || "/Sites";
+      await page.goto(
+        `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&path=${encodeURIComponent(folderPath)}&_=${Date.now()}`,
+      );
+      await page.waitForLoadState("networkidle");
+      await listWaitReady(page);
 
       const list = page.locator('[data-testid="detail-list"]');
       await expect(list).toBeVisible({ timeout: 15_000 });
 
-      // Prefer an enabled row; force-click to survive list re-renders (H2 QA).
-      const enabledRows = list.locator(
-        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      const itemRow = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]:not([aria-disabled="true"])',
       );
-      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
-      const enabledCount = await enabledRows.count();
-      const anyCount = await anyRows.count();
-      if (enabledCount === 0 && anyCount === 0) {
-        await page.locator('[data-testid="explorer-menu-view"]').click();
-        await page
-          .locator('[data-testid="explorer-toggle-relationships"]')
-          .click();
-        await expect(
-          page.locator('[data-testid="explorer-relationships-hint"]'),
-        ).toBeVisible({ timeout: 5_000 });
-        return;
+
+      if ((await itemRow.count()) === 0) {
+        const first = found.items[0];
+        const idKey = first.id ?? first.path;
+        const byId = list.locator(`[data-testid="detail-row-${idKey}"]`);
+        if ((await byId.count()) > 0) {
+          await byId.first().click({ force: true, timeout: 10_000 });
+        }
+      } else {
+        await itemRow.first().click({ force: true, timeout: 10_000 });
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+      await expect(itemRow.first().or(list.locator('[data-selected="true"]'))).toBeVisible({
+        timeout: 10_000,
       });
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
@@ -139,37 +185,19 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
         .locator('[data-testid="explorer-toggle-relationships"]')
         .click();
 
-      // Either full panel (item with id) or select-item hint (folder / no id).
-      const panel = page.locator('[data-testid="relationships-view"]');
       const region = page.locator(
         '[data-testid="explorer-relationships-panel"]',
       );
-      const hint = page.locator(
-        '[data-testid="explorer-relationships-hint"]',
+      const panel = page.locator('[data-testid="relationships-view"]');
+      await expect(region).toBeVisible({ timeout: 15_000 });
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-relationships-hint"]'),
+      ).toHaveCount(0);
+      await expect(panel).toHaveAttribute(
+        "data-testid-state",
+        /ok|loading|auth|error/,
       );
-      await expect(panel.or(hint).or(region)).toBeVisible({ timeout: 15_000 });
-
-      if ((await panel.count()) > 0) {
-        await expect(panel).toHaveAttribute(
-          "data-testid-state",
-          /ok|loading|auth|error/,
-        );
-        await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
-          timeout: 20_000,
-        });
-        const state = await panel.getAttribute("data-testid-state");
-        if (state === "ok") {
-          await expect(
-            page.locator('[data-testid="relationships-primary"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-outgoing"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-incoming"]'),
-          ).toBeVisible();
-        }
-      }
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -44,6 +44,13 @@ async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
 }
 
+/** Click the first matching row; re-query if the locator detaches mid-click. */
+async function clickFirstRowWithDetachRetry(rows) {
+  await rows.first().click({ force: true, timeout: 10_000 }).catch(async () => {
+    await rows.first().click({ force: true, timeout: 10_000 }).catch(() => {});
+  });
+}
+
 /**
  * Open the first listed content row (page/asset), drilling one folder when
  * the current list is folders only. GUID-shaped {@code data-testid} values
@@ -55,7 +62,7 @@ async function selectFirstContentRow(page) {
     'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
   );
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   const folderRows = list.locator(
@@ -66,15 +73,13 @@ async function selectFirstContentRow(page) {
   }
   await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
     async () => {
-      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
-        () => {},
-      );
+      await clickFirstRowWithDetachRetry(folderRows);
     },
   );
   await listWaitReady(page);
   await page.waitForLoadState("networkidle").catch(() => {});
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   return false;

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -20,8 +20,11 @@
  * <p>Verifies the modern React Content Explorer shell exposes the Translations
  * panel chrome and loads item locale / variants from the public REST façade
  * ({@code GET /rest/content-explorer/translations/{itemId}}). Create-variant
- * is exercised only when a content row with a numeric id is selectable and
- * the CMS returns target locales; chrome visibility is the hard gate.</p>
+ * is exercised when a content row is selectable (GUID last-segment ids such as
+ * {@code 1-101-708} → {@code 708}, #3545 / parent #2649). The client must not
+ * emit {@code Selected item does not have a numeric content id} for a
+ * GUID-shaped row. Folders/sites keep the select-item hint. Chrome visibility
+ * is the hard gate when no content row is listed.</p>
  *
  * <p>Tags: {@code @explorer-translations} {@code @p-trans} {@code @smoke}</p>
  *
@@ -32,10 +35,49 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  expectNoSeriousA11yViolations,
+} = require("./helpers/a11y");
 
 /** Wait until the detail list region is present (folder navigation settled). */
 async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
+}
+
+/**
+ * Open the first listed content row (page/asset), drilling one folder when
+ * the current list is folders only. GUID-shaped {@code data-testid} values
+ * are valid (#3545).
+ */
+async function selectFirstContentRow(page) {
+  const list = page.locator('[data-testid="detail-list"]');
+  const itemRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  const folderRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  if ((await folderRows.count()) === 0) {
+    return false;
+  }
+  await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
+    async () => {
+      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
+        () => {},
+      );
+    },
+  );
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  return false;
 }
 
 test.describe("modern React Content Explorer — translations (P-Trans #2430)", () => {
@@ -114,19 +156,22 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
         return;
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
-      });
+      const selectedContent = await selectFirstContentRow(page);
+      if (!selectedContent) {
+        const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
+        await target.click({ force: true, timeout: 10_000 }).catch(async () => {
+          // Re-query after detach from folder refresh.
+          const again = list
+            .locator('tbody tr[data-testid^="detail-row-"]')
+            .first();
+          await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+        });
+      }
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
       await page.locator('[data-testid="explorer-toggle-translations"]').click();
 
-      // Either full panel (numeric content id) or select-item hint (folder / no id).
+      // Content row (including GUID 1-101-708) → panel; folder/site → hint.
       const panel = page.locator('[data-testid="translations-panel"]');
       const hint = page.locator('[data-testid="explorer-translations-hint"]');
       await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
@@ -150,8 +195,130 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
           await expect(
             page.locator('[data-testid="translations-inflight-note"]'),
           ).toBeVisible();
+          await expectNoSeriousA11yViolations(page, {
+            scope: '[data-testid="translations-panel"]',
+          });
         }
+      } else {
+        await expect(hint).toBeVisible();
       }
+    },
+  );
+
+  test(
+    "create-variant on a content row does not emit numeric-id client error (#3545)",
+    { tag: ["@explorer-translations", "@p-trans"] },
+    async ({ page }) => {
+      test.setTimeout(75_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const selectedContent = await selectFirstContentRow(page);
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      await page.locator('[data-testid="explorer-toggle-translations"]').click();
+
+      const panel = page.locator('[data-testid="translations-panel"]');
+      const hint = page.locator('[data-testid="explorer-translations-hint"]');
+      await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
+
+      if (!selectedContent || (await panel.count()) === 0) {
+        await expect(hint).toBeVisible();
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+        timeout: 20_000,
+      });
+      const state = await panel.getAttribute("data-testid-state");
+      if (state !== "ok") {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(
+        page.locator('[data-testid="translations-current-locale"]'),
+      ).toBeVisible();
+
+      const localeOptions = page.locator(
+        '[data-testid^="translations-locale-option-"]',
+      );
+      if ((await localeOptions.count()) === 0) {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      /** @type {{ itemIds?: number[] } | null} */
+      let posted = null;
+      await page.route("**/rest/content-explorer/translations", async (route) => {
+        if (route.request().method() !== "POST") {
+          await route.continue();
+          return;
+        }
+        try {
+          posted = route.request().postDataJSON();
+        } catch {
+          posted = {};
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            created: [
+              {
+                contentId: 901,
+                locale: "xx-test",
+                role: "translation",
+              },
+            ],
+          }),
+        });
+      });
+
+      await localeOptions.first().click();
+      await page.locator('[data-testid="translations-create-submit"]').click();
+
+      await expect(
+        page.locator('[data-testid="translations-create-success"]'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator('[data-testid="translations-create-error"]'),
+      ).toHaveCount(0);
+      await expect(
+        page.getByText(/does not have a numeric content id/i),
+      ).toHaveCount(0);
+
+      expect(posted, "create-variant POST should have been sent").not.toBeNull();
+      const ids = posted && Array.isArray(posted.itemIds) ? posted.itemIds : [];
+      expect(ids.length).toBeGreaterThan(0);
+      expect(Number(ids[0])).toBeGreaterThan(0);
+      expect(Number.isFinite(Number(ids[0]))).toBe(true);
+
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -17,6 +17,9 @@ const TEST_IDS = Object.freeze({
   viewDropdown: "explorer-menu-view-dropdown",
   helpDropdown: "explorer-menu-help-dropdown",
   toggleSearch: "explorer-toggle-search",
+  /** View → Clipboard (#3544) — panel toggle, enabled even when empty. */
+  toggleClipboard: "explorer-toggle-clipboard",
+  clipboardPanel: "explorer-clipboard-panel",
   /** Content → Search (#2850) — same panel as View → Search. */
   contentSearch: "explorer-menu-content-search",
   searchPanel: "explorer-search-panel",

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
@@ -34,6 +34,8 @@ describe("explorer-menu-bar helpers (#2731)", () => {
     assert.equal(TEST_IDS.menuView, "explorer-menu-view");
     assert.equal(TEST_IDS.menuHelp, "explorer-menu-help");
     assert.equal(TEST_IDS.toggleSearch, "explorer-toggle-search");
+    assert.equal(TEST_IDS.toggleClipboard, "explorer-toggle-clipboard");
+    assert.equal(TEST_IDS.clipboardPanel, "explorer-clipboard-panel");
     assert.equal(TEST_IDS.contentSearch, "explorer-menu-content-search");
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -324,7 +324,10 @@ From the **View** menu you can also toggle:
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
-- **Clipboard** — multi-select copy/cut staging when items are selected
+- **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
+  the panel (even when empty) and shows a check mark while it is visible.
+  Use **Content → Add to clipboard** after multi-select to put items on the
+  clipboard; paste from the panel when a destination folder is selected.
 
 ## If Content Explorer cannot start
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -323,7 +323,12 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  **page or asset** is selected (not a folder or site). On sample FastForward
+  sites, expand a site in the tree, open a section folder (for example
+  **AboutEnterpriseInvestments** — not only a `Pages` folder), and select a
+  content row. **View → Relationships** then mounts the relationships panel
+  (loading, results, empty, or an error). A folder-only or empty selection
+  keeps the select-item hint.
 - **Clipboard** — multi-select copy/cut staging when items are selected
 
 ## If Content Explorer cannot start

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -122,7 +122,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open the CM1 editor (`?view=editor`). |
-| **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
+| **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`1-101-708`); the panel uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
 | **Revisions** | Opens the Revisions panel; restore is available when the selected revision is restorable. **Promote revision** opens the same chrome-less editor host (`mode=promote`) and restores the chosen revision through `GET /services/itemmanagement/item/restoreRevision/{revisionGuid}`. |
@@ -323,8 +323,25 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  suitable item is selected (see **Translations** below)
 - **Clipboard** — multi-select copy/cut staging when items are selected
+
+## Translations
+
+Open **View → Translations** after selecting a **page or asset** in the list (or use
+**Translate** on Server actions / the item context menu).
+
+The panel shows **this item’s current locale** and **related locale variants**, and lets
+an authorized user **Create variants** for catalog locales the item does not already
+have. Explorer list rows identify items with a Percussion content id. The id is often
+GUID-shaped (for example `1-101-708`); the panel uses the last segment (`708`) for
+both the variants request and create-variant. That GUID form must not fail with
+“Selected item does not have a numeric content id.”
+
+**Folders and sites** have no content id. With Translations open and only a folder or
+site selected, Explorer shows a select-item hint instead of the live panel.
+
+In-flight translation queue status is not available (product disposition).
 
 ## If Content Explorer cannot start
 


### PR DESCRIPTION
## Summary

Overnight Explorer work opened three independent PRs that all edit the same product-docs page and the same Content Explorer shell tests. Sequential merge against `main` would keep re-conflicting on:

- `product-docs/8.2/admin/content-explorer.md`
- `WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx`
- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx` (#3548 + #3549)

This cluster absorbs them onto one branch against `main` with **union** conflict resolution (keep Translations GUID docs, Clipboard empty-panel toggle docs, and Relationships FastForward row guidance).

Does **not** absorb #3532 (Create Page templates) or #3543 (homepage role filter) — different files / different surfaces.

Partial #3545 #3544 #3546 (parent QA issues stay open).

## Thrash files

- `product-docs/8.2/admin/content-explorer.md`
- `WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx`
- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx`

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #3547 | `fix/issue-3545-translations-guid-content-id` | yes | GUID content id for Translations variants + create-variant |
| yes | #3548 | `fix/issue-3544-view-clipboard-toggle` | yes | View → Clipboard opens empty panel; aria-checked toggle |
| yes | #3549 | `fix/issue-3546-relationships-content-row` | yes | Parseable GUID/sys_contentid on list rows so Relationships mounts |

## Conflict union

- `content-explorer.md` View tools: keep #3547 Translations section + pointer, #3548 Clipboard always-open-empty-panel wording, and #3549 Relationships FastForward section-folder row guidance.
- TypeScript / tests auto-merged (ORT): clipboard toggle + GUID translations + GUID relationships tests all present.

## modules_built

`WebUI,modules/perc-qa-automation`

## build_evidence

- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire Tests run: 61, Failures: 0; Vitest Tests 2791 passed (375 files)
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (npm ci; Surefire: No tests to run)

No new warnings attributable to this union (baseline javadoc/analyze-only noise only). No `final`/cross-module API shape change — reverse-deps N/A.

## Test plan

Same as the absorbed PRs, one Explorer session:

1. Login Admin; open `/Rhythmyx/cm/app/spa.jsp?entry=explorer`.
2. View → Translations with no selection → select-item hint. Select a page/asset GUID row (e.g. `1-101-708`) → current locale + variants; Create variants must not show 'Selected item does not have a numeric content id'.
3. View → Clipboard with no selection: `explorer-clipboard-panel` visible, `explorer-toggle-clipboard` aria-checked=true. Toggle off hides it.
4. Multi-select two rows: Content → Add to clipboard enabled; after Add, panel stays open / View → Clipboard checked.
5. Expand a sample site section folder (not only Pages/), select a page/asset, View → Relationships mounts `explorer-relationships-panel`. Folder/site selection keeps the hint.
6. No blocking JS console errors on those paths.

Env: H2 QA or local install. Parent QA #2649 / #2741 / #2778 stay open.

## Checklist

- [x] **Product documentation** — union of `product-docs/8.2/admin/content-explorer.md` from #3547/#3548/#3549
- [x] **Unit / module tests** — standalone `mvnw clean install` green for WebUI and perc-qa-automation
- [x] **WebUI + Playwright** — absorbed specs: `explorer-translations.spec.js`, `explorer-menu-bar.spec.js`, `explorer-multiselect.spec.js`, `explorer-relationships.spec.js`
- [x] **Build gates** — standalone clean install; no skipTests
- [x] **Cross-platform** — N/A (no new path/file I/O; union of existing portable TS/docs)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs-cluster.