### PR TITLE
fix(webui): Explorer clipboard panel after Add to clipboard (#3551)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -153,7 +153,12 @@ import {
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { resolvePublishKind } from "./itemPublish";
-import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import {
+  EMPTY_SELECTION,
+  explorerMultiSelectKey,
+  isFolder,
+  type Selection,
+} from "./selection";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 import {
   isFolderIdLookupPath,
@@ -733,8 +738,8 @@ function ContentExplorerShellInner({
 
   const handleToggleSelectItem = useCallback(
     (item: PSPathItem, next: boolean) => {
-      const id = item.id ?? item.path ?? item.name;
-      if (id == null || String(id).trim() === "") return;
+      const id = explorerMultiSelectKey(item);
+      if (id == null) return;
       setMultiSelectedIds((prev) => {
         const nextSet = new Set(prev);
         if (next) nextSet.add(id);

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -114,6 +114,7 @@ import {
 import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
+import { toClipboardItem } from "./clipboard/toClipboardItem";
 import { ContextMenu } from "./ContextMenu";
 import { TemplatePickerDialog } from "./TemplatePickerDialog";
 import { ContentTypePickerDialog } from "./ContentTypePickerDialog";
@@ -305,34 +306,6 @@ type ContextMenuState = {
   x: number;
   y: number;
 } | null;
-
-/**
- * Map a `PSPathItem` (detail-list / tree row shape) into a `ClipboardItem`
- * (clipboard-panel input shape). Single source of truth so the
- * "Add to clipboard" handler and the `<ClipboardPanel items>` prop
- * never disagree on the kind / name / accessLevel mapping.
- *
- * Returns `null` when the item has no stable id (`item.id` and
- * `item.path` both missing) so the caller can skip it instead of
- * injecting a row that would later fail the paste transport.
- */
-function toClipboardItem(item: PSPathItem): ClipboardItem | null {
-  const id = item.id ?? item.path;
-  if (id == null) return null;
-  const kind: ClipboardItem["kind"] =
-    item.type === "folder"
-      ? "folder"
-      : item.category === "asset" || item.type === "asset"
-        ? "asset"
-        : "page";
-  return {
-    id,
-    path: item.path,
-    kind,
-    name: item.name ?? item.title ?? item.path,
-    sourceAccessLevel: item.accessLevel,
-  };
-}
 
 const sidePanelStyle: React.CSSProperties = {
   padding: 8,
@@ -760,8 +733,8 @@ function ContentExplorerShellInner({
 
   const handleToggleSelectItem = useCallback(
     (item: PSPathItem, next: boolean) => {
-      const id = item.id ?? item.path;
-      if (id == null) return;
+      const id = item.id ?? item.path ?? item.name;
+      if (id == null || String(id).trim() === "") return;
       setMultiSelectedIds((prev) => {
         const nextSet = new Set(prev);
         if (next) nextSet.add(id);
@@ -784,16 +757,20 @@ function ContentExplorerShellInner({
   }, []);
 
   const handleAddToClipboard = useCallback(() => {
-    if (multiSelectedItems.size === 0) return;
+    if (multiSelectedItems.size === 0 && multiSelectedIds.size === 0) return;
     const items: ClipboardItem[] = [];
     for (const item of multiSelectedItems.values()) {
       const clipboard = toClipboardItem(item);
       if (clipboard == null) continue;
       items.push(clipboard);
     }
-    setClipboardState((prev) => buildClipboard(prev, clipboardMode, items));
+    if (items.length > 0) {
+      setClipboardState((prev) => buildClipboard(prev, clipboardMode, items));
+    }
+    // Always mount the panel after Add so View → Clipboard is checked.
+    // Clicking the View toggle after this would hide an already-open panel.
     setShowClipboard(true);
-  }, [multiSelectedItems, clipboardMode]);
+  }, [multiSelectedItems, multiSelectedIds, clipboardMode]);
 
   const handleClearClipboard = useCallback(() => {
     setClipboardState(EMPTY_CLIPBOARD);
@@ -1304,7 +1281,6 @@ function ContentExplorerShellInner({
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
-            clipboardItemCount={clipboard.items.length}
             hasSiteContext={hasSiteContext}
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -52,8 +52,6 @@ export interface ExplorerMenuBarProps {
   showSubfolderCopy?: boolean;
   /** Multi-select size for clipboard-add disable + status badge. */
   multiSelectedCount: number;
-  /** Clipboard size — enables View → Clipboard when non-empty. */
-  clipboardItemCount: number;
   /**
    * True when the current folder/selection is under {@code /Sites/&lt;name&gt;}.
    * Enables Content → Site Copy (#2767).
@@ -186,15 +184,11 @@ function menuItemTestId(item: ExplorerMenuBarItem): string {
 function isItemDisabled(
   item: ExplorerMenuBarItem,
   multiSelectedCount: number,
-  clipboardItemCount: number,
   hasSiteContext: boolean,
   hasFolderContext: boolean,
 ): boolean {
   if (item.disabledWhen === "noSelection") {
     return multiSelectedCount === 0;
-  }
-  if (item.disabledWhen === "noClipboardContext") {
-    return multiSelectedCount === 0 && clipboardItemCount === 0;
   }
   if (item.disabledWhen === "noSiteContext") {
     return !hasSiteContext;
@@ -218,7 +212,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showSiteCopy = false,
     showSubfolderCopy = false,
     multiSelectedCount,
-    clipboardItemCount,
     hasSiteContext = false,
     hasFolderContext = false,
     displayFormats,
@@ -269,7 +262,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
       isItemDisabled(
         item,
         multiSelectedCount,
-        clipboardItemCount,
         hasSiteContext,
         hasFolderContext,
       )
@@ -343,7 +335,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                     const disabled = isItemDisabled(
                       item,
                       multiSelectedCount,
-                      clipboardItemCount,
                       hasSiteContext,
                       hasFolderContext,
                     );

--- a/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map a detail-list / tree {@link PSPathItem} into a {@link ClipboardItem}.
+ *
+ * <p>Sites rows from pathmanagement use {@code type}/{@code category}
+ * {@code site} / {@code FSFolder} (not lowercase {@code folder}). The
+ * previous mapper only treated {@code type === "folder"} as a folder and
+ * required {@code item.id ?? item.path}; missing path on a named Sites
+ * row dropped the selection so Add to clipboard staged nothing.</p>
+ */
+
+import type { ClipboardItem, PSPathItem } from "../../api/contentExplorer/types";
+import { isFolder } from "../selection";
+
+function firstNonBlank(
+  ...values: ReadonlyArray<string | number | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}
+
+function isAssetItem(item: PSPathItem): boolean {
+  const type = (item.type ?? "").trim().toLowerCase();
+  const category = (item.category ?? "").trim().toLowerCase();
+  return type === "asset" || category === "asset" || category === "resource";
+}
+
+/**
+ * Convert a selected Explorer row into clipboard state.
+ *
+ * @return {@code null} only when the row has no stable id, path, or name
+ */
+export function toClipboardItem(item: PSPathItem): ClipboardItem | null {
+  const id = firstNonBlank(item.id, item.path, item.name, item.title);
+  if (id == null) return null;
+  const path = firstNonBlank(item.path, item.folderPath, item.name, id) ?? id;
+  const kind: ClipboardItem["kind"] = isFolder(item)
+    ? "folder"
+    : isAssetItem(item)
+      ? "asset"
+      : "page";
+  return {
+    id,
+    path,
+    kind,
+    name: firstNonBlank(item.name, item.title, path, id) ?? id,
+    sourceAccessLevel: item.accessLevel,
+  };
+}

--- a/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
@@ -26,7 +26,7 @@
  */
 
 import type { ClipboardItem, PSPathItem } from "../../api/contentExplorer/types";
-import { isFolder } from "../selection";
+import { isAssetContentType, isFolder } from "../selection";
 
 function firstNonBlank(
   ...values: ReadonlyArray<string | number | null | undefined>
@@ -37,12 +37,6 @@ function firstNonBlank(
     if (text.length > 0) return text;
   }
   return null;
-}
-
-function isAssetItem(item: PSPathItem): boolean {
-  const type = (item.type ?? "").trim().toLowerCase();
-  const category = (item.category ?? "").trim().toLowerCase();
-  return type === "asset" || category === "asset" || category === "resource";
 }
 
 /**
@@ -56,7 +50,7 @@ export function toClipboardItem(item: PSPathItem): ClipboardItem | null {
   const path = firstNonBlank(item.path, item.folderPath, item.name, id) ?? id;
   const kind: ClipboardItem["kind"] = isFolder(item)
     ? "folder"
-    : isAssetItem(item)
+    : isAssetContentType(item)
       ? "asset"
       : "page";
   return {

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -58,7 +58,6 @@ export interface ExplorerMenuBarItem {
   /** Optional disabled predicate flag name resolved by the host. */
   disabledWhen?:
     | "noSelection"
-    | "noClipboardContext"
     | "noSiteContext"
     | "noFolderContext";
 }
@@ -174,8 +173,8 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.CLIPBOARD_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_CLIPBOARD_ARIA,
           testId: "explorer-toggle-clipboard",
+          /** Always enabled so empty clipboard can still be viewed (#3544 / #3551). */
           toggle: true,
-          disabledWhen: "noClipboardContext",
         },
       ],
     },

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -96,6 +96,31 @@ const PAGE_OR_ASSET_TYPE_KEYS = new Set([
 /** FastForward nav types are folder-like, not previewable items. */
 const RFF_NAV_TYPE_KEYS = new Set(["rffnavon", "rffnavtree"]);
 
+/**
+ * Stock / FastForward {@code type} names that are assets, not pages.
+ * Do not treat {@code category: ASSET} alone as an asset — the server
+ * defaults every non-{@code percPage} item to {@code ASSET}
+ * ({@code previewItem.resolvePreviewKind}).
+ */
+const ASSET_TYPE_KEYS = new Set([
+  "asset",
+  "percasset",
+  "rffimage",
+  "rfffile",
+  "rffnavimage",
+]);
+
+function firstNonBlank(
+  ...values: ReadonlyArray<string | number | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}
+
 function folderTypeOrCategory(type: string, category: string): boolean {
   return (
     FOLDER_TYPE_KEYS.has(type) ||
@@ -129,6 +154,39 @@ export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   }
   // Customer / legacy type name: any non-folder type is an item.
   return type.length > 0;
+}
+
+/**
+ * True when the row is an asset (clipboard / preview kind), not a page.
+ *
+ * <p>{@code category === "resource"} is <em>not</em> an asset key here.
+ * {@link ITEM_CATEGORY_KEYS} treats {@code resource} as a workflowed
+ * item (page-or-asset), not as {@code ClipboardItem.kind === "asset"}.</p>
+ */
+export function isAssetContentType(item: PSPathItem | null): boolean {
+  if (!item || isFolder(item)) {
+    return false;
+  }
+  const type = (item.type ?? "").trim().toLowerCase();
+  if (ASSET_TYPE_KEYS.has(type)) {
+    return true;
+  }
+  const category = (item.category ?? "").trim().toLowerCase();
+  if (category === "asset" && (type === "asset" || type.length === 0)) {
+    return true;
+  }
+  const path = (item.path ?? "").trim().toLowerCase().replace(/\\/g, "/");
+  return path === "/assets" || path.startsWith("/assets/");
+}
+
+/**
+ * Stable multi-select map key. Prefer content id, then path. Do not fall
+ * back to {@code name} — two "Home" rows without id/path would collide.
+ *
+ * @return {@code null} when the row has no id or path
+ */
+export function explorerMultiSelectKey(item: PSPathItem): string | null {
+  return firstNonBlank(item.id, item.path);
 }
 
 export function isFolder(item: PSPathItem | null): boolean {

--- a/WebUI/src/test/ts/contentExplorer/ClipboardPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ClipboardPanel.test.tsx
@@ -33,6 +33,52 @@ function makeCb(items: ClipboardItem[]): Clipboard {
 }
 
 describe("ClipboardPanel", () => {
+  it("still mounts an empty clipboard list (host empty-panel contract #3551)", () => {
+    render(
+      <ClipboardPanel
+        clipboard={EMPTY_CLIPBOARD}
+        onClipboardChange={() => {}}
+        items={[]}
+        mode="copy"
+        onModeChange={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("clipboard-panel")).toBeTruthy();
+    expect(screen.getByTestId("clipboard-items")).toBeTruthy();
+    expect(screen.queryAllByTestId("clipboard-item-row")).toHaveLength(0);
+    expect(screen.getByTestId("clipboard-add")).toBeDisabled();
+  });
+
+  it("renders folder-kind Sites rows staged by Add to clipboard (#3551)", () => {
+    const sites: ClipboardItem[] = [
+      {
+        id: "s-1",
+        path: "/Sites/CorporateInvestments",
+        kind: "folder",
+        name: "CorporateInvestments",
+      },
+      {
+        id: "s-2",
+        path: "/Sites/EnterpriseInvestments",
+        kind: "folder",
+        name: "EnterpriseInvestments",
+      },
+    ];
+    render(
+      <ClipboardPanel
+        clipboard={makeCb(sites)}
+        onClipboardChange={() => {}}
+        items={sites}
+        mode="copy"
+        onModeChange={() => {}}
+      />,
+    );
+    const rows = screen.getAllByTestId("clipboard-item-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain("/Sites/CorporateInvestments");
+    expect(rows[0]?.textContent).toContain("(folder)");
+  });
+
   it("renders the clipboard panel with size 0 when empty", () => {
     render(
       <ClipboardPanel

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1175,6 +1175,126 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("View → Clipboard opens the empty clipboard panel and toggles aria-checked (#3544)", async () => {
+    stubPathFetch();
+    const { container } = renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-view")).toBeInTheDocument(),
+    );
+    openViewMenu();
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-clipboard"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+    await renderA11yGate(container);
+  });
+
+  it("Content → Add to clipboard mounts the panel with Sites rows (#3551)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "site-a",
+                  name: "CorporateInvestments",
+                  path: "/Sites/CorporateInvestments",
+                  type: "site",
+                  category: "SITE",
+                  accessLevel: "ADMIN",
+                },
+                {
+                  name: "EnterpriseInvestments",
+                  path: "/Sites/EnterpriseInvestments",
+                  type: "FSFolder",
+                  category: "site",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 2,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-site-a")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("detail-row-/Sites/EnterpriseInvestments"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("detail-select-site-a"));
+    fireEvent.click(
+      screen.getByTestId("detail-select-/Sites/EnterpriseInvestments"),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-multi-select-count")).toHaveTextContent(
+        "2",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-clipboard-add"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(screen.getAllByTestId("clipboard-item-row")).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+  });
+
   it("translations toggle shows select-item hint without a content selection (#2430)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -34,7 +34,6 @@ function renderBar(
       showDependencies={false}
       showClipboard={false}
       multiSelectedCount={0}
-      clipboardItemCount={0}
       displayFormats={[]}
       selectedFormatKey=""
       onSelectFormat={onSelectFormat}
@@ -89,6 +88,37 @@ describe("ExplorerMenuBar (#2731)", () => {
     );
     fireEvent.click(contentSearch);
     expect(onCommand).toHaveBeenCalledWith("content-search");
+  });
+
+  it("View → Clipboard is enabled with empty clipboard and invokes view-clipboard (#3544)", () => {
+    const { onCommand } = renderBar({
+      multiSelectedCount: 0,
+      showClipboard: false,
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("role")).toBe("menuitemcheckbox");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
+    fireEvent.click(toggle);
+    expect(onCommand).toHaveBeenCalledWith("view-clipboard");
+  });
+
+  it("View → Clipboard reflects showClipboard on aria-checked (#3544)", () => {
+    renderBar({ showClipboard: true, multiSelectedCount: 0 });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const checked = screen.getByTestId("explorer-toggle-clipboard");
+    expect(checked.getAttribute("aria-checked")).toBe("true");
+    expect(checked.getAttribute("aria-expanded")).toBe("true");
+    expect(checked.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
   });
 
   it("View → Folder Security menu item invokes view-security (#3268)", () => {

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -53,6 +53,14 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(byId["view-clipboard"]).toBe("explorer-toggle-clipboard");
   });
 
+  it("View → Clipboard is an always-enabled toggle (#3544)", () => {
+    const view = buildExplorerMenuBarGroups().find((g) => g.id === "view");
+    const clipboard = view?.items.find((i) => i.id === "view-clipboard");
+    expect(clipboard?.toggle).toBe(true);
+    expect(clipboard?.disabledWhen).toBeUndefined();
+    expect(clipboard?.testId).toBe("explorer-toggle-clipboard");
+  });
+
   it("puts clipboard-add under Content with stable test id", () => {
     const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
     const add = content?.items.find((i) => i.id === "content-clipboard-add");

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -20,6 +20,8 @@ import {
   canAdmin,
   canRead,
   canWrite,
+  explorerMultiSelectKey,
+  isAssetContentType,
   isFolder,
   isPageOrAssetContentType,
   sameExplorerItemId,
@@ -271,5 +273,101 @@ describe("sameExplorerItemId / canRead (#3467)", () => {
     expect(canWrite(page("read"))).toBe(false);
     expect(canAdmin(page("admin"))).toBe(true);
     expect(canAdmin(page("write"))).toBe(false);
+  });
+});
+
+describe("explorerMultiSelectKey (#3552 review)", () => {
+  it("prefers id then path and never falls back to name", () => {
+    expect(
+      explorerMultiSelectKey({
+        id: "42",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+      }),
+    ).toBe("42");
+    expect(
+      explorerMultiSelectKey({
+        name: "Home",
+        path: "/Sites/Demo/Home",
+      }),
+    ).toBe("/Sites/Demo/Home");
+    expect(
+      explorerMultiSelectKey({
+        id: "   ",
+        name: "Home",
+        path: "/Sites/Other/Home",
+      }),
+    ).toBe("/Sites/Other/Home");
+    expect(
+      explorerMultiSelectKey({
+        name: "Home",
+        path: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not collide two nameless-id rows that share a display name", () => {
+    const a = explorerMultiSelectKey({ name: "Home", path: "" });
+    const b = explorerMultiSelectKey({ name: "Home", path: "  " });
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+  });
+});
+
+describe("isAssetContentType (#3552 review)", () => {
+  it("treats stock asset types and /Assets paths as assets", () => {
+    expect(
+      isAssetContentType({
+        id: "a-1",
+        name: "hero.png",
+        path: "/Assets/hero.png",
+        type: "rffImage",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "a-2",
+        name: "file",
+        path: "/Assets/docs/a.pdf",
+        type: "percAsset",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "a-3",
+        name: "banner",
+        path: "/Assets/banner",
+        type: "asset",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat category resource or percPage as assets", () => {
+    expect(
+      isAssetContentType({
+        id: "p-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "RESOURCE",
+      }),
+    ).toBe(false);
+    expect(
+      isAssetContentType({
+        id: "p-2",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "PAGE",
+      }),
+    ).toBe(false);
+    expect(
+      isAssetContentType({
+        id: "f-1",
+        name: "Files",
+        path: "/Assets/Files/",
+        type: "FSFolder",
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
@@ -85,6 +85,19 @@ describe("toClipboardItem (#3551)", () => {
     expect(mapped?.kind).toBe("asset");
   });
 
+  it("does not treat category resource as an asset (#3552 review)", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "r-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "RESOURCE",
+      }),
+    );
+    expect(mapped?.kind).toBe("page");
+  });
+
   it("maps page rows as pages", () => {
     const mapped = toClipboardItem(
       row({

--- a/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import { toClipboardItem } from "../../../main/ts/contentExplorer/clipboard/toClipboardItem";
+
+function row(partial: Partial<PSPathItem> & { name: string }): PSPathItem {
+  return {
+    path: partial.path ?? "",
+    ...partial,
+  };
+}
+
+describe("toClipboardItem (#3551)", () => {
+  it("maps site / FSFolder rows used by the Explorer Sites list as folders", () => {
+    const site = toClipboardItem(
+      row({
+        id: "s-1",
+        name: "CorporateInvestments",
+        path: "/Sites/CorporateInvestments",
+        type: "site",
+        category: "SITE",
+        accessLevel: "ADMIN",
+      }),
+    );
+    expect(site).toEqual({
+      id: "s-1",
+      path: "/Sites/CorporateInvestments",
+      kind: "folder",
+      name: "CorporateInvestments",
+      sourceAccessLevel: "ADMIN",
+    });
+
+    const fsFolder = toClipboardItem(
+      row({
+        name: "Files",
+        path: "/Sites/Demo/Files",
+        type: "FSFolder",
+        accessLevel: "WRITE",
+      }),
+    );
+    expect(fsFolder?.kind).toBe("folder");
+    expect(fsFolder?.id).toBe("/Sites/Demo/Files");
+  });
+
+  it("keeps a named Sites row when id and path are omitted", () => {
+    const mapped = toClipboardItem(
+      row({
+        name: "EnterpriseInvestments",
+        type: "site",
+        category: "site",
+      }),
+    );
+    expect(mapped).not.toBeNull();
+    expect(mapped?.id).toBe("EnterpriseInvestments");
+    expect(mapped?.path).toBe("EnterpriseInvestments");
+    expect(mapped?.kind).toBe("folder");
+  });
+
+  it("maps asset category case-insensitively", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "a-1",
+        name: "hero.png",
+        path: "/Assets/hero.png",
+        type: "rffImage",
+        category: "ASSET",
+      }),
+    );
+    expect(mapped?.kind).toBe("asset");
+  });
+
+  it("maps page rows as pages", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "p-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "PAGE",
+      }),
+    );
+    expect(mapped?.kind).toBe("page");
+  });
+
+  it("returns null when the row has no id, path, or name", () => {
+    expect(
+      toClipboardItem({
+        name: "   ",
+        path: "",
+      }),
+    ).toBeNull();
+  });
+});

--- a/docs/ai-generated/code-reviews/3551-explorer-clipboard-panel-erlang.md
+++ b/docs/ai-generated/code-reviews/3551-explorer-clipboard-panel-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3551 Explorer clipboard panel after Add
+
+**Branch:** `fix/issue-3551-explorer-clipboard-panel`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Reviewer:** Erlang (independent of implementer)  
+**Date:** 2026-08-18  
+**Memory patterns hit:** missing behavioral tests; incomplete change-class closure (WebUI + Playwright + product-docs); Playwright for WebUI screens; no path/file I/O
+
+## Summary
+
+Content → Add to clipboard now always mounts `explorer-clipboard-panel` (`setShowClipboard(true)`). View → Clipboard is no longer gated on `noClipboardContext`, so an empty panel is a valid mount. `toClipboardItem` maps Sites / `FSFolder` / `site` rows as folders and keeps a name fallback so the multi-select list used by the spec is not dropped. Playwright no longer clicks View → Clipboard after Add (that toggle would hide an already-open panel).
+
+## Recommendation
+
+approve
+
+## Gate
+
+**May commit/push: yes**
+
+- Bugs: none
+- Behavioral tests: present (mapper unit, ClipboardPanel empty + Sites rows, ExplorerMenuBar toggle, shell Add + empty toggle)
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: WebUI Vitest, perc-qa-automation Playwright, `product-docs/8.2/admin/content-explorer.md`
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+Not applicable — no new file I/O, path joins, installer, or path assertions.
+
+## Verification (implementer evidence, reviewed)
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2783 passed (375 files)
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
+- H2 QA Playwright: explorer-multiselect 3 passed; Cycle Verify surface set 15 passed (menu-bar empty toggle + add-to-clipboard); no `Failed startup of context`

--- a/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
@@ -96,6 +96,49 @@ test.describe("modern React Content Explorer — DCE menu bar chrome (#2731)", (
   );
 
   test(
+    "View → Clipboard opens empty panel and sets aria-checked (#3544)",
+    { tag: ["@explorer-menu-bar", "@explorer", "@issue-3544"] },
+    async ({ page }) => {
+      const errors = [];
+      page.on("pageerror", (err) => errors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 15_000 });
+
+      await openViewMenu(page);
+      const toggle = page.locator(
+        `[data-testid="${TEST_IDS.toggleClipboard}"]`,
+      );
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toBeEnabled();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toBeVisible({ timeout: 5_000 });
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      expect(errors, `JS console/page errors: ${errors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
     "server action toolbar still mounts under menu bar",
     { tag: ["@explorer-menu-bar", "@explorer"] },
     async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
@@ -90,12 +90,15 @@ test.describe("modern React Content Explorer — multi-select + clipboard (#2408
     await rowCheckboxes.nth(0).check();
     await rowCheckboxes.nth(1).check();
 
-    // #2731: clipboard-add lives under Content menu; clipboard toggle under View.
+    // #2731 / #3544 / #3551: Add lives under Content and opens the clipboard
+    // panel. View → Clipboard must already be checked — do not click it
+    // again here or the toggle would hide the already-open panel.
     await page.locator('[data-testid="explorer-menu-content"]').click();
     await page.locator('[data-testid="explorer-clipboard-add"]').click();
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
-    await page.locator('[data-testid="explorer-toggle-clipboard"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-clipboard"]');
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
     const panel = page.locator('[data-testid="explorer-clipboard-panel"]');
     await expect(panel).toBeVisible();
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -17,6 +17,9 @@ const TEST_IDS = Object.freeze({
   viewDropdown: "explorer-menu-view-dropdown",
   helpDropdown: "explorer-menu-help-dropdown",
   toggleSearch: "explorer-toggle-search",
+  /** View → Clipboard (#3544 / #3551) — panel toggle, enabled even when empty. */
+  toggleClipboard: "explorer-toggle-clipboard",
+  clipboardPanel: "explorer-clipboard-panel",
   /** Content → Search (#2850) — same panel as View → Search. */
   contentSearch: "explorer-menu-content-search",
   searchPanel: "explorer-search-panel",

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
@@ -34,6 +34,8 @@ describe("explorer-menu-bar helpers (#2731)", () => {
     assert.equal(TEST_IDS.menuView, "explorer-menu-view");
     assert.equal(TEST_IDS.menuHelp, "explorer-menu-help");
     assert.equal(TEST_IDS.toggleSearch, "explorer-toggle-search");
+    assert.equal(TEST_IDS.toggleClipboard, "explorer-toggle-clipboard");
+    assert.equal(TEST_IDS.clipboardPanel, "explorer-clipboard-panel");
     assert.equal(TEST_IDS.contentSearch, "explorer-menu-content-search");
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -324,7 +324,12 @@ From the **View** menu you can also toggle:
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
-- **Clipboard** — multi-select copy/cut staging when items are selected
+- **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
+  the panel (even when empty) and shows a check mark while it is visible.
+  Use **Content → Add to clipboard** after multi-select to put items on the
+  clipboard and open the panel (including **Sites** rows). Do not click
+  **View → Clipboard** again after Add — that hides the already-open panel.
+  Paste from the panel when a destination folder is selected.
 
 ## If Content Explorer cannot start
 


### PR DESCRIPTION
## Summary

Cycle Verify residual for `explorer-multiselect.spec.js` (#3551): after multi-select, **Content → Add to clipboard** never left `data-testid=explorer-clipboard-panel` mounted. The Playwright spec then clicked **View → Clipboard**, which toggles `showClipboard` and hid an already-open (or never-opened) panel.

This PR:

- Always mounts `explorer-clipboard-panel` from **Content → Add to clipboard** (`setShowClipboard(true)`).
- Leaves **View → Clipboard** (`explorer-toggle-clipboard`) `aria-checked=true` after Add. The spec opens View only to assert that — it does **not** click the toggle again.
- Maps Sites / `FSFolder` / `site` rows through `toClipboardItem` so the two multi-selected rows become `clipboard-item-row` entries (`kind: folder`).
- Keeps **View → Clipboard** enabled when the clipboard is empty (empty panel is valid; #3544 residual). No second PR for #3544.

Parent trackers: #3544 (View clipboard toggle), #2741 (QA Failed; do not close), epic #2400 / #3102.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Open Explorer: `/Rhythmyx/cm/app/spa.jsp?entry=explorer`
2. Multi-select two Sites (or folder) rows — status shows 2 items selected
3. **Content → Add to clipboard** — `explorer-clipboard-panel` is visible with two `clipboard-item-row`s
4. Open **View** — **Clipboard** is checked (`aria-checked=true`). Do not click it (that hides the panel)
5. With nothing selected, **View → Clipboard** still opens an empty panel and checks the toggle; click again to hide
6. Env: QA H2 docker (`perc-devctl qa-up`) or local install; user **Admin**

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (View → Clipboard always opens, including empty; Add opens the panel for Sites rows; do not toggle View after Add)
- [x] **Unit / module tests** — Vitest mapper + ClipboardPanel + ExplorerMenuBar + ContentExplorerShell Add/toggle; standalone `cd WebUI && ../mvnw.cmd clean install` and `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
- [x] **WebUI + Playwright** — `tests/explorer-multiselect.spec.js` (Add keeps panel + `aria-checked`) and `tests/explorer-menu-bar.spec.js` (#3544 empty toggle)
- [x] **Build gates** — standalone clean install on changed Maven modules (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Surefire Tests run: 61, Failures: 0; Vitest Tests 2783 passed (375 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (npm ci; no Java tests)
- **downstream_checked:** none (no Java `final`/public API shape change; `ExplorerMenuBarProps.clipboardItemCount` is WebUI-internal only)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2` **HEALTH:healthy** HTTP 200 `TEST_CMS_URL=http://127.0.0.1:9993` (qa-health RESULT:FAIL is pre-existing FastForward `PSDbStorageService` import ERRORs from first cell start, not `Failed startup of context` / unhealthy)
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` then in-cell `StopJetty.sh` + `StartJetty.sh` (not `docker restart`)
- Playwright (`TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2` `TEST_PRODUCT=cms`):
  - `npm run test:surface -- --path tests/explorer-multiselect.spec.js` — **3 passed**
  - Cycle Verify set (golden-unattended-smoke, login, explorer-menu-bar, explorer-multiselect, explorer-relationships, explorer-translations) — **15 passed**
- **console-clean=yes** (`pageerror`/console listener on #3544 spec)
- **server.log-clean=yes** for the post-restart Playwright window (no `Failed startup of context`; leftover ERRORs are install-time FastForward import / search-index last-modifier noise)

Fixes #3551
Partial #3544
Partial #2741

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
