### PR TITLE
fix(explorer): Subfolder Copy Cancel/item-click dismiss overlay (#3553)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -182,6 +182,10 @@ import {
 import { SiteCopyWizard } from "./wizards/SiteCopyWizard";
 import { SiteCreateWizard } from "./wizards/SiteCreateWizard";
 import { SubfolderCopyWizard } from "./wizards/SubfolderCopyWizard";
+import {
+  captureDialogOpener,
+  useDialogEscape,
+} from "../architecture/useDialogEscape";
 import { RelationshipsView } from "./views/RelationshipsView";
 import { DependencyViewer } from "./views/DependencyViewer";
 import type { PSNodeRelationshipSummary } from "../api/contentExplorer/relationship";
@@ -543,6 +547,10 @@ function ContentExplorerShellInner({
   const [showSiteCopy, setShowSiteCopy] = useState(false);
   /** Content → Subfolder Copy wizard panel (#2792 / parent #2400). */
   const [showSubfolderCopy, setShowSubfolderCopy] = useState(false);
+  const dismissSubfolderCopy = useCallback(() => {
+    setShowSubfolderCopy(false);
+  }, []);
+  const subfolderCopyPanelRef = useRef<HTMLElement | null>(null);
   const [showRelationships, setShowRelationships] = useState(false);
   const [showDependencies, setShowDependencies] = useState(false);
   const [showRevisions, setShowRevisions] = useState(false);
@@ -726,6 +734,7 @@ function ContentExplorerShellInner({
       setContextMenu(null);
       setViewRun(null);
       setSelectedViewKey(null);
+      setShowSubfolderCopy(false);
       if (folder) onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -742,6 +751,7 @@ function ContentExplorerShellInner({
       setContextMenu(null);
       setViewRun(null);
       setSelectedViewKey(null);
+      setShowSubfolderCopy(false);
       onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -749,6 +759,7 @@ function ContentExplorerShellInner({
 
   const handleSelectItem = useCallback((item: PSPathItem) => {
     setSelection((prev) => ({ ...prev, item }));
+    setShowSubfolderCopy(false);
   }, []);
 
   const handleActivateItem = useCallback(
@@ -1186,6 +1197,12 @@ function ContentExplorerShellInner({
         case "content-subfolder-copy":
           // Only open when a folder is in context; menu item is disabled otherwise.
           if (sourceFolderPathForCopy) {
+            if (!showSubfolderCopy) {
+              const contentMenu = document.querySelector<HTMLElement>(
+                '[data-testid="explorer-menu-content"]',
+              );
+              captureDialogOpener(contentMenu ?? document.activeElement);
+            }
             setShowSubfolderCopy((v) => !v);
           }
           break;
@@ -1231,8 +1248,36 @@ function ContentExplorerShellInner({
       handleRefreshList,
       siteNameForCopy,
       sourceFolderPathForCopy,
+      showSubfolderCopy,
     ],
   );
+
+  useDialogEscape(showSubfolderCopy, false, dismissSubfolderCopy);
+
+  useEffect(() => {
+    if (!showSubfolderCopy) {
+      return;
+    }
+    function onDocMouseDown(e: MouseEvent): void {
+      const target = e.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      const panel = subfolderCopyPanelRef.current;
+      if (panel && panel.contains(target)) {
+        return;
+      }
+      const menuBar = document.querySelector(
+        '[data-testid="explorer-menu-bar"]',
+      );
+      if (menuBar instanceof Node && menuBar.contains(target)) {
+        return;
+      }
+      setShowSubfolderCopy(false);
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [showSubfolderCopy]);
 
   const folderForActions: PSPathItem | null =
     selection.item && isFolder(selection.item)
@@ -1639,6 +1684,7 @@ function ContentExplorerShellInner({
       {showSubfolderCopy && sourceFolderPathForCopy && (
         <section
           id="explorer-subfolder-copy-panel"
+          ref={subfolderCopyPanelRef}
           style={sidePanelStyle}
           data-testid="explorer-subfolder-copy-panel"
           aria-label={message(EXPLORER_MSG.SUBFOLDER_COPY_PANEL_REGION)}
@@ -1650,6 +1696,7 @@ function ContentExplorerShellInner({
           <SubfolderCopyWizard
             key={`subfolder-copy-${sourceFolderPathForCopy}`}
             initialSource={sourceFolderPathForCopy}
+            onDismiss={dismissSubfolderCopy}
             onSettled={(ok) => {
               if (ok) {
                 setListEpoch((n) => n + 1);

--- a/WebUI/src/main/ts/contentExplorer/wizards/SubfolderCopyWizard.tsx
+++ b/WebUI/src/main/ts/contentExplorer/wizards/SubfolderCopyWizard.tsx
@@ -47,6 +47,11 @@ export interface SubfolderCopyWizardProps {
   ariaLabel?: string;
   className?: string;
   onSettled?: (ok: boolean) => void;
+  /**
+   * Host dismiss (Cancel / Escape). Unmounts the overlay; does not POST.
+   * When omitted, Cancel falls back to {@link resetWizard} for standalone mounts.
+   */
+  onDismiss?: () => void;
 }
 
 const STEPS = ["source", "target", "confirm", "progress"];
@@ -61,10 +66,22 @@ export function SubfolderCopyWizard(
     ariaLabel,
     className,
     onSettled,
+    onDismiss,
   } = props;
   const [wizard, setWizard] = useState<WizardState>(() => createWizard(STEPS));
   const [sourcePath, setSourcePath] = useState(initialSource);
   const [targetPath, setTargetPath] = useState(initialTarget);
+
+  function handleCancel(): void {
+    if (wizard.submitting) {
+      return;
+    }
+    if (onDismiss) {
+      onDismiss();
+      return;
+    }
+    setWizard((w) => resetWizard(w));
+  }
 
   async function handleRun(): Promise<void> {
     setWizard((w) => ({ ...w, submitting: true }));
@@ -229,7 +246,8 @@ export function SubfolderCopyWizard(
         <button
           type="button"
           data-testid="subfolder-copy-cancel"
-          onClick={() => setWizard((w) => resetWizard(w))}
+          disabled={wizard.submitting}
+          onClick={handleCancel}
         >
           {message(EXPLORER_MSG.WIZARD_CANCEL)}
         </button>

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1277,6 +1277,161 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("Subfolder Copy Cancel unmounts the overlay instead of reset (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/Demo/Home" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+      expect(screen.queryByTestId("explorer-subfolder-copy-panel")).toBeNull();
+    });
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-menu-content"),
+    );
+  });
+
+  it("Subfolder Copy Escape unmounts the overlay (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
+  it("Subfolder Copy Back stays mounted and changes step (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/Demo/Home" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("subfolder-copy-back"));
+    expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeInTheDocument();
+  });
+
+  it("selecting a detail item dismisses Subfolder Copy without POST (#3553)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-42")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-42"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
+  it("click-away outside Subfolder Copy dismisses the overlay (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.mouseDown(screen.getByTestId("content-explorer-shell"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
   it("Content → Subfolder Copy is disabled without a folder path (#2792)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/SubfolderCopyWizard.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SubfolderCopyWizard.test.tsx
@@ -74,6 +74,55 @@ describe("SubfolderCopyWizard", () => {
     );
   });
 
+  it("Back walks to the previous step and does not dismiss", () => {
+    const onDismiss = vi.fn();
+    const submit = vi.fn();
+    render(
+      <SubfolderCopyWizard submit={submit} onDismiss={onDismiss} />,
+    );
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-back"));
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeTruthy();
+    expect(screen.getByTestId("subfolder-copy-wizard")).toBeTruthy();
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("Cancel with onDismiss dismisses instead of resetWizard (#3553)", () => {
+    const onDismiss = vi.fn();
+    const submit = vi.fn();
+    render(
+      <SubfolderCopyWizard submit={submit} onDismiss={onDismiss} />,
+    );
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(submit).not.toHaveBeenCalled();
+    // Host unmounts; without unmount, Cancel must not reset to step 1.
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    expect(screen.queryByTestId("subfolder-copy-step-source")).toBeNull();
+  });
+
+  it("Cancel without onDismiss still resetWizard to step 0", () => {
+    render(<SubfolderCopyWizard />);
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeTruthy();
+    expect(screen.queryByTestId("subfolder-copy-step-target")).toBeNull();
+  });
+
   it("passes the zero serious/critical axe-core gate (step 0)", async () => {
     const { container } = render(<SubfolderCopyWizard />);
     await renderA11yGate(container);

--- a/docs/ai-generated/code-reviews/3553-subfolder-copy-dismiss-erlang.md
+++ b/docs/ai-generated/code-reviews/3553-subfolder-copy-dismiss-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3553 Subfolder Copy Cancel/item-click dismiss
+
+**Branch:** `fix/issue-3553-subfolder-copy-dismiss`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Reviewer:** Erlang (independent of implementer)  
+**Date:** 2026-08-18  
+
+**Memory patterns hit:** missing behavioral tests; incomplete change-class closure (WebUI screen requires Playwright + product-docs); click-away vs menu-toggle races.
+
+## Summary
+
+Human QA on #2797 failed because Subfolder Copy **Cancel** called `resetWizard()` (step 1, overlay stays mounted) and selecting an Explorer item left the overlay up. This change adds `onDismiss` on `SubfolderCopyWizard`, host unmount + Escape/focus restore (`useDialogEscape`), tree/detail/click-away dismiss without POST, Vitest, Playwright, and product-docs 8.2 Explorer Subfolder Copy.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No hard-gate bugs, missing behavioral tests, or non-portable path I/O.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Wizard `onDismiss` vs `resetWizard` | Yes — Cancel with host callback does not reset steps |
+| Shell unmount + focus restore | Yes — `useDialogEscape` + Content menu opener |
+| Item select / click-away | Yes — `handleSelectFolder` / `handleSelectItem` / document mousedown excluding panel + menu bar |
+| Vitest | Wizard dismiss vs reset; shell Cancel/Escape/Back/item/click-away |
+| Playwright | `explorer-subfolder-copy.spec.js` Cancel + item-click; console/pageerror + no copy POST |
+| product-docs 8.2 Explorer | Subfolder Copy table for Cancel / Escape / item / click-away |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Playwright/helper URLs use `/` (URL paths).
+
+## Issues
+
+None (hard gate).
+
+### Notes (non-blocking)
+
+- Click-away excludes the Explorer menu bar so Content → Subfolder Copy remains a toggle instead of close-then-reopen.
+- Standalone wizard (no `onDismiss`) still `resetWizard` for residual US7 mounts.
+- Full multi-folder submit remains soft-skipped on H2 (out of scope).

--- a/modules/perc-qa-automation/frontend/tests/explorer-subfolder-copy.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-subfolder-copy.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Playwright surface: #2792 / parent #2400 — Subfolder Copy wizard in Explorer shell.
+ * Playwright surface: #2792 / #3553 / parent #2400 — Subfolder Copy wizard.
  *
- * <p>Verifies Content → Subfolder Copy chrome on the modern SPA Explorer. Full
- * multi-folder submit is soft-skipped when the H2 fixture lacks a navigable
- * folder tree suitable for a destructive copy.</p>
+ * <p>Verifies Content → Subfolder Copy chrome on the modern SPA Explorer, plus
+ * Cancel / item-click dismiss (#3553). Full multi-folder submit is soft-skipped
+ * when the H2 fixture lacks a navigable folder tree suitable for a destructive
+ * copy.</p>
  *
  * <p>Tags: {@code @explorer-subfolder-copy} {@code @explorer} {@code @smoke}</p>
  *
@@ -93,6 +94,28 @@ async function tryEnterFolder(page) {
   return false;
 }
 
+/**
+ * Open the wizard when folder context exists. Returns false when the H2
+ * fixture has no navigable folder (soft-skip caller).
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<boolean>}
+ */
+async function tryOpenWizard(page) {
+  await tryEnterFolder(page);
+  await openContentMenu(page);
+  const menuItem = page.locator(
+    `[data-testid="${TEST_IDS.subfolderCopyMenu}"]`,
+  );
+  await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  if (await menuItem.isDisabled()) {
+    return false;
+  }
+  await menuItem.click();
+  const wizard = page.locator(`[data-testid="${TEST_IDS.wizard}"]`);
+  await expect(wizard).toBeVisible({ timeout: 10_000 });
+  return true;
+}
+
 test.describe("modern React Content Explorer — subfolder copy chrome (#2792)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(45_000);
@@ -163,6 +186,113 @@ test.describe("modern React Content Explorer — subfolder copy chrome (#2792)",
           .inputValue();
         expect(sourceVal.length).toBeGreaterThan(0);
       }
+    },
+  );
+
+  test(
+    "Cancel dismisses the Subfolder Copy overlay (#3553)",
+    { tag: ["@explorer-subfolder-copy", "@explorer"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => {
+        pageErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          pageErrors.push(msg.text());
+        }
+      });
+
+      const opened = await tryOpenWizard(page);
+      if (!opened) {
+        test.info().annotations.push({
+          type: "soft-skip",
+          description:
+            "No folder context under /Sites (H2 fixture may lack navigable folders).",
+        });
+        return;
+      }
+
+      const source = page.locator(`[data-testid="${TEST_IDS.sourceInput}"]`);
+      await expect(source).toBeVisible();
+      await source.fill("/Sites/Demo/Home");
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTarget}"]`),
+      ).toBeVisible();
+
+      await page.locator(`[data-testid="${TEST_IDS.cancel}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
+      ).toHaveCount(0, { timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.subfolderCopyPanel}"]`),
+      ).toHaveCount(0);
+      expect(pageErrors, `console/pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
+    "item click dismisses the Subfolder Copy overlay without POST (#3553)",
+    { tag: ["@explorer-subfolder-copy", "@explorer"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const pageErrors = [];
+      const copyPosts = [];
+      page.on("pageerror", (err) => {
+        pageErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          pageErrors.push(msg.text());
+        }
+      });
+      page.on("request", (req) => {
+        if (
+          req.method() === "POST" &&
+          /folders\/copy|moveItem/i.test(req.url())
+        ) {
+          copyPosts.push(req.url());
+        }
+      });
+
+      const opened = await tryOpenWizard(page);
+      if (!opened) {
+        test.info().annotations.push({
+          type: "soft-skip",
+          description:
+            "No folder context under /Sites (H2 fixture may lack navigable folders).",
+        });
+        return;
+      }
+
+      const list = page.locator(`[data-testid="${TEST_IDS.detailList}"]`);
+      const rows = list.locator(
+        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      );
+      const treeNodes = page.locator('[data-testid^="tree-node-"]');
+      if ((await rows.count()) > 0) {
+        await rows.first().click();
+      } else if ((await treeNodes.count()) > 0) {
+        await treeNodes.first().click();
+      } else {
+        await page.locator(`[data-testid="${TEST_IDS.shell}"]`).click({
+          position: { x: 8, y: 8 },
+        });
+      }
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
+      ).toHaveCount(0, { timeout: 10_000 });
+      expect(copyPosts, `unexpected copy POST: ${copyPosts.join(" | ")}`).toEqual(
+        [],
+      );
+      expect(pageErrors, `console/pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-subfolder-copy.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-subfolder-copy.js
@@ -16,6 +16,11 @@ const TEST_IDS = Object.freeze({
   subfolderCopyHint: "explorer-subfolder-copy-hint",
   wizard: "subfolder-copy-wizard",
   sourceInput: "subfolder-copy-source",
+  cancel: "subfolder-copy-cancel",
+  back: "subfolder-copy-back",
+  next: "subfolder-copy-next",
+  stepSource: "subfolder-copy-step-source",
+  stepTarget: "subfolder-copy-step-target",
   tree: "explorer-tree",
   detailList: "detail-list",
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-subfolder-copy.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-subfolder-copy.test.js
@@ -34,6 +34,8 @@ describe("explorer-subfolder-copy helpers (#2792)", () => {
     assert.equal(TEST_IDS.subfolderCopyMenu, "explorer-content-subfolder-copy");
     assert.equal(TEST_IDS.wizard, "subfolder-copy-wizard");
     assert.equal(TEST_IDS.subfolderCopyPanel, "explorer-subfolder-copy-panel");
+    assert.equal(TEST_IDS.cancel, "subfolder-copy-cancel");
+    assert.equal(TEST_IDS.back, "subfolder-copy-back");
   });
 
   it("builds explorer SPA entry URL with cache buster", () => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -182,6 +182,25 @@ Related Content menu commands:
 - **Site Copy** / **Subfolder Copy** — copy workflows when a site or folder is in context
 - **Search** — same Search panel as **View → Search**
 
+### Subfolder Copy
+
+**Content → Subfolder Copy** opens a wizard overlay when a folder is in context
+(the current tree folder, or a selected folder row). Source path is prefilled from
+that folder.
+
+| Control | Behavior |
+|---------|----------|
+| **Next** | Advance to the next step (source → target → confirm → run) |
+| **Back** | Return to the previous step. The overlay stays open |
+| **Cancel** | Close the wizard without copying. Cancel is **not** Back — it does not reset to step 1 while leaving the overlay up |
+| **Escape** | Same as Cancel: dismiss without submitting |
+| Tree or list item | Selecting another folder or item closes the wizard without submitting |
+| Click outside the wizard | Also dismisses without submitting |
+
+After Cancel, Escape, item-click, or click-away, focus returns to the Explorer
+**Content** menu so you can continue working in the shell. The wizard does not
+POST a folder copy until you reach the last step and choose **Submit**.
+
 ## Views → My Content → Inbox
 
 Desktop Content Explorer **Inbox** is **not** a separate Content Explorer root and is **not**


### PR DESCRIPTION
## Summary

Residual of human QA fail on **#2797** (parent implement **#2792**, epic **#2400**): Explorer **Subfolder Copy** Cancel acted like Back (`resetWizard` to step 1) and the overlay stayed mounted. Clicking a tree/detail item also left the wizard up.

This change:

- Adds `onDismiss` to `SubfolderCopyWizard`. **Cancel** calls it (no POST). Without a host callback, Cancel still `resetWizard` for standalone mounts.
- **Back** still walks steps and does not dismiss.
- `ContentExplorerShell` unmounts the overlay on Cancel, **Escape** (`useDialogEscape` + focus restore to **Content** menu), **tree/detail select**, and **click-away** (panel + menu bar excluded so the menu toggle still works).

Parent: #2792 · Epic: #2400 · QA residual of #2797.

Fixes #3553
Partial #2797 #2792 #2400

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Java Tests run: 61; Vitest 2779 passed (374 files).
2. Standalone `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. Vitest: Cancel + `onDismiss` does not reset steps; Back stays mounted; shell Cancel/Escape/item-click/click-away unmount overlay.
4. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (Health=healthy; qa-health `server_log_errors` = pre-existing FastForward `PSDbStorageService` import noise, not feature).
5. Hot-copy `WebUI/target/generated-webui/cm/modern/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`.
6. `npm run test:surface -- --path tests/explorer-subfolder-copy.spec.js` — **5 passed** (Cancel dismiss + item-click no POST).
7. `npm run test:golden` — **2 passed**.
8. Playwright `pageerror` / console error listeners: **console-clean=yes**. Feature-related server ERROR: **none** (`server.log-clean=yes`; known FastForward/search-index noise only).

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` Subfolder Copy: Cancel / Escape / item-click / click-away close without submit; Back stays open
- [x] **Unit / module tests** — Vitest dismiss vs reset + shell unmount; both modules standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-subfolder-copy.spec.js` Cancel + item-click
- [x] **Build gates** — `WebUI`, `modules/perc-qa-automation` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path I/O; URL paths keep `/`)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (Java Tests run: 61; Vitest Tests 2779 passed / 374 files). `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (Surefire: No tests to run; npm ci only).
- **downstream_checked:** none (no `final`/public API shape change; TS/UI + Playwright only)

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build`; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`; Health=healthy
- deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- Playwright: `npm run test:surface -- --path tests/explorer-subfolder-copy.spec.js` → 5 passed; `npm run test:golden` → 2 passed
- console-clean=yes; server.log-clean=yes (feature); FastForward `PSDbStorageService` import ERROR on first cell start is pre-existing (HTTP 200 / Health=healthy)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.
