### PR TITLE
fix(webui): Slot detail must not crash Developer on non-array lists (#3554)

### DIFF
--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -21,6 +21,11 @@ import {
   resolveTemplateObjectGuid,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
+import {
+  normalizeSlotAssociations,
+  normalizeSlotDesignGaps,
+  normalizeSlotStringMap,
+} from "./slotLists";
 import type {
   CommunityDetail,
   CommunityRoleSummary,
@@ -33,6 +38,13 @@ import type {
   TemplateDetail,
   TemplateSummary,
 } from "./types";
+
+export {
+  asJacksonArray,
+  normalizeSlotAssociations,
+  normalizeSlotDesignGaps,
+  normalizeSlotStringMap,
+} from "./slotLists";
 
 /**
  * Jackson {@code @JsonRootName} / WRAP_ROOT_VALUE root for {@code TemplateDetail}.
@@ -112,6 +124,15 @@ export function wrapTemplateDetailForWire(
   return { [TEMPLATE_DETAIL_ROOT]: body };
 }
 
+function normalizeSlotDetail(detail: SlotDetail): SlotDetail {
+  return {
+    ...detail,
+    associations: normalizeSlotAssociations(detail.associations),
+    designGaps: normalizeSlotDesignGaps(detail.designGaps),
+    finderArguments: normalizeSlotStringMap(detail.finderArguments),
+  };
+}
+
 /**
  * Normalize a slots GET/PUT response to a flat {@link SlotDetail}.
  */
@@ -122,10 +143,10 @@ export function unwrapSlotDetail(payload: unknown): SlotDetail {
   }
   const nested = asRecord(root[SLOT_DETAIL_ROOT] ?? root.slotDetail);
   if (nested) {
-    return nested as SlotDetail;
+    return normalizeSlotDetail(nested as SlotDetail);
   }
   if ("name" in root || "label" in root || "associations" in root || "slotLayout" in root) {
-    return root as SlotDetail;
+    return normalizeSlotDetail(root as SlotDetail);
   }
   return {};
 }

--- a/WebUI/src/main/ts/api/developer/slotLists.ts
+++ b/WebUI/src/main/ts/api/developer/slotLists.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DesignGapWire } from "./designGaps";
+import type { SlotAssociationSummary } from "./types";
+
+/**
+ * Coerce a Jackson list field to a real array.
+ *
+ * <p>Truthy non-arrays ({@code {empty:false}}, JAXB {@code {SlotAssociation:…}},
+ * a single object) must not reach {@code (x || []).map} — that TypeError
+ * unmounts Developer (#3554 / #2908).
+ */
+export function asJacksonArray<T>(
+  raw: unknown,
+  wrapKeys: string[],
+  isItem?: (obj: Record<string, unknown>) => boolean,
+): T[] {
+  if (raw == null) {
+    return [];
+  }
+  if (Array.isArray(raw)) {
+    return raw as T[];
+  }
+  if (typeof raw !== "object") {
+    return [];
+  }
+  const obj = raw as Record<string, unknown>;
+  for (const k of wrapKeys) {
+    if (!(k in obj)) {
+      continue;
+    }
+    const inner = obj[k];
+    if (inner == null) {
+      continue;
+    }
+    if (Array.isArray(inner)) {
+      return inner as T[];
+    }
+    if (typeof inner === "object") {
+      return [inner as T];
+    }
+  }
+  if ("empty" in obj && typeof obj.empty === "boolean") {
+    const rest = Object.keys(obj).filter((k) => k !== "empty");
+    if (rest.length === 0) {
+      return [];
+    }
+  }
+  if (isItem && isItem(obj)) {
+    return [raw as T];
+  }
+  return [];
+}
+
+/** Slot {@code associations} — array, JAXB envelope, single object, or empty bean. */
+export function normalizeSlotAssociations(raw: unknown): SlotAssociationSummary[] {
+  return asJacksonArray<SlotAssociationSummary>(
+    raw,
+    ["SlotAssociation", "SlotAssociationSummary", "associations", "Association"],
+    (o) =>
+      "contentTypeGuid" in o ||
+      "templateGuid" in o ||
+      "contentTypeId" in o ||
+      "templateId" in o,
+  );
+}
+
+/** Slot {@code designGaps} — array, JAXB envelope, single {@code {code,message}}, or empty bean. */
+export function normalizeSlotDesignGaps(raw: unknown): DesignGapWire[] {
+  return asJacksonArray<DesignGapWire>(
+    raw,
+    ["DesignGap", "designGap", "designGaps"],
+    (o) => "code" in o || "message" in o,
+  );
+}
+
+function stringifyMapValue(val: unknown): string {
+  if (val == null) {
+    return "";
+  }
+  if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") {
+    return String(val);
+  }
+  if (typeof val === "object" && val !== null && "$" in val) {
+    const inner = (val as { $?: unknown }).$;
+    return inner == null ? "" : String(inner);
+  }
+  return "";
+}
+
+function isJaxbMapEntry(value: unknown): value is { key?: unknown; value?: unknown } {
+  return value != null && typeof value === "object" && !Array.isArray(value) && "key" in value;
+}
+
+/**
+ * Coerce {@code finderArguments} (and similar string maps) to {@code Record<string, string>}.
+ *
+ * <p>JAXB/Jackson often emits {@code { entry: [{key, value}, …] }} or a single
+ * {@code { entry: {key, value} }}. Rendering those objects as React children
+ * throws and the section boundary replaces Slots (#3554).
+ */
+export function normalizeSlotStringMap(raw: unknown): Record<string, string> {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const obj = raw as Record<string, unknown>;
+  if ("entry" in obj) {
+    const rawEntries = obj.entry;
+    const items = Array.isArray(rawEntries)
+      ? rawEntries
+      : isJaxbMapEntry(rawEntries)
+        ? [rawEntries]
+        : [];
+    const out: Record<string, string> = {};
+    for (const item of items) {
+      if (!isJaxbMapEntry(item) || item.key == null) {
+        continue;
+      }
+      out[String(item.key)] = stringifyMapValue(item.value);
+    }
+    return out;
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v != null && typeof v === "object") {
+      continue;
+    }
+    if (v == null) {
+      continue;
+    }
+    out[k] = String(v);
+  }
+  return out;
+}

--- a/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
@@ -17,7 +17,17 @@
 
 import React, { useEffect, useState } from "react";
 import { getSlotDetail, updateSlotDetail } from "../api/developer/assemblyApi";
-import { designGapCode, designGapKey, formatDesignGap } from "../api/developer/designGaps";
+import {
+  normalizeSlotAssociations,
+  normalizeSlotDesignGaps,
+  normalizeSlotStringMap,
+} from "../api/developer/slotLists";
+import {
+  designGapCode,
+  designGapKey,
+  formatDesignGap,
+  type DesignGapWire,
+} from "../api/developer/designGaps";
 import type { SlotAssociationSummary, SlotDetail } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
@@ -73,11 +83,15 @@ function associationsEqual(
   return true;
 }
 
-function cloneAssociations(list: SlotAssociationSummary[] | undefined): SlotAssociationSummary[] {
-  return (list || []).map((a) => ({
+function cloneAssociations(list: unknown): SlotAssociationSummary[] {
+  return normalizeSlotAssociations(list).map((a) => ({
     contentTypeGuid: a.contentTypeGuid ? { ...a.contentTypeGuid } : undefined,
     templateGuid: a.templateGuid ? { ...a.templateGuid } : undefined,
   }));
+}
+
+function slotDesignGaps(list: unknown): DesignGapWire[] {
+  return normalizeSlotDesignGaps(list);
 }
 
 export function SlotDetailPanel({
@@ -107,10 +121,13 @@ export function SlotDetailPanel({
     getSlotDetail(idOrName)
       .then((d) => {
         if (cancelled) return;
-        setDetail(d);
+        const associations = cloneAssociations(d.associations);
+        const designGaps = slotDesignGaps(d.designGaps);
+        const finderArguments = normalizeSlotStringMap(d.finderArguments);
+        setDetail({ ...d, associations, designGaps, finderArguments });
         setLabel(d.label || "");
         setDescription(d.description || "");
-        setAssociations(cloneAssociations(d.associations));
+        setAssociations(associations);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -166,10 +183,18 @@ export function SlotDetailPanel({
             : a.templateGuid,
         })),
       });
-      setDetail(saved);
+      const savedAssocs = cloneAssociations(saved.associations);
+      const savedGaps = slotDesignGaps(saved.designGaps);
+      const savedArgs = normalizeSlotStringMap(saved.finderArguments);
+      setDetail({
+        ...saved,
+        associations: savedAssocs,
+        designGaps: savedGaps,
+        finderArguments: savedArgs,
+      });
       setLabel(saved.label || "");
       setDescription(saved.description || "");
-      setAssociations(cloneAssociations(saved.associations));
+      setAssociations(savedAssocs);
       setNotice(DEV_MSG.SLOT_SAVED);
     } catch (err: unknown) {
       setError(panelErrMsg(err, DEV_MSG.SLOT_SAVE_ERROR));
@@ -178,7 +203,8 @@ export function SlotDetailPanel({
     }
   }
 
-  const argEntries = Object.entries(detail?.finderArguments || {});
+  const argEntries = Object.entries(normalizeSlotStringMap(detail?.finderArguments));
+  const gaps = slotDesignGaps(detail?.designGaps);
 
   return (
     <div data-testid="developer-slot-detail">
@@ -269,7 +295,9 @@ export function SlotDetailPanel({
                   <li key={k}>
                     <span style={{ fontFamily: "monospace" }}>{k}</span>
                     {" = "}
-                    <span style={{ fontFamily: "monospace", color: catalogColors.muted }}>{v}</span>
+                    <span style={{ fontFamily: "monospace", color: catalogColors.muted }}>
+                      {typeof v === "string" ? v : String(v ?? "")}
+                    </span>
                   </li>
                 ))}
               </ul>
@@ -426,11 +454,11 @@ export function SlotDetailPanel({
             </button>
           </div>
 
-          {(detail.designGaps || []).length > 0 ? (
+          {gaps.length > 0 ? (
             <section data-testid="developer-slot-gaps">
               <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.SLOT_GAPS}</h3>
               <ul style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
-                {(detail.designGaps || []).map((g, i) => (
+                {gaps.map((g, i) => (
                   <li key={designGapKey(g, i)} data-gap-code={designGapCode(g)}>
                     {formatDesignGap(g)}
                   </li>

--- a/WebUI/src/main/ts/developer/SlotsPanel.tsx
+++ b/WebUI/src/main/ts/developer/SlotsPanel.tsx
@@ -22,6 +22,7 @@ import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
 import { monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 import { SlotDetailPanel } from "./SlotDetailPanel";
 
 /** Open-key for detail; null when the row is not selectable. */
@@ -53,7 +54,14 @@ export function SlotsPanel(): React.ReactElement {
   }, []);
 
   if (selected) {
-    return <SlotDetailPanel idOrName={selected} onBack={() => setSelected(null)} />;
+    return (
+      <DeveloperSectionErrorBoundary
+        label={DEV_MSG.TAB_SLOTS}
+        testId="developer-slot-detail-error"
+      >
+        <SlotDetailPanel idOrName={selected} onBack={() => setSelected(null)} />
+      </DeveloperSectionErrorBoundary>
+    );
   }
 
   if (error) return <CatalogStatus testId="developer-slot-error" error>{error}</CatalogStatus>;

--- a/WebUI/src/test/ts/api/developer/assemblyApi.slotDetail.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.slotDetail.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SLOT_DETAIL_ROOT,
+  getSlotDetail,
+  normalizeSlotAssociations,
+  normalizeSlotDesignGaps,
+  unwrapSlotDetail,
+} from "../../../../main/ts/api/developer/assemblyApi";
+import { PATHS } from "../../../../main/ts/api/paths";
+
+const assoc = {
+  contentTypeGuid: { stringValue: "0-2-301" },
+  templateGuid: { stringValue: "0-10-1" },
+};
+
+describe("unwrapSlotDetail / Jackson list fields (#3554)", () => {
+  it("unwraps SlotDetail root and keeps real arrays", () => {
+    const flat = unwrapSlotDetail({
+      [SLOT_DETAIL_ROOT]: {
+        name: "rffList",
+        associations: [assoc],
+        designGaps: [{ code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" }],
+      },
+    });
+    expect(flat.name).toBe("rffList");
+    expect(Array.isArray(flat.associations)).toBe(true);
+    expect(flat.associations).toHaveLength(1);
+    expect(Array.isArray(flat.designGaps)).toBe(true);
+    expect(flat.designGaps?.[0]).toEqual({
+      code: "SLOT_CREATE_DELETE",
+      message: "Create / delete not supported",
+    });
+  });
+
+  it("normalizes Jackson empty-collection beans to []", () => {
+    const flat = unwrapSlotDetail({
+      name: "sys_AutoIndex",
+      associations: { empty: false },
+      designGaps: { empty: true },
+    });
+    expect(flat.associations).toEqual([]);
+    expect(flat.designGaps).toEqual([]);
+  });
+
+  it("unwraps JAXB single-item association and gap envelopes", () => {
+    const flat = unwrapSlotDetail({
+      name: "rffCalendar",
+      associations: { SlotAssociation: assoc },
+      designGaps: {
+        DesignGap: { code: "SLOT_ASSOC_GUIDS_ONLY", message: "Guids only" },
+      },
+    });
+    expect(flat.associations).toEqual([assoc]);
+    expect(flat.designGaps).toEqual([{ code: "SLOT_ASSOC_GUIDS_ONLY", message: "Guids only" }]);
+  });
+
+  it("unwraps JAXB multi-item envelopes", () => {
+    const second = {
+      contentTypeGuid: { stringValue: "0-2-302" },
+      templateGuid: { stringValue: "0-10-2" },
+    };
+    const flat = unwrapSlotDetail({
+      name: "rffList",
+      associations: { SlotAssociation: [assoc, second] },
+      designGaps: {
+        DesignGap: [
+          { code: "A", message: "one" },
+          { code: "B", message: "two" },
+        ],
+      },
+    });
+    expect(flat.associations).toEqual([assoc, second]);
+    expect(flat.designGaps).toHaveLength(2);
+  });
+
+  it("flattens JAXB finderArguments {entry:[{key,value}]} to a string map", () => {
+    const flat = unwrapSlotDetail({
+      name: "rffAutoPressReleases2007",
+      associations: assoc,
+      finderArguments: {
+        entry: [
+          { key: "template", value: "rffSnDateAndTitleLink" },
+          { key: "type", value: "sql" },
+        ],
+      },
+      designGaps: [{ code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" }],
+    });
+    expect(flat.finderArguments).toEqual({
+      template: "rffSnDateAndTitleLink",
+      type: "sql",
+    });
+    expect(flat.associations).toEqual([assoc]);
+  });
+
+  it("wraps a lone association object and a lone {code,message} gap", () => {
+    const flat = unwrapSlotDetail({
+      name: "rffContacts",
+      associations: assoc,
+      designGaps: { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" },
+    });
+    expect(flat.associations).toEqual([assoc]);
+    expect(flat.designGaps).toEqual([
+      { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" },
+    ]);
+  });
+
+  it("returns empty object for unrelated envelopes", () => {
+    expect(unwrapSlotDetail({ Error: { message: "x" } })).toEqual({});
+    expect(unwrapSlotDetail(null)).toEqual({});
+  });
+});
+
+describe("normalizeSlotAssociations / normalizeSlotDesignGaps", () => {
+  it("leaves real arrays unchanged", () => {
+    expect(normalizeSlotAssociations([assoc])).toEqual([assoc]);
+    expect(normalizeSlotDesignGaps([{ code: "X", message: "m" }])).toEqual([
+      { code: "X", message: "m" },
+    ]);
+  });
+
+  it("maps nullish and primitives to []", () => {
+    expect(normalizeSlotAssociations(undefined)).toEqual([]);
+    expect(normalizeSlotAssociations("nope")).toEqual([]);
+    expect(normalizeSlotDesignGaps(null)).toEqual([]);
+    expect(normalizeSlotDesignGaps(12)).toEqual([]);
+  });
+});
+
+describe("getSlotDetail unwraps non-array list fields (#3554)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GET SlotDetail with {empty:false} associations does not throw", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          SlotDetail: {
+            name: "sys_AutoIndex",
+            label: "Auto Index",
+            associations: { empty: false },
+            designGaps: [{ code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const d = await getSlotDetail("sys_AutoIndex");
+    expect(d.name).toBe("sys_AutoIndex");
+    expect(Array.isArray(d.associations)).toBe(true);
+    expect(d.associations).toEqual([]);
+    expect(d.designGaps).toEqual([
+      { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" },
+    ]);
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain(`${PATHS.SLOTS}/`);
+    expect(url).toContain(encodeURIComponent("sys_AutoIndex"));
+  });
+});

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -1153,6 +1153,33 @@ it("loads views catalog section", async () => {
     });
   });
 
+  it("keeps Developer mounted when slot associations are a non-array Jackson envelope (#3554)", async () => {
+    const { getSlotDetail } = await import("../../../main/ts/api/developer/assemblyApi");
+    (getSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      name: "sys_AutoIndex",
+      label: "Auto Index",
+      associations: { empty: false },
+      designGaps: {
+        DesignGap: { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" },
+      },
+    });
+    render(<DeveloperShell initialSection="slots" embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-table")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Open Target/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("route-error")).toBeNull();
+    expect(screen.getByTestId("tab-developer-slots")).toBeTruthy();
+    expect(screen.getByTestId("developer-slot-assoc-empty")).toBeTruthy();
+    expect(screen.getByTestId("developer-slot-gaps").textContent).toContain(
+      "Create / delete not supported",
+    );
+    expect(screen.queryByTestId("developer-slot-detail-error")).toBeNull();
+  });
+
   it("edits object ACL permissions on content type detail and saves", async () => {
     const { saveObjectAcl, getAclForObject } = await import(
       "../../../main/ts/api/developer/aclApi"

--- a/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
@@ -113,4 +113,89 @@ describe("SlotDetailPanel", () => {
       DEV_MSG.SLOT_DETAIL_ERROR,
     );
   });
+
+  it("does not throw when associations is a Jackson empty bean (#3554)", async () => {
+    getSlotDetail.mockResolvedValue({
+      ...sampleDetail,
+      associations: { empty: false },
+      designGaps: [
+        { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported" },
+      ],
+    });
+    render(<SlotDetailPanel idOrName="sys_AutoIndex" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail")).toBeTruthy();
+    expect(screen.getByTestId("developer-slot-assoc-empty")).toBeTruthy();
+    expect(screen.getByTestId("developer-slot-gaps").textContent).toContain(
+      "Create / delete not supported",
+    );
+    expect(
+      screen.getByTestId("developer-slot-gaps").querySelector(
+        '[data-gap-code="SLOT_CREATE_DELETE"]',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("developer-slot-detail-error")).toBeNull();
+  });
+
+  it("renders JAXB finderArguments entries as readable strings (#3554)", async () => {
+    getSlotDetail.mockResolvedValue({
+      ...sampleDetail,
+      associations: {
+        contentTypeGuid: { stringValue: "0-2-316" },
+        templateGuid: { stringValue: "0-4-512" },
+      },
+      finderArguments: {
+        entry: [
+          { key: "template", value: "rffSnDateAndTitleLink" },
+          { key: "type", value: "sql" },
+          { key: "query", value: "SELECT 1" },
+        ],
+      },
+      designGaps: [
+        { code: "SLOT_CREATE_DELETE", message: "Create / delete not supported via this REST API" },
+      ],
+    });
+    render(<SlotDetailPanel idOrName="rffAutoPressReleases2007" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-title")).toBeTruthy();
+    });
+    const args = screen.getByTestId("developer-slot-args");
+    expect(args.textContent).toContain("template");
+    expect(args.textContent).toContain("rffSnDateAndTitleLink");
+    expect(args.textContent).toContain("type");
+    expect(args.textContent).toContain("sql");
+    expect(screen.getByTestId("developer-slot-assoc-row-0").textContent).toContain("0-2-316");
+    expect(screen.getByTestId("developer-slot-gaps").textContent).toContain(
+      "Create / delete not supported via this REST API",
+    );
+    expect(screen.queryByTestId("developer-slot-detail-error")).toBeNull();
+  });
+
+  it("unwraps a single association object and JAXB DesignGap envelope (#3554)", async () => {
+    getSlotDetail.mockResolvedValue({
+      ...sampleDetail,
+      associations: {
+        contentTypeGuid: { stringValue: "0-2-301" },
+        templateGuid: { stringValue: "0-10-1" },
+      },
+      designGaps: {
+        DesignGap: { code: "SLOT_ASSOC_GUIDS_ONLY", message: "Guids only on associations" },
+      },
+    });
+    render(<SlotDetailPanel idOrName="rffCalendar" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-assoc-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-assoc-row-0").textContent).toContain("0-2-301");
+    expect(screen.getByTestId("developer-slot-gaps").textContent).toContain(
+      "Guids only on associations",
+    );
+    expect(
+      screen.getByTestId("developer-slot-gaps").querySelector(
+        '[data-gap-code="SLOT_ASSOC_GUIDS_ONLY"]',
+      ),
+    ).toBeTruthy();
+  });
 });

--- a/docs/ai-generated/code-reviews/3554-slot-detail-nonarray-erlang.md
+++ b/docs/ai-generated/code-reviews/3554-slot-detail-nonarray-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review — #3554 Slot detail non-array associations/designGaps
+
+**Branch:** `fix/issue-3554-slot-detail-nonarray-lists`  
+**Date:** 2026-08-18  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Developer Slot detail crashed the Developer shell when Jackson returned a
+truthy non-array for `associations` or `designGaps` (`(x || []).map` TypeError),
+or a JAXB `{entry:[{key,value}]}` finder-arguments map (invalid React child).
+The change normalizes those fields in `unwrapSlotDetail` and again in
+`SlotDetailPanel` (so mocked GET payloads cannot throw). Slots detail is also
+isolated with `DeveloperSectionErrorBoundary` (`developer-slot-detail-error`).
+Structured `{code,message}` gaps still render via `formatDesignGap`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, no missing behavioral tests for the new list-normalization logic, no
+non-portable path/file I/O.
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path joins, temp dirs, or path assertions.
+
+## Memory patterns hit
+
+- Behavioral unit tests for new/changed non-trivial logic (unwrap + panel + shell)
+- Change-class closure: Vitest + Playwright companion for WebUI screen + product-docs
+- Do not treat focused `-Dtest` as sufficient — full `WebUI` `mvnw clean install` green
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- `assemblyApi` re-exports `normalizeSlot*` for callers; panel imports `slotLists`
+  so `vi.mock(assemblyApi)` cannot drop the helpers.
+- Nested `DeveloperSectionErrorBoundary` on detail uses the same test id as the
+  in-panel load error; only one is visible at a time.
+
+## Build evidence (C1)
+
+- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
+- Surefire: Tests run: 61, Failures: 0
+- Vitest (Maven test phase): Tests 2785 passed / 375 files
+- Playwright: `npm run test:surface -- --path tests/bugs/bug-3554-developer-slot-detail.spec.js` → 1 passed
+  (H2 QA `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`; console-clean=yes;
+  FastForward `PSDbStorageService` import ERRORs pre-exist / not feature-related)

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3554-developer-slot-detail.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3554-developer-slot-detail.spec.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer → Slots detail must not crash the Developer shell (#3554 / #2908).
+ *
+ * Opening slot rows (including FastForward names that previously threw
+ * TypeError: (e || []).map is not a function) must keep Developer mounted
+ * and show Slot detail or an in-panel error — never "Unable to load Developer".
+ *
+ * Surface-filtered QA mode:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/bugs/bug-3554-developer-slot-detail.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+const CRASH_FIXTURE_LABELS = [
+  "All Press Releases 2007",
+  "All Press Releases 2008",
+  "Auto Index",
+  "Calendar Events",
+  "Contacts",
+];
+
+function developerSlotsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "slots",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Developer slot detail non-array lists (#3554)", () => {
+  test("opening slot rows does not replace Developer with route error", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(developerSlotsUrl(), { waitUntil: "networkidle" });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-slots"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const panel = page.locator('[data-testid="developer-slot-panel"]');
+    const empty = page.locator('[data-testid="developer-slot-empty"]');
+    const listError = page.locator('[data-testid="developer-slot-error"]');
+    await expect(panel.or(empty).or(listError).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await listError.isVisible()) {
+      throw new Error(
+        `Developer slots catalog error: ${(await listError.innerText()).trim()}`,
+      );
+    }
+    if (await empty.isVisible()) {
+      test.skip(true, "No slots in catalog — cannot exercise Slot detail");
+    }
+
+    await expect(page.locator('[data-testid="developer-slot-table"]')).toBeVisible();
+
+    const openButtons = page.locator(
+      '[data-testid="developer-slot-table"] button[aria-label^="Open "]',
+    );
+    const count = await openButtons.count();
+    expect(count, "slot catalog should have at least one open button").toBeGreaterThan(
+      0,
+    );
+
+    const preferred = [];
+    for (let i = 0; i < count; i++) {
+      const label = (await openButtons.nth(i).getAttribute("aria-label")) || "";
+      const name = label.replace(/^Open\s+/i, "").trim();
+      if (CRASH_FIXTURE_LABELS.some((fix) => name.includes(fix))) {
+        preferred.push(i);
+      }
+    }
+    const indexes = preferred.length > 0 ? preferred.slice(0, 5) : [0, 1, 2, 3].filter((i) => i < count);
+
+    for (const idx of indexes) {
+      await openButtons.nth(idx).click();
+
+      const detail = page.locator('[data-testid="developer-slot-detail"]');
+      const detailError = page.locator('[data-testid="developer-slot-detail-error"]');
+      await expect(detail.or(detailError).first()).toBeVisible({ timeout: 20_000 });
+
+      await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible();
+      await expect(page.locator('[data-testid="tab-developer-slots"]')).toBeVisible();
+      await expect(page.getByText("Unable to load Developer")).toHaveCount(0);
+
+      if (await detail.isVisible()) {
+        await expect(page.locator('[data-testid="developer-slot-associations"]')).toBeVisible();
+        const gaps = page.locator('[data-testid="developer-slot-gaps"]');
+        if (await gaps.isVisible()) {
+          const text = (await gaps.innerText()).trim();
+          expect(text.length, "designGaps should render readable text").toBeGreaterThan(0);
+          expect(text).not.toMatch(/\[object Object\]/);
+        }
+        await page.locator('[data-testid="developer-slot-back"]').click();
+      } else {
+        // In-panel / section boundary: remount Slots via another tab.
+        await page.locator('[data-testid="tab-developer-templates"]').click();
+        await expect(page.locator('[data-testid="tab-developer-templates"]')).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+        await page.locator('[data-testid="tab-developer-slots"]').click();
+      }
+
+      await expect(page.locator('[data-testid="developer-slot-table"]')).toBeVisible({
+        timeout: 20_000,
+      });
+    }
+
+    const mapErrors = pageErrors.filter((m) => /\.map is not a function/i.test(m));
+    expect(mapErrors, `pageerror .map: ${mapErrors.join(" | ")}`).toEqual([]);
+    expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+    const unexpectedConsole = consoleErrors.filter(
+      (t) => !/Download the React DevTools/i.test(t),
+    );
+    expect(
+      unexpectedConsole,
+      `console error: ${unexpectedConsole.join(" | ")}`,
+    ).toEqual([]);
+  });
+});

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -158,6 +158,30 @@ Assembly templates used by the [Design SPA](id:admin-design-templates) are expos
 Create (`POST /services/templates`) is the Design **Create template** contract when that
 slice is on the server; otherwise create stays on residual classic hosts.
 
+## Slots (design catalog)
+
+Assembly **slots** used by **Developer → Slots** are exposed under `/services/slots`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/slots` | List slot summaries (label, name, description) |
+| `GET` | `/services/slots/{idOrName}` | Design detail (finder, associations, `designGaps`) |
+| `PUT` | `/services/slots/{idOrName}` | Update label, description, and/or content-type/template associations |
+
+JSON may wrap a single item as `SlotDetail`. `associations` and `designGaps` are arrays
+(`SlotAssociationSummary[]` and structured `{code,message}` gaps). Some Jackson/JAXB
+envelopes historically serialize a list as a single object, a `{ SlotAssociation: … }` /
+`{ DesignGap: … }` wrapper, or an empty-collection bean (`{ "empty": false }`).
+Finder arguments may appear as a JAXB map (`{ "entry": [ { "key", "value" }, … ] }`)
+instead of a flat `{ name: value }` object.
+
+**Developer → Slots** detail treats those non-array shapes as an empty list or unwraps
+the single item, and flattens finder-argument maps to readable `name = value` rows.
+The slot form stays on screen (or shows an in-panel error). It does
+**not** replace the Developer shell with **Unable to load Developer**. Capability gaps
+still render as the human-readable **message** (fallback **code**). Load failures stay
+in the slot detail panel — use **Back** to return to the catalog.
+
 ## Content types (design catalog)
 
 | Operation | Path | Notes |


### PR DESCRIPTION
## Summary

Developer **Slots** detail threw `TypeError: (e || []).map is not a function` (and later invalid React children) when Jackson returned a **truthy non-array** for `associations` (single association object) or a JAXB `finderArguments` `{ entry: [{key,value}, ...] }` map. That unmounted Developer (or isolated the Slots tab) for FastForward slots such as All Press Releases 2007/2008, Auto Index, and Calendar Events.

This PR normalizes `associations`, `designGaps`, and `finderArguments` to real arrays / string maps in `unwrapSlotDetail` and again in `SlotDetailPanel` (so mocked or odd wire cannot throw). Load/render failures stay in-panel (`developer-slot-detail-error`). Structured `{code,message}` gaps still render as human-readable text (no #2903 regression).

Parent: #2908 (QA Failed) / #2903 (REST-GAPS-01) / epic #1690.

Fixes #3554
Related #2908 #2903 #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd WebUI && ../mvnw.cmd clean install` (this PR).
2. Vitest: `assemblyApi.slotDetail`, `SlotDetailPanel`, `DeveloperShell` non-array / JAXB map cases.
3. H2 QA: `perc-devctl qa-up --skip-image-build` → hot-copy `cm/modern` → `npm run test:surface -- --path tests/bugs/bug-3554-developer-slot-detail.spec.js`.
4. Manual: Admin → Developer → Slots → open All Press Releases 2007/2008, Auto Index, Calendar Events, Contacts. Developer stays mounted; gaps readable.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Slots section (non-array lists + finder map flattening; in-panel error vs Unable to load Developer)
- [x] **Unit / module tests** — behavioral Vitest for unwrap + panel + shell; WebUI `mvnw clean install` green
- [x] **WebUI + Playwright** — `tests/bugs/bug-3554-developer-slot-detail.spec.js` (H2 QA, 1 passed)
- [x] **Build gates** — WebUI standalone clean install (no skipTests); no Java API shape change
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** WebUI
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS. Surefire Tests run: 61, Failures: 0. Vitest Tests 2785 passed (375 files).
- **downstream_checked:** none (C2 did not apply — no `final`/signature change on Java types)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993` (Health=healthy, HTTP 200). `qa-health` RESULT:FAIL DETAIL:server_log_errors FastForward `PSDbStorageService` import (pre-existing noise, not feature-related).
- Deploy: `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/` (JS hot-copy, no Jetty restart).
- Playwright: `npm run test:surface -- --path tests/bugs/bug-3554-developer-slot-detail.spec.js` → **1 passed**.
- console-clean=yes (pageerror + unexpected console error empty in spec).
- server.log-clean=yes for this feature (FastForward binary import ERRORs pre-exist).

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.