### PR TITLE
cluster: absorb Explorer shell thrash (#3550 #3552 #3555)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -47,6 +47,7 @@
 
 import { get, post, type ApiError } from "../client";
 import { PATHS } from "../paths";
+import { bindExplorerPathItemId } from "./pathItemId";
 import type {
   PSPathItem,
   PSPagedResult,
@@ -136,7 +137,7 @@ export function unwrapPathItemList(res: PSPathItemListResponse | null | undefine
     };
     throw err;
   }
-  return list;
+  return list.map(bindExplorerPathItemId);
 }
 
 export async function findChildren(path: string): Promise<PSPathItem[]> {
@@ -180,7 +181,7 @@ export async function paginatedFolder(
     return { children: [], totalCount: 0, startIndex: params.startIndex };
   }
   return {
-    children: paged.childrenInPage ?? [],
+    children: (paged.childrenInPage ?? []).map(bindExplorerPathItemId),
     totalCount: paged.childrenCount ?? undefined,
     startIndex: paged.startIndex ?? params.startIndex,
   };
@@ -207,14 +208,16 @@ export async function findItemByPath(path: string): Promise<PSPathItem> {
     return {} as PSPathItem;
   }
   const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function findItemById(id: string): Promise<PSPathItem> {
   const res = await get<PSPathItemResponse>(
     `${PATHS.PATH_ITEM_ID}/${encodeURIComponent(id)}`,
   );
-  return res?.PathItem ?? ({} as PSPathItem);
+  const item = res?.PathItem ?? ({} as PSPathItem);
+  return bindExplorerPathItemId(item);
 }
 
 export async function addNewFolder(

--- a/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
@@ -56,14 +56,29 @@ export function unwrapExplorerWireId(
   if (typeof stringValue === "string" && stringValue.trim()) {
     return stringValue.trim();
   }
-  if (typeof rec.id === "string" || typeof rec.id === "number") {
+  if (typeof rec.id === "number" && Number.isFinite(rec.id)) {
     return rec.id;
   }
-  const host = rec.hostId ?? rec.host_id;
-  const type = rec.type;
-  const uuid = rec.uuid;
+  if (typeof rec.id === "string" && rec.id.trim()) {
+    return rec.id.trim();
+  }
+  const host = guidPart(rec.hostId ?? rec.host_id);
+  const type = guidPart(rec.type);
+  const uuid = guidPart(rec.uuid);
   if (host != null && type != null && uuid != null) {
     return `${host}-${type}-${uuid}`;
+  }
+  return undefined;
+}
+
+/** Non-blank GUID segment. {@code 0} is a valid host id; empty string is not. */
+function guidPart(value: unknown): string | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(Math.trunc(value)) : undefined;
+  }
+  if (typeof value === "string") {
+    const text = value.trim();
+    return text.length > 0 ? text : undefined;
   }
   return undefined;
 }
@@ -105,6 +120,23 @@ export function parseExplorerContentId(
   }
   const n = Number(last);
   return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+}
+
+/**
+ * Compare Explorer item ids without number/string mismatches
+ * ({@code "42"} vs {@code 42}) so list {@code aria-selected} tracks
+ * {@code selection.item} after a row click (#3467).
+ */
+export function sameExplorerItemId(
+  a: string | number | null | undefined,
+  b: string | number | null | undefined,
+): boolean {
+  if (a == null || b == null) {
+    return false;
+  }
+  const left = String(a).trim();
+  const right = String(b).trim();
+  return left.length > 0 && left === right;
 }
 
 function collectTypePropertyMap(
@@ -159,22 +191,14 @@ export function bindExplorerPathItemId(item: PSPathItem): PSPathItem {
     }
     const nextId =
       typeof unwrapped === "string" ? unwrapped.trim() : String(unwrapped);
-    if (item.id === nextId) {
+    if (sameExplorerItemId(item.id, nextId)) {
       return item;
     }
     return { ...item, id: nextId };
   }
 
-  const unwrappedId = unwrapExplorerWireId(item.id);
-  if (typeof unwrappedId === "string" && unwrappedId !== item.id) {
-    return { ...item, id: unwrappedId };
-  }
-  if (typeof unwrappedId === "number") {
-    const nextId = String(unwrappedId);
-    if (item.id === nextId) {
-      return item;
-    }
-    return { ...item, id: nextId };
-  }
+  // Nothing parseable — keep the original id (folder slugs, unparseable
+  // objects). Do not assign an unwrapped string that
+  // {@link parseExplorerContentId} rejected.
   return item;
 }

--- a/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathItemId.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer list / selection content-id bind (#3546 / parent #2778).
+ *
+ * <p>Sample-site and display-format rows sometimes omit {@code id}, send a
+ * slug, or wrap a GUID as {@code {stringValue}} / host-type-uuid parts.
+ * Relationships (and other item tools) only mount when
+ * {@link parseExplorerContentId} succeeds — bind a parseable id onto the
+ * path item before the list hands it to selection.</p>
+ */
+
+import type { PSPathItem } from "./types";
+
+/** Display-format / type-property keys that carry a CMS content id. */
+const CONTENT_ID_KEYS = [
+  "sys_contentid",
+  "sys_contentId",
+  "contentId",
+  "contentid",
+  "sys_id",
+] as const;
+
+/**
+ * Flatten a wire id (string, number, or Jackson GUID object) to a scalar.
+ */
+export function unwrapExplorerWireId(
+  raw: unknown,
+): string | number | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "number" || typeof raw === "string") {
+    return raw;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const rec = raw as Record<string, unknown>;
+  const stringValue = rec.stringValue ?? rec.string_value;
+  if (typeof stringValue === "string" && stringValue.trim()) {
+    return stringValue.trim();
+  }
+  if (typeof rec.id === "string" || typeof rec.id === "number") {
+    return rec.id;
+  }
+  const host = rec.hostId ?? rec.host_id;
+  const type = rec.type;
+  const uuid = rec.uuid;
+  if (host != null && type != null && uuid != null) {
+    return `${host}-${type}-${uuid}`;
+  }
+  return undefined;
+}
+
+/**
+ * Parse a content id from a numeric string, GUID {@code host-type-uuid}
+ * (last segment), or Jackson GUID object.
+ *
+ * @returns positive integer content id, or {@code null}
+ */
+export function parseExplorerContentId(
+  id: string | number | undefined | unknown,
+): number | null {
+  if (id == null || id === "") {
+    return null;
+  }
+  if (typeof id === "number") {
+    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
+  }
+  if (typeof id === "object") {
+    const unwrapped = unwrapExplorerWireId(id);
+    if (unwrapped == null) {
+      return null;
+    }
+    return parseExplorerContentId(unwrapped);
+  }
+  const s = String(id).trim();
+  if (!s) {
+    return null;
+  }
+  const whole = Number(s);
+  if (Number.isFinite(whole) && whole > 0) {
+    return Math.trunc(whole);
+  }
+  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
+  const last = s.split("-").pop();
+  if (!last) {
+    return null;
+  }
+  const n = Number(last);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
+}
+
+function collectTypePropertyMap(
+  typeProperties: unknown,
+): Record<string, unknown> | null {
+  if (typeProperties == null || typeof typeProperties !== "object") {
+    return null;
+  }
+  const rec = typeProperties as Record<string, unknown>;
+  const entries = rec.entries;
+  if (entries != null && typeof entries === "object" && !Array.isArray(entries)) {
+    return entries as Record<string, unknown>;
+  }
+  return rec;
+}
+
+/**
+ * Copy of {@code item} with {@code id} set to a parseable content/GUID
+ * string when the wire omitted it or used a non-GUID shape that still
+ * carries {@code sys_contentid} / a GUID object.
+ *
+ * Folders keep their original id when nothing parseable is found (site
+ * name slugs stay slugs).
+ */
+export function bindExplorerPathItemId(item: PSPathItem): PSPathItem {
+  const extras = item as PSPathItem & {
+    typeProperties?: unknown;
+    guid?: unknown;
+    Guid?: unknown;
+  };
+  const candidates: unknown[] = [item.id, extras.guid, extras.Guid];
+  const dp = item.displayProperties;
+  if (dp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(dp[key]);
+    }
+  }
+  const tp = collectTypePropertyMap(extras.typeProperties);
+  if (tp) {
+    for (const key of CONTENT_ID_KEYS) {
+      candidates.push(tp[key]);
+    }
+  }
+
+  for (const raw of candidates) {
+    const unwrapped = unwrapExplorerWireId(raw);
+    if (unwrapped == null) {
+      continue;
+    }
+    if (parseExplorerContentId(unwrapped) == null) {
+      continue;
+    }
+    const nextId =
+      typeof unwrapped === "string" ? unwrapped.trim() : String(unwrapped);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+
+  const unwrappedId = unwrapExplorerWireId(item.id);
+  if (typeof unwrappedId === "string" && unwrappedId !== item.id) {
+    return { ...item, id: unwrappedId };
+  }
+  if (typeof unwrappedId === "number") {
+    const nextId = String(unwrappedId);
+    if (item.id === nextId) {
+      return item;
+    }
+    return { ...item, id: nextId };
+  }
+  return item;
+}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -83,6 +83,7 @@ import {
   transitionItem,
 } from "../api/contentExplorer/itemWorkflowApi";
 import { findItemByPath } from "../api/contentExplorer/pathApi";
+import { bindExplorerPathItemId } from "../api/contentExplorer/pathItemId";
 import {
   executeView as executeViewApi,
   listViews as listViewsApi,
@@ -152,7 +153,12 @@ import {
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { resolvePublishKind } from "./itemPublish";
-import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import {
+  EMPTY_SELECTION,
+  isFolder,
+  sameExplorerItemId,
+  type Selection,
+} from "./selection";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 import {
   isFolderIdLookupPath,
@@ -605,7 +611,9 @@ function ContentExplorerShellInner({
     ...actionHandlers,
     onOpen: (item) => {
       if (isFolder(item)) {
-        setSelection({ folderPath: item.path, item: null });
+        const folderPath =
+          resolveExplorerListPath(item, item.path) ?? item.path;
+        setSelection({ folderPath, item: null });
         return;
       }
       onOpenItem(item);
@@ -748,7 +756,41 @@ function ContentExplorerShellInner({
   );
 
   const handleSelectItem = useCallback((item: PSPathItem) => {
-    setSelection((prev) => ({ ...prev, item }));
+    const bound = bindExplorerPathItemId(item);
+    setSelection((prev) => ({ ...prev, item: bound }));
+    // List rows that omit id / use a slug still resolve via path so
+    // View → Relationships can mount (#3546 / #2778).
+    if (
+      isFolder(bound) ||
+      parseExplorerContentId(bound.id) != null ||
+      !isFolderIdLookupPath(bound.path)
+    ) {
+      return;
+    }
+    void findItemByPath(bound.path)
+      .then((resolved) => {
+        const next = bindExplorerPathItemId({
+          ...bound,
+          ...resolved,
+          id: resolved.id ?? bound.id,
+          path: bound.path || resolved.path,
+        });
+        if (parseExplorerContentId(next.id) == null) {
+          return;
+        }
+        setSelection((prev) => {
+          if (prev.item == null) {
+            return prev;
+          }
+          const sameRow =
+            sameExplorerItemId(prev.item.id, bound.id) ||
+            (Boolean(prev.item.path) && prev.item.path === bound.path);
+          return sameRow ? { ...prev, item: next } : prev;
+        });
+      })
+      .catch(() => {
+        // Keep the list row; relationships stays hint if id never binds.
+      });
   }, []);
 
   const handleActivateItem = useCallback(
@@ -1152,6 +1194,10 @@ function ContentExplorerShellInner({
     !isFolder(selection.item) &&
     selection.item.id != null &&
     String(selection.item.id).trim().length > 0;
+  const hasRelationshipItem =
+    selection.item != null &&
+    !isFolder(selection.item) &&
+    parseExplorerContentId(selection.item.id) != null;
   const hasOpenSidePanel =
     showSearch ||
     showSecurity ||
@@ -1669,10 +1715,7 @@ function ContentExplorerShellInner({
           {message(EXPLORER_MSG.SUBFOLDER_COPY_SELECT_FOLDER)}
         </div>
       )}
-      {showRelationships &&
-        selection.item &&
-        selection.item.type !== "folder" &&
-        parseExplorerContentId(selection.item.id) != null && (
+      {showRelationships && hasRelationshipItem && (
           <section
             id="explorer-relationships-panel"
             style={sidePanelStyle}
@@ -1681,19 +1724,14 @@ function ContentExplorerShellInner({
           >
             <RelationshipsView
               item={{
-                id: String(selection.item.id),
-                path: selection.item.path,
+                id: String(selection.item!.id),
+                path: selection.item!.path,
                 folderPath: selection.folderPath || undefined,
               }}
             />
           </section>
         )}
-      {showRelationships &&
-        !(
-          selection.item &&
-          selection.item.type !== "folder" &&
-          parseExplorerContentId(selection.item.id) != null
-        ) && (
+      {showRelationships && !hasRelationshipItem && (
           <div
             id="explorer-relationships-panel"
             style={sidePanelStyle}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -114,7 +114,7 @@ import {
 } from "./actionEnablement";
 import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
-import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
+import { EMPTY_CLIPBOARD, applyClipboardAdd } from "./clipboard/model";
 import { toClipboardItem } from "./clipboard/toClipboardItem";
 import { ContextMenu } from "./ContextMenu";
 import { TemplatePickerDialog } from "./TemplatePickerDialog";
@@ -818,9 +818,9 @@ function ContentExplorerShellInner({
       if (clipboard == null) continue;
       items.push(clipboard);
     }
-    if (items.length > 0) {
-      setClipboardState((prev) => buildClipboard(prev, clipboardMode, items));
-    }
+    // Empty mapped set is a no-op (keep staged items). Opening the
+    // panel still happens so View → Clipboard stays checked.
+    setClipboardState((prev) => applyClipboardAdd(prev, clipboardMode, items));
     // Always mount the panel after Add so View → Clipboard is checked.
     // Clicking the View toggle after this would hide an already-open panel.
     setShowClipboard(true);
@@ -1748,7 +1748,10 @@ function ContentExplorerShellInner({
           >
             <RelationshipsView
               item={{
-                id: String(selection.item!.id),
+                id: String(
+                  parseExplorerContentId(selection.item!.id) ??
+                    selection.item!.id,
+                ),
                 path: selection.item!.path,
                 folderPath: selection.folderPath || undefined,
               }}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -153,7 +153,12 @@ import {
 } from "./ReducedActions";
 import { SearchPanel, type SearchPanelProps } from "./SearchPanel";
 import { resolvePublishKind } from "./itemPublish";
-import { EMPTY_SELECTION, isFolder, type Selection } from "./selection";
+import {
+  EMPTY_SELECTION,
+  explorerMultiSelectKey,
+  isFolder,
+  type Selection,
+} from "./selection";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 import {
   isFolderIdLookupPath,
@@ -733,8 +738,8 @@ function ContentExplorerShellInner({
 
   const handleToggleSelectItem = useCallback(
     (item: PSPathItem, next: boolean) => {
-      const id = item.id ?? item.path ?? item.name;
-      if (id == null || String(id).trim() === "") return;
+      const id = explorerMultiSelectKey(item);
+      if (id == null) return;
       setMultiSelectedIds((prev) => {
         const nextSet = new Set(prev);
         if (next) nextSet.add(id);

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -182,6 +182,10 @@ import {
 import { SiteCopyWizard } from "./wizards/SiteCopyWizard";
 import { SiteCreateWizard } from "./wizards/SiteCreateWizard";
 import { SubfolderCopyWizard } from "./wizards/SubfolderCopyWizard";
+import {
+  captureDialogOpener,
+  useDialogEscape,
+} from "../architecture/useDialogEscape";
 import { RelationshipsView } from "./views/RelationshipsView";
 import { DependencyViewer } from "./views/DependencyViewer";
 import type { PSNodeRelationshipSummary } from "../api/contentExplorer/relationship";
@@ -543,6 +547,10 @@ function ContentExplorerShellInner({
   const [showSiteCopy, setShowSiteCopy] = useState(false);
   /** Content → Subfolder Copy wizard panel (#2792 / parent #2400). */
   const [showSubfolderCopy, setShowSubfolderCopy] = useState(false);
+  const dismissSubfolderCopy = useCallback(() => {
+    setShowSubfolderCopy(false);
+  }, []);
+  const subfolderCopyPanelRef = useRef<HTMLElement | null>(null);
   const [showRelationships, setShowRelationships] = useState(false);
   const [showDependencies, setShowDependencies] = useState(false);
   const [showRevisions, setShowRevisions] = useState(false);
@@ -726,6 +734,7 @@ function ContentExplorerShellInner({
       setContextMenu(null);
       setViewRun(null);
       setSelectedViewKey(null);
+      setShowSubfolderCopy(false);
       if (folder) onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -742,6 +751,7 @@ function ContentExplorerShellInner({
       setContextMenu(null);
       setViewRun(null);
       setSelectedViewKey(null);
+      setShowSubfolderCopy(false);
       onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -749,6 +759,7 @@ function ContentExplorerShellInner({
 
   const handleSelectItem = useCallback((item: PSPathItem) => {
     setSelection((prev) => ({ ...prev, item }));
+    setShowSubfolderCopy(false);
   }, []);
 
   const handleActivateItem = useCallback(
@@ -1186,6 +1197,12 @@ function ContentExplorerShellInner({
         case "content-subfolder-copy":
           // Only open when a folder is in context; menu item is disabled otherwise.
           if (sourceFolderPathForCopy) {
+            if (!showSubfolderCopy) {
+              const contentMenu = document.querySelector<HTMLElement>(
+                '[data-testid="explorer-menu-content"]',
+              );
+              captureDialogOpener(contentMenu ?? document.activeElement);
+            }
             setShowSubfolderCopy((v) => !v);
           }
           break;
@@ -1231,8 +1248,36 @@ function ContentExplorerShellInner({
       handleRefreshList,
       siteNameForCopy,
       sourceFolderPathForCopy,
+      showSubfolderCopy,
     ],
   );
+
+  useDialogEscape(showSubfolderCopy, false, dismissSubfolderCopy);
+
+  useEffect(() => {
+    if (!showSubfolderCopy) {
+      return;
+    }
+    function onDocMouseDown(e: MouseEvent): void {
+      const target = e.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      const panel = subfolderCopyPanelRef.current;
+      if (panel && panel.contains(target)) {
+        return;
+      }
+      const menuBar = document.querySelector(
+        '[data-testid="explorer-menu-bar"]',
+      );
+      if (menuBar instanceof Node && menuBar.contains(target)) {
+        return;
+      }
+      setShowSubfolderCopy(false);
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [showSubfolderCopy]);
 
   const folderForActions: PSPathItem | null =
     selection.item && isFolder(selection.item)
@@ -1639,6 +1684,7 @@ function ContentExplorerShellInner({
       {showSubfolderCopy && sourceFolderPathForCopy && (
         <section
           id="explorer-subfolder-copy-panel"
+          ref={subfolderCopyPanelRef}
           style={sidePanelStyle}
           data-testid="explorer-subfolder-copy-panel"
           aria-label={message(EXPLORER_MSG.SUBFOLDER_COPY_PANEL_REGION)}
@@ -1650,6 +1696,7 @@ function ContentExplorerShellInner({
           <SubfolderCopyWizard
             key={`subfolder-copy-${sourceFolderPathForCopy}`}
             initialSource={sourceFolderPathForCopy}
+            onDismiss={dismissSubfolderCopy}
             onSettled={(ok) => {
               if (ok) {
                 setListEpoch((n) => n + 1);

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1304,7 +1304,6 @@ function ContentExplorerShellInner({
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
-            clipboardItemCount={clipboard.items.length}
             hasSiteContext={hasSiteContext}
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -114,6 +114,7 @@ import {
 import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
+import { toClipboardItem } from "./clipboard/toClipboardItem";
 import { ContextMenu } from "./ContextMenu";
 import { TemplatePickerDialog } from "./TemplatePickerDialog";
 import { ContentTypePickerDialog } from "./ContentTypePickerDialog";
@@ -305,34 +306,6 @@ type ContextMenuState = {
   x: number;
   y: number;
 } | null;
-
-/**
- * Map a `PSPathItem` (detail-list / tree row shape) into a `ClipboardItem`
- * (clipboard-panel input shape). Single source of truth so the
- * "Add to clipboard" handler and the `<ClipboardPanel items>` prop
- * never disagree on the kind / name / accessLevel mapping.
- *
- * Returns `null` when the item has no stable id (`item.id` and
- * `item.path` both missing) so the caller can skip it instead of
- * injecting a row that would later fail the paste transport.
- */
-function toClipboardItem(item: PSPathItem): ClipboardItem | null {
-  const id = item.id ?? item.path;
-  if (id == null) return null;
-  const kind: ClipboardItem["kind"] =
-    item.type === "folder"
-      ? "folder"
-      : item.category === "asset" || item.type === "asset"
-        ? "asset"
-        : "page";
-  return {
-    id,
-    path: item.path,
-    kind,
-    name: item.name ?? item.title ?? item.path,
-    sourceAccessLevel: item.accessLevel,
-  };
-}
 
 const sidePanelStyle: React.CSSProperties = {
   padding: 8,
@@ -760,8 +733,8 @@ function ContentExplorerShellInner({
 
   const handleToggleSelectItem = useCallback(
     (item: PSPathItem, next: boolean) => {
-      const id = item.id ?? item.path;
-      if (id == null) return;
+      const id = item.id ?? item.path ?? item.name;
+      if (id == null || String(id).trim() === "") return;
       setMultiSelectedIds((prev) => {
         const nextSet = new Set(prev);
         if (next) nextSet.add(id);
@@ -784,16 +757,20 @@ function ContentExplorerShellInner({
   }, []);
 
   const handleAddToClipboard = useCallback(() => {
-    if (multiSelectedItems.size === 0) return;
+    if (multiSelectedItems.size === 0 && multiSelectedIds.size === 0) return;
     const items: ClipboardItem[] = [];
     for (const item of multiSelectedItems.values()) {
       const clipboard = toClipboardItem(item);
       if (clipboard == null) continue;
       items.push(clipboard);
     }
-    setClipboardState((prev) => buildClipboard(prev, clipboardMode, items));
+    if (items.length > 0) {
+      setClipboardState((prev) => buildClipboard(prev, clipboardMode, items));
+    }
+    // Always mount the panel after Add so View → Clipboard is checked.
+    // Clicking the View toggle after this would hide an already-open panel.
     setShowClipboard(true);
-  }, [multiSelectedItems, clipboardMode]);
+  }, [multiSelectedItems, multiSelectedIds, clipboardMode]);
 
   const handleClearClipboard = useCallback(() => {
     setClipboardState(EMPTY_CLIPBOARD);
@@ -1304,7 +1281,6 @@ function ContentExplorerShellInner({
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
-            clipboardItemCount={clipboard.items.length}
             hasSiteContext={hasSiteContext}
             hasFolderContext={hasFolderContext}
             displayFormats={displayFormats}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -52,8 +52,6 @@ export interface ExplorerMenuBarProps {
   showSubfolderCopy?: boolean;
   /** Multi-select size for clipboard-add disable + status badge. */
   multiSelectedCount: number;
-  /** Clipboard size — enables View → Clipboard when non-empty. */
-  clipboardItemCount: number;
   /**
    * True when the current folder/selection is under {@code /Sites/&lt;name&gt;}.
    * Enables Content → Site Copy (#2767).
@@ -186,15 +184,11 @@ function menuItemTestId(item: ExplorerMenuBarItem): string {
 function isItemDisabled(
   item: ExplorerMenuBarItem,
   multiSelectedCount: number,
-  clipboardItemCount: number,
   hasSiteContext: boolean,
   hasFolderContext: boolean,
 ): boolean {
   if (item.disabledWhen === "noSelection") {
     return multiSelectedCount === 0;
-  }
-  if (item.disabledWhen === "noClipboardContext") {
-    return multiSelectedCount === 0 && clipboardItemCount === 0;
   }
   if (item.disabledWhen === "noSiteContext") {
     return !hasSiteContext;
@@ -218,7 +212,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showSiteCopy = false,
     showSubfolderCopy = false,
     multiSelectedCount,
-    clipboardItemCount,
     hasSiteContext = false,
     hasFolderContext = false,
     displayFormats,
@@ -269,7 +262,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
       isItemDisabled(
         item,
         multiSelectedCount,
-        clipboardItemCount,
         hasSiteContext,
         hasFolderContext,
       )
@@ -343,7 +335,6 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                     const disabled = isItemDisabled(
                       item,
                       multiSelectedCount,
-                      clipboardItemCount,
                       hasSiteContext,
                       hasFolderContext,
                     );

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -39,6 +39,7 @@ import {
 } from "../api/contentExplorer/translationsApi";
 import { formatApiError } from "../api/client";
 import { message } from "../i18n/message";
+import { parseExplorerContentId } from "./menuCatalogLoad";
 import { EXPLORER_MSG } from "./messages";
 
 export interface TranslationsPanelProps {
@@ -84,9 +85,15 @@ async function defaultCreateVariants(body: {
   return createTranslations(body);
 }
 
-function parseNumericItemId(itemId: string): number | null {
-  const n = Number(itemId);
-  return Number.isFinite(n) && n > 0 ? n : null;
+/**
+ * Resolve Explorer row id to a legacy content id.
+ *
+ * <p>List rows are usually Percussion GUIDs ({@code 1-101-708}); {@link
+ * Number}({@code itemId}) is NaN for those and must not be used (#3545 /
+ * parent #2649). Folders/sites with no content id still return null.
+ */
+function resolveTranslationsContentId(itemId: string): number | null {
+  return parseExplorerContentId(itemId);
 }
 
 function roleLabel(role: string | null | undefined): string {
@@ -130,10 +137,15 @@ export function TranslationsPanel(
       setState({ kind: "auth" });
       return;
     }
+    const resolvedId = resolveTranslationsContentId(itemId);
+    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
+    // numeric string still loads. Folders with no content id stay null.
+    const variantsKey =
+      resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });
     setCreateError(null);
     setCreateSuccess(null);
-    loadVariants(itemId)
+    loadVariants(variantsKey)
       .then((data) => {
         if (!alive) return;
         setState({ kind: "ok", data });
@@ -197,7 +209,7 @@ export function TranslationsPanel(
   }, []);
 
   const handleCreate = useCallback(async () => {
-    const numericId = parseNumericItemId(itemId);
+    const numericId = resolveTranslationsContentId(itemId);
     if (numericId == null) {
       setCreateError(message(EXPLORER_MSG.TRANSLATIONS_INVALID_ITEM));
       return;

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -138,8 +138,9 @@ export function TranslationsPanel(
       return;
     }
     const resolvedId = resolveTranslationsContentId(itemId);
-    // GUID last segment (1-101-708 → 708); fall back to the raw token so a
-    // numeric string still loads. Folders with no content id stay null.
+    // GUID last segment (1-101-708 → 708). Parse-null does not skip GET:
+    // loadVariants still receives the raw itemId (unit tests / direct mounts).
+    // The Explorer shell never mounts this panel for folders/sites.
     const variantsKey =
       resolvedId != null ? String(resolvedId) : itemId;
     setState({ kind: "loading" });

--- a/WebUI/src/main/ts/contentExplorer/clipboard/model.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/model.ts
@@ -66,6 +66,23 @@ export function setClipboard(
   });
 }
 
+/**
+ * Add / replace clipboard contents from Explorer Add. An empty mapped
+ * set is a no-op so a failed bind does not wipe items the user already
+ * staged (#3557).
+ */
+export function applyClipboardAdd(
+  current: Clipboard,
+  operation: "copy" | "cut",
+  items: ReadonlyArray<ClipboardItem>,
+  now?: () => string,
+): Clipboard {
+  if (items.length === 0) {
+    return current;
+  }
+  return setClipboard(current, operation, items, now);
+}
+
 /** True when no items are held. */
 export function isEmpty(cb: Clipboard): boolean {
   return cb.items.length === 0;

--- a/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
@@ -26,18 +26,8 @@
  */
 
 import type { ClipboardItem, PSPathItem } from "../../api/contentExplorer/types";
+import { firstNonBlank } from "../firstNonBlank";
 import { isAssetContentType, isFolder } from "../selection";
-
-function firstNonBlank(
-  ...values: ReadonlyArray<string | number | null | undefined>
-): string | null {
-  for (const value of values) {
-    if (value == null) continue;
-    const text = String(value).trim();
-    if (text.length > 0) return text;
-  }
-  return null;
-}
 
 /**
  * Convert a selected Explorer row into clipboard state.

--- a/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map a detail-list / tree {@link PSPathItem} into a {@link ClipboardItem}.
+ *
+ * <p>Sites rows from pathmanagement use {@code type}/{@code category}
+ * {@code site} / {@code FSFolder} (not lowercase {@code folder}). The
+ * previous mapper only treated {@code type === "folder"} as a folder and
+ * required {@code item.id ?? item.path}; missing path on a named Sites
+ * row dropped the selection so Add to clipboard staged nothing.</p>
+ */
+
+import type { ClipboardItem, PSPathItem } from "../../api/contentExplorer/types";
+import { isFolder } from "../selection";
+
+function firstNonBlank(
+  ...values: ReadonlyArray<string | number | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}
+
+function isAssetItem(item: PSPathItem): boolean {
+  const type = (item.type ?? "").trim().toLowerCase();
+  const category = (item.category ?? "").trim().toLowerCase();
+  return type === "asset" || category === "asset" || category === "resource";
+}
+
+/**
+ * Convert a selected Explorer row into clipboard state.
+ *
+ * @return {@code null} only when the row has no stable id, path, or name
+ */
+export function toClipboardItem(item: PSPathItem): ClipboardItem | null {
+  const id = firstNonBlank(item.id, item.path, item.name, item.title);
+  if (id == null) return null;
+  const path = firstNonBlank(item.path, item.folderPath, item.name, id) ?? id;
+  const kind: ClipboardItem["kind"] = isFolder(item)
+    ? "folder"
+    : isAssetItem(item)
+      ? "asset"
+      : "page";
+  return {
+    id,
+    path,
+    kind,
+    name: firstNonBlank(item.name, item.title, path, id) ?? id,
+    sourceAccessLevel: item.accessLevel,
+  };
+}

--- a/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
+++ b/WebUI/src/main/ts/contentExplorer/clipboard/toClipboardItem.ts
@@ -26,7 +26,7 @@
  */
 
 import type { ClipboardItem, PSPathItem } from "../../api/contentExplorer/types";
-import { isFolder } from "../selection";
+import { isAssetContentType, isFolder } from "../selection";
 
 function firstNonBlank(
   ...values: ReadonlyArray<string | number | null | undefined>
@@ -37,12 +37,6 @@ function firstNonBlank(
     if (text.length > 0) return text;
   }
   return null;
-}
-
-function isAssetItem(item: PSPathItem): boolean {
-  const type = (item.type ?? "").trim().toLowerCase();
-  const category = (item.category ?? "").trim().toLowerCase();
-  return type === "asset" || category === "asset" || category === "resource";
 }
 
 /**
@@ -56,7 +50,7 @@ export function toClipboardItem(item: PSPathItem): ClipboardItem | null {
   const path = firstNonBlank(item.path, item.folderPath, item.name, id) ?? id;
   const kind: ClipboardItem["kind"] = isFolder(item)
     ? "folder"
-    : isAssetItem(item)
+    : isAssetContentType(item)
       ? "asset"
       : "page";
   return {

--- a/WebUI/src/main/ts/contentExplorer/firstNonBlank.ts
+++ b/WebUI/src/main/ts/contentExplorer/firstNonBlank.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * First non-null, non-whitespace string among {@code values}.
+ *
+ * Shared by Explorer selection keys and clipboard mapping so the
+ * trim / stringify contract cannot drift.
+ */
+export function firstNonBlank(
+  ...values: ReadonlyArray<string | number | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -58,7 +58,6 @@ export interface ExplorerMenuBarItem {
   /** Optional disabled predicate flag name resolved by the host. */
   disabledWhen?:
     | "noSelection"
-    | "noClipboardContext"
     | "noSiteContext"
     | "noFolderContext";
 }
@@ -174,8 +173,8 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.CLIPBOARD_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_CLIPBOARD_ARIA,
           testId: "explorer-toggle-clipboard",
+          /** Always enabled so empty clipboard can still be viewed (#3544 / #3551). */
           toggle: true,
-          disabledWhen: "noClipboardContext",
         },
       ],
     },

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -58,7 +58,6 @@ export interface ExplorerMenuBarItem {
   /** Optional disabled predicate flag name resolved by the host. */
   disabledWhen?:
     | "noSelection"
-    | "noClipboardContext"
     | "noSiteContext"
     | "noFolderContext";
 }
@@ -174,8 +173,8 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.CLIPBOARD_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_CLIPBOARD_ARIA,
           testId: "explorer-toggle-clipboard",
+          /** Always enabled so empty clipboard can still be viewed (#3544). */
           toggle: true,
-          disabledWhen: "noClipboardContext",
         },
       ],
     },

--- a/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuCatalogLoad.ts
@@ -31,34 +31,13 @@ import {
   findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
 } from "../api/contentExplorer/actionMenuApi";
+import {
+  parseExplorerContentId,
+} from "../api/contentExplorer/pathItemId";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { isWorkflowEligibleItem } from "./workflowEligibility";
 
-export function parseExplorerContentId(
-  id: string | number | undefined,
-): number | null {
-  if (id == null || id === "") {
-    return null;
-  }
-  if (typeof id === "number") {
-    return Number.isFinite(id) && id > 0 ? Math.trunc(id) : null;
-  }
-  const s = String(id).trim();
-  if (!s) {
-    return null;
-  }
-  const whole = Number(s);
-  if (Number.isFinite(whole) && whole > 0) {
-    return Math.trunc(whole);
-  }
-  // Percussion GUID host-type-uuid (e.g. 1-101-708) — content id is last segment.
-  const last = s.split("-").pop();
-  if (!last) {
-    return null;
-  }
-  const n = Number(last);
-  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : null;
-}
+export { parseExplorerContentId };
 
 function isCascadeParent(action: MenuAction): boolean {
   const type = (action.menuType ?? "").toUpperCase();

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -96,6 +96,31 @@ const PAGE_OR_ASSET_TYPE_KEYS = new Set([
 /** FastForward nav types are folder-like, not previewable items. */
 const RFF_NAV_TYPE_KEYS = new Set(["rffnavon", "rffnavtree"]);
 
+/**
+ * Stock / FastForward {@code type} names that are assets, not pages.
+ * Do not treat {@code category: ASSET} alone as an asset — the server
+ * defaults every non-{@code percPage} item to {@code ASSET}
+ * ({@code previewItem.resolvePreviewKind}).
+ */
+const ASSET_TYPE_KEYS = new Set([
+  "asset",
+  "percasset",
+  "rffimage",
+  "rfffile",
+  "rffnavimage",
+]);
+
+function firstNonBlank(
+  ...values: ReadonlyArray<string | number | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}
+
 function folderTypeOrCategory(type: string, category: string): boolean {
   return (
     FOLDER_TYPE_KEYS.has(type) ||
@@ -129,6 +154,39 @@ export function isPageOrAssetContentType(item: PSPathItem | null): boolean {
   }
   // Customer / legacy type name: any non-folder type is an item.
   return type.length > 0;
+}
+
+/**
+ * True when the row is an asset (clipboard / preview kind), not a page.
+ *
+ * <p>{@code category === "resource"} is <em>not</em> an asset key here.
+ * {@link ITEM_CATEGORY_KEYS} treats {@code resource} as a workflowed
+ * item (page-or-asset), not as {@code ClipboardItem.kind === "asset"}.</p>
+ */
+export function isAssetContentType(item: PSPathItem | null): boolean {
+  if (!item || isFolder(item)) {
+    return false;
+  }
+  const type = (item.type ?? "").trim().toLowerCase();
+  if (ASSET_TYPE_KEYS.has(type)) {
+    return true;
+  }
+  const category = (item.category ?? "").trim().toLowerCase();
+  if (category === "asset" && (type === "asset" || type.length === 0)) {
+    return true;
+  }
+  const path = (item.path ?? "").trim().toLowerCase().replace(/\\/g, "/");
+  return path === "/assets" || path.startsWith("/assets/");
+}
+
+/**
+ * Stable multi-select map key. Prefer content id, then path. Do not fall
+ * back to {@code name} — two "Home" rows without id/path would collide.
+ *
+ * @return {@code null} when the row has no id or path
+ */
+export function explorerMultiSelectKey(item: PSPathItem): string | null {
+  return firstNonBlank(item.id, item.path);
 }
 
 export function isFolder(item: PSPathItem | null): boolean {

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -23,6 +23,9 @@
  */
 
 import type { PSPathItem } from "../api/contentExplorer/types";
+import { firstNonBlank } from "./firstNonBlank";
+
+export { sameExplorerItemId } from "../api/contentExplorer/pathItemId";
 
 export interface Selection {
   /** Folder path that the list is currently showing children of. */
@@ -110,16 +113,25 @@ const ASSET_TYPE_KEYS = new Set([
   "rffnavimage",
 ]);
 
-function firstNonBlank(
-  ...values: ReadonlyArray<string | number | null | undefined>
-): string | null {
-  for (const value of values) {
-    if (value == null) continue;
-    const text = String(value).trim();
-    if (text.length > 0) return text;
-  }
-  return null;
-}
+/**
+ * Stock / FastForward {@code type} names that are pages, not assets.
+ * Used so {@code category: ASSET} (server default for non-percPage
+ * items) does not reclassify known pages as assets.
+ */
+const PAGE_TYPE_KEYS = new Set([
+  "page",
+  "percpage",
+  "rffhome",
+  "rffevent",
+  "rffgeneric",
+  "rffgenericword",
+  "rffbrief",
+  "rffcalendar",
+  "rffcontacts",
+  "rffpressrelease",
+  "rffexternallink",
+  "rffautoindex",
+]);
 
 function folderTypeOrCategory(type: string, category: string): boolean {
   return (
@@ -168,15 +180,28 @@ export function isAssetContentType(item: PSPathItem | null): boolean {
     return false;
   }
   const type = (item.type ?? "").trim().toLowerCase();
+  const category = (item.category ?? "").trim().toLowerCase();
+  if (category === "page" || category === "landing_page") {
+    return false;
+  }
   if (ASSET_TYPE_KEYS.has(type)) {
     return true;
   }
-  const category = (item.category ?? "").trim().toLowerCase();
-  if (category === "asset" && (type === "asset" || type.length === 0)) {
-    return true;
+  if (PAGE_TYPE_KEYS.has(type)) {
+    return false;
   }
   const path = (item.path ?? "").trim().toLowerCase().replace(/\\/g, "/");
-  return path === "/assets" || path.startsWith("/assets/");
+  if (path === "/assets" || path.startsWith("/assets/")) {
+    return true;
+  }
+  // Server defaults every non-percPage item to ASSET. Customer pages
+  // live under /Sites; treat those as pages. Custom asset types with
+  // category ASSET and no /Sites path (including missing path) are
+  // assets (#3557).
+  if (path === "/sites" || path.startsWith("/sites/")) {
+    return false;
+  }
+  return category === "asset";
 }
 
 /**
@@ -205,23 +230,6 @@ export function isFolder(item: PSPathItem | null): boolean {
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
   return Boolean(item.hasFolderChildren);
-}
-
-/**
- * Compare Explorer item ids without number/string mismatches
- * ({@code "42"} vs {@code 42}) so list {@code aria-selected} tracks
- * {@code selection.item} after a row click (#3467).
- */
-export function sameExplorerItemId(
-  a: string | number | null | undefined,
-  b: string | number | null | undefined,
-): boolean {
-  if (a == null || b == null) {
-    return false;
-  }
-  const left = String(a).trim();
-  const right = String(b).trim();
-  return left.length > 0 && left === right;
 }
 
 /** Normalize wire ACL tokens so mixed-case server values compare consistently. */

--- a/WebUI/src/main/ts/contentExplorer/views/RelationshipsView.tsx
+++ b/WebUI/src/main/ts/contentExplorer/views/RelationshipsView.tsx
@@ -36,6 +36,7 @@ import type { PSNodeRelationshipSummary } from "../../api/contentExplorer/relati
 import { message } from "../../i18n/message";
 import { EXPLORER_MSG } from "../messages";
 import { composeFromServerSummary, labelFor } from "./dependencyModel";
+import { parseExplorerContentId } from "../../api/contentExplorer/pathItemId";
 import { fetchNodeSummary } from "../../api/contentExplorer/relationshipsApi";
 
 export interface RelationshipsViewProps {
@@ -56,6 +57,24 @@ export interface RelationshipsViewProps {
 const IA_PRIMARY: ReadonlyArray<
   "outgoing" | "incoming" | "taxonomy" | "local"
 > = ["outgoing", "incoming", "taxonomy", "local"];
+
+/**
+ * REST {@code /relationships/{id}} needs a numeric content id. Explorer
+ * rows often carry a GUID ({@code 1-101-708}); taxonomy treats a
+ * non-path string as a JCR path and the summary returns 403.
+ */
+export function relationshipSummaryItemId(
+  raw: string | number | undefined,
+): string {
+  if (raw == null || raw === "") {
+    return "";
+  }
+  const parsed = parseExplorerContentId(raw);
+  if (parsed != null) {
+    return String(parsed);
+  }
+  return String(raw).trim();
+}
 
 async function defaultLoadServerSummary(
   itemId: string,
@@ -84,7 +103,7 @@ export function RelationshipsView(
   } = props;
   const summarise = composeSummary ?? defaultComposeSummary;
 
-  const itemId = item.id ?? "";
+  const itemId = relationshipSummaryItemId(item.id);
   const [state, setState] = React.useState<
     | { kind: "loading" }
     | { kind: "ok"; summary: PSNodeRelationshipSummary }

--- a/WebUI/src/main/ts/contentExplorer/wizards/SubfolderCopyWizard.tsx
+++ b/WebUI/src/main/ts/contentExplorer/wizards/SubfolderCopyWizard.tsx
@@ -47,6 +47,11 @@ export interface SubfolderCopyWizardProps {
   ariaLabel?: string;
   className?: string;
   onSettled?: (ok: boolean) => void;
+  /**
+   * Host dismiss (Cancel / Escape). Unmounts the overlay; does not POST.
+   * When omitted, Cancel falls back to {@link resetWizard} for standalone mounts.
+   */
+  onDismiss?: () => void;
 }
 
 const STEPS = ["source", "target", "confirm", "progress"];
@@ -61,10 +66,22 @@ export function SubfolderCopyWizard(
     ariaLabel,
     className,
     onSettled,
+    onDismiss,
   } = props;
   const [wizard, setWizard] = useState<WizardState>(() => createWizard(STEPS));
   const [sourcePath, setSourcePath] = useState(initialSource);
   const [targetPath, setTargetPath] = useState(initialTarget);
+
+  function handleCancel(): void {
+    if (wizard.submitting) {
+      return;
+    }
+    if (onDismiss) {
+      onDismiss();
+      return;
+    }
+    setWizard((w) => resetWizard(w));
+  }
 
   async function handleRun(): Promise<void> {
     setWizard((w) => ({ ...w, submitting: true }));
@@ -229,7 +246,8 @@ export function SubfolderCopyWizard(
         <button
           type="button"
           data-testid="subfolder-copy-cancel"
-          onClick={() => setWizard((w) => resetWizard(w))}
+          disabled={wizard.submitting}
+          onClick={handleCancel}
         >
           {message(EXPLORER_MSG.WIZARD_CANCEL)}
         </button>

--- a/WebUI/src/test/ts/contentExplorer/ClipboardPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ClipboardPanel.test.tsx
@@ -33,6 +33,52 @@ function makeCb(items: ClipboardItem[]): Clipboard {
 }
 
 describe("ClipboardPanel", () => {
+  it("still mounts an empty clipboard list (host empty-panel contract #3551)", () => {
+    render(
+      <ClipboardPanel
+        clipboard={EMPTY_CLIPBOARD}
+        onClipboardChange={() => {}}
+        items={[]}
+        mode="copy"
+        onModeChange={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("clipboard-panel")).toBeTruthy();
+    expect(screen.getByTestId("clipboard-items")).toBeTruthy();
+    expect(screen.queryAllByTestId("clipboard-item-row")).toHaveLength(0);
+    expect(screen.getByTestId("clipboard-add")).toBeDisabled();
+  });
+
+  it("renders folder-kind Sites rows staged by Add to clipboard (#3551)", () => {
+    const sites: ClipboardItem[] = [
+      {
+        id: "s-1",
+        path: "/Sites/CorporateInvestments",
+        kind: "folder",
+        name: "CorporateInvestments",
+      },
+      {
+        id: "s-2",
+        path: "/Sites/EnterpriseInvestments",
+        kind: "folder",
+        name: "EnterpriseInvestments",
+      },
+    ];
+    render(
+      <ClipboardPanel
+        clipboard={makeCb(sites)}
+        onClipboardChange={() => {}}
+        items={sites}
+        mode="copy"
+        onModeChange={() => {}}
+      />,
+    );
+    const rows = screen.getAllByTestId("clipboard-item-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain("/Sites/CorporateInvestments");
+    expect(rows[0]?.textContent).toContain("(folder)");
+  });
+
   it("renders the clipboard panel with size 0 when empty", () => {
     render(
       <ClipboardPanel

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1175,6 +1175,47 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("View → Clipboard opens the empty clipboard panel and toggles aria-checked (#3544)", async () => {
+    stubPathFetch();
+    const { container } = renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-view")).toBeInTheDocument(),
+    );
+    openViewMenu();
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-clipboard"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+    await renderA11yGate(container);
+  });
+
   it("translations toggle shows select-item hint without a content selection (#2430)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1193,6 +1193,76 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("translations-panel")).toBeNull();
   });
 
+  it("GUID list row opens translations panel (not select-item hint) (#3545)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/content-explorer/translations/")) {
+        return new Response(
+          JSON.stringify({
+            itemId: 708,
+            locale: "en-us",
+            variants: [
+              { contentId: 708, locale: "en-us", role: "source", revision: 1 },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-translations"));
+    await waitFor(() => {
+      expect(screen.getByTestId("translations-panel")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-translations-hint")).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-708")).toBeTruthy();
+  });
+
   it("Content → Site Copy mounts wizard with source from /Sites/<name> (#2767)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1175,6 +1175,126 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("View → Clipboard opens the empty clipboard panel and toggles aria-checked (#3544)", async () => {
+    stubPathFetch();
+    const { container } = renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-view")).toBeInTheDocument(),
+    );
+    openViewMenu();
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-clipboard"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-clipboard-panel")).toBeNull();
+    });
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+    await renderA11yGate(container);
+  });
+
+  it("Content → Add to clipboard mounts the panel with Sites rows (#3551)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "site-a",
+                  name: "CorporateInvestments",
+                  path: "/Sites/CorporateInvestments",
+                  type: "site",
+                  category: "SITE",
+                  accessLevel: "ADMIN",
+                },
+                {
+                  name: "EnterpriseInvestments",
+                  path: "/Sites/EnterpriseInvestments",
+                  type: "FSFolder",
+                  category: "site",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 2,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-site-a")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("detail-row-/Sites/EnterpriseInvestments"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("detail-select-site-a"));
+    fireEvent.click(
+      screen.getByTestId("detail-select-/Sites/EnterpriseInvestments"),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-multi-select-count")).toHaveTextContent(
+        "2",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-clipboard-add"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-clipboard-panel")).toBeInTheDocument();
+    });
+    expect(screen.getAllByTestId("clipboard-item-row")).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    expect(
+      screen.getByTestId("explorer-toggle-clipboard").getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+  });
+
   it("translations toggle shows select-item hint without a content selection (#2430)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -133,13 +133,13 @@ describe("ContentExplorerShell product composition (#2400)", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
+      expect(screen.getByTestId("action-toolbar-item-open")).toBeInTheDocument();
     });
     // #2972: labeled Server actions chrome is always mounted for QA/operators.
     expect(screen.getByTestId("explorer-server-actions")).toBeInTheDocument();
     expect(
       screen.getByTestId("explorer-server-actions-label"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("action-toolbar-item-open")).toBeInTheDocument();
 
     const searchToggle = screen.getByTestId("explorer-toggle-search");
     expect(searchToggle.getAttribute("aria-expanded")).toBe("false");

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1277,6 +1277,161 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("Subfolder Copy Cancel unmounts the overlay instead of reset (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/Demo/Home" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+      expect(screen.queryByTestId("explorer-subfolder-copy-panel")).toBeNull();
+    });
+    expect(document.activeElement).toBe(
+      screen.getByTestId("explorer-menu-content"),
+    );
+  });
+
+  it("Subfolder Copy Escape unmounts the overlay (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
+  it("Subfolder Copy Back stays mounted and changes step (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/Demo/Home" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("subfolder-copy-back"));
+    expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeInTheDocument();
+  });
+
+  it("selecting a detail item dismisses Subfolder Copy without POST (#3553)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-42")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-42"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
+  it("click-away outside Subfolder Copy dismisses the overlay (#3553)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo/Home"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-menu-content")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    fireEvent.click(screen.getByTestId("explorer-content-subfolder-copy"));
+    await waitFor(() => {
+      expect(screen.getByTestId("subfolder-copy-wizard")).toBeInTheDocument();
+    });
+    fireEvent.mouseDown(screen.getByTestId("content-explorer-shell"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("subfolder-copy-wizard")).toBeNull();
+    });
+  });
+
   it("Content → Subfolder Copy is disabled without a folder path (#2792)", async () => {
     stubPathFetch();
     const { container } = renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1508,6 +1508,224 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
   });
 
+  it("relationships panel mounts for a GUID-shaped content row (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("relationships-view")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("relationships panel binds slug rows via sys_contentid (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "ci-home",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                  displayProperties: { sys_contentid: "708" },
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
+  it("relationships panel resolves omitted list id via path lookup (#3546)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/path/item/")) {
+        return new Response(
+          JSON.stringify({
+            PathItem: {
+              id: "1-101-708",
+              name: "Home",
+              path: "/Sites/Corporate_Investments/Pages/Home",
+              type: "rffHome",
+              category: "PAGE",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 0, byType: [] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByTestId("detail-row-/Sites/Corporate_Investments/Pages/Home"),
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+  });
+
   it("dependencies toggle shows select-item hint without a content selection (#2768)", async () => {
     stubPathFetch();
     renderShell(

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -34,7 +34,6 @@ function renderBar(
       showDependencies={false}
       showClipboard={false}
       multiSelectedCount={0}
-      clipboardItemCount={0}
       displayFormats={[]}
       selectedFormatKey=""
       onSelectFormat={onSelectFormat}
@@ -89,6 +88,37 @@ describe("ExplorerMenuBar (#2731)", () => {
     );
     fireEvent.click(contentSearch);
     expect(onCommand).toHaveBeenCalledWith("content-search");
+  });
+
+  it("View → Clipboard is enabled with empty clipboard and invokes view-clipboard (#3544)", () => {
+    const { onCommand } = renderBar({
+      multiSelectedCount: 0,
+      showClipboard: false,
+    });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const toggle = screen.getByTestId(
+      "explorer-toggle-clipboard",
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("role")).toBe("menuitemcheckbox");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
+    fireEvent.click(toggle);
+    expect(onCommand).toHaveBeenCalledWith("view-clipboard");
+  });
+
+  it("View → Clipboard reflects showClipboard on aria-checked (#3544)", () => {
+    renderBar({ showClipboard: true, multiSelectedCount: 0 });
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    const checked = screen.getByTestId("explorer-toggle-clipboard");
+    expect(checked.getAttribute("aria-checked")).toBe("true");
+    expect(checked.getAttribute("aria-expanded")).toBe("true");
+    expect(checked.getAttribute("aria-controls")).toBe(
+      "explorer-clipboard-panel",
+    );
   });
 
   it("View → Folder Security menu item invokes view-security (#3268)", () => {

--- a/WebUI/src/test/ts/contentExplorer/RelationshipsView.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/RelationshipsView.test.tsx
@@ -9,7 +9,10 @@
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { RelationshipsView } from "../../../main/ts/contentExplorer/views/RelationshipsView";
+import {
+  RelationshipsView,
+  relationshipSummaryItemId,
+} from "../../../main/ts/contentExplorer/views/RelationshipsView";
 import type { PSNodeRelationshipSummary } from "../../../main/ts/api/contentExplorer/relationship";
 import { renderA11yGate } from "./a11y";
 
@@ -84,6 +87,25 @@ describe("RelationshipsView", () => {
       ),
     );
     await renderA11yGate(container);
+  });
+
+  it("parses a GUID id before calling /relationships (#3557)", async () => {
+    expect(relationshipSummaryItemId("1-101-708")).toBe("708");
+    expect(relationshipSummaryItemId(708)).toBe("708");
+    const loader = vi.fn().mockResolvedValue(SYNTHETIC_SERVER);
+    render(
+      <RelationshipsView
+        item={{ id: "1-101-708", folderPath: "/Sites/Foo" }}
+        loadServerSummary={loader}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("relationships-view")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loader).toHaveBeenCalledWith("708");
   });
 
   it("renders the auth placeholder and does not call loadServerSummary when item.id is missing", async () => {

--- a/WebUI/src/test/ts/contentExplorer/SubfolderCopyWizard.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SubfolderCopyWizard.test.tsx
@@ -74,6 +74,55 @@ describe("SubfolderCopyWizard", () => {
     );
   });
 
+  it("Back walks to the previous step and does not dismiss", () => {
+    const onDismiss = vi.fn();
+    const submit = vi.fn();
+    render(
+      <SubfolderCopyWizard submit={submit} onDismiss={onDismiss} />,
+    );
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-back"));
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeTruthy();
+    expect(screen.getByTestId("subfolder-copy-wizard")).toBeTruthy();
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("Cancel with onDismiss dismisses instead of resetWizard (#3553)", () => {
+    const onDismiss = vi.fn();
+    const submit = vi.fn();
+    render(
+      <SubfolderCopyWizard submit={submit} onDismiss={onDismiss} />,
+    );
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(submit).not.toHaveBeenCalled();
+    // Host unmounts; without unmount, Cancel must not reset to step 1.
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    expect(screen.queryByTestId("subfolder-copy-step-source")).toBeNull();
+  });
+
+  it("Cancel without onDismiss still resetWizard to step 0", () => {
+    render(<SubfolderCopyWizard />);
+    fireEvent.change(screen.getByTestId("subfolder-copy-source"), {
+      target: { value: "/Sites/A" },
+    });
+    fireEvent.click(screen.getByTestId("subfolder-copy-next"));
+    expect(screen.getByTestId("subfolder-copy-step-target")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("subfolder-copy-cancel"));
+    expect(screen.getByTestId("subfolder-copy-step-source")).toBeTruthy();
+    expect(screen.queryByTestId("subfolder-copy-step-target")).toBeNull();
+  });
+
   it("passes the zero serious/critical axe-core gate (step 0)", async () => {
     const { container } = render(<SubfolderCopyWizard />);
     await renderA11yGate(container);

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -90,6 +90,30 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("resolves GUID Explorer row ids for variants GET (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        itemLabel="Home"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
+      "en-us",
+    );
+    expect(screen.getByTestId("translations-variant-row-335")).toBeTruthy();
+    expect(screen.getByTestId("translations-variant-row-900")).toBeTruthy();
+  });
+
   it("create-variant POSTs selected locales via injection seam", async () => {
     const createVariants = vi.fn(async () => ({
       created: [
@@ -127,6 +151,73 @@ describe("TranslationsPanel", () => {
       expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
     );
     expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("create-variant POSTs GUID last-segment content id (#3545)", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    const createVariants = vi.fn(async () => ({
+      created: [
+        {
+          contentId: 901,
+          locale: "de-de",
+          role: "translation",
+          sourceContentId: 708,
+        },
+      ],
+    }));
+    render(
+      <TranslationsPanel
+        itemId="1-101-708"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("708");
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() => expect(createVariants).toHaveBeenCalledTimes(1));
+    expect(createVariants).toHaveBeenCalledWith({
+      itemIds: [708],
+      locales: ["de-de"],
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-success")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("translations-create-error"),
+    ).toBeNull();
+  });
+
+  it("keeps the no-id create message for folder-like ids without a content id", async () => {
+    const createVariants = vi.fn(async () => ({ created: [] }));
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={async () => SAMPLE_VARIANTS}
+        loadLocaleCatalog={async () => CATALOG}
+        createVariants={createVariants}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("translations-locale-option-de-de"),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
+    fireEvent.click(screen.getByTestId("translations-create-submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-create-error")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("translations-create-error")).toHaveTextContent(
+      /does not have a numeric content id/i,
+    );
+    expect(createVariants).not.toHaveBeenCalled();
   });
 
   it("maps create 403 to permission chrome", async () => {

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -194,6 +194,24 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
+  it("GET variants with the raw itemId when parse yields null", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="//Sites/Demo"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("//Sites/Demo");
+  });
+
   it("keeps the no-id create message for folder-like ids without a content id", async () => {
     const createVariants = vi.fn(async () => ({ created: [] }));
     render(

--- a/WebUI/src/test/ts/contentExplorer/clipboardModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/clipboardModel.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  applyClipboardAdd,
   buildPasteSummary,
   canPasteInto,
   EMPTY_CLIPBOARD,
@@ -55,6 +56,36 @@ describe("setClipboard", () => {
     const cb = setClipboard(EMPTY_CLIPBOARD, "cut", arr);
     arr.push(item({ id: "i-2" }));
     expect(cb.items).toHaveLength(1);
+  });
+});
+
+describe("applyClipboardAdd (#3557)", () => {
+  it("is a no-op when the mapped item list is empty", () => {
+    const staged = setClipboard(EMPTY_CLIPBOARD, "copy", [item()], () =>
+      "2026-08-18T00:00:00.000Z",
+    );
+    const next = applyClipboardAdd(staged, "cut", [], () =>
+      "2026-08-18T01:00:00.000Z",
+    );
+    expect(next).toBe(staged);
+    expect(next.items).toHaveLength(1);
+    expect(next.operation).toBe("copy");
+  });
+
+  it("replaces staged items when the mapped list is non-empty", () => {
+    const staged = setClipboard(EMPTY_CLIPBOARD, "copy", [item()], () =>
+      "2026-08-18T00:00:00.000Z",
+    );
+    const next = applyClipboardAdd(
+      staged,
+      "cut",
+      [item({ id: "i-2" })],
+      () => "2026-08-18T01:00:00.000Z",
+    );
+    expect(next.operation).toBe("cut");
+    expect(next.items).toHaveLength(1);
+    expect(next.items[0]?.id).toBe("i-2");
+    expect(next.updatedAt).toBe("2026-08-18T01:00:00.000Z");
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/firstNonBlank.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/firstNonBlank.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { firstNonBlank } from "../../../main/ts/contentExplorer/firstNonBlank";
+
+describe("firstNonBlank (#3557)", () => {
+  it("returns the first non-whitespace string or number", () => {
+    expect(firstNonBlank(null, "  ", 42, "later")).toBe("42");
+    expect(firstNonBlank(undefined, "", "home")).toBe("home");
+  });
+
+  it("returns null when every value is blank", () => {
+    expect(firstNonBlank(null, undefined, "  ", "")).toBeNull();
+    expect(firstNonBlank()).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -53,6 +53,14 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(byId["view-clipboard"]).toBe("explorer-toggle-clipboard");
   });
 
+  it("View → Clipboard is an always-enabled toggle (#3544)", () => {
+    const view = buildExplorerMenuBarGroups().find((g) => g.id === "view");
+    const clipboard = view?.items.find((i) => i.id === "view-clipboard");
+    expect(clipboard?.toggle).toBe(true);
+    expect(clipboard?.disabledWhen).toBeUndefined();
+    expect(clipboard?.testId).toBe("explorer-toggle-clipboard");
+  });
+
   it("puts clipboard-add under Content with stable test id", () => {
     const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
     const add = content?.items.find((i) => i.id === "content-clipboard-add");

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -49,6 +49,7 @@ describe("parseExplorerContentId", () => {
     expect(parseExplorerContentId("")).toBeNull();
     expect(parseExplorerContentId("nope")).toBeNull();
     expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -87,6 +87,36 @@ describe("joinPathUrl", () => {
 });
 
 describe("paginatedFolder", () => {
+  it("binds parseable content ids onto childrenInPage rows (#3546)", async () => {
+    mockFetch(async () => {
+      return new Response(
+        JSON.stringify({
+          PagedItemList: {
+            childrenInPage: [
+              {
+                id: "ci-home",
+                name: "Home",
+                path: "/Sites/Corporate_Investments/Pages/Home",
+                type: "rffHome",
+                category: "PAGE",
+                displayProperties: { sys_contentid: "708" },
+              },
+            ],
+            childrenCount: 1,
+            startIndex: 0,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const res = await paginatedFolder("/Sites/Corporate_Investments/Pages", {
+      startIndex: 0,
+      maxResults: 50,
+    });
+    expect(res.children).toHaveLength(1);
+    expect(res.children[0]?.id).toBe("708");
+  });
+
   it("builds the paginated URL with required pagination params", async () => {
     const fn = mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  bindExplorerPathItemId,
+  parseExplorerContentId,
+  unwrapExplorerWireId,
+} from "../../../main/ts/api/contentExplorer/pathItemId";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+
+describe("parseExplorerContentId", () => {
+  it("parses finite numeric ids and rejects junk", () => {
+    expect(parseExplorerContentId("42")).toBe(42);
+    expect(parseExplorerContentId(7)).toBe(7);
+    expect(parseExplorerContentId("1-101-708")).toBe(708);
+    expect(parseExplorerContentId(undefined)).toBeNull();
+    expect(parseExplorerContentId("")).toBeNull();
+    expect(parseExplorerContentId("nope")).toBeNull();
+    expect(parseExplorerContentId("0")).toBeNull();
+    expect(parseExplorerContentId("ci-home")).toBeNull();
+  });
+
+  it("unwraps Jackson GUID objects (#3546)", () => {
+    expect(parseExplorerContentId({ stringValue: "1-101-708" })).toBe(708);
+    expect(
+      parseExplorerContentId({ hostId: 1, type: 101, uuid: 708 }),
+    ).toBe(708);
+    expect(parseExplorerContentId({ id: 42 })).toBe(42);
+  });
+});
+
+describe("unwrapExplorerWireId", () => {
+  it("returns scalars and GUID object forms", () => {
+    expect(unwrapExplorerWireId("1-101-708")).toBe("1-101-708");
+    expect(unwrapExplorerWireId(42)).toBe(42);
+    expect(unwrapExplorerWireId({ stringValue: "1-101-9" })).toBe("1-101-9");
+    expect(unwrapExplorerWireId({ hostId: 0, type: 101, uuid: 3 })).toBe(
+      "0-101-3",
+    );
+    expect(unwrapExplorerWireId(null)).toBeUndefined();
+    expect(unwrapExplorerWireId({})).toBeUndefined();
+  });
+});
+
+describe("bindExplorerPathItemId (#3546)", () => {
+  const page = (over: Partial<PSPathItem>): PSPathItem => ({
+    name: "Home",
+    path: "/Sites/Corporate_Investments/Pages/Home",
+    type: "rffHome",
+    category: "PAGE",
+    ...over,
+  });
+
+  it("keeps a GUID-shaped id", () => {
+    const item = page({ id: "1-101-708" });
+    expect(bindExplorerPathItemId(item)).toBe(item);
+    expect(parseExplorerContentId(item.id)).toBe(708);
+  });
+
+  it("binds sys_contentid when id is omitted or a slug", () => {
+    const omitted = bindExplorerPathItemId(
+      page({
+        displayProperties: { sys_contentid: "708" },
+      }),
+    );
+    expect(omitted.id).toBe("708");
+    expect(parseExplorerContentId(omitted.id)).toBe(708);
+
+    const slug = bindExplorerPathItemId(
+      page({
+        id: "ci-home",
+        displayProperties: { sys_contentid: 708 },
+      }),
+    );
+    expect(slug.id).toBe("708");
+    expect(parseExplorerContentId(slug.id)).toBe(708);
+  });
+
+  it("unwraps a GUID object id", () => {
+    const bound = bindExplorerPathItemId(
+      page({
+        id: { stringValue: "1-101-708" } as unknown as string,
+      }),
+    );
+    expect(bound.id).toBe("1-101-708");
+    expect(parseExplorerContentId(bound.id)).toBe(708);
+  });
+
+  it("leaves a folder slug unchanged when nothing parseable is present", () => {
+    const folder: PSPathItem = {
+      id: "Corporate_Investments",
+      name: "Corporate_Investments",
+      path: "/Sites/Corporate_Investments/",
+      type: "site",
+    };
+    const bound = bindExplorerPathItemId(folder);
+    expect(bound.id).toBe("Corporate_Investments");
+    expect(parseExplorerContentId(bound.id)).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathItemId.test.ts
@@ -55,6 +55,18 @@ describe("unwrapExplorerWireId", () => {
     expect(unwrapExplorerWireId(null)).toBeUndefined();
     expect(unwrapExplorerWireId({})).toBeUndefined();
   });
+
+  it("does not build a composite GUID when a part is blank (#3557)", () => {
+    expect(
+      unwrapExplorerWireId({ hostId: "host", type: "", uuid: "uuid" }),
+    ).toBeUndefined();
+    expect(
+      unwrapExplorerWireId({ hostId: 1, type: 101, uuid: "   " }),
+    ).toBeUndefined();
+    expect(
+      unwrapExplorerWireId({ hostId: "", type: "101", uuid: "708" }),
+    ).toBeUndefined();
+  });
 });
 
 describe("bindExplorerPathItemId (#3546)", () => {
@@ -111,5 +123,20 @@ describe("bindExplorerPathItemId (#3546)", () => {
     const bound = bindExplorerPathItemId(folder);
     expect(bound.id).toBe("Corporate_Investments");
     expect(parseExplorerContentId(bound.id)).toBeNull();
+  });
+
+  it("does not overwrite an object id with an unparseable unwrap (#3557)", () => {
+    const item = page({
+      id: { stringValue: "abc" } as unknown as string,
+    });
+    const bound = bindExplorerPathItemId(item);
+    expect(bound).toBe(item);
+    expect(bound.id).toEqual({ stringValue: "abc" });
+  });
+
+  it("keeps the original item when id already matches as string/number (#3557)", () => {
+    const item = page({ id: 708 as unknown as string });
+    const bound = bindExplorerPathItemId(item);
+    expect(bound).toBe(item);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -20,6 +20,8 @@ import {
   canAdmin,
   canRead,
   canWrite,
+  explorerMultiSelectKey,
+  isAssetContentType,
   isFolder,
   isPageOrAssetContentType,
   sameExplorerItemId,
@@ -271,5 +273,101 @@ describe("sameExplorerItemId / canRead (#3467)", () => {
     expect(canWrite(page("read"))).toBe(false);
     expect(canAdmin(page("admin"))).toBe(true);
     expect(canAdmin(page("write"))).toBe(false);
+  });
+});
+
+describe("explorerMultiSelectKey (#3552 review)", () => {
+  it("prefers id then path and never falls back to name", () => {
+    expect(
+      explorerMultiSelectKey({
+        id: "42",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+      }),
+    ).toBe("42");
+    expect(
+      explorerMultiSelectKey({
+        name: "Home",
+        path: "/Sites/Demo/Home",
+      }),
+    ).toBe("/Sites/Demo/Home");
+    expect(
+      explorerMultiSelectKey({
+        id: "   ",
+        name: "Home",
+        path: "/Sites/Other/Home",
+      }),
+    ).toBe("/Sites/Other/Home");
+    expect(
+      explorerMultiSelectKey({
+        name: "Home",
+        path: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not collide two nameless-id rows that share a display name", () => {
+    const a = explorerMultiSelectKey({ name: "Home", path: "" });
+    const b = explorerMultiSelectKey({ name: "Home", path: "  " });
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+  });
+});
+
+describe("isAssetContentType (#3552 review)", () => {
+  it("treats stock asset types and /Assets paths as assets", () => {
+    expect(
+      isAssetContentType({
+        id: "a-1",
+        name: "hero.png",
+        path: "/Assets/hero.png",
+        type: "rffImage",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "a-2",
+        name: "file",
+        path: "/Assets/docs/a.pdf",
+        type: "percAsset",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "a-3",
+        name: "banner",
+        path: "/Assets/banner",
+        type: "asset",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat category resource or percPage as assets", () => {
+    expect(
+      isAssetContentType({
+        id: "p-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "RESOURCE",
+      }),
+    ).toBe(false);
+    expect(
+      isAssetContentType({
+        id: "p-2",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "PAGE",
+      }),
+    ).toBe(false);
+    expect(
+      isAssetContentType({
+        id: "f-1",
+        name: "Files",
+        path: "/Assets/Files/",
+        type: "FSFolder",
+      }),
+    ).toBe(false);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -370,4 +370,33 @@ describe("isAssetContentType (#3552 review)", () => {
       }),
     ).toBe(false);
   });
+
+  it("treats custom types with category ASSET as assets unless under /Sites (#3557)", () => {
+    expect(
+      isAssetContentType({
+        id: "c-1",
+        name: "hero",
+        type: "customAsset",
+        category: "ASSET",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "c-2",
+        name: "hero",
+        path: "/Assets/uploads/hero",
+        type: "customAsset",
+        category: "ASSET",
+      }),
+    ).toBe(true);
+    expect(
+      isAssetContentType({
+        id: "c-3",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "customAsset",
+        category: "ASSET",
+      }),
+    ).toBe(false);
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
@@ -85,6 +85,19 @@ describe("toClipboardItem (#3551)", () => {
     expect(mapped?.kind).toBe("asset");
   });
 
+  it("does not treat category resource as an asset (#3552 review)", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "r-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "RESOURCE",
+      }),
+    );
+    expect(mapped?.kind).toBe("page");
+  });
+
   it("maps page rows as pages", () => {
     const mapped = toClipboardItem(
       row({

--- a/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import { toClipboardItem } from "../../../main/ts/contentExplorer/clipboard/toClipboardItem";
+
+function row(partial: Partial<PSPathItem> & { name: string }): PSPathItem {
+  return {
+    path: partial.path ?? "",
+    ...partial,
+  };
+}
+
+describe("toClipboardItem (#3551)", () => {
+  it("maps site / FSFolder rows used by the Explorer Sites list as folders", () => {
+    const site = toClipboardItem(
+      row({
+        id: "s-1",
+        name: "CorporateInvestments",
+        path: "/Sites/CorporateInvestments",
+        type: "site",
+        category: "SITE",
+        accessLevel: "ADMIN",
+      }),
+    );
+    expect(site).toEqual({
+      id: "s-1",
+      path: "/Sites/CorporateInvestments",
+      kind: "folder",
+      name: "CorporateInvestments",
+      sourceAccessLevel: "ADMIN",
+    });
+
+    const fsFolder = toClipboardItem(
+      row({
+        name: "Files",
+        path: "/Sites/Demo/Files",
+        type: "FSFolder",
+        accessLevel: "WRITE",
+      }),
+    );
+    expect(fsFolder?.kind).toBe("folder");
+    expect(fsFolder?.id).toBe("/Sites/Demo/Files");
+  });
+
+  it("keeps a named Sites row when id and path are omitted", () => {
+    const mapped = toClipboardItem(
+      row({
+        name: "EnterpriseInvestments",
+        type: "site",
+        category: "site",
+      }),
+    );
+    expect(mapped).not.toBeNull();
+    expect(mapped?.id).toBe("EnterpriseInvestments");
+    expect(mapped?.path).toBe("EnterpriseInvestments");
+    expect(mapped?.kind).toBe("folder");
+  });
+
+  it("maps asset category case-insensitively", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "a-1",
+        name: "hero.png",
+        path: "/Assets/hero.png",
+        type: "rffImage",
+        category: "ASSET",
+      }),
+    );
+    expect(mapped?.kind).toBe("asset");
+  });
+
+  it("maps page rows as pages", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "p-1",
+        name: "Home",
+        path: "/Sites/Demo/Home",
+        type: "percPage",
+        category: "PAGE",
+      }),
+    );
+    expect(mapped?.kind).toBe("page");
+  });
+
+  it("returns null when the row has no id, path, or name", () => {
+    expect(
+      toClipboardItem({
+        name: "   ",
+        path: "",
+      }),
+    ).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/toClipboardItem.test.ts
@@ -72,6 +72,18 @@ describe("toClipboardItem (#3551)", () => {
     expect(mapped?.kind).toBe("folder");
   });
 
+  it("maps a custom asset type with category ASSET as an asset (#3557)", () => {
+    const mapped = toClipboardItem(
+      row({
+        id: "c-1",
+        name: "hero",
+        type: "customAsset",
+        category: "ASSET",
+      }),
+    );
+    expect(mapped?.kind).toBe("asset");
+  });
+
   it("maps asset category case-insensitively", () => {
     const mapped = toClipboardItem(
       row({

--- a/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
+++ b/docs/ai-generated/code-reviews/3544-view-clipboard-toggle-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — #3544 View → Clipboard toggle
+
+**Branch:** `fix/issue-3544-view-clipboard-toggle`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-08-17  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** incomplete change-class closure (WebUI screen + Playwright + product-docs); missing behavioral tests for new/changed logic.
+
+## Summary
+
+Parent QA #2741 failed because **View → Clipboard** (`explorer-toggle-clipboard`) stayed `aria-checked=false` and `explorer-clipboard-panel` never appeared. `ContentExplorerShell` already flipped `showClipboard` on `view-clipboard`; the menu item was gated with `disabledWhen: "noClipboardContext"` so `activateItem` returned without calling `onCommand` whenever multi-select and clipboard were both empty.
+
+This change removes that disable so the View toggle always works (empty clipboard panel is an accepted state). `Content → Add to clipboard` still uses `noSelection`. Companions: Vitest (model, menubar, shell + a11y), Playwright surface (`explorer-menu-bar.spec.js` + `explorer-multiselect.spec.js` aria-checked), product-docs `content-explorer.md`.
+
+## Issues
+
+None that are hard-gate bugs.
+
+### Suggestion (low)
+
+`clipboardItemCount` was removed from `ExplorerMenuBarProps` because it only fed the disable predicate. If a later badge needs the count, reintroduce it as display-only — do not re-gate the View toggle.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Menu model (`view-clipboard` always enabled) | Done |
+| Menu bar activate + `aria-checked` | Done |
+| Shell `setShowClipboard` + panel mount | Already present; shell test added |
+| Vitest (model, menubar, shell a11y) | Done |
+| Playwright explorer menu-bar + multiselect | Done |
+| Product-docs (`content-explorer.md` View tools) | Done |
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path joins; URL/`data-testid` strings only.
+
+## Tests
+
+- Focused Vitest: ExplorerMenuBar 18, menuBarModel 9, ContentExplorerShell 49 (clipboard toggle included)
+- WebUI standalone `cd WebUI && ../mvnw.cmd clean install`: BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2775 passed (374 files)
+- perc-qa-automation helper unit: explorer-menu-bar ids include clipboard toggle/panel
+- C5 Playwright on H2 QA (`TEST_CMS_URL=http://127.0.0.1:9993`, cell `perc-matrix-cms-h2`, Health=healthy, HTTP 200 after Jetty in-cell restart):
+  - `npm run test:surface -- --path tests/explorer-menu-bar.spec.js --path tests/explorer-multiselect.spec.js` — 7 passed (including View → Clipboard empty toggle `#3544`)
+  - `npm run test:golden` — 2 passed
+  - console-clean=yes (pageerror/console listener on `#3544` spec)
+  - server.log-clean=yes for the post-restart Playwright window (no new ERROR/FATAL after `2026-08-18 03:17:50`; remaining ERRORs are pre-existing FastForward import / search-index last-modifier noise from first cell start)

--- a/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
+++ b/docs/ai-generated/code-reviews/3545-translations-guid-content-id-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review: Translations GUID content id for variants + create-variant (#3545)
+
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Base:** `origin/main`  
+**Date:** 2026-08-17  
+**Persona:** Erlang (independent of implementer)
+
+Parent QA #2649 (Failed of #2430): Explorer Translations used `Number(itemId)`
+only. List rows are Percussion GUIDs (`1-101-708`); create-variant then emitted
+`Selected item does not have a numeric content id`.
+
+## Summary
+
+`TranslationsPanel` now resolves Explorer row ids with `parseExplorerContentId`
+(GUID last segment) for variants GET (`708`) and create-variant POST
+`itemIds: [708]`. Folders/sites with no content id still return null and keep
+the existing no-id create message. Shell already gated the panel with
+`parseExplorerContentId`; a GUID-row shell test plus Vitest GUID create body
+and Playwright intercept cover the user-visible path. Product-docs note the
+GUID last-segment behavior.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests exercise GUID parse → GET key and POST body.
+Playwright companion updated. No public Java API shape change. No filesystem
+path I/O.
+
+## Change-class closure
+
+Change class: **WebUI Explorer product screen (Translations panel GUID id)**.
+
+| Companion | Status |
+|-----------|--------|
+| `TranslationsPanel` parse via `parseExplorerContentId` | present |
+| Vitest GUID GET + create body + no-id folder path | present |
+| Shell GUID row mounts panel | present |
+| Playwright `explorer-translations.spec.js` | present (create intercept) |
+| product-docs `8.2/admin/content-explorer.md` | present |
+| i18n / a11y | existing keys + axe gates; no new chrome strings |
+
+## Cross-platform path checklist
+
+No filesystem path construction. REST URLs and GUID tokens use `/` and `-`
+as protocol forms, not OS paths. **Outcome: clean.**
+
+Memory patterns hit: missing behavioral tests (covered); WebUI Playwright
+companion (updated); change-class product-docs (updated).
+
+## Issues
+
+None blocking.
+
+### nit
+
+`resolveTranslationsContentId` is a one-line alias of `parseExplorerContentId`.
+Acceptable as a named call-site comment; not required to inline.
+
+C5 live Playwright against H2 QA is a process gate after this review, not a
+code defect.

--- a/docs/ai-generated/code-reviews/3551-explorer-clipboard-panel-erlang.md
+++ b/docs/ai-generated/code-reviews/3551-explorer-clipboard-panel-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3551 Explorer clipboard panel after Add
+
+**Branch:** `fix/issue-3551-explorer-clipboard-panel`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Reviewer:** Erlang (independent of implementer)  
+**Date:** 2026-08-18  
+**Memory patterns hit:** missing behavioral tests; incomplete change-class closure (WebUI + Playwright + product-docs); Playwright for WebUI screens; no path/file I/O
+
+## Summary
+
+Content → Add to clipboard now always mounts `explorer-clipboard-panel` (`setShowClipboard(true)`). View → Clipboard is no longer gated on `noClipboardContext`, so an empty panel is a valid mount. `toClipboardItem` maps Sites / `FSFolder` / `site` rows as folders and keeps a name fallback so the multi-select list used by the spec is not dropped. Playwright no longer clicks View → Clipboard after Add (that toggle would hide an already-open panel).
+
+## Recommendation
+
+approve
+
+## Gate
+
+**May commit/push: yes**
+
+- Bugs: none
+- Behavioral tests: present (mapper unit, ClipboardPanel empty + Sites rows, ExplorerMenuBar toggle, shell Add + empty toggle)
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: WebUI Vitest, perc-qa-automation Playwright, `product-docs/8.2/admin/content-explorer.md`
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+Not applicable — no new file I/O, path joins, installer, or path assertions.
+
+## Verification (implementer evidence, reviewed)
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire Tests run: 61, Failures: 0; Vitest Tests 2783 passed (375 files)
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
+- H2 QA Playwright: explorer-multiselect 3 passed; Cycle Verify surface set 15 passed (menu-bar empty toggle + add-to-clipboard); no `Failed startup of context`

--- a/docs/ai-generated/code-reviews/3553-subfolder-copy-dismiss-erlang.md
+++ b/docs/ai-generated/code-reviews/3553-subfolder-copy-dismiss-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3553 Subfolder Copy Cancel/item-click dismiss
+
+**Branch:** `fix/issue-3553-subfolder-copy-dismiss`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Reviewer:** Erlang (independent of implementer)  
+**Date:** 2026-08-18  
+
+**Memory patterns hit:** missing behavioral tests; incomplete change-class closure (WebUI screen requires Playwright + product-docs); click-away vs menu-toggle races.
+
+## Summary
+
+Human QA on #2797 failed because Subfolder Copy **Cancel** called `resetWizard()` (step 1, overlay stays mounted) and selecting an Explorer item left the overlay up. This change adds `onDismiss` on `SubfolderCopyWizard`, host unmount + Escape/focus restore (`useDialogEscape`), tree/detail/click-away dismiss without POST, Vitest, Playwright, and product-docs 8.2 Explorer Subfolder Copy.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No hard-gate bugs, missing behavioral tests, or non-portable path I/O.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Wizard `onDismiss` vs `resetWizard` | Yes — Cancel with host callback does not reset steps |
+| Shell unmount + focus restore | Yes — `useDialogEscape` + Content menu opener |
+| Item select / click-away | Yes — `handleSelectFolder` / `handleSelectItem` / document mousedown excluding panel + menu bar |
+| Vitest | Wizard dismiss vs reset; shell Cancel/Escape/Back/item/click-away |
+| Playwright | `explorer-subfolder-copy.spec.js` Cancel + item-click; console/pageerror + no copy POST |
+| product-docs 8.2 Explorer | Subfolder Copy table for Cancel / Escape / item / click-away |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Playwright/helper URLs use `/` (URL paths).
+
+## Issues
+
+None (hard gate).
+
+### Notes (non-blocking)
+
+- Click-away excludes the Explorer menu bar so Content → Subfolder Copy remains a toggle instead of close-then-reopen.
+- Standalone wizard (no `onDismiss`) still `resetWizard` for residual US7 mounts.
+- Full multi-folder submit remains soft-skipped on H2 (out of scope).

--- a/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3545-pr-3547-review-followup-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — PR #3547 review follow-up (#3545)
+
+**Date:** 2026-08-18  
+**Branch:** `fix/issue-3545-translations-guid-content-id`  
+**Scope:** uncommitted review-response (comment accuracy + Playwright detach retry)
+
+## Summary
+
+Kilo threads on #3547: (1) `variantsKey` comment claimed folders stay null while
+code falls back to raw `itemId`; (2) item-row click lacked the detach retry used
+for folder rows. Comment rewritten, unit test asserts GET uses the raw token on
+parse-null, Playwright helper retries item (and folder fallback) clicks.
+
+## Recommendation
+
+**approve** — May commit/push: **yes**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: new Vitest case for parse-null GET fallback
+- Cross-platform path review: N/A (no filesystem I/O)
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Orphaned JSDoc above extracted helper — fixed before commit
+- Public helper comment contradicting implementation — addressed
+
+> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3546-relationships-content-row-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #3546 Relationships panel for content row
+
+**Branch:** `fix/issue-3546-relationships-content-row`  
+**Scope:** uncommitted vs `HEAD` (WebUI list/id bind, Explorer shell mount, Vitest, Playwright, product-docs)  
+**Date:** 2026-08-17  
+**Reviewer:** Erlang (pre-commit)
+
+## Summary
+
+Explorer Relationships stayed hint-only unless `selection.item.type !== "folder"` and `parseExplorerContentId(selection.item.id)` succeeded. Sample-site rows can omit `id`, use a slug (`ci-home`), or wrap a GUID object. This change binds a parseable content/GUID id onto path items at list unwrap (and path lookup on select), mounts the panel for any non-folder with a parseable id, and covers GUID + slug + omitted-id cases in Vitest plus a Playwright spec that requires a `data-row-kind="item"` row.
+
+Memory patterns hit: behavioral tests for new logic; WebUI Playwright companion; product-docs for operator-facing View → Relationships; CMS URL paths correctly use `/`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs, missing behavioral tests, or non-portable filesystem I/O. Change-class companions present (Vitest, Playwright, product-docs).
+
+## Cross-platform path checklist
+
+- No new OS filesystem joins (`"/"` / `"\\"` concatenation for files)
+- CMS Explorer paths remain URL-style `/` (correct)
+- Tests do not assert OS-specific absolute paths
+- N/A for installers / temp files
+
+## Issues
+
+None blocking.
+
+### nit
+
+- `handleSelectItem` path lookup is best-effort; a rapid second click is ignored via `sameRow`. Acceptable for this slice.
+
+## Tests / companions
+
+- `pathItemId.test.ts` — parse, unwrap, bind (GUID, slug+sys_contentid, folder slug)
+- `ContentExplorerShell.test.tsx` — GUID row → panel; slug bind → panel; omitted id + path lookup → panel; existing folder → hint
+- `pathApi.test.ts` — paginatedFolder binds `sys_contentid`
+- Playwright `explorer-relationships.spec.js` — content row must mount panel (not hint-only)
+- `product-docs/8.2/admin/content-explorer.md` — select page/asset; FastForward section folders

--- a/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js
@@ -96,6 +96,49 @@ test.describe("modern React Content Explorer — DCE menu bar chrome (#2731)", (
   );
 
   test(
+    "View → Clipboard opens empty panel and sets aria-checked (#3544)",
+    { tag: ["@explorer-menu-bar", "@explorer", "@issue-3544"] },
+    async ({ page }) => {
+      const errors = [];
+      page.on("pageerror", (err) => errors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 15_000 });
+
+      await openViewMenu(page);
+      const toggle = page.locator(
+        `[data-testid="${TEST_IDS.toggleClipboard}"]`,
+      );
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toBeEnabled();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toBeVisible({ timeout: 5_000 });
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.clipboardPanel}"]`),
+      ).toHaveCount(0);
+
+      expect(errors, `JS console/page errors: ${errors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
     "server action toolbar still mounts under menu bar",
     { tag: ["@explorer-menu-bar", "@explorer"] },
     async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
@@ -90,12 +90,15 @@ test.describe("modern React Content Explorer — multi-select + clipboard (#2408
     await rowCheckboxes.nth(0).check();
     await rowCheckboxes.nth(1).check();
 
-    // #2731: clipboard-add lives under Content menu; clipboard toggle under View.
+    // #2731 / #3544 / #3551: Add lives under Content and opens the clipboard
+    // panel. View → Clipboard must already be checked — do not click it
+    // again here or the toggle would hide the already-open panel.
     await page.locator('[data-testid="explorer-menu-content"]').click();
     await page.locator('[data-testid="explorer-clipboard-add"]').click();
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
-    await page.locator('[data-testid="explorer-toggle-clipboard"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-clipboard"]');
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
     const panel = page.locator('[data-testid="explorer-clipboard-panel"]');
     await expect(panel).toBeVisible();
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js
@@ -90,12 +90,15 @@ test.describe("modern React Content Explorer — multi-select + clipboard (#2408
     await rowCheckboxes.nth(0).check();
     await rowCheckboxes.nth(1).check();
 
-    // #2731: clipboard-add lives under Content menu; clipboard toggle under View.
+    // #2731 / #3544: Add lives under Content; it also opens the clipboard
+    // panel. View → Clipboard must already be checked — do not click it
+    // again here or the toggle would hide the panel.
     await page.locator('[data-testid="explorer-menu-content"]').click();
     await page.locator('[data-testid="explorer-clipboard-add"]').click();
 
     await page.locator('[data-testid="explorer-menu-view"]').click();
-    await page.locator('[data-testid="explorer-toggle-clipboard"]').click();
+    const toggle = page.locator('[data-testid="explorer-toggle-clipboard"]');
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
     const panel = page.locator('[data-testid="explorer-clipboard-panel"]');
     await expect(panel).toBeVisible();
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Playwright surface: #2769 / parent #2400 — Explorer IA Relationships view.
+ * Playwright surface: #2769 / #3546 / parent #2400 — Explorer IA Relationships view.
  *
  * <p>Verifies the modern React Content Explorer shell exposes the Relationships
  * panel chrome (View → IA Relationships) and mounts {@code RelationshipsView}
@@ -83,55 +83,101 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
   );
 
   test(
-    "selecting a list row opens relationships panel or select-item hint",
+    "selecting a content row mounts the relationships panel (#3546)",
     { tag: ["@explorer-relationships", "@p-adv"] },
     async ({ page }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(90_000);
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      // Navigate into a structural root so the list has selectable children.
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      await expect(tree).toBeVisible({ timeout: 15_000 });
-      const sitesNode = page
-        .locator(
-          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-        )
-        .first();
-      if ((await sitesNode.count()) > 0) {
-        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
-        await listWaitReady(page);
-        await page.waitForLoadState("networkidle").catch(() => {});
+      async function fetchChildren(folderPath) {
+        const suffix = String(folderPath || "")
+          .replace(/^\/+/, "")
+          .replace(/\/+$/, "");
+        const url = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/paginatedFolder/${suffix}?startIndex=0&maxResults=50`;
+        const res = await page.request.get(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok()) {
+          return [];
+        }
+        const body = await res.json();
+        return body?.PagedItemList?.childrenInPage ?? [];
       }
+
+      function isContentChild(child) {
+        const type = String(child?.type ?? "").trim().toLowerCase();
+        const category = String(child?.category ?? "").trim().toLowerCase();
+        if (
+          type === "folder" ||
+          type === "fsfolder" ||
+          type === "site" ||
+          category === "folder" ||
+          category === "site" ||
+          category === "section_folder"
+        ) {
+          return false;
+        }
+        if (category === "page" || category === "asset" || category === "landing_page") {
+          return true;
+        }
+        return type.length > 0 && type !== "folder";
+      }
+
+      async function findFolderWithContent(startPath, depth) {
+        const children = await fetchChildren(startPath);
+        const items = children.filter(isContentChild);
+        if (items.length > 0) {
+          return { folderPath: startPath, items };
+        }
+        if (depth <= 0) {
+          return null;
+        }
+        for (const child of children) {
+          const next =
+            child.folderPath ||
+            child.path ||
+            (child.name ? `${startPath.replace(/\/+$/, "")}/${child.name}` : null);
+          if (!next) continue;
+          const found = await findFolderWithContent(next, depth - 1);
+          if (found) return found;
+        }
+        return null;
+      }
+
+      const found = await findFolderWithContent("/Sites", 4);
+      expect(
+        found,
+        "H2 sample sites should list at least one page/asset under Sites",
+      ).toBeTruthy();
+
+      const folderPath = found.folderPath.replace(/\/+$/, "") || "/Sites";
+      await page.goto(
+        `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&path=${encodeURIComponent(folderPath)}&_=${Date.now()}`,
+      );
+      await page.waitForLoadState("networkidle");
+      await listWaitReady(page);
 
       const list = page.locator('[data-testid="detail-list"]');
       await expect(list).toBeVisible({ timeout: 15_000 });
 
-      // Prefer an enabled row; force-click to survive list re-renders (H2 QA).
-      const enabledRows = list.locator(
-        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      const itemRow = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]:not([aria-disabled="true"])',
       );
-      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
-      const enabledCount = await enabledRows.count();
-      const anyCount = await anyRows.count();
-      if (enabledCount === 0 && anyCount === 0) {
-        await page.locator('[data-testid="explorer-menu-view"]').click();
-        await page
-          .locator('[data-testid="explorer-toggle-relationships"]')
-          .click();
-        await expect(
-          page.locator('[data-testid="explorer-relationships-hint"]'),
-        ).toBeVisible({ timeout: 5_000 });
-        return;
+
+      if ((await itemRow.count()) === 0) {
+        const first = found.items[0];
+        const idKey = first.id ?? first.path;
+        const byId = list.locator(`[data-testid="detail-row-${idKey}"]`);
+        if ((await byId.count()) > 0) {
+          await byId.first().click({ force: true, timeout: 10_000 });
+        }
+      } else {
+        await itemRow.first().click({ force: true, timeout: 10_000 });
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+      await expect(itemRow.first().or(list.locator('[data-selected="true"]'))).toBeVisible({
+        timeout: 10_000,
       });
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
@@ -139,37 +185,19 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
         .locator('[data-testid="explorer-toggle-relationships"]')
         .click();
 
-      // Either full panel (item with id) or select-item hint (folder / no id).
-      const panel = page.locator('[data-testid="relationships-view"]');
       const region = page.locator(
         '[data-testid="explorer-relationships-panel"]',
       );
-      const hint = page.locator(
-        '[data-testid="explorer-relationships-hint"]',
+      const panel = page.locator('[data-testid="relationships-view"]');
+      await expect(region).toBeVisible({ timeout: 15_000 });
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-relationships-hint"]'),
+      ).toHaveCount(0);
+      await expect(panel).toHaveAttribute(
+        "data-testid-state",
+        /ok|loading|auth|error/,
       );
-      await expect(panel.or(hint).or(region)).toBeVisible({ timeout: 15_000 });
-
-      if ((await panel.count()) > 0) {
-        await expect(panel).toHaveAttribute(
-          "data-testid-state",
-          /ok|loading|auth|error/,
-        );
-        await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
-          timeout: 20_000,
-        });
-        const state = await panel.getAttribute("data-testid-state");
-        if (state === "ok") {
-          await expect(
-            page.locator('[data-testid="relationships-primary"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-outgoing"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="relationships-row-incoming"]'),
-          ).toBeVisible();
-        }
-      }
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-subfolder-copy.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-subfolder-copy.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Playwright surface: #2792 / parent #2400 — Subfolder Copy wizard in Explorer shell.
+ * Playwright surface: #2792 / #3553 / parent #2400 — Subfolder Copy wizard.
  *
- * <p>Verifies Content → Subfolder Copy chrome on the modern SPA Explorer. Full
- * multi-folder submit is soft-skipped when the H2 fixture lacks a navigable
- * folder tree suitable for a destructive copy.</p>
+ * <p>Verifies Content → Subfolder Copy chrome on the modern SPA Explorer, plus
+ * Cancel / item-click dismiss (#3553). Full multi-folder submit is soft-skipped
+ * when the H2 fixture lacks a navigable folder tree suitable for a destructive
+ * copy.</p>
  *
  * <p>Tags: {@code @explorer-subfolder-copy} {@code @explorer} {@code @smoke}</p>
  *
@@ -93,6 +94,28 @@ async function tryEnterFolder(page) {
   return false;
 }
 
+/**
+ * Open the wizard when folder context exists. Returns false when the H2
+ * fixture has no navigable folder (soft-skip caller).
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<boolean>}
+ */
+async function tryOpenWizard(page) {
+  await tryEnterFolder(page);
+  await openContentMenu(page);
+  const menuItem = page.locator(
+    `[data-testid="${TEST_IDS.subfolderCopyMenu}"]`,
+  );
+  await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  if (await menuItem.isDisabled()) {
+    return false;
+  }
+  await menuItem.click();
+  const wizard = page.locator(`[data-testid="${TEST_IDS.wizard}"]`);
+  await expect(wizard).toBeVisible({ timeout: 10_000 });
+  return true;
+}
+
 test.describe("modern React Content Explorer — subfolder copy chrome (#2792)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(45_000);
@@ -163,6 +186,113 @@ test.describe("modern React Content Explorer — subfolder copy chrome (#2792)",
           .inputValue();
         expect(sourceVal.length).toBeGreaterThan(0);
       }
+    },
+  );
+
+  test(
+    "Cancel dismisses the Subfolder Copy overlay (#3553)",
+    { tag: ["@explorer-subfolder-copy", "@explorer"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => {
+        pageErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          pageErrors.push(msg.text());
+        }
+      });
+
+      const opened = await tryOpenWizard(page);
+      if (!opened) {
+        test.info().annotations.push({
+          type: "soft-skip",
+          description:
+            "No folder context under /Sites (H2 fixture may lack navigable folders).",
+        });
+        return;
+      }
+
+      const source = page.locator(`[data-testid="${TEST_IDS.sourceInput}"]`);
+      await expect(source).toBeVisible();
+      await source.fill("/Sites/Demo/Home");
+      await page.locator(`[data-testid="${TEST_IDS.next}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.stepTarget}"]`),
+      ).toBeVisible();
+
+      await page.locator(`[data-testid="${TEST_IDS.cancel}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
+      ).toHaveCount(0, { timeout: 10_000 });
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.subfolderCopyPanel}"]`),
+      ).toHaveCount(0);
+      expect(pageErrors, `console/pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
+    },
+  );
+
+  test(
+    "item click dismisses the Subfolder Copy overlay without POST (#3553)",
+    { tag: ["@explorer-subfolder-copy", "@explorer"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const pageErrors = [];
+      const copyPosts = [];
+      page.on("pageerror", (err) => {
+        pageErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          pageErrors.push(msg.text());
+        }
+      });
+      page.on("request", (req) => {
+        if (
+          req.method() === "POST" &&
+          /folders\/copy|moveItem/i.test(req.url())
+        ) {
+          copyPosts.push(req.url());
+        }
+      });
+
+      const opened = await tryOpenWizard(page);
+      if (!opened) {
+        test.info().annotations.push({
+          type: "soft-skip",
+          description:
+            "No folder context under /Sites (H2 fixture may lack navigable folders).",
+        });
+        return;
+      }
+
+      const list = page.locator(`[data-testid="${TEST_IDS.detailList}"]`);
+      const rows = list.locator(
+        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      );
+      const treeNodes = page.locator('[data-testid^="tree-node-"]');
+      if ((await rows.count()) > 0) {
+        await rows.first().click();
+      } else if ((await treeNodes.count()) > 0) {
+        await treeNodes.first().click();
+      } else {
+        await page.locator(`[data-testid="${TEST_IDS.shell}"]`).click({
+          position: { x: 8, y: 8 },
+        });
+      }
+
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.wizard}"]`),
+      ).toHaveCount(0, { timeout: 10_000 });
+      expect(copyPosts, `unexpected copy POST: ${copyPosts.join(" | ")}`).toEqual(
+        [],
+      );
+      expect(pageErrors, `console/pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -44,6 +44,13 @@ async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
 }
 
+/** Click the first matching row; re-query if the locator detaches mid-click. */
+async function clickFirstRowWithDetachRetry(rows) {
+  await rows.first().click({ force: true, timeout: 10_000 }).catch(async () => {
+    await rows.first().click({ force: true, timeout: 10_000 }).catch(() => {});
+  });
+}
+
 /**
  * Open the first listed content row (page/asset), drilling one folder when
  * the current list is folders only. GUID-shaped {@code data-testid} values
@@ -55,7 +62,7 @@ async function selectFirstContentRow(page) {
     'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
   );
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   const folderRows = list.locator(
@@ -66,15 +73,13 @@ async function selectFirstContentRow(page) {
   }
   await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
     async () => {
-      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
-        () => {},
-      );
+      await clickFirstRowWithDetachRetry(folderRows);
     },
   );
   await listWaitReady(page);
   await page.waitForLoadState("networkidle").catch(() => {});
   if ((await itemRows.count()) > 0) {
-    await itemRows.first().click({ force: true, timeout: 10_000 });
+    await clickFirstRowWithDetachRetry(itemRows);
     return true;
   }
   return false;

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -20,8 +20,11 @@
  * <p>Verifies the modern React Content Explorer shell exposes the Translations
  * panel chrome and loads item locale / variants from the public REST façade
  * ({@code GET /rest/content-explorer/translations/{itemId}}). Create-variant
- * is exercised only when a content row with a numeric id is selectable and
- * the CMS returns target locales; chrome visibility is the hard gate.</p>
+ * is exercised when a content row is selectable (GUID last-segment ids such as
+ * {@code 1-101-708} → {@code 708}, #3545 / parent #2649). The client must not
+ * emit {@code Selected item does not have a numeric content id} for a
+ * GUID-shaped row. Folders/sites keep the select-item hint. Chrome visibility
+ * is the hard gate when no content row is listed.</p>
  *
  * <p>Tags: {@code @explorer-translations} {@code @p-trans} {@code @smoke}</p>
  *
@@ -32,10 +35,49 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  expectNoSeriousA11yViolations,
+} = require("./helpers/a11y");
 
 /** Wait until the detail list region is present (folder navigation settled). */
 async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
+}
+
+/**
+ * Open the first listed content row (page/asset), drilling one folder when
+ * the current list is folders only. GUID-shaped {@code data-testid} values
+ * are valid (#3545).
+ */
+async function selectFirstContentRow(page) {
+  const list = page.locator('[data-testid="detail-list"]');
+  const itemRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  const folderRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  if ((await folderRows.count()) === 0) {
+    return false;
+  }
+  await folderRows.first().dblclick({ force: true, timeout: 10_000 }).catch(
+    async () => {
+      await folderRows.first().click({ force: true, timeout: 10_000 }).catch(
+        () => {},
+      );
+    },
+  );
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+  if ((await itemRows.count()) > 0) {
+    await itemRows.first().click({ force: true, timeout: 10_000 });
+    return true;
+  }
+  return false;
 }
 
 test.describe("modern React Content Explorer — translations (P-Trans #2430)", () => {
@@ -114,19 +156,22 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
         return;
       }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
-        // Re-query after detach from folder refresh.
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
-      });
+      const selectedContent = await selectFirstContentRow(page);
+      if (!selectedContent) {
+        const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
+        await target.click({ force: true, timeout: 10_000 }).catch(async () => {
+          // Re-query after detach from folder refresh.
+          const again = list
+            .locator('tbody tr[data-testid^="detail-row-"]')
+            .first();
+          await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+        });
+      }
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
       await page.locator('[data-testid="explorer-toggle-translations"]').click();
 
-      // Either full panel (numeric content id) or select-item hint (folder / no id).
+      // Content row (including GUID 1-101-708) → panel; folder/site → hint.
       const panel = page.locator('[data-testid="translations-panel"]');
       const hint = page.locator('[data-testid="explorer-translations-hint"]');
       await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
@@ -150,8 +195,130 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
           await expect(
             page.locator('[data-testid="translations-inflight-note"]'),
           ).toBeVisible();
+          await expectNoSeriousA11yViolations(page, {
+            scope: '[data-testid="translations-panel"]',
+          });
         }
+      } else {
+        await expect(hint).toBeVisible();
       }
+    },
+  );
+
+  test(
+    "create-variant on a content row does not emit numeric-id client error (#3545)",
+    { tag: ["@explorer-translations", "@p-trans"] },
+    async ({ page }) => {
+      test.setTimeout(75_000);
+      const pageErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const selectedContent = await selectFirstContentRow(page);
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      await page.locator('[data-testid="explorer-toggle-translations"]').click();
+
+      const panel = page.locator('[data-testid="translations-panel"]');
+      const hint = page.locator('[data-testid="explorer-translations-hint"]');
+      await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
+
+      if (!selectedContent || (await panel.count()) === 0) {
+        await expect(hint).toBeVisible();
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+        timeout: 20_000,
+      });
+      const state = await panel.getAttribute("data-testid-state");
+      if (state !== "ok") {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      await expect(
+        page.locator('[data-testid="translations-current-locale"]'),
+      ).toBeVisible();
+
+      const localeOptions = page.locator(
+        '[data-testid^="translations-locale-option-"]',
+      );
+      if ((await localeOptions.count()) === 0) {
+        expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+          [],
+        );
+        return;
+      }
+
+      /** @type {{ itemIds?: number[] } | null} */
+      let posted = null;
+      await page.route("**/rest/content-explorer/translations", async (route) => {
+        if (route.request().method() !== "POST") {
+          await route.continue();
+          return;
+        }
+        try {
+          posted = route.request().postDataJSON();
+        } catch {
+          posted = {};
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            created: [
+              {
+                contentId: 901,
+                locale: "xx-test",
+                role: "translation",
+              },
+            ],
+          }),
+        });
+      });
+
+      await localeOptions.first().click();
+      await page.locator('[data-testid="translations-create-submit"]').click();
+
+      await expect(
+        page.locator('[data-testid="translations-create-success"]'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.locator('[data-testid="translations-create-error"]'),
+      ).toHaveCount(0);
+      await expect(
+        page.getByText(/does not have a numeric content id/i),
+      ).toHaveCount(0);
+
+      expect(posted, "create-variant POST should have been sent").not.toBeNull();
+      const ids = posted && Array.isArray(posted.itemIds) ? posted.itemIds : [];
+      expect(ids.length).toBeGreaterThan(0);
+      expect(Number(ids[0])).toBeGreaterThan(0);
+      expect(Number.isFinite(Number(ids[0]))).toBe(true);
+
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -17,6 +17,9 @@ const TEST_IDS = Object.freeze({
   viewDropdown: "explorer-menu-view-dropdown",
   helpDropdown: "explorer-menu-help-dropdown",
   toggleSearch: "explorer-toggle-search",
+  /** View → Clipboard (#3544) — panel toggle, enabled even when empty. */
+  toggleClipboard: "explorer-toggle-clipboard",
+  clipboardPanel: "explorer-clipboard-panel",
   /** Content → Search (#2850) — same panel as View → Search. */
   contentSearch: "explorer-menu-content-search",
   searchPanel: "explorer-search-panel",

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -17,6 +17,9 @@ const TEST_IDS = Object.freeze({
   viewDropdown: "explorer-menu-view-dropdown",
   helpDropdown: "explorer-menu-help-dropdown",
   toggleSearch: "explorer-toggle-search",
+  /** View → Clipboard (#3544 / #3551) — panel toggle, enabled even when empty. */
+  toggleClipboard: "explorer-toggle-clipboard",
+  clipboardPanel: "explorer-clipboard-panel",
   /** Content → Search (#2850) — same panel as View → Search. */
   contentSearch: "explorer-menu-content-search",
   searchPanel: "explorer-search-panel",

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-subfolder-copy.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-subfolder-copy.js
@@ -16,6 +16,11 @@ const TEST_IDS = Object.freeze({
   subfolderCopyHint: "explorer-subfolder-copy-hint",
   wizard: "subfolder-copy-wizard",
   sourceInput: "subfolder-copy-source",
+  cancel: "subfolder-copy-cancel",
+  back: "subfolder-copy-back",
+  next: "subfolder-copy-next",
+  stepSource: "subfolder-copy-step-source",
+  stepTarget: "subfolder-copy-step-target",
   tree: "explorer-tree",
   detailList: "detail-list",
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-menu-bar.test.js
@@ -34,6 +34,8 @@ describe("explorer-menu-bar helpers (#2731)", () => {
     assert.equal(TEST_IDS.menuView, "explorer-menu-view");
     assert.equal(TEST_IDS.menuHelp, "explorer-menu-help");
     assert.equal(TEST_IDS.toggleSearch, "explorer-toggle-search");
+    assert.equal(TEST_IDS.toggleClipboard, "explorer-toggle-clipboard");
+    assert.equal(TEST_IDS.clipboardPanel, "explorer-clipboard-panel");
     assert.equal(TEST_IDS.contentSearch, "explorer-menu-content-search");
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-subfolder-copy.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-subfolder-copy.test.js
@@ -34,6 +34,8 @@ describe("explorer-subfolder-copy helpers (#2792)", () => {
     assert.equal(TEST_IDS.subfolderCopyMenu, "explorer-content-subfolder-copy");
     assert.equal(TEST_IDS.wizard, "subfolder-copy-wizard");
     assert.equal(TEST_IDS.subfolderCopyPanel, "explorer-subfolder-copy-panel");
+    assert.equal(TEST_IDS.cancel, "subfolder-copy-cancel");
+    assert.equal(TEST_IDS.back, "subfolder-copy-back");
   });
 
   it("builds explorer SPA entry URL with cache buster", () => {

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -324,7 +324,12 @@ From the **View** menu you can also toggle:
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
-- **Clipboard** — multi-select copy/cut staging when items are selected
+- **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
+  the panel (even when empty) and shows a check mark while it is visible.
+  Use **Content → Add to clipboard** after multi-select to put items on the
+  clipboard and open the panel (including **Sites** rows). Do not click
+  **View → Clipboard** again after Add — that hides the already-open panel.
+  Paste from the panel when a destination folder is selected.
 
 ## If Content Explorer cannot start
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -324,7 +324,10 @@ From the **View** menu you can also toggle:
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
   suitable item is selected
-- **Clipboard** — multi-select copy/cut staging when items are selected
+- **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
+  the panel (even when empty) and shows a check mark while it is visible.
+  Use **Content → Add to clipboard** after multi-select to put items on the
+  clipboard; paste from the panel when a destination folder is selected.
 
 ## If Content Explorer cannot start
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -323,7 +323,12 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  **page or asset** is selected (not a folder or site). On sample FastForward
+  sites, expand a site in the tree, open a section folder (for example
+  **AboutEnterpriseInvestments** — not only a `Pages` folder), and select a
+  content row. **View → Relationships** then mounts the relationships panel
+  (loading, results, empty, or an error). A folder-only or empty selection
+  keeps the select-item hint.
 - **Clipboard** — multi-select copy/cut staging when items are selected
 
 ## If Content Explorer cannot start

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -182,6 +182,25 @@ Related Content menu commands:
 - **Site Copy** / **Subfolder Copy** — copy workflows when a site or folder is in context
 - **Search** — same Search panel as **View → Search**
 
+### Subfolder Copy
+
+**Content → Subfolder Copy** opens a wizard overlay when a folder is in context
+(the current tree folder, or a selected folder row). Source path is prefilled from
+that folder.
+
+| Control | Behavior |
+|---------|----------|
+| **Next** | Advance to the next step (source → target → confirm → run) |
+| **Back** | Return to the previous step. The overlay stays open |
+| **Cancel** | Close the wizard without copying. Cancel is **not** Back — it does not reset to step 1 while leaving the overlay up |
+| **Escape** | Same as Cancel: dismiss without submitting |
+| Tree or list item | Selecting another folder or item closes the wizard without submitting |
+| Click outside the wizard | Also dismisses without submitting |
+
+After Cancel, Escape, item-click, or click-away, focus returns to the Explorer
+**Content** menu so you can continue working in the shell. The wizard does not
+POST a folder copy until you reach the last step and choose **Submit**.
+
 ## Views → My Content → Inbox
 
 Desktop Content Explorer **Inbox** is **not** a separate Content Explorer root and is **not**

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -122,7 +122,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Workflow** | Allowed transitions run through itemmanagement (not `wfactionset.html`) |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open the CM1 editor (`?view=editor`). |
-| **Translate** | Opens the Explorer **Translations** panel (create locale copies). Does not open the legacy translate XSL wizard. |
+| **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`1-101-708`); the panel uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
 | **Revisions** | Opens the Revisions panel; restore is available when the selected revision is restorable. **Promote revision** opens the same chrome-less editor host (`mode=promote`) and restores the chosen revision through `GET /services/itemmanagement/item/restoreRevision/{revisionGuid}`. |
@@ -323,8 +323,25 @@ From the **View** menu you can also toggle:
   confirmation before save. Without a selected folder the shell shows a select-folder
   hint instead of a blank panel.
 - **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a
-  suitable item is selected
+  suitable item is selected (see **Translations** below)
 - **Clipboard** — multi-select copy/cut staging when items are selected
+
+## Translations
+
+Open **View → Translations** after selecting a **page or asset** in the list (or use
+**Translate** on Server actions / the item context menu).
+
+The panel shows **this item’s current locale** and **related locale variants**, and lets
+an authorized user **Create variants** for catalog locales the item does not already
+have. Explorer list rows identify items with a Percussion content id. The id is often
+GUID-shaped (for example `1-101-708`); the panel uses the last segment (`708`) for
+both the variants request and create-variant. That GUID form must not fail with
+“Selected item does not have a numeric content id.”
+
+**Folders and sites** have no content id. With Translations open and only a folder or
+site selected, Explorer shows a select-item hint instead of the live panel.
+
+In-flight translation queue status is not available (product disposition).
 
 ## If Content Explorer cannot start
 


### PR DESCRIPTION
## Summary

Overnight Explorer PRs independently edited the same Content Explorer shell files, so later merges against `main` would keep colliding.

**Thrash files**

- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx`
- `WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx`
- `product-docs/8.2/admin/content-explorer.md`
- `WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx` (3550 + 3552)
- `WebUI/src/main/ts/contentExplorer/menuBarModel.ts` (3550 + 3552)
- `modules/perc-qa-automation/frontend/tests/explorer-menu-bar.spec.js` (3550 + 3552)
- `modules/perc-qa-automation/frontend/tests/explorer-multiselect.spec.js` (3550 + 3552)
- `modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js` (3550 + 3552)

This PR unions those heads onto `main` (oldest first: #3550, #3552, #3555). Conflict resolution kept both sides' unique adds:

- Relationships path-id bind (`sameExplorerItemId` / `bindExplorerPathItemId`) **and** clipboard `explorerMultiSelectKey` / `toClipboardItem`
- Item-select dismisses Subfolder Copy **without** dropping the Relationships id-bind
- Product-docs: Translations/Relationships text from #3550 plus Clipboard Sites-row / do-not-reclick-toggle guidance from #3552
- One Vitest waitFor tightened so the empty `action-toolbar` chrome no longer races `loadMenuActions` after extra mount effects

Related issues: #3544 #3545 #3546 #3551 #3553 (prior cluster #3550 absorbed #3547 #3548 #3549).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|---|---|---|---|---|
| yes | #3550 | `cluster/night-issue-20260818-explorer-content` | yes | Translations / View Clipboard / Relationships cluster |
| yes | #3552 | `fix/issue-3551-explorer-clipboard-panel-2` | yes | Add to clipboard mounts panel + Sites rows |
| yes | #3555 | `fix/issue-3553-subfolder-copy-dismiss` | yes | Subfolder Copy Cancel / Escape / item-click dismiss |

Do **not** merge the superseded PRs.

Left unclustered (no shared thrash with this group): #3532, #3543, #3556.

## modules_built

`WebUI, modules/perc-qa-automation`

## build_evidence

```
cd WebUI && ../mvnw.cmd clean install
BUILD SUCCESS
Surefire Tests run: 61, Failures: 0
Vitest Tests 2771 passed (374 files)

cd modules/perc-qa-automation && ../../mvnw.cmd clean install
BUILD SUCCESS
(Maven surefire: No tests to run)
```

No Java `final`/`public` API shape change. Reverse-dep install not required.

## Test plan

1. Deploy this cluster (or hot-copy WebUI modern assets) on H2 QA.
2. Explorer: select a page/asset — View → Relationships / Translations still mount (GUID last-segment).
3. Multi-select two Sites rows → Content → Add to clipboard → panel visible with two rows; View → Clipboard is `aria-checked=true` (do not click it again).
4. Enter a Sites folder → Content → Subfolder Copy → Cancel / Escape / click a tree or detail item: overlay unmounts, no POST. Back still walks steps.
5. Confirm no blocking console errors on those paths.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` union of clipboard + translations/relationships + subfolder-copy dismiss
- [x] **Unit / module tests** — WebUI Vitest + Surefire green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — absorbed specs: explorer-menu-bar, explorer-multiselect, explorer-relationships, explorer-translations, explorer-subfolder-copy
- [x] **Build gates** — standalone clean install of WebUI and perc-qa-automation (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.4 using grok-4.6 with agent night-issue-prs-cluster.
