### PR TITLE
fix(sitemanage): path/item must not 500 on folder-root or missing site (#3558)

### DIFF
--- a/docs/ai-generated/code-reviews/3558-subfolder-copy-path-item-rollback-erlang.md
+++ b/docs/ai-generated/code-reviews/3558-subfolder-copy-path-item-rollback-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — #3558 path/item rollback-only 500
+
+**Scope:** `fix/issue-3558-subfolder-copy-rollback-500` vs `cluster/night-issue-20260818-explorer-shell`.
+**Memory patterns hit:** Spring TX rollback-only from swallowed/failed `siteDataService.find(id)`; missing behavioral tests; change-class closure (product-docs + Playwright companion).
+**Cross-platform path checklist:** CMS finder `/` paths only (`requestedRelativeSitePath`, `folderPathLeaf`). No OS filesystem I/O.
+
+## Summary
+
+Cycle Verify residual of #3553: Cancel / item-click already unmounted the Subfolder Copy overlay on the cluster tip, but Playwright empty-console failed because Explorer `GET /path/item/{path}` returned HTTP 500 (`UnexpectedRollbackException`: transaction rollback-only).
+
+Root cause: `PSSitePathItemService.findItem` called `siteDataService.find(siteId)` with the finder slug. Sample sites use SITENAME `Corporate_Investments` and FOLDER_ROOT `//Sites/CorporateInvestments`. `find("CorporateInvestments")` (and `find("Demo")` for a typed missing path) poisons the Spring TX; the REST mapper then reports 500 instead of the folder item or 404. Explorer `defaultResolveFolderId` hits that endpoint for the current folder after `tryEnterFolder`.
+
+Fix: resolve the site via `findByPath` then `findAll` + `siteFolderNameMatches` / folder-root leaf. Never call `find(id)` on this path. Missing `/Sites/Demo/Home` is 404. Folder-root slug returns the site item with `PathItem.path` set to the requested relative path so `DispatchingPathService` validation passes.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (hard-gate).
+
+Behavioral tests: `PSSitePathItemServiceFindItemSiteResolveTest` (folder-root without `find(id)`, sitename `findByPath`, missing Demo/Home 404, CMS path leaf). Product-docs browse + Subfolder Copy Next notes updated. C5: `explorer-subfolder-copy` 5 passed; Cycle Verify surface set 21 passed. No new `rollback-only` after hot-deploy.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -34,7 +34,7 @@ service (roles may hide Design/Recycling for some users):
 
 | Root | Maps to | Purpose |
 |------|---------|---------|
-| **Sites** | `//Sites` | Traditional site folders and pages. Use the tree disclosure control (not only the row label) to expand **Sites**, then expand a sample site to list FastForward folders such as **AboutEnterpriseInvestments**, **Files**, and **Images** |
+| **Sites** | `//Sites` | Traditional site folders and pages. Use the tree disclosure control (not only the row label) to expand **Sites**, then expand a sample site to list FastForward folders such as **AboutEnterpriseInvestments**, **Files**, and **Images**. Sample-site **folder names** can differ from the site name (for example folder `CorporateInvestments` vs site `Corporate_Investments`); Explorer still opens the folder. A path that is not a site or folder (for example a typed `/Sites/Demo/Home` on a cell that only has the FastForward sample site) is treated as **not found** — it does not fail the Explorer with a server error |
 | **Folders** | `//Folders` | Classic Rhythmyx folder tree (including `$System$` and other repository folders) |
 | **Assets** | `//Folders/$System$/Assets` | Shared asset library (CM1 convenience root) |
 | **Design** | Design file-system area | Templates, themes, web resources (Admin/Designer) |
@@ -190,7 +190,7 @@ that folder.
 
 | Control | Behavior |
 |---------|----------|
-| **Next** | Advance to the next step (source → target → confirm → run) |
+| **Next** | Advance to the next step (source → target → confirm → run). Next does not copy and does not require the typed source path to exist; a missing fixture path such as `/Sites/Demo/Home` is not a server error |
 | **Back** | Return to the previous step. The overlay stays open |
 | **Cancel** | Close the wizard without copying. Cancel is **not** Back — it does not reset to step 1 while leaving the overlay up |
 | **Escape** | Same as Cancel: dismiss without submitting |

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -109,33 +109,32 @@ public class PSSitePathItemService extends PSPathItemService {
           PSValidationException,
           DataServiceLoadException {
     var sfp = getSiteIdAndFolderPath(path);
-    PSSiteSummary site;
-    try {
-      site = siteDataService.find(sfp.getSiteId());
-    } catch (DataServiceLoadException | PSValidationException | IPSGenericDao.LoadException e) {
-      try {
-        site = siteDataService.findByPath(("/Sites/" + path).replace("//", "/"));
-      } catch (IPSDataService.DataServiceNotFoundException | PSValidationException e1) {
-        // Site not found, assume orphaned path (messages from TMX; EN uses curly apostrophes)
-        var msg =
-            sfp.isOnlySiteId()
-                ? PSI18NTranslationKeyValues.getInstance()
-                        .getTranslationValue(
-                            "perc.ui.pathmanagement@Oops.  We can't find the site ")
-                    + sfp.getSiteId()
-                    + PSI18NTranslationKeyValues.getInstance()
-                        .getTranslationValue("perc.ui.pathmanagement@.  It may have been deleted.")
-                : PSI18NTranslationKeyValues.getInstance()
-                    .getTranslationValue(
-                        "perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer"
-                            + " available.");
-        throw new PSPathNotFoundServiceException(msg);
-      }
+    var site = resolveSiteSummary(path, sfp);
+    if (site == null) {
+      // Orphaned / unknown site path (TMX; EN uses curly apostrophes)
+      var msg =
+          sfp.isOnlySiteId()
+              ? PSI18NTranslationKeyValues.getInstance()
+                      .getTranslationValue(
+                          "perc.ui.pathmanagement@Oops.  We can't find the site ")
+                  + sfp.getSiteId()
+                  + PSI18NTranslationKeyValues.getInstance()
+                      .getTranslationValue("perc.ui.pathmanagement@.  It may have been deleted.")
+              : PSI18NTranslationKeyValues.getInstance()
+                  .getTranslationValue(
+                      "perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer"
+                          + " available.");
+      throw new PSPathNotFoundServiceException(msg);
     }
     // Only the site id.
     if (sfp.isOnlySiteId()) {
       var item = createPathItem();
       convert(site, item);
+      // convert() sets path from SITENAME (`/Corporate_Investments/`).
+      // Explorer also looks up FOLDER_ROOT (`/CorporateInvestments`).
+      // DispatchingPathService requires PathItem.path to start with the
+      // requested relative path (#3558).
+      item.setPath(requestedRelativeSitePath(path));
       return item;
     }
     try {
@@ -147,6 +146,77 @@ public class PSSitePathItemService extends PSPathItemService {
       }
       throw e;
     }
+  }
+
+  /**
+   * Resolve the site for a finder path without {@link IPSSiteDataService#find(String)}.
+   *
+   * <p>{@code find(id)} looks up SITENAME. Sample sites use SITENAME {@code
+   * Corporate_Investments} and FOLDER_ROOT {@code //Sites/CorporateInvestments}. Calling
+   * {@code find("CorporateInvestments")} (or {@code find("Demo")} for a typed missing path)
+   * throws after a failed site-name load and marks the Spring listing transaction
+   * rollback-only. REST {@code GET /path/item/{path}} then returns HTTP 500
+   * ({@code UnexpectedRollbackException}) instead of the folder item or 404 (#3558 / #3410).
+   */
+  PSSiteSummary resolveSiteSummary(String path, SiteIdAndFolderPath sfp)
+      throws PSValidationException {
+    if (sfp == null) {
+      return null;
+    }
+    try {
+      var byPath = siteDataService.findByPath(SITE_ROOT + path);
+      if (byPath != null) {
+        return byPath;
+      }
+    } catch (IPSDataService.DataServiceNotFoundException e) {
+      log.debug("findByPath missed site for {}", path);
+    }
+    var siteId = sfp.getSiteId();
+    if (siteId == null || siteId.isBlank()) {
+      return null;
+    }
+    var sites = siteDataService.findAll();
+    if (sites == null) {
+      return null;
+    }
+    for (var sum : sites) {
+      if (sum == null) {
+        continue;
+      }
+      if (siteFolderNameMatches(siteId, sum.getName())) {
+        return sum;
+      }
+      var folderPath = sum.getFolderPath();
+      if (folderPath != null && siteFolderNameMatches(siteId, folderPathLeaf(folderPath))) {
+        return sum;
+      }
+    }
+    return null;
+  }
+
+  /** Finder-relative site path (`/Name/`) matching the request, not an OS path. */
+  static String requestedRelativeSitePath(String path) {
+    var requested = path == null ? "/" : path.trim();
+    if (!requested.startsWith("/")) {
+      requested = "/" + requested;
+    }
+    if (!requested.endsWith("/")) {
+      requested = requested + "/";
+    }
+    return requested;
+  }
+
+  /** Last segment of a CMS folder path ({@code //} finder form, not an OS path). */
+  public static String folderPathLeaf(String folderPath) {
+    if (folderPath == null || folderPath.isEmpty()) {
+      return "";
+    }
+    var t = folderPath.trim();
+    while (t.endsWith("/")) {
+      t = t.substring(0, t.length() - 1);
+    }
+    var slash = t.lastIndexOf('/');
+    return slash >= 0 ? t.substring(slash + 1) : t;
   }
 
   protected void convert(PSSiteSummary site, PSPathItem item) {

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceFindItemSiteResolveTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceFindItemSiteResolveTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.pathmanagement.data.PSPathItem;
+import com.percussion.pathmanagement.service.IPSPathService.PSPathNotFoundServiceException;
+import com.percussion.pathmanagement.service.impl.PSSitePathItemService;
+import com.percussion.share.service.IPSDataService.DataServiceLoadException;
+import com.percussion.share.service.IPSDataService.DataServiceNotFoundException;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.sitemanage.data.PSSiteSummary;
+import com.percussion.sitemanage.service.IPSSiteDataService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * #3558: {@code GET /path/item/{path}} must resolve FOLDER_ROOT slugs (and missing
+ * typed paths such as {@code /Demo/Home}) without {@code siteDataService.find(id)},
+ * which marks the listing transaction rollback-only.
+ */
+class PSSitePathItemServiceFindItemSiteResolveTest {
+
+  @Mock private IPSSiteDataService siteDataService;
+
+  private TestableSitePathItemService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service = new TestableSitePathItemService(siteDataService);
+  }
+
+  @Test
+  void folderRootSlugResolvesViaFindAllWithoutFindById() throws Exception {
+    when(siteDataService.findByPath(anyString()))
+        .thenThrow(new DataServiceNotFoundException("folder-root slug is not SITENAME"));
+    when(siteDataService.findAll()).thenReturn(List.of(corporateInvestmentsSite()));
+
+    var item = service.exposeFindItem("/CorporateInvestments");
+
+    assertEquals("Corporate_Investments", item.getId());
+    assertEquals("Corporate_Investments", item.getName());
+    assertEquals("/CorporateInvestments/", item.getPath());
+    verify(siteDataService, never()).find(anyString());
+  }
+
+  @Test
+  void sitenamePathUsesFindByPathAndNeverFindById() throws Exception {
+    when(siteDataService.findByPath(anyString())).thenReturn(corporateInvestmentsSite());
+
+    var item = service.exposeFindItem("/Corporate_Investments");
+
+    assertEquals("Corporate_Investments", item.getId());
+    assertEquals("/Corporate_Investments/", item.getPath());
+    verify(siteDataService, never()).find(anyString());
+    verify(siteDataService, never()).findAll();
+  }
+
+  @Test
+  void missingDemoHomeIsNotFoundWithoutFindById() throws Exception {
+    when(siteDataService.findByPath(anyString()))
+        .thenThrow(new DataServiceNotFoundException("Site cannot be found"));
+    when(siteDataService.findAll()).thenReturn(List.of(corporateInvestmentsSite()));
+
+    assertThrows(
+        PSPathNotFoundServiceException.class, () -> service.exposeFindItem("/Demo/Home/"));
+    verify(siteDataService, never()).find(anyString());
+  }
+
+  @Test
+  void folderPathLeafUsesLastCmsSegment() {
+    assertEquals(
+        "CorporateInvestments",
+        PSSitePathItemService.folderPathLeaf("//Sites/CorporateInvestments/"));
+    assertEquals("Home", PSSitePathItemService.folderPathLeaf("/Sites/Demo/Home"));
+    assertEquals("", PSSitePathItemService.folderPathLeaf(""));
+  }
+
+  private static PSSiteSummary corporateInvestmentsSite() {
+    var site = new PSSiteSummary();
+    site.setId("Corporate_Investments");
+    site.setName("Corporate_Investments");
+    site.setFolderPath("//Sites/CorporateInvestments");
+    site.setType("site");
+    return site;
+  }
+
+  static final class TestableSitePathItemService extends PSSitePathItemService {
+    TestableSitePathItemService(IPSSiteDataService siteDataService) {
+      super(siteDataService, null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    PSPathItem exposeFindItem(String path)
+        throws PSPathNotFoundServiceException,
+            DataServiceNotFoundException,
+            PSValidationException,
+            DataServiceLoadException {
+      return findItem(path);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Cycle Verify residual of [#3553](https://github.com/intersoftdatalabs-in/percussioncms/issues/3553) / parent QA [#2797](https://github.com/intersoftdatalabs-in/percussioncms/issues/2797) / epic [#2400](https://github.com/intersoftdatalabs-in/percussioncms/issues/2400). Cluster [#3557](https://github.com/intersoftdatalabs-in/percussioncms/pull/3557) already unmounts Subfolder Copy on Cancel / Escape / item-click. Playwright still failed empty-console because Explorer `GET /path/item/{path}` returned HTTP 500 (`Transaction silently rolled back because it has been marked as rollback-only`).

`PSSitePathItemService.findItem` called `siteDataService.find(id)` with the finder slug. FastForward sample sites use SITENAME `Corporate_Investments` and FOLDER_ROOT `//Sites/CorporateInvestments`. `find("CorporateInvestments")` (and `find("Demo")` for a typed `/Sites/Demo/Home`) poisons the Spring TX. Explorer `defaultResolveFolderId` hits that endpoint after entering a Sites folder.

This change resolves the site via `findByPath` then `findAll` + folder-root / sitename match. Missing paths return **404**. Folder-root lookups return the site item with `PathItem.path` set to the requested relative path so dispatch validation accepts them.

Based on `main` after cluster [#3557](https://github.com/intersoftdatalabs-in/percussioncms/pull/3557) (Subfolder Copy dismiss) merged. Does not re-do Cancel/Escape/item-click unmount.

Fixes #3558

## Test plan

1. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (ignore pre-existing FastForward GIF ERROR; abort on `Failed startup of context`).
2. Hot-deploy `sitemanage-8.2.0-SNAPSHOT.jar` to `Rhythmyx/WEB-INF/lib/` and this tip's `WebUI/war/modern` to `cm/modern`. Restart Jetty **inside** the cell. `qa-health` again.
3. `GET /Rhythmyx/services/pathmanagement/path/item/Sites/CorporateInvestments` → 200 (not 500).
4. `GET …/path/item/Sites/Demo/Home` → 404 (not 500).
5. `TEST_CMS_URL=… TEST_DB_TYPE=h2 npm run test:surface -- --path tests/explorer-subfolder-copy.spec.js` → 5 passed, empty console.
6. Re-run Cycle Verify surface set (login, golden, explorer-menu-bar, multiselect, relationships, subfolder-copy, translations) → 21 passed.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` (Sites folder-root vs sitename; Subfolder Copy Next on a missing typed path is not a server error)
- [x] **Unit / module tests** — `PSSitePathItemServiceFindItemSiteResolveTest` (4 tests)
- [x] **WebUI + Playwright** — existing `explorer-subfolder-copy.spec.js` (no spec change; product path is now 200/404)
- [x] **Build gates** — standalone `projects/sitemanage` `mvnw clean install`
- [x] **Cross-platform** — CMS finder `/` paths only; no OS filesystem I/O

## C3 evidence

- **modules_built:** `projects/sitemanage`
- **build_evidence:**
  ```
  cd projects/sitemanage && ..\..\mvnw.cmd clean install
  BUILD SUCCESS
  Tests run: 1319, Failures: 0, Errors: 0, Skipped: 125
  PSSitePathItemServiceFindItemSiteResolveTest: Tests run: 4, Failures: 0
  ```
- **downstream_checked:** grepped `extends PSSitePathItemService` / `new PSSitePathItemService(` — only sitemanage tests (no production reverse-deps). Additive `public static folderPathLeaf`; no `final` / signature break. Reverse-dep install not required.

## C5 UI proof

- `qa-up --skip-image-build` → cell `perc-matrix-cms-h2` `TEST_CMS_URL=http://127.0.0.1:9993` Health=healthy HTTP 200 (pre-existing FastForward GIF ERROR only; no context-fail)
- Deploy: `docker cp` sitemanage SNAPSHOT jar → WAR `WEB-INF/lib`; rebuilt `WebUI/war/modern` → `cm/modern`; `StopJetty` + `StartJetty` inside cell; `qa-health` again
- `npm run test:surface -- --path tests/explorer-subfolder-copy.spec.js` → **5 passed**
- Cycle Verify set (golden + login + explorer-menu-bar + multiselect + relationships + subfolder-copy + translations) → **21 passed**
- console-clean=yes
- server.log-clean=yes for the test window (no new `rollback-only` after hot-deploy; pre-fix 14:28–14:29 probes only). Known skip: FastForward `PSDbStorageService` GIF import ERROR (pre-existing).

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
