### PR TITLE
fix(WebUI): Explorer MENU parents stay dropdowns after #3500 (#3560)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
@@ -21,7 +21,9 @@
  * as a horizontal action bar. Leaf {@code MENUITEM} actions activate on
  * click; parent {@code MENU} (or any action with {@code children[]})
  * opens a nested dropdown instead of dumping every child as a flat
- * button (#2730 / #2731). The Workflow group (#2732) is a special case:
+ * button (#2730 / #2731 / #3560). Envelope {@code children} are unwrapped
+ * and descendant names that also appear as roots are collapsed before
+ * render. The Workflow group (#2732) is a special case:
  * it renders as a labeled button group so each transition is one-click
  * invokable. Activation always goes to {@link ActionToolbarProps.onInvoke};
  * the host dispatcher executes REST / React handlers.</p>
@@ -35,6 +37,10 @@
 import React, { useEffect, useId, useRef, useState } from "react";
 import type { MenuAction } from "../api/contentExplorer/types";
 import { message } from "../i18n/message";
+import {
+  prepareToolbarActions,
+  unwrapMenuActionChildren,
+} from "./actionEnablement";
 import { WORKFLOW_MENU_NAME } from "./workflowMenuActions";
 
 export interface ActionToolbarProps {
@@ -107,7 +113,11 @@ const groupLabelStyle: React.CSSProperties = {
 };
 
 function hasChildren(action: MenuAction): boolean {
-  return (action.children?.length ?? 0) > 0;
+  return unwrapMenuActionChildren(action.children).length > 0;
+}
+
+function isWorkflowGroup(action: MenuAction): boolean {
+  return action.name.replace(/[\s-]/g, "_").toLowerCase() === WORKFLOW_MENU_NAME;
 }
 
 function activate(
@@ -123,14 +133,15 @@ function activate(
 }
 
 export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
-  const { actions, onInvoke, ariaLabel, emptyMessage, className } = props;
+  const { onInvoke, ariaLabel, emptyMessage, className } = props;
+  const actions = prepareToolbarActions(props.actions);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const baseId = useId();
 
   useEffect(() => {
     setOpenMenu(null);
-  }, [actions]);
+  }, [props.actions]);
 
   useEffect(() => {
     if (!openMenu) return;
@@ -170,8 +181,8 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
       ) : (
         actions.map((a) => {
           // Workflow transitions (#2732): labeled one-click group.
-          if (hasChildren(a) && a.name === WORKFLOW_MENU_NAME) {
-            const children = a.children ?? [];
+          if (hasChildren(a) && isWorkflowGroup(a)) {
+            const children = unwrapMenuActionChildren(a.children);
             return (
               <span
                 key={a.name}
@@ -233,7 +244,7 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
                   {a.label}
                   <span aria-hidden="true"> ▾</span>
                 </button>
-                {expanded && a.children ? (
+                {expanded ? (
                   <ul
                     id={menuId}
                     role="menu"
@@ -241,7 +252,7 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
                     data-testid={`action-toolbar-menu-${a.name}`}
                     style={dropdownStyle}
                   >
-                    {a.children.map((child) => (
+                    {unwrapMenuActionChildren(a.children).map((child) => (
                       <li key={child.name} role="none">
                         <button
                           type="button"

--- a/WebUI/src/main/ts/contentExplorer/actionEnablement.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionEnablement.ts
@@ -39,6 +39,7 @@
  * </ul>
  */
 
+import { collapseFlattenedMenuActionRoots } from "../api/contentExplorer/actionMenuApi";
 import type { MenuAction, PSPathItem } from "../api/contentExplorer/types";
 import { classifyUrl } from "../util/safeNavigate";
 import { resolvePublishKind } from "./itemPublish";
@@ -140,8 +141,84 @@ export function isActionAllowedOnSurface(
   return true;
 }
 
+/**
+ * Unwrap {@link MenuAction.children} whether the tree is already mapped
+ * (array) or still carries a Jackson {@code ActionMenu}/{@code ActionMenuList}
+ * envelope. Toolbar chrome must see an array or MENU parents render as
+ * ordinary buttons (#3560).
+ */
+export function unwrapMenuActionChildren(
+  children: MenuAction[] | unknown,
+): MenuAction[] {
+  if (children == null) {
+    return [];
+  }
+  if (Array.isArray(children)) {
+    return children.filter(
+      (child): child is MenuAction =>
+        child != null && typeof child.name === "string" && child.name.length > 0,
+    );
+  }
+  if (typeof children === "object") {
+    const env = children as Record<string, unknown>;
+    const listed =
+      env.ActionMenuList ?? env.ActionMenu ?? env.actionMenuList ?? env.actionMenu;
+    if (Array.isArray(listed)) {
+      return unwrapMenuActionChildren(listed);
+    }
+    if (
+      listed &&
+      typeof listed === "object" &&
+      typeof (listed as MenuAction).name === "string"
+    ) {
+      return [listed as MenuAction];
+    }
+  }
+  return [];
+}
+
 function hasChildren(action: MenuAction): boolean {
-  return (action.children?.length ?? 0) > 0;
+  return unwrapMenuActionChildren(action.children).length > 0;
+}
+
+/**
+ * Recursively copy a tree so {@code children} is always an array (or omitted).
+ * Pure: does not mutate the input.
+ */
+export function normalizeMenuActionTree(
+  actions: MenuAction[] | null | undefined,
+): MenuAction[] {
+  if (actions == null || actions.length === 0) {
+    return [];
+  }
+  const out: MenuAction[] = [];
+  for (const action of actions) {
+    if (!action || !action.name) {
+      continue;
+    }
+    const kids = normalizeMenuActionTree(
+      unwrapMenuActionChildren(action.children),
+    );
+    if (kids.length === 0) {
+      const rest: MenuAction = { ...action };
+      delete rest.children;
+      out.push(rest);
+      continue;
+    }
+    out.push({ ...action, children: kids });
+  }
+  return out;
+}
+
+/**
+ * Toolbar-ready tree: unwrap envelopes, then drop roots that already
+ * appear as descendants so ActionToolbar cannot dump MENU children as
+ * extra top-level buttons (#3560 / #3379).
+ */
+export function prepareToolbarActions(
+  actions: MenuAction[] | null | undefined,
+): MenuAction[] {
+  return collapseFlattenedMenuActionRoots(normalizeMenuActionTree(actions));
 }
 
 function actionNameKey(name: string | undefined | null): string {
@@ -189,7 +266,10 @@ export function filterEnabledMenuActions(
     }
 
     if (hasChildren(action)) {
-      const filteredChildren = filterEnabledMenuActions(action.children, ctx);
+      const filteredChildren = filterEnabledMenuActions(
+        unwrapMenuActionChildren(action.children),
+        ctx,
+      );
       if (filteredChildren.length === 0) {
         // Cascade parent with no web-usable children: drop entirely.
         continue;
@@ -221,11 +301,13 @@ export function filterToolbarActions(
   baseHref?: string,
   selectionItem?: PSPathItem | null,
 ): MenuAction[] {
-  return filterEnabledMenuActions(actions, {
-    surface: "toolbar",
-    baseHref,
-    selectionItem,
-  });
+  return prepareToolbarActions(
+    filterEnabledMenuActions(actions, {
+      surface: "toolbar",
+      baseHref,
+      selectionItem,
+    }),
+  );
 }
 
 /**

--- a/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
@@ -141,6 +141,77 @@ describe("ActionToolbar", () => {
     expect(screen.queryByTestId("action-toolbar-item-new-folder")).toBeNull();
   });
 
+  it("collapses dumped MENU children so they are not top-level buttons (#3560)", () => {
+    const dumped: MenuAction[] = [
+      {
+        name: "Paste",
+        label: "Paste",
+        sortRank: 0,
+        menuType: "MENU",
+        children: [
+          { name: "Move", label: "Move", sortRank: 0, menuType: "MENUITEM" },
+          {
+            name: "Paste_As_Link",
+            label: "Paste as Link",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ],
+      },
+      { name: "Move", label: "Move", sortRank: 1, menuType: "MENUITEM" },
+      {
+        name: "Paste_As_Link",
+        label: "Paste as Link",
+        sortRank: 2,
+        menuType: "MENUITEM",
+      },
+      { name: "Open", label: "Open", sortRank: 3, menuType: "MENUITEM" },
+    ];
+    render(<ActionToolbar actions={dumped} />);
+    expect(
+      screen.getByTestId("action-toolbar-item-Paste").getAttribute(
+        "aria-haspopup",
+      ),
+    ).toBe("menu");
+    expect(screen.queryByTestId("action-toolbar-item-Move")).toBeNull();
+    expect(screen.queryByTestId("action-toolbar-item-Paste_As_Link")).toBeNull();
+    expect(screen.getByTestId("action-toolbar-item-Open")).toBeTruthy();
+    expect(screen.getAllByRole("button").length).toBe(2);
+  });
+
+  it("unwraps envelope children so static MENU parents stay dropdowns (#3560)", () => {
+    const envelope = {
+      name: "Arrange",
+      label: "Arrange",
+      sortRank: 0,
+      menuType: "MENU",
+      children: {
+        ActionMenuList: [
+          {
+            name: "Arrange_MoveUpLeft",
+            label: "Move up",
+            sortRank: 0,
+            menuType: "MENUITEM",
+          },
+        ],
+      },
+    } as unknown as MenuAction;
+    render(<ActionToolbar actions={[envelope]} />);
+    expect(
+      screen.getByTestId("action-toolbar-item-Arrange").getAttribute(
+        "aria-haspopup",
+      ),
+    ).toBe("menu");
+    expect(
+      screen.queryByTestId("action-toolbar-item-Arrange_MoveUpLeft"),
+    ).toBeNull();
+    fireEvent.click(screen.getByTestId("action-toolbar-item-Arrange"));
+    expect(screen.getByTestId("action-toolbar-menu-Arrange")).toBeTruthy();
+    expect(
+      screen.getByTestId("action-toolbar-item-Arrange_MoveUpLeft"),
+    ).toBeTruthy();
+  });
+
   it("renders cascading Workflow children as a labeled group (#2732)", () => {
     const onInvoke = vi.fn();
     const actions: MenuAction[] = [

--- a/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
@@ -20,6 +20,9 @@ import {
   filterContextMenuActions,
   filterEnabledMenuActions,
   filterToolbarActions,
+  normalizeMenuActionTree,
+  prepareToolbarActions,
+  unwrapMenuActionChildren,
   isActionAllowedOnSurface,
   isToolbarPublishNowHidden,
   isClientHandledAction,
@@ -182,6 +185,55 @@ describe("filterEnabledMenuActions", () => {
     expect(filterEnabledMenuActions([], { surface: "toolbar", baseHref: BASE })).toEqual(
       [],
     );
+  });
+
+  it("collapses descendant names that were also dumped as toolbar roots (#3560)", () => {
+    const actions: MenuAction[] = [
+      {
+        name: "View",
+        label: "View",
+        sortRank: 1,
+        menuType: "MENU",
+        children: [
+          leaf({ name: "View_Properties", url: "/Rhythmyx/ok" }),
+          leaf({ name: "Flush_Cache", url: "/Rhythmyx/flush" }),
+        ],
+      },
+      leaf({ name: "View_Properties", url: "/Rhythmyx/ok", sortRank: 2 }),
+      leaf({ name: "Open", url: "/Rhythmyx/open", sortRank: 3 }),
+    ];
+    const filtered = filterToolbarActions(actions, BASE);
+    expect(filtered.map((a) => a.name)).toEqual(["View", "Open"]);
+    expect(filtered[0]?.children?.map((c) => c.name)).toEqual([
+      "View_Properties",
+      "Flush_Cache",
+    ]);
+  });
+
+  it("unwraps envelope children before toolbar enablement (#3560)", () => {
+    const actions = [
+      {
+        name: "Create",
+        label: "Create",
+        sortRank: 1,
+        menuType: "MENU",
+        children: {
+          ActionMenu: [
+            leaf({ name: "Translate", url: "/Rhythmyx/translate" }),
+            leaf({ name: "gone", url: "javascript:void(0)" }),
+          ],
+        },
+      } as unknown as MenuAction,
+    ];
+    expect(
+      unwrapMenuActionChildren(actions[0].children).map((c) => c.name),
+    ).toEqual(["Translate", "gone"]);
+    const filtered = filterToolbarActions(actions, BASE);
+    expect(filtered.map((a) => a.name)).toEqual(["Create"]);
+    expect(filtered[0]?.children?.map((c) => c.name)).toEqual(["Translate"]);
+    expect(
+      prepareToolbarActions(normalizeMenuActionTree(actions)).map((a) => a.name),
+    ).toEqual(["Create"]);
   });
 
   it("keeps MENU children nested rather than hoisting them to the toolbar (#3379)", () => {

--- a/docs/ai-generated/code-reviews/issue-3560-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3560-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review: #3560 Explorer toolbar MENU parents
+
+**Branch:** `fix/issue-3560-explorer-toolbar-menu-parents`  
+**Date:** 2026-08-18  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class companions (WebUI Vitest + Playwright + product-docs); do not flatten nested menus; Workflow one-click group stays.
+
+## Scope
+
+Uncommitted WebUI ActionToolbar / `filterToolbarActions` + perc-qa-automation surface + `product-docs/8.2/admin/content-explorer.md`. No assembler / `GET /actions/find` changes.
+
+## Summary
+
+Live H2 `GET /actions/find` already nests Paste / Arrange / View / Create. Residual fail was SPA chrome: `children` envelopes or dumped descendant roots rendered as top-level buttons. Filter now unwraps + collapses before toolbar enablement; ActionToolbar prepares the same tree. Workflow still uses the labeled one-click group (name match is case-insensitive). Playwright no longer soft-skips when the catalog has MENU parents; it requires the four static parents as `aria-haspopup=menu`.
+
+## Issues
+
+None (no bugs, missing behavioral tests, or non-portable path I/O).
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path construction.
+
+## Tests / evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Surefire Tests run: 61; Vitest 2858 passed
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
+- H2 QA `TEST_CMS_URL=http://127.0.0.1:9993`: Playwright surface 2 passed; golden 2 passed; pageerror clean

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
@@ -39,11 +39,36 @@ const {
 const { collectMenuParents } = require("./helpers/explorer-action-toolbar-catalog");
 
 test.describe("modern React Content Explorer — nested ActionToolbar menus (#2730)", () => {
+  /** Uncaught page errors + unexpected console errors for C5. */
+  let pageErrors = [];
+
   test.beforeEach(async ({ page }) => {
     test.setTimeout(45_000);
+    pageErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") return;
+      const text = msg.text();
+      if (
+        /Failed to load resource: the server responded with a status of (404|400)/i.test(
+          text,
+        )
+      ) {
+        return;
+      }
+      pageErrors.push(text);
+    });
     await loginAsAdmin(page);
     await page.goto(explorerSpaUrl(BASE_URL));
     await page.waitForLoadState("networkidle");
+  });
+
+  test.afterEach(() => {
+    expect(pageErrors, `JS page/console errors: ${pageErrors.join(" | ")}`).toEqual(
+      [],
+    );
   });
 
   test(
@@ -110,85 +135,78 @@ test.describe("modern React Content Explorer — nested ActionToolbar menus (#27
         return { url: null, payload: null };
       });
 
+      expect(
+        catalog.url,
+        "GET /actions/find must succeed so nested chrome is asserted (#3560)",
+      ).toBeTruthy();
+
       const menuParents = collectMenuParents(catalog.payload);
       test.info().annotations.push({
         type: "note",
         description: `find() ${catalog.url || "unreached"} MENU parents=${menuParents.length}`,
       });
+      expect(
+        menuParents.length,
+        "H2 catalog must include cascading MENU parents (Paste/Arrange/View/Create)",
+      ).toBeGreaterThan(0);
+
+      const requiredNames = ["Paste", "Arrange", "View", "Create"];
+      const required = menuParents.filter((p) => requiredNames.includes(p.name));
+      expect(
+        required.map((p) => p.name).sort(),
+        "static MENU parents must stay nested in GET /actions/find",
+      ).toEqual([...requiredNames].sort());
 
       const parents = page.locator(
         `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid^="action-toolbar-item-"][aria-haspopup="menu"]`,
       );
 
-      if (menuParents.length > 0) {
-        // Live catalog has cascading MENU parents — must render dropdowns
-        // (#3379). Do not soft-skip.
-        await expect
-          .poll(async () => parents.count(), { timeout: 15_000 })
-          .toBeGreaterThan(0);
+      // Live catalog has cascading MENU parents — must render dropdowns
+      // (#3379 / #3560). Do not soft-skip.
+      await expect
+        .poll(async () => parents.count(), { timeout: 15_000 })
+        .toBeGreaterThan(0);
 
-        const parent = parents.first();
-        const parentTestId = await parent.getAttribute("data-testid");
-        const menuName = String(parentTestId || "").replace(
-          /^action-toolbar-item-/,
-          "",
+      for (const parentMenu of required) {
+        const parentBtn = page.locator(
+          `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid="action-toolbar-item-${parentMenu.name}"][aria-haspopup="menu"]`,
         );
-
-        // Closed: children of every MENU parent must not appear as extra
-        // top-level toolbar buttons (#3379).
-        const closedTopLevel = page.locator(
-          `[data-testid="${TEST_IDS.actionToolbar}"] > button[data-testid^="action-toolbar-item-"], [data-testid="${TEST_IDS.actionToolbar}"] > div > button[data-testid^="action-toolbar-item-"]`,
-        );
-        const closedNames = await closedTopLevel.evaluateAll((els) =>
-          els.map((el) => el.getAttribute("data-testid") || ""),
-        );
-        for (const parentMenu of menuParents) {
-          for (const childName of parentMenu.childNames) {
-            expect(
-              closedNames.includes(`action-toolbar-item-${childName}`),
-              `closed toolbar dumped child "${childName}" of "${parentMenu.name}" as a top-level button`,
-            ).toBe(false);
-          }
-        }
-
-        await parent.click();
         await expect(
-          page.locator(`[data-testid="action-toolbar-menu-${menuName}"]`),
-        ).toBeVisible({ timeout: 5_000 });
-        const items = page.locator(
-          `[data-testid="action-toolbar-menu-${menuName}"] [role="menuitem"]`,
-        );
-        await expect(items.first()).toBeVisible();
-        return;
+          parentBtn,
+          `MENU parent "${parentMenu.name}" must be one aria-haspopup=menu control`,
+        ).toBeVisible();
       }
 
-      const parentCount = await parents.count();
-      if (parentCount === 0) {
-        test.info().annotations.push({
-          type: "note",
-          description:
-            "Live catalog has no MENU parents; nested chrome covered by WebUI Vitest.",
-        });
-        return;
-      }
-
-      const parent = parents.first();
-      const parentTestId = await parent.getAttribute("data-testid");
-      const menuName = String(parentTestId || "").replace(
-        /^action-toolbar-item-/,
-        "",
+      // Closed: children of every MENU parent must not appear as extra
+      // top-level toolbar buttons (#3379 / #3560).
+      const closedTopLevel = page.locator(
+        `[data-testid="${TEST_IDS.actionToolbar}"] > button[data-testid^="action-toolbar-item-"], [data-testid="${TEST_IDS.actionToolbar}"] > div > button[data-testid^="action-toolbar-item-"]`,
       );
-      await parent.click();
+      const closedNames = await closedTopLevel.evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-testid") || ""),
+      );
+      for (const parentMenu of menuParents) {
+        for (const childName of parentMenu.childNames) {
+          expect(
+            closedNames.includes(`action-toolbar-item-${childName}`),
+            `closed toolbar dumped child "${childName}" of "${parentMenu.name}" as a top-level button`,
+          ).toBe(false);
+        }
+      }
+
+      const firstRequired = required[0].name;
+      await page
+        .locator(
+          `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid="action-toolbar-item-${firstRequired}"]`,
+        )
+        .click();
       await expect(
-        page.locator(`[data-testid="action-toolbar-menu-${menuName}"]`),
+        page.locator(`[data-testid="action-toolbar-menu-${firstRequired}"]`),
       ).toBeVisible({ timeout: 5_000 });
-      await expect(
-        page
-          .locator(
-            `[data-testid="action-toolbar-menu-${menuName}"] [role="menuitem"]`,
-          )
-          .first(),
-      ).toBeVisible();
+      const items = page.locator(
+        `[data-testid="action-toolbar-menu-${firstRequired}"] [role="menuitem"]`,
+      );
+      await expect(items.first()).toBeVisible();
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
@@ -68,6 +68,38 @@ describe("explorer-action-toolbar-menus helpers (#2730)", () => {
     assert.deepEqual(unwrapFindPayload(null), []);
   });
 
+  it("collectMenuParents finds static Paste/Arrange/View/Create parents (#3560)", () => {
+    const parents = collectMenuParents({
+      ActionMenu: [
+        {
+          name: "Paste",
+          menuType: "MENU",
+          children: [{ name: "Move" }, { name: "Paste_As_Link" }],
+        },
+        {
+          name: "Arrange",
+          menuType: "MENU",
+          children: [{ name: "Arrange_MoveUpLeft" }],
+        },
+        {
+          name: "View",
+          menuType: "MENU",
+          children: [{ name: "View_Properties" }],
+        },
+        {
+          name: "Create",
+          menuType: "MENU",
+          children: [{ name: "Translate" }],
+        },
+        { name: "Open", menuType: "MENUITEM" },
+      ],
+    });
+    assert.deepEqual(
+      parents.map((p) => p.name).sort(),
+      ["Arrange", "Create", "Paste", "View"],
+    );
+  });
+
   it("collectMenuParents returns every MENU parent so closed-toolbar checks cover all cascades", () => {
     const parents = collectMenuParents({
       ActionMenu: [

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -290,9 +290,12 @@ catalog region apart from the Content / View / Help menu bar and the display-for
 
 Menus and toolbar buttons come from the server action catalog used by Content Explorer:
 
-- Cascading **MENU** parents render as **one toolbar control** with a dropdown (`▾`). Open
-  the parent to choose a child command. Child items are **not** shown as extra top-level
-  buttons while the menu is closed.
+- Cascading **MENU** parents render as **one toolbar control** with a dropdown (`▾`).
+  On a typical catalog that includes **Paste**, **Arrange**, **View**, and **Create**,
+  each of those names is a single control (`aria-haspopup=menu`). Open the parent to
+  choose a child command. Child items (for example **Move** under Paste, or
+  **View Properties** under View) are **not** shown as extra top-level buttons while
+  the menu is closed. **Workflow** transitions stay a labeled one-click button group.
 - When you select a content item, the shell keeps that cascading tree and may add
   content-type **New** commands under an existing menu. It does not replace the tree with
   a flat list of every allowed command.


### PR DESCRIPTION
## Summary

Human QA on #2783 still saw Explorer **Server actions** as a flat button dump after #3500 proved `GET /actions/find` already nests. This PR does **not** touch `PSActionMenuTreeAssembler`. It fixes SPA chrome only.

`filterToolbarActions` and `ActionToolbar` now unwrap Jackson `children` envelopes and collapse descendant names that were also dumped as roots. Static MENU parents (**Paste** / **Arrange** / **View** / **Create**) render as one `aria-haspopup=menu` control; children are not top-level buttons while the menu is closed. **Workflow** stays the labeled one-click group (#2732).

Parent tracker: #2783 (epic #2400 / reality-check #3102).

Fixes #3560
Partial #2783

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 `perc-devctl qa-up` (freeport `TEST_CMS_URL`).
2. Log in as Admin; open Content Explorer.
3. Confirm Server actions shows **Paste**, **Arrange**, **View**, **Create** as dropdowns (not one button per child).
4. Closed: child names (Move, View_Properties, Translate, …) are not extra top-level toolbar buttons.
5. Open one parent; menuitems appear. Workflow (if transitions exist) remains a labeled button group.
6. Playwright: `npm run test:surface -- --path tests/explorer-action-toolbar-menus.spec.js` (no soft-skip).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (Paste/Arrange/View/Create dropdowns; Workflow one-click)
- [x] **Unit / module tests** — Vitest ActionToolbar + filterToolbarActions; perc-qa unit helper; standalone clean install green
- [x] **WebUI + Playwright** — `explorer-action-toolbar-menus.spec.js` requires the four static MENU parents
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- `modules_built=WebUI,modules/perc-qa-automation`
- `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Surefire `Tests run: 61, Failures: 0`; Vitest `Tests 2858 passed` (380 files)
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- `downstream_checked=none` (no Java public API / final / signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health`: HTTP 200, `HEALTH:healthy`, `TEST_CMS_URL=http://127.0.0.1:9993`. `DETAIL:server_log_errors` is pre-existing FastForward import (`navEI_about_off.gif` / `CI_PS_products_on.gif`) — same known noise as #3500, not `rhythmyx_context_failed`.
- Hot-copy: `WebUI/target/generated-webui/cm/modern/assets` → `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets` (no `docker restart`).
- `npm run test:surface -- --path tests/explorer-action-toolbar-menus.spec.js` — **2 passed** (4.9s). Nested parent assertion ran (not soft-skipped).
- `npm run test:golden` — **2 passed** (1.9s).
- `console-clean=yes` (pageerror + unexpected console.error; 404/400 resource noise filtered)
- `server.log-clean=yes` for this feature (startup FastForward/search-index ERROR only; BUG: known H2 import noise, not ActionToolbar)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.