### PR TITLE
fix(WebUI): unwrap Jackson Workflow envelope on developer detail (#3562)

### DIFF
--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -103,6 +103,106 @@ function withGaps(w: WorkflowDef): WorkflowDef {
   };
 }
 
+/** Same envelope keys as the list plus the JAXB/Jackson class alias. */
+const DETAIL_WRAPPER_KEYS = [
+  "Workflow",
+  "workflow",
+  "PSUiWorkflow",
+  "uiWorkflow",
+] as const;
+
+/**
+ * Resolve a catalog name from {@code workflowName} or the Jackson {@code name} alias.
+ */
+function resolveWorkflowName(obj: Record<string, unknown>): string {
+  if (typeof obj.workflowName === "string" && obj.workflowName.trim()) {
+    return obj.workflowName.trim();
+  }
+  if (typeof obj.name === "string" && obj.name.trim()) {
+    return obj.name.trim();
+  }
+  return "";
+}
+
+/**
+ * Unwrap Jackson WRAP_ROOT / nested {@code Workflow} envelopes for a single detail
+ * payload. Mirrors {@link unwrapWorkflowWrapper} but returns one object, not a list.
+ */
+function unwrapWorkflowDetailObject(
+  obj: Record<string, unknown>,
+  depth: number,
+): Record<string, unknown> | null {
+  if (depth > 5) {
+    return null;
+  }
+  for (const key of DETAIL_WRAPPER_KEYS) {
+    const raw = obj[key];
+    if (raw == null) {
+      continue;
+    }
+    const nested = asJsonRecord(raw);
+    if (nested) {
+      const deeper = unwrapWorkflowDetailObject(nested, depth + 1);
+      if (deeper) {
+        return deeper;
+      }
+    }
+    if (Array.isArray(raw) && raw.length > 0) {
+      const first = asJsonRecord(raw[0]);
+      if (first) {
+        const deeper = unwrapWorkflowDetailObject(first, depth + 1);
+        if (deeper) {
+          return deeper;
+        }
+      }
+    }
+  }
+  if (looksLikeWorkflowItem(obj) || resolveWorkflowName(obj)) {
+    return obj;
+  }
+  return null;
+}
+
+/**
+ * Parse GET /services/workflowmanagement/workflows/{name}.
+ *
+ * Accepts a flat PSUiWorkflow body, Jackson WRAP_ROOT {@code { Workflow: { … } }},
+ * nested wrappers, a one-item array, and the {@code name} alias when
+ * {@code workflowName} is absent (#3562 / #2640).
+ */
+export function parseWorkflowDetail(payload: unknown): WorkflowDef {
+  if (payload == null) {
+    throw new Error("Workflow not found or empty response");
+  }
+  if (Array.isArray(payload)) {
+    if (payload.length === 0) {
+      throw new Error("Workflow not found or empty response");
+    }
+    return parseWorkflowDetail(payload[0]);
+  }
+  const obj = asJsonRecord(payload);
+  if (!obj) {
+    throw new Error("Workflow not found or empty response");
+  }
+  const unwrapped = unwrapWorkflowDetailObject(obj, 0);
+  if (!unwrapped) {
+    throw new Error("Workflow response missing workflowName");
+  }
+  const workflowName = resolveWorkflowName(unwrapped);
+  if (!workflowName) {
+    throw new Error("Workflow response missing workflowName");
+  }
+  const stepsRaw = unwrapped.workflowSteps ?? unwrapped.steps;
+  const detail: WorkflowDef = {
+    ...(unwrapped as WorkflowDef),
+    workflowName,
+  };
+  if (Array.isArray(stepsRaw)) {
+    detail.workflowSteps = stepsRaw as WorkflowDef["workflowSteps"];
+  }
+  return detail;
+}
+
 /**
  * GET /services/workflowmanagement/workflows/metadata
  * (existing stepped-workflow catalog; Developer SY-04 browse surface)
@@ -118,14 +218,6 @@ export async function listWorkflows(): Promise<WorkflowDef[]> {
 export async function getWorkflowDetail(name: string): Promise<WorkflowDef> {
   const key = encodeURIComponent(name);
   // PATHS.WORKFLOWS already ends with '/'
-  const detail = await get<WorkflowDef | null | undefined>(`${PATHS.WORKFLOWS}${key}`);
-  if (detail == null || typeof detail !== "object") {
-    throw new Error("Workflow not found or empty response");
-  }
-  const workflowName =
-    typeof detail.workflowName === "string" ? detail.workflowName.trim() : "";
-  if (!workflowName) {
-    throw new Error("Workflow response missing workflowName");
-  }
-  return withGaps(detail);
+  const payload = await get<unknown>(`${PATHS.WORKFLOWS}${key}`);
+  return withGaps(parseWorkflowDetail(payload));
 }

--- a/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
@@ -84,6 +84,7 @@ export function WorkflowsPanel(): React.ReactElement {
                 key="open"
                 type="button"
                 data-testid="developer-wf-open"
+                data-wf-name={openKey}
                 aria-label={`Open ${openKey}`}
                 onClick={(ev) => {
                   ev.stopPropagation();

--- a/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { parseWorkflowList } from "../../../../main/ts/api/developer/workflowsApi";
+import {
+  parseWorkflowDetail,
+  parseWorkflowList,
+} from "../../../../main/ts/api/developer/workflowsApi";
 
 describe("parseWorkflowList", () => {
   it("returns bare arrays", () => {
@@ -91,5 +94,95 @@ describe("parseWorkflowList", () => {
     expect(() => parseWorkflowList("not-json-list")).toThrow(
       /Unexpected workflow list payload type/,
     );
+  });
+});
+
+describe("parseWorkflowDetail (#3562)", () => {
+  it("returns a flat body with workflowName", () => {
+    expect(
+      parseWorkflowDetail({
+        workflowName: "Default Workflow",
+        defaultWorkflow: true,
+      }),
+    ).toEqual({
+      workflowName: "Default Workflow",
+      defaultWorkflow: true,
+    });
+  });
+
+  it("unwraps Jackson Workflow WRAP_ROOT without top-level workflowName", () => {
+    expect(
+      parseWorkflowDetail({
+        Workflow: {
+          workflowName: "Default Workflow",
+          workflowDescription: "Stock default",
+          defaultWorkflow: true,
+          workflowSteps: [{ stepName: "Draft" }],
+        },
+      }),
+    ).toEqual({
+      workflowName: "Default Workflow",
+      workflowDescription: "Stock default",
+      defaultWorkflow: true,
+      workflowSteps: [{ stepName: "Draft" }],
+    });
+  });
+
+  it("unwraps nested Workflow envelopes", () => {
+    expect(
+      parseWorkflowDetail({
+        Workflow: {
+          Workflow: { workflowName: "Simple Workflow", defaultWorkflow: false },
+        },
+      }),
+    ).toEqual({
+      workflowName: "Simple Workflow",
+      defaultWorkflow: false,
+    });
+  });
+
+  it("accepts name alias when workflowName is absent", () => {
+    expect(
+      parseWorkflowDetail({
+        Workflow: { name: "Simple Workflow", defaultWorkflow: false },
+      }),
+    ).toEqual({
+      name: "Simple Workflow",
+      workflowName: "Simple Workflow",
+      defaultWorkflow: false,
+    });
+  });
+
+  it("unwraps one-item Workflow array envelope", () => {
+    expect(
+      parseWorkflowDetail({
+        Workflow: [{ workflowName: "Default Workflow" }],
+      }),
+    ).toEqual({ workflowName: "Default Workflow" });
+  });
+
+  it("maps steps alias onto workflowSteps", () => {
+    expect(
+      parseWorkflowDetail({
+        workflowName: "Default Workflow",
+        steps: [{ stepName: "Review" }],
+      }),
+    ).toEqual({
+      workflowName: "Default Workflow",
+      steps: [{ stepName: "Review" }],
+      workflowSteps: [{ stepName: "Review" }],
+    });
+  });
+
+  it("throws when wrapped payload has no name", () => {
+    expect(() => parseWorkflowDetail({ Workflow: { unexpected: true } })).toThrow(
+      /missing workflowName/,
+    );
+  });
+
+  it("throws on empty or non-object payloads", () => {
+    expect(() => parseWorkflowDetail(null)).toThrow(/not found or empty/);
+    expect(() => parseWorkflowDetail([])).toThrow(/not found or empty/);
+    expect(() => parseWorkflowDetail("nope")).toThrow(/not found or empty/);
   });
 });

--- a/docs/ai-generated/code-reviews/3562-workflow-detail-unwrap-erlang.md
+++ b/docs/ai-generated/code-reviews/3562-workflow-detail-unwrap-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review — #3562 Workflow detail missing workflowName unwrap
+
+**Branch:** `fix/issue-3562-workflow-detail-unwrap`  
+**Date:** 2026-08-18  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+`getWorkflowDetail` required a top-level `workflowName` on the GET
+`/services/workflowmanagement/workflows/{name}` body. Jackson WRAP_ROOT /
+`@XmlRootElement(name = "Workflow")` returns `{ Workflow: { workflowName, … } }`,
+so Developer workflow detail failed with **Workflow response missing
+workflowName** and QA could not complete #2640 step 5 (no Object ACL).
+
+The change adds `parseWorkflowDetail` that mirrors list unwrap: `Workflow`
+root, nested wrappers, one-item arrays, and the `name` alias. Catalog open
+buttons now expose `data-wf-name`. Vitest covers wrapped payloads; Playwright
+smokes Default/Simple detail and asserts no Object ACL section.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, no missing behavioral tests for the unwrap logic, no non-portable
+path/file I/O.
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path joins, temp dirs, or path assertions.
+
+## Memory patterns hit
+
+- Behavioral unit tests for new/changed non-trivial logic (`parseWorkflowDetail`)
+- Change-class closure: Vitest + Playwright companion + product-docs REST note
+- Do not treat focused `-Dtest` as sufficient — full `WebUI` `mvnw clean install` green
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- List parse is unchanged; catalog already binds `workflowName` from metadata.
+- Workflow still has no Object ACL / GUID (out of #2640 / #3562 scope).
+
+## Build evidence (C1)
+
+- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
+- Vitest (Maven test phase): Tests 2862 passed / 380 files
+- Playwright: `npm run test:surface -- --path tests/bugs/bug-3562-developer-workflow-detail.spec.js` → **1 passed**
+  (H2 QA `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`; console-clean=yes;
+  FastForward `PSDbStorageService` import + search-index last-modifier ERRORs pre-exist / not feature-related)

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3562-developer-workflow-detail.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3562-developer-workflow-detail.spec.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer → Workflows detail must unwrap Jackson Workflow envelopes (#3562 / #2640).
+ *
+ * Opening Default Workflow / Simple Workflow must show developer-wf-detail, not
+ * "Workflow response missing workflowName". Workflow has no Object ACL section
+ * (no GUID on the workflow DTO in this release).
+ *
+ * Surface-filtered QA mode:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/bugs/bug-3562-developer-workflow-detail.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const { catalogOpenByExactName } = require("../helpers/developer-catalog-selectors");
+
+const STOCK_WORKFLOWS = ["Default Workflow", "Simple Workflow"];
+
+function developerWorkflowsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "workflows",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Developer workflow detail unwrap (#3562)", () => {
+  test("Default and Simple workflow detail load without Object ACL", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(developerWorkflowsUrl(), { waitUntil: "networkidle" });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-workflows"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const panel = page.locator('[data-testid="developer-wf-panel"]');
+    const empty = page.locator('[data-testid="developer-wf-empty"]');
+    const listError = page.locator('[data-testid="developer-wf-error"]');
+    await expect(panel.or(empty).or(listError).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await listError.isVisible()) {
+      throw new Error(
+        `Developer workflows catalog error: ${(await listError.innerText()).trim()}`,
+      );
+    }
+    if (await empty.isVisible()) {
+      test.skip(true, "No workflows in catalog — cannot exercise workflow detail");
+    }
+
+    await expect(page.locator('[data-testid="developer-wf-table"]')).toBeVisible();
+
+    const openButtons = page.locator(
+      '[data-testid="developer-wf-table"] button[aria-label^="Open "]',
+    );
+    const count = await openButtons.count();
+    expect(count, "workflow catalog should have at least one open button").toBeGreaterThan(
+      0,
+    );
+
+    const names = [];
+    for (let i = 0; i < count; i++) {
+      const label = (await openButtons.nth(i).getAttribute("aria-label")) || "";
+      names.push(label.replace(/^Open\s+/i, "").trim());
+    }
+    const toOpen = STOCK_WORKFLOWS.filter((n) => names.includes(n));
+    const targets = toOpen.length > 0 ? toOpen : names.slice(0, 1);
+
+    for (const name of targets) {
+      const openBtn = page.locator(
+        catalogOpenByExactName("developer-wf-open", "data-wf-name", name),
+      );
+      await expect(openBtn).toBeVisible();
+      await openBtn.click();
+
+      const detail = page.locator('[data-testid="developer-wf-detail"]');
+      const detailError = page.locator('[data-testid="developer-wf-detail-error"]');
+      await expect(detail.or(detailError).first()).toBeVisible({ timeout: 20_000 });
+
+      if (await detailError.isVisible()) {
+        const msg = (await detailError.innerText()).trim();
+        throw new Error(
+          `Workflow detail failed for "${name}" (unwrap #3562): ${msg}`,
+        );
+      }
+
+      await expect(page.locator('[data-testid="developer-wf-detail-title"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-wf-detail-title"]')).toContainText(
+        name,
+      );
+      await expect(page.getByText(/missing workflowName/i)).toHaveCount(0);
+      await expect(page.locator('[data-testid="route-error"]')).toHaveCount(0);
+      await expect(page.getByText("Unable to load Developer")).toHaveCount(0);
+
+      // #2640 step 5 negative: Workflow has no Object ACL section.
+      await expect(page.locator('[data-testid$="-acl-section"]')).toHaveCount(0);
+      await expect(detail.getByText(/Object ACL/i)).toHaveCount(0);
+
+      await page.locator('[data-testid="developer-wf-back"]').click();
+      await expect(page.locator('[data-testid="developer-wf-table"]')).toBeVisible({
+        timeout: 20_000,
+      });
+    }
+
+    expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+    const unexpectedConsole = consoleErrors.filter(
+      (t) => !/Download the React DevTools/i.test(t),
+    );
+    expect(
+      unexpectedConsole,
+      `console error: ${unexpectedConsole.join(" | ")}`,
+    ).toEqual([]);
+  });
+});

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -401,6 +401,26 @@ display format, max results, and case sensitivity stored on the view design.
 - The Developer SPA lists views via `GET`. Operator Inbox run-from-tree is Explorer
   **Views → My Content → Inbox**, not a free-floating Inbox root.
 
+## Workflows (design catalog)
+
+Workflow definitions used by **Developer → Workflows** (SY-04 browse) are exposed under
+`/services/workflowmanagement/workflows`. This is the existing stepped-workflow catalog,
+not a full graph editor and **not** an Object ACL surface (workflow DTOs have no GUID
+in this release).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/workflowmanagement/workflows/metadata` | List workflow metadata (`workflowName`, default flag, steps) |
+| `GET` | `/services/workflowmanagement/workflows/{name}` | Load one workflow by name (steps, staging roles, default flag) |
+
+JSON list and detail may wrap under Jackson / JAXB root `Workflow` (including nested
+`{ "Workflow": { "Workflow": { … } } }` envelopes). The name field is `workflowName`;
+some serializers also emit `name`. **Developer → Workflows** unwraps those envelopes
+and binds `workflowName` (or the `name` alias) before rendering detail. A wrapped
+payload without a top-level `workflowName` must still open **Default Workflow** /
+**Simple Workflow** instead of **Could not load workflow**. There is **no Object ACL**
+section on workflow detail.
+
 ## Design capability gaps (`designGaps`)
 
 Some Developer detail payloads include a **`designGaps`** array so clients know what the REST


### PR DESCRIPTION
## Summary

Developer → Workflows detail failed on every catalog row with **Could not load workflow. Workflow response missing workflowName**. Jackson WRAP_ROOT / `@XmlRootElement(name = "Workflow")` returns `{ "Workflow": { "workflowName": "…" } }` (sometimes nested, sometimes with a `name` alias). `getWorkflowDetail` only read a top-level `workflowName`, so #2640 QA step 5 (Workflow has **no** Object ACL) could not run.

This slice unwraps the detail payload the same way as the metadata list. It does **not** invent Workflow GUID / Object ACL.

Parent tracker: #2640 (epic #2274 / #2262). Residual of failed QA #2640.

Fixes #3562

## Test plan

Env: QA H2 docker (`perc-devctl qa-up`) or local CMS with Developer access; Admin.

1. Open **Developer → Workflows**. Confirm Default Workflow and Simple Workflow appear.
2. Open **Default Workflow**. Expect `developer-wf-detail` with the name/title — **not** missing-workflowName.
3. Confirm there is **no Object ACL** section on workflow detail.
4. Back, open **Simple Workflow**. Same: detail loads, no Object ACL.
5. Browser console has no uncaught errors on this path.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (**Workflows (design catalog)** unwrap + no Object ACL)
- [x] **Unit / module tests** — `parseWorkflowDetail` Vitest (flat, WRAP_ROOT, nested, `name` alias, one-item array, `steps` alias, missing-name throw)
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3562-developer-workflow-detail.spec.js`
- [x] **Build gates** — standalone `cd WebUI && ../mvnw.cmd clean install` **BUILD SUCCESS**
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-18). Vitest (Maven test phase): **Tests 2862 passed / 380 files**.
- **downstream_checked:** none (TypeScript-only WebUI + Playwright spec; no Java type/`final`/public API signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2` **HEALTH:healthy** HTTP 200 `TEST_CMS_URL=http://127.0.0.1:9993` (qa-up/qa-health RESULT:FAIL on pre-existing FastForward `PSDbStorageService` import ERRORs; not `rhythmyx_context_failed` / unhealthy)
- Hot-deploy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (static JS; no Jetty restart)
- `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/bugs/bug-3562-developer-workflow-detail.spec.js` → **1 passed** (1.9s)
- **console-clean:** yes (spec asserts zero pageerror / unexpected console error)
- **server.log-clean:** yes for this feature (no workflow unwrap ERRORs). Pre-existing FastForward import + search-index last-modifier ERRORs ignored (same noise as #3554)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
