### PR TITLE
feat(virtual-site): git remote fetch/clone before Virtual Site build (#3568)

### DIFF
--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -141,6 +141,12 @@ blank). Load failures show **Could not load sites** rather than the empty state.
 6. To return a Virtual Site to traditional repository mode, set source kind back to
    **Repository (traditional)** and save (clears `virtual.*` properties).
 
+To use a **Git remote** as the system of record (clone/fetch on Build), set **Remote URL**
+and **Branch** on this panel (or `virtual.remoteUrl` / `virtual.branch` via
+`PUT /services/sites/{name}/virtual`) — see
+[Virtual Sites (developer)](id:developer-virtual-sites). Leave **Remote URL** blank to keep
+a local Git checkout path.
+
 Validation matches the server helper (`PSVirtualSiteHelper`): allow-listed source kinds,
 required local root path when virtual and no remote, safe remote URLs/branches, and
 safe path/config names. After root, remote, or config changes, re-run the offline
@@ -161,9 +167,10 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
    server properties, not unsaved form fields. When a remote is set, Build clones or
    fetches first (`git` must be on the CMS `PATH`).
 4. Choose **Build Virtual Site**.
-5. After a `git pull` or a local Markdown/frontmatter edit on the host, choose **Build Virtual
-   Site** again. The build re-reads the current filesystem — **do not restart the CMS** just to
-   pick up those edits. There is no file watcher; the next explicit build is the refresh.
+5. After a `git pull` or a local Markdown/frontmatter edit on the host — or after the remote
+   branch moves — choose **Build Virtual Site** again. The build re-reads the current tree
+   (and re-fetches when a remote is configured) — **do not restart the CMS** just to pick up
+   those edits. There is no file watcher; the next explicit build is the refresh.
 6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -131,8 +131,8 @@ Explorer chrome does not probe the named preference. A blank list entry (or no e
 |-----------|------|--------|
 | List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array — **not** `{ "empty": false }`. Each entry includes a plain string `name` when the Site has one. |
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
-| Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag. PUT JSON is `{ "VirtualSiteProperties": { "sourceKind", "rootPath", "configFile", "siteKey" } }` (Jackson/JAXB root wrap). A flat `{ "sourceKind": … }` body returns **400** unexpected element `sourceKind`. |
-| Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites |
+| Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag. PUT JSON is `{ "VirtualSiteProperties": { "sourceKind", "rootPath", "remoteUrl", "branch", "configFile", "siteKey" } }` (Jackson/JAXB root wrap). A flat `{ "sourceKind": … }` body returns **400** unexpected element `sourceKind`. Optional `remoteUrl` + `branch` clone/fetch before Build; omit `remoteUrl` to keep a stored remote; send `""` to clear. |
+| Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites. Fetches `remoteUrl` when set, else reads local `rootPath`. |
 | Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
 | Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root. Same action as **Developer → Sites → Publish Virtual Site** |

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -85,7 +85,9 @@ treated as a safe Virtual Site source.
 | Property | Required | Example | Meaning |
 |----------|----------|---------|---------|
 | `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem` only. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. |
-| `virtual.rootPath` | Yes (when virtual) | absolute path to `product-docs` (or install-relative) | Filesystem root of the Virtual Site tree. Non-blank required when virtual. Resolved with NIO `Path` (cross-platform). |
+| `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` (or install-relative) | Local filesystem root when `virtual.remoteUrl` is blank. When a remote is set, optional **relative** path inside the checkout (for example `product-docs`). |
+| `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. When set, **Build** clones or fetches into a contained work directory, then reuses git-filesystem discover. Blank keeps local-path mode. Allowed: `https://`, `ssh://`, `file://`, or `git@host:path`. `http` and other schemes are rejected. |
+| `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. Simple ref name only (no `..` or leading `-`). |
 | `virtual.configFile` | No | `_config.yaml` | Config file name under the root; default `_config.yaml`. Must be a simple file name (no path separators or `..`). |
 | `virtual.siteKey` | No | `product-docs` | Participant registry key; default = Site name, else `default`. |
 
@@ -96,11 +98,16 @@ Empty / missing `virtual.sourceKind` (or value `repository`) means a traditional
 - **Source kind allow-list** — only registered adapter wire names are accepted for Virtual Sites
   (Phase 1: `git-filesystem`). Values such as future `sql` / `api` kinds are rejected until
   implemented.
-- **Required root** — when `virtual.sourceKind` is virtual, `virtual.rootPath` must be non-blank.
+- **Required root** — when `virtual.sourceKind` is virtual and `virtual.remoteUrl` is blank,
+  `virtual.rootPath` must be non-blank.
+- **Optional Git remote** — `virtual.remoteUrl` + `virtual.branch` fetch or clone before Build.
+  URLs must not contain `..`, whitespace, or shell metacharacters, and must not start with `-`.
+  The CMS never logs credentials (userinfo is redacted). `git` must be on the CMS host `PATH`.
 - **Safe paths** — `virtual.rootPath` is normalized with `java.nio.file.Path`. After normalize, empty
   paths and any remaining `..` segments are rejected (path traversal). Prefer absolute paths on
-  Windows (`C:\…`) and Unix (`/opt/…`); relative paths under the install are allowed when they do not
-  escape via `..`.
+  Windows (`C:\…`) and Unix (`/opt/…`) for **local** roots; relative paths under the install are
+  allowed when they do not escape via `..`. When a remote is set, `virtual.rootPath` must be a
+  relative path inside the checkout (not `C:\…` / `/opt/…`).
 - **Config file name** — when set, `virtual.configFile` must not contain `/`, `\`, or `..`.
 
 ## Offline build
@@ -165,11 +172,46 @@ element `sourceKind`). GET returns the same envelope (or a plain object the SPA 
 After save, the Developer Sites panel GET-roundtrips so `virtual=true` and Build chrome appear
 without reloading the page.
 
+### Git remote fetch before Build
+
+Operators can point a Virtual Site at a **remote Git URL + branch** instead of (or in addition to)
+a pre-checked-out local path. Configure via `PUT /sites/{nameOrId}/virtual`:
+
+```json
+{
+  "VirtualSiteProperties": {
+    "sourceKind": "git-filesystem",
+    "remoteUrl": "https://git.example.com/org/product-docs.git",
+    "branch": "main",
+    "rootPath": "product-docs"
+  }
+}
+```
+
+On **Build Virtual Site** (`POST …/virtual/build`) the server:
+
+1. Validates the URL and branch (fail-closed; never logs credentials).
+2. Clones or fetches into a contained work directory (`{install}/tmp/virtual-site-checkouts/{siteKey}`,
+   or `{java.io.tmpdir}/percussion-virtual-site-checkouts/{siteKey}`).
+3. Uses optional `virtual.rootPath` as a **relative** sub-folder inside that checkout.
+4. Reuses the existing git-filesystem discover / assemble path.
+
+Leave `remoteUrl` blank (or omit it) to keep **local-path** `git-filesystem` behavior — Build
+reads `virtual.rootPath` on the CMS host as before. Send `"remoteUrl": ""` to clear a stored remote.
+
+The Developer → Sites source panel does not yet expose remote URL / branch fields. Configure
+those properties over REST (or a later UI slice). If a remote is stored, do not save an absolute
+local root from the panel until the remote is cleared.
+
+The CMS host must have `git` on `PATH`. Checkouts are server-managed; do not point `remoteUrl` at
+untrusted remotes.
+
 ### Rebuild after git pull or a local edit (no CMS restart)
 
 The Git/filesystem adapter always sees the **current** tree on the CMS host:
 
-1. Update Markdown or frontmatter under `virtual.rootPath` (`git pull`, copy, or an editor).
+1. Update Markdown or frontmatter under `virtual.rootPath` (`git pull`, copy, or an editor),
+   **or** change the remote branch and Build again so the server fetches.
 2. Run **Build Virtual Site** again (UI, `POST …/virtual/build`, or `scripts/build-cms-docs.*`).
 3. Preview or publish the new output.
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -78,7 +78,9 @@ When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` co
 | Property name | Required | Example | Meaning |
 |---------------|----------|---------|---------|
 | `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. |
-| `virtual.rootPath` | Yes (when virtual) | absolute or install-relative path to tree | Filesystem source root. Non-blank when virtual. NIO `Path` normalize; no empty path / remaining `..` segments. |
+| `virtual.rootPath` | Yes when remote is blank | absolute or install-relative path to tree | Local filesystem source root when `virtual.remoteUrl` is blank. NIO `Path` normalize; no empty path / remaining `..`. When a remote is set, optional relative path inside the checkout. |
+| `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones/fetches into `{install}/tmp/virtual-site-checkouts/{siteKey}`. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. Fail-closed on `..`, `http`, option injection. Credentials are never logged. |
+| `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. |
 | `virtual.configFile` | No | `_config.yaml` | Optional; default `_config.yaml`. Simple file name only (no separators / `..`). |
 | `virtual.siteKey` | No | `product-docs` | Participant registry key; default Site name, else `default`. |
 
@@ -128,13 +130,16 @@ GET uses the same envelope. The Developer Sites **Save Virtual Site source** act
 wrap and then GET-roundtrips so Build chrome appears without a full reload.
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
-enforced server-side (allow-listed source kinds, required root path when virtual, portable
-path safety).
+enforced server-side (allow-listed source kinds, required local root path when virtual and
+remote is blank, safe remote URL/branch, portable path safety).
 
 #### Build Virtual Site (`POST …/virtual/build`)
 
-Runs the Phase 1 static build for a Site configured with `virtual.sourceKind=git-filesystem`
-and a valid `virtual.rootPath` (directory must exist on the CMS host). Requires **Admin**.
+Runs the Phase 1 static build for a Site configured with `virtual.sourceKind=git-filesystem`.
+When `virtual.remoteUrl` is set, the server clones or fetches that branch into a contained
+work directory, then discovers Markdown from the checkout (optional relative `virtual.rootPath`).
+When remote is blank, `virtual.rootPath` must be an existing directory on the CMS host.
+Requires **Admin**. `git` must be on the CMS `PATH` for remotes.
 
 | Status | When |
 |--------|------|

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -38,6 +38,7 @@ import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.services.sitemgr.PSSiteManagerLocator;
 import com.percussion.services.sitemgr.data.PSSite;
 import com.percussion.services.virtualsite.PSGitFilesystemVirtualSiteSource;
+import com.percussion.services.virtualsite.PSGitRemoteCheckout;
 import com.percussion.services.virtualsite.PSInMemoryVirtualParticipantService;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildService;
@@ -120,6 +121,9 @@ public class SitesAdaptor implements ISiteAdaptor {
    */
   private final BuildRunner buildRunner;
 
+  /** Git remote checkout before discover; tests may inject a stub. */
+  private final PSGitRemoteCheckout gitRemoteCheckout;
+
   /** Functional hook for the static build (production or test double). */
   @FunctionalInterface
   interface BuildRunner {
@@ -161,6 +165,20 @@ public class SitesAdaptor implements ISiteAdaptor {
       BooleanSupplier adminChecker,
       Function<String, Path> defaultOutputRootResolver,
       BuildRunner buildRunner) {
+    this(siteManager, adminChecker, defaultOutputRootResolver, buildRunner, null);
+  }
+
+  /**
+   * Fully injectable constructor including Git remote checkout.
+   *
+   * @param gitRemoteCheckout null uses the production {@link PSGitRemoteCheckout}
+   */
+  SitesAdaptor(
+      IPSSiteManager siteManager,
+      BooleanSupplier adminChecker,
+      Function<String, Path> defaultOutputRootResolver,
+      BuildRunner buildRunner,
+      PSGitRemoteCheckout gitRemoteCheckout) {
     this.siteManager = siteManager != null ? siteManager : PSSiteManagerLocator.getSiteManager();
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
     this.defaultOutputRootResolver =
@@ -168,6 +186,8 @@ public class SitesAdaptor implements ISiteAdaptor {
             ? defaultOutputRootResolver
             : SitesAdaptor::defaultOutputRootForSiteKey;
     this.buildRunner = buildRunner;
+    this.gitRemoteCheckout =
+        gitRemoteCheckout != null ? gitRemoteCheckout : new PSGitRemoteCheckout();
   }
 
   @Override
@@ -258,6 +278,9 @@ public class SitesAdaptor implements ISiteAdaptor {
         PSVirtualSiteHelper.putProperty(
             psSite, contextId, PSVirtualSiteHelper.PROP_CONFIG_FILE, null);
         PSVirtualSiteHelper.putProperty(psSite, contextId, PSVirtualSiteHelper.PROP_SITE_KEY, null);
+        PSVirtualSiteHelper.putProperty(
+            psSite, contextId, PSVirtualSiteHelper.PROP_REMOTE_URL, null);
+        PSVirtualSiteHelper.putProperty(psSite, contextId, PSVirtualSiteHelper.PROP_BRANCH, null);
       } else {
         PSVirtualSiteHelper.putProperty(
             psSite, contextId, PSVirtualSiteHelper.PROP_SOURCE_KIND, sourceKind);
@@ -267,6 +290,15 @@ public class SitesAdaptor implements ISiteAdaptor {
             psSite, contextId, PSVirtualSiteHelper.PROP_CONFIG_FILE, configFile);
         PSVirtualSiteHelper.putProperty(
             psSite, contextId, PSVirtualSiteHelper.PROP_SITE_KEY, siteKey);
+        // Null (omitted on the wire) keeps an existing remote so older UIs do not wipe it.
+        if (props.getRemoteUrl() != null) {
+          PSVirtualSiteHelper.putProperty(
+              psSite, contextId, PSVirtualSiteHelper.PROP_REMOTE_URL, blankToNull(props.getRemoteUrl()));
+        }
+        if (props.getBranch() != null) {
+          PSVirtualSiteHelper.putProperty(
+              psSite, contextId, PSVirtualSiteHelper.PROP_BRANCH, blankToNull(props.getBranch()));
+        }
       }
 
       try {
@@ -331,19 +363,29 @@ public class SitesAdaptor implements ISiteAdaptor {
           Response.Status.BAD_REQUEST);
     }
 
-    Path siteRoot =
-        PSVirtualSiteHelper.rootPath(site)
-            .orElseThrow(
-                () ->
-                    new WebApplicationException(
-                        PSVirtualSiteHelper.PROP_ROOT_PATH + " is required for Virtual Site build",
-                        Response.Status.BAD_REQUEST));
-    if (!Files.isDirectory(siteRoot)) {
+    Path siteRoot;
+    try {
+      siteRoot = resolveDiscoverRoot(site);
+    } catch (VirtualSiteException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (IOException e) {
+      log.error(
+          "Virtual Site Git checkout I/O failed for '{}' ({}): {}",
+          nameOrId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
       throw new WebApplicationException(
-          PSVirtualSiteHelper.PROP_ROOT_PATH
-              + " is not an existing directory: '"
-              + siteRoot
-              + "'",
+          "Virtual Site Git checkout failed: " + PSGitRemoteCheckout.redact(e.getMessage()),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    if (!Files.isDirectory(siteRoot)) {
+      String which =
+          PSVirtualSiteHelper.hasRemote(site)
+              ? "Git checkout / relative rootPath"
+              : PSVirtualSiteHelper.PROP_ROOT_PATH;
+      throw new WebApplicationException(
+          which + " is not an existing directory: '" + siteRoot + "'",
           Response.Status.BAD_REQUEST);
     }
 
@@ -517,6 +559,10 @@ public class SitesAdaptor implements ISiteAdaptor {
         .ifPresent(v::setConfigFile);
     PSVirtualSiteHelper.findProperty(site, PSVirtualSiteHelper.PROP_SITE_KEY)
         .ifPresent(v::setSiteKey);
+    PSVirtualSiteHelper.findProperty(site, PSVirtualSiteHelper.PROP_REMOTE_URL)
+        .ifPresent(v::setRemoteUrl);
+    PSVirtualSiteHelper.findProperty(site, PSVirtualSiteHelper.PROP_BRANCH)
+        .ifPresent(v::setBranch);
     v.setVirtual(PSVirtualSiteHelper.isVirtual(site));
     return v;
   }
@@ -921,6 +967,39 @@ public class SitesAdaptor implements ISiteAdaptor {
           Response.Status.BAD_REQUEST);
     }
     return path.normalize();
+  }
+
+  /**
+   * Local discover root, or a Git checkout work tree when {@code virtual.remoteUrl} is set.
+   *
+   * @param site validated virtual site
+   * @return existing or newly fetched tree
+   */
+  Path resolveDiscoverRoot(IPSSite site) throws VirtualSiteException, IOException {
+    if (!PSVirtualSiteHelper.hasRemote(site)) {
+      return PSVirtualSiteHelper.resolveDiscoverRoot(site, null);
+    }
+    Path workBase = defaultCheckoutWorkBase();
+    return gitRemoteCheckout.ensureCurrent(site, workBase);
+  }
+
+  /**
+   * Contained checkout parent: {@code {rxDir}/tmp/virtual-site-checkouts} when the install root is
+   * known, else {@code {java.io.tmpdir}/percussion-virtual-site-checkouts}.
+   */
+  static Path defaultCheckoutWorkBase() {
+    try {
+      File rx = PSServer.getRxDir();
+      if (rx != null) {
+        Path base = rx.toPath().normalize();
+        if (PSVirtualSiteHelper.isSafeRootPath(base)) {
+          return base.resolve("tmp").resolve("virtual-site-checkouts");
+        }
+      }
+    } catch (RuntimeException e) {
+      log.debug("PSServer.getRxDir unavailable for virtual checkout work base: {}", e.getMessage());
+    }
+    return Path.of(System.getProperty("java.io.tmpdir"), "percussion-virtual-site-checkouts");
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -45,11 +45,14 @@ import com.percussion.services.sitemgr.IPSPublishingContext;
 import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.services.sitemgr.data.PSSite;
 import com.percussion.services.sitemgr.data.PSSiteProperty;
+import com.percussion.services.virtualsite.PSGitRemoteCheckout;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
 import com.percussion.services.virtualsite.PSManagedNavSiteHelper;
 import com.percussion.services.virtualsite.PSVirtualSiteHelper;
+import java.time.Duration;
 import com.percussion.utils.guid.IPSGuid;
 import jakarta.ws.rs.WebApplicationException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -92,12 +95,16 @@ class SitesAdaptorTest {
     put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, "C:/docs/product-docs");
     put(site, PSVirtualSiteHelper.PROP_CONFIG_FILE, "custom.yaml");
     put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "product-docs");
+    put(site, PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/docs.git");
+    put(site, PSVirtualSiteHelper.PROP_BRANCH, "release/8.2");
 
     VirtualSiteProperties v = SitesAdaptor.readVirtual(site);
     assertEquals("git-filesystem", v.getSourceKind());
     assertEquals("C:/docs/product-docs", v.getRootPath());
     assertEquals("custom.yaml", v.getConfigFile());
     assertEquals("product-docs", v.getSiteKey());
+    assertEquals("https://git.example.com/org/docs.git", v.getRemoteUrl());
+    assertEquals("release/8.2", v.getBranch());
     assertTrue(Boolean.TRUE.equals(v.getVirtual()));
   }
 
@@ -199,6 +206,7 @@ class SitesAdaptorTest {
         PSVirtualSiteHelper.findProperty(persisted, PSVirtualSiteHelper.PROP_SITE_KEY)
             .orElse(null));
     assertEquals(100L, persisted.getSiteId());
+    assertTrue(PSVirtualSiteHelper.remoteUrl(persisted).isEmpty());
     assertFalse(persisted.getProperties().isEmpty());
     for (PSSiteProperty property : persisted.getProperties()) {
       assertSame(persisted, property.getSite(), property.getName());
@@ -253,6 +261,88 @@ class SitesAdaptorTest {
     VirtualSiteProperties body = new VirtualSiteProperties();
     body.setSourceKind("git-filesystem");
     // rootPath missing
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.updateVirtualSiteProperties("Help", body));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(siteManager, never()).saveSite(any());
+  }
+
+  @Test
+  void updateVirtualSiteProperties_persistsRemoteWithoutLocalRoot() throws Exception {
+    PSSite existing = new PSSite();
+    existing.setName("Help");
+    existing.setGUID(siteGuid);
+    PSSite modifiable = new PSSite();
+    modifiable.setName("Help");
+    modifiable.setGUID(siteGuid);
+    when(siteManager.findSite("Help")).thenReturn(existing);
+    when(siteManager.loadSiteModifiable(siteGuid)).thenReturn(modifiable);
+    IPSPublishingContext preview = mock(IPSPublishingContext.class);
+    when(preview.getGUID()).thenReturn(previewCtx);
+    when(siteManager.loadContext(SitesAdaptor.DEFAULT_PROPERTY_CONTEXT)).thenReturn(preview);
+
+    VirtualSiteProperties body = new VirtualSiteProperties();
+    body.setSourceKind("git-filesystem");
+    body.setRemoteUrl("https://git.example.com/org/product-docs.git");
+    body.setBranch("main");
+    body.setRootPath("product-docs");
+
+    VirtualSiteProperties out = adaptor.updateVirtualSiteProperties("Help", body);
+    assertEquals("https://git.example.com/org/product-docs.git", out.getRemoteUrl());
+    assertEquals("main", out.getBranch());
+    assertEquals("product-docs", out.getRootPath());
+    ArgumentCaptor<PSSite> saved = ArgumentCaptor.forClass(PSSite.class);
+    verify(siteManager).saveSite(saved.capture());
+    assertEquals(
+        "https://git.example.com/org/product-docs.git",
+        PSVirtualSiteHelper.remoteUrl(saved.getValue()).orElse(null));
+  }
+
+  @Test
+  void updateVirtualSiteProperties_omittedRemoteKeepsExisting() throws Exception {
+    PSSite existing = new PSSite();
+    existing.setName("Help");
+    existing.setGUID(siteGuid);
+    PSSite modifiable = new PSSite();
+    modifiable.setName("Help");
+    modifiable.setGUID(siteGuid);
+    put(modifiable, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(modifiable, PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/docs.git");
+    put(modifiable, PSVirtualSiteHelper.PROP_BRANCH, "main");
+    put(modifiable, PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs");
+    when(siteManager.findSite("Help")).thenReturn(existing);
+    when(siteManager.loadSiteModifiable(siteGuid)).thenReturn(modifiable);
+
+    VirtualSiteProperties body = new VirtualSiteProperties();
+    body.setSourceKind("git-filesystem");
+    body.setRootPath("product-docs");
+    body.setSiteKey("docs");
+
+    VirtualSiteProperties out = adaptor.updateVirtualSiteProperties("Help", body);
+    assertEquals("https://git.example.com/org/docs.git", out.getRemoteUrl());
+    assertEquals("main", out.getBranch());
+  }
+
+  @Test
+  void updateVirtualSiteProperties_rejectsUnsafeRemote() throws Exception {
+    PSSite existing = new PSSite();
+    existing.setName("Help");
+    existing.setGUID(siteGuid);
+    PSSite modifiable = new PSSite();
+    modifiable.setName("Help");
+    modifiable.setGUID(siteGuid);
+    when(siteManager.findSite("Help")).thenReturn(existing);
+    when(siteManager.loadSiteModifiable(siteGuid)).thenReturn(modifiable);
+    IPSPublishingContext preview = mock(IPSPublishingContext.class);
+    when(preview.getGUID()).thenReturn(previewCtx);
+    when(siteManager.loadContext(SitesAdaptor.DEFAULT_PROPERTY_CONTEXT)).thenReturn(preview);
+
+    VirtualSiteProperties body = new VirtualSiteProperties();
+    body.setSourceKind("git-filesystem");
+    body.setRemoteUrl("http://evil.example/../x");
 
     WebApplicationException ex =
         assertThrows(
@@ -407,6 +497,47 @@ class SitesAdaptorTest {
     assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
     assertTrue(Files.isRegularFile(out.resolve("8.2").resolve("index.html")));
     assertTrue(Files.isRegularFile(out.resolve("link-report.txt")));
+  }
+
+  @Test
+  void buildVirtualSite_remoteCheckoutThenDiscover() throws Exception {
+    Path out = tempDir.resolve("remote-out");
+    PSGitRemoteCheckout remote =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              if (command.contains("clone")) {
+                Path dest = Path.of(command.get(command.size() - 1));
+                try {
+                  createMinimalVirtualTree(dest);
+                } catch (IOException e) {
+                  throw e;
+                } catch (Exception e) {
+                  throw new IOException(e);
+                }
+                Files.createDirectories(dest.resolve(".git"));
+              }
+              return 0;
+            },
+            Duration.ofSeconds(10));
+
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/docs.git");
+    put(site, PSVirtualSiteHelper.PROP_BRANCH, "main");
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "help-docs");
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    SitesAdaptor building =
+        new SitesAdaptor(
+            siteManager, () -> true, key -> out, null, remote);
+
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+    VirtualSiteBuildResult result = building.buildVirtualSite("Help", req);
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(Files.isRegularFile(out.resolve("8.2").resolve("index.html")));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -85,7 +85,7 @@ public interface ISiteAdaptor {
   /**
    * Creates or updates Virtual Site properties for a site identified by name or GUID string.
    * Validation aligns with {@code PSVirtualSiteHelper} (source-kind allow-list, required root path
-   * when virtual, safe path / config file name).
+   * when virtual and remote is blank, optional remoteUrl/branch, safe path / config file name).
    *
    * @param nameOrId site name or GUID string, not blank
    * @param props properties to apply; not null
@@ -98,9 +98,10 @@ public interface ISiteAdaptor {
    * Builds a Virtual Site from configured {@code virtual.*} properties (Phase 1:
    * {@code git-filesystem}).
    *
-   * <p>Loads the site, validates via {@code PSVirtualSiteHelper}, runs {@code
-   * PSVirtualSiteBuildService} with portable NIO {@code Path} I/O, and returns pages-written plus
-   * link-problem summary. Requires Admin (or equivalent site-manage) authorization.
+   * <p>Loads the site, validates via {@code PSVirtualSiteHelper}, optionally clones/fetches {@code
+   * virtual.remoteUrl} into a contained work directory, runs {@code PSVirtualSiteBuildService} with
+   * portable NIO {@code Path} I/O, and returns pages-written plus link-problem summary. Requires
+   * Admin (or equivalent site-manage) authorization.
    *
    * @param nameOrId site name or GUID string, not blank
    * @param request optional body (output root override); may be null

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -204,8 +204,9 @@ public class SitesResource {
       summary = "Update Virtual Site properties",
       description =
           "Persists virtual.* properties. Validation aligns with PSVirtualSiteHelper: Phase 1"
-              + " sourceKind allow-list (git-filesystem), required non-blank rootPath when"
-              + " virtual, safe NIO path (no '..' after normalize), simple configFile name."
+              + " sourceKind allow-list (git-filesystem), required non-blank rootPath when virtual"
+              + " and remoteUrl is blank, optional remoteUrl+branch (https/ssh/file/git@host:path;"
+              + " fail-closed on unsafe URLs / '..'), safe NIO path, simple configFile name."
               + " Blank/repository sourceKind clears virtual configuration.",
       responses = {
         @ApiResponse(
@@ -255,8 +256,10 @@ public class SitesResource {
       summary = "Build Virtual Site",
       description =
           "Runs the Phase 1 Virtual Site static build for a site configured with"
-              + " virtual.sourceKind=git-filesystem (and valid virtual.rootPath / configFile /"
-              + " siteKey). Uses PSVirtualSiteBuildService with portable NIO Path I/O. Requires"
+              + " virtual.sourceKind=git-filesystem. When virtual.remoteUrl is set, the server"
+              + " clones or fetches that branch into a contained work directory, then reuses the"
+              + " git-filesystem discover path. Blank remote keeps local virtual.rootPath. Uses"
+              + " PSVirtualSiteBuildService with portable NIO Path I/O. Requires"
               + " Admin. Traditional repository Sites and invalid source kinds/paths return 4xx."
               + " Optional body may set outputRoot; otherwise the server writes under"
               + " {install}/tmp/virtual-sites/{siteKey}. Link problems are reported in the result"

--- a/rest/src/main/java/com/percussion/rest/sites/VirtualSiteProperties.java
+++ b/rest/src/main/java/com/percussion/rest/sites/VirtualSiteProperties.java
@@ -29,18 +29,22 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * <ul>
  *   <li>{@code virtual.sourceKind}
  *   <li>{@code virtual.rootPath}
+ *   <li>{@code virtual.remoteUrl}
+ *   <li>{@code virtual.branch}
  *   <li>{@code virtual.configFile}
  *   <li>{@code virtual.siteKey}
  * </ul>
  *
  * <p>Blank / missing {@code sourceKind} (or value {@code repository}) means a traditional repository
- * Site. Phase 1 virtual adapter: {@code git-filesystem}.
+ * Site. Phase 1 virtual adapter: {@code git-filesystem}. Optional {@code remoteUrl} + {@code branch}
+ * fetch/clone into a contained work directory before discover; blank remote keeps local {@code
+ * rootPath}.
  *
  * <p>Wire getters return plain {@code String} (not {@code Optional}) so JAXB/Jettison and Jackson
  * {@code WRAP_ROOT_VALUE} emit/accept child elements {@code sourceKind}, {@code rootPath},
- * {@code configFile}, and {@code siteKey} under root {@code VirtualSiteProperties}. Optional
- * getters historically produced JAXB {@code unexpected element sourceKind} on PUT (#3365 / QA
- * #3030).
+ * {@code remoteUrl}, {@code branch}, {@code configFile}, and {@code siteKey} under root {@code
+ * VirtualSiteProperties}. Optional getters historically produced JAXB {@code unexpected element
+ * sourceKind} on PUT (#3365 / QA #3030).
  */
 @XmlRootElement(name = "VirtualSiteProperties")
 @JsonRootName("VirtualSiteProperties")
@@ -49,7 +53,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
     name = "VirtualSiteProperties",
     description =
         "Virtual Site source configuration (virtual.sourceKind, virtual.rootPath,"
-            + " virtual.configFile, virtual.siteKey)")
+            + " virtual.remoteUrl, virtual.branch, virtual.configFile, virtual.siteKey)")
 public class VirtualSiteProperties {
 
   @Schema(
@@ -60,10 +64,23 @@ public class VirtualSiteProperties {
 
   @Schema(
       description =
-          "Filesystem path to the Virtual Site root (absolute or install-relative). Required when"
-              + " sourceKind is virtual.",
+          "Filesystem path to the Virtual Site root (absolute or install-relative) when remoteUrl"
+              + " is blank. When remoteUrl is set, optional relative path inside the checkout.",
       example = "C:/workspaces/product-docs")
   private String rootPath;
+
+  @Schema(
+      description =
+          "Optional Git remote (https://, ssh://, file://, or git@host:path). When set, Build"
+              + " clones or fetches into a contained work directory before discover. Blank keeps"
+              + " local-path git-filesystem.",
+      example = "https://git.example.com/org/product-docs.git")
+  private String remoteUrl;
+
+  @Schema(
+      description = "Git branch to checkout when remoteUrl is set. Optional; default main.",
+      example = "main")
+  private String branch;
 
   @Schema(
       description = "Config file name under rootPath. Optional; default _config.yaml.",
@@ -101,6 +118,22 @@ public class VirtualSiteProperties {
 
   public void setRootPath(String rootPath) {
     this.rootPath = rootPath;
+  }
+
+  public String getRemoteUrl() {
+    return remoteUrl;
+  }
+
+  public void setRemoteUrl(String remoteUrl) {
+    this.remoteUrl = remoteUrl;
+  }
+
+  public String getBranch() {
+    return branch;
+  }
+
+  public void setBranch(String branch) {
+    this.branch = branch;
   }
 
   public String getConfigFile() {

--- a/rest/src/test/java/com/percussion/rest/sites/VirtualSitePropertiesSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/VirtualSitePropertiesSerialDeserialTest.java
@@ -49,7 +49,9 @@ public class VirtualSitePropertiesSerialDeserialTest {
   private static VirtualSiteProperties sample() {
     VirtualSiteProperties props = new VirtualSiteProperties();
     props.setSourceKind("git-filesystem");
-    props.setRootPath("C:/docs/product-docs");
+    props.setRootPath("product-docs");
+    props.setRemoteUrl("https://git.example.com/org/product-docs.git");
+    props.setBranch("main");
     props.setConfigFile("_config.yaml");
     props.setSiteKey("product-docs");
     props.setVirtual(true);
@@ -71,13 +73,17 @@ public class VirtualSitePropertiesSerialDeserialTest {
     assertTrue(json.contains("\"sourceKind\""), json);
     assertTrue(json.contains("\"git-filesystem\""), json);
     assertTrue(json.contains("\"rootPath\""), json);
+    assertTrue(json.contains("\"remoteUrl\""), json);
+    assertTrue(json.contains("\"branch\""), json);
     assertFalse(
         json.contains("\"empty\"") && json.contains("\"present\""),
         "sourceKind must be a plain string, not an Optional bean: " + json);
 
     VirtualSiteProperties roundTrip = mapper.readValue(json, VirtualSiteProperties.class);
     assertEquals("git-filesystem", roundTrip.getSourceKind());
-    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+    assertEquals("product-docs", roundTrip.getRootPath());
+    assertEquals("https://git.example.com/org/product-docs.git", roundTrip.getRemoteUrl());
+    assertEquals("main", roundTrip.getBranch());
     assertEquals("_config.yaml", roundTrip.getConfigFile());
     assertEquals("product-docs", roundTrip.getSiteKey());
     assertEquals(Boolean.TRUE, roundTrip.getVirtual());
@@ -96,7 +102,9 @@ public class VirtualSitePropertiesSerialDeserialTest {
 
     VirtualSiteProperties roundTrip = mapper.readValue(json, VirtualSiteProperties.class);
     assertEquals("git-filesystem", roundTrip.getSourceKind());
-    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+    assertEquals("product-docs", roundTrip.getRootPath());
+    assertEquals("https://git.example.com/org/product-docs.git", roundTrip.getRemoteUrl());
+    assertEquals("main", roundTrip.getBranch());
   }
 
   @Test
@@ -138,13 +146,17 @@ public class VirtualSitePropertiesSerialDeserialTest {
     assertTrue(xml.contains("sourceKind"), xml);
     assertTrue(xml.contains("git-filesystem"), xml);
     assertTrue(xml.contains("rootPath"), xml);
+    assertTrue(xml.contains("remoteUrl"), xml);
+    assertTrue(xml.contains("branch"), xml);
     assertFalse(xml.contains("<empty>"), "must not marshal Optional beans: " + xml);
 
     Unmarshaller unmarshaller = ctx.createUnmarshaller();
     VirtualSiteProperties roundTrip =
         (VirtualSiteProperties) unmarshaller.unmarshal(new StringReader(xml));
     assertEquals("git-filesystem", roundTrip.getSourceKind());
-    assertEquals("C:/docs/product-docs", roundTrip.getRootPath());
+    assertEquals("product-docs", roundTrip.getRootPath());
+    assertEquals("https://git.example.com/org/product-docs.git", roundTrip.getRemoteUrl());
+    assertEquals("main", roundTrip.getBranch());
     assertEquals("_config.yaml", roundTrip.getConfigFile());
     assertEquals("product-docs", roundTrip.getSiteKey());
   }

--- a/system/services/src/com/percussion/services/virtualsite/PSGitRemoteCheckout.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSGitRemoteCheckout.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.sitemgr.IPSSite;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Fetches or clones a Git remote into a contained NIO work directory before Virtual Site discover.
+ *
+ * <p>Uses {@link ProcessBuilder} with an argument list (never a shell). Fail-closed on unsafe URLs,
+ * {@code ..} paths, and option-injection. Never logs credentials — remote URLs are redacted.
+ */
+public class PSGitRemoteCheckout {
+
+  private static final Logger log = LogManager.getLogger(PSGitRemoteCheckout.class);
+
+  static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2);
+
+  private static final int MAX_URL_LENGTH = 2048;
+  private static final int MAX_OUTPUT_CHARS = 4000;
+  private static final Pattern SAFE_BRANCH =
+      Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$");
+  private static final Pattern SCP_LIKE =
+      Pattern.compile("^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[A-Za-z0-9._/+-]+(?:\\.git)?$");
+  private static final Pattern SAFE_HOST =
+      Pattern.compile("^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$");
+  private static final Pattern UNSAFE_URL_CHARS = Pattern.compile("[\\s;|&$`<>\"'\\\\]");
+
+  /** Runs {@code git} with a portable argument list. */
+  @FunctionalInterface
+  public interface ProcessRunner {
+    /**
+     * Execute {@code command} with optional working directory.
+     *
+     * @param workingDirectory may be null (inherit)
+     * @param command argument list; first element is the executable
+     * @param output combined stdout/stderr (already redacted by the caller after return)
+     * @return process exit code
+     * @throws IOException when the process cannot be started
+     * @throws InterruptedException when interrupted while waiting
+     */
+    int run(Path workingDirectory, List<String> command, StringBuilder output)
+        throws IOException, InterruptedException;
+  }
+
+  private final ProcessRunner runner;
+  private final Duration timeout;
+
+  public PSGitRemoteCheckout() {
+    this(null, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * @param runner process runner; null uses the default {@link ProcessBuilder} implementation
+   * @param timeout wait limit per git invocation
+   */
+  public PSGitRemoteCheckout(ProcessRunner runner, Duration timeout) {
+    this.timeout = timeout != null && !timeout.isNegative() && !timeout.isZero() ? timeout : DEFAULT_TIMEOUT;
+    this.runner = runner != null ? runner : this::runGitProcess;
+  }
+
+  /**
+   * Clone or fetch the site remote into {@code workBase}/{siteKey} and return the discover root.
+   *
+   * @param site virtual site with a remote
+   * @param workBase contained parent directory (created if missing)
+   * @return discover root (checkout or relative sub-path)
+   * @throws VirtualSiteException validation or git failure
+   * @throws IOException filesystem failure
+   */
+  public Path ensureCurrent(IPSSite site, Path workBase)
+      throws VirtualSiteException, IOException {
+    Objects.requireNonNull(site, "site");
+    String url =
+        PSVirtualSiteHelper.remoteUrl(site)
+            .orElseThrow(
+                () ->
+                    new VirtualSiteException(
+                        PSVirtualSiteHelper.PROP_REMOTE_URL + " is required for Git remote checkout."));
+    return ensureCurrent(
+        url,
+        PSVirtualSiteHelper.branch(site),
+        PSVirtualSiteHelper.siteKey(site),
+        workBase,
+        site);
+  }
+
+  /**
+   * Clone or fetch {@code remoteUrl} at {@code branch} into a contained work directory.
+   *
+   * @param remoteUrl validated Git URL
+   * @param branch validated branch (blank ⇒ {@link PSVirtualSiteHelper#DEFAULT_BRANCH})
+   * @param siteKey used as the work-directory name
+   * @param workBase parent directory
+   * @param site optional site for relative {@code virtual.rootPath}; may be null
+   * @return discover root
+   */
+  public Path ensureCurrent(
+      String remoteUrl, String branch, String siteKey, Path workBase, IPSSite site)
+      throws VirtualSiteException, IOException {
+    String safeUrl = requireSafeRemoteUrl(remoteUrl);
+    String safeBranch = requireSafeBranch(StringUtils.isBlank(branch) ? PSVirtualSiteHelper.DEFAULT_BRANCH : branch);
+    Path safeBase = requireSafeWorkBase(workBase);
+    String segment = safeWorkSegment(siteKey);
+    Path workDir = safeBase.resolve(segment).normalize();
+    if (!workDir.startsWith(safeBase) || !PSVirtualSiteHelper.isSafeRootPath(workDir)) {
+      throw new VirtualSiteException("Git checkout work directory is not contained under the work base.");
+    }
+    Files.createDirectories(safeBase);
+    if (Files.exists(workDir) && !Files.isDirectory(workDir)) {
+      throw new VirtualSiteException("Git checkout path exists and is not a directory.");
+    }
+    Path gitDir = workDir.resolve(".git");
+    if (Files.exists(gitDir)) {
+      fetchExisting(workDir, safeUrl, safeBranch);
+    } else {
+      cloneFresh(workDir, safeUrl, safeBranch);
+    }
+    return PSVirtualSiteHelper.resolveDiscoverRoot(site, workDir);
+  }
+
+  /**
+   * Fail-closed Git remote validation. Never returns a URL that starts with {@code -} or contains
+   * {@code ..} / shell metacharacters.
+   *
+   * @param raw operator-supplied URL
+   * @return trimmed URL
+   * @throws VirtualSiteException when the URL is unsafe or unsupported
+   */
+  public static String requireSafeRemoteUrl(String raw) throws VirtualSiteException {
+    if (StringUtils.isBlank(raw)) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " must not be blank when set.");
+    }
+    String url = raw.trim();
+    if (url.length() > MAX_URL_LENGTH) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " exceeds maximum length.");
+    }
+    if (url.startsWith("-")) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " must not start with '-'.");
+    }
+    if (url.indexOf('\0') >= 0 || UNSAFE_URL_CHARS.matcher(url).find()) {
+      throw new VirtualSiteException(
+          PSVirtualSiteHelper.PROP_REMOTE_URL
+              + " contains unsafe characters (whitespace, quotes, or shell metacharacters).");
+    }
+    if (url.contains("..")) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " must not contain '..'.");
+    }
+    String lower = url.toLowerCase(Locale.ROOT);
+    if (lower.startsWith("https://")) {
+      return requireSafeHierarchicalUrl(url, "https");
+    }
+    if (lower.startsWith("ssh://")) {
+      return requireSafeHierarchicalUrl(url, "ssh");
+    }
+    if (lower.startsWith("file:")) {
+      return requireSafeFileUrl(url);
+    }
+    if (SCP_LIKE.matcher(url).matches()) {
+      return url;
+    }
+    throw new VirtualSiteException(
+        PSVirtualSiteHelper.PROP_REMOTE_URL
+            + " must be https://, ssh://, file://, or git@host:path (http and other schemes are"
+            + " rejected).");
+  }
+
+  /**
+   * Fail-closed Git branch / ref name. Rejects option injection and {@code ..}.
+   *
+   * @param raw branch name
+   * @return trimmed branch
+   */
+  public static String requireSafeBranch(String raw) throws VirtualSiteException {
+    if (StringUtils.isBlank(raw)) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_BRANCH + " must not be blank when set.");
+    }
+    String branch = raw.trim();
+    if (branch.startsWith("-") || branch.startsWith("/") || branch.endsWith(".lock")) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_BRANCH + " is not a safe Git ref name.");
+    }
+    if (branch.contains("..") || !SAFE_BRANCH.matcher(branch).matches()) {
+      throw new VirtualSiteException(
+          PSVirtualSiteHelper.PROP_BRANCH
+              + " must be a simple ref (letters, digits, '.', '_', '/', '-') with no '..'.");
+    }
+    return branch;
+  }
+
+  /**
+   * Redact userinfo / obvious secrets from a remote URL or process output for logs and exceptions.
+   *
+   * @param text may be null
+   * @return redacted text, never null
+   */
+  public static String redact(String text) {
+    if (text == null || text.isEmpty()) {
+      return "";
+    }
+    String s = text.replaceAll("://[^\\s/@]+@", "://***@");
+    return s.replaceAll("(?i)(token|password|passwd|secret|authorization)[=:]\\S+", "$1=***");
+  }
+
+  static String safeWorkSegment(String siteKey) {
+    String raw = StringUtils.isBlank(siteKey) ? "default" : siteKey.trim();
+    StringBuilder b = new StringBuilder(Math.min(raw.length(), 80));
+    for (int i = 0; i < raw.length() && b.length() < 80; i++) {
+      char c = raw.charAt(i);
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || c == '.'
+          || c == '_'
+          || c == '-') {
+        b.append(c);
+      } else {
+        b.append('_');
+      }
+    }
+    String segment = b.toString();
+    if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+      return "default";
+    }
+    return segment;
+  }
+
+  private void cloneFresh(Path workDir, String safeUrl, String safeBranch)
+      throws VirtualSiteException, IOException {
+    if (Files.exists(workDir) && !isEmptyDirectory(workDir)) {
+      throw new VirtualSiteException(
+          "Git checkout directory exists and is not an empty Git work tree. Refusing to clone.");
+    }
+    Files.createDirectories(workDir.getParent());
+    List<String> command = new ArrayList<>();
+    command.add("git");
+    command.add("clone");
+    command.add("--depth");
+    command.add("1");
+    command.add("--branch");
+    command.add(safeBranch);
+    command.add("--single-branch");
+    command.add("--");
+    command.add(safeUrl);
+    command.add(workDir.toString());
+    runChecked(workDir.getParent(), command, "clone");
+    if (!Files.isDirectory(workDir.resolve(".git")) && !Files.isRegularFile(workDir.resolve(".git"))) {
+      throw new VirtualSiteException("Git clone did not produce a .git directory.");
+    }
+  }
+
+  private void fetchExisting(Path workDir, String safeUrl, String safeBranch)
+      throws VirtualSiteException, IOException {
+    String origin = readOriginUrl(workDir);
+    if (StringUtils.isNotBlank(origin) && !sameRemote(origin, safeUrl)) {
+      throw new VirtualSiteException(
+          "Existing checkout origin does not match the configured remote. Refusing to fetch.");
+    }
+    List<String> fetch = List.of("git", "fetch", "--depth", "1", "--", "origin", safeBranch);
+    runChecked(workDir, fetch, "fetch");
+    List<String> checkout = List.of("git", "checkout", "--force", "-B", safeBranch, "FETCH_HEAD");
+    runChecked(workDir, checkout, "checkout");
+  }
+
+  private String readOriginUrl(Path workDir) throws VirtualSiteException {
+    StringBuilder output = new StringBuilder();
+    List<String> command = List.of("git", "remote", "get-url", "origin");
+    try {
+      int code = runner.run(workDir, command, output);
+      if (code != 0) {
+        return "";
+      }
+      return output.toString().trim();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new VirtualSiteException("Interrupted while reading Git origin URL.", e);
+    } catch (IOException e) {
+      throw new VirtualSiteException("Unable to read Git origin URL: " + e.getMessage(), e);
+    }
+  }
+
+  private static boolean sameRemote(String existing, String configured) {
+    String a = normalizeRemoteForCompare(existing);
+    String b = normalizeRemoteForCompare(configured);
+    return a.equalsIgnoreCase(b);
+  }
+
+  private static String normalizeRemoteForCompare(String url) {
+    String s = redact(url).trim();
+    if (s.endsWith(".git")) {
+      s = s.substring(0, s.length() - 4);
+    }
+    if (s.endsWith("/")) {
+      s = s.substring(0, s.length() - 1);
+    }
+    return s;
+  }
+
+  private void runChecked(Path cwd, List<String> command, String action)
+      throws VirtualSiteException {
+    StringBuilder output = new StringBuilder();
+    int code;
+    try {
+      code = runner.run(cwd, command, output);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new VirtualSiteException("Interrupted during Git " + action + ".", e);
+    } catch (IOException e) {
+      throw new VirtualSiteException(
+          "Unable to run git " + action + " (is git on PATH?): " + redact(e.getMessage()), e);
+    }
+    if (code != 0) {
+      String snippet = redact(truncate(output.toString(), MAX_OUTPUT_CHARS));
+      log.warn("Git {} failed with exit {} (credentials redacted).", action, code);
+      throw new VirtualSiteException("Git " + action + " failed (exit " + code + "): " + snippet);
+    }
+    log.info("Git {} completed for Virtual Site checkout.", action);
+  }
+
+  private int runGitProcess(Path workingDirectory, List<String> command, StringBuilder output)
+      throws IOException, InterruptedException {
+    ProcessBuilder builder = new ProcessBuilder(command);
+    if (workingDirectory != null) {
+      builder.directory(workingDirectory.toFile());
+    }
+    builder.redirectErrorStream(true);
+    Process process = builder.start();
+    try (InputStream in = process.getInputStream()) {
+      byte[] buf = in.readAllBytes();
+      if (output != null) {
+        output.append(new String(buf, StandardCharsets.UTF_8));
+      }
+    }
+    boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      throw new IOException("git timed out after " + timeout.toSeconds() + "s");
+    }
+    return process.exitValue();
+  }
+
+  private static String requireSafeHierarchicalUrl(String url, String scheme)
+      throws VirtualSiteException {
+    URI uri;
+    try {
+      uri = new URI(url);
+    } catch (URISyntaxException e) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " is not a valid URI.", e);
+    }
+    if (!scheme.equalsIgnoreCase(uri.getScheme())) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " scheme is not " + scheme + ".");
+    }
+    String host = uri.getHost();
+    if (StringUtils.isBlank(host) || !SAFE_HOST.matcher(host).matches() || host.contains("..")) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " host is missing or unsafe.");
+    }
+    String path = uri.getPath();
+    if (path != null && path.contains("..")) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " path must not contain '..'.");
+    }
+    return url;
+  }
+
+  private static String requireSafeFileUrl(String url) throws VirtualSiteException {
+    URI uri;
+    try {
+      uri = new URI(url);
+    } catch (URISyntaxException e) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " is not a valid file URI.", e);
+    }
+    if (!"file".equalsIgnoreCase(uri.getScheme())) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " file URL must use the file scheme.");
+    }
+    String host = uri.getHost();
+    if (StringUtils.isNotBlank(host) && !"localhost".equalsIgnoreCase(host)) {
+      throw new VirtualSiteException(
+          PSVirtualSiteHelper.PROP_REMOTE_URL + " file URL host must be empty or localhost.");
+    }
+    Path path;
+    try {
+      path = Path.of(uri).normalize();
+    } catch (RuntimeException e) {
+      throw new VirtualSiteException(PSVirtualSiteHelper.PROP_REMOTE_URL + " file URL is not a usable path.", e);
+    }
+    if (!PSVirtualSiteHelper.isSafeRootPath(path)) {
+      throw new VirtualSiteException(
+          PSVirtualSiteHelper.PROP_REMOTE_URL + " file URL path is unsafe after normalize.");
+    }
+    return url;
+  }
+
+  private static Path requireSafeWorkBase(Path workBase) throws VirtualSiteException {
+    if (workBase == null) {
+      throw new VirtualSiteException("Git checkout work base is required.");
+    }
+    Path normalized = workBase.normalize();
+    if (!PSVirtualSiteHelper.isSafeRootPath(normalized)) {
+      throw new VirtualSiteException("Git checkout work base is not a safe path.");
+    }
+    return normalized;
+  }
+
+  private static boolean isEmptyDirectory(Path dir) throws IOException {
+    if (!Files.isDirectory(dir)) {
+      return false;
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+      return !stream.iterator().hasNext();
+    }
+  }
+
+  private static String truncate(String text, int max) {
+    if (text == null) {
+      return "";
+    }
+    if (text.length() <= max) {
+      return text;
+    }
+    return text.substring(0, max) + "...";
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
@@ -40,7 +40,12 @@ import org.apache.commons.lang3.StringUtils;
  * <ul>
  *   <li>{@code virtual.sourceKind} — allow-listed adapter wire name (e.g. {@code git-filesystem});
  *       blank or {@code repository} ⇒ traditional repository Site
- *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root (required when virtual)
+ *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root when no remote is set
+ *       (required when virtual and {@code virtual.remoteUrl} is blank); when a remote is set,
+ *       an optional relative path inside the checkout
+ *   <li>{@code virtual.remoteUrl} — optional Git remote (https / ssh / file / {@code git@host:path});
+ *       blank keeps local-path {@code git-filesystem} behavior
+ *   <li>{@code virtual.branch} — optional ref to checkout; default {@code main}
  *   <li>{@code virtual.configFile} — optional; default {@code _config.yaml}; simple file name only
  *   <li>{@code virtual.siteKey} — optional participant key; default site name
  * </ul>
@@ -54,9 +59,14 @@ public final class PSVirtualSiteHelper {
   public static final String PROP_ROOT_PATH = "virtual.rootPath";
   public static final String PROP_CONFIG_FILE = "virtual.configFile";
   public static final String PROP_SITE_KEY = "virtual.siteKey";
+  public static final String PROP_REMOTE_URL = "virtual.remoteUrl";
+  public static final String PROP_BRANCH = "virtual.branch";
 
   /** Wire name for traditional repository-backed Sites. */
   public static final String SOURCE_KIND_REPOSITORY = "repository";
+
+  /** Default Git branch when {@link #PROP_BRANCH} is blank. */
+  public static final String DEFAULT_BRANCH = "main";
 
   private PSVirtualSiteHelper() {}
 
@@ -122,6 +132,38 @@ public final class PSVirtualSiteHelper {
   }
 
   /**
+   * Configured Git remote when {@link #PROP_REMOTE_URL} is non-blank.
+   *
+   * @param site may be null
+   * @return trimmed remote URL
+   */
+  public static Optional<String> remoteUrl(IPSSite site) {
+    return findProperty(site, PROP_REMOTE_URL).filter(StringUtils::isNotBlank);
+  }
+
+  /**
+   * Whether a Virtual Site is configured to fetch from a Git remote before discover.
+   *
+   * @param site may be null
+   * @return true when {@link #PROP_REMOTE_URL} is non-blank
+   */
+  public static boolean hasRemote(IPSSite site) {
+    return remoteUrl(site).isPresent();
+  }
+
+  /**
+   * Branch to checkout. Blank / missing {@link #PROP_BRANCH} ⇒ {@link #DEFAULT_BRANCH}.
+   *
+   * @param site may be null
+   * @return non-blank branch name
+   */
+  public static String branch(IPSSite site) {
+    return findProperty(site, PROP_BRANCH)
+        .filter(StringUtils::isNotBlank)
+        .orElse(DEFAULT_BRANCH);
+  }
+
+  /**
    * Validates the Virtual Site property contract.
    *
    * <p>Traditional repository Sites (missing/blank {@code virtual.sourceKind} or value {@code
@@ -129,9 +171,12 @@ public final class PSVirtualSiteHelper {
    *
    * <ul>
    *   <li>use an allow-listed {@code virtual.sourceKind} (see {@link #allowedSourceKindWireNames()})
-   *   <li>provide a non-blank {@code virtual.rootPath}
+   *   <li>when {@code virtual.remoteUrl} is blank: provide a non-blank safe {@code virtual.rootPath}
+   *   <li>when {@code virtual.remoteUrl} is set: a safe Git URL (https / ssh / file / {@code
+   *       git@host:path}); optional {@code virtual.branch}; optional relative {@code
+   *       virtual.rootPath} inside the checkout (no {@code ..}, not absolute)
    *   <li>use a safe root path after NIO {@link Path#normalize()} (no empty path; no remaining {@code
-   *       ..} segments)
+   *       ..} segments) when a local root is required
    *   <li>when set, use a simple {@code virtual.configFile} name (no directory separators or {@code
    *       ..})
    * </ul>
@@ -161,33 +206,128 @@ public final class PSVirtualSiteHelper {
               + " for traditional Sites).");
     }
 
-    Optional<String> rootRaw = findProperty(site, PROP_ROOT_PATH);
-    if (rootRaw.isEmpty()) {
-      throw new VirtualSiteException(
-          PROP_ROOT_PATH + " is required when " + PROP_SOURCE_KIND + " is '" + kind + "'.");
-    }
+    Optional<String> remoteRaw = remoteUrl(site);
+    if (remoteRaw.isPresent()) {
+      PSGitRemoteCheckout.requireSafeRemoteUrl(remoteRaw.get());
+      String branchRaw = findProperty(site, PROP_BRANCH).orElse("");
+      if (StringUtils.isNotBlank(branchRaw)) {
+        PSGitRemoteCheckout.requireSafeBranch(branchRaw);
+      }
+      Optional<String> rootRaw = findProperty(site, PROP_ROOT_PATH);
+      if (rootRaw.isPresent()) {
+        validateRemoteSubPath(rootRaw.get());
+      }
+    } else {
+      Optional<String> rootRaw = findProperty(site, PROP_ROOT_PATH);
+      if (rootRaw.isEmpty()) {
+        throw new VirtualSiteException(
+            PROP_ROOT_PATH
+                + " is required when "
+                + PROP_SOURCE_KIND
+                + " is '"
+                + kind
+                + "' and "
+                + PROP_REMOTE_URL
+                + " is blank.");
+      }
 
-    Path root;
-    try {
-      root = Path.of(rootRaw.get()).normalize();
-    } catch (InvalidPathException e) {
-      throw new VirtualSiteException(
-          PROP_ROOT_PATH + " is not a valid filesystem path: '" + rootRaw.get() + "'.", e);
-    }
+      Path root;
+      try {
+        root = Path.of(rootRaw.get()).normalize();
+      } catch (InvalidPathException e) {
+        throw new VirtualSiteException(
+            PROP_ROOT_PATH + " is not a valid filesystem path: '" + rootRaw.get() + "'.", e);
+      }
 
-    if (!isSafeRootPath(root)) {
-      throw new VirtualSiteException(
-          PROP_ROOT_PATH
-              + " must be a non-empty path with no '..' segments after normalize (cross-platform NIO"
-              + " Path). Rejected: '"
-              + rootRaw.get()
-              + "'.");
+      if (!isSafeRootPath(root)) {
+        throw new VirtualSiteException(
+            PROP_ROOT_PATH
+                + " must be a non-empty path with no '..' segments after normalize (cross-platform NIO"
+                + " Path). Rejected: '"
+                + rootRaw.get()
+                + "'.");
+      }
     }
 
     Optional<String> configRaw = findProperty(site, PROP_CONFIG_FILE);
     if (configRaw.isPresent()) {
       validateConfigFileName(configRaw.get());
     }
+  }
+
+  /**
+   * When a remote is configured, {@link #PROP_ROOT_PATH} is an optional relative path inside the
+   * checkout (for example {@code product-docs}). Absolute paths and remaining {@code ..} are
+   * rejected.
+   *
+   * @param raw property value, not blank
+   * @throws VirtualSiteException when the sub-path is unsafe
+   */
+  public static void validateRemoteSubPath(String raw) throws VirtualSiteException {
+    if (StringUtils.isBlank(raw)) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH + " must not be blank when set (omit it to use the checkout root).");
+    }
+    Path sub;
+    try {
+      sub = Path.of(raw.trim()).normalize();
+    } catch (InvalidPathException e) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH + " is not a valid filesystem path: '" + raw + "'.", e);
+    }
+    if (sub.isAbsolute() || raw.indexOf(':') >= 0) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH
+              + " must be a relative path inside the Git checkout when "
+              + PROP_REMOTE_URL
+              + " is set. Rejected absolute path.");
+    }
+    if (!isSafeRootPath(sub)) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH
+              + " must be a non-empty relative path with no '..' segments after normalize when "
+              + PROP_REMOTE_URL
+              + " is set. Rejected: '"
+              + raw
+              + "'.");
+    }
+  }
+
+  /**
+   * Discover root after an optional Git checkout.
+   *
+   * <p>When {@code checkoutRoot} is null, returns the local {@link #rootPath(IPSSite)}. When a
+   * checkout is supplied, returns that directory or a validated relative sub-path under it.
+   *
+   * @param site configured site
+   * @param checkoutRoot checkout work directory, or null for local-path mode
+   * @return discover root
+   * @throws VirtualSiteException when the path is missing or escapes the checkout
+   */
+  public static Path resolveDiscoverRoot(IPSSite site, Path checkoutRoot)
+      throws VirtualSiteException {
+    if (checkoutRoot == null) {
+      return rootPath(site)
+          .orElseThrow(
+              () ->
+                  new VirtualSiteException(
+                      PROP_ROOT_PATH + " is required when " + PROP_REMOTE_URL + " is blank."));
+    }
+    Path safeCheckout = checkoutRoot.normalize();
+    if (!isSafeRootPath(safeCheckout)) {
+      throw new VirtualSiteException("Git checkout work directory is not a safe path.");
+    }
+    Optional<String> raw = findProperty(site, PROP_ROOT_PATH);
+    if (raw.isEmpty()) {
+      return safeCheckout;
+    }
+    validateRemoteSubPath(raw.get());
+    Path resolved = safeCheckout.resolve(Path.of(raw.get().trim())).normalize();
+    if (!resolved.startsWith(safeCheckout)) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH + " escapes the Git checkout work directory.");
+    }
+    return resolved;
   }
 
   /**

--- a/system/src/test/java/com/percussion/services/virtualsite/PSGitRemoteCheckoutTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSGitRemoteCheckoutTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.sitemgr.data.PSSite;
+import com.percussion.services.sitemgr.data.PSSiteProperty;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+class PSGitRemoteCheckoutTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void rejectHttpAndTraversalAndOptionInjection() {
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSGitRemoteCheckout.requireSafeRemoteUrl("http://git.example.com/repo.git"));
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSGitRemoteCheckout.requireSafeRemoteUrl("https://git.example.com/../repo.git"));
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSGitRemoteCheckout.requireSafeRemoteUrl("-uhttps://git.example.com/repo.git"));
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSGitRemoteCheckout.requireSafeRemoteUrl("https://git.example.com/repo.git;rm -rf /"));
+    assertThrows(
+        VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeRemoteUrl("javascript:alert(1)"));
+    assertThrows(VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeRemoteUrl("   "));
+  }
+
+  @Test
+  void acceptHttpsSshFileAndScp() throws Exception {
+    assertEquals(
+        "https://git.example.com/org/repo.git",
+        PSGitRemoteCheckout.requireSafeRemoteUrl("https://git.example.com/org/repo.git"));
+    assertEquals(
+        "ssh://git@git.example.com/org/repo.git",
+        PSGitRemoteCheckout.requireSafeRemoteUrl("ssh://git@git.example.com/org/repo.git"));
+    assertEquals(
+        "git@git.example.com:org/repo.git",
+        PSGitRemoteCheckout.requireSafeRemoteUrl("git@git.example.com:org/repo.git"));
+    Path local = tempDir.resolve("fixture-repo");
+    Files.createDirectories(local);
+    String fileUrl = local.toUri().toString();
+    assertEquals(fileUrl, PSGitRemoteCheckout.requireSafeRemoteUrl(fileUrl));
+  }
+
+  @Test
+  void rejectUnsafeBranch() {
+    assertThrows(VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeBranch("-main"));
+    assertThrows(VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeBranch("feat/../x"));
+    assertThrows(VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeBranch("main;rm"));
+    assertThrows(VirtualSiteException.class, () -> PSGitRemoteCheckout.requireSafeBranch(""));
+  }
+
+  @Test
+  void acceptSafeBranch() throws Exception {
+    assertEquals("main", PSGitRemoteCheckout.requireSafeBranch("main"));
+    assertEquals("release/8.2", PSGitRemoteCheckout.requireSafeBranch("release/8.2"));
+  }
+
+  @Test
+  void redactStripsUserinfoAndNeverLeavesToken() {
+    String redacted =
+        PSGitRemoteCheckout.redact("https://user:super-secret@git.example.com/org/repo.git");
+    assertFalse(redacted.contains("super-secret"));
+    assertTrue(redacted.contains("***"));
+    assertTrue(redacted.contains("git.example.com"));
+    assertEquals(
+        "token=*** in log",
+        PSGitRemoteCheckout.redact("token=abc123 in log"));
+  }
+
+  @Test
+  void cloneUsesProcessBuilderSafeArgsAndContainedWorkDir() throws Exception {
+    List<List<String>> commands = new ArrayList<>();
+    PSGitRemoteCheckout checkout =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              commands.add(List.copyOf(command));
+              if (command.contains("clone")) {
+                Path dest = Path.of(command.get(command.size() - 1));
+                Files.createDirectories(dest.resolve(".git"));
+                Files.writeString(dest.resolve(".git").resolve("HEAD"), "ref: refs/heads/main");
+              }
+              return 0;
+            },
+            Duration.ofSeconds(5));
+
+    Path workBase = tempDir.resolve("checkouts");
+    Path discovered =
+        checkout.ensureCurrent(
+            "https://git.example.com/org/repo.git", "main", "Help Docs", workBase, null);
+
+    Path expected = workBase.resolve("Help_Docs");
+    assertEquals(expected.normalize(), discovered.normalize());
+    assertTrue(Files.isDirectory(expected.resolve(".git")));
+    assertEquals(1, commands.size());
+    List<String> clone = commands.get(0);
+    assertEquals("git", clone.get(0));
+    assertTrue(clone.contains("clone"));
+    assertTrue(clone.contains("--"));
+    int dash = clone.indexOf("--");
+    assertEquals("https://git.example.com/org/repo.git", clone.get(dash + 1));
+    assertFalse(clone.stream().anyMatch(a -> a.startsWith("-u") && a.length() > 2 && !a.equals("--")));
+    assertFalse(clone.contains(".."));
+  }
+
+  @Test
+  void fetchExistingWhenGitDirPresent() throws Exception {
+    Path workBase = tempDir.resolve("existing");
+    Path workDir = workBase.resolve("docs");
+    Files.createDirectories(workDir.resolve(".git"));
+    List<List<String>> commands = new ArrayList<>();
+    PSGitRemoteCheckout checkout =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              commands.add(List.copyOf(command));
+              if (command.contains("get-url")) {
+                output.append("https://git.example.com/org/repo.git");
+              }
+              return 0;
+            },
+            Duration.ofSeconds(5));
+
+    checkout.ensureCurrent(
+        "https://git.example.com/org/repo.git", "release/8.2", "docs", workBase, null);
+
+    assertTrue(commands.stream().anyMatch(c -> c.contains("fetch")));
+    assertTrue(commands.stream().anyMatch(c -> c.contains("checkout")));
+    assertTrue(
+        commands.stream()
+            .filter(c -> c.contains("fetch"))
+            .anyMatch(c -> c.contains("--") && c.contains("origin") && c.contains("release/8.2")));
+  }
+
+  @Test
+  void failClosedWhenExistingOriginDoesNotMatch() throws Exception {
+    Path workBase = tempDir.resolve("mismatch");
+    Path workDir = workBase.resolve("docs");
+    Files.createDirectories(workDir.resolve(".git"));
+    PSGitRemoteCheckout checkout =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              if (command.contains("get-url")) {
+                output.append("https://evil.example.com/other.git");
+              }
+              return 0;
+            },
+            Duration.ofSeconds(5));
+
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                checkout.ensureCurrent(
+                    "https://git.example.com/org/repo.git", "main", "docs", workBase, null));
+    assertTrue(ex.getMessage().toLowerCase().contains("origin"));
+    assertFalse(ex.getMessage().contains("evil.example.com"));
+  }
+
+  @Test
+  void resolveRelativeSubPathUnderCheckout() throws Exception {
+    List<List<String>> commands = new ArrayList<>();
+    PSGitRemoteCheckout checkout =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              commands.add(List.copyOf(command));
+              if (command.contains("clone")) {
+                Path dest = Path.of(command.get(command.size() - 1));
+                Files.createDirectories(dest.resolve(".git"));
+                Files.createDirectories(dest.resolve("product-docs"));
+              }
+              return 0;
+            },
+            Duration.ofSeconds(5));
+    PSSite site = siteWith(
+        prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+        prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/repo.git"),
+        prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"));
+
+    Path discovered =
+        checkout.ensureCurrent(
+            "https://git.example.com/org/repo.git", "main", "docs", tempDir.resolve("sub"), site);
+    assertTrue(discovered.endsWith(Path.of("product-docs")));
+    assertEquals(1, commands.size());
+  }
+
+  @Test
+  void neverLogsRawSecretInExceptionFromFailedClone() {
+    PSGitRemoteCheckout checkout =
+        new PSGitRemoteCheckout(
+            (cwd, command, output) -> {
+              output.append("fatal: could not read Username for 'https://user:hunter2@host/x.git'");
+              return 128;
+            },
+            Duration.ofSeconds(5));
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () ->
+                checkout.ensureCurrent(
+                    "https://git.example.com/org/repo.git",
+                    "main",
+                    "docs",
+                    tempDir.resolve("fail"),
+                    null));
+    assertFalse(ex.getMessage().contains("hunter2"));
+    assertTrue(ex.getMessage().contains("***") || ex.getMessage().contains("failed"));
+  }
+
+  @Test
+  @EnabledIf("gitAvailable")
+  void clonesLocalFileRemoteAndReusesFilesystemDiscover() throws Exception {
+    Path origin = createLocalGitRepo(tempDir.resolve("origin-repo"));
+    String fileUrl = origin.toUri().toString();
+    PSGitRemoteCheckout checkout = new PSGitRemoteCheckout();
+    Path workBase = tempDir.resolve("live-checkouts");
+    Path discovered = checkout.ensureCurrent(fileUrl, "main", "sample", workBase, null);
+
+    assertTrue(Files.isRegularFile(discovered.resolve("_config.yaml")));
+    assertTrue(Files.isRegularFile(discovered.resolve("8.2").resolve("index.md")));
+
+    PSGitFilesystemVirtualSiteSource source = new PSGitFilesystemVirtualSiteSource();
+    VirtualSiteConfig config = VirtualSiteConfigLoader.load(discovered, "_config.yaml", "sample");
+    assertFalse(source.discover(config).isEmpty());
+  }
+
+  static boolean gitAvailable() {
+    try {
+      Process process = new ProcessBuilder("git", "--version").start();
+      if (!process.waitFor(15, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return false;
+      }
+      return process.exitValue() == 0;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static Path createLocalGitRepo(Path origin) throws Exception {
+    Files.createDirectories(origin.resolve("_theme"));
+    Files.createDirectories(origin.resolve("8.2"));
+    Files.writeString(
+        origin.resolve("_config.yaml"),
+        """
+        site:
+          title: Remote Docs
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        origin.resolve("_theme").resolve("page.html"),
+        "<html><body>{{content}}</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        origin.resolve("8.2").resolve("index.md"),
+        """
+        ---
+        id: remote-home
+        title: Home
+        ---
+
+        Remote hello.
+        """,
+        StandardCharsets.UTF_8);
+    runGit(origin, "git", "init");
+    runGit(origin, "git", "config", "user.email", "virtual-site-test@example.com");
+    runGit(origin, "git", "config", "user.name", "Virtual Site Test");
+    runGit(origin, "git", "add", ".");
+    runGit(origin, "git", "commit", "-m", "init");
+    runGit(origin, "git", "checkout", "-B", "main");
+    return origin;
+  }
+
+  private static void runGit(Path cwd, String... command) throws Exception {
+    Process process = new ProcessBuilder(command).directory(cwd.toFile()).start();
+    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      throw new IllegalStateException("git timed out: " + String.join(" ", command));
+    }
+    if (process.exitValue() != 0) {
+      throw new IllegalStateException("git failed: " + String.join(" ", command));
+    }
+  }
+
+  private static PSSiteProperty prop(String name, String value) {
+    PSSiteProperty p = new PSSiteProperty();
+    p.setName(name);
+    p.setValue(value);
+    return p;
+  }
+
+  private static PSSite siteWith(PSSiteProperty... properties) {
+    PSSite site = Mockito.mock(PSSite.class);
+    Set<PSSiteProperty> props = new HashSet<>();
+    for (PSSiteProperty p : properties) {
+      props.add(p);
+    }
+    Mockito.when(site.getProperties()).thenReturn(props);
+    return site;
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
@@ -179,6 +179,84 @@ class PSVirtualSiteHelperTest {
   }
 
   @Test
+  void validatePassesForRemoteWithoutLocalRoot() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/docs/product-docs.git"),
+            prop(PSVirtualSiteHelper.PROP_BRANCH, "main"));
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(site));
+    assertTrue(PSVirtualSiteHelper.hasRemote(site));
+    assertEquals("main", PSVirtualSiteHelper.branch(site));
+  }
+
+  @Test
+  void validatePassesForRemoteWithRelativeSubPath() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/repo.git"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"));
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(site));
+  }
+
+  @Test
+  void validateRejectsUnsafeRemoteUrl() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "http://evil.example/../x"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_REMOTE_URL));
+    assertFalse(ex.getMessage().contains("http://evil.example"));
+  }
+
+  @Test
+  void validateRejectsAbsoluteRootWhenRemoteSet() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/repo.git"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "C:/docs/product-docs"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+    assertTrue(ex.getMessage().toLowerCase().contains("relative"));
+  }
+
+  @Test
+  void validateRejectsParentSegmentInRemoteSubPath() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/repo.git"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "../outside"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+  }
+
+  @Test
+  void branchDefaultsToMain() {
+    PSSite site = siteWith(prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"));
+    assertEquals(PSVirtualSiteHelper.DEFAULT_BRANCH, PSVirtualSiteHelper.branch(site));
+    assertEquals(PSVirtualSiteHelper.DEFAULT_BRANCH, PSVirtualSiteHelper.branch(null));
+  }
+
+  @Test
+  void resolveDiscoverRootUsesCheckoutAndRelativeSubPath() throws Exception {
+    Path checkout = Path.of("work", "docs-checkout").normalize();
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/repo.git"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"));
+    Path resolved = PSVirtualSiteHelper.resolveDiscoverRoot(site, checkout);
+    assertEquals(checkout.resolve("product-docs").normalize(), resolved);
+  }
+
+  @Test
   void validateRejectsBlankRootPathWhenVirtual() {
     PSSite site =
         siteWith(


### PR DESCRIPTION
## Summary

Parent epic: #2678. Slice: #3568.

Phase 1 `git-filesystem` Virtual Sites only read a local directory. This change adds optional **`virtual.remoteUrl`** + **`virtual.branch`** so Build can clone or fetch a remote Git branch into a contained NIO work directory, then reuse `PSGitFilesystemVirtualSiteSource` discover.

- Blank `remoteUrl` keeps existing local-path behavior (`virtual.rootPath` required).
- When a remote is set, `virtual.rootPath` is an optional **relative** sub-folder inside the checkout.
- Portable `ProcessBuilder` argument lists and `java.nio.file.Path` only (no hardcoded `/tmp`, no `"/" +` filesystem joins).
- Fail-closed on `http`, `..`, option injection, and shell metacharacters. Credentials / userinfo are redacted in logs and exceptions.
- Existing Developer → Sites PUT that omits `remoteUrl` does **not** wipe a stored remote. Send `"remoteUrl": ""` to clear.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3568
Parent: #2678

## Test plan

1. Configure a Virtual Site via `PUT /services/sites/{name}/virtual` with `{ "VirtualSiteProperties": { "sourceKind": "git-filesystem", "remoteUrl": "https://…", "branch": "main", "rootPath": "product-docs" } }`.
2. Confirm GET returns `remoteUrl` / `branch`.
3. As Admin, `POST /services/sites/{name}/virtual/build` — server clones/fetches into `{install}/tmp/virtual-site-checkouts/{siteKey}` (or JVM temp) and assembles from the checkout.
4. Confirm a Site with blank remote and a local `rootPath` still builds from that directory.
5. Confirm unsafe remotes (`http://…`, `..`, leading `-`) return **400** and do not log credentials.
6. Confirm `git` is on the CMS host `PATH` for remotes.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `developer/virtual-sites.md`, `developer/rest.md`, `reference/site-config.md`
- [x] **Unit / module tests** — `PSGitRemoteCheckoutTest`, helper validation, REST serial, `SitesAdaptor` persist/build
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; operators configure remotes via documented REST)
- [x] **Build gates** — standalone `clean install` on `system`, `rest`, `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — NIO `Path` + `ProcessBuilder` lists; work dir under rxDir tmp or `java.io.tmpdir`

### C3 evidence

- **modules_built:** `system`, `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2168, Failures: 0, Errors: 0, Skipped: 238. New: `PSGitRemoteCheckoutTest` Tests run: 11, Failures: 0; `PSVirtualSiteHelperTest` Tests run: 27, Failures: 0, Skipped: 1.
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 535, Failures: 0. `VirtualSitePropertiesSerialDeserialTest` Tests run: 5, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1253, Failures: 0, Skipped: 125. `SitesAdaptorTest` Tests run: 40, Failures: 0.
  - No new compiler warnings attributable to this change (baseline javadoc/analyze warnings only).
- **downstream_checked:** grep `extends VirtualSiteProperties` / `new VirtualSiteProperties() {` — none. Additive getters/setters only (no `final`/removed signatures). Reverse-dep `projects/sitemanage` standalone clean install green against the new `system` + `rest` SNAPSHOTs.

### C5 UI proof

N/A — no WebUI / Playwright surface in this slice.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
