### PR TITLE
feat(virtualsite): assembled-page heading TOC (#3569)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3569-assembled-page-heading-toc-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3569-assembled-page-heading-toc-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #3569 assembled-page heading TOC
+
+- **Branch:** `feat/issue-3569-assembled-page-heading-toc`
+- **Scope:** uncommitted vs `HEAD` (Virtual Site heading TOC + product-docs theme)
+- **Reviewer:** Erlang (independent of implementer)
+- **Date:** 2026-08-18
+- **Memory patterns hit:** behavioral unit tests; change-class closure; portable Path/Files; XSS/escape of generated HTML; product-docs companion
+
+## Summary
+
+Adds h2–h3 TOC generation from assembled Markdown HTML (`PSVirtualSiteHeadingToc`), binds `${toc}` in `PSVirtualSiteLayoutRenderer` (theme + built-in default layout), annotates headings with stable fragment ids, and documents the placeholder under `product-docs/`. Tests cover empty/safe, nesting, id stability/collision, unsafe-id replacement, HTML escape of labels, renderer bind, and the sample-docs build fixture.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No hard-gate bugs found. Change-class companions are present (helper + renderer bind + theme + CSS + product-docs + unit/integration tests). No new filesystem path construction. C2 (API shape) does not apply: existing `render(...)` signature is unchanged; new type is additive.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Tests use `Path` / `Files` / `@TempDir`
+- [x] No Unix-only absolute path assertions
+- [x] N/A: no new scripts, temp roots, or path-separator lists
+
+## Issues
+
+None (hard-gate).
+
+### Low / nits (non-blocking)
+
+- `PSVirtualSiteHeadingToc` calls package-private `PSVirtualSiteLayoutRenderer.htmlEscape`. Same package; acceptable. A shared escape helper would be slightly cleaner if a third caller appears.
+- Default-layout empty-TOC path is covered via theme placeholder test + helper empty tests, not a dedicated default-layout assertion. Sufficient.
+
+## Tests exercised (focused)
+
+`PSVirtualSiteHeadingTocTest` (9), `PSVirtualSiteLayoutRendererTest` (4), `PSVirtualSiteBuildServiceTest` (8) — 21/0/0 before module clean install.
+
+## Re-review
+
+Product-docs prose that used literal `${toc}` / `${content}` was emptied by `PSTextAssemblerSupport.renderMarkdown(..., Map.of())`. Tokens in Markdown are now written as `&#36;{name}` so assembled help still shows the placeholder names. Theme HTML still uses real `${toc}`. Not a code bug; docs-only fix. Gate unchanged.

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -46,6 +46,7 @@ product-docs/
 - Folder structure drives navigation hierarchy.
 - `index.md` is the landing page for a section.
 - One top-level folder per documentation version (for example `8.2/`).
+- Assembled pages bind theme placeholders including <code>&#36;{toc}</code> (h2–h3 heading TOC). See [Site configuration](id:reference-site-config).
 
 ## Stable identity
 

--- a/product-docs/8.2/reference/frontmatter.md
+++ b/product-docs/8.2/reference/frontmatter.md
@@ -55,6 +55,8 @@ Use stable id links in Markdown bodies:
 
 Relative `.md` links also work and are rewritten to site-root HTML paths during build.
 
+Assembled HTML also gets stable fragment ids on **h2** and **h3** headings (from `##` / `###` in Markdown). The built-in theme binds <code>&#36;{toc}</code> to an on-this-page list of those headings. See [Site configuration](id:reference-site-config).
+
 ## Related
 
 - [Site configuration](id:reference-site-config)

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -45,6 +45,32 @@ theme:
 - `theme.layout` is relative to `_theme/` (default `page.html`).
 - `nav[].id` values should match section landing page frontmatter `id`s.
 
+### Theme placeholders (`_theme/page.html`)
+
+The assembler binds dollar-brace placeholders (HTML-first, ADR-002) when it applies the
+layout. Write these tokens in `_theme` HTML only — the same syntax in Markdown bodies is
+substituted (missing bindings become empty).
+
+| Placeholder | Value |
+|-------------|--------|
+| <code>&#36;{siteTitle}</code> | Site title from `_config.yaml` |
+| <code>&#36;{pageTitle}</code> | Page frontmatter `title` |
+| <code>&#36;{description}</code> | Page frontmatter `description` (empty when omitted) |
+| <code>&#36;{content}</code> | Assembled Markdown HTML. h2–h3 headings receive stable `id` attributes for fragment links. |
+| <code>&#36;{nav}</code> | Site sidebar navigation HTML |
+| <code>&#36;{toc}</code> | In-page table of contents from that page’s h2–h3 headings. Empty when the page has none (no leftover token). |
+| <code>&#36;{versionLabel}</code> | Current version label |
+| <code>&#36;{versionSwitcher}</code> | Version `<select>` HTML when the site has more than one version; otherwise empty |
+
+<code>&#36;{toc}</code> is a `<nav class="vs-toc" aria-label="On this page">` list of links
+to `#heading-id`. Heading ids are derived from heading text (lowercase, hyphenated). Existing
+safe `id` values on headings are kept. Duplicate titles get a numeric suffix (`install`,
+`install-1`). Built-in theme `product-docs/_theme/page.html` includes <code>&#36;{toc}</code>
+above the article.
+
+Custom layouts may omit <code>&#36;{toc}</code>; heading ids are still written into
+<code>&#36;{content}</code>.
+
 ## CMS Site properties (Virtual)
 
 When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` columns):

--- a/product-docs/_theme/page.html
+++ b/product-docs/_theme/page.html
@@ -18,6 +18,7 @@
     </nav>
     <main class="content">
       <p class="version-label">${versionLabel}</p>
+      ${toc}
       <article>
         ${content}
       </article>

--- a/product-docs/assets/site.css
+++ b/product-docs/assets/site.css
@@ -79,6 +79,32 @@ article h1:first-child {
   margin-top: 0;
 }
 
+.vs-toc {
+  margin: 0 0 1.25rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-size: 0.875rem;
+}
+
+.vs-toc ol {
+  margin: 0.25rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.vs-toc > ol {
+  margin-top: 0;
+}
+
+.vs-toc a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.vs-toc a:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 800px) {
   .layout {
     grid-template-columns: 1fr;

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHeadingToc.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHeadingToc.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Builds an in-page heading TOC (h2–h3) from assembled Markdown HTML and assigns stable fragment
+ * ids when a heading does not already have a safe {@code id}.
+ */
+public final class PSVirtualSiteHeadingToc {
+
+  private static final Pattern SAFE_ID = Pattern.compile("[A-Za-z][A-Za-z0-9._:-]*");
+
+  private PSVirtualSiteHeadingToc() {}
+
+  /**
+   * Annotates h2/h3 headings with fragment ids and builds a {@code ${toc}} HTML fragment.
+   *
+   * @param contentHtml assembled page body (CommonMark HTML fragment); may be null
+   * @return annotated content plus TOC HTML (empty string when there are no h2/h3 headings)
+   */
+  public static Result build(String contentHtml) {
+    if (contentHtml == null || contentHtml.isBlank()) {
+      return new Result(contentHtml == null ? "" : contentHtml, "");
+    }
+    Document doc = Jsoup.parseBodyFragment(contentHtml);
+    doc.outputSettings().prettyPrint(false);
+    Elements headings = doc.body().select("h2, h3");
+    if (headings.isEmpty()) {
+      return new Result(contentHtml, "");
+    }
+
+    Set<String> usedIds = new LinkedHashSet<>();
+    List<Heading> collected = new ArrayList<>();
+    for (Element heading : headings) {
+      String text = heading.text().trim();
+      String id = resolveId(heading.id(), text, usedIds);
+      heading.attr("id", id);
+      collected.add(new Heading("h3".equalsIgnoreCase(heading.tagName()) ? 3 : 2, id, text));
+    }
+    return new Result(doc.body().html(), renderToc(collected));
+  }
+
+  static String slugify(String text) {
+    if (text == null || text.isBlank()) {
+      return "section";
+    }
+    String normalized = Normalizer.normalize(text, Normalizer.Form.NFKD);
+    StringBuilder sb = new StringBuilder(normalized.length());
+    boolean pendingHyphen = false;
+    for (int i = 0; i < normalized.length(); i++) {
+      char c = normalized.charAt(i);
+      if (Character.getType(c) == Character.NON_SPACING_MARK) {
+        continue;
+      }
+      if (Character.isLetterOrDigit(c)) {
+        if (pendingHyphen && sb.length() > 0) {
+          sb.append('-');
+        }
+        sb.append(Character.toLowerCase(c));
+        pendingHyphen = false;
+      } else if (c == '_' || c == '-' || Character.isWhitespace(c)) {
+        pendingHyphen = sb.length() > 0;
+      }
+    }
+    return sb.length() == 0 ? "section" : sb.toString();
+  }
+
+  private static String resolveId(String existing, String text, Set<String> usedIds) {
+    String candidate = existing != null ? existing.trim() : "";
+    if (!SAFE_ID.matcher(candidate).matches()) {
+      candidate = slugify(text);
+    }
+    return uniquify(candidate, usedIds);
+  }
+
+  private static String uniquify(String base, Set<String> usedIds) {
+    String id = base;
+    int n = 1;
+    while (usedIds.contains(id.toLowerCase(Locale.ROOT))) {
+      id = base + "-" + n;
+      n++;
+    }
+    usedIds.add(id.toLowerCase(Locale.ROOT));
+    return id;
+  }
+
+  private static String renderToc(List<Heading> headings) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("<nav class=\"vs-toc\" aria-label=\"On this page\">\n<ol>\n");
+    boolean openH2 = false;
+    boolean openH3List = false;
+    for (Heading heading : headings) {
+      if (heading.level == 2) {
+        if (openH3List) {
+          sb.append("</ol>\n");
+          openH3List = false;
+        }
+        if (openH2) {
+          sb.append("</li>\n");
+        }
+        appendLinkItem(sb, heading, false);
+        openH2 = true;
+      } else if (!openH2) {
+        appendLinkItem(sb, heading, true);
+      } else {
+        if (!openH3List) {
+          sb.append("\n<ol>\n");
+          openH3List = true;
+        }
+        appendLinkItem(sb, heading, true);
+      }
+    }
+    if (openH3List) {
+      sb.append("</ol>\n");
+    }
+    if (openH2) {
+      sb.append("</li>\n");
+    }
+    sb.append("</ol>\n</nav>\n");
+    return sb.toString();
+  }
+
+  private static void appendLinkItem(StringBuilder sb, Heading heading, boolean close) {
+    sb.append("<li><a href=\"#")
+        .append(PSVirtualSiteLayoutRenderer.htmlEscape(heading.id))
+        .append("\">")
+        .append(PSVirtualSiteLayoutRenderer.htmlEscape(heading.text))
+        .append("</a>");
+    if (close) {
+      sb.append("</li>\n");
+    }
+  }
+
+  /**
+   * TOC generation result.
+   *
+   * @param contentHtml page body with stable heading ids (or the original fragment when none)
+   * @param tocHtml {@code <nav class="vs-toc">} fragment, or empty when there are no h2/h3 headings
+   */
+  public record Result(String contentHtml, String tocHtml) {
+    public Result {
+      contentHtml = contentHtml != null ? contentHtml : "";
+      tocHtml = tocHtml != null ? tocHtml : "";
+    }
+
+    public boolean isEmpty() {
+      return tocHtml.isBlank();
+    }
+  }
+
+  private record Heading(int level, String id, String text) {}
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteLayoutRenderer.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteLayoutRenderer.java
@@ -44,19 +44,28 @@ public final class PSVirtualSiteLayoutRenderer {
       String versionLabel,
       String versionSwitcherHtml)
       throws IOException, VirtualSiteException {
+    PSVirtualSiteHeadingToc.Result toc = PSVirtualSiteHeadingToc.build(contentHtml);
     Path layout = themeDir.resolve(layoutFile);
     if (!Files.isRegularFile(layout)) {
       // Built-in minimal layout when theme missing
       return defaultLayout(
-          siteTitle, pageTitle, description, contentHtml, navHtml, versionLabel, versionSwitcherHtml);
+          siteTitle,
+          pageTitle,
+          description,
+          toc.contentHtml(),
+          navHtml,
+          toc.tocHtml(),
+          versionLabel,
+          versionSwitcherHtml);
     }
     String template = Files.readString(layout, StandardCharsets.UTF_8);
     Map<String, Object> bindings = new HashMap<>();
     bindings.put("siteTitle", siteTitle);
     bindings.put("pageTitle", pageTitle);
     bindings.put("description", description != null ? description : "");
-    bindings.put("content", contentHtml);
+    bindings.put("content", toc.contentHtml());
     bindings.put("nav", navHtml);
+    bindings.put("toc", toc.tocHtml());
     bindings.put("versionLabel", versionLabel != null ? versionLabel : "");
     bindings.put("versionSwitcher", versionSwitcherHtml != null ? versionSwitcherHtml : "");
     return PSBindingPlaceholderRenderer.render(template, bindings);
@@ -120,6 +129,7 @@ public final class PSVirtualSiteLayoutRenderer {
       String description,
       String contentHtml,
       String navHtml,
+      String tocHtml,
       String versionLabel,
       String versionSwitcherHtml) {
     return "<!DOCTYPE html>\n"
@@ -153,6 +163,7 @@ public final class PSVirtualSiteLayoutRenderer {
         + "<h1>"
         + htmlEscape(pageTitle)
         + "</h1>\n"
+        + (tocHtml != null ? tocHtml : "")
         + contentHtml
         + "\n</main>\n"
         + "</div>\n"

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -59,6 +59,11 @@ class PSVirtualSiteBuildServiceTest {
     assertTrue(html.contains("/8.2/getting-started/index.html"), html);
     assertFalse(html.contains("getting-started/index.md"), html);
     assertTrue(html.contains("href=\"/8.2/getting-started/install.html\""), html);
+    assertTrue(html.contains("class=\"vs-toc\""), html);
+    assertTrue(html.contains("id=\"sample-overview\""), html);
+    assertTrue(html.contains("href=\"#sample-overview\""), html);
+    assertTrue(html.contains("id=\"sample-details\""), html);
+    assertTrue(html.contains("href=\"#sample-details\""), html);
 
     Path install = out.resolve("8.2").resolve("getting-started").resolve("install.html");
     assertTrue(Files.isRegularFile(install));

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHeadingTocTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHeadingTocTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class PSVirtualSiteHeadingTocTest {
+
+  @Test
+  void emptyOrBlankContentYieldsEmptyToc() {
+    assertTrue(PSVirtualSiteHeadingToc.build(null).isEmpty());
+    assertEquals("", PSVirtualSiteHeadingToc.build(null).contentHtml());
+    assertTrue(PSVirtualSiteHeadingToc.build("").isEmpty());
+    assertEquals("", PSVirtualSiteHeadingToc.build("").contentHtml());
+    assertTrue(PSVirtualSiteHeadingToc.build("   ").isEmpty());
+  }
+
+  @Test
+  void noHeadingsOrH1OnlyYieldsEmptyTocAndUnchangedContent() {
+    String para = "<p>No headings here.</p>";
+    PSVirtualSiteHeadingToc.Result noHeadings = PSVirtualSiteHeadingToc.build(para);
+    assertTrue(noHeadings.isEmpty());
+    assertEquals("", noHeadings.tocHtml());
+    assertEquals(para, noHeadings.contentHtml());
+
+    String h1Only = "<h1>Page title</h1><p>Body</p>";
+    PSVirtualSiteHeadingToc.Result h1 = PSVirtualSiteHeadingToc.build(h1Only);
+    assertTrue(h1.isEmpty());
+    assertEquals(h1Only, h1.contentHtml());
+  }
+
+  @Test
+  void h2AndH3GetStableIdsAndNestedToc() {
+    String html =
+        "<h2>Overview</h2><p>A</p><h3>Details</h3><p>B</p><h2>Next steps</h2><p>C</p>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertFalse(result.isEmpty());
+    assertTrue(result.contentHtml().contains("id=\"overview\""), result.contentHtml());
+    assertTrue(result.contentHtml().contains("id=\"details\""), result.contentHtml());
+    assertTrue(result.contentHtml().contains("id=\"next-steps\""), result.contentHtml());
+
+    String toc = result.tocHtml();
+    assertTrue(toc.contains("class=\"vs-toc\""), toc);
+    assertTrue(toc.contains("aria-label=\"On this page\""), toc);
+    assertTrue(toc.contains("href=\"#overview\""), toc);
+    assertTrue(toc.contains("href=\"#details\""), toc);
+    assertTrue(toc.contains("href=\"#next-steps\""), toc);
+    assertTrue(toc.contains(">Overview</a>"), toc);
+    assertTrue(toc.contains(">Details</a>"), toc);
+    int overview = toc.indexOf("href=\"#overview\"");
+    int innerOl = toc.indexOf("<ol>", overview + 1);
+    int details = toc.indexOf("href=\"#details\"");
+    int next = toc.indexOf("href=\"#next-steps\"");
+    assertTrue(overview >= 0 && innerOl > overview && details > innerOl && next > details, toc);
+  }
+
+  @Test
+  void existingSafeIdsArePreserved() {
+    String html = "<h2 id=\"custom-id\">Overview</h2><h3>Notes</h3>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertTrue(result.contentHtml().contains("id=\"custom-id\""), result.contentHtml());
+    assertTrue(result.tocHtml().contains("href=\"#custom-id\""), result.tocHtml());
+    assertTrue(result.tocHtml().contains("href=\"#notes\""), result.tocHtml());
+  }
+
+  @Test
+  void duplicateTitlesGetUniqueSuffixes() {
+    String html = "<h2>Install</h2><h2>Install</h2><h3>Install</h3>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertTrue(result.contentHtml().contains("id=\"install\""), result.contentHtml());
+    assertTrue(result.contentHtml().contains("id=\"install-1\""), result.contentHtml());
+    assertTrue(result.contentHtml().contains("id=\"install-2\""), result.contentHtml());
+    assertTrue(result.tocHtml().contains("href=\"#install\""), result.tocHtml());
+    assertTrue(result.tocHtml().contains("href=\"#install-1\""), result.tocHtml());
+    assertTrue(result.tocHtml().contains("href=\"#install-2\""), result.tocHtml());
+  }
+
+  @Test
+  void unsafeExistingIdIsReplacedWithSlug() {
+    String html = "<h2 id=\"bad id\">Safe Title</h2>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertFalse(result.contentHtml().contains("id=\"bad id\""), result.contentHtml());
+    assertTrue(result.contentHtml().contains("id=\"safe-title\""), result.contentHtml());
+    assertTrue(result.tocHtml().contains("href=\"#safe-title\""), result.tocHtml());
+  }
+
+  @Test
+  void slugifyIsStableAndSafe() {
+    assertEquals("hello-world", PSVirtualSiteHeadingToc.slugify("Hello World"));
+    assertEquals("cafe", PSVirtualSiteHeadingToc.slugify("Café"));
+    assertEquals("section", PSVirtualSiteHeadingToc.slugify("   "));
+    assertEquals("section", PSVirtualSiteHeadingToc.slugify("***"));
+    assertEquals("a-b", PSVirtualSiteHeadingToc.slugify("A  --  B"));
+  }
+
+  @Test
+  void tocLabelsAreHtmlEscaped() {
+    String html = "<h2>Use &lt;script&gt; tags</h2>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertTrue(result.tocHtml().contains("&lt;script&gt;"), result.tocHtml());
+    assertFalse(result.tocHtml().contains("<script>"), result.tocHtml());
+  }
+
+  @Test
+  void orphanH3IsEmittedAsTopLevel() {
+    String html = "<h3>Only three</h3>";
+    PSVirtualSiteHeadingToc.Result result = PSVirtualSiteHeadingToc.build(html);
+    assertFalse(result.isEmpty());
+    assertTrue(result.contentHtml().contains("id=\"only-three\""), result.contentHtml());
+    assertTrue(result.tocHtml().contains("href=\"#only-three\""), result.tocHtml());
+    assertTrue(result.tocHtml().contains("<li><a href=\"#only-three\">Only three</a></li>"), result.tocHtml());
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteLayoutRendererTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteLayoutRendererTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PSVirtualSiteLayoutRendererTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void themeBindsTocAndAnnotatesHeadingIds() throws Exception {
+    Path theme = tempDir.resolve("theme");
+    Files.createDirectories(theme);
+    Files.writeString(
+        theme.resolve("page.html"),
+        "<html><body>${toc}<article>${content}</article></body></html>",
+        StandardCharsets.UTF_8);
+
+    String html =
+        PSVirtualSiteLayoutRenderer.render(
+            theme,
+            "page.html",
+            "Docs",
+            "Page",
+            "desc",
+            "<h2>Overview</h2><p>Body</p>",
+            "<ul></ul>",
+            "8.2",
+            "");
+
+    assertTrue(html.contains("class=\"vs-toc\""), html);
+    assertTrue(html.contains("href=\"#overview\""), html);
+    assertTrue(html.contains("id=\"overview\""), html);
+    assertTrue(html.contains("<article>"), html);
+    assertTrue(html.contains("Overview"), html);
+  }
+
+  @Test
+  void missingThemeUsesDefaultLayoutWithToc() throws Exception {
+    String html =
+        PSVirtualSiteLayoutRenderer.render(
+            tempDir.resolve("missing-theme"),
+            "page.html",
+            "Docs",
+            "Page",
+            "desc",
+            "<h2>Overview</h2>",
+            "<ul class=\"vs-nav\"></ul>",
+            "8.2",
+            "");
+    assertTrue(html.contains("class=\"vs-toc\""), html);
+    assertTrue(html.contains("id=\"overview\""), html);
+    assertTrue(html.contains("Docs"), html);
+  }
+
+  @Test
+  void noHeadingsLeavesTocPlaceholderEmpty() throws Exception {
+    Path theme = tempDir.resolve("empty-toc");
+    Files.createDirectories(theme);
+    Files.writeString(
+        theme.resolve("page.html"),
+        "START${toc}END<article>${content}</article>",
+        StandardCharsets.UTF_8);
+
+    String html =
+        PSVirtualSiteLayoutRenderer.render(
+            theme,
+            "page.html",
+            "Docs",
+            "Page",
+            "",
+            "<p>Plain paragraph.</p>",
+            "",
+            "",
+            "");
+
+    assertTrue(html.contains("STARTEND"), html);
+    assertFalse(html.contains("vs-toc"), html);
+    assertTrue(html.contains("<p>Plain paragraph.</p>"), html);
+  }
+
+  @Test
+  void renderNavHtmlEscapesTitlesAndHrefs() {
+    VirtualNavNode child =
+        new VirtualNavNode("Child <x>", "c", "/8.2/child.html", 20, List.of());
+    VirtualNavNode root = new VirtualNavNode("Root", "r", "/8.2/index.html", 10, List.of(child));
+    String nav = PSVirtualSiteLayoutRenderer.renderNavHtml(List.of(root));
+    assertTrue(nav.contains("Child &lt;x&gt;"), nav);
+    assertTrue(nav.contains("href=\"/8.2/child.html\""), nav);
+    assertFalse(nav.contains("<x>"), nav);
+  }
+}

--- a/system/src/test/resources/virtualsite/sample-docs/8.2/index.md
+++ b/system/src/test/resources/virtualsite/sample-docs/8.2/index.md
@@ -10,4 +10,10 @@ order: 0
 
 This is the sample documentation home page for Virtual Site builds.
 
+## Sample overview
+
 See [Getting Started](getting-started/index.md) or jump by id: [Install](id:install-overview).
+
+### Sample details
+
+Heading ids on this page are used to verify the assembled-page TOC.

--- a/system/src/test/resources/virtualsite/sample-docs/_theme/page.html
+++ b/system/src/test/resources/virtualsite/sample-docs/_theme/page.html
@@ -11,6 +11,7 @@
 <nav>${nav}</nav>
 <main>
 <p class="version">${versionLabel}</p>
+${toc}
 <article>
 ${content}
 </article>


### PR DESCRIPTION
## Summary

Parent: #2678 (Virtual Sites & Git-backed documentation). Slice #3569 — assembled-page heading TOC (spec §9 leftover).

Virtual Site assembly already bound nav and the version switcher, but not an in-page table of contents. This change:

- Generates an **h2–h3 TOC** from assembled Markdown HTML (`PSVirtualSiteHeadingToc`)
- Assigns **stable fragment ids** (slug from heading text; existing safe `id` kept; duplicates get `-1`, `-2`)
- Binds **`${toc}`** in `PSVirtualSiteLayoutRenderer` (theme + built-in default layout)
- Is **empty/safe** when the page has no h2/h3 headings
- Adds `${toc}` to `product-docs/_theme/page.html` and documents the placeholder on the 8.2 site-config / Virtual Sites / frontmatter pages

Does **not** add git remote fetch or `_redirects.yaml` (sibling slices).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3569

## Test plan

1. `cd system && ../mvnw.cmd clean install` — compile + Surefire green.
2. Unit: `PSVirtualSiteHeadingTocTest` (empty/h1-only, nested h2/h3, id stability, unsafe id, escape), `PSVirtualSiteLayoutRendererTest` (`${toc}` bind + default layout), `PSVirtualSiteBuildServiceTest` sample fixture TOC ids.
3. `scripts\ci-smoke-product-docs.bat` — 23 pages; assembled pages with headings include `<nav class="vs-toc">`.
4. Open an assembled page with `##` / `###` headings and confirm TOC links jump to those headings; a page with only `#` / paragraphs has no TOC nav.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/reference/site-config.md` (theme placeholders, `${toc}`), `product-docs/8.2/developer/virtual-sites.md`, `product-docs/8.2/reference/frontmatter.md`; theme `product-docs/_theme/page.html` + `assets/site.css`
- [x] **Unit / module tests** — new HeadingToc + LayoutRenderer tests; sample-docs fixture; `system` standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change; static Virtual Site / product-docs theme only)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` **BUILD SUCCESS**; C2 N/A (existing `render(...)` signature unchanged; new helper is additive)
- [x] **Cross-platform** — no new filesystem path joins; tests use `Path` / `Files` / `@TempDir`

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-18). Tests run: **2215**, Failures: **0**, Errors: **0**, Skipped: 241. Focused: `PSVirtualSiteHeadingTocTest` 9, `PSVirtualSiteLayoutRendererTest` 4, `PSVirtualSiteBuildServiceTest` 8. Product-docs smoke: `scripts\ci-smoke-product-docs.bat` OK (23 pages).
- **downstream_checked:** none (C2 did not apply — no `final`/`sealed` change, no existing public/protected signature change). Grep: no `extends PSVirtualSiteLayoutRenderer` / anonymous subclass.

### C5 UI proof

N/A — not a WebUI SPA/Explorer screen. Assembled static docs verified via unit tests + `ci-smoke-product-docs`.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
