### PR TITLE
feat(WebUI): Developer Sites remote URL and branch fields (#3573)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -347,6 +347,8 @@ export function parseVirtualSiteProperties(payload: unknown): VirtualSitePropert
   return {
     sourceKind: asNullableString(root.sourceKind),
     rootPath: asNullableString(root.rootPath),
+    remoteUrl: asNullableString(root.remoteUrl),
+    branch: asNullableString(root.branch),
     configFile: asNullableString(root.configFile),
     siteKey: asNullableString(root.siteKey),
     virtual: typeof root.virtual === "boolean" ? root.virtual : undefined,
@@ -363,13 +365,23 @@ export function parseVirtualSiteProperties(payload: unknown): VirtualSitePropert
 export function toVirtualSitePropertiesEnvelope(
   props: VirtualSiteProperties,
 ): { VirtualSiteProperties: Record<string, string | null> } {
+  const body: Record<string, string | null> = {
+    sourceKind: props.sourceKind ?? null,
+    rootPath: props.rootPath ?? null,
+    configFile: props.configFile ?? null,
+    siteKey: props.siteKey ?? null,
+  };
+  // Omit when undefined so older create/save callers (no remote) stay
+  // compatible with servers that do not yet declare the properties.
+  // Empty string is intentional: #3568 treats "" as clear, null/omit as keep.
+  if (props.remoteUrl !== undefined) {
+    body.remoteUrl = props.remoteUrl;
+  }
+  if (props.branch !== undefined) {
+    body.branch = props.branch;
+  }
   return {
-    VirtualSiteProperties: {
-      sourceKind: props.sourceKind ?? null,
-      rootPath: props.rootPath ?? null,
-      configFile: props.configFile ?? null,
-      siteKey: props.siteKey ?? null,
-    },
+    VirtualSiteProperties: body,
   };
 }
 

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -731,6 +731,13 @@ export interface SiteDef {
 export interface VirtualSiteProperties {
   sourceKind?: string | null;
   rootPath?: string | null;
+  /**
+   * Optional Git remote ({@code virtual.remoteUrl}). When set, Build clones or
+   * fetches before discover (#3568). Blank keeps local {@code rootPath}.
+   */
+  remoteUrl?: string | null;
+  /** Optional Git branch when {@code remoteUrl} is set (default {@code main}). */
+  branch?: string | null;
   configFile?: string | null;
   siteKey?: string | null;
   /** Read-only on responses; ignored on write. */

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -422,6 +422,42 @@ export function VirtualSiteSourcePanel({
                 />
               </div>
               <div style={formRow}>
+                <label htmlFor="site-virt-remote-url">{DEV_MSG.SITE_VIRT_REMOTE_URL}</label>
+                <input
+                  id="site-virt-remote-url"
+                  data-testid="developer-site-virtual-remote-url"
+                  type="text"
+                  value={form.remoteUrl}
+                  onChange={(e) => setForm((prev) => ({ ...prev, remoteUrl: e.target.value }))}
+                  style={inputStyle}
+                  placeholder="https://git.example.com/org/docs.git"
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={busy}
+                />
+              </div>
+              <div style={formRow}>
+                <label htmlFor="site-virt-branch">{DEV_MSG.SITE_VIRT_BRANCH}</label>
+                <input
+                  id="site-virt-branch"
+                  data-testid="developer-site-virtual-branch"
+                  type="text"
+                  value={form.branch}
+                  onChange={(e) => setForm((prev) => ({ ...prev, branch: e.target.value }))}
+                  style={inputStyle}
+                  placeholder="main"
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={busy}
+                />
+              </div>
+              <p
+                style={{ ...mutedHintText, margin: "0 0 10px" }}
+                data-testid="developer-site-virtual-remote-hint"
+              >
+                {DEV_MSG.SITE_VIRT_REMOTE_HINT}
+              </p>
+              <div style={formRow}>
                 <label htmlFor="site-virt-config-file">{DEV_MSG.SITE_VIRT_CONFIG_FILE}</label>
                 <input
                   id="site-virt-config-file"

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -760,6 +760,10 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_RETRY: "perc.ui.developer@Retry",
   SITE_VIRT_SOURCE_KIND: "perc.ui.developer@Source kind",
   SITE_VIRT_ROOT_PATH: "perc.ui.developer@Root path",
+  SITE_VIRT_REMOTE_URL: "perc.ui.developer@Remote URL",
+  SITE_VIRT_BRANCH: "perc.ui.developer@Branch",
+  SITE_VIRT_REMOTE_HINT:
+    "perc.ui.developer@Optional Git remote. Leave blank to keep the local root path. When set, Build clones or fetches on the CMS host (https://, ssh://, file://, or git@host:path). Branch defaults to main. The server validates the URL.",
   SITE_VIRT_CONFIG_FILE: "perc.ui.developer@Config file",
   SITE_VIRT_SITE_KEY: "perc.ui.developer@Site key",
   SITE_VIRT_KIND_REPOSITORY: "perc.ui.developer@Repository (traditional)",

--- a/WebUI/src/main/ts/developer/virtualSiteForm.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteForm.ts
@@ -32,6 +32,8 @@ export type VirtualSourceKindOption =
 export interface VirtualSiteFormModel {
   sourceKind: VirtualSourceKindOption;
   rootPath: string;
+  remoteUrl: string;
+  branch: string;
   configFile: string;
   siteKey: string;
 }
@@ -72,6 +74,8 @@ export function virtualPropsToForm(
   return {
     sourceKind: normalizeSourceKindOption(asOptionalString(props?.sourceKind)),
     rootPath: asOptionalString(props?.rootPath) ?? "",
+    remoteUrl: asOptionalString(props?.remoteUrl) ?? "",
+    branch: asOptionalString(props?.branch) ?? "",
     configFile: asOptionalString(props?.configFile) ?? "",
     siteKey: asOptionalString(props?.siteKey) ?? "",
   };
@@ -94,6 +98,10 @@ export function formToVirtualProps(form: VirtualSiteFormModel): VirtualSitePrope
   return {
     sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
     rootPath: form.rootPath.trim() || null,
+    // Empty string (not omit) so Save can clear a stored remote on #3568;
+    // omitted remoteUrl/branch would keep the previous server value.
+    remoteUrl: form.remoteUrl.trim(),
+    branch: form.branch.trim(),
     configFile: form.configFile.trim() || null,
     siteKey: form.siteKey.trim() || null,
   };
@@ -101,7 +109,9 @@ export function formToVirtualProps(form: VirtualSiteFormModel): VirtualSitePrope
 
 /**
  * Lightweight client-side checks aligned with PSVirtualSiteHelper (not a full
- * NIO walk — server still validates on PUT).
+ * NIO walk — server still validates on PUT). Remote URL / branch are optional
+ * and are not validated here (checkout and fail-closed URL rules live on the
+ * server).
  *
  * @returns error message key fragment, or null when OK
  */
@@ -133,6 +143,8 @@ export function emptyVirtualSiteForm(): VirtualSiteFormModel {
   return {
     sourceKind: SOURCE_KIND_REPOSITORY,
     rootPath: "",
+    remoteUrl: "",
+    branch: "",
     configFile: "",
     siteKey: "",
   };

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -45,6 +45,8 @@ describe("sitesApi virtual properties", () => {
     ).toEqual({
       sourceKind: "git-filesystem",
       rootPath: "/docs",
+      remoteUrl: undefined,
+      branch: undefined,
       configFile: undefined,
       siteKey: undefined,
       virtual: true,
@@ -59,9 +61,30 @@ describe("sitesApi virtual properties", () => {
     ).toEqual({
       sourceKind: "repository",
       rootPath: undefined,
+      remoteUrl: undefined,
+      branch: undefined,
       configFile: undefined,
       siteKey: undefined,
       virtual: false,
+    });
+    expect(
+      parseVirtualSiteProperties({
+        VirtualSiteProperties: {
+          sourceKind: "git-filesystem",
+          rootPath: "docs",
+          remoteUrl: "https://git.example.com/org/docs.git",
+          branch: "main",
+          virtual: true,
+        },
+      }),
+    ).toEqual({
+      sourceKind: "git-filesystem",
+      rootPath: "docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "main",
+      configFile: undefined,
+      siteKey: undefined,
+      virtual: true,
     });
     expect(parseVirtualSiteProperties(null)).toEqual({});
   });
@@ -86,6 +109,40 @@ describe("sitesApi virtual properties", () => {
         rootPath: "C:/docs",
         configFile: null,
         siteKey: null,
+      },
+    });
+    expect(
+      toVirtualSitePropertiesEnvelope({
+        sourceKind: "git-filesystem",
+        rootPath: "docs",
+        remoteUrl: "https://git.example.com/org/docs.git",
+        branch: "main",
+      }),
+    ).toEqual({
+      VirtualSiteProperties: {
+        sourceKind: "git-filesystem",
+        rootPath: "docs",
+        configFile: null,
+        siteKey: null,
+        remoteUrl: "https://git.example.com/org/docs.git",
+        branch: "main",
+      },
+    });
+    expect(
+      toVirtualSitePropertiesEnvelope({
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        remoteUrl: "",
+        branch: "",
+      }),
+    ).toEqual({
+      VirtualSiteProperties: {
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        configFile: null,
+        siteKey: null,
+        remoteUrl: "",
+        branch: "",
       },
     });
   });

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -56,8 +56,10 @@ describe("VirtualSiteSourcePanel", () => {
       DEV_MSG.SITE_VIRT_STATUS_REPO,
     );
     expect(screen.getByTestId("developer-site-virtual-source-kind")).toBeTruthy();
-    // Root path hidden until virtual selected
+    // Root path / remote hidden until virtual selected
     expect(screen.queryByTestId("developer-site-virtual-root-path")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-remote-url")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-branch")).toBeNull();
     // Repository sites must not show Build or Publish chrome
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
@@ -87,9 +89,50 @@ describe("VirtualSiteSourcePanel", () => {
     expect((screen.getByTestId("developer-site-virtual-site-key") as HTMLInputElement).value).toBe(
       "product-docs",
     );
+    expect(
+      (screen.getByTestId("developer-site-virtual-remote-url") as HTMLInputElement).value,
+    ).toBe("");
+    expect((screen.getByTestId("developer-site-virtual-branch") as HTMLInputElement).value).toBe("");
+    expect(screen.getByTestId("developer-site-virtual-remote-hint")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
       DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
     );
+  });
+
+  it("loads and re-saves a stored remote URL so Save does not drop it", async () => {
+    const stored = {
+      sourceKind: "git-filesystem",
+      rootPath: "product-docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "main",
+      configFile: "_config.yaml",
+      siteKey: "docs",
+      virtual: true,
+    };
+    getVirtual.mockResolvedValue(stored);
+    updateVirtual.mockResolvedValue(stored);
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-remote-url")).toBeTruthy();
+    });
+    expect(
+      (screen.getByTestId("developer-site-virtual-remote-url") as HTMLInputElement).value,
+    ).toBe("https://git.example.com/org/docs.git");
+    expect((screen.getByTestId("developer-site-virtual-branch") as HTMLInputElement).value).toBe(
+      "main",
+    );
+    fireEvent.click(screen.getByTestId("developer-site-virtual-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-saved")).toBeTruthy();
+    });
+    expect(updateVirtual).toHaveBeenCalledWith("Help", {
+      sourceKind: "git-filesystem",
+      rootPath: "product-docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "main",
+      configFile: "_config.yaml",
+      siteKey: "docs",
+    });
   });
 
   it("shows error state and retry on load failure", async () => {
@@ -157,6 +200,8 @@ describe("VirtualSiteSourcePanel", () => {
     expect(updateVirtual).toHaveBeenCalledWith("Corporate", {
       sourceKind: "git-filesystem",
       rootPath: "C:/docs",
+      remoteUrl: "",
+      branch: "",
       configFile: null,
       siteKey: null,
     });
@@ -164,10 +209,68 @@ describe("VirtualSiteSourcePanel", () => {
     expect(
       (screen.getByTestId("developer-site-virtual-root-path") as HTMLInputElement).value,
     ).toBe("C:/docs");
+    expect(
+      (screen.getByTestId("developer-site-virtual-remote-url") as HTMLInputElement).value,
+    ).toBe("");
     expect(screen.getByTestId("developer-site-virtual-build-section")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
       DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
     );
+  });
+
+  it("saves optional remote URL and branch with local root path", async () => {
+    getVirtual
+      .mockResolvedValueOnce({ sourceKind: null, virtual: false })
+      .mockResolvedValueOnce({
+        sourceKind: "git-filesystem",
+        rootPath: "C:/docs",
+        remoteUrl: "https://git.example.com/org/docs.git",
+        branch: "main",
+        configFile: null,
+        siteKey: null,
+        virtual: true,
+      });
+    updateVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "main",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Corporate" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-form")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-source-kind"), {
+      target: { value: "git-filesystem" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-remote-url")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-root-path"), {
+      target: { value: "C:/docs" },
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-remote-url"), {
+      target: { value: "https://git.example.com/org/docs.git" },
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-branch"), {
+      target: { value: "main" },
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-saved")).toBeTruthy();
+    });
+    expect(updateVirtual).toHaveBeenCalledWith("Corporate", {
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "main",
+      configFile: null,
+      siteKey: null,
+    });
+    expect(
+      (screen.getByTestId("developer-site-virtual-remote-url") as HTMLInputElement).value,
+    ).toBe("https://git.example.com/org/docs.git");
   });
 
   it("saves repository mode to clear virtual configuration", async () => {

--- a/WebUI/src/test/ts/developer/virtualSiteForm.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteForm.test.ts
@@ -60,13 +60,39 @@ describe("virtualSiteForm helpers", () => {
     });
     expect(form.sourceKind).toBe(SOURCE_KIND_GIT_FILESYSTEM);
     expect(form.rootPath).toBe("C:/docs");
+    expect(form.remoteUrl).toBe("");
+    expect(form.branch).toBe("");
     expect(form.configFile).toBe("_config.yaml");
     expect(form.siteKey).toBe("product-docs");
     expect(formToVirtualProps(form)).toEqual({
       sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
       rootPath: "C:/docs",
+      remoteUrl: "",
+      branch: "",
       configFile: "_config.yaml",
       siteKey: "product-docs",
+    });
+  });
+
+  it("virtualPropsToForm and formToVirtualProps round-trip remote URL and branch", () => {
+    const form = virtualPropsToForm({
+      sourceKind: "git-filesystem",
+      rootPath: "product-docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "release/8.2",
+      configFile: "_config.yaml",
+      siteKey: "docs",
+      virtual: true,
+    });
+    expect(form.remoteUrl).toBe("https://git.example.com/org/docs.git");
+    expect(form.branch).toBe("release/8.2");
+    expect(formToVirtualProps(form)).toEqual({
+      sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
+      rootPath: "product-docs",
+      remoteUrl: "https://git.example.com/org/docs.git",
+      branch: "release/8.2",
+      configFile: "_config.yaml",
+      siteKey: "docs",
     });
   });
 
@@ -74,12 +100,16 @@ describe("virtualSiteForm helpers", () => {
     const body = formToVirtualProps({
       sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
       rootPath: "  /opt/docs  ",
+      remoteUrl: "  ",
+      branch: "  ",
       configFile: "  ",
       siteKey: "",
     });
     expect(body).toEqual({
       sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
       rootPath: "/opt/docs",
+      remoteUrl: "",
+      branch: "",
       configFile: null,
       siteKey: null,
     });
@@ -90,6 +120,8 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_REPOSITORY,
         rootPath: "",
+        remoteUrl: "",
+        branch: "",
         configFile: "",
         siteKey: "",
       }),
@@ -99,6 +131,8 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
         rootPath: "",
+        remoteUrl: "",
+        branch: "",
         configFile: "",
         siteKey: "",
       }),
@@ -108,6 +142,8 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
         rootPath: "../escape",
+        remoteUrl: "",
+        branch: "",
         configFile: "",
         siteKey: "",
       }),
@@ -117,6 +153,8 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
         rootPath: "C:/docs",
+        remoteUrl: "",
+        branch: "",
         configFile: "subdir/config.yaml",
         siteKey: "",
       }),
@@ -126,6 +164,8 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
         rootPath: "C:/docs",
+        remoteUrl: "https://git.example.com/org/docs.git",
+        branch: "main",
         configFile: "_config.yaml",
         siteKey: "k",
       }),

--- a/docs/ai-generated/code-reviews/3573-virtual-site-remote-fields-erlang.md
+++ b/docs/ai-generated/code-reviews/3573-virtual-site-remote-fields-erlang.md
@@ -1,0 +1,51 @@
+# Erlang review — #3573 Developer Sites remote URL and branch fields
+
+## Summary
+
+Optional **Remote URL** and **Branch** fields on Developer → Sites Virtual Site
+source, with GET/PUT round-trip so Save does not drop a stored remote and a
+blank remote still saves local `rootPath`. No client checkout/URL validation
+(server owns that on #3568 / PR #3572).
+
+## Scope
+
+- Branch: `feat/issue-3573-virtual-site-remote-fields` vs `origin/main`
+- Files: WebUI form + `sitesApi` envelope, Vitest, Playwright
+  `developer-site-virtual-source`, `product-docs/8.2/admin/sites.md`
+- Memory: change-class WebUI product screen (Vitest + Playwright + product-docs)
+- Cross-platform path review: no filesystem I/O. `C:/docs` strings are form/API
+  fixtures (same pattern as existing panel tests), not path joins.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None at bug severity.
+
+### suggestion — merge order with #3572
+
+`formToVirtualProps` always includes `remoteUrl`/`branch` (empty string when
+blank) on virtual PUTs. Production Jackson is `FAIL_ON_UNKNOWN_PROPERTIES`.
+Servers that do not yet have PR #3572 `VirtualSiteProperties.remoteUrl` will
+400 a virtual Save that includes those keys. Create-site PUT omits the keys
+when they are undefined (safe). Persist of remotes requires #3568 / PR #3572.
+
+### nit — client still requires root when a remote is set
+
+`validateVirtualSiteForm` still returns `root-required` when `rootPath` is
+blank even if `remoteUrl` is set. #3568 treats root as required only when the
+remote is blank. Acceptable for this slice (do not re-implement checkout
+rules); operators can enter a relative checkout folder.
+
+## Prior report / Memory patterns
+
+No prior 3573 report. Matched change-class completeness: Vitest helpers +
+panel + Playwright surface + product-docs admin Sites panel.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -128,9 +128,12 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
       }
 
-      // Switch to git-filesystem reveals root path + Build / Publish controls
+      // Switch to git-filesystem reveals root path, optional remote, + Build / Publish
       await kind.selectOption("git-filesystem");
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-branch"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-remote-hint"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
@@ -454,6 +457,8 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     let virtualState = {
       sourceKind: "repository",
       rootPath: null,
+      remoteUrl: null,
+      branch: null,
       configFile: null,
       siteKey: null,
       virtual: false,
@@ -496,6 +501,14 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         virtualState = {
           sourceKind: envelope.sourceKind || "repository",
           rootPath: envelope.rootPath || null,
+          remoteUrl:
+            envelope.remoteUrl === undefined || envelope.remoteUrl === null
+              ? virtualState.remoteUrl
+              : envelope.remoteUrl || null,
+          branch:
+            envelope.branch === undefined || envelope.branch === null
+              ? virtualState.branch
+              : envelope.branch || null,
           configFile: envelope.configFile || null,
           siteKey: envelope.siteKey || null,
           virtual: envelope.sourceKind === "git-filesystem",
@@ -560,6 +573,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await page.locator('[data-testid="developer-site-virtual-source-kind"]').selectOption(
       "git-filesystem",
     );
+    await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toBeVisible();
     await page.locator('[data-testid="developer-site-virtual-root-path"]').fill("C:/docs/product-docs");
     await page.locator('[data-testid="developer-site-virtual-save"]').click();
 
@@ -570,10 +584,34 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     expect(lastPutBody).toHaveProperty("VirtualSiteProperties");
     expect(lastPutBody.VirtualSiteProperties.sourceKind).toBe("git-filesystem");
     expect(lastPutBody.VirtualSiteProperties.rootPath).toBe("C:/docs/product-docs");
+    expect(lastPutBody.VirtualSiteProperties.remoteUrl ?? "").toBe("");
     expect(lastPutBody).not.toHaveProperty("sourceKind");
 
     await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+
+    await page
+      .locator('[data-testid="developer-site-virtual-remote-url"]')
+      .fill("https://git.example.com/org/docs.git");
+    await page.locator('[data-testid="developer-site-virtual-branch"]').fill("main");
+    lastPutBody = null;
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect
+      .poll(() => lastPutBody && lastPutBody.VirtualSiteProperties && lastPutBody.VirtualSiteProperties.remoteUrl)
+      .toBe("https://git.example.com/org/docs.git");
+    expect(lastPutBody.VirtualSiteProperties.branch).toBe("main");
+    expect(lastPutBody.VirtualSiteProperties.rootPath).toBe("C:/docs/product-docs");
+    await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveValue(
+      "https://git.example.com/org/docs.git",
+    );
+    await expect(page.locator('[data-testid="developer-site-virtual-branch"]')).toHaveValue("main");
+
+    lastPutBody = null;
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect
+      .poll(() => lastPutBody && lastPutBody.VirtualSiteProperties && lastPutBody.VirtualSiteProperties.remoteUrl)
+      .toBe("https://git.example.com/org/docs.git");
+    expect(lastPutBody.VirtualSiteProperties.branch).toBe("main");
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -54,7 +54,7 @@ Use **Content Explorer** or **Navigation → New Site** when you need a new Site
 
 With **Traditional** and **Include managed navigation** checked, the server seeds a NavTree, a site template, and the homepage (`index.html`) in that folder in one operation. If the folder already has a NavTree or Navon, Create Site returns HTTP 400 with a clear error (not HTTP 500).
 
-Full Git `rootPath` / config-file editing remains on **Developer → Sites** (Virtual Site source panel). See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
+Full Git `rootPath`, remote URL, branch, and config-file editing remains on **Developer → Sites** (Virtual Site source panel). See [Virtual Sites (developer)](id:developer-virtual-sites) and the Virtual Sites section below.
 
 ## Virtual Sites (8.2)
 
@@ -72,7 +72,9 @@ and Markdown tooling, not the classic page editor.
 | Property | Required | Example | Notes |
 |----------|----------|---------|-------|
 | `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Phase 1 allow-list: **`git-filesystem` only**. Blank or `repository` = traditional Site. |
-| `virtual.rootPath` | Yes (when virtual) | absolute path to `product-docs` | Must be non-blank for Virtual Sites. Prefer absolute paths; use portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. |
+| `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` | Local tree when `virtual.remoteUrl` is blank. Prefer absolute portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. When a remote is set, use a **relative** folder inside the checkout (for example `product-docs`). |
+| `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones or fetches into a contained server work directory, then discovers Markdown as usual. Blank = local-path mode. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. |
+| `virtual.branch` | No | `main` | Branch to checkout when a remote is set. Default `main`. |
 | `virtual.configFile` | No | `_config.yaml` | Default `_config.yaml`. Simple file name under the root (no `..` or directory separators). |
 | `virtual.siteKey` | No | `product-docs` | Optional participant key; defaults to the Site name. |
 
@@ -116,21 +118,34 @@ blank). Load failures show **Could not load sites** rather than the empty state.
    - **Source kind** — leave **Repository (traditional)** for ordinary CMS Sites
      (blank/`repository` on the server). Choose **Git filesystem** for Phase 1 Virtual Sites.
    - **Root path** — absolute or install-relative path to the documentation tree
-     (required when source kind is Virtual). Do not use `..` path segments.
+     (required when source kind is Virtual and no remote is set). Do not use `..`
+     path segments. When a **Remote URL** is set, this may be a relative folder
+     inside the checkout.
+   - **Remote URL** (optional) — Git remote (`https://`, `ssh://`, `file://`, or
+     `git@host:path`). Leave blank to keep the local **Root path**. When set,
+     **Build Virtual Site** clones or fetches on the CMS host (`git` must be on
+     the server `PATH`). The server validates the URL; the panel does not
+     re-implement checkout.
+   - **Branch** (optional) — branch to checkout when a remote is set. Defaults
+     to `main` on the server when blank.
    - **Config file** (optional) — simple file name under the root (default `_config.yaml`
      when unset). No path separators.
    - **Site key** (optional) — participant registry key; defaults to the Site name when blank.
 5. Choose **Save Virtual Site source**. The SPA sends the Jackson/JAXB envelope
-   `{ "VirtualSiteProperties": { "sourceKind": "git-filesystem", "rootPath": "…", … } }`
-   (not a bare `sourceKind` object). After a successful save the panel reloads
-   properties from GET so **Build Virtual Site** appears without a full page reload.
+   `{ "VirtualSiteProperties": { "sourceKind": "git-filesystem", "rootPath": "…",
+   "remoteUrl": "…", "branch": "…", … } }`
+   (not a bare `sourceKind` object). Blank remote URL still saves the local
+   `rootPath`. After a successful save the panel reloads properties from GET so
+   a stored remote is not dropped and **Build Virtual Site** appears without a
+   full page reload.
 6. To return a Virtual Site to traditional repository mode, set source kind back to
    **Repository (traditional)** and save (clears `virtual.*` properties).
 
 Validation matches the server helper (`PSVirtualSiteHelper`): allow-listed source kinds,
-required root path when virtual, and safe path/config names. After root or config changes,
-re-run the offline docs build, the in-product **Build Virtual Site** action (below), or the
-CMS publish path to verify links.
+required local root path when virtual and no remote, safe remote URLs/branches, and
+safe path/config names. After root, remote, or config changes, re-run the offline
+docs build, the in-product **Build Virtual Site** action (below), or the CMS
+publish path to verify links.
 
 ### Build a Virtual Site from the product UI
 
@@ -140,9 +155,11 @@ When **Source kind** is **Git filesystem** (Virtual), the Site detail panel show
 
 1. Sign in as an **Admin** (the build REST operation requires Admin).
 2. Open **Developer** → **Sites** and open the Virtual Site detail.
-3. Confirm **Virtual Site source** is saved as **Git filesystem** with a valid **Root path**
-   that exists on the CMS host. If you just edited properties, choose **Save Virtual Site source**
-   first — the build uses the **saved** server properties, not unsaved form fields.
+3. Confirm **Virtual Site source** is saved as **Git filesystem** with either a valid **Root path**
+   on the CMS host **or** a saved **Remote URL** and **Branch**. If you just edited
+   properties, choose **Save Virtual Site source** first — the build uses the **saved**
+   server properties, not unsaved form fields. When a remote is set, Build clones or
+   fetches first (`git` must be on the CMS `PATH`).
 4. Choose **Build Virtual Site**.
 5. After a `git pull` or a local Markdown/frontmatter edit on the host, choose **Build Virtual
    Site** again. The build re-reads the current filesystem — **do not restart the CMS** just to


### PR DESCRIPTION
## Summary

Add optional **Remote URL** and **Branch** fields on Developer → Sites → Virtual Site source (`VirtualSiteSourcePanel` + `virtualSiteForm` helpers). Save GET/PUT round-trips `virtual.remoteUrl` / `virtual.branch` so a stored remote is not dropped; a blank remote still saves local `rootPath`. Client does **not** re-implement checkout or fail-closed URL validation (server work on #3568 / PR #3572).

Parent: #2678
Fixes #3573

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Vitest 2869 passed.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. C5: `python docker/scripts/perc-devctl.py qa-up` (H2 cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`). Container `Health=healthy`, HTTP 200. FastForward binary import / search-index ERROR lines are pre-existing sample-data noise (not this surface).
4. Hot-copy `WebUI/target/generated-webui/cm/modern` into `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern` (no `docker restart`).
5. `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — 4 passed (7.7s). Specs assert remote fields, blank-remote save of `rootPath`, and PUT envelope round-trip of remote URL/branch. Uncaught page errors = none.
6. Open Developer → Sites → Site detail, switch source kind to Git filesystem, set root path, leave remote blank, Save; then set Remote URL + Branch, Save; confirm GET reloads the values.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md` (property table + Configure Virtual Site source steps for Remote URL / Branch)
- [x] **Unit / module tests** — Vitest for `virtualSiteForm`, `sitesApi` parse/envelope, `VirtualSiteSourcePanel` load/save/no-drop
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js`
- [x] **Build gates** — standalone clean install on changed Maven modules (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem I/O; path strings are form/API values)

### C3 evidence

- `modules_built=WebUI,modules/perc-qa-automation`
- `build_evidence=`
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-18T19:03:07-04:00), Tests run: 2869 (Vitest files 380 passed)
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-18T19:01:25-04:00), No Java tests to run (npm ci)
- `downstream_checked=none` (no Java public/protected API or `final`/`sealed` type change)

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up` from worktree; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2` healthy
- deploy: `docker cp WebUI/target/generated-webui/cm/modern perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/` (SPA assets; no Jetty restart)
- Playwright: `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **4 passed**
- console-clean=yes (spec `pageerror` assertions)
- server.log-clean=yes for this feature (no Virtual Site / Sites REST ERRORs in the test window; FastForward `PSDbStorageService` import + `PSSearchIndexFieldValueModifier` lines are startup sample-data noise)

### Notes

- Persist of remotes on the server is #3568 / PR #3572. This PR sends `remoteUrl`/`branch` on virtual PUT (empty string when blank so #3572 can clear). Create-site PUT omits the keys when undefined so older servers stay compatible.
- Human QA is deferred (`include_human_qa=false`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
