### PR TITLE
fix(explorer): H2 saved-search picker/run no-skip proof (#3576)

### DIFF
--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -84,16 +84,75 @@ export const SEARCH_DESIGN_GAPS: string[] = [
   "Views are a separate catalog (Developer Views / UI-07)",
 ];
 
-function asArray<T>(payload: unknown): T[] {
-  if (payload == null) return [];
-  if (Array.isArray(payload)) return payload as T[];
-  if (typeof payload === "object") {
-    const obj = payload as Record<string, unknown>;
-    const raw = obj.SearchDef ?? obj.searchDef ?? obj.SearchDefList;
-    if (raw == null) return [];
-    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+const SEARCH_DEF_WRAP_KEYS = [
+  "SearchDef",
+  "searchDef",
+  "SearchDefList",
+  "searchDefList",
+  "ArrayList",
+  "arrayList",
+  "items",
+] as const;
+
+const MAX_UNWRAP_DEPTH = 6;
+
+function hasSearchDefIdentity(obj: Record<string, unknown>): boolean {
+  const name = obj.name != null ? String(obj.name).trim() : "";
+  if (name) {
+    return true;
+  }
+  const id = obj.id != null ? String(obj.id).trim() : "";
+  if (id && id !== "0") {
+    return true;
+  }
+  const label = obj.label != null ? String(obj.label).trim() : "";
+  return Boolean(label);
+}
+
+/**
+ * Unwrap Jackson / JAXB / ArrayList wrappers for {@link SearchDef} lists.
+ * Nested {@code SearchDefList.SearchDef} must not collapse to one empty row
+ * (#3576).
+ */
+export function unwrapSearchDefList(payload: unknown, depth = 0): SearchDef[] {
+  if (payload == null || depth > MAX_UNWRAP_DEPTH) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    const out: SearchDef[] = [];
+    for (const item of payload) {
+      if (item == null || typeof item !== "object") {
+        continue;
+      }
+      const rec = item as Record<string, unknown>;
+      if (
+        !hasSearchDefIdentity(rec) &&
+        SEARCH_DEF_WRAP_KEYS.some((k) => rec[k] != null)
+      ) {
+        out.push(...unwrapSearchDefList(rec, depth + 1));
+      } else {
+        out.push(item as SearchDef);
+      }
+    }
+    return out;
+  }
+  const obj = asRecord(payload);
+  if (obj == null) {
+    return [];
+  }
+  for (const key of SEARCH_DEF_WRAP_KEYS) {
+    if (obj[key] != null) {
+      return unwrapSearchDefList(obj[key], depth + 1);
+    }
+  }
+  if (hasSearchDefIdentity(obj)) {
+    return [obj as SearchDef];
   }
   return [];
+}
+
+function asArray<T>(payload: unknown): T[] {
+  return unwrapSearchDefList(payload) as T[];
 }
 
 function withGaps(s: SearchDef): SearchDef {

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -19,6 +19,7 @@ import {
   executeSearch,
   listExplorerSavedSearches,
   listSearches,
+  unwrapSearchDefList,
   unwrapSearchExecuteResult,
   wrapSearchExecuteRequest,
 } from "../../../main/ts/api/developer/searchesApi";
@@ -60,6 +61,28 @@ describe("unwrapSearchExecuteResult", () => {
   });
 });
 
+describe("unwrapSearchDefList", () => {
+  it("unwraps nested SearchDefList.SearchDef so the picker sees rows (#3576)", () => {
+    expect(
+      unwrapSearchDefList({
+        SearchDefList: {
+          SearchDef: [
+            { name: "View_All", label: "All" },
+            { name: "My Pages" },
+          ],
+        },
+      }).map((s) => s.name),
+    ).toEqual(["View_All", "My Pages"]);
+  });
+
+  it("unwraps ArrayList and ignores empty beans", () => {
+    expect(unwrapSearchDefList({ ArrayList: [{ name: "All Content" }] })).toEqual(
+      [{ name: "All Content" }],
+    );
+    expect(unwrapSearchDefList({ empty: true })).toEqual([]);
+  });
+});
+
 describe("listSearches", () => {
   it("GETs /searches without includeViews by default", async () => {
     const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
@@ -91,6 +114,22 @@ describe("listSearches", () => {
       `${PATHS.SEARCHES}?includeViews=true`,
     );
     expect(out.map((s) => s.name)).toEqual(["View_All", "My Pages"]);
+  });
+
+  it("listExplorerSavedSearches unwraps nested SearchDefList (#3576)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          SearchDefList: {
+            SearchDef: [{ name: "View_All", label: "All" }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const out = await listExplorerSavedSearches();
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("View_All");
   });
 });
 

--- a/docs/ai-generated/code-reviews/issue-3576-h2-saved-search-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3576-h2-saved-search-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3576 H2 saved-search picker/run
+
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3576-h2-saved-search-picker-run`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral unit tests; Playwright companion for WebUI; no path I/O
+
+## Summary
+
+Slice proves Explorer SearchPanel picker + Run on H2 QA and stops Playwright from
+soft-skipping when a catalog search exists. Nested Jackson `SearchDefList.SearchDef`
+unwrap is shared by WebUI `searchesApi` and the Playwright helper. Custom-URL
+rows stay non-executable (Run disabled). SearchPanel chrome was not rebuilt.
+
+## Issues
+
+None (hard gate).
+
+### Nits
+
+- `unwrapSearchDefList` / `unwrapSearchDefs` are duplicated in TS and JS. Acceptable:
+  Playwright helpers cannot import the Vite TS client. Keep both tested.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O. URLs correctly use `/`.
+
+## Evidence
+
+- WebUI `mvnw clean install`: BUILD SUCCESS; Surefire Tests run: 61; Vitest 2872 passed
+- perc-qa-automation `mvnw clean install`: BUILD SUCCESS
+- Helper unit: 14 passed
+- Playwright `test:surface --path tests/explorer-saved-search.spec.js`: 4 passed, 0 skipped
+  on `TEST_CMS_URL=http://127.0.0.1:9993` (H2 QA cell healthy)
+- console-clean=yes (pageerror/console error collector)
+- server.log-clean=no BUG:#3592 (FastForward import + search-index modifier noise;
+  not saved-search execute)

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -803,9 +803,10 @@ SearchPanel → asserts catalog chrome (picker / empty / error) → when the
 fixture has a runnable design search, selects it and asserts post-execute
 results list, empty, or error region wiring.
 
-**Soft-skip:** if `GET /services/searches` has no non-custom-URL design search,
-the execute-path test soft-skips after catalog UI assertions (documented for
-minimal H2 fixtures). Shell open + catalog settle remain hard.
+**Soft-skip:** execute soft-skips **only** when the catalog is empty or every
+row is a custom-URL search. A visible picker (or REST catalog) with a
+standard/user search **must Run** — do not skip (#3576). Custom URL searches
+stay listed but Run stays disabled. Shell open + catalog settle remain hard.
 
 | Item | Value |
 |------|--------|

--- a/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
@@ -42,10 +42,10 @@
  *   python docker/scripts/perc-devctl.py qa-down
  * </pre>
  *
- * <p><strong>Fixture soft-skip:</strong> when GET /services/searches returns
- * no runnable (non-custom-URL) design search, the execute-path test soft-skips
- * after asserting catalog empty / picker-only-custom UI. Catalog mount and
- * shell toggle remain hard assertions.</p>
+ * <p><strong>Fixture soft-skip:</strong> execute soft-skips <em>only</em>
+ * when the catalog is empty or every row is a custom-URL search. A visible
+ * picker with a standard/user search (or REST View_All) must Run — do not
+ * skip (#3576 / parent #3102).</p>
  */
 
 const { test, expect } = require("@playwright/test");
@@ -60,14 +60,41 @@ const {
   searchesCatalogUrl,
   unwrapSearchDefs,
   pickRunnableSavedSearch,
+  pickRunnableSelectOption,
+  shouldSkipMissingRunnableSearch,
   noRunnableSearchSkipMessage,
   postExecuteRegionSelector,
   catalogSettledSelector,
   isCustomUrlSearch,
+  isCustomSelectOption,
   isDefaultAllView,
   searchDefKey,
   searchesExecuteUrl,
 } = require("./helpers/explorer-saved-search");
+
+/**
+ * Collect uncaught page errors for the C5 zero-errors gate.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {string[]}
+ */
+function attachPageErrors(page) {
+  const pageErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = String(msg.text() || "");
+    if (/Failed to load resource: the server responded with a status of (404|400)/i.test(text)) {
+      return;
+    }
+    pageErrors.push(text);
+  });
+  return pageErrors;
+}
 
 // Tags live on individual test() titles only — Playwright ignores @tags on describe names.
 test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
@@ -129,8 +156,8 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
     page,
     request,
   }) => {
-    // Probe REST catalog so we know a runnable key before UI drive; soft-skip
-    // when QA H2 fixture has no design searches (documented acceptance).
+    const pageErrors = attachPageErrors(page);
+    // Probe REST catalog so we prefer View_All; UI picker is the no-skip gate.
     const headers = adminBasicAuthHeaders();
     const catalogUrl = searchesCatalogUrl(BASE_URL, { includeViews: true });
     let restStatus = 0;
@@ -167,16 +194,42 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
       timeout: 20_000,
     });
 
-    if (!runnable) {
-      // Soft path: empty catalog or custom-only — still prove UI state.
-      const empty = page.locator(`[data-testid="${TEST_IDS.savedEmpty}"]`);
-      const picker = page.locator(`[data-testid="${TEST_IDS.savedPicker}"]`);
+    const empty = page.locator(`[data-testid="${TEST_IDS.savedEmpty}"]`);
+    const picker = page.locator(`[data-testid="${TEST_IDS.savedPicker}"]`);
+    const pickerVisible = await picker.isVisible().catch(() => false);
+    const select = page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`);
+    const selectOptions = pickerVisible
+      ? await select.locator("option").evaluateAll((opts) =>
+          opts.map((o) => ({
+            value: /** @type {HTMLOptionElement} */ (o).value,
+            text: String(/** @type {HTMLOptionElement} */ (o).textContent || ""),
+          })),
+        )
+      : [];
+    const uiRunnable = pickRunnableSelectOption(selectOptions);
+    const optionCount = selectOptions.filter((o) => String(o.value || "").trim())
+      .length;
+
+    if (
+      shouldSkipMissingRunnableSearch({
+        runnable,
+        pickerVisible,
+        optionCount,
+        hasRunnableOption: Boolean(uiRunnable),
+        onlyCustom,
+        catalogEmpty: defs.length === 0 && !pickerVisible,
+      })
+    ) {
       if (await empty.isVisible()) {
         await expect(empty).toBeVisible();
-      } else if (await picker.isVisible()) {
-        await expect(
-          page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`),
-        ).toBeVisible();
+      } else if (pickerVisible) {
+        await expect(select).toBeVisible();
+        const runBtn = page.locator(`[data-testid="${TEST_IDS.savedRun}"]`);
+        const customOpt = selectOptions.find((o) => isCustomSelectOption(o));
+        if (customOpt && customOpt.value) {
+          await select.selectOption(customOpt.value);
+          await expect(runBtn).toBeDisabled();
+        }
       }
       test.skip(
         true,
@@ -184,28 +237,40 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
           empty: defs.length === 0,
           onlyCustom,
           restStatus,
+          pickerVisible,
         }),
       );
       return;
     }
 
-    const select = page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`);
+    expect(
+      pickerVisible,
+      "catalog has a runnable search so SearchPanel picker must be visible (#3576)",
+    ).toBe(true);
     await expect(select).toBeVisible({ timeout: 10_000 });
 
-    // Prefer REST-known key; fall back to first non-empty option value.
-    const optionValues = await select.locator("option").evaluateAll((opts) =>
-      opts.map((o) => /** @type {HTMLOptionElement} */ (o).value).filter(Boolean),
-    );
-    const keyToPick = optionValues.includes(runnable.key)
-      ? runnable.key
-      : optionValues[0];
+    const runBtn = page.locator(`[data-testid="${TEST_IDS.savedRun}"]`);
+    const customOpt = selectOptions.find((o) => isCustomSelectOption(o));
+    if (customOpt && customOpt.value) {
+      await select.selectOption(customOpt.value);
+      await expect(runBtn).toBeDisabled();
+    }
+
+    const optionValues = selectOptions
+      .map((o) => String(o.value || "").trim())
+      .filter(Boolean);
+    const keyToPick =
+      runnable && optionValues.includes(runnable.key)
+        ? runnable.key
+        : uiRunnable
+          ? uiRunnable.value
+          : optionValues[0];
     expect(
       keyToPick,
       "saved-search select should expose at least one design search option",
     ).toBeTruthy();
 
     await select.selectOption(keyToPick);
-    const runBtn = page.locator(`[data-testid="${TEST_IDS.savedRun}"]`);
     await expect(runBtn).toBeEnabled({ timeout: 5_000 });
     await runBtn.click();
 
@@ -255,6 +320,9 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
         page.locator(`[data-testid="search-panel-retry"]`),
       ).toBeVisible();
     }
+    expect(pageErrors, "uncaught pageerror on saved-search picker/run").toEqual(
+      [],
+    );
   });
 
   test("REST: POST /services/searches/View_All/execute is 200 page not IOException @saved-search @explorer-saved-search", async ({
@@ -281,14 +349,21 @@ test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
       catalogRes.ok() ? await catalogRes.json().catch(() => null) : null,
     );
     const allView = defs.find((d) => isDefaultAllView(d));
-    if (!allView) {
+    const runnable = pickRunnableSavedSearch(defs);
+    if (defs.length === 0) {
       test.skip(
         true,
-        "H2 catalog has no All / View_All — soft-skip execute REST (#3517).",
+        "H2 catalog empty — soft-skip execute REST (no catalog search exists).",
       );
       return;
     }
-    const key = searchDefKey(allView);
+    expect(
+      allView || runnable,
+      `catalog has searches so execute must run (names=${defs
+        .map((d) => searchDefKey(d))
+        .join(",")})`,
+    ).toBeTruthy();
+    const key = allView ? searchDefKey(allView) : runnable.key;
     const execUrl = searchesExecuteUrl(BASE_URL, key);
     const body = JSON.stringify({
       SearchExecuteRequest: { startIndex: 1, maxResults: 25 },

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
@@ -85,30 +85,75 @@ function searchesExecuteUrl(baseUrl, idOrName) {
   return `${root}${PATH_SEARCHES}/${key}/execute`;
 }
 
+const SEARCH_DEF_WRAP_KEYS = Object.freeze([
+  "SearchDef",
+  "searchDef",
+  "SearchDefList",
+  "searchDefList",
+  "ArrayList",
+  "arrayList",
+  "items",
+]);
+
+const MAX_UNWRAP_DEPTH = 6;
+
 /**
- * Unwrap Jackson / list wrappers for {@code SearchDef[]} catalog payloads.
+ * True when {@code obj} looks like a design-search row (has a catalog key).
+ *
+ * @param {Record<string, unknown>} obj
+ * @returns {boolean}
+ */
+function hasSearchDefIdentity(obj) {
+  const name = obj.name != null ? String(obj.name).trim() : "";
+  if (name) {
+    return true;
+  }
+  const id = obj.id != null ? String(obj.id).trim() : "";
+  if (id && id !== "0") {
+    return true;
+  }
+  const label = obj.label != null ? String(obj.label).trim() : "";
+  return Boolean(label);
+}
+
+/**
+ * Unwrap Jackson / JAXB / ArrayList wrappers for {@code SearchDef[]} catalog
+ * payloads. Nested {@code SearchDefList.SearchDef} must not be treated as a
+ * single empty row (#3576).
  *
  * @param {unknown} payload
+ * @param {number} [depth]
  * @returns {Record<string, unknown>[]}
  */
-function unwrapSearchDefs(payload) {
-  if (payload == null) {
+function unwrapSearchDefs(payload, depth = 0) {
+  if (payload == null || depth > MAX_UNWRAP_DEPTH) {
     return [];
   }
   if (Array.isArray(payload)) {
-    return payload.filter((x) => x != null && typeof x === "object");
+    /** @type {Record<string, unknown>[]} */
+    const out = [];
+    for (const item of payload) {
+      if (item == null || typeof item !== "object") {
+        continue;
+      }
+      const rec = /** @type {Record<string, unknown>} */ (item);
+      if (!hasSearchDefIdentity(rec) && SEARCH_DEF_WRAP_KEYS.some((k) => rec[k] != null)) {
+        out.push(...unwrapSearchDefs(rec, depth + 1));
+      } else {
+        out.push(rec);
+      }
+    }
+    return out;
   }
   if (typeof payload === "object") {
     const obj = /** @type {Record<string, unknown>} */ (payload);
-    const raw = obj.SearchDef ?? obj.searchDef ?? obj.SearchDefList ?? obj.items;
-    if (raw == null) {
-      return [];
+    for (const key of SEARCH_DEF_WRAP_KEYS) {
+      if (obj[key] != null) {
+        return unwrapSearchDefs(obj[key], depth + 1);
+      }
     }
-    if (Array.isArray(raw)) {
-      return raw.filter((x) => x != null && typeof x === "object");
-    }
-    if (typeof raw === "object") {
-      return [/** @type {Record<string, unknown>} */ (raw)];
+    if (hasSearchDefIdentity(obj)) {
+      return [obj];
     }
   }
   return [];
@@ -219,21 +264,100 @@ function isCatalogSettled(kind) {
 }
 
 /**
+ * True when a picker {@code <option>} is the custom-URL marker
+ * ({@code SearchPanel} appends {@code  (URL)}).
+ *
+ * @param {{ value?: string, text?: string, label?: string } | null | undefined} option
+ * @returns {boolean}
+ */
+function isCustomSelectOption(option) {
+  if (option == null) {
+    return false;
+  }
+  const text = String(option.text ?? option.label ?? "").trim();
+  return /\(URL\)\s*$/.test(text);
+}
+
+/**
+ * First non-empty, non-custom select option (UI catalog).
+ *
+ * @param {{ value?: string, text?: string, label?: string }[]} options
+ * @returns {{ value: string, text: string } | null}
+ */
+function pickRunnableSelectOption(options) {
+  const list = Array.isArray(options) ? options : [];
+  for (const opt of list) {
+    const value = opt && opt.value != null ? String(opt.value).trim() : "";
+    if (!value) {
+      continue;
+    }
+    if (isCustomSelectOption(opt)) {
+      continue;
+    }
+    const text = String(opt.text ?? opt.label ?? value).trim();
+    return { value, text };
+  }
+  return null;
+}
+
+/**
+ * Soft-skip execute only when neither REST nor the picker expose a runnable
+ * design search. A visible picker with a catalog search must run (#3576).
+ *
+ * @param {{
+ *   runnable?: unknown,
+ *   pickerVisible?: boolean,
+ *   optionCount?: number,
+ *   hasRunnableOption?: boolean,
+ *   onlyCustom?: boolean,
+ *   catalogEmpty?: boolean,
+ * }} [detail]
+ * @returns {boolean}
+ */
+function shouldSkipMissingRunnableSearch(detail = {}) {
+  if (detail.runnable) {
+    return false;
+  }
+  if (detail.hasRunnableOption === true) {
+    return false;
+  }
+  if (
+    detail.pickerVisible === true &&
+    Number(detail.optionCount) > 0 &&
+    detail.onlyCustom !== true
+  ) {
+    return false;
+  }
+  if (detail.onlyCustom === true) {
+    return true;
+  }
+  return detail.catalogEmpty === true;
+}
+
+/**
  * Soft-skip message when QA fixture has no runnable design searches.
  *
- * @param {{ empty?: boolean, onlyCustom?: boolean, restStatus?: number }} [detail]
+ * @param {{
+ *   empty?: boolean,
+ *   onlyCustom?: boolean,
+ *   restStatus?: number,
+ *   pickerVisible?: boolean,
+ * }} [detail]
  * @returns {string}
  */
 function noRunnableSearchSkipMessage(detail = {}) {
   const parts = [
-    "No runnable design search in fixture for Explorer saved-search E2E (#2507).",
-    "Catalog empty or only custom-URL searches — soft skip after asserting catalog UI.",
+    "No runnable design search in fixture for Explorer saved-search E2E (#3576 / #2507).",
+    "Soft-skip only when catalog is empty or only custom-URL searches — never skip Run when a catalog search exists.",
   ];
   if (detail.empty) {
     parts.push("catalog empty.");
   }
   if (detail.onlyCustom) {
     parts.push("only customSearch=true entries.");
+  }
+  if (detail.pickerVisible === false) {
+    parts.push("picker not visible.");
   }
   if (detail.restStatus != null) {
     parts.push(`REST status=${detail.restStatus}.`);
@@ -279,7 +403,10 @@ module.exports = {
   searchDefKey,
   searchDefLabel,
   isCustomUrlSearch,
+  isCustomSelectOption,
+  pickRunnableSelectOption,
   pickRunnableSavedSearch,
+  shouldSkipMissingRunnableSearch,
   isCatalogSettled,
   noRunnableSearchSkipMessage,
   postExecuteRegionSelector,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
@@ -20,7 +20,10 @@ const {
   searchDefKey,
   searchDefLabel,
   isCustomUrlSearch,
+  isCustomSelectOption,
+  pickRunnableSelectOption,
   pickRunnableSavedSearch,
+  shouldSkipMissingRunnableSearch,
   isCatalogSettled,
   noRunnableSearchSkipMessage,
   postExecuteRegionSelector,
@@ -73,6 +76,24 @@ describe("explorer-saved-search helpers (#2507)", () => {
       unwrapSearchDefs({ searchDef: [{ name: "C" }, { name: "D" }] }),
       [{ name: "C" }, { name: "D" }],
     );
+    assert.deepEqual(
+      unwrapSearchDefs({
+        SearchDefList: {
+          SearchDef: [
+            { name: "View_All", label: "All" },
+            { name: "My Pages" },
+          ],
+        },
+      }),
+      [
+        { name: "View_All", label: "All" },
+        { name: "My Pages" },
+      ],
+    );
+    assert.deepEqual(unwrapSearchDefs({ ArrayList: [{ name: "E" }] }), [
+      { name: "E" },
+    ]);
+    assert.deepEqual(unwrapSearchDefs({ empty: true }), []);
   });
 
   it("searchDefKey prefers name then id", () => {
@@ -130,16 +151,74 @@ describe("explorer-saved-search helpers (#2507)", () => {
     assert.equal(picked.label, "All");
   });
 
+  it("pickRunnableSelectOption skips placeholder and custom URL options", () => {
+    assert.equal(isCustomSelectOption({ text: "Inbox (URL)" }), true);
+    assert.equal(isCustomSelectOption({ text: "All" }), false);
+    assert.equal(pickRunnableSelectOption([]), null);
+    assert.equal(
+      pickRunnableSelectOption([
+        { value: "", text: "Choose a saved search" },
+        { value: "Inbox", text: "Inbox (URL)" },
+      ]),
+      null,
+    );
+    const picked = pickRunnableSelectOption([
+      { value: "", text: "Choose…" },
+      { value: "Custom", text: "Custom (URL)" },
+      { value: "View_All", text: "All" },
+    ]);
+    assert.ok(picked);
+    assert.equal(picked.value, "View_All");
+  });
+
+  it("shouldSkipMissingRunnableSearch never skips when catalog search exists", () => {
+    assert.equal(
+      shouldSkipMissingRunnableSearch({
+        runnable: { key: "View_All" },
+      }),
+      false,
+    );
+    assert.equal(
+      shouldSkipMissingRunnableSearch({
+        pickerVisible: true,
+        optionCount: 2,
+        hasRunnableOption: true,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldSkipMissingRunnableSearch({
+        pickerVisible: true,
+        optionCount: 1,
+        onlyCustom: false,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldSkipMissingRunnableSearch({
+        onlyCustom: true,
+        pickerVisible: true,
+        optionCount: 1,
+      }),
+      true,
+    );
+    assert.equal(
+      shouldSkipMissingRunnableSearch({ catalogEmpty: true }),
+      true,
+    );
+  });
+
   it("isCatalogSettled and soft-skip message", () => {
     assert.equal(isCatalogSettled("loading"), false);
     assert.equal(isCatalogSettled("picker"), true);
     assert.equal(isCatalogSettled("empty"), true);
     assert.equal(isCatalogSettled("error"), true);
     const msg = noRunnableSearchSkipMessage({ empty: true, restStatus: 200 });
-    assert.match(msg, /#2507/);
-    assert.match(msg, /soft skip/i);
+    assert.match(msg, /#3576/);
+    assert.match(msg, /soft-skip/i);
     assert.match(msg, /empty/i);
     assert.match(msg, /200/);
+    assert.match(msg, /never skip/i);
   });
 
   it("region selectors include key test ids", () => {


### PR DESCRIPTION
## Summary

H2 operator proof for Explorer **SearchPanel** saved-search picker + Run (parent #3102 / #2400 saved-search row).

Nested Jackson `SearchDefList.SearchDef` (and ArrayList) catalog payloads now unwrap to real rows in `listExplorerSavedSearches`, so the picker is not a silent empty list. Playwright `explorer-saved-search.spec.js` **must not skip Run** when REST or the picker expose a standard/user search. Custom URL searches stay listed and **Run stays disabled**. SearchPanel chrome was not rebuilt. Gap-matrix saved-search remains **Partial** — do not claim Present.

Fixes #3576  
Parent: #3102

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Surefire 61; Vitest 2872).
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. `npm --prefix modules/perc-qa-automation/frontend run test:unit` includes `explorer-saved-search.test.js` (14 passed).
4. QA H2: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health` (cell `HEALTH:healthy` HTTP 200; FastForward import/index ERROR is BUG:#3592).
5. Hot-deploy `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2` Rhythmyx `cm/modern/assets/`.
6. `npm run test:surface -- --path tests/explorer-saved-search.spec.js` with `TEST_CMS_URL` from qa-up — **4 passed, 0 skipped**.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): operator picker/run steps already documented in `product-docs/8.2/admin/content-explorer.md`; this slice is H2 proof + no-skip Playwright + catalog unwrap residual
- [x] **Unit / module tests** — helper skip/unwrap tests + `unwrapSearchDefList` Vitest
- [x] **WebUI + Playwright** — `explorer-saved-search.spec.js` no-skip run path + custom-URL Run disabled
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation`
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-18T19:37:29-04:00); Surefire Tests run: 61, Failures: 0; Vitest Test Files 380 passed / Tests 2872 passed
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-18T19:35:48-04:00); No Java tests
  - `node --test tests/unit/explorer-saved-search.test.js` → 14 passed
- **downstream_checked:** none (C2 did not apply — no Java `final`/public signature change)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build --timeout-seconds 1200`
- **TEST_CMS_URL:** `http://127.0.0.1:9993` (container `perc-matrix-cms-h2`, `QA_CMS_HOST_PORT=9993`)
- **qa-health:** HTTP 200, `HEALTH:healthy`; RESULT:FAIL `DETAIL:server_log_errors` FastForward `PSDbStorageService` import — **BUG:#3592** (pre-existing; not saved-search execute)
- **deploy:** `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- **Playwright:** `npm run test:surface -- --path tests/explorer-saved-search.spec.js` → **4 passed (6.8s), 0 skipped**
- **console-clean:** yes (pageerror/console error collector empty on picker/run)
- **server.log-clean:** no **BUG:#3592** (FastForward import + `PSSearchIndexFieldValueModifier` last-modifier noise; no saved-search I/O execute error)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
