### PR TITLE
fix(qa): Design SPA create-template Playwright no-skip on H2 (#3578)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -735,20 +735,21 @@ npm run test:surface:list -- --path tests/profile-shell.spec.js
 npm run test:surface:list -- --tag profile
 ```
 
-#### Design SPA library + create/edit consolidation (#3307 / parent #2631)
+#### Design SPA library + create/edit consolidation (#3307 / #3578 / parent #2631)
 
 Surface-filtered companion for the Design SPA template library (list + editor) after
-Phase 4 shells (#2808–#2810). **Create** (#3305) and **classic list redirect** (#3306)
-are asserted when that chrome is on the QA cell; otherwise the spec **skips cleanly**
-(do not run the full suite).
+Phase 4 shells (#2808–#2810). **Create** (#3305 / #3578) is **required** on
+`perc-devctl qa-up` H2 (no skip). **Classic list redirect** (#3306) still skips
+cleanly when that cutover is not on the cell (do not run the full suite).
 
 | Item | Value |
 |------|--------|
-| Spec | `frontend/tests/design-spa-consolidation.spec.js` |
+| Spec (create, no-skip) | `frontend/tests/design-template-create.spec.js` |
+| Spec (consolidation) | `frontend/tests/design-spa-consolidation.spec.js` |
 | Helpers / unit | `frontend/tests/helpers/design-spa-surface.js`, `tests/unit/design-spa-surface.test.js` |
 | Tags | `@design-spa` `@smoke` `@ui` |
-| Soft skip (shell) | No `perc-design-shell` on the cell |
-| Soft skip (create) | No `design-tpl-create` (sibling #3305 not deployed) |
+| Soft skip (shell) | No `perc-design-shell` on the cell (library/edit cases only) |
+| Create | Fail if `design-tpl-create` is missing; assert `POST /services/templates` and no Widget XML |
 | Soft skip (redirect) | `admin.jsp` still classic CM1 list (sibling #3306 not deployed) |
 | Product docs | `product-docs/8.2/admin/design-templates.md` |
 

--- a/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
@@ -25,8 +25,9 @@
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Library + edit run when Design chrome is on the cell (#2808–#2810).
- * Create (#3305) and classic-list redirect (#3306) skip cleanly when that
- * chrome is not deployed yet.
+ * Create (#3305 / #3578) is required — fail if design-tpl-create is missing.
+ * Classic-list redirect (#3306) still skips cleanly when that cutover is not
+ * deployed yet.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -160,15 +161,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     await openDesignLibrary(page);
 
     const createBtn = page.locator(tid(TEST_IDS.create));
-    const createPresent = await softVisible(createBtn, 8_000);
-    const createSkip = skipReasonForChrome({
-      shellPresent: true,
-      wantCreate: true,
-      createPresent,
-    });
-    if (createSkip) {
-      test.skip(true, createSkip);
-    }
+    await expect(createBtn).toBeVisible({ timeout: 30_000 });
 
     const error = page.locator(tid(TEST_IDS.error));
     if (await error.isVisible()) {

--- a/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
@@ -15,7 +15,9 @@
  */
 
 /**
- * Design SPA create template without Widget XML (#3305 / parent #2631).
+ * Design SPA create template without Widget XML (#3305 / #3578 / parent #2631).
+ *
+ * Required on perc-devctl qa-up H2 — no skip when create chrome is missing.
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/design-template-create.spec.js
@@ -27,6 +29,10 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  createBodyHasWidgetXml,
+  isTemplateCreatePost,
+} = require("./helpers/design-spa-surface");
 
 function designTemplatesUrl() {
   const q = new URLSearchParams({
@@ -81,7 +87,17 @@ test.describe("Design template create (#3305)", () => {
       page.locator('[data-testid="design-tpl-create-dialog"]'),
     ).toHaveAttribute("aria-describedby", "design-tpl-create-hint");
     await page.locator('[data-testid="design-tpl-create-name"]').fill(name);
+
+    const createPost = page.waitForResponse(
+      (r) => isTemplateCreatePost(r.request()),
+      { timeout: 20_000 },
+    );
     await page.locator('[data-testid="design-tpl-create-submit"]').click();
+    const postResp = await createPost;
+    expect(postResp.ok(), `POST /services/templates ${postResp.status()}`).toBe(
+      true,
+    );
+    expect(createBodyHasWidgetXml(postResp.request().postData())).toBe(false);
 
     await expect(
       page.locator('[data-testid="design-tpl-create-dialog"]'),

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -18,10 +18,10 @@
 /**
  * Design SPA surface helpers (#3307 / parent #2631).
  *
- * URL builders, stable test ids, and skip reasons for library + create/edit
- * consolidation. Sibling slices #3305 (create) and #3306 (classic list
- * redirect) may not be on the QA cell — callers must skip cleanly instead of
- * running the full Playwright suite.
+ * URL builders, stable test ids, and skip reasons for library + edit
+ * consolidation. Create (#3305 / #3578) is required on H2 — do not skip
+ * when design-tpl-create is missing. Sibling #3306 (classic list redirect)
+ * may still skip cleanly when that cutover is not on the cell.
  */
 
 "use strict";
@@ -57,12 +57,14 @@ const CLASSIC_ASSIGNED_TEMPLATES_ID = "perc-assigned-templates";
 const SKIP = Object.freeze({
   SHELL:
     "Design SPA chrome not on this QA cell (perc-design-shell missing) — skip; do not run full suite. Parent #2631 / #3307.",
-  CREATE:
-    "Create-template chrome not on this QA cell (design-tpl-create missing; sibling #3305). Clean skip.",
   EDIT_EMPTY: "No templates in catalog — cannot exercise Design SPA editor.",
   REDIRECT:
     "Classic Design list still hosted (no perc-design-shell on admin.jsp / ?view=design; sibling #3306). Clean skip.",
 });
+
+/** Payload markers that would mean create still authored Widget definition XML. */
+const WIDGET_XML_RE =
+  /widgetXml|WidgetDef|sys_Widget|widgetDefinition|WidgetDefinition/i;
 
 /**
  * @param {string} baseUrl
@@ -112,10 +114,8 @@ function designLegacyViewUrl(baseUrl) {
  *
  * @param {{
  *   shellPresent?: boolean,
- *   createPresent?: boolean,
  *   catalogEmpty?: boolean,
  *   redirectToSpa?: boolean,
- *   wantCreate?: boolean,
  *   wantEdit?: boolean,
  *   wantRedirect?: boolean,
  * }} flags
@@ -126,9 +126,6 @@ function skipReasonForChrome(flags) {
   if (!f.shellPresent) {
     return SKIP.SHELL;
   }
-  if (f.wantCreate && !f.createPresent) {
-    return SKIP.CREATE;
-  }
   if (f.wantEdit && f.catalogEmpty) {
     return SKIP.EDIT_EMPTY;
   }
@@ -136,6 +133,51 @@ function skipReasonForChrome(flags) {
     return SKIP.REDIRECT;
   }
   return null;
+}
+
+/**
+ * True when {@code url} is the templates collection (POST create), not
+ * {@code /services/templates/{idOrName}}.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isTemplatesCollectionUrl(url) {
+  try {
+    const pathname = new URL(String(url)).pathname.replace(/\/+$/, "");
+    return /\/services\/templates$/.test(pathname);
+  } catch {
+    return /\/services\/templates\/?(\?|$)/.test(String(url));
+  }
+}
+
+/**
+ * @param {{ method?: () => string, url?: () => string }|null|undefined} request
+ * @returns {boolean}
+ */
+function isTemplateCreatePost(request) {
+  if (!request || typeof request.method !== "function") {
+    return false;
+  }
+  if (String(request.method()).toUpperCase() !== "POST") {
+    return false;
+  }
+  const url = typeof request.url === "function" ? request.url() : "";
+  return isTemplatesCollectionUrl(url);
+}
+
+/**
+ * True when a create POST body still carries Widget definition XML.
+ *
+ * @param {unknown} payload
+ * @returns {boolean}
+ */
+function createBodyHasWidgetXml(payload) {
+  if (payload == null) {
+    return false;
+  }
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return WIDGET_XML_RE.test(text);
 }
 
 /**
@@ -161,6 +203,9 @@ module.exports = {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isTemplatesCollectionUrl,
+  isTemplateCreatePost,
+  createBodyHasWidgetXml,
   filterConsoleNoise,
   softVisible,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -31,6 +31,9 @@ const {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isTemplatesCollectionUrl,
+  isTemplateCreatePost,
+  createBodyHasWidgetXml,
   filterConsoleNoise,
 } = require("../helpers/design-spa-surface");
 
@@ -71,15 +74,16 @@ describe("design-spa-surface helpers (#3307)", () => {
     );
   });
 
-  it("skips create when sibling #3305 chrome is absent", () => {
+  it("does not skip create when chrome is absent (#3578 no-skip)", () => {
     assert.equal(
       skipReasonForChrome({
         shellPresent: true,
         wantCreate: true,
         createPresent: false,
       }),
-      SKIP.CREATE,
+      null,
     );
+    assert.equal(SKIP.CREATE, undefined);
   });
 
   it("skips editor when catalog is empty", () => {
@@ -129,6 +133,49 @@ describe("design-spa-surface helpers (#3307)", () => {
       }),
       null,
     );
+  });
+
+  it("matches POST /services/templates collection only", () => {
+    assert.equal(
+      isTemplatesCollectionUrl("http://127.0.0.1:2050/Rhythmyx/services/templates"),
+      true,
+    );
+    assert.equal(
+      isTemplatesCollectionUrl(
+        "http://127.0.0.1:2050/Rhythmyx/services/templates/Home",
+      ),
+      false,
+    );
+    assert.equal(
+      isTemplateCreatePost({
+        method: () => "POST",
+        url: () => "http://127.0.0.1:2050/Rhythmyx/services/templates",
+      }),
+      true,
+    );
+    assert.equal(
+      isTemplateCreatePost({
+        method: () => "GET",
+        url: () => "http://127.0.0.1:2050/Rhythmyx/services/templates",
+      }),
+      false,
+    );
+  });
+
+  it("rejects Widget XML on create payloads", () => {
+    assert.equal(
+      createBodyHasWidgetXml({
+        TemplateDetail: { name: "qa.create.tpl", assembler: "htmlAssembler" },
+      }),
+      false,
+    );
+    assert.equal(
+      createBodyHasWidgetXml(
+        JSON.stringify({ TemplateDetail: { widgetXml: "<Widget/>" } }),
+      ),
+      true,
+    );
+    assert.equal(createBodyHasWidgetXml(null), false);
   });
 
   it("filters known console noise", () => {

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -43,7 +43,7 @@ The **Templates** tab lists assembly templates from `GET /services/templates`.
 | State | What you see |
 |-------|----------------|
 | List | A table of templates. Open a row to edit. |
-| Empty | **No templates found.** Use **Create template** when that control is present. |
+| Empty | **No templates found.** Use **Create template**. |
 | Error | An operator-facing message. The rest of the Design shell stays usable. |
 
 ## Create a template (no Widget XML)
@@ -66,10 +66,6 @@ written.**
 
 If create fails (duplicate name, invalid name, or server error), the dialog stays open and
 shows an operator-facing message. Correct the fields and try again.
-
-If **Create template** is not on this deployment yet, new templates remain on residual
-classic hosts (`editTemplate.jsp` and related upgrade-only JSPs) until that flow is
-installed. The library and editor on this page still apply.
 
 ## Edit assembler, slots, source, and bindings
 


### PR DESCRIPTION
## Summary

Parent tracker: #2631 (epic #2626). Slice: #3578 — Design SPA create-template Playwright no-skip on H2.

#3305 / #3307 shipped create chrome and a consolidation spec that **skipped** create when `design-tpl-create` was missing from the QA cell. Create dialog and `POST /services/templates` are now on the stock H2 cell. This PR:

- Makes `design-template-create.spec.js` a hard H2 gate (still no skip) and asserts a successful `POST /services/templates` with a **Widget-XML-free** body
- Removes the create skip from `design-spa-consolidation.spec.js` (fail if the Create button is absent)
- Updates Design templates product docs so Create is a required control, not an optional sibling

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3578
Partial #2631

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up` (H2). Capture `TEST_CMS_URL` (this run: `http://127.0.0.1:9993`).
2. `python docker/scripts/perc-devctl.py qa-health` — cell HTTP 200 / Health=healthy. FastForward `PSDbStorageService` import ERROR lines are pre-existing noise (not `Failed startup of context`).
3. From `modules/perc-qa-automation/frontend`:
   - `npm run test:unit` (includes `design-spa-surface` helpers)
   - `TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/design-template-create.spec.js`
   - Same env: `npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "create template when chrome present"`
4. Confirm 1+ passed, **no skip**, catalog row appears, no Widget XML on the POST body.
5. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/design-templates.md` (Create is required; removed “not on this deployment yet”)
- [x] **Unit / module tests** — `design-spa-surface` helper tests for no-skip create + POST/Widget-XML matchers; `perc-qa-automation` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `design-template-create.spec.js` + consolidation create case on H2 QA
- [x] **Build gates** — `modules/perc-qa-automation` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (URL helpers only; no host file I/O)

### C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-18T19:59:36-04:00)
  - `npm run test:unit` → **310 passed**
  - `scripts/ci-smoke-product-docs.bat` → **OK**
- **downstream_checked:** none (C2 did not apply — no Java public/protected API or `final`/`sealed` type change)

### C5 UI proof (H2 Docker QA)

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up` → container `perc-matrix-cms-h2`, **TEST_CMS_URL=`http://127.0.0.1:9993`**
- **qa-health:** HTTP 200, Health=healthy. RESULT:FAIL `DETAIL:server_log_errors` FastForward `PSDbStorageService` binary import (pre-existing; not `rhythmyx_context_failed`)
- **deploy:** none required — create chrome (`design-tpl-create`) and `POST /services/templates` already on the cell image
- **Playwright:**
  - `npm run test:surface -- --path tests/design-template-create.spec.js` → **1 passed** (2.2s), no skip
  - `npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "create template when chrome present"` → **1 passed** (2.2s), no skip
- **console-clean:** yes
- **server.log-clean:** yes for this feature (no template/create ERROR/FATAL in the test window; FastForward import ERROR is pre-existing)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
