### PR TITLE
fix(qa): Design classic list redirect Playwright no-skip on H2 (#3579)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -759,21 +759,22 @@ npm run test:surface:list -- --path tests/profile-shell.spec.js
 npm run test:surface:list -- --tag profile
 ```
 
-#### Design SPA library + create/edit consolidation (#3307 / parent #2631)
+#### Design SPA library + create/edit consolidation (#3307 / #3579 / parent #2631)
 
 Surface-filtered companion for the Design SPA template library (list + editor) after
-Phase 4 shells (#2808–#2810). **Create** (#3305) and **classic list redirect** (#3306)
-are asserted when that chrome is on the QA cell; otherwise the spec **skips cleanly**
-(do not run the full suite).
+Phase 4 shells (#2808–#2810). **Classic list redirect** (#3306 / #3579) is
+**required** on `perc-devctl qa-up` H2 (no skip). **Create** (#3305) still skips
+cleanly when that chrome is not on the cell (do not run the full suite).
 
 | Item | Value |
 |------|--------|
-| Spec | `frontend/tests/design-spa-consolidation.spec.js` |
+| Spec (redirect, no-skip) | `frontend/tests/design-legacy-redirect.spec.js` |
+| Spec (consolidation) | `frontend/tests/design-spa-consolidation.spec.js` |
 | Helpers / unit | `frontend/tests/helpers/design-spa-surface.js`, `tests/unit/design-spa-surface.test.js` |
 | Tags | `@design-spa` `@smoke` `@ui` |
-| Soft skip (shell) | No `perc-design-shell` on the cell |
+| Soft skip (shell) | No `perc-design-shell` on the cell (library/edit cases only) |
 | Soft skip (create) | No `design-tpl-create` (sibling #3305 not deployed) |
-| Soft skip (redirect) | `admin.jsp` still classic CM1 list (sibling #3306 not deployed) |
+| Redirect | Fail if `admin.jsp` / `?view=design` do not land on `perc-design-shell` |
 | Product docs | `product-docs/8.2/admin/design-templates.md` |
 
 ```bash
@@ -781,9 +782,10 @@ cd modules/perc-qa-automation/frontend
 # After perc-devctl qa-up (use printed TEST_CMS_URL):
 TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
   ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
-  npm run test:surface -- --path tests/design-spa-consolidation.spec.js
+  npm run test:surface -- --path tests/design-legacy-redirect.spec.js
 
-npm run test:surface:list -- --path tests/design-spa-consolidation.spec.js
+npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "legacy Design list"
+npm run test:surface:list -- --path tests/design-legacy-redirect.spec.js
 npm run test:surface -- --tag design-spa
 ```
 

--- a/modules/perc-qa-automation/frontend/tests/design-legacy-redirect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-legacy-redirect.spec.js
@@ -15,82 +15,111 @@
  */
 
 /**
- * Design template-list legacy entry retirement (#3306 / parent #2631).
+ * Design template-list legacy entry retirement (#3306 / #3579 / parent #2631).
+ *
+ * Required on perc-devctl qa-up H2 — no skip when classic Design list is
+ * still hosted. Fail if admin.jsp / ?view=design do not land on
+ * perc-design-shell.
  *
  * Surface-filtered:
  *   npm run test:surface -- --path tests/design-legacy-redirect.spec.js
- *
- * Proves admin.jsp and ?view=design land on SPA Design template library
- * (not the retired CM1 Design list). Broader Design SPA Playwright is #3307.
  */
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  TEST_IDS,
+  CLASSIC_ASSIGNED_TEMPLATES_ID,
+  designLegacyAdminUrl,
+  designLegacyViewUrl,
+  isDesignSpaLandingUrl,
+  filterConsoleNoise,
+} = require("./helpers/design-spa-surface");
 
-test.describe("Design legacy list entry retirement (#3306)", () => {
+function tid(id) {
+  return `[data-testid="${id}"]`;
+}
+
+function attachConsoleGate(page) {
+  const errors = [];
+  page.on("pageerror", (err) => {
+    errors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      errors.push(msg.text());
+    }
+  });
+  return errors;
+}
+
+test.describe("Design legacy list entry retirement (#3306 / #3579)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
     await loginAsAdmin(page);
   });
 
-  function attachPageErrorGate(page) {
-    const pageErrors = [];
-    page.on("pageerror", (err) => {
-      pageErrors.push(String(err && err.message ? err.message : err));
-    });
-    return pageErrors;
-  }
-
   test("admin.jsp hard-redirects to SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/admin.jsp?_=${Date.now()}`;
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    const consoleErrors = attachConsoleGate(page);
+    await page.goto(designLegacyAdminUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
 
-    await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.nav))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
-    const finalUrl = page.url();
-    expect(finalUrl).toMatch(/design|entry=design|view=design/i);
-    expect(pageErrors, "uncaught pageerror on Design redirect").toEqual([]);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
   test("admin.jsp?view=admin still lands on SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/admin.jsp?view=admin&_=${Date.now()}`;
+    const consoleErrors = attachConsoleGate(page);
+    const url = `${BASE_URL.replace(/\/+$/, "")}/Rhythmyx/cm/app/admin.jsp?view=admin&_=${Date.now()}`;
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
     const finalUrl = page.url();
-    expect(finalUrl).toMatch(/design|entry=design|view=design/i);
+    expect(isDesignSpaLandingUrl(finalUrl)).toBe(true);
     expect(finalUrl).not.toMatch(/[?&]view=admin(?:&|$)/i);
-    expect(pageErrors, "uncaught pageerror on view= override").toEqual([]);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
   test("?view=design deep link lands on SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/?view=design&_=${Date.now()}`;
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    const consoleErrors = attachConsoleGate(page);
+    await page.goto(designLegacyViewUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
 
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator(tid(TEST_IDS.panel))).toBeVisible({
       timeout: 30_000,
     });
     await expect(page.getByTestId("panel-design-templates")).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
-    expect(pageErrors, "uncaught pageerror on view=design").toEqual([]);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
@@ -25,8 +25,9 @@
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Library + edit run when Design chrome is on the cell (#2808–#2810).
- * Create (#3305) and classic-list redirect (#3306) skip cleanly when that
- * chrome is not deployed yet.
+ * Create (#3305) still skips cleanly when that chrome is not deployed yet.
+ * Classic-list redirect (#3306 / #3579) is required on H2 — fail if
+ * admin.jsp / ?view=design do not land on perc-design-shell.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -37,11 +38,11 @@ const {
 const {
   TEST_IDS,
   CLASSIC_ASSIGNED_TEMPLATES_ID,
-  SKIP,
   designTemplatesUrl,
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
   softVisible,
 } = require("./helpers/design-spa-surface");
@@ -193,7 +194,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
-  test("legacy Design list lands on SPA when cutover present @smoke @ui @design-spa", async ({
+  test("legacy Design list lands on SPA (#3579 no-skip) @smoke @ui @design-spa", async ({
     page,
   }) => {
     const consoleErrors = attachConsoleGate(page);
@@ -201,28 +202,13 @@ test.describe("Design SPA consolidation (#3307)", () => {
       waitUntil: "domcontentloaded",
     });
 
-    const spaShell = page.locator(tid(TEST_IDS.shell));
-    const redirectToSpa = await softVisible(spaShell, 15_000);
-    const redirectSkip = skipReasonForChrome({
-      shellPresent: true,
-      wantRedirect: true,
-      redirectToSpa,
-    });
-    if (redirectSkip) {
-      // Extra evidence: classic list marker may still be present on main.
-      const classic = page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`);
-      if (await softVisible(classic, 3_000)) {
-        test.skip(true, `${SKIP.REDIRECT} Classic #${CLASSIC_ASSIGNED_TEMPLATES_ID} still visible.`);
-      }
-      test.skip(true, redirectSkip);
-    }
-
     await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
-      timeout: 15_000,
+      timeout: 30_000,
     });
     await expect(
       page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`),
     ).toHaveCount(0);
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
 
     await page.goto(designLegacyViewUrl(BASE_URL), {
       waitUntil: "domcontentloaded",
@@ -230,6 +216,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 20_000,
     });
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
     expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -16,12 +16,13 @@
  */
 
 /**
- * Design SPA surface helpers (#3307 / parent #2631).
+ * Design SPA surface helpers (#3307 / #3579 / parent #2631).
  *
  * URL builders, stable test ids, and skip reasons for library + create/edit
- * consolidation. Sibling slices #3305 (create) and #3306 (classic list
- * redirect) may not be on the QA cell — callers must skip cleanly instead of
- * running the full Playwright suite.
+ * consolidation. Classic list redirect (#3306 / #3579) is required on
+ * perc-devctl qa-up H2 — do not skip when admin.jsp / ?view=design miss
+ * perc-design-shell. Sibling #3305 (create) may still skip cleanly when
+ * that chrome is not on the cell.
  */
 
 "use strict";
@@ -60,8 +61,6 @@ const SKIP = Object.freeze({
   CREATE:
     "Create-template chrome not on this QA cell (design-tpl-create missing; sibling #3305). Clean skip.",
   EDIT_EMPTY: "No templates in catalog — cannot exercise Design SPA editor.",
-  REDIRECT:
-    "Classic Design list still hosted (no perc-design-shell on admin.jsp / ?view=design; sibling #3306). Clean skip.",
 });
 
 /**
@@ -114,10 +113,8 @@ function designLegacyViewUrl(baseUrl) {
  *   shellPresent?: boolean,
  *   createPresent?: boolean,
  *   catalogEmpty?: boolean,
- *   redirectToSpa?: boolean,
  *   wantCreate?: boolean,
  *   wantEdit?: boolean,
- *   wantRedirect?: boolean,
  * }} flags
  * @returns {string|null} skip message, or null when the case should run
  */
@@ -132,10 +129,20 @@ function skipReasonForChrome(flags) {
   if (f.wantEdit && f.catalogEmpty) {
     return SKIP.EDIT_EMPTY;
   }
-  if (f.wantRedirect && !f.redirectToSpa) {
-    return SKIP.REDIRECT;
-  }
   return null;
+}
+
+/**
+ * True when a landed URL is the Design SPA (view=design, entry=design, or
+ * /design path). Used by the no-skip H2 redirect gate (#3579).
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isDesignSpaLandingUrl(url) {
+  return /(?:[?&]view=design(?:[&?#]|$)|[?&]entry=design(?:[&?#]|$)|\/design(?:[/?#]|$))/i.test(
+    String(url || ""),
+  );
 }
 
 /**
@@ -161,6 +168,7 @@ module.exports = {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
   softVisible,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * Unit tests for Design SPA surface helpers (#3307) — no live CMS.
+ * Unit tests for Design SPA surface helpers (#3307 / #3579) — no live CMS.
  */
 
 "use strict";
@@ -31,6 +31,7 @@ const {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
 } = require("../helpers/design-spa-surface");
 
@@ -93,15 +94,16 @@ describe("design-spa-surface helpers (#3307)", () => {
     );
   });
 
-  it("skips redirect when sibling #3306 cutover is absent", () => {
+  it("does not skip redirect when classic list chrome is still present (#3579 no-skip)", () => {
     assert.equal(
       skipReasonForChrome({
         shellPresent: true,
         wantRedirect: true,
         redirectToSpa: false,
       }),
-      SKIP.REDIRECT,
+      null,
     );
+    assert.equal(SKIP.REDIRECT, undefined);
   });
 
   it("runs when requested chrome is present", () => {
@@ -129,6 +131,36 @@ describe("design-spa-surface helpers (#3307)", () => {
       }),
       null,
     );
+  });
+
+  it("matches Design SPA landing URLs after classic redirect", () => {
+    assert.equal(
+      isDesignSpaLandingUrl("http://127.0.0.1:2050/Rhythmyx/cm/app/?view=design"),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/spa.jsp?entry=design&section=templates",
+      ),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl("http://127.0.0.1:2050/Rhythmyx/cm/app/design"),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/?view=design#templates",
+      ),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/admin.jsp?view=admin",
+      ),
+      false,
+    );
+    assert.equal(isDesignSpaLandingUrl(""), false);
   });
 
   it("filters known console noise", () => {

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -23,11 +23,10 @@ In Percussion CMS 8.2 the primary template-list entry is the SPA shell. The clas
    library). Design is not a top-nav item. You can also open:
    - Query contract: `spa.jsp?entry=design&section=templates`
    - Path route: `/cm/app/design` or `/cm/app/design/templates`
-   - Legacy bookmarks: `/cm/app/?view=design` and `/cm/app/admin.jsp` redirect here
-     when the Design list cutover is installed. `admin.jsp` then always forces
-     `view=design` (a bookmark such as `admin.jsp?view=admin` still opens Design, not
-     Admin). Until that cutover is on the server, `admin.jsp` may still show the
-     classic CM1 Design list.
+   - Legacy bookmarks: `/cm/app/?view=design` and `/cm/app/admin.jsp` always
+     redirect here. `admin.jsp` forces `view=design` (a bookmark such as
+     `admin.jsp?view=admin` still opens Design, not Admin). The classic CM1
+     Design list is not a product entry for these bookmarks.
 3. The **Templates** tab lists assembly templates (label, name, id, description).
    The shell loads under the same product top nav as Explorer, Navigation, Developer, Publish, and Admin.
 


### PR DESCRIPTION
## Summary

Parent tracker: #2631 (epic #2626). Slice: #3579 — classic Design redirect Playwright no-skip on H2.

#3306 redirected `admin.jsp` / `?view=design` to SPA Design, but #3307 skipped the redirect case when `perc-design-shell` was missing from the QA cell. The stock H2 cell already serves the Design list cutover. This PR:

- Makes `design-legacy-redirect.spec.js` a hard H2 gate (no skip) for `admin.jsp`, `admin.jsp?view=admin`, and `?view=design`
- Removes the redirect skip from `design-spa-consolidation.spec.js` (fail if the shell is absent or the classic list marker remains)
- Updates Design templates product docs so legacy bookmarks always land on the SPA (not “until cutover is installed”)

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3579
Partial #2631

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` (H2). Capture `TEST_CMS_URL` (this run: `http://127.0.0.1:9993`).
2. `python docker/scripts/perc-devctl.py qa-health` — cell HTTP 200 / Health=healthy. FastForward `PSDbStorageService` import ERROR lines are pre-existing noise (not `Failed startup of context`).
3. From `modules/perc-qa-automation/frontend`:
   - `npm run test:unit` (includes `design-spa-surface` helpers)
   - `TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/design-legacy-redirect.spec.js`
   - Same env: `npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "legacy Design list"`
4. Confirm 3+1 passed, **no skip**, `perc-design-shell` visible, `#perc-assigned-templates` count 0.
5. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/design-templates.md` (legacy Design bookmarks always redirect to the SPA)
- [x] **Unit / module tests** — `design-spa-surface` helper tests for no-skip redirect + landing URL matcher; `perc-qa-automation` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `design-legacy-redirect.spec.js` + consolidation redirect case on H2 QA
- [x] **Build gates** — `modules/perc-qa-automation` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (URL helpers only; no host file I/O)

### C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-18T20:12:04-04:00)
  - `npm run test:unit` → **319 passed**
  - `scripts/ci-smoke-product-docs.bat` → **OK**
- **downstream_checked:** none (C2 did not apply — no Java public/protected API or `final`/`sealed` type change)

### C5 UI proof (H2 Docker QA)

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → container `perc-matrix-cms-h2`, **TEST_CMS_URL=`http://127.0.0.1:9993`**
- **qa-health:** HTTP 200, Health=healthy. RESULT:FAIL `DETAIL:server_log_errors` FastForward `PSDbStorageService` binary import (pre-existing; not `rhythmyx_context_failed`)
- **deploy:** none required — `admin.jsp` / `?view=design` cutover (#3306) already on the cell image
- **Playwright:**
  - `npm run test:surface -- --path tests/design-legacy-redirect.spec.js` → **3 passed** (3.7s), no skip
  - `npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "legacy Design list"` → **1 passed** (1.7s), no skip
- **console-clean:** yes
- **server.log-clean:** yes for this feature (no design/template/admin.jsp ERROR/FATAL in the test window; FastForward import + search-index modifier ERROR lines are pre-existing)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
