### PR TITLE
fix(packages): stop authoring Widget XML archive-manifest paths (#3582)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3582-archive-manifest-widget-xml-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3582-archive-manifest-widget-xml-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review: issue #3582 archive-manifest Widget XML dual-ship
+
+**Scope:** uncommitted changes on `fix/issue-3582-archive-manifest-widget-xml` vs `origin/main`  
+**Module:** `modules/perc-packages`  
+**Date:** 2026-08-18
+
+## Summary
+
+Product package source `psx_archiveInfo.xml` / `psx_archiveManifest.xml` no longer author `rxconfig/Widgets/*.xml` except waived `perc.Test`. Install emitter re-injects those user-dependencies on the staging copy so built `.ppkg` still ships Widget XML. Surefire inventory fails if the paths return.
+
+## Recommendation
+
+approve
+
+## Gate
+
+pass
+
+## Cross-platform path checklist
+
+- [x] On-disk I/O uses `Path.resolve` / `Files`
+- [x] ZIP / archive / install-relative paths use `/` (not OS separators)
+- [x] Widget stems reject `/`, `\`, and `..`
+- [x] Tests do not assert OS `toString()` path shapes
+- [x] Line-ending sensitive inject uses the file's existing `\r\n` or `\n`
+
+## Issues
+
+None (hard-gate).
+
+Nit: stripped descriptors may retain a blank line where the Widget XML block was removed; remaining user-dependencies and XML structure stay valid.
+
+## Memory patterns hit
+
+- Missing behavioral unit tests — covered (scan/strip/inject/encode/materialize + product tree)
+- Non-portable path joins — not present
+- Deployer/packaging: install wire format preserved via emit-time inject; shim not deleted
+- Incomplete change-class — companions present (inventory, tests, product source strip, emitter, README)
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-packages/README.md
+++ b/modules/perc-packages/README.md
@@ -29,3 +29,16 @@ Product packages must not reintroduce committed install Widget definition XML un
 See root `scripts/README.md` (Widget definition XML inventory gate) and
 `docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md`.
 
+## Archive-manifest Widget XML paths (#3582)
+
+Non-waived product `psx_archiveInfo.xml` / `psx_archiveManifest.xml` must not author
+`rxconfig/Widgets/*.xml` (or encoded `rxconfig_Widgets_`) when modern `widgets/` roots exist.
+Waiver is **`perc.Test` only**. Package build re-injects those user-dependencies on the staging
+copy via `PSWidgetXmlInstallEmitter` / `PSWidgetArchiveManifestInventory` so the built `.ppkg`
+still installs Widget XML.
+
+| Piece | Class |
+|-------|--------|
+| Inventory + strip + install inject | `com.percussion.packages.widgetxml.PSWidgetArchiveManifestInventory` |
+| Surefire assertion | `PSWidgetArchiveManifestInventoryTest` |
+

--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -56,8 +56,9 @@ import java.util.zip.ZipOutputStream;
  * <p>Widget packages that author modern {@code widgets/&lt;stem&gt;/component-package.json} without
  * committed install Widget XML (batch A+B+C ship-exit #2883/#2884/#2885) materialize
  * {@code sys__UserDependency--rxconfig/Widgets/*.xml} before reorganize so deployer / {@code
- * PSWidgetDao} still receive the legacy install wire format. Dual-ship packages that still commit
- * Widget XML are left unchanged.
+ * PSWidgetDao} still receive the legacy install wire format. Source archive descriptors no longer
+ * author those Widget XML paths (#3582); install emit re-injects them on the staging copy.
+ * Dual-ship packages that still commit Widget XML are left unchanged.
  *
  * <p>Usage: {@code PSPackageBuilder <packagesDir> <outputDir> <tempDir>}
  */

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetArchiveManifestInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetArchiveManifestInventory.java
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Inventory and install-time rewrite for Widget definition XML paths in product package archive
+ * descriptors ({@code psx_archiveInfo.xml} / {@code psx_archiveManifest.xml}).
+ *
+ * <p>Phase 3 leftover of parent #2630 / issue #3582: product packages with modern {@code
+ * widgets/} roots must not <em>author</em> {@code rxconfig/Widgets/*.xml} user-dependencies. Package
+ * build still materializes install Widget XML and re-injects those archive entries so deployer /
+ * {@code PSWidgetDao} keep the legacy wire format. Waiver: {@code perc.Test} only.
+ *
+ * <p>Archive/ZIP logical paths use {@code /}. On-disk I/O uses {@link Path#resolve(String)}.
+ *
+ * @see PSWidgetXmlInstallEmitter
+ * @see PSWidgetDefinitionXmlInventory
+ */
+public final class PSWidgetArchiveManifestInventory {
+
+  /** Same explicit waiver as committed Widget XML files ({@code perc.Test} only). */
+  public static final Set<String> WAIVED_PACKAGE_DIRS =
+      PSWidgetDefinitionXmlInventory.WAIVED_PACKAGE_DIRS;
+
+  public static final String ARCHIVE_INFO_FILE_NAME = "psx_archiveInfo.xml";
+  public static final String ARCHIVE_MANIFEST_FILE_NAME = "psx_archiveManifest.xml";
+
+  /** Install-relative Widget definition path prefix (ZIP / archive / URL form). */
+  public static final String WIDGET_XML_INSTALL_PREFIX = "rxconfig/Widgets/";
+
+  /** Encoded archive-folder token for {@code rxconfig/Widgets} (package-build layout). */
+  public static final String WIDGET_XML_ENCODED_TOKEN = "rxconfig_Widgets_";
+
+  private static final Pattern ARCHIVE_INFO_WIDGET_DEP =
+      Pattern.compile(
+          "<PSXUserDependency\\b[^>]*\\bpath\\s*=\\s*\"rxconfig[/\\\\]Widgets/[^\"]+\"[^>]*>.*?</PSXUserDependency>",
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  private static final Pattern ARCHIVE_MANIFEST_WIDGET_DEP =
+      Pattern.compile(
+          "<PSXDepFilesIdTypes\\b[^>]*DependencyKey\\s*=\\s*\"[^\"]*"
+              + Pattern.quote(WIDGET_XML_ENCODED_TOKEN)
+              + "[^\"]+\"[^>]*>.*?</PSXDepFilesIdTypes>",
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  private static final Pattern ARCHIVE_INFO_PATH_ATTR =
+      Pattern.compile(
+          "\\b(?:path|dependencyId)\\s*=\\s*\"(rxconfig[/\\\\]Widgets/[^\"]+)\"",
+          Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern ARCHIVE_MANIFEST_KEY_ATTR =
+      Pattern.compile(
+          "DependencyKey\\s*=\\s*\"([^\"]*"
+              + Pattern.quote(WIDGET_XML_ENCODED_TOKEN)
+              + "[^\"]+)\"",
+          Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern RXFILE_WIDGET_XML =
+      Pattern.compile(
+          "<RxFile>\\s*[^<]*rxconfig[/\\\\]Widgets[/\\\\]([^<]+?)\\s*</RxFile>",
+          Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern SYS_USER_DEP_DEPENDENCIES =
+      Pattern.compile(
+          "(dependencyId\\s*=\\s*\"sys_UserDependency\"[\\s\\S]*?<Dependencies>)",
+          Pattern.CASE_INSENSITIVE);
+
+  private PSWidgetArchiveManifestInventory() {
+    // utility
+  }
+
+  /**
+   * One authored Widget definition XML path in an archive descriptor.
+   *
+   * @param packageDirName immediate child under Packages
+   * @param descriptorFile {@link #ARCHIVE_INFO_FILE_NAME} or {@link #ARCHIVE_MANIFEST_FILE_NAME}
+   * @param excerpt path, dependencyId, or DependencyKey
+   * @param waived whether the package is waived
+   */
+  public record Finding(
+      String packageDirName, String descriptorFile, String excerpt, boolean waived) {}
+
+  /**
+   * Scan result for a Packages root.
+   *
+   * @param all waived + non-waived findings, sorted
+   * @param nonWaived findings whose package is not waived
+   * @param waived findings whose package is waived
+   */
+  public record Report(List<Finding> all, List<Finding> nonWaived, List<Finding> waived) {
+
+    public boolean isClean() {
+      return nonWaived.isEmpty();
+    }
+  }
+
+  /**
+   * Scan every immediate package directory for authored Widget def XML archive paths.
+   *
+   * @param packagesRoot {@code modules/perc-packages/src/main/resources/Packages}
+   * @return report; never null
+   */
+  public static Report scan(Path packagesRoot) throws IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new IllegalArgumentException("Packages root is not a directory: " + packagesRoot);
+    }
+
+    List<Finding> all = new ArrayList<>();
+    try (DirectoryStream<Path> packages = Files.newDirectoryStream(packagesRoot)) {
+      for (Path packageDir : packages) {
+        if (!Files.isDirectory(packageDir)) {
+          continue;
+        }
+        Path namePath = packageDir.getFileName();
+        if (namePath == null) {
+          continue;
+        }
+        String packageDirName = namePath.toString();
+        boolean waived = isWaivedPackage(packageDirName);
+        all.addAll(scanPackage(packageDir, packageDirName, waived));
+      }
+    }
+
+    all.sort(
+        Comparator.comparing((Finding f) -> f.packageDirName().toLowerCase(Locale.ROOT))
+            .thenComparing(f -> f.descriptorFile().toLowerCase(Locale.ROOT))
+            .thenComparing(f -> f.excerpt().toLowerCase(Locale.ROOT)));
+
+    List<Finding> nonWaived = all.stream().filter(f -> !f.waived()).collect(Collectors.toList());
+    List<Finding> waivedOnly = all.stream().filter(Finding::waived).collect(Collectors.toList());
+    return new Report(
+        Collections.unmodifiableList(all),
+        Collections.unmodifiableList(nonWaived),
+        Collections.unmodifiableList(waivedOnly));
+  }
+
+  /**
+   * Fail-fast Surefire / CI gate: non-waived product archive manifests must not author Widget def
+   * XML paths.
+   */
+  public static void assertNoNonWaivedWidgetXmlArchivePaths(Path packagesRoot) throws IOException {
+    Report report = scan(packagesRoot);
+    if (report.isClean()) {
+      return;
+    }
+    String detail =
+        report.nonWaived().stream()
+            .map(f -> f.packageDirName() + " " + f.descriptorFile() + " -> " + f.excerpt())
+            .collect(Collectors.joining(System.lineSeparator() + "  "));
+    throw new IllegalStateException(
+        "Archive-manifest Widget XML gate (#3582): non-waived product package authored "
+            + "rxconfig/Widgets/*.xml paths under "
+            + packagesRoot
+            + " (only waived package dirs: "
+            + WAIVED_PACKAGE_DIRS
+            + "):"
+            + System.lineSeparator()
+            + "  "
+            + detail);
+  }
+
+  public static boolean isWaivedPackage(String packageDirName) {
+    return PSWidgetDefinitionXmlInventory.isWaivedPackage(packageDirName);
+  }
+
+  /**
+   * Whether {@code xml} authors a Widget definition XML install path or encoded archive token.
+   */
+  public static boolean containsWidgetXmlArchivePath(String xml) {
+    if (xml == null || xml.isBlank()) {
+      return false;
+    }
+    return !listWidgetXmlArchiveExcerpts(xml).isEmpty();
+  }
+
+  /** Distinct path / DependencyKey excerpts for Widget def XML in an archive descriptor. */
+  public static List<String> listWidgetXmlArchiveExcerpts(String xml) {
+    if (xml == null || xml.isBlank()) {
+      return List.of();
+    }
+    LinkedHashSet<String> found = new LinkedHashSet<>();
+    Matcher paths = ARCHIVE_INFO_PATH_ATTR.matcher(xml);
+    while (paths.find()) {
+      found.add(normalizeInstallPath(paths.group(1)));
+    }
+    Matcher keys = ARCHIVE_MANIFEST_KEY_ATTR.matcher(xml);
+    while (keys.find()) {
+      found.add(keys.group(1));
+    }
+    Matcher rxFiles = RXFILE_WIDGET_XML.matcher(xml);
+    while (rxFiles.find()) {
+      found.add(WIDGET_XML_INSTALL_PREFIX + rxFiles.group(1).trim());
+    }
+    return List.copyOf(found);
+  }
+
+  /**
+   * Remove authored Widget def XML user-dependency blocks from archive-info or archive-manifest
+   * XML. Other user-dependencies are left unchanged.
+   */
+  public static String stripWidgetXmlArchivePaths(String xml) {
+    if (xml == null || xml.isBlank()) {
+      return xml;
+    }
+    String stripped = ARCHIVE_INFO_WIDGET_DEP.matcher(xml).replaceAll("");
+    stripped = ARCHIVE_MANIFEST_WIDGET_DEP.matcher(stripped).replaceAll("");
+    return stripped;
+  }
+
+  /**
+   * Strip Widget def XML archive paths from a package's source descriptors when the package is
+   * non-waived and has modern {@code widgets/} roots. No-op for {@code perc.Test} and packages
+   * without modern roots.
+   *
+   * @return number of descriptor files rewritten
+   */
+  public static int stripAuthoredWidgetXmlArchivePaths(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      return 0;
+    }
+    Path namePath = packageDir.getFileName();
+    String name = namePath != null ? namePath.toString() : "";
+    if (isWaivedPackage(name)) {
+      return 0;
+    }
+    if (!PSWidgetXmlDualShip.hasModernWidgetSources(packageDir)) {
+      return 0;
+    }
+    int rewritten = 0;
+    for (String fileName : List.of(ARCHIVE_INFO_FILE_NAME, ARCHIVE_MANIFEST_FILE_NAME)) {
+      Path file = packageDir.resolve(fileName);
+      if (!Files.isRegularFile(file)) {
+        continue;
+      }
+      String original = Files.readString(file, StandardCharsets.UTF_8);
+      String stripped = stripWidgetXmlArchivePaths(original);
+      if (!stripped.equals(original)) {
+        Files.writeString(file, stripped, StandardCharsets.UTF_8);
+        rewritten++;
+      }
+    }
+    return rewritten;
+  }
+
+  /**
+   * Ensure staged archive descriptors list install Widget XML user-dependencies for each stem.
+   * Idempotent. Creates a minimal {@code psx_archiveManifest.xml} when missing; updates {@code
+   * psx_archiveInfo.xml} only when that file already exists.
+   *
+   * @return number of descriptor files written or updated
+   */
+  public static int ensureInstallWidgetXmlArchivePaths(Path packageDir, List<String> widgetStems)
+      throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (widgetStems == null || widgetStems.isEmpty()) {
+      return 0;
+    }
+    List<String> stems = new ArrayList<>();
+    LinkedHashSet<String> seen = new LinkedHashSet<>();
+    for (String stem : widgetStems) {
+      if (stem == null || stem.isBlank()) {
+        continue;
+      }
+      String trimmed = stem.trim();
+      if (seen.add(trimmed)) {
+        stems.add(trimmed);
+      }
+    }
+    if (stems.isEmpty()) {
+      return 0;
+    }
+
+    int updated = 0;
+    Path info = packageDir.resolve(ARCHIVE_INFO_FILE_NAME);
+    if (Files.isRegularFile(info)) {
+      String original = Files.readString(info, StandardCharsets.UTF_8);
+      String next = injectArchiveInfoEntries(original, stems);
+      if (!next.equals(original)) {
+        Files.writeString(info, next, StandardCharsets.UTF_8);
+        updated++;
+      }
+    }
+
+    Path manifest = packageDir.resolve(ARCHIVE_MANIFEST_FILE_NAME);
+    String originalManifest =
+        Files.isRegularFile(manifest)
+            ? Files.readString(manifest, StandardCharsets.UTF_8)
+            : "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\n<PSXArchiveManifest>\n</PSXArchiveManifest>\n";
+    String nextManifest = injectArchiveManifestEntries(originalManifest, stems);
+    if (!Files.isRegularFile(manifest) || !nextManifest.equals(originalManifest)) {
+      Files.writeString(manifest, nextManifest, StandardCharsets.UTF_8);
+      updated++;
+    }
+    return updated;
+  }
+
+  /**
+   * Archive-folder name used by {@link com.percussion.packages.PSPackageBuilder} for a Widget XML
+   * user-dependency ({@code sys__UserDependency--rxconfig_Widgets_&lt;stem&gt;-xml}). ZIP logical
+   * path — always {@code /} in the file name portion.
+   */
+  public static String encodeWidgetXmlArchiveFolder(String widgetFileName) {
+    Objects.requireNonNull(widgetFileName, "widgetFileName");
+    String fileName = widgetFileName.trim();
+    if (fileName.isEmpty()) {
+      throw new IllegalArgumentException("widgetFileName is blank");
+    }
+    // Match PSPackageBuilder user-dependency encoding (ZIP layout, not OS separators).
+    String encodedPath = "rxconfig/Widgets".replace("_", "__").replace(".", "-").replace("/", "_");
+    String encodedSuffix = fileName.replace("-", "--").replace(".", "-").replace("_", "__");
+    return "sys__UserDependency--" + encodedPath + "_" + encodedSuffix;
+  }
+
+  public static String widgetXmlInstallPath(String stem) {
+    return WIDGET_XML_INSTALL_PREFIX + requireStem(stem) + ".xml";
+  }
+
+  /**
+   * CLI: {@code scan <packagesRoot>} or {@code strip <packagesRoot>}.
+   *
+   * @param args command + packages root
+   */
+  public static void main(String[] args) throws IOException {
+    if (args == null || args.length < 2 || args[0] == null || args[1] == null) {
+      System.err.println("Usage: PSWidgetArchiveManifestInventory scan|strip <packagesRoot>");
+      System.exit(2);
+      return;
+    }
+    String cmd = args[0].trim().toLowerCase(Locale.ROOT);
+    Path root = Path.of(args[1]).toAbsolutePath().normalize();
+    if ("strip".equals(cmd)) {
+      int rewritten = 0;
+      try (DirectoryStream<Path> packages = Files.newDirectoryStream(root)) {
+        for (Path packageDir : packages) {
+          if (Files.isDirectory(packageDir)) {
+            rewritten += stripAuthoredWidgetXmlArchivePaths(packageDir);
+          }
+        }
+      }
+      System.out.println("Stripped Widget XML archive paths from " + rewritten + " descriptor(s)");
+    }
+    Report report = scan(root);
+    System.out.println(
+        "Widget XML archive-manifest inventory under "
+            + root
+            + ": total="
+            + report.all().size()
+            + " waived="
+            + report.waived().size()
+            + " nonWaived="
+            + report.nonWaived().size()
+            + " waivedPackages="
+            + WAIVED_PACKAGE_DIRS);
+    for (Finding f : report.all()) {
+      System.out.println(
+          (f.waived() ? "WAIVED " : "FAIL   ")
+              + f.packageDirName()
+              + " "
+              + f.descriptorFile()
+              + " "
+              + f.excerpt());
+    }
+    if (!report.isClean()) {
+      System.err.println("FAIL: non-waived Widget XML archive-manifest paths present (#3582)");
+      System.exit(1);
+    }
+    System.out.println("PASS: zero non-waived Widget XML archive-manifest paths");
+  }
+
+  static String injectArchiveInfoEntries(String xml, List<String> stems) {
+    String working = xml;
+    String nl = working.contains("\r\n") ? "\r\n" : "\n";
+    List<String> missing = new ArrayList<>();
+    for (String stem : stems) {
+      String path = widgetXmlInstallPath(stem);
+      if (!containsExactInstallPath(working, path)) {
+        missing.add(stem);
+      }
+    }
+    if (missing.isEmpty()) {
+      return working;
+    }
+    StringBuilder block = new StringBuilder();
+    for (String stem : missing) {
+      block.append(archiveInfoUserDependencyBlock(stem, nl));
+    }
+    Matcher parent = SYS_USER_DEP_DEPENDENCIES.matcher(working);
+    if (parent.find()) {
+      return working.substring(0, parent.end()) + block + working.substring(parent.end());
+    }
+    int packagesClose = indexOfIgnoreCase(working, "</Packages>");
+    if (packagesClose < 0) {
+      throw new IllegalStateException(
+          "Cannot inject Widget XML user-dependencies: no sys_UserDependency <Dependencies> "
+              + "and no </Packages> in psx_archiveInfo.xml");
+    }
+    return working.substring(0, packagesClose)
+        + sysUserDependencyElement(block.toString(), nl)
+        + working.substring(packagesClose);
+  }
+
+  static String injectArchiveManifestEntries(String xml, List<String> stems) {
+    String working = xml;
+    String nl = working.contains("\r\n") ? "\r\n" : "\n";
+    List<String> missing = new ArrayList<>();
+    for (String stem : stems) {
+      String folder = encodeWidgetXmlArchiveFolder(stem + ".xml");
+      if (!working.contains(folder)) {
+        missing.add(stem);
+      }
+    }
+    if (missing.isEmpty()) {
+      return working;
+    }
+    StringBuilder block = new StringBuilder();
+    for (String stem : missing) {
+      block.append(archiveManifestDepBlock(stem, nl));
+    }
+    int close = indexOfIgnoreCase(working, "</PSXArchiveManifest>");
+    if (close < 0) {
+      throw new IllegalStateException(
+          "Cannot inject Widget XML archive-manifest entries: missing </PSXArchiveManifest>");
+    }
+    return working.substring(0, close) + block + working.substring(close);
+  }
+
+  private static List<Finding> scanPackage(Path packageDir, String packageDirName, boolean waived)
+      throws IOException {
+    List<Finding> findings = new ArrayList<>();
+    for (String fileName : List.of(ARCHIVE_INFO_FILE_NAME, ARCHIVE_MANIFEST_FILE_NAME)) {
+      Path file = packageDir.resolve(fileName);
+      if (!Files.isRegularFile(file)) {
+        continue;
+      }
+      String xml = Files.readString(file, StandardCharsets.UTF_8);
+      for (String excerpt : listWidgetXmlArchiveExcerpts(xml)) {
+        findings.add(new Finding(packageDirName, fileName, excerpt, waived));
+      }
+    }
+    return findings;
+  }
+
+  private static String archiveInfoUserDependencyBlock(String stem, String nl) {
+    String fileName = requireStem(stem) + ".xml";
+    String path = WIDGET_XML_INSTALL_PREFIX + fileName;
+    return nl
+        + "\t\t\t\t\t\t\t<PSXUserDependency"
+        + nl
+        + "\t\t\t\t\t\t\t\tparentId=\"sys_UserDependency\""
+        + nl
+        + "\t\t\t\t\t\t\t\tparentKey=\"Custom-sys_UserDependency\" parentType=\"Custom\""
+        + nl
+        + "\t\t\t\t\t\t\t\tpath=\""
+        + path
+        + "\">"
+        + nl
+        + "\t\t\t\t\t\t\t\t<PSXDeployableObject>"
+        + nl
+        + "\t\t\t\t\t\t\t\t\t<PSXDependency autoDep=\"no\" autoExpand=\"yes\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tdependencyId=\""
+        + path
+        + "\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tdependencyType=\"User\" displayName=\""
+        + fileName
+        + "\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tisAssociation=\"no\" isIncluded=\"yes\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tobjectType=\"sys_UserDependency\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tobjectTypeName=\"User Dependency\" supportsIdMapping=\"no\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tsupportsIdTypes=\"no\" supportsParentId=\"no\""
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\tsupportsUserDependencies=\"no\">"
+        + nl
+        + "\t\t\t\t\t\t\t\t\t\t<Dependencies />"
+        + nl
+        + "\t\t\t\t\t\t\t\t\t</PSXDependency>"
+        + nl
+        + "\t\t\t\t\t\t\t\t\t<RequiredClasses />"
+        + nl
+        + "\t\t\t\t\t\t\t\t</PSXDeployableObject>"
+        + nl
+        + "\t\t\t\t\t\t\t</PSXUserDependency>";
+  }
+
+  private static String sysUserDependencyElement(String innerDeps, String nl) {
+    return "\t\t\t\t<PSXDeployableElement>"
+        + nl
+        + "\t\t\t\t\t<PSXDependency autoDep=\"no\" autoExpand=\"yes\""
+        + nl
+        + "\t\t\t\t\t\tdependencyId=\"sys_UserDependency\" dependencyType=\"Shared\""
+        + nl
+        + "\t\t\t\t\t\tdisplayName=\"User Dependency\" isAssociation=\"yes\" isIncluded=\"yes\""
+        + nl
+        + "\t\t\t\t\t\tobjectType=\"Custom\" objectTypeName=\"Custom\" supportsIdMapping=\"no\""
+        + nl
+        + "\t\t\t\t\t\tsupportsIdTypes=\"no\" supportsParentId=\"no\""
+        + nl
+        + "\t\t\t\t\t\tsupportsUserDependencies=\"yes\">"
+        + nl
+        + "\t\t\t\t\t\t<Dependencies>"
+        + innerDeps
+        + nl
+        + "\t\t\t\t\t\t</Dependencies>"
+        + nl
+        + "\t\t\t\t\t</PSXDependency>"
+        + nl
+        + "\t\t\t\t\t<Description />"
+        + nl
+        + "\t\t\t\t</PSXDeployableElement>"
+        + nl;
+  }
+
+  private static String archiveManifestDepBlock(String stem, String nl) {
+    String fileName = requireStem(stem) + ".xml";
+    String folder = encodeWidgetXmlArchiveFolder(fileName);
+    String installPath = WIDGET_XML_INSTALL_PREFIX + fileName;
+    // ArchiveFile is a ZIP entry path — always '/'.
+    return "\t<PSXDepFilesIdTypes"
+        + nl
+        + "\t\tDependencyKey=\""
+        + folder
+        + "\">"
+        + nl
+        + "\t\t<PSXDependencyFile fileType=\"SUPPORT_FILE\">"
+        + nl
+        + "\t\t\t<RxFile>"
+        + installPath
+        + "</RxFile>"
+        + nl
+        + "\t\t\t<ArchiveFile>"
+        + folder
+        + "/"
+        + fileName
+        + "</ArchiveFile>"
+        + nl
+        + "\t\t</PSXDependencyFile>"
+        + nl
+        + "\t</PSXDepFilesIdTypes>"
+        + nl;
+  }
+
+  private static boolean containsExactInstallPath(String xml, String path) {
+    return xml.contains("path=\"" + path + "\"") || xml.contains("dependencyId=\"" + path + "\"");
+  }
+
+  private static String normalizeInstallPath(String raw) {
+    return raw.replace('\\', '/');
+  }
+
+  private static String requireStem(String stem) {
+    if (stem == null || stem.isBlank()) {
+      throw new IllegalArgumentException("widget stem is blank");
+    }
+    String trimmed = stem.trim();
+    if (trimmed.contains("/") || trimmed.contains("\\") || trimmed.contains("..")) {
+      throw new IllegalArgumentException("widget stem must be a single path segment: " + stem);
+    }
+    return trimmed;
+  }
+
+  private static int indexOfIgnoreCase(String haystack, String needle) {
+    return haystack.toLowerCase(Locale.ROOT).indexOf(needle.toLowerCase(Locale.ROOT));
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlInstallEmitter.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlInstallEmitter.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -37,11 +38,12 @@ import java.util.Objects;
  * <p><strong>Install wire format (transitional):</strong> package build materializes {@code
  * sys__UserDependency--rxconfig/Widgets/*.xml} from modern sources so deployer / {@code
  * PSWidgetDao} still receive legacy Widget XML. Product source trees for converted batches no
- * longer commit that XML.
+ * longer commit that XML, and no longer author {@code rxconfig/Widgets/*.xml} in archive
+ * descriptors (#3582). This emitter re-injects those archive entries on the staging copy.
  *
  * <p>Policy: materialize only when modern widget packages are present <em>and</em> the package has
- * no committed install Widget XML (so perc.Test may still commit Widget XML \(waiver\)).
- * Keep {@code PSLegacyDefinitionXmlShim} and upgrade-input compilers.
+ * no committed install Widget XML (so perc.Test may still commit Widget XML \(waiver\)). Keep
+ * {@code PSLegacyDefinitionXmlShim} and upgrade-input compilers.
  *
  * @see PSWidgetXmlDualShip
  * @see PSWidgetXmlPackageCompiler
@@ -74,8 +76,9 @@ public final class PSWidgetXmlInstallEmitter {
 
   /**
    * Materialize install-path Widget XML from modern {@code widgets/} sources when the package is
-   * modern-only (modern present, no committed Widget XML). No-op when dual-ship XML is still
-   * committed or when no modern widgets exist.
+   * modern-only (modern present, no committed Widget XML). Also re-injects archive-manifest Widget
+   * XML user-dependencies for those stems (#3582). No-op when dual-ship XML is still committed or
+   * when no modern widgets exist.
    *
    * @param packageDir product package source or staging copy
    * @return number of Widget XML files written
@@ -91,7 +94,7 @@ public final class PSWidgetXmlInstallEmitter {
     if (!PSWidgetXmlDualShip.hasModernWidgetSources(packageDir)) {
       return 0;
     }
-    // Packages with committed install XML are left alone \(e.g. waived perc.Test\).
+    // Packages with committed install XML are left alone (e.g. waived perc.Test).
     if (hasCommittedWidgetXml(packageDir)) {
       return 0;
     }
@@ -99,6 +102,7 @@ public final class PSWidgetXmlInstallEmitter {
     List<PSWidgetXmlCompileResult> modern = PSWidgetXmlDualShip.compileModernWidgets(packageDir);
     Path widgetsDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(packageDir);
     Files.createDirectories(widgetsDir);
+    List<String> stems = new ArrayList<>();
     int written = 0;
     for (PSWidgetXmlCompileResult result : modern) {
       PSWidgetXmlModel model = modelFromModern(result);
@@ -110,10 +114,13 @@ public final class PSWidgetXmlInstallEmitter {
         throw new PSWidgetXmlException(
             "Cannot emit install Widget XML without stem/id under " + packageDir);
       }
+      stems.add(stem);
       Path out = widgetsDir.resolve(stem + ".xml");
       Files.writeString(out, emitWidgetXml(model), StandardCharsets.UTF_8);
       written++;
     }
+    // Product source no longer authors Widget XML archive paths (#3582); re-inject on staging.
+    PSWidgetArchiveManifestInventory.ensureInstallWidgetXmlArchivePaths(packageDir, stems);
     return written;
   }
 

--- a/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/psx_archiveInfo.xml
@@ -1540,24 +1540,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percFile.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percFile.xml"
-										dependencyType="User" displayName="percFile.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/psx_archiveManifest.xml
@@ -43,13 +43,7 @@
 			<ArchiveFile>AclDef-7023114102759227515\perc.fileBinary.templateDef.aclDef</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percFile-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percFile.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percFile-xml\percFile.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef--2005495941909446534">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/psx_archiveInfo.xml
@@ -1518,24 +1518,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percImageAutoList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percImageAutoList.xml"
-										dependencyType="User" displayName="percImageAutoList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/psx_archiveManifest.xml
@@ -124,13 +124,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_imageAutoList_images_buttonBlueMinusOver-gif\buttonBlueMinusOver.gif</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percImageAutoList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percImageAutoList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percImageAutoList-xml\percImageAutoList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_imageAutoList_images_buttonBluePlusOver-gif">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/psx_archiveInfo.xml
@@ -1013,24 +1013,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percPageAutoList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percPageAutoList.xml"
-										dependencyType="User" displayName="percPageAutoList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/psx_archiveManifest.xml
@@ -60,13 +60,7 @@
 			<OriginalFile>rxs_ct_feeds_shared.xml</OriginalFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percPageAutoList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion_5.3.14_2016-06-13_port12401\rxconfig\Widgets\percPageAutoList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percPageAutoList-xml\percPageAutoList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="ContentType-340">
 		<PSXDependencyFile fileType="ITEM_DEFINITION">
 			<RxFile>C:\WINDOWS\TEMP\percPageAutoList.itemDef.contentType</RxFile>

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/psx_archiveInfo.xml
@@ -4955,60 +4955,9 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percRawHtml.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percRawHtml.xml"
-										dependencyType="User" displayName="percRawHtml.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percRichText.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percRichText.xml"
-										dependencyType="User" displayName="percRichText.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percSimpleText.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percSimpleText.xml"
-										dependencyType="User" displayName="percSimpleText.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
+							
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/psx_archiveManifest.xml
@@ -93,13 +93,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_PSWidget__RawHtml_images_widgetHtmSampleBackground-png\widgetHtmSampleBackground.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percRawHtml-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percRawHtml.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percRawHtml-xml\percRawHtml.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="ContentType-330">
 		<PSXDependencyFile fileType="ITEM_DEFINITION">
 			<RxFile>C:\Users\Santi\AppData\Local\Temp\PSWidgetProperties.itemDef.contentType</RxFile>
@@ -142,13 +136,7 @@
 			<ArchiveFile>ImageFile-rx_resources\images\ContentTypeIcons\filetypeIconsSimpleText.png\filetypeIconsSimpleText.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percRichText-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percRichText.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percRichText-xml\percRichText.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_PSWidget__RichText_images_widgetIconTextOver-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -184,13 +172,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_PSWidget__SimpleText_images_widgetIconSimpleTextOver-png\widgetIconSimpleTextOver.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percSimpleText-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percSimpleText.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percSimpleText-xml\percSimpleText.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_cm_themes_smoothness_jquery--ui--1-8-9-custom-css">

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/psx_archiveInfo.xml
@@ -1583,24 +1583,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percDefaultLang.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percDefaultLang.xml"
-										dependencyType="User" displayName="percDefaultLang.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"
@@ -1692,24 +1675,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percLocalLang.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percLocalLang.xml"
-										dependencyType="User" displayName="percLocalLang.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/psx_archiveManifest.xml
@@ -89,13 +89,7 @@
 			<OriginalFile>widgets\percDefaultLang\css\percDefaultLang.css</OriginalFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percDefaultLang-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion_5.3_04-APR-2016_Derby\rxconfig\Widgets\percDefaultLang.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percDefaultLang-xml\percDefaultLang.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="SupportFile-rx_resources/stylesheets/controls/percLocalLangControl.xsl">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -133,13 +127,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_percDefaultLang_css_percDefaultLang-css\percDefaultLang.css</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percLocalLang-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion_5.3_04-APR-2016_Derby\rxconfig\Widgets\percLocalLang.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percLocalLang-xml\percLocalLang.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rxconfig_Resources_percLocalLang-xml">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/psx_archiveInfo.xml
@@ -1338,24 +1338,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percEvent.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percEvent.xml"
-										dependencyType="User" displayName="percEvent.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/psx_archiveManifest.xml
@@ -37,13 +37,7 @@
 			<ArchiveFile>ContentType-335\percEventAsset.schemaDef.contentType</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percEvent-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percEvent.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percEvent-xml\percEvent.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_event_images_widgetEventSampleBackground-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/psx_archiveInfo.xml
@@ -1483,24 +1483,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percOpenGraph.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percOpenGraph.xml"
-										dependencyType="User" displayName="percOpenGraph.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 						</Dependencies>
 					</PSXDependency>
 					<Description />

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/psx_archiveManifest.xml
@@ -70,11 +70,5 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_percOpenGraph_images_open--graph--placeholder-png\open-graph-placeholder.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percOpenGraph-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\5.4\jetty\..\rxconfig\Widgets\percOpenGraph.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percOpenGraph-xml\percOpenGraph.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 </PSXArchiveManifest>

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/psx_archiveInfo.xml
@@ -1190,24 +1190,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percTwitterSummaryCards.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percTwitterSummaryCards.xml"
-										dependencyType="User"
-										displayName="percTwitterSummaryCards.xml" isAssociation="no"
-										isIncluded="yes" objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percTwitterSummaryCards-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\dev\rxconfig\Widgets\percTwitterSummaryCards.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percTwitterSummaryCards-xml\percTwitterSummaryCards.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="ContentType-638">
 		<PSXDependencyFile fileType="ITEM_DEFINITION">
 			<RxFile>C:\Users\NATE__~1\AppData\Local\Temp\percTwitterCards.itemDef.contentType</RxFile>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/psx_archiveInfo.xml
@@ -57,24 +57,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percMostReadBlogPosts.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percMostReadBlogPosts.xml"
-										dependencyType="User" displayName="percMostReadBlogPosts.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/psx_archiveManifest.xml
@@ -9,13 +9,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_percMostReadBlogPosts_images_percMostReadBlogPostsIcon-png\percMostReadBlogPostsIcon.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percMostReadBlogPosts-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percMostReadBlogPosts.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percMostReadBlogPosts-xml\percMostReadBlogPosts.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rxconfig_Resources_percMostReadBlogPosts-xml">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/psx_archiveInfo.xml
@@ -57,24 +57,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percResult.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percResult.xml"
-										dependencyType="User" displayName="percResult.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/psx_archiveManifest.xml
@@ -30,11 +30,5 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_result_images_widgetIconLinkResult-png\widgetIconLinkResult.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percResult-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percResult.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percResult-xml\percResult.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 </PSXArchiveManifest>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/psx_archiveInfo.xml
@@ -632,24 +632,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percArchiveList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percArchiveList.xml"
-										dependencyType="User" displayName="percArchiveList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/psx_archiveManifest.xml
@@ -59,13 +59,7 @@
 			<ArchiveFile>sys__UserDependency--rxconfig_Resources_percArchiveList-xml\percArchiveList.xml</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percArchiveList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\ins\dev\rxconfig\Widgets\percArchiveList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percArchiveList-xml\percArchiveList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="ContentType-351">
 		<PSXDependencyFile fileType="ITEM_DEFINITION">
 			<RxFile>C:\Users\Usuario\AppData\Local\Temp\percArchiveList.itemDef.contentType</RxFile>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/psx_archiveInfo.xml
@@ -1517,24 +1517,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percBlogIndexPage.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percBlogIndexPage.xml"
-										dependencyType="User" displayName="percBlogIndexPage.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/psx_archiveManifest.xml
@@ -36,13 +36,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_blogIndexPage_images_widgetIconBlogIndex-gif\widgetIconBlogIndex.gif</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percBlogIndexPage-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percBlogIndexPage.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percBlogIndexPage-xml\percBlogIndexPage.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef-6502868081449107528">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/psx_archiveInfo.xml
@@ -1273,24 +1273,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percCalendar.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percCalendar.xml"
-										dependencyType="User" displayName="percCalendar.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"
@@ -1345,24 +1328,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percCalendarTwo.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percCalendarTwo.xml"
-										dependencyType="User" displayName="percCalendarTwo.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/psx_archiveManifest.xml
@@ -200,13 +200,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_calendar_images_widgetCalendarSampleBackground-png\widgetCalendarSampleBackground.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percCalendar-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion\rxconfig\Widgets\percCalendar.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percCalendar-xml\percCalendar.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="SupportFile-rx_resources/widgets/percCalendarTwo/js/percCalendarTwo.js">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -251,13 +245,7 @@
 			<OriginalFile>widgets\percCalendarTwo\js\jquery.minicolors.js</OriginalFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percCalendarTwo-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion\rxconfig\Widgets\percCalendarTwo.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percCalendarTwo-xml\percCalendarTwo.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_calendar_images_calendarIconOver-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/psx_archiveInfo.xml
@@ -1747,24 +1747,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percCategoryList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percCategoryList.xml"
-										dependencyType="User" displayName="percCategoryList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/psx_archiveManifest.xml
@@ -167,11 +167,5 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_categoryList_images_widgetIconLinkCategoryList-png\widgetIconLinkCategoryList.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percCategoryList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percCategoryList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percCategoryList-xml\percCategoryList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 </PSXArchiveManifest>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/psx_archiveInfo.xml
@@ -1548,24 +1548,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percCommentsForm.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percCommentsForm.xml"
-										dependencyType="User" displayName="percCommentsForm.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/psx_archiveManifest.xml
@@ -333,13 +333,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_commentsForm_images_form--minus-png\form-minus.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percCommentsForm-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\ins\dev\rxconfig\Widgets\percCommentsForm.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percCommentsForm-xml\percCommentsForm.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_commentsForm_images_ButtonApplyOver-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/psx_archiveInfo.xml
@@ -1456,24 +1456,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percCookieConsent.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percCookieConsent.xml"
-										dependencyType="User" displayName="percCookieConsent.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/psx_archiveManifest.xml
@@ -30,13 +30,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_percCookieConsent_images_percCookieConsentIcon-png\percCookieConsentIcon.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percCookieConsent-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>c:\DevEnv\Installs\dev\rxconfig\Widgets\percCookieConsent.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percCookieConsent-xml\percCookieConsent.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_cookieConsent_css_cookie--consent-css">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/psx_archiveInfo.xml
@@ -6130,24 +6130,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percDepartment.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percDepartment.xml"
-										dependencyType="User" displayName="percDepartment.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"
@@ -6238,24 +6221,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percDirectory.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percDirectory.xml"
-										dependencyType="User" displayName="percDirectory.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"
@@ -6346,24 +6312,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percOrganization.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percOrganization.xml"
-										dependencyType="User" displayName="percOrganization.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"
@@ -6455,24 +6404,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percPerson.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percPerson.xml"
-										dependencyType="User" displayName="percPerson.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/psx_archiveManifest.xml
@@ -71,13 +71,7 @@
 			<ArchiveFile>sys__UserDependency--rxconfig_Resources_percDirectory-xml\percDirectory.xml</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percOrganization-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percOrganization.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percOrganization-xml\percOrganization.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_percDepartment_images_percDepartmentIcon-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -107,13 +101,7 @@
 			<OriginalFile>widgets\percDirectory\css\directoryDropdown.css</OriginalFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percDirectory-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percDirectory.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percDirectory-xml\percDirectory.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_AssetFinder_js_AssetFinder-js">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -281,13 +269,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_stylesheets_controls_percAssetFinderControl-xsl\percAssetFinderControl.xsl</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percPerson-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percPerson.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percPerson-xml\percPerson.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rxconfig_Resources_percOrganization-xml">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -402,11 +384,5 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_AssetFinder_css_AssetFinder-css\AssetFinder.css</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percDepartment-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percDepartment.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percDepartment-xml\percDepartment.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 </PSXArchiveManifest>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/psx_archiveInfo.xml
@@ -1698,24 +1698,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percFileAutoList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percFileAutoList.xml"
-										dependencyType="User" displayName="percFileAutoList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/psx_archiveManifest.xml
@@ -117,13 +117,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_fileAutoList_images_widgetIconFileAutoListOver-png\widgetIconFileAutoListOver.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percFileAutoList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percFileAutoList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percFileAutoList-xml\percFileAutoList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_controls_percResourceAutoListControl_css_jquery-resourceAutoList-css">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.form/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.form/psx_archiveInfo.xml
@@ -2429,24 +2429,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percForm.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percForm.xml"
-										dependencyType="User" displayName="percForm.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.form/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.form/psx_archiveManifest.xml
@@ -417,13 +417,7 @@
 			<ArchiveFile>sys__UserDependency--web__resources_widgets_form_images_calendar-gif\calendar.gif</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percForm-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percForm.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percForm-xml\percForm.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_form_images_radio--button--icon--over-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/psx_archiveInfo.xml
@@ -39,24 +39,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percIframe.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percIframe.xml"
-										dependencyType="User" displayName="percIframe.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/psx_archiveManifest.xml
@@ -16,13 +16,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_iframe_images_widgetIconIframeInactive-jpg\widgetIconIframeInactive.jpg</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percIframe-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\rxinst\Dev\cmlite\rxconfig\Widgets\percIframe.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percIframe-xml\percIframe.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_iframe_images_widgetIconIframeOver-jpg">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/psx_archiveInfo.xml
@@ -1599,24 +1599,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percImageSlider.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percImageSlider.xml"
-										dependencyType="User" displayName="percImageSlider.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/psx_archiveManifest.xml
@@ -38,13 +38,7 @@
 			<ArchiveFile>sys__UserDependency--web__resources_widgets_imageSlider_css_slick-css\slick.css</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percImageSlider-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percImageSlider.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percImageSlider-xml\percImageSlider.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_imageSlider_js_slick-min-js">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/psx_archiveInfo.xml
@@ -40,24 +40,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percJQueryWidget.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percJQueryWidget.xml"
-										dependencyType="User" displayName="percJQueryWidget.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percJQueryWidget-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion\rxconfig\Widgets\percJQueryWidget.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percJQueryWidget-xml\percJQueryWidget.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_percJQueryWidget_images_widgeticonjqueryover-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/psx_archiveInfo.xml
@@ -40,24 +40,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percJQueryUIWidget.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percJQueryUIWidget.xml"
-										dependencyType="User" displayName="percJQueryUIWidget.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percJQueryUIWidget-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\Percussion\rxconfig\Widgets\percJQueryUIWidget.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percJQueryUIWidget-xml\percJQueryUIWidget.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_percJQueryUIWidget_images_widgeticonjqueryuiover-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.login/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.login/psx_archiveInfo.xml
@@ -1384,24 +1384,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percLogin.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percLogin.xml"
-										dependencyType="User" displayName="percLogin.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.login/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.login/psx_archiveManifest.xml
@@ -37,13 +37,7 @@
 			<ArchiveFile>ImageFile-rx_resources\images\ContentTypeIcons\filetypeIconsLogin.png\filetypeIconsLogin.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percLogin-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percLogin.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percLogin-xml\percLogin.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_login_js_loginform-min-js">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/psx_archiveInfo.xml
@@ -1530,24 +1530,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percPoll.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percPoll.xml"
-										dependencyType="User" displayName="percPoll.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/psx_archiveManifest.xml
@@ -59,13 +59,7 @@
 			<ArchiveFile>sys__UserDependency--web__resources_widgets_percPoll_js_percPoll-min-js\percPoll.min.js</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percPoll-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percPoll.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percPoll-xml\percPoll.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rxconfig_Resources_percPoll-xml">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/psx_archiveInfo.xml
@@ -1329,24 +1329,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percRegistration.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percRegistration.xml"
-										dependencyType="User" displayName="percRegistration.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/psx_archiveManifest.xml
@@ -44,13 +44,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_registration_images_widgetIconRegistration-gif\widgetIconRegistration.gif</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percRegistration-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percRegistration.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percRegistration-xml\percRegistration.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_registration_js_registrationform-js">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/psx_archiveInfo.xml
@@ -591,24 +591,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percRss.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percRss.xml"
-										dependencyType="User" displayName="percRss.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/psx_archiveManifest.xml
@@ -16,13 +16,7 @@
 			<ArchiveFile>sys__UserDependency--rxconfig_Resources_percRss-xml\percRss.xml</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percRss-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\ins\dev\rxconfig\Widgets\percRss.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percRss-xml\percRss.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="ContentType-359">
 		<PSXDependencyFile fileType="ITEM_DEFINITION">
 			<RxFile>C:\Users\FEDERI~1\AppData\Local\Temp\percRssAsset.itemDef.contentType</RxFile>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/psx_archiveInfo.xml
@@ -1321,24 +1321,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percSecureLogin.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percSecureLogin.xml"
-										dependencyType="User" displayName="percSecureLogin.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percSecureLogin-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percSecureLogin.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percSecureLogin-xml\percSecureLogin.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef--7462949394166316985">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
@@ -1530,24 +1530,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percSocialButtons.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percSocialButtons.xml"
-										dependencyType="User" displayName="percSocialButtons.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveManifest.xml
@@ -23,13 +23,7 @@
 			<ArchiveFile>ContentType-390\percSocialButtons.schemaDef.contentType</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percSocialButtons-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percSocialButtons.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percSocialButtons-xml\percSocialButtons.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef-1098109823465029735">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/psx_archiveInfo.xml
@@ -922,24 +922,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percTagList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percTagList.xml"
-										dependencyType="User" displayName="percTagList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/psx_archiveManifest.xml
@@ -131,13 +131,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_tagList_images_buttonBlueMinus-gif\buttonBlueMinus.gif</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percTagList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\ins\dev\rxconfig\Widgets\percTagList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percTagList-xml\percTagList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef-89617967259582535">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.title/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.title/psx_archiveInfo.xml
@@ -1322,24 +1322,7 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percTitle.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percTitle.xml"
-										dependencyType="User" displayName="percTitle.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.title/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.title/psx_archiveManifest.xml
@@ -37,13 +37,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_title_images_widgetTitleEmpty-png\widgetTitleEmpty.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percTitle-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percTitle.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percTitle-xml\percTitle.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef--5081574334170922937">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/psx_archiveInfo.xml
@@ -1299,24 +1299,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percRedirect.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percRedirect.xml"
-										dependencyType="User" displayName="percRedirect.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/psx_archiveManifest.xml
@@ -30,13 +30,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_percRedirect_images_redirect--widget--icon--tray-png\redirect-widget-icon-tray.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percRedirect-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percRedirect.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percRedirect-xml\percRedirect.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef-2665817691603862185">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/psx_archiveInfo.xml
@@ -1334,24 +1334,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percBlogPost.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percBlogPost.xml"
-										dependencyType="User" displayName="percBlogPost.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/psx_archiveManifest.xml
@@ -23,13 +23,7 @@
 			<ArchiveFile>ContentType-357\percBlogPostAsset.schemaDef.contentType</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percBlogPost-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percBlogPost.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percBlogPost-xml\percBlogPost.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef--6788329741293191107">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/psx_archiveInfo.xml
@@ -58,24 +58,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percComments.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percComments.xml"
-										dependencyType="User" displayName="percComments.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/psx_archiveManifest.xml
@@ -9,13 +9,7 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_comments_images_widgetCommentEmpty-png\widgetCommentEmpty.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percComments-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\ins\dev\rxconfig\Widgets\percComments.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percComments-xml\percComments.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--rx__resources_widgets_comments_images_WidgetIconCommentOVER-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/psx_archiveInfo.xml
@@ -2168,24 +2168,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percImage.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percImage.xml"
-										dependencyType="User" displayName="percImage.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/psx_archiveManifest.xml
@@ -179,13 +179,7 @@
 			<ArchiveFile>Extension-Java\global\percussion\widgets\rx_ImageAssetInputTranslation\rx_ImageAssetInputTranslation.extension</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percImage-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\DevEnv\Installs\dev\rxconfig\Widgets\percImage.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percImage-xml\percImage.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes DependencyKey="TemplateDef-618">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">
 			<RxFile>C:\Users\ANDREW~1\AppData\Local\Temp\perc.imageMainBinary.templateDef</RxFile>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/psx_archiveInfo.xml
@@ -201,24 +201,7 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percLiked.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percLiked.xml"
-										dependencyType="User" displayName="percLiked.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percLiked-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>D:\Percussion\ins\dev\rxconfig\Widgets\percLiked.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percLiked-xml\percLiked.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_liked_images_IconLikeDisabled-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/psx_archiveInfo.xml
@@ -595,42 +595,8 @@
 						supportsIdTypes="no" supportsParentId="no"
 						supportsUserDependencies="yes">
 						<Dependencies>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/simplePageAutoList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/simplePageAutoList.xml"
-										dependencyType="User" displayName="simplePageAutoList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/simpleTextAutoList.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/simpleTextAutoList.xml"
-										dependencyType="User" displayName="simpleTextAutoList.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/psx_archiveManifest.xml
@@ -16,13 +16,7 @@
 			<ArchiveFile>ContentType-337\percSimpleAutoList.schemaDef.contentType</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_simplePageAutoList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\installs\dev\cm20101130\rxconfig\Widgets\simplePageAutoList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_simplePageAutoList-xml\simplePageAutoList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="AclDef--7722608960670269336">
 		<PSXDependencyFile fileType="SERVICEGENERATED_XML">
@@ -51,11 +45,5 @@
 			<ArchiveFile>sys__UserDependency--rx__resources_widgets_simpleList_images_widgetIconTextAutoList-png\widgetIconTextAutoList.png</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_simpleTextAutoList-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>C:\installs\dev\cm20101130\rxconfig\Widgets\simpleTextAutoList.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_simpleTextAutoList-xml\simpleTextAutoList.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 </PSXArchiveManifest>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/psx_archiveInfo.xml
@@ -181,42 +181,8 @@
 									<RequiredClasses />
 								</PSXDeployableObject>
 							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percNavBar.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percNavBar.xml"
-										dependencyType="User" displayName="percNavBar.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
-							<PSXUserDependency
-								parentId="sys_UserDependency"
-								parentKey="Custom-sys_UserDependency" parentType="Custom"
-								path="rxconfig/Widgets/percNavBreadcrumb.xml">
-								<PSXDeployableObject>
-									<PSXDependency autoDep="no" autoExpand="yes"
-										dependencyId="rxconfig/Widgets/percNavBreadcrumb.xml"
-										dependencyType="User" displayName="percNavBreadcrumb.xml"
-										isAssociation="no" isIncluded="yes"
-										objectType="sys_UserDependency"
-										objectTypeName="User Dependency" supportsIdMapping="no"
-										supportsIdTypes="no" supportsParentId="no"
-										supportsUserDependencies="no">
-										<Dependencies />
-									</PSXDependency>
-									<RequiredClasses />
-								</PSXDeployableObject>
-							</PSXUserDependency>
+							
+							
 							<PSXUserDependency
 								parentId="sys_UserDependency"
 								parentKey="Custom-sys_UserDependency" parentType="Custom"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/psx_archiveManifest.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/psx_archiveManifest.xml
@@ -2,13 +2,7 @@
 
 
 <PSXArchiveManifest>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percNavBar-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percNavBar.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percNavBar-xml\percNavBar.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_navBar_images_widgetIconBreadcrumb-png">
 		<PSXDependencyFile fileType="SUPPORT_FILE">
@@ -107,13 +101,7 @@
 			<ArchiveFile>sys__UserDependency--web__resources_widgets_navBar_js_navbar-js\navbar.js</ArchiveFile>
 		</PSXDependencyFile>
 	</PSXDepFilesIdTypes>
-	<PSXDepFilesIdTypes
-		DependencyKey="sys__UserDependency--rxconfig_Widgets_percNavBreadcrumb-xml">
-		<PSXDependencyFile fileType="SUPPORT_FILE">
-			<RxFile>e:\DevEnv\Installs\5315Patch\rxconfig\Widgets\percNavBreadcrumb.xml</RxFile>
-			<ArchiveFile>sys__UserDependency--rxconfig_Widgets_percNavBreadcrumb-xml\percNavBreadcrumb.xml</ArchiveFile>
-		</PSXDependencyFile>
-	</PSXDepFilesIdTypes>
+	
 	<PSXDepFilesIdTypes
 		DependencyKey="sys__UserDependency--web__resources_widgets_navBar_css_superfish--navbar-css">
 		<PSXDependencyFile fileType="SUPPORT_FILE">

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetArchiveManifestInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetArchiveManifestInventoryTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Archive-manifest Widget XML dual-ship exit gate (issue #3582 / parent #2630). Product source
+ * descriptors must not author {@code rxconfig/Widgets/*.xml} except waived {@code perc.Test}.
+ * Install emitter re-injects those paths on staging copies.
+ *
+ * <p>Cross-platform: {@link Path#resolve(String)} / {@link Files} only.
+ */
+class PSWidgetArchiveManifestInventoryTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void waivedPackageSet_isExplicitlyPercTestOnly() {
+    assertEquals(Set.of("perc.Test"), PSWidgetArchiveManifestInventory.WAIVED_PACKAGE_DIRS);
+    assertTrue(PSWidgetArchiveManifestInventory.isWaivedPackage("perc.Test"));
+    assertFalse(PSWidgetArchiveManifestInventory.isWaivedPackage("perc.baseWidgets"));
+    assertFalse(PSWidgetArchiveManifestInventory.isWaivedPackage(null));
+  }
+
+  @Test
+  void productPackagesTree_hasZeroNonWaivedWidgetXmlArchivePaths() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    assertNotNull(
+        packagesRoot,
+        "Packages root must be visible when running module Surefire from perc-packages");
+
+    PSWidgetArchiveManifestInventory.Report report =
+        PSWidgetArchiveManifestInventory.scan(packagesRoot);
+    assertTrue(
+        report.isClean(),
+        () ->
+            "non-waived archive manifests must not author rxconfig/Widgets/*.xml; found: "
+                + report.nonWaived());
+
+    assertFalse(
+        report.waived().isEmpty(),
+        "expected waived Widget XML archive paths under perc.Test");
+    for (PSWidgetArchiveManifestInventory.Finding f : report.waived()) {
+      assertEquals("perc.Test", f.packageDirName());
+      assertTrue(f.waived());
+    }
+
+    PSWidgetArchiveManifestInventory.assertNoNonWaivedWidgetXmlArchivePaths(packagesRoot);
+  }
+
+  @Test
+  void tempTree_dummyNonWaivedArchivePath_failsGate() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.baseWidgets");
+    Files.createDirectories(pkg);
+    Files.writeString(
+        pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME),
+        archiveInfoFixture("rxconfig/Widgets/percSimpleText.xml"),
+        StandardCharsets.UTF_8);
+
+    PSWidgetArchiveManifestInventory.Report report =
+        PSWidgetArchiveManifestInventory.scan(packages);
+    assertFalse(report.isClean());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals("perc.baseWidgets", report.nonWaived().get(0).packageDirName());
+    assertTrue(report.nonWaived().get(0).excerpt().contains("percSimpleText.xml"));
+
+    IllegalStateException err =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                PSWidgetArchiveManifestInventory.assertNoNonWaivedWidgetXmlArchivePaths(packages));
+    assertTrue(err.getMessage().contains("#3582"));
+    assertTrue(err.getMessage().contains("perc.baseWidgets"));
+  }
+
+  @Test
+  void tempTree_onlyWaivedArchivePaths_isClean() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path waived = packages.resolve("perc.Test");
+    Files.createDirectories(waived);
+    Files.writeString(
+        waived.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME),
+        archiveInfoFixture("rxconfig/Widgets/PSWidget_TestProperties.xml"),
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        waived.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_MANIFEST_FILE_NAME),
+        archiveManifestFixture("PSWidget_TestProperties.xml"),
+        StandardCharsets.UTF_8);
+
+    PSWidgetArchiveManifestInventory.Report report =
+        PSWidgetArchiveManifestInventory.scan(packages);
+    assertTrue(report.isClean());
+    assertEquals(0, report.nonWaived().size());
+    assertFalse(report.waived().isEmpty());
+  }
+
+  @Test
+  void strip_removesWidgetBlocks_keepsOtherUserDependencies() {
+    String info = archiveInfoFixture("rxconfig/Widgets/percIframe.xml");
+    assertTrue(PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(info));
+    String stripped = PSWidgetArchiveManifestInventory.stripWidgetXmlArchivePaths(info);
+    assertFalse(PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(stripped));
+    assertTrue(stripped.contains("rx_resources/widgets/iframe/images/keep.png"));
+    assertTrue(stripped.contains("sys_UserDependency"));
+
+    String manifest = archiveManifestFixture("percIframe.xml");
+    String strippedManifest = PSWidgetArchiveManifestInventory.stripWidgetXmlArchivePaths(manifest);
+    assertFalse(PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(strippedManifest));
+    assertTrue(strippedManifest.contains("rx__resources_widgets_iframe"));
+  }
+
+  @Test
+  void stripPackage_skipsWaivedAndRequiresModernRoots() throws Exception {
+    Path waived = tempDir.resolve("perc.Test");
+    Files.createDirectories(waived);
+    Path waivedInfo = waived.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME);
+    String original = archiveInfoFixture("rxconfig/Widgets/PSWidget_TestProperties.xml");
+    Files.writeString(waivedInfo, original, StandardCharsets.UTF_8);
+    assertEquals(0, PSWidgetArchiveManifestInventory.stripAuthoredWidgetXmlArchivePaths(waived));
+    assertEquals(original, Files.readString(waivedInfo, StandardCharsets.UTF_8));
+
+    Path noModern = tempDir.resolve("perc.orphan");
+    Files.createDirectories(noModern);
+    Path orphanInfo = noModern.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME);
+    Files.writeString(
+        orphanInfo, archiveInfoFixture("rxconfig/Widgets/percOrphan.xml"), StandardCharsets.UTF_8);
+    assertEquals(0, PSWidgetArchiveManifestInventory.stripAuthoredWidgetXmlArchivePaths(noModern));
+    assertTrue(
+        PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+            Files.readString(orphanInfo, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void stripPackage_rewritesModernNonWaivedDescriptors() throws Exception {
+    Path pkg = tempDir.resolve("perc.widget.iframe");
+    writeMinimalModernWidget(pkg, "percIframe");
+    Path info = pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME);
+    Path manifest = pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_MANIFEST_FILE_NAME);
+    Files.writeString(
+        info, archiveInfoFixture("rxconfig/Widgets/percIframe.xml"), StandardCharsets.UTF_8);
+    Files.writeString(
+        manifest, archiveManifestFixture("percIframe.xml"), StandardCharsets.UTF_8);
+
+    assertEquals(2, PSWidgetArchiveManifestInventory.stripAuthoredWidgetXmlArchivePaths(pkg));
+    assertFalse(
+        PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+            Files.readString(info, StandardCharsets.UTF_8)));
+    assertFalse(
+        PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+            Files.readString(manifest, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void inject_addsMissingEntries_andIsIdempotent() throws Exception {
+    Path pkg = tempDir.resolve("staged");
+    Files.createDirectories(pkg);
+    Path info = pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME);
+    Files.writeString(
+        info,
+        archiveInfoFixture("rx_resources/widgets/iframe/images/keep.png"),
+        StandardCharsets.UTF_8);
+
+    int first =
+        PSWidgetArchiveManifestInventory.ensureInstallWidgetXmlArchivePaths(
+            pkg, List.of("percIframe"));
+    assertTrue(first >= 1);
+    String infoAfter = Files.readString(info, StandardCharsets.UTF_8);
+    assertTrue(infoAfter.contains("path=\"rxconfig/Widgets/percIframe.xml\""));
+    assertTrue(infoAfter.contains("rx_resources/widgets/iframe/images/keep.png"));
+
+    Path manifest = pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(manifest));
+    String manAfter = Files.readString(manifest, StandardCharsets.UTF_8);
+    assertTrue(
+        manAfter.contains(
+            PSWidgetArchiveManifestInventory.encodeWidgetXmlArchiveFolder("percIframe.xml")));
+    assertTrue(manAfter.contains("rxconfig/Widgets/percIframe.xml"));
+    assertTrue(manAfter.contains("/percIframe.xml"));
+
+    int second =
+        PSWidgetArchiveManifestInventory.ensureInstallWidgetXmlArchivePaths(
+            pkg, List.of("percIframe"));
+    assertEquals(0, second);
+  }
+
+  @Test
+  void encodeWidgetXmlArchiveFolder_matchesHistoricalPackageLayout() {
+    assertEquals(
+        "sys__UserDependency--rxconfig_Widgets_percIframe-xml",
+        PSWidgetArchiveManifestInventory.encodeWidgetXmlArchiveFolder("percIframe.xml"));
+    assertEquals(
+        "sys__UserDependency--rxconfig_Widgets_PSWidget__TestProperties-xml",
+        PSWidgetArchiveManifestInventory.encodeWidgetXmlArchiveFolder(
+            "PSWidget_TestProperties.xml"));
+    assertEquals(
+        "sys__UserDependency--rxconfig_Widgets_simplePageAutoList-xml",
+        PSWidgetArchiveManifestInventory.encodeWidgetXmlArchiveFolder("simplePageAutoList.xml"));
+  }
+
+  @Test
+  void requireStem_rejectsPathTraversal() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSWidgetArchiveManifestInventory.widgetXmlInstallPath("../escape"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSWidgetArchiveManifestInventory.widgetXmlInstallPath("a/b"));
+  }
+
+  @Test
+  void materializeInstall_injectsArchivePathsForModernOnly() throws Exception {
+    Path pkg = tempDir.resolve("modernOnly");
+    Path fixture = tempDir.resolve("percSimpleText.xml");
+    try (var in =
+        PSWidgetArchiveManifestInventoryTest.class.getResourceAsStream(
+            "/widgetxml/percSimpleText.xml")) {
+      assertNotNull(in);
+      Files.write(fixture, in.readAllBytes());
+    }
+    PSWidgetXmlCompileResult modern = PSWidgetXmlCompiler.compile(fixture, null);
+    Path modernRoot =
+        pkg.resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME).resolve("percSimpleText");
+    PSWidgetXmlCompiler.writeArtifacts(modern, modernRoot);
+    Files.writeString(
+        pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME),
+        archiveInfoFixture("rx_resources/widgets/simpletext/keep.png"),
+        StandardCharsets.UTF_8);
+
+    int written = PSWidgetXmlInstallEmitter.materializeInstallWidgetXml(pkg);
+    assertEquals(1, written);
+    String info =
+        Files.readString(
+            pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME),
+            StandardCharsets.UTF_8);
+    assertTrue(info.contains("rxconfig/Widgets/percSimpleText.xml"));
+    String man =
+        Files.readString(
+            pkg.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_MANIFEST_FILE_NAME),
+            StandardCharsets.UTF_8);
+    assertTrue(man.contains("rxconfig_Widgets_percSimpleText-xml"));
+  }
+
+  @Test
+  void scan_rejectsNonDirectoryRoot() {
+    Path missing = tempDir.resolve("does-not-exist");
+    assertThrows(
+        IllegalArgumentException.class, () -> PSWidgetArchiveManifestInventory.scan(missing));
+  }
+
+  private static void writeMinimalModernWidget(Path pkg, String stem) throws Exception {
+    Path modern = pkg.resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME).resolve(stem);
+    Files.createDirectories(modern.resolve("templates"));
+    Files.writeString(
+        modern.resolve("component-package.json"),
+        """
+        {"schemaVersion":"1.0","id":"%s","name":"%s","version":"1.0.0",
+         "catalog":{"kind":"component","title":"%s"},
+         "templates":[{"name":"%sSnippet","type":"snippet","assembler":"velocityAssembler",
+           "sourceRef":"templates/%sSnippet.vm","bindings":[]}],
+         "contentTypes":[],"slots":[],"resources":[],"userPreferences":[],"cssPreferences":[]}
+        """
+            .formatted(stem, stem, stem, stem, stem),
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        modern.resolve("templates").resolve(stem + "Snippet.vm"),
+        "#loadRelatedWidgetContents()",
+        StandardCharsets.UTF_8);
+  }
+
+  private static String archiveInfoFixture(String path) {
+    return """
+        <?xml version="1.0" encoding="utf-8"?>
+        <PSXArchiveInfo archiveRef="demo">
+          <PSXArchiveDetail>
+            <PSXExportDescriptor>
+              <Packages>
+                <PSXDeployableElement>
+                  <PSXDependency dependencyId="sys_UserDependency" objectType="Custom"
+                      supportsUserDependencies="yes">
+                    <Dependencies>
+                      <PSXUserDependency parentId="sys_UserDependency"
+                          parentKey="Custom-sys_UserDependency" parentType="Custom"
+                          path="%s">
+                        <PSXDeployableObject>
+                          <PSXDependency dependencyId="%s" dependencyType="User"
+                              displayName="keep" objectType="sys_UserDependency">
+                            <Dependencies />
+                          </PSXDependency>
+                          <RequiredClasses />
+                        </PSXDeployableObject>
+                      </PSXUserDependency>
+                      <PSXUserDependency parentId="sys_UserDependency"
+                          parentKey="Custom-sys_UserDependency" parentType="Custom"
+                          path="rx_resources/widgets/iframe/images/keep.png">
+                        <PSXDeployableObject>
+                          <PSXDependency dependencyId="rx_resources/widgets/iframe/images/keep.png"
+                              dependencyType="User" displayName="keep.png"
+                              objectType="sys_UserDependency">
+                            <Dependencies />
+                          </PSXDependency>
+                          <RequiredClasses />
+                        </PSXDeployableObject>
+                      </PSXUserDependency>
+                    </Dependencies>
+                  </PSXDependency>
+                </PSXDeployableElement>
+              </Packages>
+            </PSXExportDescriptor>
+          </PSXArchiveDetail>
+        </PSXArchiveInfo>
+        """
+        .formatted(path, path);
+  }
+
+  private static String archiveManifestFixture(String widgetFileName) {
+    String folder = PSWidgetArchiveManifestInventory.encodeWidgetXmlArchiveFolder(widgetFileName);
+    return """
+        <?xml version="1.0" encoding="utf-8"?>
+        <PSXArchiveManifest>
+          <PSXDepFilesIdTypes
+              DependencyKey="sys__UserDependency--rx__resources_widgets_iframe_images_keep-png">
+            <PSXDependencyFile fileType="SUPPORT_FILE">
+              <RxFile>rx_resources/widgets/iframe/images/keep.png</RxFile>
+              <ArchiveFile>sys__UserDependency--rx__resources_widgets_iframe_images_keep-png/keep.png</ArchiveFile>
+            </PSXDependencyFile>
+          </PSXDepFilesIdTypes>
+          <PSXDepFilesIdTypes
+              DependencyKey="%s">
+            <PSXDependencyFile fileType="SUPPORT_FILE">
+              <RxFile>rxconfig/Widgets/%s</RxFile>
+              <ArchiveFile>%s/%s</ArchiveFile>
+            </PSXDependencyFile>
+          </PSXDepFilesIdTypes>
+        </PSXArchiveManifest>
+        """
+        .formatted(folder, widgetFileName, folder, widgetFileName);
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt = cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
@@ -111,6 +111,7 @@ class PSWidgetXmlDualShipTest {
       assertFalse(
           PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(product),
           pkgName + " must not commit sys__UserDependency--rxconfig/Widgets/*.xml (#2883)");
+      assertNoAuthoredWidgetXmlArchivePaths(product, pkgName);
 
       List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
       // compilePackage falls back to modern when XML absent.
@@ -138,6 +139,11 @@ class PSWidgetXmlDualShipTest {
           written,
           pkgName + " materialize-install must write one XML per modern widget");
       assertTrue(PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(staging));
+      assertTrue(
+          PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+              Files.readString(
+                  staging.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME))),
+          pkgName + " staging archiveInfo must list Widget XML after install emit (#3582)");
       installXmlWritten += written;
 
       List<PSWidgetXmlCompileResult> fromMaterialized =
@@ -258,6 +264,7 @@ class PSWidgetXmlDualShipTest {
       assertFalse(
           PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(product),
           pkgName + " must not commit sys__UserDependency--rxconfig/Widgets/*.xml (#2884)");
+      assertNoAuthoredWidgetXmlArchivePaths(product, pkgName);
 
       List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
       // compilePackage falls back to modern when XML absent.
@@ -285,6 +292,11 @@ class PSWidgetXmlDualShipTest {
           written,
           pkgName + " materialize-install must write one XML per modern widget");
       assertTrue(PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(staging));
+      assertTrue(
+          PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+              Files.readString(
+                  staging.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME))),
+          pkgName + " staging archiveInfo must list Widget XML after install emit (#3582)");
       installXmlWritten += written;
 
       List<PSWidgetXmlCompileResult> fromMaterialized =
@@ -388,6 +400,7 @@ class PSWidgetXmlDualShipTest {
       assertFalse(
           PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(product),
           pkgName + " must not commit sys__UserDependency--rxconfig/Widgets/*.xml (#2885)");
+      assertNoAuthoredWidgetXmlArchivePaths(product, pkgName);
 
       List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
       // compilePackage falls back to modern when XML absent.
@@ -415,6 +428,11 @@ class PSWidgetXmlDualShipTest {
           written,
           pkgName + " materialize-install must write one XML per modern widget");
       assertTrue(PSWidgetXmlInstallEmitter.hasCommittedWidgetXml(staging));
+      assertTrue(
+          PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(
+              Files.readString(
+                  staging.resolve(PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME))),
+          pkgName + " staging archiveInfo must list Widget XML after install emit (#3582)");
       installXmlWritten += written;
 
       List<PSWidgetXmlCompileResult> fromMaterialized =
@@ -499,6 +517,23 @@ class PSWidgetXmlDualShipTest {
       throw new AssertionError("expected IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       assertTrue(expected.getMessage().contains(".."));
+    }
+  }
+
+  private static void assertNoAuthoredWidgetXmlArchivePaths(Path product, String pkgName)
+      throws Exception {
+    for (String fileName :
+        List.of(
+            PSWidgetArchiveManifestInventory.ARCHIVE_INFO_FILE_NAME,
+            PSWidgetArchiveManifestInventory.ARCHIVE_MANIFEST_FILE_NAME)) {
+      Path descriptor = product.resolve(fileName);
+      if (!Files.isRegularFile(descriptor)) {
+        continue;
+      }
+      String xml = Files.readString(descriptor);
+      assertFalse(
+          PSWidgetArchiveManifestInventory.containsWidgetXmlArchivePath(xml),
+          pkgName + " must not author rxconfig/Widgets/*.xml in " + fileName + " (#3582)");
     }
   }
 


### PR DESCRIPTION
## Summary

Parent: #2630 (epic #2626). M1 already PASS for committed Widget definition XML files, but product `psx_archiveInfo.xml` / `psx_archiveManifest.xml` still authored `rxconfig/Widgets/*.xml` user-dependencies.

This PR stops authoring those paths in non-waived product packages that have modern `widgets/` roots. Waiver remains **`perc.Test` only**. `PSWidgetXmlInstallEmitter` re-injects the user-dependencies on the package-build staging copy so deployer / `PSWidgetDao` still receive the legacy install wire format. `PSLegacyDefinitionXmlShim` is not deleted (#2852 remains out of scope).

Fixes #3582
Parent tracker: #2630

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-packages && ../../mvnw.cmd clean install` (standalone; no skipTests)
2. Confirm `PSWidgetArchiveManifestInventoryTest` — product tree clean except waived `perc.Test`; TempDir dummy non-waived archive path fails the gate; inject is idempotent
3. Confirm dual-ship batch A/B/C tests assert source manifests have no Widget XML paths and staging copies regain them after materialize
4. Optional CLI: `-Dexec.mainClass=com.percussion.packages.widgetxml.PSWidgetArchiveManifestInventory` with `scan <packagesRoot>`
5. Confirm `PSLegacyDefinitionXmlShim` is unchanged

## Checklist

- [x] **Product documentation** — N/A (not product-facing): packaging source-authoring cleanup; install wire format and operator steps unchanged
- [x] **Unit / module tests** — behavioral tests for scan/strip/inject/encode/materialize; `modules/perc-packages` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install of changed module (no skipTests); C2 N/A (new type + same-signature emitter call; no existing type made `final`/sealed)
- [x] **Cross-platform** — `Path.resolve` / `Files` for disk I/O; ZIP/archive paths use `/`; stem traversal rejected

### C3 evidence

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **145**, Failures: 0, Errors: 0, Skipped: 0 (includes 12 archive-manifest inventory tests). Package build wrote install Widget XML from modern for all converted packages.
- **downstream_checked:** none (no existing public/protected signature change; no type made `final`/sealed). Grep not required for anonymous subclass / `extends` blast radius.

### C5 UI proof

N/A — no UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
