### PR TITLE
cluster(design-spa): absorb create/redirect/delete overnight thrash (#3578 #3579 #3580)

### DIFF
--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { get, post, put } from "../client";
+import { del, get, post, put } from "../client";
 import {
   normalizeDesignObjectGuid,
   resolveTemplateObjectGuid,
@@ -246,6 +246,15 @@ export async function createTemplate(
     wrapTemplateDetailForWire(body),
   );
   return unwrapTemplateDetail(payload);
+}
+
+/**
+ * DELETE /services/templates/{idOrName} — remove a modern assembly template.
+ * Does not write Widget definition XML. 204 has no body.
+ */
+export async function deleteTemplate(idOrName: string): Promise<void> {
+  const key = encodeURIComponent(idOrName);
+  await del<void>(`${PATHS.TEMPLATES}/${key}`);
 }
 
 /** GET /services/slots */

--- a/WebUI/src/main/ts/design/DeleteTemplateDialog.tsx
+++ b/WebUI/src/main/ts/design/DeleteTemplateDialog.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useDialogEscape } from "../architecture/useDialogEscape";
+import { catalogColors } from "../developer/catalogStyles";
+import { DESIGN_MSG } from "./messages";
+
+export interface DeleteTemplateDialogProps {
+  open: boolean;
+  busy: boolean;
+  error: string | null;
+  /** Operator-facing label or name shown in the confirm sentence. */
+  label: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  border: `1px solid ${catalogColors.headerBorder}`,
+  maxWidth: 480,
+  width: "100%",
+  padding: "1.25rem 1.5rem",
+  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+};
+
+/**
+ * Confirm delete of a modern assembly template (no Widget XML).
+ */
+export function DeleteTemplateDialog({
+  open,
+  busy,
+  error,
+  label,
+  onCancel,
+  onConfirm,
+}: DeleteTemplateDialogProps): React.ReactElement | null {
+  useDialogEscape(open, busy, onCancel);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="design-tpl-delete-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="design-tpl-delete-title"
+      aria-describedby="design-tpl-delete-hint"
+    >
+      <div style={panelStyle}>
+        <h2 id="design-tpl-delete-title" style={{ marginTop: 0 }}>
+          {DESIGN_MSG.TPL_DELETE_TITLE}
+        </h2>
+        <p
+          id="design-tpl-delete-hint"
+          style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+        >
+          {DESIGN_MSG.TPL_DELETE_HINT}
+        </p>
+        <p data-testid="design-tpl-delete-confirm">
+          {DESIGN_MSG.TPL_DELETE_CONFIRM.replace("{0}", label)}
+        </p>
+        {error ? (
+          <div
+            role="alert"
+            data-testid="design-tpl-delete-error"
+            style={{ color: catalogColors.error, marginBottom: 12 }}
+          >
+            {error}
+          </div>
+        ) : null}
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            data-testid="design-tpl-delete-cancel"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            {DESIGN_MSG.TPL_DELETE_CANCEL}
+          </button>
+          <button
+            type="button"
+            data-testid="design-tpl-delete-submit"
+            disabled={busy}
+            onClick={onConfirm}
+            style={{
+              background: catalogColors.error,
+              color: "#fff",
+              border: "none",
+              borderRadius: 4,
+              padding: "6px 12px",
+              cursor: busy ? "not-allowed" : "pointer",
+              font: "inherit",
+            }}
+          >
+            {DESIGN_MSG.TPL_DELETE_SUBMIT}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
+++ b/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
@@ -18,6 +18,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createTemplate,
+  deleteTemplate,
   listTemplates,
 } from "../api/developer/assemblyApi";
 import type { TemplateSummary } from "../api/developer/types";
@@ -38,8 +39,15 @@ import {
   openButtonStyle,
 } from "../developer/catalogStyles";
 import { CreateTemplateDialog } from "./CreateTemplateDialog";
+import { DeleteTemplateDialog } from "./DeleteTemplateDialog";
 import { DESIGN_MSG } from "./messages";
 import { TemplateSourceEditor } from "./TemplateSourceEditor";
+
+/** Target for confirm-delete; {@code key} is the REST idOrName. */
+export type TemplateDeleteTarget = {
+  key: string;
+  label: string;
+};
 
 /** Open-key for source editor; null when the row is not selectable. */
 export function templateSelectionKey(t: TemplateSummary): string | null {
@@ -61,7 +69,7 @@ function listErrMsg(err: unknown, fallback: string): string {
 
 /**
  * Design template library (#2808 list + #2809 source/JEXL + #2810 assembler/slots
- * + #3305 create without Widget XML).
+ * + #3305 create + #3580 delete without Widget XML).
  */
 export function TemplateLibraryPanel(): React.ReactElement {
   const [items, setItems] = useState<TemplateSummary[] | null>(null);
@@ -70,6 +78,11 @@ export function TemplateLibraryPanel(): React.ReactElement {
   const [createOpen, setCreateOpen] = useState(false);
   const [createBusy, setCreateBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TemplateDeleteTarget | null>(
+    null,
+  );
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
 
   const reload = useCallback(() => {
@@ -109,6 +122,10 @@ export function TemplateLibraryPanel(): React.ReactElement {
       <TemplateSourceEditor
         idOrName={selected}
         onBack={() => setSelected(null)}
+        onDeleted={() => {
+          setSelected(null);
+          reload();
+        }}
       />
     );
   }
@@ -175,6 +192,37 @@ export function TemplateLibraryPanel(): React.ReactElement {
     />
   );
 
+  const deleteDialog = (
+    <DeleteTemplateDialog
+      open={deleteTarget != null}
+      busy={deleteBusy}
+      error={deleteError}
+      label={deleteTarget?.label || ""}
+      onCancel={() => {
+        if (!deleteBusy) {
+          setDeleteTarget(null);
+          setDeleteError(null);
+        }
+      }}
+      onConfirm={() => {
+        if (!deleteTarget) return;
+        setDeleteBusy(true);
+        setDeleteError(null);
+        deleteTemplate(deleteTarget.key)
+          .then(() => {
+            setDeleteTarget(null);
+            reload();
+          })
+          .catch((e: unknown) => {
+            setDeleteError(listErrMsg(e, DESIGN_MSG.TPL_DELETE_ERROR));
+          })
+          .finally(() => {
+            setDeleteBusy(false);
+          });
+      }}
+    />
+  );
+
   if (error) {
     return (
       <div data-testid="design-tpl-panel">
@@ -183,6 +231,7 @@ export function TemplateLibraryPanel(): React.ReactElement {
           {error}
         </CatalogStatus>
         {dialog}
+        {deleteDialog}
       </div>
     );
   }
@@ -198,6 +247,7 @@ export function TemplateLibraryPanel(): React.ReactElement {
         <CatalogHint>{DESIGN_MSG.TPL_HINT}</CatalogHint>
         <CatalogStatus testId="design-tpl-empty">{DESIGN_MSG.TPL_EMPTY}</CatalogStatus>
         {dialog}
+        {deleteDialog}
       </div>
     );
   }
@@ -214,6 +264,7 @@ export function TemplateLibraryPanel(): React.ReactElement {
           DESIGN_MSG.TPL_COL_NAME,
           DESIGN_MSG.TPL_COL_ID,
           DESIGN_MSG.TPL_COL_DESCRIPTION,
+          DESIGN_MSG.TPL_COL_ACTIONS,
         ]}
         rows={sorted.map((t, index) => {
           const openKey = templateSelectionKey(t);
@@ -244,11 +295,37 @@ export function TemplateLibraryPanel(): React.ReactElement {
               <span key="d" style={mutedCell}>
                 {t.templateDescription || ""}
               </span>,
+              openKey ? (
+                <button
+                  key="delete"
+                  type="button"
+                  data-testid={`design-tpl-delete-${index}`}
+                  aria-label={DESIGN_MSG.TPL_DELETE_ARIA.replace("{0}", label)}
+                  style={{
+                    background: "transparent",
+                    border: `1px solid ${catalogColors.error}`,
+                    color: catalogColors.error,
+                    borderRadius: 4,
+                    padding: "4px 8px",
+                    cursor: "pointer",
+                    font: "inherit",
+                  }}
+                  onClick={() => {
+                    setDeleteError(null);
+                    setDeleteTarget({ key: openKey, label });
+                  }}
+                >
+                  {DESIGN_MSG.TPL_DELETE}
+                </button>
+              ) : (
+                "—"
+              ),
             ],
           };
         })}
       />
       {dialog}
+      {deleteDialog}
     </div>
   );
 }

--- a/WebUI/src/main/ts/design/TemplateSourceEditor.tsx
+++ b/WebUI/src/main/ts/design/TemplateSourceEditor.tsx
@@ -17,6 +17,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import {
+  deleteTemplate,
   getTemplateDetail,
   updateSlotDetail,
   updateTemplateDetail,
@@ -40,6 +41,7 @@ import {
 } from "../developer/catalogStyles";
 import { AssemblerPicker } from "./AssemblerPicker";
 import { isValidAssemblerValue } from "./assemblerOptions";
+import { DeleteTemplateDialog } from "./DeleteTemplateDialog";
 import { DESIGN_MSG } from "./messages";
 import {
   dirtySlotSaves,
@@ -105,9 +107,11 @@ function dash(value: string | number | null | undefined): string {
 export function TemplateSourceEditor({
   idOrName,
   onBack,
+  onDeleted,
 }: {
   idOrName: string;
   onBack: () => void;
+  onDeleted?: () => void;
 }): React.ReactElement {
   const [detail, setDetail] = useState<TemplateDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -115,6 +119,9 @@ export function TemplateSourceEditor({
   const [notice, setNotice] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [source, setSource] = useState("");
   const [bindings, setBindings] = useState<TemplateBindingSummary[]>([]);
   const [assembler, setAssembler] = useState("");
@@ -252,6 +259,27 @@ export function TemplateSourceEditor({
       setBusy(false);
     }
   }
+
+  async function handleDelete() {
+    setDeleteBusy(true);
+    setDeleteError(null);
+    setError(null);
+    try {
+      await deleteTemplate(idOrName);
+      setDeleteOpen(false);
+      if (onDeleted) {
+        onDeleted();
+      } else {
+        onBack();
+      }
+    } catch (err: unknown) {
+      setDeleteError(editorErrMsg(err, DESIGN_MSG.TPL_DELETE_ERROR));
+    } finally {
+      setDeleteBusy(false);
+    }
+  }
+
+  const deleteLabel = detail?.label || detail?.name || idOrName;
 
   return (
     <div data-testid="design-tpl-editor">
@@ -480,12 +508,12 @@ export function TemplateSourceEditor({
             />
           </section>
 
-          <div style={{ marginBottom: "16px" }}>
+          <div style={{ marginBottom: "16px", display: "flex", gap: 8 }}>
             <button
               type="button"
               data-testid="design-tpl-editor-save"
               aria-label={DESIGN_MSG.EDITOR_SAVE}
-              disabled={busy || !dirty}
+              disabled={busy || deleteBusy || !dirty}
               onClick={() => void handleSave()}
               style={{
                 padding: "8px 16px",
@@ -493,14 +521,49 @@ export function TemplateSourceEditor({
                 color: "#fff",
                 border: "none",
                 borderRadius: "4px",
-                cursor: busy || !dirty ? "not-allowed" : "pointer",
+                cursor: busy || deleteBusy || !dirty ? "not-allowed" : "pointer",
               }}
             >
               {DESIGN_MSG.EDITOR_SAVE}
             </button>
+            <button
+              type="button"
+              data-testid="design-tpl-editor-delete"
+              aria-label={DESIGN_MSG.EDITOR_DELETE_ARIA}
+              disabled={busy || deleteBusy}
+              onClick={() => {
+                setDeleteError(null);
+                setDeleteOpen(true);
+              }}
+              style={{
+                padding: "8px 16px",
+                background: "transparent",
+                color: catalogColors.error,
+                border: `1px solid ${catalogColors.error}`,
+                borderRadius: "4px",
+                cursor: busy || deleteBusy ? "not-allowed" : "pointer",
+              }}
+            >
+              {DESIGN_MSG.EDITOR_DELETE}
+            </button>
           </div>
         </>
       ) : null}
+      <DeleteTemplateDialog
+        open={deleteOpen}
+        busy={deleteBusy}
+        error={deleteError}
+        label={deleteLabel}
+        onCancel={() => {
+          if (!deleteBusy) {
+            setDeleteOpen(false);
+            setDeleteError(null);
+          }
+        }}
+        onConfirm={() => {
+          void handleDelete();
+        }}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/design/index.ts
+++ b/WebUI/src/main/ts/design/index.ts
@@ -19,6 +19,7 @@ export { DesignShell, normalizeDesignSection } from "./DesignShell";
 export type { DesignShellProps, DesignSection } from "./DesignShell";
 export { TemplateLibraryPanel, templateSelectionKey } from "./TemplateLibraryPanel";
 export { CreateTemplateDialog } from "./CreateTemplateDialog";
+export { DeleteTemplateDialog } from "./DeleteTemplateDialog";
 export { validateTemplateCreateInput } from "./templateCreate";
 export { DEFAULT_CREATE_ASSEMBLER } from "./assemblerOptions";
 export { TemplateDetailDrawer } from "./TemplateDetailDrawer";

--- a/WebUI/src/main/ts/design/messages.ts
+++ b/WebUI/src/main/ts/design/messages.ts
@@ -25,11 +25,11 @@ import { message } from "../i18n/message";
 const KEYS = {
   TITLE: "perc.ui.design.modern@Design",
   INTRO:
-    "perc.ui.design.modern@Browse modern templates from the design catalog. Create a new template without Widget XML, or open a row to edit assembler, slots, source, and JEXL bindings.",
+    "perc.ui.design.modern@Browse modern templates from the design catalog. Create or delete a template without Widget XML, or open a row to edit assembler, slots, source, and JEXL bindings.",
   SHELL_LOADING: "perc.ui.design.modern@Loading Design…",
   TAB_TEMPLATES: "perc.ui.design.modern@Templates",
   TPL_HINT:
-    "perc.ui.design.modern@Assembly templates available in this CMS. Create a modern template (no Widget XML) or open a row to edit assembler, slots, source, and JEXL bindings.",
+    "perc.ui.design.modern@Assembly templates available in this CMS. Create or delete a modern template (no Widget XML), or open a row to edit assembler, slots, source, and JEXL bindings.",
   TPL_CREATE: "perc.ui.design.modern@Create template",
   TPL_CREATE_ARIA: "perc.ui.design.modern@Create a new assembly template",
   TPL_CREATE_TITLE: "perc.ui.design.modern@Create template",
@@ -47,6 +47,15 @@ const KEYS = {
   TPL_CREATE_NAME_FORMAT:
     "perc.ui.design.modern@Name must start with a letter and use only letters, digits, '.', '_' or '-'.",
   TPL_CREATE_ASSEMBLER_REQUIRED: "perc.ui.design.modern@Choose an assembler.",
+  TPL_DELETE: "perc.ui.design.modern@Delete",
+  TPL_DELETE_ARIA: "perc.ui.design.modern@Delete template {0}",
+  TPL_DELETE_TITLE: "perc.ui.design.modern@Delete template",
+  TPL_DELETE_HINT:
+    "perc.ui.design.modern@Permanently removes this assembly template from the catalog. No Widget definition XML is written.",
+  TPL_DELETE_CONFIRM: "perc.ui.design.modern@Delete {0}? This cannot be undone.",
+  TPL_DELETE_SUBMIT: "perc.ui.design.modern@Delete",
+  TPL_DELETE_CANCEL: "perc.ui.design.modern@Cancel",
+  TPL_DELETE_ERROR: "perc.ui.design.modern@Could not delete template.",
   TPL_LOADING: "perc.ui.design.modern@Loading templates…",
   TPL_EMPTY: "perc.ui.design.modern@No templates found.",
   TPL_ERROR: "perc.ui.design.modern@Could not load templates.",
@@ -54,6 +63,7 @@ const KEYS = {
   TPL_COL_NAME: "perc.ui.design.modern@Name",
   TPL_COL_ID: "perc.ui.design.modern@Id",
   TPL_COL_DESCRIPTION: "perc.ui.design.modern@Description",
+  TPL_COL_ACTIONS: "perc.ui.design.modern@Actions",
   TPL_OPEN_ARIA: "perc.ui.design.modern@Edit template assembler, slots, source, and bindings for {0}",
   DRAWER_TITLE: "perc.ui.design.modern@Template details",
   DRAWER_CLOSE: "perc.ui.design.modern@Close",
@@ -78,6 +88,8 @@ const KEYS = {
   EDITOR_SAVE_ERROR: "perc.ui.design.modern@Could not save template.",
   EDITOR_SAVED: "perc.ui.design.modern@Template assembler, slots, source, and bindings saved.",
   EDITOR_SAVE: "perc.ui.design.modern@Save",
+  EDITOR_DELETE: "perc.ui.design.modern@Delete",
+  EDITOR_DELETE_ARIA: "perc.ui.design.modern@Delete this template",
   EDITOR_SOURCE: "perc.ui.design.modern@Template source",
   EDITOR_SOURCE_HINT:
     "perc.ui.design.modern@Velocity / assembler source text for this template.",

--- a/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   TEMPLATE_DETAIL_ROOT,
   createTemplate,
+  deleteTemplate,
   getTemplateDetail,
   unwrapTemplateDetail,
   updateTemplateDetail,
@@ -177,5 +178,16 @@ describe("getTemplateDetail / updateTemplateDetail wire binding (#3039)", () => 
       },
     });
     expect(String(fetchMock.mock.calls[0][0])).toContain(PATHS.TEMPLATES);
+  });
+
+  it("deleteTemplate sends DELETE to templates/{idOrName}", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    await deleteTemplate("site.html.snippet");
+    expect(fetchMock).toHaveBeenCalled();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain(`${PATHS.TEMPLATES}/`);
+    expect(url).toContain(encodeURIComponent("site.html.snippet"));
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("DELETE");
   });
 });

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -90,6 +90,7 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn().mockResolvedValue([]),
   getTemplateDetail: vi.fn().mockResolvedValue({ templateName: "x" }),
   createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
   updateTemplateDetail: vi.fn(),
   listSlots: vi.fn().mockResolvedValue([]),
   getSlotDetail: vi.fn().mockResolvedValue({}),

--- a/WebUI/src/test/ts/design/DesignShell.test.tsx
+++ b/WebUI/src/test/ts/design/DesignShell.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn(),
   getTemplateDetail: vi.fn(),
   createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
   updateTemplateDetail: vi.fn(),
   getSlotDetail: vi.fn(),
   updateSlotDetail: vi.fn(),

--- a/WebUI/src/test/ts/design/TemplateAssemblerSlotsEditor.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateAssemblerSlotsEditor.test.tsx
@@ -25,6 +25,7 @@ import { DESIGN_MSG } from "../../../main/ts/design/messages";
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   getTemplateDetail: vi.fn(),
   updateTemplateDetail: vi.fn(),
+  deleteTemplate: vi.fn(),
   getSlotDetail: vi.fn(),
   updateSlotDetail: vi.fn(),
 }));

--- a/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
@@ -31,12 +31,14 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   getTemplateDetail: vi.fn(),
   updateTemplateDetail: vi.fn(),
   createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
   getSlotDetail: vi.fn(),
   updateSlotDetail: vi.fn(),
 }));
 
 const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
 const createTemplate = assemblyApi.createTemplate as ReturnType<typeof vi.fn>;
+const deleteTemplate = assemblyApi.deleteTemplate as ReturnType<typeof vi.fn>;
 const getTemplateDetail = assemblyApi.getTemplateDetail as ReturnType<
   typeof vi.fn
 >;
@@ -59,6 +61,7 @@ describe("TemplateLibraryPanel (#2808)", () => {
     };
     listTemplates.mockReset();
     createTemplate.mockReset();
+    deleteTemplate.mockReset();
     getTemplateDetail.mockReset();
     getSlotDetail.mockReset();
     getSlotDetail.mockResolvedValue({
@@ -231,5 +234,83 @@ describe("TemplateLibraryPanel (#2808)", () => {
         "already exists",
       );
     });
+  });
+
+  it("deletes a template from the library after confirm", async () => {
+    listTemplates
+      .mockResolvedValueOnce([
+        {
+          templateId: 101,
+          templateName: "site.html.snippet",
+          templateLabel: "HTML snippet",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    deleteTemplate.mockResolvedValue(undefined);
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-delete-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-delete-0"));
+    expect(screen.getByTestId("design-tpl-delete-dialog")).toBeTruthy();
+    expect(screen.getByTestId("design-tpl-delete-confirm").textContent).toContain(
+      "HTML snippet",
+    );
+    fireEvent.click(screen.getByTestId("design-tpl-delete-submit"));
+    await waitFor(() => {
+      expect(deleteTemplate).toHaveBeenCalledWith("site.html.snippet");
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("design-tpl-delete-dialog")).toBeNull();
+      expect(screen.getByTestId("design-tpl-empty")).toBeTruthy();
+    });
+  });
+
+  it("cancel on delete confirm does not call deleteTemplate", async () => {
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 101,
+        templateName: "site.html.snippet",
+        templateLabel: "HTML snippet",
+      },
+    ]);
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-delete-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-delete-0"));
+    fireEvent.click(screen.getByTestId("design-tpl-delete-cancel"));
+    expect(deleteTemplate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("design-tpl-delete-dialog")).toBeNull();
+    expect(screen.getByTestId("design-tpl-table").textContent).toContain(
+      "site.html.snippet",
+    );
+  });
+
+  it("shows operator-facing delete errors", async () => {
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 101,
+        templateName: "site.html.snippet",
+        templateLabel: "HTML snippet",
+      },
+    ]);
+    deleteTemplate.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: { message: "in use" },
+    });
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-delete-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-delete-0"));
+    fireEvent.click(screen.getByTestId("design-tpl-delete-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-delete-error").textContent).toContain(
+        "in use",
+      );
+    });
+    expect(screen.getByTestId("design-tpl-delete-dialog")).toBeTruthy();
   });
 });

--- a/WebUI/src/test/ts/design/TemplateSourceEditor.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateSourceEditor.test.tsx
@@ -25,6 +25,7 @@ import { DESIGN_MSG } from "../../../main/ts/design/messages";
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   getTemplateDetail: vi.fn(),
   updateTemplateDetail: vi.fn(),
+  deleteTemplate: vi.fn(),
   getSlotDetail: vi.fn(),
   updateSlotDetail: vi.fn(),
 }));
@@ -35,6 +36,7 @@ const getTemplateDetail = assemblyApi.getTemplateDetail as ReturnType<
 const updateTemplateDetail = assemblyApi.updateTemplateDetail as ReturnType<
   typeof vi.fn
 >;
+const deleteTemplate = assemblyApi.deleteTemplate as ReturnType<typeof vi.fn>;
 const getSlotDetail = assemblyApi.getSlotDetail as ReturnType<typeof vi.fn>;
 
 const baseDetail = {
@@ -58,6 +60,7 @@ describe("TemplateSourceEditor (#2809)", () => {
     };
     getTemplateDetail.mockReset();
     updateTemplateDetail.mockReset();
+    deleteTemplate.mockReset();
     getSlotDetail.mockReset();
     getSlotDetail.mockResolvedValue({
       name: "main",
@@ -149,5 +152,29 @@ describe("TemplateSourceEditor (#2809)", () => {
     );
     fireEvent.click(screen.getByTestId("design-tpl-editor-back"));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("deletes from the editor after confirm", async () => {
+    const onDeleted = vi.fn();
+    deleteTemplate.mockResolvedValue(undefined);
+    render(
+      <TemplateSourceEditor
+        idOrName="site.base"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-editor-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-editor-delete"));
+    expect(screen.getByTestId("design-tpl-delete-dialog")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("design-tpl-delete-submit"));
+    await waitFor(() => {
+      expect(deleteTemplate).toHaveBeenCalledWith("site.base");
+    });
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
   });
 });

--- a/docs/ai-generated/code-reviews/3580-design-spa-delete-template-lazy-stub-erlang.md
+++ b/docs/ai-generated/code-reviews/3580-design-spa-delete-template-lazy-stub-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — PR #3597 `@Lazy` on `TestTemplatesAdaptor`
+
+## Summary
+
+Add `@Lazy` next to `@Component` on the rest Spring test stub
+`TestTemplatesAdaptor`, matching `rest/AGENTS.md` and peers (`TestLocalesAdaptor`,
+`TestSystemDefAdaptor`). Addresses kilo-code-bot WARNING on PR #3597.
+
+## Scope
+
+- Branch: `feat/issue-3580-design-spa-delete-template` vs `HEAD`
+- Files: `rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java`
+- Memory: shared Spring test stubs must use `@Component` + `@Lazy`; `MainTest`
+  needs the adaptor bean without eager-init side effects
+- Cross-platform path review: no filesystem I/O in this diff
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None at bug severity.
+
+Annotation-only change; no new production logic. `cd rest && ../mvnw.cmd clean
+install` BUILD SUCCESS, Tests run: 539, Failures: 0 (`MainTest` 2 passed).

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -759,21 +759,22 @@ npm run test:surface:list -- --path tests/profile-shell.spec.js
 npm run test:surface:list -- --tag profile
 ```
 
-#### Design SPA library + create/edit consolidation (#3307 / parent #2631)
+#### Design SPA library + create/edit consolidation (#3307 / #3579 / parent #2631)
 
 Surface-filtered companion for the Design SPA template library (list + editor) after
-Phase 4 shells (#2808–#2810). **Create** (#3305) and **classic list redirect** (#3306)
-are asserted when that chrome is on the QA cell; otherwise the spec **skips cleanly**
-(do not run the full suite).
+Phase 4 shells (#2808–#2810). **Classic list redirect** (#3306 / #3579) is
+**required** on `perc-devctl qa-up` H2 (no skip). **Create** (#3305) still skips
+cleanly when that chrome is not on the cell (do not run the full suite).
 
 | Item | Value |
 |------|--------|
-| Spec | `frontend/tests/design-spa-consolidation.spec.js` |
+| Spec (redirect, no-skip) | `frontend/tests/design-legacy-redirect.spec.js` |
+| Spec (consolidation) | `frontend/tests/design-spa-consolidation.spec.js` |
 | Helpers / unit | `frontend/tests/helpers/design-spa-surface.js`, `tests/unit/design-spa-surface.test.js` |
 | Tags | `@design-spa` `@smoke` `@ui` |
-| Soft skip (shell) | No `perc-design-shell` on the cell |
+| Soft skip (shell) | No `perc-design-shell` on the cell (library/edit cases only) |
 | Soft skip (create) | No `design-tpl-create` (sibling #3305 not deployed) |
-| Soft skip (redirect) | `admin.jsp` still classic CM1 list (sibling #3306 not deployed) |
+| Redirect | Fail if `admin.jsp` / `?view=design` do not land on `perc-design-shell` |
 | Product docs | `product-docs/8.2/admin/design-templates.md` |
 
 ```bash
@@ -781,9 +782,10 @@ cd modules/perc-qa-automation/frontend
 # After perc-devctl qa-up (use printed TEST_CMS_URL):
 TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
   ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
-  npm run test:surface -- --path tests/design-spa-consolidation.spec.js
+  npm run test:surface -- --path tests/design-legacy-redirect.spec.js
 
-npm run test:surface:list -- --path tests/design-spa-consolidation.spec.js
+npm run test:surface -- --path tests/design-spa-consolidation.spec.js --grep "legacy Design list"
+npm run test:surface:list -- --path tests/design-legacy-redirect.spec.js
 npm run test:surface -- --tag design-spa
 ```
 

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -735,20 +735,21 @@ npm run test:surface:list -- --path tests/profile-shell.spec.js
 npm run test:surface:list -- --tag profile
 ```
 
-#### Design SPA library + create/edit consolidation (#3307 / parent #2631)
+#### Design SPA library + create/edit consolidation (#3307 / #3578 / parent #2631)
 
 Surface-filtered companion for the Design SPA template library (list + editor) after
-Phase 4 shells (#2808–#2810). **Create** (#3305) and **classic list redirect** (#3306)
-are asserted when that chrome is on the QA cell; otherwise the spec **skips cleanly**
-(do not run the full suite).
+Phase 4 shells (#2808–#2810). **Create** (#3305 / #3578) is **required** on
+`perc-devctl qa-up` H2 (no skip). **Classic list redirect** (#3306) still skips
+cleanly when that cutover is not on the cell (do not run the full suite).
 
 | Item | Value |
 |------|--------|
-| Spec | `frontend/tests/design-spa-consolidation.spec.js` |
+| Spec (create, no-skip) | `frontend/tests/design-template-create.spec.js` |
+| Spec (consolidation) | `frontend/tests/design-spa-consolidation.spec.js` |
 | Helpers / unit | `frontend/tests/helpers/design-spa-surface.js`, `tests/unit/design-spa-surface.test.js` |
 | Tags | `@design-spa` `@smoke` `@ui` |
-| Soft skip (shell) | No `perc-design-shell` on the cell |
-| Soft skip (create) | No `design-tpl-create` (sibling #3305 not deployed) |
+| Soft skip (shell) | No `perc-design-shell` on the cell (library/edit cases only) |
+| Create | Fail if `design-tpl-create` is missing; assert `POST /services/templates` and no Widget XML |
 | Soft skip (redirect) | `admin.jsp` still classic CM1 list (sibling #3306 not deployed) |
 | Product docs | `product-docs/8.2/admin/design-templates.md` |
 

--- a/modules/perc-qa-automation/frontend/tests/design-legacy-redirect.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-legacy-redirect.spec.js
@@ -15,82 +15,111 @@
  */
 
 /**
- * Design template-list legacy entry retirement (#3306 / parent #2631).
+ * Design template-list legacy entry retirement (#3306 / #3579 / parent #2631).
+ *
+ * Required on perc-devctl qa-up H2 — no skip when classic Design list is
+ * still hosted. Fail if admin.jsp / ?view=design do not land on
+ * perc-design-shell.
  *
  * Surface-filtered:
  *   npm run test:surface -- --path tests/design-legacy-redirect.spec.js
- *
- * Proves admin.jsp and ?view=design land on SPA Design template library
- * (not the retired CM1 Design list). Broader Design SPA Playwright is #3307.
  */
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  TEST_IDS,
+  CLASSIC_ASSIGNED_TEMPLATES_ID,
+  designLegacyAdminUrl,
+  designLegacyViewUrl,
+  isDesignSpaLandingUrl,
+  filterConsoleNoise,
+} = require("./helpers/design-spa-surface");
 
-test.describe("Design legacy list entry retirement (#3306)", () => {
+function tid(id) {
+  return `[data-testid="${id}"]`;
+}
+
+function attachConsoleGate(page) {
+  const errors = [];
+  page.on("pageerror", (err) => {
+    errors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      errors.push(msg.text());
+    }
+  });
+  return errors;
+}
+
+test.describe("Design legacy list entry retirement (#3306 / #3579)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
     await loginAsAdmin(page);
   });
 
-  function attachPageErrorGate(page) {
-    const pageErrors = [];
-    page.on("pageerror", (err) => {
-      pageErrors.push(String(err && err.message ? err.message : err));
-    });
-    return pageErrors;
-  }
-
   test("admin.jsp hard-redirects to SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/admin.jsp?_=${Date.now()}`;
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    const consoleErrors = attachConsoleGate(page);
+    await page.goto(designLegacyAdminUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
 
-    await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.nav))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
-    const finalUrl = page.url();
-    expect(finalUrl).toMatch(/design|entry=design|view=design/i);
-    expect(pageErrors, "uncaught pageerror on Design redirect").toEqual([]);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
   test("admin.jsp?view=admin still lands on SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/admin.jsp?view=admin&_=${Date.now()}`;
+    const consoleErrors = attachConsoleGate(page);
+    const url = `${BASE_URL.replace(/\/+$/, "")}/Rhythmyx/cm/app/admin.jsp?view=admin&_=${Date.now()}`;
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
     const finalUrl = page.url();
-    expect(finalUrl).toMatch(/design|entry=design|view=design/i);
+    expect(isDesignSpaLandingUrl(finalUrl)).toBe(true);
     expect(finalUrl).not.toMatch(/[?&]view=admin(?:&|$)/i);
-    expect(pageErrors, "uncaught pageerror on view= override").toEqual([]);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
   test("?view=design deep link lands on SPA Design @smoke @ui", async ({
     page,
   }) => {
-    const pageErrors = attachPageErrorGate(page);
-    const url = `${BASE_URL}/Rhythmyx/cm/app/?view=design&_=${Date.now()}`;
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    const consoleErrors = attachConsoleGate(page);
+    await page.goto(designLegacyViewUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
 
-    await expect(page.getByTestId("perc-design-shell")).toBeVisible({
+    await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator(tid(TEST_IDS.panel))).toBeVisible({
       timeout: 30_000,
     });
     await expect(page.getByTestId("panel-design-templates")).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.locator("#perc-assigned-templates")).toHaveCount(0);
-    expect(pageErrors, "uncaught pageerror on view=design").toEqual([]);
+    await expect(page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`)).toHaveCount(
+      0,
+    );
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
@@ -25,8 +25,9 @@
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Library + edit run when Design chrome is on the cell (#2808–#2810).
- * Create (#3305) and classic-list redirect (#3306) skip cleanly when that
- * chrome is not deployed yet.
+ * Create (#3305 / #3578) is required — fail if design-tpl-create is missing.
+ * Classic-list redirect (#3306) still skips cleanly when that cutover is not
+ * deployed yet.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -160,15 +161,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     await openDesignLibrary(page);
 
     const createBtn = page.locator(tid(TEST_IDS.create));
-    const createPresent = await softVisible(createBtn, 8_000);
-    const createSkip = skipReasonForChrome({
-      shellPresent: true,
-      wantCreate: true,
-      createPresent,
-    });
-    if (createSkip) {
-      test.skip(true, createSkip);
-    }
+    await expect(createBtn).toBeVisible({ timeout: 30_000 });
 
     const error = page.locator(tid(TEST_IDS.error));
     if (await error.isVisible()) {

--- a/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js
@@ -25,8 +25,9 @@
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Library + edit run when Design chrome is on the cell (#2808–#2810).
- * Create (#3305) and classic-list redirect (#3306) skip cleanly when that
- * chrome is not deployed yet.
+ * Create (#3305) still skips cleanly when that chrome is not deployed yet.
+ * Classic-list redirect (#3306 / #3579) is required on H2 — fail if
+ * admin.jsp / ?view=design do not land on perc-design-shell.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -37,11 +38,11 @@ const {
 const {
   TEST_IDS,
   CLASSIC_ASSIGNED_TEMPLATES_ID,
-  SKIP,
   designTemplatesUrl,
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
   softVisible,
 } = require("./helpers/design-spa-surface");
@@ -193,7 +194,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 
-  test("legacy Design list lands on SPA when cutover present @smoke @ui @design-spa", async ({
+  test("legacy Design list lands on SPA (#3579 no-skip) @smoke @ui @design-spa", async ({
     page,
   }) => {
     const consoleErrors = attachConsoleGate(page);
@@ -201,28 +202,13 @@ test.describe("Design SPA consolidation (#3307)", () => {
       waitUntil: "domcontentloaded",
     });
 
-    const spaShell = page.locator(tid(TEST_IDS.shell));
-    const redirectToSpa = await softVisible(spaShell, 15_000);
-    const redirectSkip = skipReasonForChrome({
-      shellPresent: true,
-      wantRedirect: true,
-      redirectToSpa,
-    });
-    if (redirectSkip) {
-      // Extra evidence: classic list marker may still be present on main.
-      const classic = page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`);
-      if (await softVisible(classic, 3_000)) {
-        test.skip(true, `${SKIP.REDIRECT} Classic #${CLASSIC_ASSIGNED_TEMPLATES_ID} still visible.`);
-      }
-      test.skip(true, redirectSkip);
-    }
-
     await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
-      timeout: 15_000,
+      timeout: 30_000,
     });
     await expect(
       page.locator(`#${CLASSIC_ASSIGNED_TEMPLATES_ID}`),
     ).toHaveCount(0);
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
 
     await page.goto(designLegacyViewUrl(BASE_URL), {
       waitUntil: "domcontentloaded",
@@ -230,6 +216,7 @@ test.describe("Design SPA consolidation (#3307)", () => {
     await expect(page.locator(tid(TEST_IDS.shell))).toBeVisible({
       timeout: 20_000,
     });
+    expect(isDesignSpaLandingUrl(page.url())).toBe(true);
     expect(filterConsoleNoise(consoleErrors)).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-create.spec.js
@@ -15,7 +15,9 @@
  */
 
 /**
- * Design SPA create template without Widget XML (#3305 / parent #2631).
+ * Design SPA create template without Widget XML (#3305 / #3578 / parent #2631).
+ *
+ * Required on perc-devctl qa-up H2 — no skip when create chrome is missing.
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/design-template-create.spec.js
@@ -27,6 +29,10 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  createBodyHasWidgetXml,
+  isTemplateCreatePost,
+} = require("./helpers/design-spa-surface");
 
 function designTemplatesUrl() {
   const q = new URLSearchParams({
@@ -81,7 +87,17 @@ test.describe("Design template create (#3305)", () => {
       page.locator('[data-testid="design-tpl-create-dialog"]'),
     ).toHaveAttribute("aria-describedby", "design-tpl-create-hint");
     await page.locator('[data-testid="design-tpl-create-name"]').fill(name);
+
+    const createPost = page.waitForResponse(
+      (r) => isTemplateCreatePost(r.request()),
+      { timeout: 20_000 },
+    );
     await page.locator('[data-testid="design-tpl-create-submit"]').click();
+    const postResp = await createPost;
+    expect(postResp.ok(), `POST /services/templates ${postResp.status()}`).toBe(
+      true,
+    );
+    expect(createBodyHasWidgetXml(postResp.request().postData())).toBe(false);
 
     await expect(
       page.locator('[data-testid="design-tpl-create-dialog"]'),

--- a/modules/perc-qa-automation/frontend/tests/design-template-delete.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-delete.spec.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Design SPA delete template without Widget XML (#3580 / parent #2631).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/design-template-delete.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Entry: spa.jsp?entry=design&section=templates
+ * Flow: create (or use fixture) then delete with confirm; list refreshes.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  TEST_IDS,
+  SKIP,
+  designTemplatesUrl,
+  filterConsoleNoise,
+} = require("./helpers/design-spa-surface");
+
+test.describe("Design template delete (#3580)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+  });
+
+  test("creates then deletes a modern template and refreshes the list @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    const name = `qa.delete.tpl.${Date.now()}`;
+
+    await page.goto(designTemplatesUrl(BASE_URL), { waitUntil: "networkidle" });
+
+    await expect(page.locator(`[data-testid="${TEST_IDS.shell}"]`)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const createBtn = page.locator(`[data-testid="${TEST_IDS.create}"]`);
+    if (!(await createBtn.isVisible().catch(() => false))) {
+      test.skip(true, SKIP.CREATE);
+      return;
+    }
+
+    const error = page.locator(`[data-testid="${TEST_IDS.error}"]`);
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Design templates catalog error: ${msg}`);
+    }
+
+    await createBtn.click();
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.createDialog}"]`),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.locator(`[data-testid="${TEST_IDS.createName}"]`).fill(name);
+    await page.locator(`[data-testid="${TEST_IDS.createSubmit}"]`).click();
+
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.createDialog}"]`),
+    ).toHaveCount(0, { timeout: 20_000 });
+    await expect(page.locator(`[data-testid="${TEST_IDS.table}"]`)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-testid="${TEST_IDS.table}"]`)).toContainText(
+      name,
+    );
+
+    const namedRow = page.locator(`[data-testid^="design-tpl-row"]`).filter({
+      hasText: name,
+    });
+    await expect(namedRow).toHaveCount(1, { timeout: 10_000 });
+    const deleteBtn = namedRow.locator('[data-testid^="design-tpl-delete-"]');
+    if (!(await deleteBtn.isVisible().catch(() => false))) {
+      test.skip(true, SKIP.DELETE);
+      return;
+    }
+    await deleteBtn.click();
+
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.deleteDialog}"]`),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.deleteConfirm}"]`),
+    ).toContainText(name);
+    await page.locator(`[data-testid="${TEST_IDS.deleteSubmit}"]`).click();
+
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.deleteDialog}"]`),
+    ).toHaveCount(0, { timeout: 20_000 });
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.panel}"]`),
+    ).not.toContainText(name, { timeout: 20_000 });
+
+    expect(filterConsoleNoise(consoleErrors)).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -18,10 +18,10 @@
 /**
  * Design SPA surface helpers (#3307 / parent #2631).
  *
- * URL builders, stable test ids, and skip reasons for library + create/edit
- * consolidation. Sibling slices #3305 (create) and #3306 (classic list
- * redirect) may not be on the QA cell — callers must skip cleanly instead of
- * running the full Playwright suite.
+ * URL builders, stable test ids, and skip reasons for library + edit
+ * consolidation. Create (#3305 / #3578) is required on H2 — do not skip
+ * when design-tpl-create is missing. Sibling #3306 (classic list redirect)
+ * may still skip cleanly when that cutover is not on the cell.
  */
 
 "use strict";
@@ -57,12 +57,14 @@ const CLASSIC_ASSIGNED_TEMPLATES_ID = "perc-assigned-templates";
 const SKIP = Object.freeze({
   SHELL:
     "Design SPA chrome not on this QA cell (perc-design-shell missing) — skip; do not run full suite. Parent #2631 / #3307.",
-  CREATE:
-    "Create-template chrome not on this QA cell (design-tpl-create missing; sibling #3305). Clean skip.",
   EDIT_EMPTY: "No templates in catalog — cannot exercise Design SPA editor.",
   REDIRECT:
     "Classic Design list still hosted (no perc-design-shell on admin.jsp / ?view=design; sibling #3306). Clean skip.",
 });
+
+/** Payload markers that would mean create still authored Widget definition XML. */
+const WIDGET_XML_RE =
+  /widgetXml|WidgetDef|sys_Widget|widgetDefinition|WidgetDefinition/i;
 
 /**
  * @param {string} baseUrl
@@ -112,10 +114,8 @@ function designLegacyViewUrl(baseUrl) {
  *
  * @param {{
  *   shellPresent?: boolean,
- *   createPresent?: boolean,
  *   catalogEmpty?: boolean,
  *   redirectToSpa?: boolean,
- *   wantCreate?: boolean,
  *   wantEdit?: boolean,
  *   wantRedirect?: boolean,
  * }} flags
@@ -126,9 +126,6 @@ function skipReasonForChrome(flags) {
   if (!f.shellPresent) {
     return SKIP.SHELL;
   }
-  if (f.wantCreate && !f.createPresent) {
-    return SKIP.CREATE;
-  }
   if (f.wantEdit && f.catalogEmpty) {
     return SKIP.EDIT_EMPTY;
   }
@@ -136,6 +133,51 @@ function skipReasonForChrome(flags) {
     return SKIP.REDIRECT;
   }
   return null;
+}
+
+/**
+ * True when {@code url} is the templates collection (POST create), not
+ * {@code /services/templates/{idOrName}}.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isTemplatesCollectionUrl(url) {
+  try {
+    const pathname = new URL(String(url)).pathname.replace(/\/+$/, "");
+    return /\/services\/templates$/.test(pathname);
+  } catch {
+    return /\/services\/templates\/?(\?|$)/.test(String(url));
+  }
+}
+
+/**
+ * @param {{ method?: () => string, url?: () => string }|null|undefined} request
+ * @returns {boolean}
+ */
+function isTemplateCreatePost(request) {
+  if (!request || typeof request.method !== "function") {
+    return false;
+  }
+  if (String(request.method()).toUpperCase() !== "POST") {
+    return false;
+  }
+  const url = typeof request.url === "function" ? request.url() : "";
+  return isTemplatesCollectionUrl(url);
+}
+
+/**
+ * True when a create POST body still carries Widget definition XML.
+ *
+ * @param {unknown} payload
+ * @returns {boolean}
+ */
+function createBodyHasWidgetXml(payload) {
+  if (payload == null) {
+    return false;
+  }
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return WIDGET_XML_RE.test(text);
 }
 
 /**
@@ -161,6 +203,9 @@ module.exports = {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isTemplatesCollectionUrl,
+  isTemplateCreatePost,
+  createBodyHasWidgetXml,
   filterConsoleNoise,
   softVisible,
 };

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -16,12 +16,13 @@
  */
 
 /**
- * Design SPA surface helpers (#3307 / parent #2631).
+ * Design SPA surface helpers (#3307 / #3579 / parent #2631).
  *
  * URL builders, stable test ids, and skip reasons for library + create/edit
- * consolidation. Sibling slices #3305 (create) and #3306 (classic list
- * redirect) may not be on the QA cell — callers must skip cleanly instead of
- * running the full Playwright suite.
+ * consolidation. Classic list redirect (#3306 / #3579) is required on
+ * perc-devctl qa-up H2 — do not skip when admin.jsp / ?view=design miss
+ * perc-design-shell. Sibling #3305 (create) may still skip cleanly when
+ * that chrome is not on the cell.
  */
 
 "use strict";
@@ -60,8 +61,6 @@ const SKIP = Object.freeze({
   CREATE:
     "Create-template chrome not on this QA cell (design-tpl-create missing; sibling #3305). Clean skip.",
   EDIT_EMPTY: "No templates in catalog — cannot exercise Design SPA editor.",
-  REDIRECT:
-    "Classic Design list still hosted (no perc-design-shell on admin.jsp / ?view=design; sibling #3306). Clean skip.",
 });
 
 /**
@@ -114,10 +113,8 @@ function designLegacyViewUrl(baseUrl) {
  *   shellPresent?: boolean,
  *   createPresent?: boolean,
  *   catalogEmpty?: boolean,
- *   redirectToSpa?: boolean,
  *   wantCreate?: boolean,
  *   wantEdit?: boolean,
- *   wantRedirect?: boolean,
  * }} flags
  * @returns {string|null} skip message, or null when the case should run
  */
@@ -132,10 +129,20 @@ function skipReasonForChrome(flags) {
   if (f.wantEdit && f.catalogEmpty) {
     return SKIP.EDIT_EMPTY;
   }
-  if (f.wantRedirect && !f.redirectToSpa) {
-    return SKIP.REDIRECT;
-  }
   return null;
+}
+
+/**
+ * True when a landed URL is the Design SPA (view=design, entry=design, or
+ * /design path). Used by the no-skip H2 redirect gate (#3579).
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isDesignSpaLandingUrl(url) {
+  return /(?:[?&]view=design(?:[&?#]|$)|[?&]entry=design(?:[&?#]|$)|\/design(?:[/?#]|$))/i.test(
+    String(url || ""),
+  );
 }
 
 /**
@@ -161,6 +168,7 @@ module.exports = {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
   softVisible,
 };

--- a/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js
@@ -42,7 +42,13 @@ const TEST_IDS = Object.freeze({
   createDialog: "design-tpl-create-dialog",
   createName: "design-tpl-create-name",
   createSubmit: "design-tpl-create-submit",
+  deleteRow: "design-tpl-delete-0",
+  deleteDialog: "design-tpl-delete-dialog",
+  deleteConfirm: "design-tpl-delete-confirm",
+  deleteSubmit: "design-tpl-delete-submit",
+  deleteCancel: "design-tpl-delete-cancel",
   editor: "design-tpl-editor",
+  editorDelete: "design-tpl-editor-delete",
   editorBack: "design-tpl-editor-back",
   editorSource: "design-tpl-editor-source-edit",
   editorName: "design-tpl-editor-name",
@@ -59,6 +65,8 @@ const SKIP = Object.freeze({
     "Design SPA chrome not on this QA cell (perc-design-shell missing) — skip; do not run full suite. Parent #2631 / #3307.",
   CREATE:
     "Create-template chrome not on this QA cell (design-tpl-create missing; sibling #3305). Clean skip.",
+  DELETE:
+    "Delete-template chrome not on this QA cell (design-tpl-delete-0 missing; sibling #3580). Clean skip.",
   EDIT_EMPTY: "No templates in catalog — cannot exercise Design SPA editor.",
   REDIRECT:
     "Classic Design list still hosted (no perc-design-shell on admin.jsp / ?view=design; sibling #3306). Clean skip.",
@@ -116,6 +124,8 @@ function designLegacyViewUrl(baseUrl) {
  *   catalogEmpty?: boolean,
  *   redirectToSpa?: boolean,
  *   wantCreate?: boolean,
+ *   wantDelete?: boolean,
+ *   deletePresent?: boolean,
  *   wantEdit?: boolean,
  *   wantRedirect?: boolean,
  * }} flags
@@ -128,6 +138,9 @@ function skipReasonForChrome(flags) {
   }
   if (f.wantCreate && !f.createPresent) {
     return SKIP.CREATE;
+  }
+  if (f.wantDelete && !f.deletePresent) {
+    return SKIP.DELETE;
   }
   if (f.wantEdit && f.catalogEmpty) {
     return SKIP.EDIT_EMPTY;

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * Unit tests for Design SPA surface helpers (#3307) — no live CMS.
+ * Unit tests for Design SPA surface helpers (#3307 / #3579) — no live CMS.
  */
 
 "use strict";
@@ -31,6 +31,7 @@ const {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isDesignSpaLandingUrl,
   filterConsoleNoise,
 } = require("../helpers/design-spa-surface");
 
@@ -93,15 +94,16 @@ describe("design-spa-surface helpers (#3307)", () => {
     );
   });
 
-  it("skips redirect when sibling #3306 cutover is absent", () => {
+  it("does not skip redirect when classic list chrome is still present (#3579 no-skip)", () => {
     assert.equal(
       skipReasonForChrome({
         shellPresent: true,
         wantRedirect: true,
         redirectToSpa: false,
       }),
-      SKIP.REDIRECT,
+      null,
     );
+    assert.equal(SKIP.REDIRECT, undefined);
   });
 
   it("runs when requested chrome is present", () => {
@@ -129,6 +131,36 @@ describe("design-spa-surface helpers (#3307)", () => {
       }),
       null,
     );
+  });
+
+  it("matches Design SPA landing URLs after classic redirect", () => {
+    assert.equal(
+      isDesignSpaLandingUrl("http://127.0.0.1:2050/Rhythmyx/cm/app/?view=design"),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/spa.jsp?entry=design&section=templates",
+      ),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl("http://127.0.0.1:2050/Rhythmyx/cm/app/design"),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/?view=design#templates",
+      ),
+      true,
+    );
+    assert.equal(
+      isDesignSpaLandingUrl(
+        "http://127.0.0.1:2050/Rhythmyx/cm/app/admin.jsp?view=admin",
+      ),
+      false,
+    );
+    assert.equal(isDesignSpaLandingUrl(""), false);
   });
 
   it("filters known console noise", () => {

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -31,6 +31,9 @@ const {
   designLegacyAdminUrl,
   designLegacyViewUrl,
   skipReasonForChrome,
+  isTemplatesCollectionUrl,
+  isTemplateCreatePost,
+  createBodyHasWidgetXml,
   filterConsoleNoise,
 } = require("../helpers/design-spa-surface");
 
@@ -71,15 +74,16 @@ describe("design-spa-surface helpers (#3307)", () => {
     );
   });
 
-  it("skips create when sibling #3305 chrome is absent", () => {
+  it("does not skip create when chrome is absent (#3578 no-skip)", () => {
     assert.equal(
       skipReasonForChrome({
         shellPresent: true,
         wantCreate: true,
         createPresent: false,
       }),
-      SKIP.CREATE,
+      null,
     );
+    assert.equal(SKIP.CREATE, undefined);
   });
 
   it("skips editor when catalog is empty", () => {
@@ -129,6 +133,49 @@ describe("design-spa-surface helpers (#3307)", () => {
       }),
       null,
     );
+  });
+
+  it("matches POST /services/templates collection only", () => {
+    assert.equal(
+      isTemplatesCollectionUrl("http://127.0.0.1:2050/Rhythmyx/services/templates"),
+      true,
+    );
+    assert.equal(
+      isTemplatesCollectionUrl(
+        "http://127.0.0.1:2050/Rhythmyx/services/templates/Home",
+      ),
+      false,
+    );
+    assert.equal(
+      isTemplateCreatePost({
+        method: () => "POST",
+        url: () => "http://127.0.0.1:2050/Rhythmyx/services/templates",
+      }),
+      true,
+    );
+    assert.equal(
+      isTemplateCreatePost({
+        method: () => "GET",
+        url: () => "http://127.0.0.1:2050/Rhythmyx/services/templates",
+      }),
+      false,
+    );
+  });
+
+  it("rejects Widget XML on create payloads", () => {
+    assert.equal(
+      createBodyHasWidgetXml({
+        TemplateDetail: { name: "qa.create.tpl", assembler: "htmlAssembler" },
+      }),
+      false,
+    );
+    assert.equal(
+      createBodyHasWidgetXml(
+        JSON.stringify({ TemplateDetail: { widgetXml: "<Widget/>" } }),
+      ),
+      true,
+    );
+    assert.equal(createBodyHasWidgetXml(null), false);
   });
 
   it("filters known console noise", () => {

--- a/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js
@@ -41,7 +41,9 @@ describe("design-spa-surface helpers (#3307)", () => {
     assert.equal(TEST_IDS.tabTemplates, "tab-design-templates");
     assert.equal(TEST_IDS.panel, "design-tpl-panel");
     assert.equal(TEST_IDS.create, "design-tpl-create");
+    assert.equal(TEST_IDS.deleteDialog, "design-tpl-delete-dialog");
     assert.equal(TEST_IDS.editor, "design-tpl-editor");
+    assert.equal(TEST_IDS.editorDelete, "design-tpl-editor-delete");
     assert.equal(CLASSIC_ASSIGNED_TEMPLATES_ID, "perc-assigned-templates");
   });
 
@@ -68,6 +70,17 @@ describe("design-spa-surface helpers (#3307)", () => {
     assert.equal(
       skipReasonForChrome({ shellPresent: false }),
       SKIP.SHELL,
+    );
+  });
+
+  it("skips delete when sibling #3580 chrome is absent", () => {
+    assert.equal(
+      skipReasonForChrome({
+        shellPresent: true,
+        wantDelete: true,
+        deletePresent: false,
+      }),
+      SKIP.DELETE,
     );
   });
 

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -43,7 +43,7 @@ The **Templates** tab lists assembly templates from `GET /services/templates`.
 | State | What you see |
 |-------|----------------|
 | List | A table of templates. Open a row to edit. |
-| Empty | **No templates found.** Use **Create template** when that control is present. |
+| Empty | **No templates found.** Use **Create template**. |
 | Error | An operator-facing message. The rest of the Design shell stays usable. |
 
 ## Create a template (no Widget XML)
@@ -66,10 +66,6 @@ written.**
 
 If create fails (duplicate name, invalid name, or server error), the dialog stays open and
 shows an operator-facing message. Correct the fields and try again.
-
-If **Create template** is not on this deployment yet, new templates remain on residual
-classic hosts (`editTemplate.jsp` and related upgrade-only JSPs) until that flow is
-installed. The library and editor on this page still apply.
 
 ## Edit assembler, slots, source, and bindings
 

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -1,7 +1,7 @@
 ---
 id: admin-design-templates
 title: Design templates
-description: Create and edit modern assembly templates in the Design SPA; classic list bookmarks redirect here
+description: Create, edit, and delete modern assembly templates in the Design SPA; classic list bookmarks redirect here
 version: "8.2"
 order: 44
 tags: [admin, design, templates, ui]
@@ -10,8 +10,9 @@ tags: [admin, design, templates, ui]
 # Design templates
 
 **Design** is the SPA surface for the modern assembly **template library**. Designers and
-administrators list existing templates and **create new templates** using the public REST
-catalog (`/services/templates`). Create does **not** author Widget definition XML.
+administrators list existing templates, **create new templates**, and **delete** templates
+using the public REST catalog (`/services/templates`). Create and delete do **not** author
+Widget definition XML.
 
 In Percussion CMS 8.2 the primary template-list entry is the SPA shell. The classic
 `admin.jsp` Design page and `?view=design` bookmarks hard-redirect into the SPA.
@@ -71,6 +72,22 @@ If **Create template** is not on this deployment yet, new templates remain on re
 classic hosts (`editTemplate.jsp` and related upgrade-only JSPs) until that flow is
 installed. The library and editor on this page still apply.
 
+## Delete a template
+
+1. On the Templates library, choose **Delete** on the row you want to remove. You can
+   also open the template and choose **Delete** on the editor.
+2. Confirm in the dialog. Delete permanently removes the assembly template from the
+   catalog. **No Widget definition XML is written.**
+3. After a successful delete the library list refreshes. The deleted name is gone.
+
+Delete uses `DELETE /services/templates/{idOrName}` (`idOrName` is the unique name or
+numeric id). If delete fails (template in use, not found, or server error), the confirm
+dialog stays open with an operator-facing message. Choose **Cancel** to leave the
+template unchanged.
+
+Lock and content-type associations remain out of scope on this REST surface (see
+`designGaps` on the template detail payload).
+
 ## Edit assembler, slots, source, and bindings
 
 Open a template row from the library. The editor (same Design tab) lets you:
@@ -81,10 +98,8 @@ Open a template row from the library. The editor (same Design tab) lets you:
 - Add, edit, or remove **JEXL bindings** (saved as a full replace)
 
 Choose **Save**. Success and validation errors stay on the editor. Use **Templates** to
-return to the library.
-
-Content-type associations, delete, and lock are not available on this REST surface yet
-(see `designGaps` on the template detail payload).
+return to the library. **Delete** on the editor asks for confirmation, then returns you
+to the refreshed library.
 
 The visual layout editor may still open residual classic hosts (`editTemplate.jsp` and
 related upgrade-only JSPs) until those flows are signed off on the SPA. Bookmarks to the
@@ -92,7 +107,7 @@ related upgrade-only JSPs) until those flows are signed off on the SPA. Bookmark
 
 ## Related
 
-- [REST API](id:developer-rest) — `GET`/`POST`/`PUT /services/templates`
+- [REST API](id:developer-rest) — `GET`/`POST`/`PUT`/`DELETE /services/templates`
 - [Extensions & packages](id:developer-extensions)
 - [Navigation & site structure](id:admin-architecture-navigation)
 - [Administration](id:admin)

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -23,11 +23,10 @@ In Percussion CMS 8.2 the primary template-list entry is the SPA shell. The clas
    library). Design is not a top-nav item. You can also open:
    - Query contract: `spa.jsp?entry=design&section=templates`
    - Path route: `/cm/app/design` or `/cm/app/design/templates`
-   - Legacy bookmarks: `/cm/app/?view=design` and `/cm/app/admin.jsp` redirect here
-     when the Design list cutover is installed. `admin.jsp` then always forces
-     `view=design` (a bookmark such as `admin.jsp?view=admin` still opens Design, not
-     Admin). Until that cutover is on the server, `admin.jsp` may still show the
-     classic CM1 Design list.
+   - Legacy bookmarks: `/cm/app/?view=design` and `/cm/app/admin.jsp` always
+     redirect here. `admin.jsp` forces `view=design` (a bookmark such as
+     `admin.jsp?view=admin` still opens Design, not Admin). The classic CM1
+     Design list is not a product entry for these bookmarks.
 3. The **Templates** tab lists assembly templates (label, name, id, description).
    The shell loads under the same product top nav as Explorer, Navigation, Developer, Publish, and Admin.
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -152,9 +152,12 @@ Assembly templates used by the [Design SPA](id:admin-design-templates) are expos
 | `GET` | `/services/templates/{idOrName}` | Design detail (source, bindings, slots, assembler, `designGaps`) |
 | `PUT` | `/services/templates/{idOrName}` | Update label, description, templateSource, assembler, bindings, and/or slots |
 | `POST` | `/services/templates` | Create a modern assembly template (**when installed**) — no Widget XML |
+| `DELETE` | `/services/templates/{idOrName}` | Delete a modern assembly template — no Widget XML |
 | `POST` | `/services/templates/summaries-by-filter` | List summaries matching a `TemplateFilter` |
 
-`PUT` omits unchanged fields. Name/id and delete remain unsupported (`designGaps`).
+`PUT` omits unchanged fields. Name/id remain unsupported. Delete returns **204** when
+the template is removed and **404** when it is not found. Lock remains unsupported
+(`designGaps` code `TPL_LOCK`).
 Create (`POST /services/templates`) is the Design **Create template** contract when that
 slice is on the server; otherwise create stays on residual classic hosts.
 
@@ -225,6 +228,7 @@ Create uses the modern package/manifest model — **no Widget definition XML**.
 | `GET` | `/services/templates/{idOrName}` | Load design detail (source, bindings, slots, assembler) |
 | `PUT` | `/services/templates/{idOrName}` | Update label, description, source, assembler, bindings, slots |
 | `POST` | `/services/templates` | Create a modern assembly template (`name` required, unique, no spaces) |
+| `DELETE` | `/services/templates/{idOrName}` | Delete a modern assembly template (204; no Widget XML) |
 
 Create body is a Jackson-wrapped `TemplateDetail`:
 
@@ -241,10 +245,13 @@ Create body is a Jackson-wrapped `TemplateDetail`:
 
 When `assembler` is omitted, the server defaults to HTML-first
 (`Java/global/percussion/assembly/htmlAssembler`). `400` is returned for a missing or
-invalid name or a duplicate name. Delete and lock remain out of scope (`designGaps` code
-`TPL_DELETE_LOCK`).
+invalid name or a duplicate name.
 
-The Design SPA **Create template** action uses this POST. See
+`DELETE /services/templates/{idOrName}` removes the template from the assembly catalog
+and returns **204**. It does **not** write Widget definition XML. `404` means the name
+or id was not found. Lock remains out of scope (`designGaps` code `TPL_LOCK`).
+
+The Design SPA **Create template** action uses POST; **Delete** uses this DELETE. See
 [Design templates](id:admin-design-templates).
 
 ## Display formats (design catalog)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -252,12 +252,21 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
     }
     try {
       IPSAssemblyTemplate t = resolveTemplate(idOrName.trim());
-      if (t == null || t.getGUID() == null) {
+      if (t == null) {
         return false;
+      }
+      if (t.getGUID() == null) {
+        log.error(
+            "Template '{}' loaded without a GUID; refusing delete (corrupt identifier).",
+            idOrName);
+        throw new IllegalStateException(
+            "Template '" + idOrName + "' has no GUID (corrupt identifier); cannot delete");
       }
       asmSvc.deleteTemplate(t.getGUID());
       return true;
     } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (IllegalStateException e) {
       throw e;
     } catch (PSAssemblyException e) {
       if (e.getErrorCode() == IPSAssemblyErrors.TEMPLATE_MISSING) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -68,7 +68,7 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
   /** API capability notes shared by every detail payload (not per-template data). */
   static final List<DesignGap> TEMPLATE_DESIGN_GAPS =
       List.of(
-          DesignGap.of("TPL_DELETE_LOCK", "Delete / lock not supported via this API"),
+          DesignGap.of("TPL_LOCK", "Lock not supported via this API"),
           DesignGap.of(
               "TPL_CONTENT_TYPE_ASSOC", "Content-type associations not listed on this payload"));
 
@@ -242,6 +242,37 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
           e.getMessage(),
           e);
       throw new IllegalStateException("Failed to create template", e);
+    }
+  }
+
+  @Override
+  public boolean deleteTemplate(URI baseUri, String idOrName) {
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    try {
+      IPSAssemblyTemplate t = resolveTemplate(idOrName.trim());
+      if (t == null || t.getGUID() == null) {
+        return false;
+      }
+      asmSvc.deleteTemplate(t.getGUID());
+      return true;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSAssemblyException e) {
+      if (e.getErrorCode() == IPSAssemblyErrors.TEMPLATE_MISSING) {
+        return false;
+      }
+      log.error("Failed to delete template {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete template", e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to delete template {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new IllegalStateException("Failed to delete template", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -61,8 +61,8 @@ class DesignGapsStructuredTest {
   void templateDesignGaps_areStructured() {
     assertEquals(2, TemplateAdaptor.TEMPLATE_DESIGN_GAPS.size());
     DesignGap first = TemplateAdaptor.TEMPLATE_DESIGN_GAPS.get(0);
-    assertEquals("TPL_DELETE_LOCK", first.getCode());
-    assertTrue(first.getMessage().contains("Delete"));
+    assertEquals("TPL_LOCK", first.getCode());
+    assertTrue(first.getMessage().contains("Lock"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorDeleteTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.assembly.IPSAssemblyErrors;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.PSAssemblyException;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class TemplateAdaptorDeleteTest {
+
+  private static PSAssemblyTemplate mockTemplate(String name) {
+    PSAssemblyTemplate template = mock(PSAssemblyTemplate.class);
+    PSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, 99L);
+    when(template.getGUID()).thenReturn(guid);
+    when(template.getName()).thenReturn(name);
+    when(template.getLabel()).thenReturn(name);
+    when(template.getAssembler()).thenReturn(TemplateAdaptor.DEFAULT_CREATE_ASSEMBLER);
+    when(template.getBindings()).thenReturn(new ArrayList<>());
+    when(template.getSlots()).thenReturn(new HashSet<>());
+    when(template.getTemplate()).thenReturn("");
+    return template;
+  }
+
+  @Test
+  void deleteTemplate_deletesByName() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate existing = mockTemplate("site.html.snippet");
+    when(asm.findTemplateByName("site.html.snippet")).thenReturn(existing);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertTrue(adaptor.deleteTemplate(null, "site.html.snippet"));
+    verify(asm).deleteTemplate(existing.getGUID());
+  }
+
+  @Test
+  void deleteTemplate_returnsFalseWhenMissing() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    when(asm.findTemplateByName("missing"))
+        .thenThrow(new PSAssemblyException(IPSAssemblyErrors.TEMPLATE_MISSING, "missing"));
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertFalse(adaptor.deleteTemplate(null, "missing"));
+    verify(asm, never()).deleteTemplate(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void deleteTemplate_rejectsBlankId() {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteTemplate(null, "  "));
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteTemplate(null, null));
+  }
+
+  @Test
+  void deleteTemplate_wrapsAssemblyFailure() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate existing = mockTemplate("site.html.snippet");
+    when(asm.findTemplateByName("site.html.snippet")).thenReturn(existing);
+    org.mockito.Mockito.doThrow(
+            new PSAssemblyException(IPSAssemblyErrors.UNKNOWN_CRUD_ERROR, "constraint"))
+        .when(asm)
+        .deleteTemplate(org.mockito.ArgumentMatchers.any());
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class, () -> adaptor.deleteTemplate(null, "site.html.snippet"));
+    assertTrue(ex.getMessage().contains("Failed to delete template"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorDeleteTest.java
@@ -78,6 +78,40 @@ class TemplateAdaptorDeleteTest {
   }
 
   @Test
+  void deleteTemplate_nullGuidIsCorruptionNotNotFound() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate corrupt = mock(PSAssemblyTemplate.class);
+    when(corrupt.getGUID()).thenReturn(null);
+    when(corrupt.getName()).thenReturn("corrupt.html");
+    when(asm.findTemplateByName("corrupt.html")).thenReturn(corrupt);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class, () -> adaptor.deleteTemplate(null, "corrupt.html"));
+    assertTrue(ex.getMessage().contains("no GUID"));
+    verify(asm, never()).deleteTemplate(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void deleteTemplate_returnsFalseWhenConcurrentDelete() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate existing = mockTemplate("site.html.snippet");
+    var guid = existing.getGUID();
+    when(asm.findTemplateByName("site.html.snippet")).thenReturn(existing);
+    org.mockito.Mockito.doThrow(
+            new PSAssemblyException(IPSAssemblyErrors.TEMPLATE_MISSING, "site.html.snippet"))
+        .when(asm)
+        .deleteTemplate(guid);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertFalse(adaptor.deleteTemplate(null, "site.html.snippet"));
+    verify(asm).deleteTemplate(guid);
+  }
+
+  @Test
   void deleteTemplate_rejectsBlankId() {
     IPSAssemblyService asm = mock(IPSAssemblyService.class);
     IPSContentWs contentWs = mock(IPSContentWs.class);

--- a/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
@@ -58,8 +58,7 @@ public interface ITemplatesAdaptor {
    * Update mutable template design fields (label, description, source, assembler) and optionally
    * bindings / contained slots. When {@code body.assembler} is non-null, sets the assembler
    * extension name (must be non-blank). When {@code body.bindings} or {@code body.slots} is
-   * non-null, that collection is fully replaced (empty list clears). Name/id and delete remain
-   * out of scope.
+   * non-null, that collection is fully replaced (empty list clears). Name/id remain out of scope.
    *
    * @return updated detail, or {@code null} if not found
    */
@@ -75,4 +74,14 @@ public interface ITemplatesAdaptor {
    * @throws IllegalArgumentException when the name is invalid or already exists
    */
   TemplateDetail createTemplate(URI baseUri, TemplateDetail body);
+
+  /**
+   * Delete an assembly template by numeric id or unique name (no Widget XML).
+   *
+   * @param baseUri the base URI (reserved for HATEOAS)
+   * @param idOrName template uuid or name
+   * @return {@code true} if deleted, {@code false} if not found
+   * @throws IllegalArgumentException when {@code idOrName} is blank
+   */
+  boolean deleteTemplate(URI baseUri, String idOrName);
 }

--- a/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
@@ -32,6 +32,7 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
@@ -183,7 +184,8 @@ public class TemplatesResource {
       summary = "Get template design detail",
       description =
           "Template detail including bindings and slots. Source is included when present."
-              + " Create is POST /templates. Delete/lock remain unsupported (see designGaps).",
+              + " Create is POST /templates. Delete is DELETE /templates/{idOrName}."
+              + " Lock remains unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -217,7 +219,8 @@ public class TemplatesResource {
           "Updates mutable template fields: label, description, templateSource, and/or"
               + " assembler. When assembler is present it must be non-blank. When bindings or"
               + " slots is present (including empty), replaces that collection. Omit fields to"
-              + " leave unchanged. Name/id and delete remain unsupported (see designGaps).",
+              + " leave unchanged. Name/id remain unsupported. Delete is DELETE"
+              + " /templates/{idOrName}. Lock remains unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -275,6 +278,41 @@ public class TemplatesResource {
         throw new WebApplicationException("Failed to create template", 500);
       }
       return detail;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Deletes an assembly template (no Widget definition XML).
+   *
+   * @param idOrName template uuid or unique name
+   * @return 204 when deleted
+   */
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete assembly template",
+      description =
+          "Deletes a template from the modern assembly catalog (package/manifest). Does not"
+              + " write Widget definition XML.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "404", description = "Template not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteTemplate(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = adaptor.deleteTemplate(uriInfo.getBaseUri(), idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Template not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
     } catch (WebApplicationException e) {
       throw e;
     } catch (IllegalArgumentException e) {

--- a/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
@@ -23,10 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.rest.DesignGap;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -192,6 +194,39 @@ public class TemplatesResourceDetailTest {
     WebApplicationException ex =
         assertThrows(
             WebApplicationException.class, () -> resource.createTemplate(new TemplateDetail()));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteTemplateSuccess() {
+    when(adaptor.deleteTemplate(any(), eq("site.html.snippet"))).thenReturn(true);
+    Response out = resource.deleteTemplate("site.html.snippet");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteTemplate(any(), eq("site.html.snippet"));
+  }
+
+  @Test
+  public void deleteTemplateNotFound() {
+    when(adaptor.deleteTemplate(any(), eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteTemplate("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteTemplateBadRequest() {
+    when(adaptor.deleteTemplate(any(), eq("  ")))
+        .thenThrow(new IllegalArgumentException("idOrName is required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteTemplate("  "));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteTemplateWrapsFailures() {
+    when(adaptor.deleteTemplate(any(), eq("boom"))).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteTemplate("boom"));
     assertEquals(500, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
@@ -55,4 +55,9 @@ public class TestTemplatesAdaptor implements ITemplatesAdaptor {
   public TemplateDetail createTemplate(URI baseUri, TemplateDetail body) {
     return null;
   }
+
+  @Override
+  public boolean deleteTemplate(URI baseUri, String idOrName) {
+    return false;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
@@ -25,10 +25,12 @@ import com.percussion.rest.templates.TemplateFilter;
 import com.percussion.rest.templates.TemplateSummary;
 import java.net.URI;
 import java.util.List;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /** Test adaptor for Templates API bridge. */
 @Component
+@Lazy
 public class TestTemplatesAdaptor implements ITemplatesAdaptor {
 
   @Override


### PR DESCRIPTION
## Summary

Overnight owned PRs #3595, #3596, and #3597 all edit the same Design SPA surface helper, unit tests, consolidation spec, README, and `product-docs/8.2/admin/design-templates.md`. Merging them independently would keep thrashing those files. This cluster unions the three heads against `main`.

**Thrash files**

- `modules/perc-qa-automation/frontend/tests/helpers/design-spa-surface.js`
- `modules/perc-qa-automation/frontend/tests/unit/design-spa-surface.test.js`
- `modules/perc-qa-automation/frontend/tests/design-spa-consolidation.spec.js`
- `modules/perc-qa-automation/README.md`
- `product-docs/8.2/admin/design-templates.md`

Union: H2 **create** (#3578) and **classic list redirect** (#3579) stay hard no-skip; **delete** (#3580) keeps `SKIP.DELETE` when delete chrome is missing. Create skip is not restored. Product docs keep required Create template plus the Delete section.

Fixes #3578
Fixes #3579
Fixes #3580
Parent #2631

Operator: Grok: night-issue-prs (model grok-4.6)

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3595](https://github.com/intersoftdatalabs-in/percussioncms/pull/3595) | `fix/issue-3578-design-create-pw-h2` | yes | Create-template Playwright no-skip on H2 |
| yes | [#3596](https://github.com/intersoftdatalabs-in/percussioncms/pull/3596) | `fix/issue-3579-design-redirect-h2-no-skip` | yes | Classic Design list redirect Playwright no-skip on H2 |
| yes | [#3597](https://github.com/intersoftdatalabs-in/percussioncms/pull/3597) | `feat/issue-3580-design-spa-delete-template` | yes | Design SPA delete + REST `DELETE /services/templates/{idOrName}` |

Do not merge the superseded PRs.

## modules_built

`WebUI, rest, projects/sitemanage, modules/perc-qa-automation`

## build_evidence

B1 standalone `mvnw.cmd clean install` on cluster tip `50c19aa8d7` (2026-08-18T21:51–21:55-04:00):

- `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 539, Failures: 0, Errors: 0, Skipped: 0
- `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 1253, Failures: 0, Errors: 0, Skipped: 125
- `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** Surefire Tests run: 61, Failures: 0; Vitest Test Files 380 passed / Tests 2874 passed
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Surefire: No tests to run). Extra: `frontend` `npm run test:unit` → 322 passed, 0 failed (includes unioned `design-spa-surface` helpers)

B3 reverse-deps: `ITemplatesAdaptor.deleteTemplate` is a **new** public method (no existing API made `final`/`sealed`). Grep `implements ITemplatesAdaptor`: `TemplateAdaptor` (sitemanage) and `TestTemplatesAdaptor` (rest test stub). Both modules installed above.

## Test plan

1. Review the union of Design SPA helper exports (`isTemplateCreatePost`, `isDesignSpaLandingUrl`, `SKIP.DELETE`) and product-docs Create + Delete sections.
2. After `perc-devctl qa-up` H2: `npm run test:surface -- --path tests/design-template-create.spec.js`, `design-legacy-redirect.spec.js`, `design-template-delete.spec.js`.
3. Do not merge this PR from overnight; human review.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/design-templates.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — unioned helper unit tests; changed Maven modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — create / redirect / delete specs absorbed (Playwright live cell not re-run on the cluster tip; original PRs had C5 H2 evidence)
- [x] **Build gates** — each changed Maven module standalone clean install; reverse-deps grepped and installed
- [x] **Cross-platform** — no new path/file I/O

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
