### PR TITLE
fix(filestorage): FastForward import persist + ISO-Z dates for cycle-verify (#3606)

### DIFF
--- a/docs/ai-generated/code-reviews/3592-h2-demo-fastforward-import-erlang.md
+++ b/docs/ai-generated/code-reviews/3592-h2-demo-fastforward-import-erlang.md
@@ -1,0 +1,61 @@
+# Erlang review — #3592 H2 demo-sites FastForward import + ISO date index
+
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3592-h2-demo-fastforward-import` (parent #3102 residual after #3575 / PR #3591).
+
+**Recommendation:** approve
+
+**Gate:** May commit/push: yes
+
+**Memory patterns hit:** behavioral unit tests for changed logic; incomplete change-class (companions: persist + date parse + tests); Hibernate persist/merge / `@Version` / cascade; empty-catch with justified ignore.
+
+## Summary
+
+Two stock H2 `--demo-sites` `server.log` ERROR families that fail `qa-health` `server_log_errors`:
+
+1. FastForward file-store import: `PSBinary.data` is inverse `@OneToOne(mappedBy="binary")` with no persist cascade; `PSBinaryData` uses a foreign-id generator. `PSHashedFileDAO.save` `merge()` of the transient graph throws `TransientPropertyValueException`.
+2. Search-index dates: `PSDateUtils.getDateFromString` used `SimpleDateFormat` `yyyy-MM-dd'T'HH:mm:ss.SSSZ` which does not parse demo ISO `2008-11-02T00:00:00.000Z`.
+
+Fixes stay in `system` + `projects/sitemanage`. No public method signature change. Product-docs N/A (internal persist + parse). No WebUI.
+
+## Cross-platform path checklist
+
+No filesystem path join, install path, or OS-specific I/O in this diff. N/A / clean.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- `getDateFromString` swallows `DateTimeException` then falls through to `OffsetDateTime` / `SimpleDateFormat` so invalid input still throws `ParseException` (existing contract + test).
+- `save` uses `id == 0` as new-entity (next-number generator; `PSBinary.version` has no accessor). Acceptable.
+- Persist/import tests cover cascade mapping, bidirectional link, persist-vs-merge order, and `create()` graph. Not a live Hibernate Session; H2 `qa-up`/`qa-health` is the runtime proof.
+
+## Tests
+
+- `PSBinaryPersistImportTest` (system): 5 tests, 0 fail
+- `PSDateUtilsTest` (sitemanage): 2 tests including `2008-11-02T00:00:00.000Z`
+- `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2168, Failures: 0, Errors: 0, Skipped: 238)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 1250, Failures: 0, Errors: 0, Skipped: 125)
+
+## Re-review (PR #3602 Kilo threads)
+
+**Recommendation:** approve
+
+**Gate:** May commit/push: yes
+
+Addressed four unresolved Kilo review threads:
+
+1. `save(null)` now throws `IllegalArgumentException` (restores pre-mask contract). `PSDbStorageService.getBinary` saves only when a row exists.
+2. Inverse `@OneToOne` cascade narrowed to `PERSIST`+`MERGE` (no `ALL`/`REMOVE`).
+3. Redundant `binary.setData` after constructor removed.
+4. Dead `endsWith("z")` Instant branch removed; lowercase `z` still parses via `OffsetDateTime.parse`.
+
+No public method signature change. No path I/O. Cross-platform checklist N/A / clean.
+
+### Tests (this pass)
+
+- `PSBinaryPersistImportTest` (system): 7 tests, 0 fail (added `saveNullThrows`, `getBinaryMissingHashDoesNotSave`)
+- `PSDateUtilsTest` (sitemanage): lowercase `z` still parses to the same Instant as uppercase `Z`
+- `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2222, Failures: 0, Errors: 0, Skipped: 241)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 1322, Failures: 0, Errors: 0, Skipped: 125)

--- a/docs/ai-generated/code-reviews/3606-cycle-verify-fastforward-import-erlang.md
+++ b/docs/ai-generated/code-reviews/3606-cycle-verify-fastforward-import-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — #3606 Cycle Verify residual: FastForward import + ISO-Z dates
+
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3606-fastforward-import` (ports PR #3602 / #3592 onto current `main` for cycle-verify residual #3606). Prior report: `docs/ai-generated/code-reviews/3592-h2-demo-fastforward-import-erlang.md`.
+
+**Recommendation:** approve
+
+**Gate:** May commit/push: yes
+
+**Memory patterns hit:** behavioral unit tests for changed logic; incomplete change-class (companions: persist + date parse + tests); Hibernate persist/merge / cascade; empty-catch with justified ignore.
+
+## Summary
+
+Stock CMS+H2 `--demo-sites` `qa-up` failed cycle-verify because FastForward import logged ERROR (`TransientPropertyValueException` on `PSBinary` → `PSBinaryData`) and timed out. Search-index ISO `…Z` dates also ERROR. This residual lands the same product fix as PR #3602 on a branch from current `main` so a fresh `qa-up` / `qa-health` is RESULT:OK without allowlisting `PSDbStorageService` / generic `server_log_errors`.
+
+1. `PSBinary.data` inverse `@OneToOne` now cascades `PERSIST`+`MERGE` (not `ALL`/`REMOVE`).
+2. `PSHashedFileDAO.save` persist-orders parent then blob; `save(null)` throws; `getBinary` skips save when the row is missing.
+3. `PSDateUtils.getDateFromString` accepts Instant / trailing `Z` / `OffsetDateTime`.
+
+No public/protected method or ctor signature change. Product-docs N/A (internal persist + parse). No WebUI product-screen change (Playwright golden/login is issue-acceptance proof after `qa-health`, not a screen companion).
+
+Does not close #3592.
+
+## Cross-platform path checklist
+
+No filesystem path join, install path, or OS-specific I/O in this diff. N/A / clean.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- `getDateFromString` swallows `DateTimeException` then falls through to `OffsetDateTime` / `SimpleDateFormat` so invalid input still throws `ParseException` (existing contract + test).
+- `save` uses `id == 0` as new-entity (next-number generator; `PSBinary.version` has no accessor). Acceptable.
+- Persist/import tests cover cascade mapping, bidirectional link, persist-vs-merge order, `create()` graph, `save(null)`, and missing-hash skip. Not a live Hibernate Session; H2 `qa-up`/`qa-health` is the runtime proof.
+
+## Tests
+
+- `PSBinaryPersistImportTest` (system): 7 tests, 0 fail
+- `PSDateUtilsTest` (sitemanage): ISO-Z including lowercase `z`
+- `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2170, Failures: 0, Errors: 0, Skipped: 238)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 1250, Failures: 0, Errors: 0, Skipped: 125)

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSDateUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSDateUtils.java
@@ -20,6 +20,9 @@ package com.percussion.share.dao;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -69,14 +72,30 @@ public class PSDateUtils {
    */
   public static Date getDateFromString(String date) throws ParseException {
     if (!StringUtils.isBlank(date)) {
-      DateFormat fmt = new SimpleDateFormat(ISO_8601_STRING);
       // JSON objects may return long milliseconds as time
       try {
         return new Date(Long.parseLong(date));
       } catch (NumberFormatException ignored) {
         // Not a long, continue parsing as date string
       }
-      var format = new StringBuilder(date);
+      String trimmed = date.trim();
+      // Demo-site / search-index values are ISO-8601 with a trailing Z
+      // (e.g. 2008-11-02T00:00:00.000Z). SimpleDateFormat pattern
+      // ISO_8601_STRING uses RFC-822 Z and does not accept literal Z.
+      if (trimmed.endsWith("Z")) {
+        try {
+          return Date.from(Instant.parse(trimmed));
+        } catch (DateTimeException ignored) {
+          // Fall through to OffsetDateTime / SimpleDateFormat
+        }
+      }
+      try {
+        return Date.from(OffsetDateTime.parse(trimmed).toInstant());
+      } catch (DateTimeException ignored) {
+        // Fall through to legacy SimpleDateFormat (RFC-822 offset, no colon)
+      }
+      DateFormat fmt = new SimpleDateFormat(ISO_8601_STRING);
+      var format = new StringBuilder(trimmed);
       if (format.length() > 2 && ":".equals(String.valueOf(format.charAt(format.length() - 3)))) {
         format.deleteCharAt(format.length() - 3);
       }

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/PSDateUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/PSDateUtilsTest.java
@@ -20,6 +20,7 @@ package com.percussion.share.dao;
 import static com.percussion.test.TestAssertions.*;
 
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 
@@ -44,5 +45,26 @@ public class PSDateUtilsTest {
     assertNull(PSDateUtils.getDateFromString(""));
 
     assertThrows(ParseException.class, () -> PSDateUtils.getDateFromString("This is not a date!"));
+  }
+
+  /**
+   * FastForward / demo-site last-modified values are ISO-8601 with a trailing
+   * {@code Z}. Search indexing must parse them instead of ERROR-logging
+   * {@code Unparseable date}.
+   */
+  @Test
+  void testGetDateFromStringIso8601TrailingZ() throws Exception {
+    Date withMillis = PSDateUtils.getDateFromString("2008-11-02T00:00:00.000Z");
+    assertEquals(Instant.parse("2008-11-02T00:00:00.000Z"), withMillis.toInstant());
+
+    Date noMillis = PSDateUtils.getDateFromString("2008-11-02T00:00:00Z");
+    assertEquals(Instant.parse("2008-11-02T00:00:00Z"), noMillis.toInstant());
+
+    Date offsetColon = PSDateUtils.getDateFromString("2008-11-02T00:00:00.000+00:00");
+    assertEquals(Instant.parse("2008-11-02T00:00:00.000Z"), offsetColon.toInstant());
+
+    // Instant.parse is uppercase-Z only; lowercase z is handled by OffsetDateTime.parse.
+    Date lowerZ = PSDateUtils.getDateFromString("2008-11-02T00:00:00.000z");
+    assertEquals(Instant.parse("2008-11-02T00:00:00.000Z"), lowerZ.toInstant());
   }
 }

--- a/system/services/src/com/percussion/services/filestorage/IPSHashedFileDAO.java
+++ b/system/services/src/com/percussion/services/filestorage/IPSHashedFileDAO.java
@@ -42,8 +42,12 @@ public interface IPSHashedFileDAO
    public PSBinary getBinary(String hash);
 
    /**
-    * Save a binary
-    * @param binary
+    * Save a binary. {@code binary} must not be {@code null}; callers that
+    * look up by hash must skip save when the row is missing rather than
+    * relying on a no-op.
+    *
+    * @param binary the entity to persist or merge, never {@code null}
+    * @throws IllegalArgumentException if {@code binary} is {@code null}
     */
    public void save(PSBinary binary);
 

--- a/system/services/src/com/percussion/services/filestorage/data/PSBinary.java
+++ b/system/services/src/com/percussion/services/filestorage/data/PSBinary.java
@@ -92,9 +92,16 @@ public class PSBinary implements Serializable
    private String hash;
 
    /**
-    * Reference to the table containing the binary content
+    * Reference to the table containing the binary content. Cascade persist/merge
+    * (not ALL) is required: {@link PSBinaryData} uses a foreign-id generator and
+    * this inverse {@code mappedBy} side has no owning FK. Without persist
+    * cascade, Hibernate 6 throws TransientPropertyValueException when FastForward
+    * import persists a new {@code PSBinary} that still references unsaved
+    * {@code PSBinaryData}. REMOVE is omitted so delete stays on the owning side
+    * / explicit DAO {@code remove}; orphanRemoval still drops detached data.
     */
-   @OneToOne(mappedBy = "binary", fetch = FetchType.LAZY, optional=false, orphanRemoval = true)
+   @OneToOne(mappedBy = "binary", fetch = FetchType.LAZY, optional=false, orphanRemoval = true,
+         cascade = {CascadeType.PERSIST, CascadeType.MERGE})
    @PrimaryKeyJoinColumn
    PSBinaryData data;
 

--- a/system/services/src/com/percussion/services/filestorage/impl/PSDbStorageService.java
+++ b/system/services/src/com/percussion/services/filestorage/impl/PSDbStorageService.java
@@ -1368,6 +1368,8 @@ public class PSDbStorageService implements IPSFileStorageService, InitializingBe
       notNull(hash);
       PSBinaryData binaryData = new PSBinaryData(hashDao.createBlob(is,meta.getLength()));
       Set<PSBinaryMetaEntry> dbMeta = convertMetaToDbMeta(meta);
+      // Constructor setData already wires binaryData.binary (shared PK) before
+      // DAO persist; persist order is parent-then-child in PSHashedFileDAO.save.
       PSBinary binary = new PSBinary(meta.getHash(), binaryData, dbMeta);
       binary.setMetaEntries(dbMeta);
       binary.setExtractError(meta.hasParseError());
@@ -1426,8 +1428,8 @@ public class PSDbStorageService implements IPSFileStorageService, InitializingBe
          {
             binary.setLastAccessedDate(today);
          }
+         hashDao.save(binary);
       }
-      hashDao.save(binary);
 
       return binary;
 

--- a/system/services/src/com/percussion/services/filestorage/impl/PSHashedFileDAO.java
+++ b/system/services/src/com/percussion/services/filestorage/impl/PSHashedFileDAO.java
@@ -19,6 +19,7 @@ package com.percussion.services.filestorage.impl;
 import com.percussion.cms.IPSConstants;
 import com.percussion.services.filestorage.IPSHashedFileDAO;
 import com.percussion.services.filestorage.data.PSBinary;
+import com.percussion.services.filestorage.data.PSBinaryData;
 import com.percussion.services.filestorage.data.PSBinaryMetaEntry;
 import com.percussion.services.filestorage.data.PSBinaryMetaKey;
 import com.percussion.services.filestorage.data.PSHashedColumn;
@@ -97,8 +98,37 @@ public class PSHashedFileDAO implements IPSHashedFileDAO
 
    public void save(PSBinary binary)
    {
-      getSession().merge(binary);
-      getSession().merge(binary.getData());
+      if (binary == null)
+      {
+         throw new IllegalArgumentException("binary may not be null");
+      }
+      Session session = getSession();
+      PSBinaryData data = binary.getData();
+      if (data != null)
+      {
+         // Foreign-id generator on PSBinaryData copies PSBinary.id; both sides
+         // must be linked before persist so Hibernate can assign the shared PK.
+         data.setBinary(binary);
+      }
+      if (binary.getId() == 0)
+      {
+         // New FastForward import: persist parent first (next-number id), then
+         // the blob row. merge() on a transient graph without this order throws
+         // TransientPropertyValueException for unsaved PSBinaryData.
+         session.persist(binary);
+         if (data != null && !session.contains(data))
+         {
+            session.persist(data);
+         }
+      }
+      else
+      {
+         session.merge(binary);
+         if (data != null)
+         {
+            session.merge(data);
+         }
+      }
    }
 
    /* (non-Javadoc)

--- a/system/src/test/java/com/percussion/services/filestorage/impl/PSBinaryPersistImportTest.java
+++ b/system/src/test/java/com/percussion/services/filestorage/impl/PSBinaryPersistImportTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.filestorage.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.filestorage.IPSHashedFileDAO;
+import com.percussion.services.filestorage.data.PSBinary;
+import com.percussion.services.filestorage.data.PSBinaryData;
+import com.percussion.services.filestorage.data.PSBinaryMetaKey;
+import com.percussion.services.filestorage.data.PSMeta;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.OneToOne;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import java.sql.Blob;
+import java.util.Arrays;
+import java.util.EnumSet;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * FastForward file-store import persists a new {@link PSBinary} that references
+ * unsaved {@link PSBinaryData} (shared PK / foreign-id generator). Hibernate 6
+ * throws TransientPropertyValueException unless both sides are linked and
+ * persist is cascaded / ordered parent-then-child.
+ */
+@Tag("UnitTest")
+class PSBinaryPersistImportTest {
+
+  private PSHashedFileDAO dao;
+  private Session session;
+  private EntityManager entityManager;
+
+  @BeforeEach
+  void setUp() {
+    dao = new PSHashedFileDAO();
+    session = mock(Session.class);
+    entityManager = mock(EntityManager.class);
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    ReflectionTestUtils.setField(dao, "entityManager", entityManager);
+  }
+
+  @Test
+  @DisplayName("PSBinary.data OneToOne cascades persist so import does not leave PSBinaryData transient")
+  void binaryDataMappingCascadesPersist() throws Exception {
+    Field dataField = PSBinary.class.getDeclaredField("data");
+    OneToOne oneToOne = dataField.getAnnotation(OneToOne.class);
+    assertNotNull(oneToOne, "PSBinary.data must be a OneToOne");
+    assertEquals("binary", oneToOne.mappedBy());
+    EnumSet<CascadeType> cascades = EnumSet.noneOf(CascadeType.class);
+    cascades.addAll(Arrays.asList(oneToOne.cascade()));
+    assertTrue(
+        cascades.contains(CascadeType.PERSIST),
+        "PSBinary.data must cascade persist so FastForward import can save PSBinaryData");
+    assertTrue(
+        cascades.contains(CascadeType.MERGE),
+        "PSBinary.data must cascade merge for existing hashed files");
+    assertTrue(
+        !cascades.contains(CascadeType.ALL) && !cascades.contains(CascadeType.REMOVE),
+        "Inverse OneToOne must not cascade REMOVE/ALL; delete stays on DAO/owning side");
+  }
+
+  @Test
+  @DisplayName("setData wires the bidirectional shared-PK link")
+  void setDataLinksBothSides() {
+    PSBinary binary = new PSBinary();
+    PSBinaryData data = new PSBinaryData(mock(Blob.class));
+    binary.setData(data);
+    assertSame(data, binary.getData());
+    assertSame(binary, data.getBinary());
+  }
+
+  @Test
+  @DisplayName("save persists new PSBinary then PSBinaryData (not merge)")
+  void savePersistsNewBinaryThenData() {
+    PSBinary binary = new PSBinary();
+    PSBinaryData data = new PSBinaryData(mock(Blob.class));
+    binary.setData(data);
+    when(session.contains(data)).thenReturn(false);
+
+    dao.save(binary);
+
+    InOrder order = inOrder(session);
+    order.verify(session).persist(binary);
+    order.verify(session).persist(data);
+    verify(session, never()).merge(any());
+    assertSame(binary, data.getBinary());
+  }
+
+  @Test
+  @DisplayName("save merges an existing PSBinary and its data")
+  void saveMergesExistingBinaryAndData() {
+    PSBinary binary = new PSBinary();
+    binary.setId(42);
+    PSBinaryData data = new PSBinaryData(mock(Blob.class));
+    binary.setData(data);
+
+    dao.save(binary);
+
+    verify(session).merge(binary);
+    verify(session).merge(data);
+    verify(session, never()).persist(any());
+  }
+
+  @Test
+  @DisplayName("create links blob data before DAO save")
+  void createLinksDataBeforeSave() throws Exception {
+    PSDbStorageService storage = new PSDbStorageService();
+    IPSHashedFileDAO hashDao = mock(IPSHashedFileDAO.class);
+    Blob blob = mock(Blob.class);
+    when(hashDao.createBlob(any(), anyLong())).thenReturn(blob);
+    when(hashDao.findOrCreateMetaKey(any(), anyBoolean()))
+        .thenAnswer(invocation -> new PSBinaryMetaKey(invocation.getArgument(0), true));
+    ReflectionTestUtils.setField(storage, "hashDao", hashDao);
+
+    PSMeta meta = new PSMeta();
+    meta.setHash("abc123def456");
+    meta.setLength(4);
+
+    PSBinary[] saved = new PSBinary[1];
+    doAnswer(
+            invocation -> {
+              saved[0] = invocation.getArgument(0);
+              return null;
+            })
+        .when(hashDao)
+        .save(any(PSBinary.class));
+
+    PSBinary created = storage.create(new ByteArrayInputStream(new byte[] {1, 2, 3, 4}), meta);
+
+    assertSame(saved[0], created);
+    assertNotNull(created.getData());
+    assertSame(created, created.getData().getBinary());
+    assertEquals("abc123def456", created.getHash());
+  }
+
+  @Test
+  @DisplayName("save(null) throws rather than silently returning")
+  void saveNullThrows() {
+    assertThrows(IllegalArgumentException.class, () -> dao.save(null));
+    verify(session, never()).persist(any());
+    verify(session, never()).merge(any());
+  }
+
+  @Test
+  @DisplayName("getBinary does not save when the hash is missing")
+  void getBinaryMissingHashDoesNotSave() {
+    PSDbStorageService storage = new PSDbStorageService();
+    IPSHashedFileDAO hashDao = mock(IPSHashedFileDAO.class);
+    when(hashDao.getBinary("missing-hash")).thenReturn(null);
+    ReflectionTestUtils.setField(storage, "hashDao", hashDao);
+
+    assertNull(storage.getBinary("missing-hash"));
+    verify(hashDao, never()).save(any());
+    verify(hashDao, never()).save(null);
+  }
+}


### PR DESCRIPTION
## Summary

Cycle-verify residual of last night: stock CMS+H2 `--demo-sites` `qa-up` failed because FastForward file-store import logged ERROR (`TransientPropertyValueException` on `PSBinary` → `PSBinaryData`) and timed out. Search-index ISO `2008-11-02T00:00:00.000Z` dates also ERROR. `qa-health` and Playwright never ran.

This PR ports the product persist-cascade + ISO-8601 trailing-Z parse from PR #3602 onto a branch from current `main` so a fresh `qa-up` / `qa-health` is RESULT:OK **without** allowlisting FastForward `PSDbStorageService` or generic `server_log_errors`.

- `PSBinary.data` inverse `@OneToOne` now cascades `PERSIST`+`MERGE` (not `ALL`/`REMOVE`).
- `PSHashedFileDAO.save` persist-orders parent then blob; `save(null)` throws; `getBinary` skips save when the row is missing.
- `PSDateUtils.getDateFromString` accepts Instant / trailing `Z` / `OffsetDateTime`.

Fixes #3606  
Related: #3592 (do **not** close from this residual). Sibling product PR: #3602.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install`
2. `cd projects/sitemanage && ../../mvnw.cmd clean install`
3. `python docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-up --timeout-seconds 1800`
4. `python docker/scripts/perc-devctl.py qa-health` → `RESULT:OK`
5. Confirm `server.log` has no `Could not import item` / `TransientPropertyValueException` / `Unparseable date: "2008-11-02T00:00:00.000Z"`
6. From `modules/perc-qa-automation/frontend`:
   - `npm run test:surface -- --path tests/golden-unattended-smoke.spec.js`
   - `npm run test:surface -- --path tests/login.spec.js`
7. `python docker/scripts/perc-devctl.py qa-down`
8. Do **not** add these lines to the generic `server_log_errors` allowlist

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal Hibernate persist order + date parse used by import/search-index; no operator/admin/REST/UI contract change
- [x] **Unit / module tests** — `PSBinaryPersistImportTest` (7) + `PSDateUtilsTest` ISO-Z; both modules standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — no WebUI product screen change; issue acceptance still required golden + login surface after `qa-health` (passed)
- [x] **Build gates** — standalone clean install on `system` and `projects/sitemanage`; no public/protected signature change
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `system`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (01:34 min). Tests run: 2170, Failures: 0, Errors: 0, Skipped: 238. `PSBinaryPersistImportTest` Tests run: 7, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (51.148 s). Tests run: 1250, Failures: 0, Errors: 0, Skipped: 125.
- **downstream_checked:** none (no type made `final`/`sealed`; no public/protected method or ctor signature change). `sitemanage` standalone install still green as perc-system consumer.

### C5 UI proof (issue-acceptance Playwright after cell start)

- `python docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-up --timeout-seconds 1800`
- `TEST_CMS_URL=http://127.0.0.1:9993` `TEST_DB_TYPE=h2` `QA_CONTAINER:perc-matrix-cms-h2`
- Matrix cell: pass (121.8s) HTTP 200 health=healthy
- `python docker/scripts/perc-devctl.py qa-health --timeout-seconds 180`
- `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy URL:http://127.0.0.1:9993/Rhythmyx/rest/mimetypes`
- `server.log` ERROR/FATAL/SEVERE count: 0; no FastForward import or ISO date parse ERROR lines
- These ERRORs were **not** added to the generic `server_log_errors` allowlist
- Playwright (`modules/perc-qa-automation/frontend`):
  - `npm run test:surface -- --path tests/golden-unattended-smoke.spec.js` → 2 passed
  - `npm run test:surface -- --path tests/login.spec.js` → 2 passed
- console-clean=yes (surface tests passed; no test-failing pageerror)
- server.log-clean=yes (0 ERROR after Playwright)
- `python docker/scripts/perc-devctl.py qa-down` → `RESULT:OK`

Human QA is deferred (`include_human_qa=false`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
