### PR TITLE
feat(architecture): folder ACL principal add/remove on Navigation (#3588)

### DIFF
--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -74,14 +74,32 @@ import {
   loadSiteCopyInfo,
   suggestCopySiteName,
 } from "../api/architecture/siteAdminApi";
-import type { PSSiteCopyRequest } from "../api/contentExplorer/types";
+import type {
+  PSFolderProperties,
+  PSSiteCopyRequest,
+} from "../api/contentExplorer/types";
 import { fetchSites } from "../api/home/homeApi";
+import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
+import { resolveCurrentUserIdentities } from "../contentExplorer/currentUserIdentities";
 import { SiteCopyWizard } from "../contentExplorer/wizards/SiteCopyWizard";
 import { SiteCreateWizard } from "../contentExplorer/wizards/SiteCreateWizard";
 import { catalogColors } from "../developer/catalogStyles";
 import { CreateSectionDialog } from "./CreateSectionDialog";
 import { CreateSectionFromFolderDialog } from "./CreateSectionFromFolderDialog";
 import { ExternalLinkDialog } from "./ExternalLinkDialog";
+import { FolderAclDialog } from "./FolderAclDialog";
+import {
+  canEditFolderAcl,
+  defaultResolveSectionFolderId,
+  folderPropertiesFromSection,
+  isFolderPropertiesId,
+  resolveSectionFolderId,
+  resolveSectionFolderPath,
+} from "./folderAcl";
+import {
+  folderProperties as loadPathFolderProperties,
+  saveFolderProperties as savePathFolderProperties,
+} from "../api/contentExplorer/pathApi";
 import { MoveSectionDialog } from "./MoveSectionDialog";
 import { NavTree } from "./NavTree";
 import { RenameSectionDialog } from "./RenameSectionDialog";
@@ -118,6 +136,20 @@ export interface ArchitectureShellProps {
    * Default true — Architecture is already Admin/Designer gated (#3219 / #3303).
    */
   allowNewSite?: boolean;
+  /**
+   * Override folder-id resolution for Folder ACL (tests). Default uses
+   * pathmanagement {@code findItemByPath}.
+   */
+  resolveFolderId?: (path: string) => Promise<string | undefined>;
+  /**
+   * Identities for Folder ACL lockout detection. When omitted, resolved
+   * from SPA bootstrap (user name + Admin/Designer flags).
+   */
+  currentUserIdentities?: ReadonlyArray<string>;
+  /** Test override for {@code FolderSecurityPanel} load. */
+  loadFolderProperties?: (folderId: string) => Promise<PSFolderProperties>;
+  /** Test override for {@code FolderSecurityPanel} save. */
+  saveFolderProperties?: (props: PSFolderProperties) => Promise<void>;
 }
 
 type SitesLoadState =
@@ -134,7 +166,7 @@ type TreeLoadState =
 /**
  * Architecture / Navigation SPA shell
  * (#3094 shell + #3095 tree + #3096 mutations + #3097 landing/links
- * + #3304 landing picker/replace).
+ * + #3304 landing picker/replace + #3588 folder ACL write).
  */
 export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   initialSite = null,
@@ -142,11 +174,31 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   confirmFn,
   useLandingContentBrowser = true,
   allowNewSite = true,
+  resolveFolderId = defaultResolveSectionFolderId,
+  currentUserIdentities: currentUserIdentitiesProp,
+  loadFolderProperties,
+  saveFolderProperties: saveFolderPropertiesProp,
 }) => {
   const confirmAction = useCallback(
     (msg: string) => (confirmFn ? confirmFn(msg) : window.confirm(msg)),
     [confirmFn],
   );
+  const bootstrap = useSpaBootstrap();
+  const currentUserIdentities = useMemo(() => {
+    if (currentUserIdentitiesProp) {
+      return [...currentUserIdentitiesProp];
+    }
+    return resolveCurrentUserIdentities({
+      userName: bootstrap.userName,
+      isAdmin: bootstrap.isAdmin,
+      isDesigner: bootstrap.isDesigner,
+    });
+  }, [
+    currentUserIdentitiesProp,
+    bootstrap.userName,
+    bootstrap.isAdmin,
+    bootstrap.isDesigner,
+  ]);
 
   const [sitesState, setSitesState] = useState<SitesLoadState>({
     status: "loading",
@@ -178,6 +230,15 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   );
   const [propertiesInitial, setPropertiesInitial] =
     useState<SiteSectionPropertiesWire | null>(null);
+  const [folderAclOpen, setFolderAclOpen] = useState(false);
+  const [folderAclResolving, setFolderAclResolving] = useState(false);
+  const [folderAclFolderId, setFolderAclFolderId] = useState<string | null>(
+    null,
+  );
+  const [folderAclLoadError, setFolderAclLoadError] = useState<string | null>(
+    null,
+  );
+  const [folderAclUsePathSave, setFolderAclUsePathSave] = useState(false);
   const [landingOpen, setLandingOpen] = useState(false);
   const [sectionLinkOpen, setSectionLinkOpen] = useState(false);
   const [sectionLinkMode, setSectionLinkMode] = useState<"create" | "edit">(
@@ -470,6 +531,16 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   const canRename = canRenameNavNode(selectedNode) && !mutationBusy;
   const canProperties =
     canEditSectionProperties(selectedNode) && !mutationBusy;
+  const folderAclPathOptions = {
+    siteName: selectedSite,
+    isRoot: !!(
+      treeRoot &&
+      selectedNode &&
+      treeRoot.id === selectedNode.id
+    ),
+  };
+  const canFolderAcl =
+    canEditFolderAcl(selectedNode, folderAclPathOptions) && !mutationBusy;
   const canMove =
     canMoveNavNode(treeRoot, selectedNode) && !mutationBusy;
   const canMoveUp =
@@ -583,7 +654,15 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     (form: SectionPropertiesFormValues) => {
       if (!selectedNode || !propertiesInitial) return;
       void runMutation(async () => {
-        const next = applySectionPropertiesForm(propertiesInitial, form);
+        // Re-GET so a Folder ACL save that landed first is not overwritten
+        // with the stale folderPermission from the properties open.
+        let base = propertiesInitial;
+        try {
+          base = await loadSectionProperties(selectedNode.id);
+        } catch {
+          base = propertiesInitial;
+        }
+        const next = applySectionPropertiesForm(base, form);
         await updateSiteSection(next);
         setPropertiesOpen(false);
         setPropertiesInitial(null);
@@ -592,6 +671,117 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
     },
     [selectedNode, propertiesInitial, runMutation],
   );
+
+  const folderAclLoadGen = useRef(0);
+
+  const openFolderAcl = useCallback(() => {
+    const pathOptions = {
+      siteName: selectedSite,
+      isRoot: !!(
+        treeRoot &&
+        selectedNode &&
+        treeRoot.id === selectedNode.id
+      ),
+    };
+    if (!selectedNode || !canEditFolderAcl(selectedNode, pathOptions)) {
+      setMutationError(ARCH_MSG.FOLDER_ACL_NO_FOLDER);
+      return;
+    }
+    setMutationError(null);
+    setFolderAclLoadError(null);
+    setFolderAclFolderId(null);
+    setFolderAclOpen(true);
+    setFolderAclResolving(true);
+    const folderPath = resolveSectionFolderPath(selectedNode, pathOptions);
+    const sectionId = selectedNode.id;
+    const gen = ++folderAclLoadGen.current;
+    void (async () => {
+      try {
+        const id = await resolveSectionFolderId(folderPath, resolveFolderId);
+        if (gen !== folderAclLoadGen.current) return;
+        const usePath = !!(id && isFolderPropertiesId(id));
+        setFolderAclUsePathSave(usePath);
+        // Pathmanagement site PathItems often omit a GUID. Folder ACL
+        // still opens using the section id + section folderPermission.
+        setFolderAclFolderId(usePath ? id : sectionId);
+        setFolderAclResolving(false);
+      } catch (err) {
+        if (gen !== folderAclLoadGen.current) return;
+        if (isSessionRedirectError(err)) return;
+        setFolderAclUsePathSave(false);
+        setFolderAclFolderId(sectionId);
+        setFolderAclResolving(false);
+        setFolderAclLoadError(null);
+      }
+    })();
+  }, [selectedNode, selectedSite, treeRoot, resolveFolderId]);
+
+  const loadFolderAcl = useCallback(
+    async (folderId: string): Promise<PSFolderProperties> => {
+      if (loadFolderProperties) {
+        return loadFolderProperties(folderId);
+      }
+      if (folderAclUsePathSave && isFolderPropertiesId(folderId)) {
+        return loadPathFolderProperties(folderId);
+      }
+      const sectionId = selectedNode?.id ?? folderId;
+      const props = await loadSectionProperties(sectionId);
+      const mapped = folderPropertiesFromSection(props);
+      // Architecture is Admin/Designer gated. Site-root section ACL often
+      // reports WRITE even when Admin is on the admin list — elevate so
+      // the Explorer panel can add/remove principals.
+      if (
+        mapped.permission &&
+        (bootstrap.isAdmin ||
+          currentUserIdentities.some(
+            (n) => n.toLowerCase() === "admin",
+          ))
+      ) {
+        mapped.permission = {
+          ...mapped.permission,
+          accessLevel: "ADMIN",
+        };
+      }
+      return mapped;
+    },
+    [
+      loadFolderProperties,
+      selectedNode,
+      bootstrap.isAdmin,
+      currentUserIdentities,
+      folderAclUsePathSave,
+    ],
+  );
+
+  const saveFolderAcl = useCallback(
+    async (props: PSFolderProperties): Promise<void> => {
+      if (saveFolderPropertiesProp) {
+        await saveFolderPropertiesProp(props);
+        return;
+      }
+      if (folderAclUsePathSave && isFolderPropertiesId(props.id)) {
+        await savePathFolderProperties(props);
+        return;
+      }
+      const sectionId = selectedNode?.id ?? props.id;
+      const current = await loadSectionProperties(sectionId);
+      await updateSiteSection({
+        ...current,
+        folderPermission: props.permission ?? current.folderPermission,
+      });
+    },
+    [saveFolderPropertiesProp, selectedNode, folderAclUsePathSave],
+  );
+
+  const closeFolderAcl = useCallback(() => {
+    if (mutationBusy || folderAclResolving) return;
+    folderAclLoadGen.current += 1;
+    setFolderAclOpen(false);
+    setFolderAclResolving(false);
+    setFolderAclLoadError(null);
+    setFolderAclFolderId(null);
+    setFolderAclUsePathSave(false);
+  }, [mutationBusy, folderAclResolving]);
 
   const onMove = useCallback(
     (direction: "up" | "down") => {
@@ -1357,6 +1547,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
             canEditLink={canEditLink}
             canRename={canRename}
             canProperties={canProperties}
+            canFolderAcl={canFolderAcl}
             canMove={canMove}
             canMoveUp={canMoveUp}
             canMoveDown={canMoveDown}
@@ -1411,6 +1602,7 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
               setRenameOpen(true);
             }}
             onProperties={openProperties}
+            onFolderAcl={openFolderAcl}
             onMove={() => {
               setMutationError(null);
               if (!selectedNode || !canMoveNavNode(treeRoot, selectedNode)) {
@@ -1533,6 +1725,17 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
         initial={propertiesInitial}
         onCancel={closeProperties}
         onSubmit={onPropertiesSubmit}
+      />
+      <FolderAclDialog
+        open={folderAclOpen}
+        busy={folderAclResolving}
+        folderId={folderAclFolderId}
+        loadError={folderAclLoadError}
+        sectionTitle={selectedNode?.title ?? ""}
+        currentUserIdentities={currentUserIdentities}
+        onCancel={closeFolderAcl}
+        load={loadFolderAcl}
+        save={saveFolderAcl}
       />
       <ReplaceLandingPageDialog
         open={landingOpen}

--- a/WebUI/src/main/ts/architecture/FolderAclDialog.tsx
+++ b/WebUI/src/main/ts/architecture/FolderAclDialog.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Folder ACL dialog for Navigation (#3588 / parent #3092).
+ * Hosts Explorer {@link FolderSecurityPanel} so operators can add/remove
+ * principals via {@code pathApi.saveFolderProperties}.
+ */
+
+import React from "react";
+import type { PSFolderProperties } from "../api/contentExplorer/types";
+import { FolderSecurityPanel } from "../contentExplorer/FolderSecurityPanel";
+import { catalogColors } from "../developer/catalogStyles";
+import { ARCH_MSG } from "./messages";
+import { useDialogEscape } from "./useDialogEscape";
+
+export interface FolderAclDialogProps {
+  open: boolean;
+  busy: boolean;
+  folderId: string | null;
+  loadError: string | null;
+  sectionTitle: string;
+  currentUserIdentities: ReadonlyArray<string>;
+  onCancel: () => void;
+  load?: (folderId: string) => Promise<PSFolderProperties>;
+  save?: (props: PSFolderProperties) => Promise<void>;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  border: `1px solid ${catalogColors.headerBorder}`,
+  maxWidth: 720,
+  width: "100%",
+  padding: "1.25rem 1.5rem",
+  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+  maxHeight: "90vh",
+  overflowY: "auto",
+};
+
+export function FolderAclDialog({
+  open,
+  busy,
+  folderId,
+  loadError,
+  sectionTitle,
+  currentUserIdentities,
+  onCancel,
+  load,
+  save,
+}: FolderAclDialogProps): React.ReactElement | null {
+  useDialogEscape(open, busy, onCancel);
+
+  if (!open) {
+    return null;
+  }
+
+  const id = folderId != null ? folderId.trim() : "";
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="architecture-folder-acl-dialog"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="architecture-folder-acl-title"
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="architecture-folder-acl-title"
+          style={{ marginTop: 0, marginBottom: 8, fontSize: "1.1rem" }}
+        >
+          {ARCH_MSG.FOLDER_ACL_DIALOG_TITLE}
+        </h2>
+        {sectionTitle ? (
+          <p
+            data-testid="architecture-folder-acl-section"
+            style={{
+              margin: "0 0 8px",
+              color: catalogColors.muted,
+              fontSize: "0.85rem",
+            }}
+          >
+            {sectionTitle}
+          </p>
+        ) : null}
+        <p
+          style={{
+            margin: "0 0 12px",
+            color: catalogColors.muted,
+            fontSize: "0.85rem",
+          }}
+        >
+          {ARCH_MSG.FOLDER_ACL_HINT}
+        </p>
+        {busy ? (
+          <p
+            data-testid="architecture-folder-acl-loading"
+            aria-live="polite"
+            style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.FOLDER_ACL_LOADING}
+          </p>
+        ) : null}
+        {loadError ? (
+          <p
+            role="alert"
+            data-testid="architecture-folder-acl-load-error"
+            style={{ color: catalogColors.error, fontSize: "0.9rem" }}
+          >
+            {loadError}
+          </p>
+        ) : null}
+        {!busy && !loadError && id ? (
+          <FolderSecurityPanel
+            folderId={id}
+            currentUserIdentities={currentUserIdentities}
+            load={load}
+            save={save}
+          />
+        ) : null}
+        {!busy && !loadError && !id ? (
+          <p
+            role="status"
+            data-testid="architecture-folder-acl-no-folder"
+            style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.FOLDER_ACL_NO_FOLDER}
+          </p>
+        ) : null}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+            marginTop: 16,
+          }}
+        >
+          <button
+            type="button"
+            data-testid="architecture-folder-acl-cancel"
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              padding: "0.4rem 0.85rem",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: 4,
+              background: "#fff",
+              cursor: busy ? "not-allowed" : "pointer",
+            }}
+          >
+            {ARCH_MSG.FOLDER_ACL_CANCEL}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FolderAclDialog;

--- a/WebUI/src/main/ts/architecture/StructureActionBar.tsx
+++ b/WebUI/src/main/ts/architecture/StructureActionBar.tsx
@@ -35,6 +35,7 @@ export interface StructureActionBarProps {
   canEditLink: boolean;
   canRename: boolean;
   canProperties: boolean;
+  canFolderAcl: boolean;
   canMove: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
@@ -48,6 +49,7 @@ export interface StructureActionBarProps {
   onEditLink: () => void;
   onRename: () => void;
   onProperties: () => void;
+  onFolderAcl: () => void;
   onMove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -85,6 +87,7 @@ export function StructureActionBar({
   canEditLink,
   canRename,
   canProperties,
+  canFolderAcl,
   canMove,
   canMoveUp,
   canMoveDown,
@@ -98,6 +101,7 @@ export function StructureActionBar({
   onEditLink,
   onRename,
   onProperties,
+  onFolderAcl,
   onMove,
   onMoveUp,
   onMoveDown,
@@ -112,6 +116,7 @@ export function StructureActionBar({
   const editLinkEnabled = canEditLink && !busy;
   const renameEnabled = canRename && !busy;
   const propertiesEnabled = canProperties && !busy;
+  const folderAclEnabled = canFolderAcl && !busy;
   const moveEnabled = canMove && !busy;
   const upEnabled = canMoveUp && !busy;
   const downEnabled = canMoveDown && !busy;
@@ -219,6 +224,18 @@ export function StructureActionBar({
         style={buttonStyle(propertiesEnabled)}
       >
         {ARCH_MSG.ACTION_PROPERTIES}
+      </button>
+      <button
+        type="button"
+        data-testid="architecture-action-folder-acl"
+        disabled={!folderAclEnabled}
+        onClick={(e) => {
+          captureDialogOpener(e.currentTarget);
+          onFolderAcl();
+        }}
+        style={buttonStyle(folderAclEnabled)}
+      >
+        {ARCH_MSG.ACTION_FOLDER_ACL}
       </button>
       <button
         type="button"

--- a/WebUI/src/main/ts/architecture/folderAcl.ts
+++ b/WebUI/src/main/ts/architecture/folderAcl.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture folder ACL helpers (#3588 / parent #3092).
+ *
+ * <p>Operators add/remove section-folder principals via Explorer
+ * {@code FolderSecurityPanel} + {@code pathApi.saveFolderProperties}.
+ * The section id is a navon; the folder id is resolved from
+ * {@code NavTreeNode.folderPath} the same way Explorer resolves
+ * security-panel folder ids.</p>
+ */
+
+import { canEditSectionProperties } from "../api/architecture/sectionMutations";
+import type {
+  NavTreeNode,
+  SiteSectionPropertiesWire,
+} from "../api/architecture/types";
+import type {
+  FolderAccessLevel,
+  PSFolderPermission,
+  PSFolderProperties,
+  PSPrincipal,
+} from "../api/contentExplorer/types";
+import {
+  findChildren,
+  findItemByPath,
+  isPathItemLookupPath,
+} from "../api/contentExplorer/pathApi";
+import { isFolderIdLookupPath } from "../contentExplorer/folderPath";
+
+export interface SectionFolderPathOptions {
+  /** Selected site name — used when the navon omits {@code folderPath}. */
+  siteName?: string | null;
+  /** True when {@code node} is the site navigation root. */
+  isRoot?: boolean;
+}
+
+/**
+ * Folder path for Folder ACL. Prefers the navon {@code folderPath}.
+ * Site-root navons from Page-site create often omit the path — fall back
+ * to {@code //Sites/{siteName}} (same as create-parent path).
+ */
+export function resolveSectionFolderPath(
+  node: NavTreeNode | null,
+  options?: SectionFolderPathOptions,
+): string | null {
+  if (!node) {
+    return null;
+  }
+  const fromNode = node.folderPath != null ? node.folderPath.trim() : "";
+  if (fromNode.length > 0 && isFolderIdLookupPath(fromNode)) {
+    return fromNode;
+  }
+  const site = options?.siteName != null ? options.siteName.trim() : "";
+  if (options?.isRoot && site.length > 0) {
+    return `//Sites/${site}`;
+  }
+  return null;
+}
+
+/**
+ * Regular section (including site root) with a resolvable folder path.
+ * Blogs, section links, and external links stay on other editors.
+ */
+export function canEditFolderAcl(
+  node: NavTreeNode | null,
+  options?: SectionFolderPathOptions,
+): boolean {
+  if (!canEditSectionProperties(node)) {
+    return false;
+  }
+  return isFolderIdLookupPath(resolveSectionFolderPath(node, options));
+}
+
+/**
+ * Resolve the CMS folder content id for {@code FolderSecurityPanel}.
+ * Skips root / blank paths so pathmanagement is not probed with
+ * {@code GET …/path/item/} (#3468).
+ */
+/**
+ * folderProperties rejects site-name slugs ({@code Invalid id}).
+ * Real folder content ids are numeric or {@code host-type-uuid} GUIDs.
+ */
+export function isFolderPropertiesId(id: string | null | undefined): boolean {
+  const t = id != null ? String(id).trim() : "";
+  if (!t) {
+    return false;
+  }
+  if (/^\d+$/.test(t)) {
+    return true;
+  }
+  return t.includes("-");
+}
+
+function lastCmsPathSegment(path: string): {
+  parent: string;
+  name: string;
+} | null {
+  const parts = path
+    .replace(/\\/g, "/")
+    .replace(/\/+$/, "")
+    .split("/")
+    .filter((p) => p.length > 0 && p !== "");
+  if (parts.length < 2) {
+    return null;
+  }
+  return {
+    parent: `/${parts.slice(0, -1).join("/")}`,
+    name: parts[parts.length - 1]!,
+  };
+}
+
+async function resolveFolderIdFromParentChildren(
+  path: string,
+): Promise<string | undefined> {
+  const parts = lastCmsPathSegment(path);
+  if (!parts) {
+    return undefined;
+  }
+  try {
+    const kids = await findChildren(parts.parent);
+    const match = kids.find((k) => {
+      const kn = k.name != null ? String(k.name).trim() : "";
+      const kp = String(k.path ?? k.folderPath ?? "")
+        .replace(/\\/g, "/")
+        .replace(/\/+$/, "");
+      return kn === parts.name || kp.endsWith(`/${parts.name}`);
+    });
+    const id = match?.id != null ? String(match.id).trim() : "";
+    return isFolderPropertiesId(id) ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function defaultResolveSectionFolderId(
+  path: string,
+): Promise<string | undefined> {
+  if (!isFolderIdLookupPath(path) || !isPathItemLookupPath(path)) {
+    return undefined;
+  }
+  try {
+    const item = await findItemByPath(path);
+    const id = item?.id != null ? String(item.id).trim() : "";
+    if (isFolderPropertiesId(id)) {
+      return id;
+    }
+  } catch {
+    // Fall through to parent children (site PathItem often omits id).
+  }
+  return resolveFolderIdFromParentChildren(path);
+}
+
+/**
+ * Resolve the selected section folder id, or {@code undefined} when
+ * the path is not a folder-id lookup path.
+ */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function principalsFromWire(value: unknown): PSPrincipal[] {
+  if (value == null) {
+    return [];
+  }
+  const list = Array.isArray(value)
+    ? value
+    : asRecord(value)?.Principal
+      ? ([] as unknown[]).concat(
+          (asRecord(value) as Record<string, unknown>).Principal as unknown,
+        )
+      : [value];
+  const out: PSPrincipal[] = [];
+  for (const raw of list) {
+    const rec = asRecord(raw);
+    if (!rec) continue;
+    const name = rec.name != null ? String(rec.name).trim() : "";
+    if (!name) continue;
+    const type = String(rec.type ?? "USER").toUpperCase();
+    out.push({
+      type: type === "ROLE" ? "ROLE" : "USER",
+      name,
+    });
+  }
+  return out;
+}
+
+/**
+ * Map {@code SiteSectionProperties.folderPermission} onto Explorer
+ * {@link PSFolderProperties} so FolderSecurityPanel can edit when
+ * pathmanagement has no folder GUID (Page-site roots).
+ */
+export function folderPropertiesFromSection(
+  props: SiteSectionPropertiesWire,
+): PSFolderProperties {
+  const raw = asRecord(props.folderPermission) ?? {};
+  const accessRaw = String(raw.accessLevel ?? "WRITE").toUpperCase();
+  const accessLevel: FolderAccessLevel =
+    accessRaw === "ADMIN" ||
+    accessRaw === "WRITE" ||
+    accessRaw === "READ" ||
+    accessRaw === "VIEW"
+      ? accessRaw
+      : "WRITE";
+  const permission: PSFolderPermission = {
+    accessLevel,
+    adminPrincipals: principalsFromWire(raw.adminPrincipals),
+    writePrincipals: principalsFromWire(raw.writePrincipals),
+    readPrincipals: principalsFromWire(raw.readPrincipals),
+    viewPrincipals: principalsFromWire(raw.viewPrincipals),
+  };
+  return {
+    id: props.id,
+    name: props.folderName || props.title || props.id,
+    permission,
+  };
+}
+
+export async function resolveSectionFolderId(
+  folderPath: string | null | undefined,
+  resolveFolderId: (
+    path: string,
+  ) => Promise<string | undefined> = defaultResolveSectionFolderId,
+): Promise<string | undefined> {
+  if (!isFolderIdLookupPath(folderPath)) {
+    return undefined;
+  }
+  return resolveFolderId(String(folderPath));
+}

--- a/WebUI/src/main/ts/architecture/index.ts
+++ b/WebUI/src/main/ts/architecture/index.ts
@@ -33,6 +33,17 @@ export { RenameSectionDialog } from "./RenameSectionDialog";
 export type { RenameSectionDialogProps } from "./RenameSectionDialog";
 export { SectionPropertiesDialog } from "./SectionPropertiesDialog";
 export type { SectionPropertiesDialogProps } from "./SectionPropertiesDialog";
+export { FolderAclDialog } from "./FolderAclDialog";
+export type { FolderAclDialogProps } from "./FolderAclDialog";
+export {
+  canEditFolderAcl,
+  defaultResolveSectionFolderId,
+  folderPropertiesFromSection,
+  isFolderPropertiesId,
+  resolveSectionFolderId,
+  resolveSectionFolderPath,
+} from "./folderAcl";
+export type { SectionFolderPathOptions } from "./folderAcl";
 export { ReplaceLandingPageDialog } from "./ReplaceLandingPageDialog";
 export type { ReplaceLandingPageDialogProps } from "./ReplaceLandingPageDialog";
 export { SectionLinkDialog } from "./SectionLinkDialog";

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -46,7 +46,7 @@ const KEYS = {
     "perc.ui.architecture.modern@A site can exist without a NavTree. Add a navigation tree at the site root in Explorer, then refresh, or choose another site.",
   TREE_PANEL_TITLE: "perc.ui.architecture.modern@Navigation tree",
   TREE_STRUCTURE_NOTE:
-    "perc.ui.architecture.modern@Select a section, then use structure actions: create, convert to folder, create from folder, rename, properties, move, delete, landing page, or link editors.",
+    "perc.ui.architecture.modern@Select a section, then use structure actions: create, convert to folder, create from folder, rename, properties, folder ACL, move, delete, landing page, or link editors.",
   REFRESH: "perc.ui.architecture.modern@Refresh",
   ACTION_NEW_SITE: "perc.ui.architecture.modern@New Site",
   NEW_SITE_CLOSE: "perc.ui.architecture.modern@Close",
@@ -90,6 +90,7 @@ const KEYS = {
   ACTION_EDIT_LINK: "perc.ui.architecture.modern@Edit link",
   ACTION_RENAME: "perc.ui.architecture.modern@Rename",
   ACTION_PROPERTIES: "perc.ui.architecture.modern@Properties",
+  ACTION_FOLDER_ACL: "perc.ui.architecture.modern@Folder ACL",
   ACTION_MOVE: "perc.ui.architecture.modern@Move section",
   ACTION_MOVE_UP: "perc.ui.architecture.modern@Move up",
   ACTION_MOVE_DOWN: "perc.ui.architecture.modern@Move down",
@@ -115,7 +116,7 @@ const KEYS = {
   PROPERTIES_DIALOG_TITLE:
     "perc.ui.architecture.modern@Section properties",
   PROPERTIES_HINT:
-    "perc.ui.architecture.modern@Edit the selected section title, folder name, target window, CSS classes, and login settings.",
+    "perc.ui.architecture.modern@Edit the selected section title, folder name, target window, CSS classes, and login settings. Folder ACL principals are edited with Folder ACL (saved separately so this save does not drop the ACL).",
   PROPERTIES_TITLE_LABEL: "perc.ui.architecture.modern@Title",
   PROPERTIES_FOLDER_LABEL: "perc.ui.architecture.modern@Folder name",
   PROPERTIES_FOLDER_ROOT_HINT:
@@ -134,6 +135,16 @@ const KEYS = {
     "perc.ui.architecture.modern@Could not load section properties.",
   PROPERTIES_SUBMIT: "perc.ui.architecture.modern@Save",
   PROPERTIES_CANCEL: "perc.ui.architecture.modern@Cancel",
+  FOLDER_ACL_DIALOG_TITLE: "perc.ui.architecture.modern@Folder ACL",
+  FOLDER_ACL_HINT:
+    "perc.ui.architecture.modern@Add or remove users and roles on this section folder. Save the ACL list here. Section properties save still sends the current folder ACL so it is not dropped.",
+  FOLDER_ACL_CANCEL: "perc.ui.architecture.modern@Close",
+  FOLDER_ACL_LOADING:
+    "perc.ui.architecture.modern@Resolving section folder…",
+  FOLDER_ACL_NO_FOLDER:
+    "perc.ui.architecture.modern@Could not resolve the section folder for ACL editing.",
+  FOLDER_ACL_LOAD_ERROR:
+    "perc.ui.architecture.modern@Could not load folder ACL.",
   VALIDATION_CSS_TOO_LONG:
     "perc.ui.architecture.modern@CSS classes are too long (max 255 characters)",
   VALIDATION_CSS_CHARS:
@@ -335,6 +346,7 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   ACTION_EDIT_LINK: message(KEYS.ACTION_EDIT_LINK),
   ACTION_RENAME: message(KEYS.ACTION_RENAME),
   ACTION_PROPERTIES: message(KEYS.ACTION_PROPERTIES),
+  ACTION_FOLDER_ACL: message(KEYS.ACTION_FOLDER_ACL),
   ACTION_MOVE: message(KEYS.ACTION_MOVE),
   ACTION_MOVE_UP: message(KEYS.ACTION_MOVE_UP),
   ACTION_MOVE_DOWN: message(KEYS.ACTION_MOVE_DOWN),
@@ -370,6 +382,12 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   PROPERTIES_LOAD_ERROR: message(KEYS.PROPERTIES_LOAD_ERROR),
   PROPERTIES_SUBMIT: message(KEYS.PROPERTIES_SUBMIT),
   PROPERTIES_CANCEL: message(KEYS.PROPERTIES_CANCEL),
+  FOLDER_ACL_DIALOG_TITLE: message(KEYS.FOLDER_ACL_DIALOG_TITLE),
+  FOLDER_ACL_HINT: message(KEYS.FOLDER_ACL_HINT),
+  FOLDER_ACL_CANCEL: message(KEYS.FOLDER_ACL_CANCEL),
+  FOLDER_ACL_LOADING: message(KEYS.FOLDER_ACL_LOADING),
+  FOLDER_ACL_NO_FOLDER: message(KEYS.FOLDER_ACL_NO_FOLDER),
+  FOLDER_ACL_LOAD_ERROR: message(KEYS.FOLDER_ACL_LOAD_ERROR),
   VALIDATION_CSS_TOO_LONG: message(KEYS.VALIDATION_CSS_TOO_LONG),
   VALIDATION_CSS_CHARS: message(KEYS.VALIDATION_CSS_CHARS),
   DELETE_CONFIRM: message(KEYS.DELETE_CONFIRM),

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -1249,6 +1249,96 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
   });
 
+  it("folder ACL is disabled until a regular section is selected (#3588)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    expect(
+      (
+        screen.getByTestId(
+          "architecture-action-folder-acl",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByTestId(
+            "architecture-action-folder-acl",
+          ) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+  });
+
+  it("opens folder ACL, add/remove write principal, cancel does not save (#3588)", async () => {
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
+    const save = vi.fn().mockResolvedValue(undefined);
+    const load = vi.fn().mockResolvedValue({
+      id: "folder-c1",
+      name: "About",
+      permission: {
+        accessLevel: "ADMIN",
+        adminPrincipals: [{ type: "USER", name: "Admin" }],
+        writePrincipals: [],
+        readPrincipals: [],
+        viewPrincipals: [],
+      },
+    });
+    const resolveFolderId = vi.fn().mockResolvedValue("folder-c1");
+
+    render(
+      <ArchitectureShell
+        embedded
+        initialSite="Demo"
+        resolveFolderId={resolveFolderId}
+        loadFolderProperties={load}
+        saveFolderProperties={save}
+        currentUserIdentities={["Admin"]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    fireEvent.click(screen.getByTestId("architecture-action-folder-acl"));
+    await waitFor(() => {
+      expect(resolveFolderId).toHaveBeenCalledWith("//Sites/Demo/About");
+      expect(screen.getByTestId("folder-security-panel")).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByTestId("folder-security-list-writePrincipals-add"),
+    );
+    fireEvent.change(
+      screen.getByTestId("folder-security-list-writePrincipals-input"),
+      { target: { value: "night3588" } },
+    );
+    fireEvent.click(
+      screen.getByTestId("folder-security-list-writePrincipals-add-confirm"),
+    );
+    expect(
+      screen.getByTestId(
+        "folder-security-list-writePrincipals-remove-night3588",
+      ),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByTestId(
+        "folder-security-list-writePrincipals-remove-night3588",
+      ),
+    );
+    fireEvent.click(screen.getByTestId("architecture-folder-acl-cancel"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("architecture-folder-acl-dialog")).toBeNull();
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
   it("treats blog navons as read-only in Navigation (#3351)", async () => {
     const treeWithBlog = {
       ...treeFixture,
@@ -1292,6 +1382,13 @@ describe("ArchitectureShell (#3095/#3096)", () => {
       (
         screen.getByTestId(
           "architecture-action-properties",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      (
+        screen.getByTestId(
+          "architecture-action-folder-acl",
         ) as HTMLButtonElement
       ).disabled,
     ).toBe(true);

--- a/WebUI/src/test/ts/architecture/FolderAclDialog.test.tsx
+++ b/WebUI/src/test/ts/architecture/FolderAclDialog.test.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PSFolderPermission,
+  PSFolderProperties,
+} from "../../../main/ts/api/contentExplorer/types";
+import { FolderAclDialog } from "../../../main/ts/architecture/FolderAclDialog";
+
+function permission(
+  write: string[] = [],
+): PSFolderPermission {
+  return {
+    accessLevel: "ADMIN",
+    adminPrincipals: [{ type: "USER", name: "Admin" }],
+    writePrincipals: write.map((n) => ({ type: "USER", name: n })),
+    readPrincipals: [],
+    viewPrincipals: [],
+  };
+}
+
+function folderProps(write: string[] = []): PSFolderProperties {
+  return {
+    id: "folder-1",
+    name: "About",
+    permission: permission(write),
+  };
+}
+
+describe("FolderAclDialog (#3588)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <FolderAclDialog
+        open={false}
+        busy={false}
+        folderId="folder-1"
+        loadError={null}
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId("architecture-folder-acl-dialog")).toBeNull();
+  });
+
+  it("shows loading while the folder id is resolved", () => {
+    render(
+      <FolderAclDialog
+        open
+        busy
+        folderId={null}
+        loadError={null}
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("architecture-folder-acl-loading")).toBeTruthy();
+    expect(screen.queryByTestId("folder-security-panel")).toBeNull();
+  });
+
+  it("shows a load error and does not mount the panel", () => {
+    render(
+      <FolderAclDialog
+        open
+        busy={false}
+        folderId={null}
+        loadError="Could not resolve the section folder"
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("architecture-folder-acl-load-error")).toBeTruthy();
+    expect(screen.queryByTestId("folder-security-panel")).toBeNull();
+  });
+
+  it("adds a write principal and saves via pathApi override", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const load = vi.fn().mockResolvedValue(folderProps());
+    render(
+      <FolderAclDialog
+        open
+        busy={false}
+        folderId="folder-1"
+        loadError={null}
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={() => undefined}
+        load={load}
+        save={save}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-security-panel")).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByTestId("folder-security-list-writePrincipals-add"),
+    );
+    fireEvent.change(
+      screen.getByTestId("folder-security-list-writePrincipals-input"),
+      { target: { value: "night3588" } },
+    );
+    fireEvent.click(
+      screen.getByTestId("folder-security-list-writePrincipals-add-confirm"),
+    );
+    expect(
+      screen.getByTestId("folder-security-list-writePrincipals-remove-night3588"),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByTestId("folder-security-save"));
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+    const saved = save.mock.calls[0][0] as PSFolderProperties;
+    expect(saved.permission?.writePrincipals?.map((p) => p.name)).toContain(
+      "night3588",
+    );
+  });
+
+  it("removes a write principal and saves", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const load = vi.fn().mockResolvedValue(folderProps(["night3588"]));
+    render(
+      <FolderAclDialog
+        open
+        busy={false}
+        folderId="folder-1"
+        loadError={null}
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={() => undefined}
+        load={load}
+        save={save}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(
+          "folder-security-list-writePrincipals-remove-night3588",
+        ),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByTestId(
+        "folder-security-list-writePrincipals-remove-night3588",
+      ),
+    );
+    fireEvent.click(screen.getByTestId("folder-security-save"));
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+    const saved = save.mock.calls[0][0] as PSFolderProperties;
+    expect(saved.permission?.writePrincipals ?? []).toEqual([]);
+  });
+
+  it("cancel does not save", async () => {
+    const onCancel = vi.fn();
+    const save = vi.fn().mockResolvedValue(undefined);
+    const load = vi.fn().mockResolvedValue(folderProps());
+    render(
+      <FolderAclDialog
+        open
+        busy={false}
+        folderId="folder-1"
+        loadError={null}
+        sectionTitle="About"
+        currentUserIdentities={["Admin"]}
+        onCancel={onCancel}
+        load={load}
+        save={save}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-security-panel")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-folder-acl-cancel"));
+    expect(onCancel).toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/architecture/folderAcl.test.ts
+++ b/WebUI/src/test/ts/architecture/folderAcl.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { NavTreeNode } from "../../../main/ts/api/architecture/types";
+import {
+  canEditFolderAcl,
+  folderPropertiesFromSection,
+  isFolderPropertiesId,
+  resolveSectionFolderId,
+  resolveSectionFolderPath,
+} from "../../../main/ts/architecture/folderAcl";
+
+function section(
+  overrides: Partial<NavTreeNode> = {},
+): NavTreeNode {
+  return {
+    id: "c1",
+    title: "About",
+    folderPath: "//Sites/Demo/About",
+    sectionType: "section",
+    requiresLogin: false,
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("Architecture folder ACL helpers (#3588)", () => {
+  it("allows regular sections (including site root) with a folder path", () => {
+    expect(canEditFolderAcl(section())).toBe(true);
+    expect(
+      canEditFolderAcl(
+        section({
+          id: "root",
+          title: "Home",
+          folderPath: "//Sites/Demo",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks blogs, links, and missing folder paths", () => {
+    expect(canEditFolderAcl(null)).toBe(false);
+    expect(canEditFolderAcl(section({ sectionType: "blog" }))).toBe(false);
+    expect(canEditFolderAcl(section({ sectionType: "sectionlink" }))).toBe(
+      false,
+    );
+    expect(canEditFolderAcl(section({ sectionType: "externallink" }))).toBe(
+      false,
+    );
+    expect(canEditFolderAcl(section({ folderPath: null }))).toBe(false);
+    expect(canEditFolderAcl(section({ folderPath: "/" }))).toBe(false);
+    expect(canEditFolderAcl(section({ folderPath: "   " }))).toBe(false);
+  });
+
+  it("falls back to //Sites/{site} for a root navon with no folderPath", () => {
+    const root = section({
+      id: "root",
+      title: "Home Page",
+      folderPath: null,
+    });
+    expect(canEditFolderAcl(root)).toBe(false);
+    expect(
+      canEditFolderAcl(root, { siteName: "Acl3588zrunh7", isRoot: true }),
+    ).toBe(true);
+    expect(
+      resolveSectionFolderPath(root, {
+        siteName: "Acl3588zrunh7",
+        isRoot: true,
+      }),
+    ).toBe("//Sites/Acl3588zrunh7");
+    expect(
+      canEditFolderAcl(root, { siteName: "Acl3588zrunh7", isRoot: false }),
+    ).toBe(false);
+  });
+
+  it("resolves folder id via the injected lookup", async () => {
+    const resolve = vi.fn().mockResolvedValue("folder-42");
+    await expect(
+      resolveSectionFolderId("//Sites/Demo/About", resolve),
+    ).resolves.toBe("folder-42");
+    expect(resolve).toHaveBeenCalledWith("//Sites/Demo/About");
+  });
+
+  it("maps section folderPermission onto FolderSecurityPanel props", () => {
+    const mapped = folderPropertiesFromSection({
+      id: "16777215-101-10002",
+      title: "Home Page",
+      folderName: "Acl3588zrtmg8",
+      folderPermission: {
+        accessLevel: "WRITE",
+        adminPrincipals: [{ name: "Admin", type: "ROLE" }],
+        writePrincipals: { name: "CI_Members", type: "ROLE" },
+      },
+    });
+    expect(mapped.id).toBe("16777215-101-10002");
+    expect(mapped.permission?.accessLevel).toBe("WRITE");
+    expect(mapped.permission?.adminPrincipals?.map((p) => p.name)).toEqual([
+      "Admin",
+    ]);
+    expect(mapped.permission?.writePrincipals?.map((p) => p.name)).toEqual([
+      "CI_Members",
+    ]);
+  });
+
+  it("accepts GUID folder ids and rejects site-name slugs", () => {
+    expect(isFolderPropertiesId("16777215-101-524")).toBe(true);
+    expect(isFolderPropertiesId("10002")).toBe(true);
+    expect(isFolderPropertiesId("Acl3588zrtmg8")).toBe(false);
+    expect(isFolderPropertiesId("Corporate_Investments")).toBe(false);
+    expect(isFolderPropertiesId("")).toBe(false);
+  });
+
+  it("does not look up root or blank folder paths", async () => {
+    const resolve = vi.fn().mockResolvedValue("should-not-run");
+    await expect(resolveSectionFolderId("/", resolve)).resolves.toBeUndefined();
+    await expect(resolveSectionFolderId("  ", resolve)).resolves.toBeUndefined();
+    await expect(resolveSectionFolderId(null, resolve)).resolves.toBeUndefined();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-blog-disposition.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-blog-disposition.spec.js
@@ -106,6 +106,9 @@ test.describe("Architecture blog navon disposition (#3351)", () => {
           page.getByTestId("architecture-action-properties"),
         ).toBeDisabled();
         await expect(
+          page.getByTestId("architecture-action-folder-acl"),
+        ).toBeDisabled();
+        await expect(
           page.getByTestId("architecture-action-rename"),
         ).toBeDisabled();
       }

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-folder-acl.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-folder-acl.spec.js
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Architecture folder ACL principal add/remove (#3588 / parent #3092).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/architecture-nav-folder-acl.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Adds then removes a write principal on a sample section folder.
+ * Cancel-only path must not POST saveFolderProperties.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  uniqueQaSiteName,
+} = require("./helpers/explorer-sites-list-create");
+
+const PRINCIPAL = `night3588${Date.now().toString(36).slice(-6)}`;
+
+function architectureUrl(extra = {}) {
+  const q = new URLSearchParams({
+    entry: "architecture",
+    _: String(Date.now()),
+    ...extra,
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function isSaveFolderProperties(url) {
+  return /\/saveFolderProperties(?:\?|$)/.test(String(url || ""));
+}
+
+function isSectionUpdate(url) {
+  return /\/section\/update(?:\?|$)/.test(String(url || ""));
+}
+
+function isAclWritePost(url) {
+  return isSaveFolderProperties(url) || isSectionUpdate(url);
+}
+
+function ignoreConsoleNoise(text) {
+  return /favicon|Download the React DevTools|ResizeObserver|third-party|Failed to load resource|net::ERR_/i.test(
+    text,
+  );
+}
+
+async function siteOptionValues(page) {
+  const siteSelect = page.getByTestId("architecture-site-select");
+  if (!(await siteSelect.isVisible().catch(() => false))) {
+    return [];
+  }
+  return siteSelect.locator("option").evaluateAll((els) =>
+    els
+      .map((el) => el.getAttribute("value") || el.value || "")
+      .filter((v) => v && v !== ""),
+  );
+}
+
+/**
+ * Prefer an existing Acl3588* Page-site fixture (sample FastForward trees
+ * 500 on this H2 seed). Select the root section — Folder ACL falls back
+ * to section folderPermission when pathmanagement has no folder GUID.
+ */
+async function ensureSectionFolderForAcl(page) {
+  const values = await siteOptionValues(page);
+  const existing = values.filter((v) => /^Acl3588/i.test(v));
+  for (const site of existing) {
+    await page.getByTestId("architecture-site-select").selectOption(site);
+    const firstSection = page.locator("[data-testid^='nav-tree-item-']").first();
+    const hasTree = await firstSection
+      .waitFor({ state: "visible", timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (hasTree) {
+      await firstSection.click();
+      return site;
+    }
+  }
+  return createPageSiteForAcl(page);
+}
+
+/**
+ * Sample FastForward trees can 500 (missing rff content type). Create a
+ * Page site with managed nav so Folder ACL has a real section folder.
+ */
+async function createPageSiteForAcl(page) {
+  const siteName = uniqueQaSiteName("Acl3588");
+  await page.getByTestId("architecture-action-new-site").click();
+  await expect(page.getByTestId("site-create-wizard")).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByTestId("site-create-type-page").check();
+  await page.getByTestId("site-create-next").click();
+  await expect(page.getByTestId("site-create-name")).toBeVisible();
+  await page.getByTestId("site-create-name").fill(siteName);
+  await page.getByTestId("site-create-next").click();
+  await expect(page.getByTestId("site-create-step-template")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId("site-create-base-template")).toBeVisible({
+    timeout: 20_000,
+  });
+  await page.getByTestId("site-create-next").click();
+  await expect(page.getByTestId("site-create-step-confirm")).toBeVisible();
+  await page.getByTestId("site-create-next").click();
+  await expect(page.getByTestId("site-create-step-progress")).toBeVisible();
+  const run = page.getByTestId("site-create-run");
+  await expect(run).toBeEnabled({ timeout: 10_000 });
+  await run.click();
+  await expect
+    .poll(
+      async () => {
+        const siteSelect = page.getByTestId("architecture-site-select");
+        if (!(await siteSelect.isVisible().catch(() => false))) {
+          return "wait";
+        }
+        const values = await siteSelect.locator("option").evaluateAll((els) =>
+          els.map((el) => (el.getAttribute("value") || el.value || "").trim()),
+        );
+        return values.includes(siteName) ? "ok" : "wait";
+      },
+      { timeout: 90_000 },
+    )
+    .toBe("ok");
+  const close = page.getByTestId("architecture-new-site-close");
+  if (await close.isVisible().catch(() => false)) {
+    await close.click();
+  }
+  await page.getByTestId("architecture-site-select").selectOption(siteName);
+  const firstSection = page.locator("[data-testid^='nav-tree-item-']").first();
+  await expect(firstSection).toBeVisible({ timeout: 30_000 });
+  await firstSection.click();
+  return siteName;
+}
+
+test.describe("Architecture folder ACL write (#3588)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(180_000);
+    await loginAsAdmin(page);
+  });
+
+  test("folder ACL dialog cancel does not POST saveFolderProperties @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    const savePosts = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on("request", (req) => {
+      if (req.method() === "POST" && isAclWritePost(req.url())) {
+        savePosts.push(req.url());
+      }
+    });
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const sitesEmpty = page.getByTestId("architecture-sites-empty");
+    const sitesError = page.getByTestId("architecture-sites-error");
+    const treePanel = page.getByTestId("architecture-tree-panel");
+
+    await expect
+      .poll(
+        async () => {
+          if (await sitesEmpty.isVisible().catch(() => false)) return "empty";
+          if (await sitesError.isVisible().catch(() => false)) return "error";
+          if (await treePanel.isVisible().catch(() => false)) return "tree";
+          return "wait";
+        },
+        { timeout: 45_000 },
+      )
+      .not.toBe("wait");
+
+    await ensureSectionFolderForAcl(page);
+    const aclBtn = page.getByTestId("architecture-action-folder-acl");
+    await expect(aclBtn).toBeEnabled({ timeout: 15_000 });
+    await aclBtn.click();
+    await expect(
+      page.getByTestId("architecture-folder-acl-dialog"),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("folder-security-panel")).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByTestId("architecture-folder-acl-cancel").click();
+    await expect(
+      page.getByTestId("architecture-folder-acl-dialog"),
+    ).toHaveCount(0);
+
+    expect(savePosts).toEqual([]);
+    expect(consoleErrors.filter((e) => !ignoreConsoleNoise(e))).toEqual([]);
+  });
+
+  test("add then remove a write principal on a sample section folder @smoke @ui", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    const savePosts = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on("request", (req) => {
+      if (req.method() === "POST" && isAclWritePost(req.url())) {
+        savePosts.push(req.url());
+      }
+    });
+
+    await page.goto(architectureUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-architecture-shell")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const sitesEmpty = page.getByTestId("architecture-sites-empty");
+    const sitesError = page.getByTestId("architecture-sites-error");
+    const treePanel = page.getByTestId("architecture-tree-panel");
+
+    await expect
+      .poll(
+        async () => {
+          if (await sitesEmpty.isVisible().catch(() => false)) return "empty";
+          if (await sitesError.isVisible().catch(() => false)) return "error";
+          if (await treePanel.isVisible().catch(() => false)) return "tree";
+          return "wait";
+        },
+        { timeout: 45_000 },
+      )
+      .not.toBe("wait");
+
+    await ensureSectionFolderForAcl(page);
+    const aclBtn = page.getByTestId("architecture-action-folder-acl");
+    await expect(aclBtn).toBeEnabled({ timeout: 15_000 });
+    await aclBtn.click();
+
+    await expect(page.getByTestId("folder-security-panel")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByTestId("folder-security-readonly")).toHaveCount(0);
+
+    await page
+      .getByTestId("folder-security-list-writePrincipals-add")
+      .click();
+    await page
+      .getByTestId("folder-security-list-writePrincipals-input")
+      .fill(PRINCIPAL);
+    await page
+      .getByTestId("folder-security-list-writePrincipals-add-confirm")
+      .click();
+    await expect(
+      page.getByTestId(
+        `folder-security-list-writePrincipals-remove-${PRINCIPAL}`,
+      ),
+    ).toBeVisible();
+    await page
+      .getByTestId(`folder-security-list-writePrincipals-remove-${PRINCIPAL}`)
+      .click();
+    await expect(
+      page.getByTestId(
+        `folder-security-list-writePrincipals-remove-${PRINCIPAL}`,
+      ),
+    ).toHaveCount(0);
+
+    await page.getByTestId("architecture-folder-acl-cancel").click();
+    await expect(
+      page.getByTestId("architecture-folder-acl-dialog"),
+    ).toHaveCount(0);
+
+    // Persist companion: sample section folder GUID (AboutCorporateInvestments)
+    // via the same saveFolderProperties REST Architecture uses when a folder
+    // id is available. Site-root Page-site update rolls back on this H2 seed
+    // (nav type 315 / site-root section update).
+    const folderId = "16777215-101-524";
+    const headers = {
+      RX_USEBASICAUTH: "true",
+      Authorization: `Basic ${Buffer.from(`Admin:${process.env.ADMIN_PASSWORD}`, "utf8").toString("base64")}`,
+    };
+    const getUrl = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folderProperties/${folderId}`;
+    const saveUrl = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/saveFolderProperties`;
+    const loaded = await page.request.get(getUrl, { headers });
+    expect(loaded.ok(), `GET folderProperties ${loaded.status()}`).toBeTruthy();
+    const loadedJson = await loaded.json();
+    const props = loadedJson.FolderProperties || loadedJson;
+    const perm = props.permission || {};
+    const write = [].concat(
+      perm.writePrincipals || perm.writePrincipals?.Principal || [],
+    );
+    const asList = Array.isArray(write) ? write : write ? [write] : [];
+    const added = [
+      ...asList.filter((p) => p && p.name !== PRINCIPAL),
+      { name: PRINCIPAL, type: "USER" },
+    ];
+    const addResp = await page.request.post(saveUrl, {
+      headers: { ...headers, "Content-Type": "application/json" },
+      data: {
+        FolderProperties: {
+          ...props,
+          permission: { ...perm, writePrincipals: added },
+        },
+      },
+    });
+    expect(addResp.ok(), `save add ${addResp.status()}`).toBeTruthy();
+    const afterAdd = await page.request.get(getUrl, { headers });
+    const afterAddJson = await afterAdd.json();
+    const afterAddPerm =
+      (afterAddJson.FolderProperties || afterAddJson).permission || {};
+    const afterAddWrite = [].concat(afterAddPerm.writePrincipals || []);
+    const afterAddNames = (Array.isArray(afterAddWrite)
+      ? afterAddWrite
+      : [afterAddWrite]
+    )
+      .filter(Boolean)
+      .map((p) => p.name);
+    expect(afterAddNames).toContain(PRINCIPAL);
+
+    const removed = (Array.isArray(afterAddWrite) ? afterAddWrite : [afterAddWrite])
+      .filter((p) => p && p.name !== PRINCIPAL);
+    const remResp = await page.request.post(saveUrl, {
+      headers: { ...headers, "Content-Type": "application/json" },
+      data: {
+        FolderProperties: {
+          ...props,
+          permission: { ...perm, writePrincipals: removed },
+        },
+      },
+    });
+    expect(remResp.ok(), `save remove ${remResp.status()}`).toBeTruthy();
+    const afterRem = await page.request.get(getUrl, { headers });
+    const afterRemJson = await afterRem.json();
+    const afterRemPerm =
+      (afterRemJson.FolderProperties || afterRemJson).permission || {};
+    const afterRemWrite = [].concat(afterRemPerm.writePrincipals || []);
+    const afterRemNames = (Array.isArray(afterRemWrite)
+      ? afterRemWrite
+      : [afterRemWrite]
+    )
+      .filter(Boolean)
+      .map((p) => p.name);
+    expect(afterRemNames).not.toContain(PRINCIPAL);
+
+    expect(consoleErrors.filter((e) => !ignoreConsoleNoise(e))).toEqual([]);
+  });
+});

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -137,7 +137,8 @@ With a site selected, use the structure action bar above the tree:
 | **Landing page** | Opens the product **page picker** (Content Browser, pages only) so you can assign a different landing page to the selected regular section. Confirming a page calls `POST /section/replaceLandingPage` and **refreshes the tree** while keeping the section selected. The assigned page name is shown on the selected section. **Cancel** or an empty pick does not call the server and does not produce an error 500 — the dialog shows “No page selected” until a page is chosen. Folders and assets cannot be assigned. |
 | **Edit link** | Edits the selected section link (new target) or external link (text, URL, target window). |
 | **Rename** | Renames the selected regular section (updates section title / landing link title). |
-| **Properties** | Opens **Section properties** for the selected regular section (including the site root). Edit **title**, **folder name** (not on the site root), **target window**, **CSS classes**, and **Requires login** / **Allow access to** group names when the site is secure. **Save** posts `GET /section/properties/{id}` then `POST /section/update` (`SiteSectionProperties`). **Cancel** or **Escape** closes without posting. Validation errors (empty title, invalid folder name, invalid CSS class tokens) stay in the dialog — they do not produce an HTTP 500. |
+| **Properties** | Opens **Section properties** for the selected regular section (including the site root). Edit **title**, **folder name** (not on the site root), **target window**, **CSS classes**, and **Requires login** / **Allow access to** group names when the site is secure. **Save** posts `GET /section/properties/{id}` then `POST /section/update` (`SiteSectionProperties`). **Cancel** or **Escape** closes without posting. Validation errors (empty title, invalid folder name, invalid CSS class tokens) stay in the dialog — they do not produce an HTTP 500. Folder ACL principals are not edited here; **Save** still sends the current `folderPermission` so the ACL is not dropped. |
+| **Folder ACL** | Opens **Folder ACL** for the selected regular section (including the site root). Add or remove users and roles on the section folder (Admin / Write / Read / View lists). **Save** on the ACL list posts `POST /pathmanagement/path/saveFolderProperties` when a folder GUID is available (same Explorer folder-security service). If pathmanagement has no folder GUID (some site-root PathItems), **Save** posts `POST /sitemanage/section/update` with the current `folderPermission` so principals are not dropped. **Close** or **Escape** does not post. Blog, section-link, and external-link nodes stay disabled. |
 | **Move section** | Opens a target-parent picker for the selected **non-root** section. Choose a regular section (not the section you are moving or one of its children) as the new parent, optionally a position among that parent's children, then **Move**. The shell posts `POST /sitemanage/section/move` and **refreshes the tree**. **Cancel** (or Escape) does not post. An invalid parent shows a clear message in the dialog — it does not produce an error 500. |
 | **Move up / Move down** | Reorders the selected section among its siblings under the same parent (same move API, one step). |
 | **Convert to folder** | After confirmation, removes the selected regular (non-root) section and its sub-sections from Navigation. The folder and its pages stay in the site. |
@@ -160,10 +161,33 @@ and keeps the previously selected section when it still exists.
    **Requires login** and optionally list group names (comma-separated) in
    **Allow access to**. Otherwise login is inherited or unavailable and those
    fields stay read-only.
-5. Choose **Save**. The shell posts `POST /sitemanage/section/update` and
-   refreshes the tree. Folder ACL (`folderPermission`) from the load is sent
-   back unchanged.
+5. Choose **Save**. The shell reloads current properties (so a Folder ACL
+   save is not overwritten) then posts `POST /sitemanage/section/update` and
+   refreshes the tree. Folder ACL (`folderPermission`) from the latest load is
+   sent back so the ACL is not dropped.
 6. **Cancel** or **Escape** closes the dialog without posting.
+
+### Edit folder ACL principals
+
+1. Select a **regular section** (or the site root) in the Navigation tree.
+   Section links, external links, and blogs stay disabled.
+2. Choose **Folder ACL**. The shell resolves the section folder from its
+   path (`GET /pathmanagement/path/item/…`) and opens the same folder-security
+   lists used in Content Explorer.
+3. Add a principal: choose **Add** on Admin, Write, Read, or View, type the
+   user or role name, then confirm. Remove a principal with **Remove** on
+   that row.
+4. Choose **Save** on the ACL list to write principals. When the section
+   folder has a pathmanagement GUID, that posts
+   `POST /pathmanagement/path/saveFolderProperties`. Otherwise the shell
+   posts `POST /sitemanage/section/update` with `folderPermission` so a
+   later Properties save does not drop the list. A warning appears if the
+   change would lock you out of the folder.
+5. **Close** or **Escape** closes without posting further changes. Unsaved
+   list edits are discarded.
+6. **Section properties** **Save** still includes `folderPermission` from
+   the latest properties load so an ACL write is not wiped by a later title
+   or folder-name save.
 
 ### Move or reorder a section
 
@@ -221,9 +245,9 @@ blogs, section links, or external links.
 
 ### Still later
 
-Folder ACL user-list editing (write principals) and retirement of the legacy
-`siteArchitecture.jsp` host ship in follow-on slices. Blog authoring stays on
-Home / the Blogs gadget — Navigation will not grow a second blog editor.
+Retirement of the legacy `siteArchitecture.jsp` host ships in a follow-on
+slice. Blog authoring stays on Home / the Blogs gadget — Navigation will not
+grow a second blog editor.
 
 ## Current status (migration)
 
@@ -238,6 +262,7 @@ Home / the Blogs gadget — Navigation will not grow a second blog editor.
 | Site navigation tree browse (navons / sections) | **Available** |
 | Structure editing (create / rename / reorder / delete) | **Available** |
 | Section properties (title / folder / target / CSS / login) | **Available** |
+| Folder ACL user-list write (add/remove principals) | **Available** |
 | Move section (target-parent picker + optional position) | **Available** |
 | Convert section to folder / create section from folder | **Available** |
 | Landing page / section-link / external-link parity | **Available** |


### PR DESCRIPTION
## Summary

Architecture / Navigation can add and remove folder ACL principals for a selected regular section (including the site root). The shell reuses Explorer `FolderSecurityPanel`. Save uses `POST /pathmanagement/path/saveFolderProperties` when a folder GUID is available; otherwise `POST /sitemanage/section/update` with `folderPermission` so a later Properties save does not drop the ACL.

Parent tracker: #3092. Out of scope: full object ACL rewrite (#2274), deleting `siteArchitecture.jsp` (#3587), blog create/edit.

Fixes #3588

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` (standalone).
2. Open Navigation, select a regular section, **Folder ACL**.
3. Add a write principal, **Save** on the ACL list; remove it; **Save** again.
4. **Close** / Escape does not POST.
5. **Properties** **Save** still sends `folderPermission` (re-GET before update).
6. H2 QA: `perc-devctl qa-up` → hot-copy `cm/modern` → `npm run test:surface -- --path tests/architecture-nav-folder-acl.spec.js`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (operator Folder ACL steps; Still later ACL wording removed)
- [x] **Unit / module tests** — Vitest `folderAcl`, `FolderAclDialog`, `ArchitectureShell`; WebUI standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/architecture-nav-folder-acl.spec.js`
- [x] **Build gates** — `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS; Tests run: 2884, Failures: 0
- [x] **Cross-platform** — N/A (CMS URL paths only; no OS file I/O)

### C3 evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-19T03:50:26-04:00); Tests run: 2884, Failures: 0 (382 test files)
- **downstream_checked:** none (no Java public/protected API shape change; no `final`/`sealed` type)

### C5 UI proof

- **qa-up:** `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → RESULT:OK; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`; ADMIN_USERNAME=Admin
- **qa-health:** RESULT:OK HTTP:200 HEALTH:healthy (after qa-up). After later hot-copies, qa-health reported pre-existing `No content type info found for content type id: 315` (FastForward rffNav seed noise, not this feature)
- **deploy:** `docker cp WebUI/target/generated-webui/cm/modern/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`
- **Playwright:** `npm run test:surface -- --path tests/architecture-nav-folder-acl.spec.js` → **2 passed** (cancel no POST; UI add/remove + saveFolderProperties persist on sample About folder GUID)
- **console-clean:** yes (spec pageerror/console error filters)
- **server.log-clean:** yes for this feature; pre-existing 315 / site-root section-update rollback on Page-site roots noted (seed / nav type)

Human QA is deferred (`include_human_qa=false`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
