### PR TITLE
fix(sitemanage): load FastForward rffNavTree via percNav JCR alias (#3611)

### DIFF
--- a/docs/ai-generated/code-reviews/3611-section-tree-get-500-erlang.md
+++ b/docs/ai-generated/code-reviews/3611-section-tree-get-500-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3611 section/tree GET 500 FastForward NavTree
+
+**Branch:** `fix/issue-3611-section-tree-get-500`  
+**Base:** `origin/main`  
+**Date:** 2026-08-19  
+**Reviewer:** Erlang (independent pre-commit)  
+**Memory patterns hit:** missing behavioral tests; change-class completeness (product-docs + unit tests); FastForward rffNav* vs percNav* dual ids
+
+## Summary
+
+H2 QA sample sites keep `rffNavTree` items at content type **315**. ItemDefManager catalogs those editors, but after `perc.nav` the JCR `ms_configuration` map often only has `percNavTree` **1017**. `findNodesByIds` then threw `No content type info found for content type id: 315`, and `GET /section/tree/Corporate_Investments` returned HTTP 500 so Architecture Create section never mounted treeitems.
+
+Fix: perc/rff alias lookup in `PSContentRepository` (shared `RXS_CT_NAV*` tables). Missing-NavTree empty-200 is unchanged. Does not seed a second NavTree. Does not allowlist 500.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests cover alias selection, existing-rff load without seed, and REST not mapping type-315 failures to empty-200.
+
+Cross-platform path checklist: **clean** — no filesystem path construction.
+
+## Issues
+
+None (blocking).
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| JCR type lookup alias (313–315 ↔ 1015–1017) | Done |
+| `PSNavNameAliases.findRegisteredNavAliasTypeId` + tests | Done |
+| sitemanage loadTree existing-rff / REST no-empty-on-315 | Done |
+| `product-docs/8.2/admin/architecture-navigation.md` | Done |
+| Do not seed second NavTree / do not allowlist 500 | Honored |
+
+## Tests / builds observed
+
+- `cd system && ../mvnw.cmd clean install` BUILD SUCCESS — `PSNavNameAliasesTest` Tests run: 5; `PSServicesContentmgrTypedTest` Tests run: 6
+- `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS (stale SNAPSHOT so sitemanage compiled)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS — `PSSiteSectionServiceLoadTreeEmptyTest` Tests run: 8; `PSSiteSectionRestServiceLoadTreeEmptyTest` Tests run: 6
+- Live H2: `GET …/section/tree/Corporate_Investments` HTTP 200 with SectionNode children after perc-system hot-deploy
+- Playwright: `npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js` 2 passed; console-clean=yes; no new type-315 ERROR after Jetty restart

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -95,6 +95,14 @@ names as the same Navigation types. A site that already has an `rffNavTree` at
 the folder root is **not** empty — do not create a second tree. New sites
 created in this product use the `percNav*` names.
 
+`GET /Rhythmyx/services/sitemanage/section/tree/{site}` for a FastForward sample
+site (for example **Corporate_Investments**) returns **HTTP 200** with the seeded
+`rffNavTree` nodes — not HTTP 500 and not an empty tree. Sample items stay on
+type ids **313–315**. The `perc.nav` package registers `percNav*` under
+**1015–1017** and may omit a separate JCR mapping for 313–315; the server still
+loads those items through the matching perc/rff mapping (shared `RXS_CT_NAV*`
+tables). A site with no NavTree item still returns HTTP 200 with an empty tree.
+
 ## Keyboard and accessibility
 
 The navigation tree follows the ARIA tree pattern. **Tab** moves focus into

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
@@ -100,4 +100,13 @@ class PSSiteSectionRestServiceLoadTreeEmptyTest {
     assertThrows(
         IPSSiteSectionService.PSSiteSectionException.class, () -> rest.loadTree("Demo"));
   }
+
+  @Test
+  void loadTreeDoesNotMapType315FailureToEmptyTree() throws Exception {
+    when(siteSectionService.loadTree("Corporate_Investments"))
+        .thenThrow(
+            new RuntimeException("Failed to find items by IDs: No content type info found for content type id: 315"));
+    assertThrows(
+        RuntimeException.class, () -> rest.loadTree("Corporate_Investments"));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
@@ -185,6 +185,20 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
   }
 
   @Test
+  void loadTreeUsesExistingRffNavTreeWithoutSeedingSecond() throws Exception {
+    PSLegacyGuid existing = new PSLegacyGuid(360, 1);
+    when(navService.findNavigationIdFromFolder("//Sites/Demo")).thenReturn(existing);
+    stubCreatedNavTreeLoad(existing);
+
+    PSSectionNode tree = service.loadTree("Demo");
+    assertEquals(new PSLegacyGuid(360, -1).toString(), tree.getId());
+    assertEquals("Demo", tree.getTitle());
+    verify(navService, never())
+        .addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
   void loadTreeUsesExistingNavTreeAfterConcurrentCreate() throws Exception {
     PSLegacyGuid raced = new PSLegacyGuid(361, 1);
     when(navService.addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt()))

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -28,6 +28,7 @@ import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemChild;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.PSKey;
+import com.percussion.cms.objectstore.PSNavNameAliases;
 import com.percussion.cms.objectstore.server.IPSItemDefElementProcessor;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
@@ -149,6 +150,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import static com.percussion.services.utils.orm.PSDataCollectionHelper.clearIdSet;
 import static com.percussion.services.utils.orm.PSDataCollectionHelper.executeQuery;
@@ -503,10 +505,86 @@ public class PSContentRepository
      */
     public static PSTypeConfiguration getTypeConfiguration(int contenttypeid)
     {
-        synchronized (ms_configuration)
+        return lookupTypeConfiguration(contenttypeid);
+    }
+
+    /**
+     * JCR type map lookup with perc/rff Managed Nav alias fallback (#3611).
+     * {@code perc.nav} can drop the Hibernate mapping for FastForward ids
+     * 313–315 while {@link PSItemDefManager} still catalogs {@code rffNav*}
+     * editors. Those items share {@code RXS_CT_NAV*} with {@code percNav*}
+     * (1015–1017), so the registered sibling mapping loads the node.
+     */
+    static PSTypeConfiguration lookupTypeConfiguration(long contentTypeId)
+    {
+        PSTypeConfiguration config = ms_configuration.get(new PSContentTypeKey(contentTypeId));
+        if (config != null)
         {
-            PSContentTypeKey key = new PSContentTypeKey(contenttypeid);
-            return ms_configuration.get(key);
+            return config;
+        }
+        return lookupNavAliasTypeConfiguration(contentTypeId);
+    }
+
+    static PSTypeConfiguration lookupNavAliasTypeConfiguration(long contentTypeId)
+    {
+        Long aliasId =
+            resolveNavAliasTypeId(
+                contentTypeId,
+                ms_configuration.keySet(),
+                PSContentRepository::contentTypeNameQuietly);
+        if (aliasId == null)
+        {
+            return null;
+        }
+        PSTypeConfiguration alias = ms_configuration.get(new PSContentTypeKey(aliasId));
+        if (alias != null)
+        {
+            ms_log.debug(
+                "Using JCR type configuration {} as perc/rff alias for content type id {}",
+                aliasId,
+                contentTypeId);
+        }
+        return alias;
+    }
+
+    /**
+     * Package-visible so unit tests can pin perc/rff JCR alias selection
+     * without a live ItemDefManager (#3611).
+     */
+    static Long resolveNavAliasTypeId(
+        long missingTypeId,
+        Iterable<IPSTypeKey> registeredKeys,
+        Function<Long, String> typeIdToName)
+    {
+        if (registeredKeys == null)
+        {
+            return null;
+        }
+        Set<Long> registered = new HashSet<>();
+        for (IPSTypeKey k : registeredKeys)
+        {
+            if (k instanceof PSContentTypeKey)
+            {
+                registered.add(k.getContentType());
+            }
+        }
+        return PSNavNameAliases.findRegisteredNavAliasTypeId(
+            missingTypeId, typeIdToName, registered);
+    }
+
+    private static String contentTypeNameQuietly(long typeId)
+    {
+        try
+        {
+            return PSItemDefManager.getInstance().contentTypeIdToName(typeId);
+        }
+        catch (PSInvalidContentTypeException e)
+        {
+            return null;
+        }
+        catch (RuntimeException e)
+        {
+            return null;
         }
     }
 
@@ -674,9 +752,8 @@ public class PSContentRepository
                     if (summary == null)
                         continue;
                     GeneratedClassBase instance = loadedInstances.get(legacyguid);
-                    // Create type key
-                    IPSTypeKey key = new PSContentTypeKey(summary.getContentTypeId());
-                    PSTypeConfiguration config = ms_configuration.get(key);
+                    PSTypeConfiguration config =
+                            lookupTypeConfiguration(summary.getContentTypeId());
                     if (config == null)
                     {
                         throw new RepositoryException(
@@ -882,8 +959,7 @@ public class PSContentRepository
             long type = s.getContentTypeId();
             if (typeToClassMap.get(type) == null)
             {
-                IPSTypeKey key = new PSContentTypeKey(type);
-                PSTypeConfiguration config = ms_configuration.get(key);
+                PSTypeConfiguration config = lookupTypeConfiguration(type);
                 if (config == null)
                 {
                     ms_log.error("No content type info found for content type id: {}",type);
@@ -1644,8 +1720,12 @@ public class PSContentRepository
                 // level cache has already booted the data.
                 if (s == null)
                     continue;
-                IPSTypeKey key = new PSContentTypeKey(s.getContentTypeId());
-                PSTypeConfiguration config = ms_configuration.get(key);
+                PSTypeConfiguration config =
+                        lookupTypeConfiguration(s.getContentTypeId());
+                if (config == null)
+                {
+                    continue;
+                }
                 List<PSTypeConfiguration.ImplementingClass> classes = config
                         .getImplementingClasses();
                 for (PSTypeConfiguration.ImplementingClass ic : classes)
@@ -1839,8 +1919,7 @@ public class PSContentRepository
         // types
         for (Long typeid : typeids)
         {
-            IPSTypeKey key = new PSContentTypeKey(typeid);
-            PSTypeConfiguration type = ms_configuration.get(key);
+            PSTypeConfiguration type = lookupTypeConfiguration(typeid);
             if (type == null)
             {
                 throw new InvalidQueryException("Unknown content type id "
@@ -2014,8 +2093,7 @@ public class PSContentRepository
                                IPSQueryNode internalwhere, int maxresults,
                                Map<String, ? extends Object> params) throws InvalidQueryException
     {
-        IPSTypeKey key = new PSContentTypeKey(typeid);
-        PSTypeConfiguration type = ms_configuration.get(key);
+        PSTypeConfiguration type = lookupTypeConfiguration(typeid);
         if (type == null)
         {
             // Demoted from WARN in v8.1.7 PR #853 / GH-849: this fires frequently for obsolete

--- a/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
@@ -17,8 +17,10 @@
 package com.percussion.cms.objectstore;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -61,6 +63,57 @@ public final class PSNavNameAliases {
   /** {@code percNavon} or {@code rffNavon} (any case). */
   public static boolean isNavonTypeName(String typeName) {
     return "navon".equals(navRoleKey(typeName));
+  }
+
+  /** {@code percNavImage} or {@code rffNavImage} (any case). */
+  public static boolean isNavImageTypeName(String typeName) {
+    return "navimage".equals(navRoleKey(typeName));
+  }
+
+  /** True for perc/rff NavTree, Navon, or Nav Image type names. */
+  public static boolean isNavTypeName(String typeName) {
+    return isNavTreeTypeName(typeName)
+        || isNavonTypeName(typeName)
+        || isNavImageTypeName(typeName);
+  }
+
+  /**
+   * When a FastForward {@code rffNav*} type (313–315) is missing from the JCR
+   * configuration map but a {@code percNav*} sibling is registered (1015–1017),
+   * or the inverse, return the registered alias id. Both pairs share {@code
+   * RXS_CT_NAV*} tables, so items of the missing id load with the alias
+   * mapping. Returns {@code null} when the missing id is not a nav type or no
+   * sibling is registered.
+   */
+  public static Long findRegisteredNavAliasTypeId(
+      long missingTypeId,
+      Function<Long, String> typeIdToName,
+      Collection<Long> registeredTypeIds) {
+    if (typeIdToName == null || registeredTypeIds == null || registeredTypeIds.isEmpty()) {
+      return null;
+    }
+    String missingName = typeNameQuietly(typeIdToName, missingTypeId);
+    if (!isNavTypeName(missingName)) {
+      return null;
+    }
+    for (Long registered : registeredTypeIds) {
+      if (registered == null || registered.longValue() == missingTypeId) {
+        continue;
+      }
+      String registeredName = typeNameQuietly(typeIdToName, registered);
+      if (sameNavRole(missingName, registeredName)) {
+        return registered;
+      }
+    }
+    return null;
+  }
+
+  private static String typeNameQuietly(Function<Long, String> typeIdToName, long typeId) {
+    try {
+      return typeIdToName.apply(typeId);
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
@@ -18,9 +18,11 @@ package com.percussion.cms.objectstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class PSNavNameAliasesTest {
@@ -58,6 +60,37 @@ class PSNavNameAliasesTest {
     assertTrue(PSNavNameAliases.isNavonTypeName("rffNavon"));
     assertTrue(PSNavNameAliases.isNavonTypeName("percNavon"));
     assertFalse(PSNavNameAliases.isNavonTypeName("rffNavTree"));
+    assertTrue(PSNavNameAliases.isNavImageTypeName("rffNavImage"));
+    assertTrue(PSNavNameAliases.isNavImageTypeName("percNavImage"));
+    assertTrue(PSNavNameAliases.isNavTypeName("rffNavTree"));
+    assertFalse(PSNavNameAliases.isNavTypeName("percPage"));
+    assertFalse(PSNavNameAliases.isNavTypeName(null));
+  }
+
+  @Test
+  void findRegisteredNavAliasTypeIdMapsRffNavTreeToPercNavTree() {
+    Map<Long, String> names =
+        Map.of(
+            315L, "rffNavTree",
+            1017L, "percNavTree",
+            314L, "rffNavon",
+            1016L, "percNavon",
+            1001L, "percPage");
+    assertEquals(
+        1017L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, names.keySet()));
+    assertEquals(
+        315L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(1017L, names::get, names.keySet()));
+    assertEquals(
+        1016L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(314L, names::get, names.keySet()));
+    assertNull(
+        PSNavNameAliases.findRegisteredNavAliasTypeId(1001L, names::get, names.keySet()));
+    assertNull(
+        PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, List.of(315L, 1001L)));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, List.of()));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, null, names.keySet()));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
@@ -21,10 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.contentmgr.IPSContentPropertyConstants;
+import com.percussion.services.contentmgr.impl.IPSTypeKey;
 import com.percussion.system.utils.IPSHtmlParameters;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -92,5 +95,18 @@ class PSServicesContentmgrTypedTest {
     Map<String, Object> remapped = PSContentRepository.remapFolderId(raw);
     assertEquals(8, remapped.get("rx:sys_contentid"));
     assertNull(remapped.get(IPSContentPropertyConstants.RX_SYS_FOLDERID));
+  }
+
+  @Test
+  @DisplayName("rffNavTree 315 aliases to percNavTree 1017 JCR mapping")
+  void resolveNavAliasTypeIdMapsRffNavTreeToPerc() {
+    Set<IPSTypeKey> registered =
+        Set.of(new PSContentTypeKey(1017), new PSContentTypeKey(1001));
+    Map<Long, String> names =
+        Map.of(315L, "rffNavTree", 1017L, "percNavTree", 1001L, "percPage");
+    assertEquals(
+        1017L, PSContentRepository.resolveNavAliasTypeId(315L, registered, names::get));
+    assertNull(PSContentRepository.resolveNavAliasTypeId(1001L, registered, names::get));
+    assertNull(PSContentRepository.resolveNavAliasTypeId(315L, List.of(), names::get));
   }
 }


### PR DESCRIPTION
## Summary

H2 QA FastForward sample sites already have `rffNavTree` items (content type **315**). After `perc.nav` registers `percNavTree` at **1017**, the JCR type map often has no mapping for 315. `GET /Rhythmyx/services/sitemanage/section/tree/Corporate_Investments` then threw `No content type info found for content type id: 315` (HTTP 500), so Architecture never mounted `role="treeitem"` and Create section stayed dead.

This change resolves perc/rff Managed Nav aliases in `PSContentRepository` so 313–315 items load through the registered 1015–1017 Hibernate mapping (shared `RXS_CT_NAV*` tables). Missing-NavTree still returns empty HTTP 200. Does **not** seed a second NavTree. Does **not** allowlist 500.

Parent trackers: #3589 / #3092. Cycle-verify residual of cluster #3610.

Fixes #3611
Partial #3589
Partial #3092

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (H2 cell HEALTH:healthy / HTTP 200). Known #3606 FastForward GIF `server_log_errors` may still fail the RESULT line while Health=healthy.
2. Login as Admin. `GET /Rhythmyx/services/sitemanage/section/tree/Corporate_Investments` must be HTTP **200** with `SectionNode` children (not empty, not 500).
3. From `modules/perc-qa-automation/frontend`:
   `TEST_CMS_URL=<from qa-health> ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from cell> TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js`
   Expect 2 passed: treeitems visible, Create section enabled, Escape closes, console-clean via `isKnownArchitectureConsoleNoise`.
4. Always `python docker/scripts/perc-devctl.py qa-down`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (sample-site tree GET 200 + perc/rff JCR alias)
- [x] **Unit / module tests** — `PSNavNameAliasesTest`, `PSServicesContentmgrTypedTest`, `PSSiteSectionServiceLoadTreeEmptyTest`, `PSSiteSectionRestServiceLoadTreeEmptyTest`
- [x] **WebUI + Playwright** — existing `architecture-create-section-noskip.spec.js` (no skip); C5 H2 surface 2 passed
- [x] **Build gates** — standalone `mvnw clean install` on changed modules
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `system`, `projects/sitemanage` (`rest` installed first because local SNAPSHOT was stale vs `origin/main` VirtualSiteProperties; not a source change in this PR)
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (01:40). `PSNavNameAliasesTest` Tests run: 5, Failures: 0. `PSServicesContentmgrTypedTest` Tests run: 6, Failures: 0.
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS (stale SNAPSHOT so sitemanage compiled)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (52.7s). `PSSiteSectionServiceLoadTreeEmptyTest` Tests run: 8, Failures: 0. `PSSiteSectionRestServiceLoadTreeEmptyTest` Tests run: 6, Failures: 0.
- **downstream_checked:** none (no type made `final`/`sealed`; no public/protected method or ctor signature change). `getTypeConfiguration(int)` same signature; null-miss now may resolve perc/rff alias. Grep `extends PSContentRepository` / `new PSContentRepository() {` — no matches.

## C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up` — cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`
- qa-health: HTTP 200 / HEALTH:healthy; RESULT:FAIL `DETAIL:server_log_errors` FastForward GIF import (BUG:#3606 / PR #3607, not this spec)
- Deploy: `docker cp` `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/WEB-INF/lib/`; in-cell `StopJetty.sh` / `StartJetty.sh` (not `docker restart`)
- After restart: `GET …/section/tree/Corporate_Investments` HTTP 200 with Corporate Investments Home + child sections
- Playwright: `node scripts/run-surface.js --path tests/architecture-create-section-noskip.spec.js` → **2 passed** (2.9s)
- console-clean=yes (spec asserts `isKnownArchitectureConsoleNoise`)
- server.log-clean=yes for the post-restart test window (no new type-315 ERROR)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
