### PR TITLE
fix(sitemanage): SiteManageErrorCodes call-site in PSSiteDao (#3584)

### DIFF
--- a/docs/ai-generated/code-reviews/3584-sitemanage-error-codes-erlang.md
+++ b/docs/ai-generated/code-reviews/3584-sitemanage-error-codes-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — #3584 SiteManage IPSSiteManageErrors → SiteManageErrorCodes
+
+- Branch: `fix/issue-3584-sitemanage-error-codes`
+- Base: `origin/main`
+- Date: 2026-08-19
+- Recommendation: **approve**
+- Gate: **May commit/push: yes**
+- Memory patterns hit: behavioral tests for changed logic; incomplete change-class closure (enum + skip dual-write + production call-site already present)
+
+## Summary
+
+Leftover sitemanage production call site in `PSSiteDao.loadSite` now constructs `PSException` from typed `SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD` (`IPSErrorCode`). Legacy `IPSSiteManageErrors` remains as a documented int bridge. Dual-write skip already existed on the registry test and is now also asserted from `SiteManageErrorCodesTest`. Focused `PSSiteDaoLoadSiteBadNavTest` covers the missing-nav delete path and the non-matching nav rethrow without cactus.
+
+## Change class
+
+Typed ErrorCodes production call-site conversion (non-auditable CFG 18252).
+
+Companions present: existing enum + registry registration; skip dual-write tests; same-package unit test for `loadSite`; bridge interface retained.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path / I/O changes.
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd modules/perc-auditlog && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 292, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1336, Failures: 0, Skipped: 125 (`PSSiteDaoLoadSiteBadNavTest` 3/3)

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodesTest.java
@@ -22,7 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.AuditLogId;
 import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.Test;
 
 class SiteManageErrorCodesTest {
@@ -38,5 +43,20 @@ class SiteManageErrorCodesTest {
     assertNotNull(code.userMessageTemplate());
     assertNotNull(code.logMessageTemplate());
     assertTrue(code.qualifiedCode().startsWith("CFG-"));
+  }
+
+  @Test
+  void deletingBadSiteRecordSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD.numericCode(),
+            AuditContext.empty());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteDao.java
@@ -20,6 +20,7 @@ package com.percussion.sitemanage.dao.impl;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
+import com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.error.PSException;
 import com.percussion.fastforward.managednav.IPSNavigationErrors;
@@ -38,7 +39,6 @@ import com.percussion.sitemanage.dao.IPSiteDao;
 import com.percussion.sitemanage.data.PSSite;
 import com.percussion.sitemanage.data.PSSitePublishProperties;
 import com.percussion.sitemanage.data.PSSiteSummary;
-import com.percussion.sitemanage.error.IPSSiteManageErrors;
 import com.percussion.util.PSPathUtil;
 import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.publishing.PSPublishingWsLocator;
@@ -160,7 +160,8 @@ public class PSSiteDao implements IPSiteDao {
     } catch (PSNavException e) {
       if (e.getErrorCode() == IPSNavigationErrors.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH) {
         var ex =
-            new PSException(IPSSiteManageErrors.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD, name);
+            new PSException(
+                SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD, name);
         log.warn(PSExceptionUtils.getMessageForLog(ex));
         log.debug(ex);
         this.delete(sum.getId());

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/error/IPSSiteManageErrors.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/error/IPSSiteManageErrors.java
@@ -18,7 +18,13 @@
 
 package com.percussion.sitemanage.error;
 
-/** Defines the error codes produced by the site management service. */
+/**
+ * Legacy int bridge for site-management service error codes.
+ *
+ * <p>New production call sites must use {@link
+ * com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes}. Do not delete this interface until
+ * the family migration is complete.
+ */
 public interface IPSSiteManageErrors {
   /** Error code category for site management service errors. */
   int SITE_MANAGE_SERVICE_CATEGORY = 18251; // through 1900

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteDaoLoadSiteBadNavTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/dao/impl/PSSiteDaoLoadSiteBadNavTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes;
+import com.percussion.error.PSException;
+import com.percussion.fastforward.managednav.IPSNavigationErrors;
+import com.percussion.fastforward.managednav.PSNavException;
+import com.percussion.sitemanage.dao.IPSSiteContentDao;
+import com.percussion.sitemanage.dao.IPSSitePublishDao;
+import com.percussion.sitemanage.data.PSSite;
+import com.percussion.sitemanage.data.PSSiteSummary;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * {@link PSSiteDao#loadSite(String)} deletes a site whose nav folder is missing, using typed {@link
+ * SiteManageErrorCodes} (non-auditable). Avoids cactus / publishing locator.
+ */
+class PSSiteDaoLoadSiteBadNavTest {
+
+  @Mock private IPSSiteContentDao siteContentDao;
+  @Mock private IPSSitePublishDao sitePublishDao;
+
+  private RecordingSiteDao dao;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    dao = new RecordingSiteDao(siteContentDao, sitePublishDao);
+  }
+
+  @Test
+  void loadSiteDeletesWhenNavFolderMissing() throws Exception {
+    PSSiteSummary sum = summary("BrokenSite");
+    when(sitePublishDao.findSummary("BrokenSite")).thenReturn(sum);
+    when(siteContentDao.getNavTitle(sum))
+        .thenThrow(
+            new PSNavException(
+                IPSNavigationErrors.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH));
+
+    PSSite result = dao.loadSite("BrokenSite");
+
+    assertNull(result);
+    // PSSiteSummary.getId() is the site name (legacy identity used by delete()).
+    assertEquals(List.of("BrokenSite"), dao.deletedIds);
+  }
+
+  @Test
+  void loadSiteRethrowsOtherNavErrorsWithoutDelete() throws Exception {
+    PSSiteSummary sum = summary("OtherNav");
+    when(sitePublishDao.findSummary("OtherNav")).thenReturn(sum);
+    when(siteContentDao.getNavTitle(sum))
+        .thenThrow(
+            new PSNavException(
+                IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE));
+
+    PSNavException thrown = assertThrows(PSNavException.class, () -> dao.loadSite("OtherNav"));
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE,
+        thrown.getErrorCode());
+    assertTrue(dao.deletedIds.isEmpty());
+  }
+
+  @Test
+  void typedSiteManageExceptionIsNonAuditable() {
+    PSException ex =
+        new PSException(
+            SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD, "BrokenSite");
+    assertSame(
+        SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD, ex.getTypedErrorCode());
+    assertEquals(18252, ex.getErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  private static PSSiteSummary summary(String name) {
+    PSSiteSummary sum = new PSSiteSummary();
+    sum.setName(name);
+    return sum;
+  }
+
+  static final class RecordingSiteDao extends PSSiteDao {
+    final List<String> deletedIds = new ArrayList<>();
+
+    RecordingSiteDao(IPSSiteContentDao content, IPSSitePublishDao publish) {
+      super(content, publish);
+    }
+
+    @Override
+    public void delete(String id) {
+      deletedIds.add(id);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Parent #2616 leftover sitemanage production call site now uses typed `SiteManageErrorCodes` instead of a bare `IPSSiteManageErrors` int.

`PSSiteDao.loadSite` constructs `PSException(SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD, name)`. The enum already existed (CFG 18252, `isAuditable=false`); this slice does not recreate it. Legacy `IPSSiteManageErrors` is kept as a documented int bridge.

No new bare `IPSSiteManageErrors` production constants remain.

Fixes #3584
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
2. Confirm `SiteManageErrorCodesTest` (2 tests) and `LegacyErrorCodeRegistryTest.siteManageNonAuditableSkipsDualWrite`.
3. `cd projects/sitemanage && ../../mvnw.cmd clean install`
4. Confirm `PSSiteDaoLoadSiteBadNavTest` (missing-nav delete, other-nav rethrow, typed exception non-auditable).

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-code call-site conversion; no operator/admin/UI/API/config change
- [x] **Unit / module tests** — `SiteManageErrorCodesTest.deletingBadSiteRecordSkipsDualWrite`; `PSSiteDaoLoadSiteBadNavTest`; both modules standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `projects/sitemanage`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 292, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1336, Failures: 0, Skipped: 125
- **downstream_checked:** none (C2 did not apply — no public/protected API shape change, no `final`/`sealed` type change)

### C5 UI proof

N/A — Java backend typed-error conversion only.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
