### PR TITLE
fix(webservices): leftover IPSWebserviceErrors call sites to WebserviceErrorCodes (#3585)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRelationshipDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRelationshipDefDependencyHandler.java
@@ -42,7 +42,7 @@ import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.config.PSConfigManager;
 import com.percussion.services.error.PSNotFoundException;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -227,7 +227,7 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
       }
 
       // save the new one
-      PSWebserviceUtils.saveRelationshipConfigSet(cfgSet, IPSWebserviceErrors.SAVE_FAILED);
+      PSWebserviceUtils.saveRelationshipConfigSet(cfgSet, WebserviceErrorCodes.SAVE_FAILED);
 
       // log txn entry
       int action =

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
@@ -20,10 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditLogId;
 import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -84,5 +90,59 @@ class WebserviceErrorCodesTest {
     assertEquals(32, WebserviceErrorCodes.ACCESS_CONTROL_ERROR.numericCode());
     assertEquals(72, WebserviceErrorCodes.NOT_AUTHORIZED.numericCode());
     assertEquals(73, WebserviceErrorCodes.FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID.numericCode());
+  }
+
+  @Test
+  void collidingSessionCodesDualWriteViaEnumNotFlatInt() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId invalid =
+        svc.log(
+            WebserviceErrorCodes.INVALID_SESSION,
+            AuditContext.builder().actor("jdoe").build(),
+            "sid");
+    assertFalse(invalid.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(WebserviceErrorCodes.INVALID_SESSION, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-3]-"));
+
+    AuditLogId missing =
+        svc.log(
+            WebserviceErrorCodes.MISSING_SESSION,
+            AuditContext.builder().actor("jdoe").build());
+    assertFalse(missing.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(WebserviceErrorCodes.MISSING_SESSION, sink.records().get(1).code());
+  }
+
+  @Test
+  void accessControlDualWritesViaRegisteredInt() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebserviceErrorCodes.ACCESS_CONTROL_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "guid",
+            "READ");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertSame(WebserviceErrorCodes.ACCESS_CONTROL_ERROR, sink.records().get(0).code());
+  }
+
+  @Test
+  void operationalSaveFailedSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        svc.log(
+            WebserviceErrorCodes.SAVE_FAILED,
+            AuditContext.builder().actor("jdoe").build(),
+            "obj");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
   }
 }

--- a/system/business/src/com/percussion/rx/design/impl/PSRelationshipConfigModel.java
+++ b/system/business/src/com/percussion/rx/design/impl/PSRelationshipConfigModel.java
@@ -27,7 +27,7 @@ import com.percussion.services.relationship.IPSRelationshipService;
 import com.percussion.services.relationship.PSRelationshipServiceLocator;
 import com.percussion.util.IOTools;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -180,7 +180,7 @@ public class PSRelationshipConfigModel extends PSDesignModel
             PSRelationshipCommandHandler.getConfigurationSet();
          cfgSet.deleteConfig(name);
          PSWebserviceUtils.saveRelationshipConfigSet(cfgSet, 
-               IPSWebserviceErrors.DELETE_FAILED);
+               WebserviceErrorCodes.DELETE_FAILED);
       }
       catch (Exception e) 
       {

--- a/system/services/src/com/percussion/services/locking/impl/PSObjectLockService.java
+++ b/system/services/src/com/percussion/services/locking/impl/PSObjectLockService.java
@@ -28,7 +28,7 @@ import com.percussion.services.utils.orm.PSCriteriaQueryRepeater;
 import com.percussion.services.utils.orm.PSORMUtils;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.PSWebserviceErrors;
@@ -218,7 +218,7 @@ public class PSObjectLockService
 
             createLock(id, session, user, version, overrideLock);
          } catch (PSLockException e) {
-            int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+            var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
             PSLockErrorException error = new PSLockErrorException(code,
                     PSWebserviceErrors.createErrorMessage(code,
                             value.getClass().getName(), new PSDesignGuid(id).getValue(),

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
@@ -51,7 +51,7 @@ import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSWebserviceErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.IOException;
@@ -535,7 +535,7 @@ public class PSContentTypeHelper {
    */
   public static void validateUniqueName(String name) {
     if (doesContentTypeExist(name)) {
-      int code = IPSWebserviceErrors.OBJECT_ALREADY_EXISTS;
+      var code = WebserviceErrorCodes.OBJECT_ALREADY_EXISTS;
       throw new IllegalArgumentException(
           PSWebserviceErrors.createErrorMessage(code, PSTypeEnum.NODEDEF, name));
     }

--- a/system/src/test/java/com/percussion/webservices/PSWebserviceTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/webservices/PSWebserviceTypedErrorCodeSliceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webservices;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3585 (parent #2616): leftover webservice production call sites must throw typed {@link
+ * WebserviceErrorCodes} via IPSErrorCode-aware {@link PSErrorException} constructors — not bare
+ * {@code IPSWebserviceErrors} ints.
+ */
+@Tag("UnitTest")
+public class PSWebserviceTypedErrorCodeSliceTest {
+
+  @Test
+  public void accessControlRetainsTypedAuditableCode() {
+    PSErrorException ex =
+        new PSErrorException(
+            WebserviceErrorCodes.ACCESS_CONTROL_ERROR, "denied", "stack");
+    assertEquals(WebserviceErrorCodes.ACCESS_CONTROL_ERROR.numericCode(), ex.getCode());
+    assertSame(WebserviceErrorCodes.ACCESS_CONTROL_ERROR, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+  }
+
+  @Test
+  public void invalidSessionRetainsTypedAuditableCode() {
+    PSErrorException ex =
+        new PSErrorException(WebserviceErrorCodes.INVALID_SESSION, "bad session", "stack");
+    assertEquals(3, ex.getCode());
+    assertSame(WebserviceErrorCodes.INVALID_SESSION, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+  }
+
+  @Test
+  public void saveFailedRetainsTypedNonAuditableCode() {
+    PSErrorException ex =
+        new PSErrorException(WebserviceErrorCodes.SAVE_FAILED, "save failed", "stack");
+    assertEquals(6, ex.getCode());
+    assertSame(WebserviceErrorCodes.SAVE_FAILED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void legacyIntConstructionHasNoTypedCode() {
+    PSErrorException ex = new PSErrorException(6, "save failed", "stack");
+    assertEquals(6, ex.getCode());
+    assertNull(ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSErrorException(null, "msg", "stack"));
+  }
+
+  @Test
+  public void createErrorMessageAcceptsTypedCode() {
+    String msg =
+        PSWebserviceErrors.createErrorMessage(
+            WebserviceErrorCodes.OBJECT_NOT_FOUND, "PSAclImpl", 42L);
+    assertFalse(msg.isBlank());
+  }
+
+  @Test
+  public void notAuthorizedLockSubclassRetainsTypedCode() {
+    PSLockErrorException ex =
+        new PSLockErrorException(
+            WebserviceErrorCodes.CREATE_LOCK_FAILED, "lock failed", "stack", "alice", 5L);
+    assertEquals(5, ex.getCode());
+    assertSame(WebserviceErrorCodes.CREATE_LOCK_FAILED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+    assertEquals("alice", ex.getLocker());
+    assertEquals(5L, ex.getRemainingTime());
+  }
+}

--- a/system/src/test/java/com/percussion/webservices/transformation/PSTransformationTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/webservices/transformation/PSTransformationTypedErrorCodeSliceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webservices.transformation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.percussion.webservices.transformation.converter.PSConverter;
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.beanutils.Converter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3585 (parent #2616): leftover transformation call sites use typed {@link
+ * TransformationErrorCodes} (not bare {@code IPSTransformationErrors} ints). Package-local int 1 is
+ * not flat-registered (Workflow collision).
+ */
+@Tag("UnitTest")
+public class PSTransformationTypedErrorCodeSliceTest {
+
+  @Test
+  public void noConverterFoundRetainsTypedNonAuditableCode() {
+    PSTransformationException ex =
+        new PSTransformationException(
+            TransformationErrorCodes.NO_CONVERTER_FOUND, "com.example.Missing");
+    assertEquals(1, ex.getErrorCode());
+    assertSame(TransformationErrorCodes.NO_CONVERTER_FOUND, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSTransformationException(null));
+  }
+
+  @Test
+  public void missingConverterMessageUsesTypedCatalogCode() {
+    BeanUtilsBean beans = new BeanUtilsBean();
+    beans.getConvertUtils().deregister();
+    ProbeConverter probe = new ProbeConverter(beans);
+    ConversionException ex =
+        assertThrows(ConversionException.class, () -> probe.lookup(UnregisteredType.class));
+    assertTrue(ex.getMessage().contains("UnregisteredType") || ex.getMessage().contains("1:"));
+  }
+
+  /** Exposes protected {@link PSConverter#getConverter(Class)} for the leftover throw site. */
+  private static final class ProbeConverter extends PSConverter {
+    ProbeConverter(BeanUtilsBean beanUtils) {
+      super(beanUtils);
+    }
+
+    Converter lookup(Class<?> type) {
+      return getConverter(type);
+    }
+  }
+
+  private static final class UnregisteredType {}
+}

--- a/system/webservices/src/com/percussion/webservices/PSBaseSOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/PSBaseSOAPImpl.java
@@ -17,6 +17,8 @@
 // REFACTORED: CP-JAVA11, CP-SOAP
 package com.percussion.webservices;
 
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
+
 import com.percussion.cms.IPSConstants;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.services.security.PSServletRequestWrapper;
@@ -219,16 +221,16 @@ public class PSBaseSOAPImpl {
         try {
             var sessionOpt = getRhythmyxSession();
             if (sessionOpt.isEmpty()) {
-                var code = IPSWebserviceErrors.MISSING_SESSION;
+                var code = WebserviceErrorCodes.MISSING_SESSION;
                 logger.debug("Authentication Error: Missing session header");
-                throw new PSInvalidSessionFault(code,
+                throw new PSInvalidSessionFault(code.numericCode(),
                     PSWebserviceErrors.createErrorMessage(code, "Missing session header"),
                     "Missing required Rhythmyx session header");
             }
 
             var sessionId = sessionOpt.get();
             var request = getServletRequest().orElseThrow(() ->
-                new PSInvalidSessionFault(IPSWebserviceErrors.INVALID_SESSION,
+                new PSInvalidSessionFault(WebserviceErrorCodes.INVALID_SESSION.numericCode(),
                     "Servlet request not available", "No servlet request context"));
 
             PSSecurityFilter.authenticate(request, sessionId);
@@ -236,11 +238,11 @@ public class PSBaseSOAPImpl {
 
         } catch (LoginException | SOAPException ex) {
             var code = ex instanceof SOAPException
-                ? IPSWebserviceErrors.MISSING_SESSION
-                : IPSWebserviceErrors.INVALID_SESSION;
+                ? WebserviceErrorCodes.MISSING_SESSION
+                : WebserviceErrorCodes.INVALID_SESSION;
 
             logger.debug("Authentication Error Code: {}", code, ex);
-            throw new PSInvalidSessionFault(code,
+            throw new PSInvalidSessionFault(code.numericCode(),
                 PSWebserviceErrors.createErrorMessage(code, ex.toString()),
                 ExceptionUtils.getStackTrace(ex));
         }
@@ -311,10 +313,10 @@ public class PSBaseSOAPImpl {
             throw new IllegalArgumentException("serviceName may not be null.");
         }
 
-        var code = IPSWebserviceErrors.INVALID_CONTRACT;
+        var code = WebserviceErrorCodes.INVALID_CONTRACT;
         logger.error("SOAP Invalid Contract for service {}", serviceName, e);
 
-        throw new PSContractViolationFault(code,
+        throw new PSContractViolationFault(code.numericCode(),
             PSWebserviceErrors.createErrorMessage(code, serviceName, e.toString()),
             ExceptionUtils.getStackTrace(e));
     }
@@ -342,10 +344,10 @@ public class PSBaseSOAPImpl {
 
         if (e.getCause() instanceof PSAuthorizationException) {
             logger.debug("SOAP PSAuthorizationException for service {}", serviceName, e);
-            var code = IPSWebserviceErrors.NOT_AUTHORIZED;
+            var code = WebserviceErrorCodes.NOT_AUTHORIZED;
             var remoteUser = getRemoteUser().orElse("unknown");
 
-            throw new PSNotAuthorizedFault(code,
+            throw new PSNotAuthorizedFault(code.numericCode(),
                 PSWebserviceErrors.createErrorMessage(code, remoteUser, serviceName, e.toString()),
                 ExceptionUtils.getStackTrace(e));
         } else {

--- a/system/webservices/src/com/percussion/webservices/PSErrorException.java
+++ b/system/webservices/src/com/percussion/webservices/PSErrorException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -34,6 +35,12 @@ public class PSErrorException extends RuntimeException
     * The error code.
     */
    private int code;
+
+   /**
+    * Typed catalog code when constructed via {@link IPSErrorCode} overloads;
+    * otherwise {@code null} for legacy int construction.
+    */
+   private transient IPSErrorCode typedErrorCode;
    
    /**
     * The error message, never <code>null</code> or empty after construction.
@@ -79,6 +86,22 @@ public class PSErrorException extends RuntimeException
       setErrorMessage(errorMessage);
       setStack(stack);
    }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}. Sets the legacy
+    * numeric code for SOAP / message lookup and retains the typed code for
+    * {@link #getTypedErrorCode()} / {@link #isAuditable()}.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param errorMessage the error message, may be <code>null</code> or empty.
+    * @param stack the stack trace from where the error happened, not
+    *    <code>null</code> or empty.
+    */
+   public PSErrorException(IPSErrorCode code, String errorMessage, String stack)
+   {
+      this(requireCode(code).numericCode(), errorMessage, stack);
+      this.typedErrorCode = code;
+   }
    
    public PSErrorException(String errorMsg)
    {
@@ -105,6 +128,21 @@ public class PSErrorException extends RuntimeException
    }
 
    /**
+    * Typed construction with a causal exception.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param errorMessage the error message, may be <code>null</code> or empty.
+    * @param stack the stack trace from where the error happened, not
+    *    <code>null</code> or empty.
+    * @param e The original exception that needs to be set as cause.
+    */
+   public PSErrorException(IPSErrorCode code, String errorMessage, String stack, Exception e)
+   {
+      this(requireCode(code).numericCode(), errorMessage, stack, e);
+      this.typedErrorCode = code;
+   }
+
+   /**
     * Get the error code.
     * 
     * @return the error code uniquely identifies a specific error.
@@ -122,6 +160,46 @@ public class PSErrorException extends RuntimeException
    public void setCode(int code)
    {
       this.code = code;
+      this.typedErrorCode = null;
+   }
+
+   /**
+    * Set a catalogued error code. Retains {@code code} for
+    * {@link #getTypedErrorCode()} / {@link #isAuditable()}.
+    *
+    * @param code catalogued error code, never {@code null}
+    */
+   public void setCode(IPSErrorCode code)
+   {
+      this.code = requireCode(code).numericCode();
+      this.typedErrorCode = code;
+   }
+
+   /**
+    * Typed error code when constructed via {@link #PSErrorException(IPSErrorCode, String, String)}
+    * (or overloads); otherwise {@code null} for legacy int construction.
+    */
+   public IPSErrorCode getTypedErrorCode()
+   {
+      return typedErrorCode;
+   }
+
+   /**
+    * Whether dual-write should consider this exception auditable. Prefer the typed
+    * code when present; legacy int construction returns {@code false}.
+    */
+   public boolean isAuditable()
+   {
+      return typedErrorCode != null && typedErrorCode.isAuditable();
+   }
+
+   private static IPSErrorCode requireCode(IPSErrorCode code)
+   {
+      if (code == null)
+      {
+         throw new IllegalArgumentException("code may not be null");
+      }
+      return code;
    }
    
    /**

--- a/system/webservices/src/com/percussion/webservices/PSInvalidLocaleException.java
+++ b/system/webservices/src/com/percussion/webservices/PSInvalidLocaleException.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * Thrown for services operating with locales. 
  */
@@ -38,6 +40,15 @@ public class PSInvalidLocaleException extends PSErrorException
     * @see PSErrorException#PSErrorException(int, String, String)
     */
    public PSInvalidLocaleException(int code, String errorMessage, 
+      String stack)
+   {
+      super(code, errorMessage, stack);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    */
+   public PSInvalidLocaleException(IPSErrorCode code, String errorMessage,
       String stack)
    {
       super(code, errorMessage, stack);

--- a/system/webservices/src/com/percussion/webservices/PSInvalidStateException.java
+++ b/system/webservices/src/com/percussion/webservices/PSInvalidStateException.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * Thrown for services operating on objects in an invalid state for that 
  * service. 
@@ -39,6 +41,15 @@ public class PSInvalidStateException extends PSErrorException
     * @see PSErrorException#PSErrorException(int, String, String)
     */
    public PSInvalidStateException(int code, String errorMessage, 
+      String stack)
+   {
+      super(code, errorMessage, stack);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    */
+   public PSInvalidStateException(IPSErrorCode code, String errorMessage,
       String stack)
    {
       super(code, errorMessage, stack);

--- a/system/webservices/src/com/percussion/webservices/PSLockErrorException.java
+++ b/system/webservices/src/com/percussion/webservices/PSLockErrorException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.services.locking.PSLockException;
 import com.percussion.services.locking.data.PSObjectLock;
 import com.percussion.utils.guid.IPSGuid;
@@ -135,6 +136,19 @@ public class PSLockErrorException extends PSErrorException
    }
 
    /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param message the error message, may be <code>null</code> or empty.
+    * @param stack the stack trace from where the error happened, not
+    *    <code>null</code> or empty.
+    */
+   public PSLockErrorException(IPSErrorCode code, String message, String stack)
+   {
+      super(code, message, stack);
+   }
+
+   /**
     * Constructor the adds additional parameters to 
     * {@link #PSLockErrorException(int, String, String)}.
     * 
@@ -148,6 +162,28 @@ public class PSLockErrorException extends PSErrorException
    {
       super(code, message, stack);
       
+      setLocker(locker);
+      if (locker != null)
+         setRemainingTime(remainingTime);
+   }
+
+   /**
+    * Typed construction with locker metadata.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param message the error message, may be <code>null</code> or empty.
+    * @param stack the stack trace from where the error happened, not
+    *    <code>null</code> or empty.
+    * @param locker the name of the user locking the requested object, may
+    *    be <code>null</code>, not empty.
+    * @param remainingTime the remaining lock time, is ignored if the supplied
+    *    locker is <code>null</code>.
+    */
+   public PSLockErrorException(IPSErrorCode code, String message, String stack,
+      String locker, long remainingTime)
+   {
+      super(code, message, stack);
+
       setLocker(locker);
       if (locker != null)
          setRemainingTime(remainingTime);

--- a/system/webservices/src/com/percussion/webservices/PSUnknownChildException.java
+++ b/system/webservices/src/com/percussion/webservices/PSUnknownChildException.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * Thrown for services operating with unknown child tables. 
  */
@@ -38,6 +40,15 @@ public class PSUnknownChildException extends PSErrorException
     * @see PSErrorException#PSErrorException(int, String, String)
     */
    public PSUnknownChildException(int code, String errorMessage, 
+      String stack)
+   {
+      super(code, errorMessage, stack);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    */
+   public PSUnknownChildException(IPSErrorCode code, String errorMessage,
       String stack)
    {
       super(code, errorMessage, stack);

--- a/system/webservices/src/com/percussion/webservices/PSUserNotMemberOfCommunityException.java
+++ b/system/webservices/src/com/percussion/webservices/PSUserNotMemberOfCommunityException.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * Thrown for services operating with community members. 
  */
@@ -39,6 +41,15 @@ public class PSUserNotMemberOfCommunityException extends PSErrorException
     */
    public PSUserNotMemberOfCommunityException(int code, String errorMessage, 
       String stack)
+   {
+      super(code, errorMessage, stack);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    */
+   public PSUserNotMemberOfCommunityException(IPSErrorCode code,
+      String errorMessage, String stack)
    {
       super(code, errorMessage, stack);
    }

--- a/system/webservices/src/com/percussion/webservices/PSWebserviceErrors.java
+++ b/system/webservices/src/com/percussion/webservices/PSWebserviceErrors.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.webservices;
 
+import com.percussion.error.IPSErrorCode;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.MessageFormat;
@@ -64,6 +65,18 @@ public class PSWebserviceErrors
    public static String createErrorMessage(int code, Object... args)
    {
       return createErrorMessage(code, Locale.getDefault(), args);
+   }
+
+   /**
+    * Convenience overload that uses {@link IPSErrorCode#numericCode()} for bundle lookup.
+    *
+    * @param code catalogued error code, never {@code null}
+    */
+   public static String createErrorMessage(IPSErrorCode code, Object... args)
+   {
+      if (code == null)
+         throw new IllegalArgumentException("code may not be null");
+      return createErrorMessage(code.numericCode(), args);
    }
    
    /**

--- a/system/webservices/src/com/percussion/webservices/PSWebserviceUtils.java
+++ b/system/webservices/src/com/percussion/webservices/PSWebserviceUtils.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.webservices;
 
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
+
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.handlers.PSRelationshipCommandHandler;
@@ -33,6 +35,7 @@ import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSRelationshipConfigSet;
 import com.percussion.design.objectstore.PSRelationshipSet;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.rx.design.PSDesignModelUtils;
@@ -459,7 +462,7 @@ public class PSWebserviceUtils
             Object error = errors.get(id);
             if (error instanceof PSErrorException)
             {
-               if (((PSErrorException) error).getCode() != IPSWebserviceErrors.OBJECT_NOT_FOUND)
+               if (((PSErrorException) error).getCode() != WebserviceErrorCodes.OBJECT_NOT_FOUND.numericCode())
                {
                   // error is for a persisted object, pass it through
                   newException.addError(id, error);
@@ -616,7 +619,7 @@ public class PSWebserviceUtils
 
       if (lock == null)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+         var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
          PSDesignGuid guid = new PSDesignGuid(id);
          PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, cz.getName(), guid
@@ -626,7 +629,7 @@ public class PSWebserviceUtils
       }
       else
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+         var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
          PSDesignGuid guid = new PSDesignGuid(id);
          PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, cz.getName(), guid
@@ -676,7 +679,7 @@ public class PSWebserviceUtils
          log.error(PSExceptionUtils.getMessageForLog(e));
          log.debug(PSExceptionUtils.getDebugMessageForLog(e));
 
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          PSDesignGuid guid = new PSDesignGuid(id);
          PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, cz.getName(), guid
@@ -699,7 +702,7 @@ public class PSWebserviceUtils
       String depTypes = PSDesignModelUtils.checkDependencies(id);
       if (depTypes != null)
       {
-         int code = IPSWebserviceErrors.DELETE_FAILED_DEPENDENTS;
+         var code = WebserviceErrorCodes.DELETE_FAILED_DEPENDENTS;
          PSTypeEnum type = PSTypeEnum.valueOf(id.getType());
          String displayName = "Undefined";
          if(type!=null){
@@ -734,7 +737,7 @@ public class PSWebserviceUtils
 
       if (!pair.getFirst().isEmpty())
       {
-         int code = IPSWebserviceErrors.DELETE_ASSOCIATION_FAILED_DEPENDENTS;
+         var code = WebserviceErrorCodes.DELETE_ASSOCIATION_FAILED_DEPENDENTS;
          error = new PSErrorException(code, PSWebserviceErrors
                .createErrorMessage(code, Objects.requireNonNull(PSTypeEnum.valueOf(parent.getType()))
                      .getDisplayName(), parent.longValue(), Objects.requireNonNull(PSTypeEnum
@@ -829,8 +832,8 @@ public class PSWebserviceUtils
       PSComponentSummary summary = cms.loadComponentSummary(id,refresh);
       if (summary == null)
       {
-         throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND,
+         throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND,
                      PSComponentSummary.class.getName(), id), ExceptionUtils
                      .getFullStackTrace(new Exception()));
       }
@@ -960,8 +963,8 @@ public class PSWebserviceUtils
       catch (PSAssemblyException e)
       {
          log.error(PSExceptionUtils.getMessageForLog(e));
-         throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME, PSSlotType.class
+         throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME, PSSlotType.class
                      .getName(), name), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -1019,8 +1022,8 @@ public class PSWebserviceUtils
       }
       catch (PSAssemblyException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND,
+         throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND,
                      IPSTemplateSlot.class.getName(), slotId), ExceptionUtils
                      .getFullStackTrace(e));
 
@@ -1054,8 +1057,8 @@ public class PSWebserviceUtils
       }
       catch (PSAssemblyException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND,
+         throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND,
                      IPSAssemblyTemplate.class.getName(), new PSDesignGuid(templateId).getValue()),
                ExceptionUtils.getFullStackTrace(e));
       }
@@ -1086,8 +1089,8 @@ public class PSWebserviceUtils
       catch (PSAssemblyException e)
       {
 
-        throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND,
+        throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND,
                      IPSAssemblyTemplate.class.getName(), new PSDesignGuid(templateId).getValue()),
                ExceptionUtils.getFullStackTrace(e));
       }
@@ -1176,8 +1179,8 @@ public class PSWebserviceUtils
       {
          log.error(PSExceptionUtils.getMessageForLog(e));
 
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS, e
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS, e
                      .getLocalizedMessage()), ExceptionUtils
                      .getFullStackTrace(e));
 
@@ -1245,8 +1248,8 @@ public class PSWebserviceUtils
       {
         log.error(PSExceptionUtils.getMessageForLog(e));
 
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS, PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS, PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
                      .getFullStackTrace(e));
       }
    }
@@ -1283,8 +1286,8 @@ public class PSWebserviceUtils
             var relOpt = relsvc.loadRelationship(id.getUUID());
             if (relOpt.isEmpty())
             {
-               throw new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP,
-                     PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP, id
+               throw new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP,
+                     PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP, id
                            .longValue(), "Relationship not found"), PSExceptionUtils.getDebugMessageForLog(new Exception()));
             }
             rel = relOpt.get();
@@ -1295,16 +1298,16 @@ public class PSWebserviceUtils
          {
             log.error(PSExceptionUtils.getMessageForLog(e));
 
-            throw new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP,
-                  PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP, id
+            throw new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP,
+                  PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP, id
                         .longValue(), PSExceptionUtils.getMessageForLog(e)), PSExceptionUtils.getDebugMessageForLog(e));
 
          }
 
          if (rel == null)
          {
-            throw new PSErrorException(IPSWebserviceErrors.CANNOT_FIND_RELATIONSHIP,
-                  PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CANNOT_FIND_RELATIONSHIP, id
+            throw new PSErrorException(WebserviceErrorCodes.CANNOT_FIND_RELATIONSHIP,
+                  PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CANNOT_FIND_RELATIONSHIP, id
                         .longValue()), PSExceptionUtils.getDebugMessageForLog(new Exception()));
          }
 
@@ -1326,8 +1329,8 @@ public class PSWebserviceUtils
          catch (PSCmsException e)
          {
             log.error(PSExceptionUtils.getMessageForLog(e));
-            PSErrorException error = new PSErrorException(IPSWebserviceErrors.FAILED_DELETE_RELATIONSHIPS,
-                  PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_DELETE_RELATIONSHIPS,
+            PSErrorException error = new PSErrorException(WebserviceErrorCodes.FAILED_DELETE_RELATIONSHIPS,
+                  PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_DELETE_RELATIONSHIPS,
                           PSExceptionUtils.getMessageForLog(e)), PSExceptionUtils.getDebugMessageForLog(e));
 
             results.addError(r.getGuid(), error);
@@ -1359,8 +1362,8 @@ public class PSWebserviceUtils
       if (!isItemCheckedOutToUser(summary))
       {
 
-         throw new PSErrorException(IPSWebserviceErrors.ITEM_NOT_CHECKOUT_BY_USER,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.ITEM_NOT_CHECKOUT_BY_USER, locator
+         throw new PSErrorException(WebserviceErrorCodes.ITEM_NOT_CHECKOUT_BY_USER,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.ITEM_NOT_CHECKOUT_BY_USER, locator
                      .getId(), getUserName()), ExceptionUtils
                      .getFullStackTrace(new Exception()));
       }
@@ -1416,7 +1419,7 @@ public class PSWebserviceUtils
          {
             throw new IllegalArgumentException(PSWebserviceErrors
                   .createErrorMessage(
-                        IPSWebserviceErrors.INVALID_EDIT_REVISION, lguid
+                        WebserviceErrorCodes.INVALID_EDIT_REVISION, lguid
                               .getContentId(), revision, getUserName()));
          }
          // if not checked, must be current rev
@@ -1424,7 +1427,7 @@ public class PSWebserviceUtils
          {
             throw new IllegalArgumentException(PSWebserviceErrors
                   .createErrorMessage(
-                        IPSWebserviceErrors.INVALID_CURRENT_REVISION, lguid
+                        WebserviceErrorCodes.INVALID_CURRENT_REVISION, lguid
                               .getContentId(), revision, getUserName()));
          }
       }
@@ -1528,8 +1531,8 @@ public class PSWebserviceUtils
       {
         log.error(PSExceptionUtils.getMessageForLog(e));
 
-         throw new PSErrorException(IPSWebserviceErrors.LOAD_OBJECTS_ERROR,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.LOAD_OBJECTS_ERROR,
+         throw new PSErrorException(WebserviceErrorCodes.LOAD_OBJECTS_ERROR,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.LOAD_OBJECTS_ERROR,
                      PSRelationship.class.getName(),
                        filter.toString(),
                        PSExceptionUtils.getMessageForLog(e)),
@@ -1868,8 +1871,8 @@ public class PSWebserviceUtils
 
       if (wf == null)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_WORKFLOW,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_WORKFLOW,
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_WORKFLOW,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_WORKFLOW,
                      workflowId), ExceptionUtils
                      .getFullStackTrace(new Exception()));
       }
@@ -1896,8 +1899,8 @@ public class PSWebserviceUtils
             return s;
       }
 
-      throw new PSErrorException(IPSWebserviceErrors.CANNOT_FIND_WORKFLOW_STATE_ID,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CANNOT_FIND_WORKFLOW_STATE_ID, id, wf.getGUID()
+      throw new PSErrorException(WebserviceErrorCodes.CANNOT_FIND_WORKFLOW_STATE_ID,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CANNOT_FIND_WORKFLOW_STATE_ID, id, wf.getGUID()
                   .longValue(), wf.getName()), ExceptionUtils
                   .getFullStackTrace(new Exception()));
    }
@@ -1948,8 +1951,8 @@ public class PSWebserviceUtils
       catch (PSException e)
       {
          Throwable rootCause = PSExceptionHelper.findRootCause(e,false);
-         PSErrorException error = new PSErrorException(IPSWebserviceErrors.FAILED_TRANSITION_ITEM,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_TRANSITION_ITEM, trigger, id),
+         PSErrorException error = new PSErrorException(WebserviceErrorCodes.FAILED_TRANSITION_ITEM,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_TRANSITION_ITEM, trigger, id),
                ExceptionUtils.getFullStackTrace(rootCause),e);
          throw new PSErrorException("Failed transition due to server error.",error);
 
@@ -2068,7 +2071,7 @@ public class PSWebserviceUtils
          }
          catch (RuntimeException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, PSAclImpl.class
                         .getName(), id.longValue()), ExceptionUtils
@@ -2077,7 +2080,7 @@ public class PSWebserviceUtils
          }
          catch (PSServiceSecurityException e)
          {
-            int code = IPSWebserviceErrors.NOT_AUTHORIZED;
+            var code = WebserviceErrorCodes.NOT_AUTHORIZED;
             PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, PSAclImpl.class
                         .getName(), id.longValue()), ExceptionUtils
@@ -2200,7 +2203,7 @@ public class PSWebserviceUtils
       if (type == null)
          throw new IllegalArgumentException("type must not be null.");
 
-      int code = IPSWebserviceErrors.OBJECT_ALREADY_EXISTS;
+      var code = WebserviceErrorCodes.OBJECT_ALREADY_EXISTS;
       throw new IllegalArgumentException(PSWebserviceErrors
             .createErrorMessage(code, type, name));
    }
@@ -2310,6 +2313,45 @@ public class PSWebserviceUtils
             PSWebserviceErrors.createErrorMessage(errorCode, e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
 
+      }
+   }
+
+   /**
+    * Saves the specified relationship configurations, retaining the typed catalog
+    * code on any {@link PSErrorException} thrown.
+    *
+    * @param configSet the to be saved relationship config set, may not be
+    *    <code>null</code>.
+    * @param errorCode catalogued error code should an error occur, never
+    *    {@code null}.
+    */
+   public static void saveRelationshipConfigSet(
+      PSRelationshipConfigSet configSet, IPSErrorCode errorCode)
+         throws PSErrorException
+   {
+      if (configSet == null)
+         throw new IllegalArgumentException("configSet may not be null");
+      if (errorCode == null)
+         throw new IllegalArgumentException("errorCode may not be null");
+
+      Document doc = PSXmlDocumentBuilder.createXmlDocument();
+      Element root = configSet.toXml(doc);
+      PSXmlDocumentBuilder.replaceRoot(doc, root);
+      try
+      {
+         PSConfigManager.getInstance().saveConfig(
+            PSConfigurationFactory.RELATIONSHIPS_CFG, doc);
+
+         PSRelationshipCommandHandler.reloadConfigs();
+         IPSRelationshipService relsvc = PSRelationshipServiceLocator
+            .getRelationshipService();
+         relsvc.reloadConfigs();
+      }
+      catch (PSException e)
+      {
+         throw new PSErrorException(errorCode,
+            PSWebserviceErrors.createErrorMessage(errorCode, e
+               .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
    }
 

--- a/system/webservices/src/com/percussion/webservices/aop/security/strategy/PSSecurityStrategy.java
+++ b/system/webservices/src/com/percussion/webservices/aop/security/strategy/PSSecurityStrategy.java
@@ -24,7 +24,7 @@ import com.percussion.services.security.PSAclServiceLocator;
 import com.percussion.services.security.PSPermissions;
 import com.percussion.services.security.data.PSUserAccessLevel;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -425,7 +425,7 @@ public abstract class PSSecurityStrategy
          } catch (com.percussion.services.security.PSServiceSecurityException e) {
             m_log.warn("Failed to load ACLs for object ids: " + e.getMessage());
             PSDesignGuid dguid = new PSDesignGuid(ids.get(0));
-            int code = IPSWebserviceErrors.ACCESS_CONTROL_ERROR;
+            var code = WebserviceErrorCodes.ACCESS_CONTROL_ERROR;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                   dguid.toString(), perm),
@@ -519,7 +519,7 @@ public abstract class PSSecurityStrategy
       } catch (Exception e) {
          m_log.warn("Failed to load ACL for guid " + guid + ": " + e.getMessage());
          PSDesignGuid dguid = new PSDesignGuid(guid);
-         int code = IPSWebserviceErrors.ACCESS_CONTROL_ERROR;
+         var code = WebserviceErrorCodes.ACCESS_CONTROL_ERROR;
          PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                      dguid.toString(), perm),
@@ -567,7 +567,7 @@ public abstract class PSSecurityStrategy
          } catch (Exception e) {
             m_log.warn("Failed to calculate user access level for guid " + guid + ": " + e.getMessage());
             PSDesignGuid dguid = new PSDesignGuid(guid);
-            int code = IPSWebserviceErrors.ACCESS_CONTROL_ERROR;
+            var code = WebserviceErrorCodes.ACCESS_CONTROL_ERROR;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                   dguid.toString(), perm),
@@ -581,7 +581,7 @@ public abstract class PSSecurityStrategy
       if (!hasAccess(perm, accessLevel))
       {
          PSDesignGuid dguid = new PSDesignGuid(guid);
-         int code = IPSWebserviceErrors.ACCESS_CONTROL_ERROR;
+         var code = WebserviceErrorCodes.ACCESS_CONTROL_ERROR;
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code,
                dguid.toString(), perm),

--- a/system/webservices/src/com/percussion/webservices/assembly/impl/PSAssemblyDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/assembly/impl/PSAssemblyDesignWs.java
@@ -45,7 +45,7 @@ import com.percussion.services.sitemgr.PSSiteManagerLocator;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.types.PSPair;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -253,7 +253,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -377,7 +377,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
             }
             catch (PSAssemblyException e)
             {
-               int code = IPSWebserviceErrors.DELETE_FAILED;
+               var code = WebserviceErrorCodes.DELETE_FAILED;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,
@@ -535,7 +535,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
          }
          catch (PSAssemblyException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -604,7 +604,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,
@@ -948,7 +948,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
                      PSObjectLock lock = lockService.findLockByObjectId(id, null,
                      null);
                      if (lock == null) {
-                        int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                        var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                         PSDesignGuid guid = new PSDesignGuid(id);
                         PSErrorException error = new PSErrorException(code,
                         PSWebserviceErrors.createErrorMessage(code,
@@ -956,7 +956,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
                         ExceptionUtils.getFullStackTrace(new Exception()));
                         results.addError(id, error);
                      }else {
-                        int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                        var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                         PSDesignGuid guid = new PSDesignGuid(id);
                         PSErrorException error = new PSErrorException(code,
                         PSWebserviceErrors.createErrorMessage(code,
@@ -982,7 +982,7 @@ public class PSAssemblyDesignWs extends PSAssemblyBaseWs implements
             }
             catch (Exception e)
             {
-               int code = IPSWebserviceErrors.SAVE_FAILED;
+               var code = WebserviceErrorCodes.SAVE_FAILED;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,

--- a/system/webservices/src/com/percussion/webservices/content/ContentSOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/content/ContentSOAPImpl.java
@@ -44,7 +44,7 @@ import com.percussion.services.system.data.PSContentStatusHistory;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.util.PSPurgableTempFile;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSBaseSOAPImpl;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
@@ -619,8 +619,8 @@ public class ContentSOAPImpl extends PSBaseSOAPImpl implements Content {
       catch (PSUnknownContentTypeException e)
       {
          PSUnknownContentTypeFault fault = new PSUnknownContentTypeFault();
-         fault.setCode(IPSWebserviceErrors.UNKNOWN_CONTENT_TYPE);
-         fault.setErrorMessage(PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.UNKNOWN_CONTENT_TYPE, serviceName, createItemsRequest.getContentType(), e.getLocalizedMessage()));
+         fault.setCode(WebserviceErrorCodes.UNKNOWN_CONTENT_TYPE.numericCode());
+         fault.setErrorMessage(PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.UNKNOWN_CONTENT_TYPE, serviceName, createItemsRequest.getContentType(), e.getLocalizedMessage()));
          fault.setStack(ExceptionUtils.getFullStackTrace(e));
          throw new com.percussion.webservices.content.UnknownContentTypeFaultMessage(e.getLocalizedMessage(), fault);
       }

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentBaseWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentBaseWs.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.webservices.content.impl;
 
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceErrors;
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +60,7 @@ public class PSContentBaseWs
       if (e == null)
          throw new IllegalArgumentException("e cannot be null");
 
-      int code = IPSWebserviceErrors.OPERATION_FAILED_ERROR;
+      var code = WebserviceErrorCodes.OPERATION_FAILED_ERROR;
       throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(
          code, operation, e.getLocalizedMessage()), ExceptionUtils
          .getFullStackTrace(e));
@@ -78,7 +78,7 @@ public class PSContentBaseWs
       if (e == null)
          throw new IllegalArgumentException("e cannot be null");
 
-      int code = IPSWebserviceErrors.UNEXPECTED_ERROR;
+      var code = WebserviceErrorCodes.UNEXPECTED_ERROR;
       throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(
          code, e.getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
 

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
@@ -73,7 +73,7 @@ import com.percussion.utils.exceptions.PSORMException;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.utils.string.PSStringUtils;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -355,7 +355,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          boolean existing = (mgr.findLocaleByLanguageString(lang) != null);
          if (existing)
          {
-            int code = IPSWebserviceErrors.OBJECT_ALREADY_EXISTS;
+            var code = WebserviceErrorCodes.OBJECT_ALREADY_EXISTS;
             throw new IllegalArgumentException(PSWebserviceErrors
                .createErrorMessage(code, PSTypeEnum.LOCALE, lang));
          }
@@ -444,7 +444,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -565,7 +565,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (PSORMException e)
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSTemplateSlot.class
@@ -678,7 +678,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             catch (PSLockException e)
             {
-               int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+               var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                PSLockErrorException error = new PSLockErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, nodeDef
                      .getClass().getName(), nodeDef.getGUID().longValue(), e
@@ -690,7 +690,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (RepositoryException e)
       {
-         int code = IPSWebserviceErrors.LOAD_FAILED;
+         var code = WebserviceErrorCodes.LOAD_FAILED;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, IPSNodeDefinition.class.getName(), guid
@@ -755,7 +755,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             catch (PSLockException e)
             {
-               int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+               var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                PSLockErrorException error = new PSLockErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, nodeDef
                      .getClass().getName(), nodeDef.getGUID().longValue(), e
@@ -767,7 +767,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (RepositoryException e)
       {
-         int code = IPSWebserviceErrors.LOAD_FAILED;
+         var code = WebserviceErrorCodes.LOAD_FAILED;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, IPSNodeDefinition.class.getName(), guid
@@ -809,7 +809,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             catch (PSLockException e)
             {
-               int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+               var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, def.getClass().getName(), id
                      .longValue(), e.getLocalizedMessage()), ExceptionUtils
@@ -852,7 +852,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             catch (PSLockException e)
             {
-               int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+               var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, def.getClass().getName(), id
                      .longValue(), e.getLocalizedMessage()), ExceptionUtils
@@ -901,7 +901,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       catch (RuntimeException e)
       {
          // claims to throw exception only if no node def is found
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
          for (IPSGuid id : ids)
          {
             PSDesignGuid guid = new PSDesignGuid(id);
@@ -925,7 +925,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -959,7 +959,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                }
                catch (PSLockException e)
                {
-                  int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+                  var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                   PSLockErrorException error = new PSLockErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code, nodeDef
                         .getClass().getName(), nodeDef.getGUID().longValue(), e
@@ -1011,7 +1011,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (PSContentException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSKeyword.class
@@ -1061,7 +1061,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          java.util.Optional<PSLocale> optLocale = objMgr.loadLocale((int) id.longValue());
          if (optLocale.isEmpty())
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSLocale.class
@@ -1235,7 +1235,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
 
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                PSDesignGuid guid = new PSDesignGuid(contentTypeId);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, TYPE, guid
@@ -1245,7 +1245,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             else
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                PSDesignGuid guid = new PSDesignGuid(contentTypeId);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, TYPE, guid
@@ -1257,7 +1257,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (NoSuchNodeTypeException e)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, TYPE, guid.toString()), ExceptionUtils
@@ -1266,7 +1266,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (Exception e)
       {
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, TYPE, guid.toString(), e
@@ -1362,7 +1362,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
 
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                PSDesignGuid guid = new PSDesignGuid(contentTypeId);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, TYPE, guid
@@ -1372,7 +1372,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             else
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                PSDesignGuid guid = new PSDesignGuid(contentTypeId);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, TYPE, guid
@@ -1384,7 +1384,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (NoSuchNodeTypeException e)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, TYPE, guid.toString()), ExceptionUtils
@@ -1393,7 +1393,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (Exception e)
       {
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          PSDesignGuid guid = new PSDesignGuid(contentTypeId);
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, TYPE, guid.toString(), e
@@ -1474,7 +1474,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                .getContentEditorSystemDef(), def);
             if (errMsg != null)
             {
-               int code = IPSWebserviceErrors.UNABLE_SAVE_SHARED_DEF_VALIDATION;
+               var code = WebserviceErrorCodes.UNABLE_SAVE_SHARED_DEF_VALIDATION;
                throw new PSErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, errMsg), ExceptionUtils
                   .getFullStackTrace(new Exception()));
@@ -1488,14 +1488,14 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             PSObjectLock lock = lockService.findLockByObjectId(id, null, null);
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, def.getClass().getName(), id
                      .longValue()), ExceptionUtils
                   .getFullStackTrace(new Exception()));
             }
 
-            int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+            var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
             throw new PSLockErrorException(code, PSWebserviceErrors
                .createErrorMessage(code, def.getClass().getName(), id
                   .longValue(), lock.getLocker(), lock.getRemainingTime()),
@@ -1504,7 +1504,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (PSLockException e)
       {
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          throw new PSLockErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, def.getClass().getName(), id.longValue(),
                e.getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -1557,7 +1557,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                .getContentEditorSharedDef());
             if (errMsg != null)
             {
-               int code = IPSWebserviceErrors.SAVE_FAILED;
+               var code = WebserviceErrorCodes.SAVE_FAILED;
                throw new PSErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, def.getClass().getName(), id
                      .longValue(), errMsg), ExceptionUtils
@@ -1572,14 +1572,14 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             PSObjectLock lock = lockService.findLockByObjectId(id, null, null);
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, def.getClass().getName(), id
                      .longValue()), ExceptionUtils
                   .getFullStackTrace(new Exception()));
             }
 
-            int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+            var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
             throw new PSLockErrorException(code, PSWebserviceErrors
                .createErrorMessage(code, def.getClass().getName(), id
                   .longValue(), lock.getLocker(), lock.getRemainingTime()),
@@ -1588,7 +1588,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
       }
       catch (PSLockException e)
       {
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          throw new PSLockErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, def.getClass().getName(), id.longValue(),
                e.getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -1674,7 +1674,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
 
                   if (lock == null)
                   {
-                     int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                     var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                      PSDesignGuid guid = new PSDesignGuid(id);
                      PSErrorException error = new PSErrorException(code,
                         PSWebserviceErrors.createErrorMessage(code,
@@ -1684,7 +1684,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                   }
                   else
                   {
-                     int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                     var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                      PSDesignGuid guid = new PSDesignGuid(id);
                      PSErrorException error = new PSErrorException(code,
                         PSWebserviceErrors.createErrorMessage(code,
@@ -1697,7 +1697,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             catch (Exception e)
             {
-               int code = IPSWebserviceErrors.SAVE_FAILED;
+               var code = WebserviceErrorCodes.SAVE_FAILED;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,
@@ -1777,7 +1777,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSKeyword.class
@@ -1870,7 +1870,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
 
                if (lock == null)
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code, PSLocale.class
@@ -1880,7 +1880,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                }
                else
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code, PSLocale.class
@@ -1893,7 +1893,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSLocale.class
@@ -1988,7 +1988,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
 
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                PSDesignGuid guid = new PSDesignGuid(id);
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, PSAutoTranslation.class.getName(),
@@ -1997,7 +1997,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
             }
             else
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                PSDesignGuid guid = new PSDesignGuid(id);
                throw new PSLockErrorException(code, PSWebserviceErrors
                   .createErrorMessage(code, PSAutoTranslation.class.getName(),
@@ -2139,7 +2139,7 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                if (bldr.length() > 0)
                   bldr.append("; ");
                bldr.append(PSWebserviceErrors.createErrorMessage(
-                  IPSWebserviceErrors.FAILED_SYS_SHARED_DEF_VALIDATION, entry
+                  WebserviceErrorCodes.FAILED_SYS_SHARED_DEF_VALIDATION, entry
                      .getKey(), PSStringUtils.listToString(entry.getValue(),
                      ", ")));
             }

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentWs.java
@@ -119,7 +119,8 @@ import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.utils.exceptions.PSORMException;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.thread.PSThreadUtils;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -442,7 +443,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSException | PSValidationException | PSErrorException e)
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSCoreItem.class
                   .getName(), id.getUUID(), PSExceptionUtils.getMessageForLog(e)),
@@ -517,7 +518,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException | PSNotFoundException e)
       {
-         int code = IPSWebserviceErrors.FAILED_FIND_PATH_FROM_ID;
+         var code = WebserviceErrorCodes.FAILED_FIND_PATH_FROM_ID;
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code, locator.getId(), e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -547,8 +548,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       catch (Exception e)
       {
 
-         throw new PSErrorException(IPSWebserviceErrors.LOAD_OBJECTS_ERROR,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.LOAD_OBJECTS_ERROR,  e
+         throw new PSErrorException(WebserviceErrorCodes.LOAD_OBJECTS_ERROR,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.LOAD_OBJECTS_ERROR,  e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
       PSComponentSummaries cs = new PSComponentSummaries();
@@ -585,7 +586,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         int code = IPSWebserviceErrors.UNEXPECTED_ERROR;
+         var code = WebserviceErrorCodes.UNEXPECTED_ERROR;
          PSErrorException error =  new PSErrorException(code, PSWebserviceErrors.createErrorMessage(
                code, PSExceptionUtils.getMessageForLog(e)), ExceptionUtils.getFullStackTrace(e));
          logger.error(PSExceptionUtils.getMessageForLog(e));
@@ -990,7 +991,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
             results.addResult(id, enableViewForceFully? loadNewlyItem(copyId) :loadItem(copyId));
          } catch (PSORMException | PSException | PSErrorException e)
          {
-            int code = IPSWebserviceErrors.NEWCOPY_FAILED;
+            var code = WebserviceErrorCodes.NEWCOPY_FAILED;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.getUUID(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -1094,7 +1095,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
             results.addResult(id, loadItem(copyId));
          } catch (PSORMException | PSErrorException | PSException e)
          {
-            int code = IPSWebserviceErrors.NEWPROMOTABLEVERSION_FAILED;
+            var code = WebserviceErrorCodes.NEWPROMOTABLEVERSION_FAILED;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.getUUID(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -1185,7 +1186,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       boolean enableRevisions)
       throws PSErrorResultsException, PSErrorException
    {
-      final int errorCode = IPSWebserviceErrors.NEWTRANSLATION_FAILED;
+      var errorCode = WebserviceErrorCodes.NEWTRANSLATION_FAILED;
       PSWebserviceUtils.validateLegacyGuids(ids);
 
       final List<PSComponentSummary> summaries = loadSummaries(ids);
@@ -1270,7 +1271,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
     * Assumed not <code>null</code>.
     */
    private void addToErrorResults(final Exception e,
-         final PSLegacyGuid id, final int code,
+         final PSLegacyGuid id, final IPSErrorCode code,
          final PSErrorResultsException errorResults)
    {
       final PSErrorException error = new PSErrorException(code,
@@ -1371,7 +1372,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSCmsException e)
          {
-            int code = IPSWebserviceErrors.NEWTRANSLATION_FAILED;
+            var code = WebserviceErrorCodes.NEWTRANSLATION_FAILED;
             throw new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, id.getUUID(),
                         PSExceptionUtils.getMessageForLog(e)),
@@ -1571,8 +1572,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
 
       if (currState == null)
       {
-         throw new PSErrorException(IPSWebserviceErrors.CANNOT_FIND_WORKFLOW_STATE_ID,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CANNOT_FIND_WORKFLOW_STATE_ID, stateId, wf
+         throw new PSErrorException(WebserviceErrorCodes.CANNOT_FIND_WORKFLOW_STATE_ID,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CANNOT_FIND_WORKFLOW_STATE_ID, stateId, wf
                .getGUID().longValue(), wf.getName()), ExceptionUtils
                .getFullStackTrace(new Exception()));
       }
@@ -1624,8 +1625,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
       }
 
-      throw new PSErrorException(IPSWebserviceErrors.CANNOT_FIND_TRANS_TO_QE_STATE,
-         PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CANNOT_FIND_TRANS_TO_QE_STATE,
+      throw new PSErrorException(WebserviceErrorCodes.CANNOT_FIND_TRANS_TO_QE_STATE,
+         PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CANNOT_FIND_TRANS_TO_QE_STATE,
             pubState.getStateId(), pubState.getName(),
             wf.getGUID().longValue(), wf.getName()), ExceptionUtils
             .getFullStackTrace(new Exception()));
@@ -1705,11 +1706,11 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSException e)
       {
-         int errorCode;
+         WebserviceErrorCodes errorCode;
          if (isCheckout)
-            errorCode = IPSWebserviceErrors.FAILED_CHECK_OUT_ITEM;
+            errorCode = WebserviceErrorCodes.FAILED_CHECK_OUT_ITEM;
          else
-            errorCode = IPSWebserviceErrors.FAILED_CHECK_IN_ITEM;
+            errorCode = WebserviceErrorCodes.FAILED_CHECK_IN_ITEM;
          String message = PSWebserviceErrors.createErrorMessage(errorCode, id, PSExceptionUtils.getMessageForLog(e));
          String stack = ExceptionUtils.getFullStackTrace(e);
          throw  new PSErrorException(errorCode, message, stack, e);
@@ -1768,7 +1769,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
                .getItemSummary(contentId);
             if (!StringUtils.isBlank(sum.getCheckoutUserName()))
             {
-               int code = IPSWebserviceErrors.ITEM_NOT_CHECKED_IN;
+               var code = WebserviceErrorCodes.ITEM_NOT_CHECKED_IN;
                results.addError(id,
                   new PSErrorException(code, PSWebserviceErrors
                      .createErrorMessage(code, guid.longValue(), method),
@@ -1782,7 +1783,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
                .getContentStateId());
             if (currState.isPublishable())
             {
-               int code = IPSWebserviceErrors.INAVLID_ACTION_FOR_STATE;
+               var code = WebserviceErrorCodes.INAVLID_ACTION_FOR_STATE;
                results.addError(id, new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, guid.longValue(),
                      wf.getName(), currState.getName()), ExceptionUtils
@@ -1899,8 +1900,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       PSState currState = PSWebserviceUtils.getStateById(wf, item
             .getContentStateId());
 
-      throw  new PSErrorException(IPSWebserviceErrors.CURR_STATE_NOT_MATCH,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CURR_STATE_NOT_MATCH, currState
+      throw  new PSErrorException(WebserviceErrorCodes.CURR_STATE_NOT_MATCH,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CURR_STATE_NOT_MATCH, currState
                   .getStateId(), currState.getName(), toState.getStateId(),
                   toState.getName()), ExceptionUtils
                   .getFullStackTrace(new Exception()));
@@ -1941,8 +1942,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
             return t;
          }
       }
-      throw new PSErrorException(IPSWebserviceErrors.CANNOT_FIND_TRANS_4_STATE_2_STATE,
-         PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.CANNOT_FIND_TRANS_4_STATE_2_STATE, fromState
+      throw new PSErrorException(WebserviceErrorCodes.CANNOT_FIND_TRANS_4_STATE_2_STATE,
+         PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.CANNOT_FIND_TRANS_4_STATE_2_STATE, fromState
             .getStateId(), fromState.getName(), toState.getStateId(), toState
             .getName(), wf.getGUID().longValue(), wf.getName()), ExceptionUtils
             .getFullStackTrace(new Exception()));
@@ -2071,7 +2072,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSException | PSORMException | PSErrorsException e)
          {
-            int code = IPSWebserviceErrors.FAILED_SAVE_ITEM;
+            var code = WebserviceErrorCodes.FAILED_SAVE_ITEM;
             PSErrorException error = new PSErrorException(code,
                     PSWebserviceErrors.createErrorMessage(code, guid.getUUID(),
                             PSExceptionUtils.getMessageForLog(e)), PSExceptionUtils.getDebugMessageForLog(e),e);
@@ -2270,8 +2271,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSErrorException | PSException e)
          {
-            int code = isView ? IPSWebserviceErrors.FAILED_VIEW_ITEM
-               : IPSWebserviceErrors.FAILED_LOAD_ITEM;
+            var code = isView ? WebserviceErrorCodes.FAILED_VIEW_ITEM
+               : WebserviceErrorCodes.FAILED_LOAD_ITEM;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.getUUID(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -2845,7 +2846,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
    {
       if (!PSWebserviceUtils.getUserName().equals(parent.getCheckedOutByName()))
       {
-         int code = IPSWebserviceErrors.ITEM_NOT_CHECKED_OUT;
+         var code = WebserviceErrorCodes.ITEM_NOT_CHECKED_OUT;
          throw new PSInvalidStateException(code, PSWebserviceErrors
             .createErrorMessage(code, parent.getContentId(), operation),
             ExceptionUtils.getFullStackTrace(new Exception()));
@@ -2861,7 +2862,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
     */
    private PSErrorException handleLoadFailed(IPSGuid id, Exception e)
    {
-      int code = IPSWebserviceErrors.LOAD_FAILED;
+      var code = WebserviceErrorCodes.LOAD_FAILED;
       PSDesignGuid dguid = new PSDesignGuid(id);
       return new PSErrorException(code, PSWebserviceErrors.createErrorMessage(
          code, PSTypeEnum.valueOf(id.getType()), dguid.getValue(), e
@@ -2877,7 +2878,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
     */
    private PSErrorException handleItemSaveFailedError(IPSGuid id, Exception e)
    {
-      int code = IPSWebserviceErrors.SAVE_FAILED;
+      var code = WebserviceErrorCodes.SAVE_FAILED;
       PSDesignGuid dguid = new PSDesignGuid(id);
       return new PSErrorException(code, PSWebserviceErrors.createErrorMessage(
          code, PSTypeEnum.valueOf(id.getType()), dguid.getValue(), e
@@ -2897,7 +2898,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
    private PSErrorException handleMissingChildId(IPSGuid guid, String name,
       IPSGuid id)
    {
-      int code = IPSWebserviceErrors.CHILD_ENTRY_NOT_FOUND;
+      var code = WebserviceErrorCodes.CHILD_ENTRY_NOT_FOUND;
       return handleChildError(code, guid, name, id);
    }
 
@@ -2914,7 +2915,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
    private PSErrorException handleInvalidChildId(IPSGuid guid, String name,
       IPSGuid id)
    {
-      int code = IPSWebserviceErrors.INVALID_CHILD_ID;
+      var code = WebserviceErrorCodes.INVALID_CHILD_ID;
       return handleChildError(code, guid, name, id);
    }
 
@@ -2931,7 +2932,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
    private PSErrorException handleExistingChildId(IPSGuid guid, String name,
       IPSGuid id)
    {
-      int code = IPSWebserviceErrors.CHILD_ENTRY_ALREADY_EXISTS;
+      var code = WebserviceErrorCodes.CHILD_ENTRY_ALREADY_EXISTS;
       return handleChildError(code, guid, name, id);
    }
 
@@ -2945,7 +2946,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
     * @param id The parent item guid, assumed not <code>null</code>.
     * @return The exception, never <code>null</code>.
     */
-   private PSErrorException handleChildError(int code, IPSGuid guid,
+   private PSErrorException handleChildError(IPSErrorCode code, IPSGuid guid,
       String name, IPSGuid id)
    {
       PSDesignGuid childGuid = new PSDesignGuid(guid);
@@ -2965,7 +2966,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
    private void handleMissingChildType(String child)
       throws PSUnknownChildException
    {
-      int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+      var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
       throw new PSUnknownChildException(code, PSWebserviceErrors
          .createErrorMessage(code, PSTypeEnum.LEGACY_CHILD_CONTENT_TYPE.name(),
             child), ExceptionUtils.getFullStackTrace(new Exception()));
@@ -3342,8 +3343,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_CHILD_ITEMS, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_CHILD_ITEMS, id.toString(), PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_CHILD_ITEMS, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_CHILD_ITEMS, id.toString(), PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -3444,8 +3445,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_PARENT_ITEMS, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_PARENT_ITEMS, id.toString(), PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_PARENT_ITEMS, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_PARENT_ITEMS, id.toString(), PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -3578,9 +3579,9 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          String[] paths = processor.getItemPaths(locator);
          if (paths == null || paths.length == 0)
          {
-            throw new PSErrorException(IPSWebserviceErrors.NO_FOLDER_PATH_FOR_FOLDERID,
+            throw new PSErrorException(WebserviceErrorCodes.NO_FOLDER_PATH_FOR_FOLDERID,
                PSWebserviceErrors
-                  .createErrorMessage(IPSWebserviceErrors.NO_FOLDER_PATH_FOR_FOLDERID, folderId.getContentId()),
+                  .createErrorMessage(WebserviceErrorCodes.NO_FOLDER_PATH_FOR_FOLDERID, folderId.getContentId()),
                ExceptionUtils.getFullStackTrace(new Exception()));
          }
          return paths[0];
@@ -3588,8 +3589,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       catch (PSCmsException | PSNotFoundException e)
       {
          // error occurred while finding folder path, may caused by a bad data.
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_FOLDER_PATH, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_FOLDER_PATH, folderId.toString(), e
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_FOLDER_PATH, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_FOLDER_PATH, folderId.toString(), e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -3711,8 +3712,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          {
             // cannot find site, may caused by bad data.
             PSDesignGuid guid = new PSDesignGuid(siteId);
-            throw new PSErrorException(IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.OBJECT_NOT_FOUND, IPSSite.class
+            throw new PSErrorException(WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.OBJECT_NOT_FOUND, IPSSite.class
                   .getName(), guid.longValue()), ExceptionUtils
                   .getFullStackTrace(e));
          }
@@ -3913,8 +3914,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          rels = processor.getRelationshipList(filter);
          if (rels.isEmpty())
          {
-            throw new PSErrorException( IPSWebserviceErrors.OBJECT_NOT_FOUND,
-               PSWebserviceErrors.createErrorMessage( IPSWebserviceErrors.OBJECT_NOT_FOUND, PSRelationship.class
+            throw new PSErrorException( WebserviceErrorCodes.OBJECT_NOT_FOUND,
+               PSWebserviceErrors.createErrorMessage( WebserviceErrorCodes.OBJECT_NOT_FOUND, PSRelationship.class
                   .getName(), rid.longValue()), ExceptionUtils
                   .getFullStackTrace(new Exception()));
          }
@@ -3922,8 +3923,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw  new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_RELATIONSHIP, rid.longValue(), e
+         throw  new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_RELATIONSHIP, rid.longValue(), e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4033,7 +4034,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSErrorResultsException e)
       {
-         int code = IPSWebserviceErrors.FAILED_LOAD_FOLDER;
+         var code = WebserviceErrorCodes.FAILED_LOAD_FOLDER;
          throw new PSErrorException(code, PSWebserviceErrors
             .createErrorMessage(code, ids.get(0).toString(), e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -4109,8 +4110,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
             logger.warn("Error: {} when trying to delete orphaned child folder.",
                     PSExceptionUtils.getMessageForLog(e1));
          }
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_SAVE_RELATIONSHIPS, PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS, PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
             .getFullStackTrace(e));
       }
 
@@ -4137,8 +4138,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_ADD_FOLDER_CHILDREN, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_ADD_FOLDER_CHILDREN, childIds.toString(), parentId.toString(),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_ADD_FOLDER_CHILDREN, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_ADD_FOLDER_CHILDREN, childIds.toString(), parentId.toString(),
                PSExceptionUtils.getMessageForLog(e)), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4295,7 +4296,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSException | PSValidationException e)
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSFolder.class
                   .getName(), id.toString(), PSExceptionUtils.getMessageForLog(e)),
@@ -4359,8 +4360,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_FOLDER_CHILDREN, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_FOLDER_CHILDREN, id.toString(), PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_FOLDER_CHILDREN, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_FOLDER_CHILDREN, id.toString(), PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4380,8 +4381,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-        throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_FOLDER_CHILDREN, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_FOLDER_CHILDREN, id.toString(), PSExceptionUtils.getMessageForLog(e)),
+        throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_FOLDER_CHILDREN, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_FOLDER_CHILDREN, id.toString(), PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4446,8 +4447,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_PATH_FROM_ID,
-            PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_FIND_PATH_FROM_ID, locator.getId(), e
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_PATH_FROM_ID,
+            PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_FIND_PATH_FROM_ID, locator.getId(), e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4463,8 +4464,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_PATH_FROM_ID,
-                 PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_FIND_PATH_FROM_ID, locator.getId(), e
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_PATH_FROM_ID,
+                 PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_FIND_PATH_FROM_ID, locator.getId(), e
                          .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -4524,8 +4525,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_LOAD_FOLDER,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.FAILED_LOAD_FOLDER, id.toString(), e
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_LOAD_FOLDER,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.FAILED_LOAD_FOLDER, id.toString(), e
                      .getLocalizedMessage()), ExceptionUtils
                      .getFullStackTrace(e));
       }
@@ -4662,8 +4663,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSServiceSecurityException e)
          {
-            throw new PSErrorException(IPSWebserviceErrors.LOAD_FAILED,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.LOAD_FAILED, PSCommunity.class
+            throw new PSErrorException(WebserviceErrorCodes.LOAD_FAILED,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.LOAD_FAILED, PSCommunity.class
                   .getName(), id.longValue(), PSExceptionUtils.getMessageForLog(e)),
                ExceptionUtils.getFullStackTrace(e));
 
@@ -4686,8 +4687,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSErrorResultsException e)
          {
-            throw new PSErrorException(IPSWebserviceErrors.LOAD_FAILED,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.LOAD_FAILED,
+            throw new PSErrorException(WebserviceErrorCodes.LOAD_FAILED,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.LOAD_FAILED,
                   PSDisplayFormat.class.getName(), id.longValue(), e
                      .getLocalizedMessage()), ExceptionUtils
                   .getFullStackTrace(e));
@@ -4741,7 +4742,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          catch (PSCmsException e)
          {
             // id is always valid if we get here
-            int code = IPSWebserviceErrors.FAILED_LOAD_FOLDER;
+            var code = WebserviceErrorCodes.FAILED_LOAD_FOLDER;
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.toString(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -4804,16 +4805,16 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
 
          if (id == -1 && isRequired)
          {
-           throw new PSErrorException(IPSWebserviceErrors.PATH_NOT_EXIST,
-               PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.PATH_NOT_EXIST, path),
+           throw new PSErrorException(WebserviceErrorCodes.PATH_NOT_EXIST,
+               PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.PATH_NOT_EXIST, path),
                ExceptionUtils.getFullStackTrace(new Exception()));
          }
          return id;
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException( IPSWebserviceErrors.FAILED_FIND_ID_FROM_PATH, PSWebserviceErrors
-            .createErrorMessage( IPSWebserviceErrors.FAILED_FIND_ID_FROM_PATH, path, PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException( WebserviceErrorCodes.FAILED_FIND_ID_FROM_PATH, PSWebserviceErrors
+            .createErrorMessage( WebserviceErrorCodes.FAILED_FIND_ID_FROM_PATH, path, PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -5059,7 +5060,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSCmsException e1) // failed to attach folder children
          {
-            int errorCode = IPSWebserviceErrors.FAILED_DELETE_RELATIONSHIPS;
+            var errorCode = WebserviceErrorCodes.FAILED_DELETE_RELATIONSHIPS;
             PSErrorException error = new PSErrorException(errorCode,
                     PSWebserviceErrors.createErrorMessage(errorCode, e1
                             .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e1));
@@ -5067,7 +5068,7 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
          }
          catch (PSException | PSValidationException e) // failed to delete item
          {
-            int code = IPSWebserviceErrors.DELETE_FAILED;
+            var code = WebserviceErrorCodes.DELETE_FAILED;
             PSErrorException error = new PSErrorException(code,
                     PSWebserviceErrors.createErrorMessage(code, "Item", id
                             .toString(), PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
@@ -5137,8 +5138,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
                PSLegacyGuid guid = (PSLegacyGuid) id;
                if (!allChildIds.contains(guid.getContentId()))
                {
-                  throw new PSErrorException(IPSWebserviceErrors.INVALID_FOLDER_CHILD,
-                     PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.INVALID_FOLDER_CHILD,
+                  throw new PSErrorException(WebserviceErrorCodes.INVALID_FOLDER_CHILD,
+                     PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.INVALID_FOLDER_CHILD,
                         parent.getId(), guid.getContentId()), ExceptionUtils
                         .getFullStackTrace(new Exception()));
                }
@@ -5161,8 +5162,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_CHILD_ITEMS, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_CHILD_ITEMS, parent.getId(), PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_CHILD_ITEMS, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_CHILD_ITEMS, parent.getId(), PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
    }
@@ -5269,8 +5270,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-        throw new PSErrorException(IPSWebserviceErrors.SAVE_FAILED, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.SAVE_FAILED, PSFolder.class.getName(), folder
+        throw new PSErrorException(WebserviceErrorCodes.SAVE_FAILED, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.SAVE_FAILED, PSFolder.class.getName(), folder
                .getLocator().getId(), PSExceptionUtils.getMessageForLog(e)), ExceptionUtils
             .getFullStackTrace(e));
       }
@@ -5522,8 +5523,8 @@ public class PSContentWs extends PSContentBaseWs implements IPSContentWs
       }
       catch (PSCmsException e)
       {
-         throw new PSErrorException(IPSWebserviceErrors.FAILED_FIND_ID_FROM_PATH, PSWebserviceErrors
-            .createErrorMessage(IPSWebserviceErrors.FAILED_FIND_ID_FROM_PATH, path, PSExceptionUtils.getMessageForLog(e)),
+         throw new PSErrorException(WebserviceErrorCodes.FAILED_FIND_ID_FROM_PATH, PSWebserviceErrors
+            .createErrorMessage(WebserviceErrorCodes.FAILED_FIND_ID_FROM_PATH, path, PSExceptionUtils.getMessageForLog(e)),
             ExceptionUtils.getFullStackTrace(e));
       }
 

--- a/system/webservices/src/com/percussion/webservices/publishing/impl/PSPublishingWs.java
+++ b/system/webservices/src/com/percussion/webservices/publishing/impl/PSPublishingWs.java
@@ -37,7 +37,7 @@ import com.percussion.services.sitemgr.IPSPublishingContext;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceErrors;
 import com.percussion.webservices.publishing.IPSPublishingWs;
@@ -193,7 +193,7 @@ public class PSPublishingWs implements IPSPublishingWs
       }
       catch (PSFilterException e)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME;
          throw new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                      IPSItemFilter.class.getName(), name),
@@ -211,7 +211,7 @@ public class PSPublishingWs implements IPSPublishingWs
       }
       catch (PSNotFoundException e)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME;
          throw new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                      IPSContentList.class.getName(), name),
@@ -230,7 +230,7 @@ public class PSPublishingWs implements IPSPublishingWs
       }
       catch (PSNotFoundException e)
       {
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME;
          throw new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
                      IPSPublishingContext.class.getName(), contextname),
@@ -254,7 +254,7 @@ public class PSPublishingWs implements IPSPublishingWs
       if (site != null)
          return site;
 
-      int code = IPSWebserviceErrors.OBJECT_NOT_FOUND_BY_NAME;
+      var code = WebserviceErrorCodes.OBJECT_NOT_FOUND_BY_NAME;
       PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code,
                   IPSSite.class.getName(), sitename),

--- a/system/webservices/src/com/percussion/webservices/security/impl/PSSecurityDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/security/impl/PSSecurityDesignWs.java
@@ -49,7 +49,7 @@ import com.percussion.services.security.data.PSCommunity;
 import com.percussion.services.security.data.PSCommunityVisibility;
 import com.percussion.webservices.security.data.PSRole;
 import com.percussion.webservices.PSWebserviceUtils;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSWebserviceErrors;
 import org.apache.commons.lang3.StringUtils;
 import com.percussion.webservices.ExceptionUtils;
@@ -268,7 +268,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
             }
          }
 
-         int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+         var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
          PSDesignGuid guid = new PSDesignGuid(id);
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code, PSCommunity.class
@@ -337,7 +337,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
             }
          }
 
-         int code = IPSWebserviceErrors.FAILED_RENAMING_ACLS;
+         var code = WebserviceErrorCodes.FAILED_RENAMING_ACLS;
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code,
                PSCommunity.class.getName(), message),
@@ -351,7 +351,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
       }
       catch (RemoteException e)
       {
-         int code = IPSWebserviceErrors.FAILED_RENAMING_ACLS;
+         var code = WebserviceErrorCodes.FAILED_RENAMING_ACLS;
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code,
                PSCommunity.class.getName(), e.getLocalizedMessage()),
@@ -395,7 +395,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
                lock = lockService.findLockByObjectId(id, null, null);
                if (lock == null)
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -405,7 +405,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
                }
                else
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -418,7 +418,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
          }
          catch (PSLockException e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -804,7 +804,7 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
                break;
 
             default:
-               int code = IPSWebserviceErrors
+               var code = WebserviceErrorCodes
                   .UNSUPPORTD_COMMUNITY_VISIBILITY_LOOKUP_TYPE;
                throw new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,

--- a/system/webservices/src/com/percussion/webservices/system/SystemSOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/system/SystemSOAPImpl.java
@@ -25,7 +25,6 @@ import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.services.system.data.PSContentStatusHistory;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
 import com.percussion.webservices.PSBaseSOAPImpl;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorsException;

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSSystemBaseWs.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSSystemBaseWs.java
@@ -21,7 +21,7 @@ import com.percussion.cms.handlers.PSRelationshipCommandHandler;
 import com.percussion.design.objectstore.PSRelationshipConfigSet;
 import com.percussion.error.PSException;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceErrors;
 import org.apache.logging.log4j.LogManager;
@@ -67,7 +67,7 @@ public class PSSystemBaseWs
       catch (PSException e)
       {
          log.error(PSExceptionUtils.getMessageForLog(e));
-         int code = IPSWebserviceErrors.FAILED_LOAD_REL_CONFIGS;
+         var code = WebserviceErrorCodes.FAILED_LOAD_REL_CONFIGS;
          throw new PSErrorException(code, PSWebserviceErrors
                .createErrorMessage(code,PSExceptionUtils.getMessageForLog(e)),
                  PSExceptionUtils.getDebugMessageForLog(e));

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSSystemDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSSystemDesignWs.java
@@ -58,7 +58,7 @@ import com.percussion.services.system.data.PSSharedProperty;
 import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -191,7 +191,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          }
          catch (PSLockException e)
          {
-            int code = IPSWebserviceErrors.CREATE_EXTEND_LOCK_FAILED;
+            var code = WebserviceErrorCodes.CREATE_EXTEND_LOCK_FAILED;
             PSLockErrorException error = new PSLockErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.longValue(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e),
@@ -297,7 +297,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
             }
             catch (PSServiceSecurityException e)
             {
-               int code = IPSWebserviceErrors.DELETE_FAILED;
+               var code = WebserviceErrorCodes.DELETE_FAILED;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,
@@ -357,7 +357,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
        * <code>PSErrorException</code> and no lock will be released.
        */
       PSWebserviceUtils.saveRelationshipConfigSet(configSet,
-            IPSWebserviceErrors.DELETE_FAILED);
+            WebserviceErrorCodes.DELETE_FAILED);
 
       /*
        * This may only have errors if no valid locks exist for any relationship
@@ -535,7 +535,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          }
          catch (PSLockException e)
          {
-            int code = IPSWebserviceErrors.CREATE_EXTEND_LOCK_FAILED;
+            var code = WebserviceErrorCodes.CREATE_EXTEND_LOCK_FAILED;
             PSLockErrorException error = new PSLockErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, id.longValue(), e
                   .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e),
@@ -838,7 +838,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          }
          catch (PSNotFoundException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSItemFilter.class
@@ -914,7 +914,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          else
          // cannot find config with the id
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,
@@ -984,7 +984,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
             }
             catch (PSLockException e)
             {
-               int code = IPSWebserviceErrors.CREATE_LOCK_FAILED;
+               var code = WebserviceErrorCodes.CREATE_LOCK_FAILED;
                PSLockErrorException error = new PSLockErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, property
                      .getClass().getName(), id.longValue(), e
@@ -1068,7 +1068,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          {
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, className,
@@ -1078,7 +1078,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
             }
             else
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code, className,
@@ -1099,7 +1099,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          /* assign error to all guids that don't already have one and skip
           * processing below
           */
-         int code = IPSWebserviceErrors.SAVE_FAILED;
+         var code = WebserviceErrorCodes.SAVE_FAILED;
          PSDesignGuid guid = new PSDesignGuid(-1);
          PSErrorException error = new PSErrorException(code,
             PSWebserviceErrors.createErrorMessage(code,
@@ -1211,14 +1211,14 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
 
             if (lock == null)
             {
-               int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+               var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                PSDesignGuid guid = new PSDesignGuid(id);
-               throw new PSLockException(code, guid.getValue());
+               throw new PSLockException(code.numericCode(), guid.getValue());
             }
 
-            int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+            var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
             PSDesignGuid guid = new PSDesignGuid(id);
-            throw new PSLockException(code, guid.getValue(), lock.getLocker(),
+            throw new PSLockException(code.numericCode(), guid.getValue(), lock.getLocker(),
                lock.getRemainingTime());
          }
       }
@@ -1289,7 +1289,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
 
                if (lock == null)
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -1299,7 +1299,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
                }
                else
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -1312,7 +1312,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          }
          catch (Exception e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code, PSItemFilter.class
@@ -1388,7 +1388,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          throw results;
 
       PSWebserviceUtils.saveRelationshipConfigSet(configSet,
-            IPSWebserviceErrors.SAVE_FAILED);
+            WebserviceErrorCodes.SAVE_FAILED);
    }
 
    // @see IPSSystemDesignWs#saveSharedProperties(List, boolean, String, String)
@@ -1455,7 +1455,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
                   null);
                if (lock == null)
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -1465,7 +1465,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
                }
                else
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code,
                      PSWebserviceErrors.createErrorMessage(code,
@@ -1478,7 +1478,7 @@ public class PSSystemDesignWs extends PSSystemBaseWs implements
          }
          catch (PSLockException e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code,
                PSWebserviceErrors.createErrorMessage(code,

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSSystemWs.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSSystemWs.java
@@ -51,7 +51,7 @@ import com.percussion.system.utils.PSBaseBean;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.PSInvalidLocaleException;
@@ -329,7 +329,7 @@ public class PSSystemWs extends PSSystemBaseWs implements IPSSystemWs
          // treat as contract violation
          if (e.getErrorCode() == IPSServerErrors.COMMUNITIES_AUTHENTICATION_FAILED_INVALID_COMMUNITY)
          {
-            int code = IPSWebserviceErrors.USER_NOT_MEMBER_COMMUNITY;
+            var code = WebserviceErrorCodes.USER_NOT_MEMBER_COMMUNITY;
             throw new PSUserNotMemberOfCommunityException(code,
                PSWebserviceErrors.createErrorMessage(code, name),
                ExceptionUtils.getFullStackTrace(e));
@@ -384,7 +384,7 @@ public class PSSystemWs extends PSSystemBaseWs implements IPSSystemWs
          msgSfx.append(">");
 
          // throw invalid locale exception with a set of active locales
-         int errcode = IPSWebserviceErrors.INVALID_LOCALE;
+         var errcode = WebserviceErrorCodes.INVALID_LOCALE;
          throw new PSInvalidLocaleException(errcode, PSWebserviceErrors
             .createErrorMessage(errcode, code)+msgSfx.toString(), ExceptionUtils
             .getFullStackTrace(new Exception()));

--- a/system/webservices/src/com/percussion/webservices/systemdesign/SystemDesignSOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/systemdesign/SystemDesignSOAPImpl.java
@@ -27,7 +27,6 @@ import com.percussion.services.security.data.PSUserAccessLevel;
 import com.percussion.services.system.IPSSystemService;
 import com.percussion.services.system.PSSystemServiceLocator;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
 import com.percussion.webservices.PSBaseSOAPImpl;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;

--- a/system/webservices/src/com/percussion/webservices/transformation/PSTransformationException.java
+++ b/system/webservices/src/com/percussion/webservices/transformation/PSTransformationException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.webservices.transformation;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.utils.exceptions.PSBaseException;
 
 public class PSTransformationException extends PSBaseException
@@ -24,6 +25,8 @@ public class PSTransformationException extends PSBaseException
     * Compiler generated serial version ID used for serialization.
     */
    private static final long serialVersionUID = -763062444961430893L;
+
+   private transient IPSErrorCode typedErrorCode;
 
    /*
     * (non-Javadoc)
@@ -54,6 +57,55 @@ public class PSTransformationException extends PSBaseException
       Object... arrayArgs)
    {
       super(msgCode, cause, arrayArgs);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode}.
+    *
+    * @param code catalogued error code, never {@code null}
+    */
+   public PSTransformationException(IPSErrorCode code)
+   {
+      super(requireCode(code).numericCode());
+      this.typedErrorCode = code;
+   }
+
+   /**
+    * Typed construction with message arguments.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param arrayArgs message arguments; may be {@code null}
+    */
+   public PSTransformationException(IPSErrorCode code, Object... arrayArgs)
+   {
+      super(requireCode(code).numericCode(), arrayArgs);
+      this.typedErrorCode = code;
+   }
+
+   /**
+    * Typed error code when constructed via {@link IPSErrorCode} overloads;
+    * otherwise {@code null}.
+    */
+   public IPSErrorCode getTypedErrorCode()
+   {
+      return typedErrorCode;
+   }
+
+   /**
+    * Whether dual-write should consider this exception auditable.
+    */
+   public boolean isAuditable()
+   {
+      return typedErrorCode != null && typedErrorCode.isAuditable();
+   }
+
+   private static IPSErrorCode requireCode(IPSErrorCode code)
+   {
+      if (code == null)
+      {
+         throw new IllegalArgumentException("code may not be null");
+      }
+      return code;
    }
 
    /*

--- a/system/webservices/src/com/percussion/webservices/transformation/converter/PSConverter.java
+++ b/system/webservices/src/com/percussion/webservices/transformation/converter/PSConverter.java
@@ -16,7 +16,9 @@
  */
 package com.percussion.webservices.transformation.converter;
 
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.percussion.cms.IPSConstants;
+import com.percussion.webservices.transformation.PSTransformationException;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.Converter;
@@ -144,7 +146,9 @@ public class PSConverter implements Converter
       Converter converter = getBeanUtils().getConvertUtils().lookup(type);
       if (converter == null)
          throw new ConversionException(
-            "No converter registered for type " + type.getName());
+            new PSTransformationException(
+               TransformationErrorCodes.NO_CONVERTER_FOUND, type.getName())
+               .getLocalizedMessage());
       
       return converter;
    }

--- a/system/webservices/src/com/percussion/webservices/transformation/converter/PSItemConverterUtils.java
+++ b/system/webservices/src/com/percussion/webservices/transformation/converter/PSItemConverterUtils.java
@@ -42,7 +42,7 @@ import com.percussion.services.assembly.PSAssemblyServiceLocator;
 import com.percussion.services.guidmgr.data.PSDesignGuid;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSWebserviceErrors;
 import com.percussion.webservices.content.PSChildEntry;
 import com.percussion.webservices.content.PSField;
@@ -227,7 +227,7 @@ public class PSItemConverterUtils
          {
             throw new ConversionException(
                PSWebserviceErrors.createErrorMessage(
-                  IPSWebserviceErrors.UNKNOWN_FIELD_NAME, id.toString(),
+                  WebserviceErrorCodes.UNKNOWN_FIELD_NAME, id.toString(),
                   field.getName()));
          }
 

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
@@ -26,7 +26,7 @@ import com.percussion.server.PSServer;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.util.PSCharSets;
 import com.percussion.utils.request.PSRequestInfo;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSWebserviceErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -161,7 +161,7 @@ public class PSUiBaseWs
       catch (Exception e)
       {
 
-         int code = IPSWebserviceErrors.FIND_FAILED;
+         var code = WebserviceErrorCodes.FIND_FAILED;
          // Report the requested component type (search/view/action/display format), not a hardcoded
          // PSAction — callers use this for PSSearch and others; wrong type misled GH-2712 triage.
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -51,7 +51,7 @@ import com.percussion.services.ui.data.PSHierarchyNodeProperty;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.utils.timing.PSTimer;
-import com.percussion.webservices.IPSWebserviceErrors;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -764,7 +764,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          }
          catch (PSUiException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                   PSHierarchyNode.class.getName(), guid.getValue()), ExceptionUtils.getFullStackTrace(e));
@@ -906,7 +906,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          }
          catch (PSUiException e)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                   PSHierarchyNode.class.getName(), guid.getValue()), ExceptionUtils.getFullStackTrace(e));
@@ -1093,7 +1093,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
                }
                catch (PSUiException e)
                {
-                  int code = IPSWebserviceErrors.SAVE_FAILED;
+                  var code = WebserviceErrorCodes.SAVE_FAILED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                         PSHierarchyNode.class.getName(), guid.getValue(), e.getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
@@ -1105,7 +1105,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
                PSObjectLock lock = lockService.findLockByObjectId(id, null, null);
                if (lock == null)
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                         PSHierarchyNode.class.getName(), guid.getValue()),
@@ -1114,7 +1114,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
                }
                else
                {
-                  int code = IPSWebserviceErrors.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
+                  var code = WebserviceErrorCodes.OBJECT_NOT_LOCKED_FOR_REQUESTOR;
                   PSDesignGuid guid = new PSDesignGuid(id);
                   PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                         PSHierarchyNode.class.getName(), guid.getValue(), lock.getLocker(), lock.getRemainingTime()),
@@ -1125,7 +1125,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          }
          catch (PSLockException e)
          {
-            int code = IPSWebserviceErrors.SAVE_FAILED;
+            var code = WebserviceErrorCodes.SAVE_FAILED;
             PSDesignGuid guid = new PSDesignGuid(id);
             PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                   PSHierarchyNode.class.getName(), guid.getValue(), e.getLocalizedMessage()),
@@ -1251,7 +1251,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
          catch (PSNavException e)
          {
-            int code = IPSWebserviceErrors.FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID;
+            var code = WebserviceErrorCodes.FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID;
             PSErrorException error = new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                   e.getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
             results.addError(id, error);
@@ -1820,8 +1820,8 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          log.error(PSExceptionUtils.getMessageForLog(e));
 
          PSDesignGuid guid = new PSDesignGuid(id);
-         PSErrorException error = new PSErrorException(IPSWebserviceErrors.SAVE_FAILED,
-                 PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.SAVE_FAILED,
+         PSErrorException error = new PSErrorException(WebserviceErrorCodes.SAVE_FAILED,
+                 PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.SAVE_FAILED,
                          cz.getName(),
                guid.longValue(),
                          PSExceptionUtils.getMessageForLog(e)),
@@ -1858,7 +1858,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
          if (elem.length == 0) // if failed to load the object (not exist)
          {
-            int code = IPSWebserviceErrors.OBJECT_NOT_FOUND;
+            var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;
             throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                   objClass.getName(), guid.longValue()), ExceptionUtils.getFullStackTrace(new Exception()));
 
@@ -1868,7 +1868,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       }
       catch (PSCmsException e)
       {
-         int code = IPSWebserviceErrors.LOAD_FAILED;
+         var code = WebserviceErrorCodes.LOAD_FAILED;
          throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code,
                objClass.getName(), guid.longValue()), ExceptionUtils.getFullStackTrace(e));
 
@@ -1978,7 +1978,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
             if (parentId != null)
                parent = parentId.toString();
 
-            int code = IPSWebserviceErrors.MISSING_HIERARCHY_NODE_FOR_PARENT;
+            var code = WebserviceErrorCodes.MISSING_HIERARCHY_NODE_FOR_PARENT;
             throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code, name,
                   parent), ExceptionUtils.getFullStackTrace(new Exception()));
 
@@ -1989,7 +1989,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
             if (parentId != null)
                parent = parentId.toString();
 
-            int code = IPSWebserviceErrors.DUPLICATE_HIERARCHY_NODE_FOR_PARENT;
+            var code = WebserviceErrorCodes.DUPLICATE_HIERARCHY_NODE_FOR_PARENT;
             throw new PSErrorException(code, PSWebserviceErrors.createErrorMessage(code, name,
                   parent), ExceptionUtils.getFullStackTrace(new Exception()));
          }
@@ -2036,8 +2036,8 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          }
          else
          {
-            PSErrorException error = new PSErrorException(IPSWebserviceErrors.DELETE_FAILED,
-                    PSWebserviceErrors.createErrorMessage(IPSWebserviceErrors.DELETE_FAILED,
+            PSErrorException error = new PSErrorException(WebserviceErrorCodes.DELETE_FAILED,
+                    PSWebserviceErrors.createErrorMessage(WebserviceErrorCodes.DELETE_FAILED,
                   cz.getName(), id.longValue(), PSExceptionUtils.getMessageForLog(e)),
                     PSExceptionUtils.getDebugMessageForLog(e));
             results.addError(id, error);


### PR DESCRIPTION
## Summary

Leftover production `IPSWebserviceErrors` / `IPSTransformationErrors` call sites now throw typed `WebserviceErrorCodes` / `TransformationErrorCodes` via `IPSErrorCode` constructors (`PSErrorException` and SOAP peers). `IPS*` catalogs remain as numeric bridges. Webservice package-local ints 1–27 stay unflattened (Workflow/assembly collisions); auditable session/ACL codes dual-write; operational CRUD skips.

Parent: #2616. Sibling SiteManage family (#3584) and inventory gate (#3586) are out of scope.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3585

## Test plan

1. `cd modules/perc-auditlog` then `..\..\mvnw.cmd clean install` — WebserviceErrorCodes dual-write tests.
2. `cd system` then `..\mvnw.cmd clean install` — `PSWebserviceTypedErrorCodeSliceTest` + `PSTransformationTypedErrorCodeSliceTest`.
3. `cd deployer` then `..\mvnw.cmd clean install` — relationship-def handler compiles against typed `SAVE_FAILED`.
4. Confirm `LegacyErrorCodeRegistry.find(1)` is still Workflow, not Webservice `INVALID_CONTRACT`.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog / dual-write migration; no operator/UI/API contract change
- [x] **Unit / module tests** — behavioral tests for typed constructors and dual-write; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when `final`/API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `system`, `deployer`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 294, Failures: 0 (WebserviceErrorCodesTest: 8)
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2216, Failures: 0 (PSWebserviceTypedErrorCodeSliceTest: 7; PSTransformationTypedErrorCodeSliceTest: 3)
  - `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 279, Failures: 0, Skipped: 19
- **downstream_checked:** grepped `extends PSErrorException` (8 in-module subclasses; added IPSErrorCode overloads, existing int ctors unchanged). No types made `final`/`sealed`. `PSLockException` call sites pass `.numericCode()` (int ctor). SiteManage `PSSitePublishDao` left on IPS ints (sibling #3584).

### C5 UI proof

N/A — Java backend error-catalog migration; no WebUI/Playwright surface.
