### PR TITLE
fix(sitemanage): load FastForward rffNavTree via percNav JCR alias (#3611)

### DIFF
--- a/docs/ai-generated/code-reviews/3611-section-tree-get-500-erlang.md
+++ b/docs/ai-generated/code-reviews/3611-section-tree-get-500-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3611 section/tree GET 500 FastForward NavTree
+
+**Branch:** `fix/issue-3611-rff-navtree-jcr-alias`  
+**Base:** `origin/main`  
+**Date:** 2026-08-19  
+**Reviewer:** Erlang (independent pre-commit)  
+**Memory patterns hit:** missing behavioral tests; change-class completeness (product-docs + unit tests); FastForward rffNav* vs percNav* dual ids; ItemDef catalog drop of 313–315 names
+
+## Summary
+
+H2 QA sample sites keep `rffNavTree` items at content type **315**. ItemDefManager may catalog those editors, but after `perc.nav` the JCR `ms_configuration` map often only has `percNavTree` **1017**. Live H2 also drops FastForward names from the running catalog (`Invalid content type id (313)`), so a name-only perc/rff alias still 500s. `findNodesByIds` then threw `No content type info found for content type id: 315`, and `GET /section/tree/Corporate_Investments` returned HTTP 500 so Architecture Create section never mounted treeitems.
+
+Fix: perc/rff alias lookup in `PSContentRepository` (shared `RXS_CT_NAV*` tables) plus well-known id roles 313–315 ↔ 1015–1017 when the catalog has no name. Missing-NavTree empty-200 is unchanged. Does not seed a second NavTree. Does not allowlist 500.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests cover name-based alias selection, well-known ids when names are missing, existing-rff load without seed, and REST not mapping type-315 failures to empty-200.
+
+Cross-platform path checklist: **clean** — no filesystem path construction.
+
+## Issues
+
+None (blocking).
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| JCR type lookup alias (313–315 ↔ 1015–1017) | Done |
+| Well-known id role when ItemDef has no name | Done |
+| `PSNavNameAliases.findRegisteredNavAliasTypeId` + tests | Done |
+| sitemanage loadTree existing-rff / REST no-empty-on-315 | Done |
+| `product-docs/8.2/admin/architecture-navigation.md` (tree GET 200 + Create section enabled) | Done |
+| Playwright `architecture-create-section-noskip.spec.js` (no skip) | Existing; C5 proof required |
+| Do not seed second NavTree / do not allowlist 500 | Honored |
+
+## Tests / builds observed
+
+- `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (01:51). `PSNavNameAliasesTest` Tests run: 6, Failures: 0. `PSServicesContentmgrTypedTest` Tests run: 7, Failures: 0.
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (58.7s). `PSSiteSectionServiceLoadTreeEmptyTest` Tests run: 8, Failures: 0. `PSSiteSectionRestServiceLoadTreeEmptyTest` Tests run: 6, Failures: 0.
+- C2: no `extends PSNavNameAliases` / `new PSNavNameAliases() {` / `extends PSContentRepository` / `new PSContentRepository() {`. Additive public helpers only.

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -95,6 +95,21 @@ names as the same Navigation types. A site that already has an `rffNavTree` at
 the folder root is **not** empty — do not create a second tree. New sites
 created in this product use the `percNav*` names.
 
+`GET /Rhythmyx/services/sitemanage/section/tree/{site}` for a FastForward sample
+site (for example **Corporate_Investments**) returns **HTTP 200** with the seeded
+`rffNavTree` nodes — not HTTP 500 and not an empty tree. Sample items stay on
+type ids **313–315**. The `perc.nav` package registers `percNav*` under
+**1015–1017** and may omit a separate JCR mapping for 313–315 (and may omit the
+FastForward editor from the running catalog). The server still loads those
+items through the matching perc/rff mapping (shared `RXS_CT_NAV*` tables),
+including when the catalog has no name for type 315. A site with no NavTree
+item still returns HTTP 200 with an empty tree.
+
+When that tree GET is HTTP 200 with nodes, the Navigation tree shows
+`role="treeitem"` rows and **Create section** stays enabled. **Escape** closes
+the Create section dialog. Do not create a second NavTree for a sample site
+that already has an `rffNavTree`.
+
 ## Keyboard and accessibility
 
 The navigation tree follows the ARIA tree pattern. **Tab** moves focus into

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionRestServiceLoadTreeEmptyTest.java
@@ -100,4 +100,13 @@ class PSSiteSectionRestServiceLoadTreeEmptyTest {
     assertThrows(
         IPSSiteSectionService.PSSiteSectionException.class, () -> rest.loadTree("Demo"));
   }
+
+  @Test
+  void loadTreeDoesNotMapType315FailureToEmptyTree() throws Exception {
+    when(siteSectionService.loadTree("Corporate_Investments"))
+        .thenThrow(
+            new RuntimeException(
+                "Failed to find items by IDs: No content type info found for content type id: 315"));
+    assertThrows(RuntimeException.class, () -> rest.loadTree("Corporate_Investments"));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteSectionServiceLoadTreeEmptyTest.java
@@ -185,6 +185,20 @@ class PSSiteSectionServiceLoadTreeEmptyTest {
   }
 
   @Test
+  void loadTreeUsesExistingRffNavTreeWithoutSeedingSecond() throws Exception {
+    PSLegacyGuid existing = new PSLegacyGuid(360, 1);
+    when(navService.findNavigationIdFromFolder("//Sites/Demo")).thenReturn(existing);
+    stubCreatedNavTreeLoad(existing);
+
+    PSSectionNode tree = service.loadTree("Demo");
+    assertEquals(new PSLegacyGuid(360, -1).toString(), tree.getId());
+    assertEquals("Demo", tree.getTitle());
+    verify(navService, never())
+        .addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt());
+    verify(siteMgr, never()).deleteSite(any());
+  }
+
+  @Test
   void loadTreeUsesExistingNavTreeAfterConcurrentCreate() throws Exception {
     PSLegacyGuid raced = new PSLegacyGuid(361, 1);
     when(navService.addNavTreeToFolder(anyString(), anyString(), anyString(), anyInt()))

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -454,6 +454,16 @@ public class PSContentRepository
     private static final Map<IPSTypeKey, PSTypeConfiguration> ms_configuration = new ConcurrentHashMap<>();
 
     /**
+     * Memoized perc/rff JCR alias type ids keyed by the missing content-type id.
+     * {@link #NO_NAV_ALIAS} means a completed lookup found no sibling. Cleared
+     * when {@link #ms_configuration} keys change ({@link #configure}).
+     */
+    private static final ConcurrentHashMap<Long, Long> ms_navAliasTypeIdCache = new ConcurrentHashMap<>();
+
+    /** Sentinel in {@link #ms_navAliasTypeIdCache} for a negative (no alias) result. */
+    static final long NO_NAV_ALIAS = Long.MIN_VALUE;
+
+    /**
      * Stores correspondances between content summary "properties" and the system
      * field names. This is derived at startup from the system def normally, and
      * a subset is created for unit testing. Never <code>null</code> and never
@@ -496,8 +506,12 @@ public class PSContentRepository
     }
 
     /**
-     * Get a given content type configuration. Child configurations can be
-     * obtained from the parent
+     * Exact JCR mapping only — no perc/rff alias. Public callers and any future
+     * write path must use this so an aliased Hibernate mapping cannot re-stamp a
+     * FastForward id (315) as perc.nav (1017) on persist. Load/query/evict use
+     * {@link #lookupTypeConfiguration(long)} which may alias for read-only
+     * Hibernate class resolution. This repository's {@link #save} is
+     * unimplemented ({@link Capability#READ} only).
      *
      * @param contenttypeid the content type id
      * @return the type configuration, this will return <code>null</code> if
@@ -505,19 +519,28 @@ public class PSContentRepository
      */
     public static PSTypeConfiguration getTypeConfiguration(int contenttypeid)
     {
-        return lookupTypeConfiguration(contenttypeid);
+        return lookupTypeConfigurationExact(contenttypeid);
     }
 
     /**
-     * JCR type map lookup with perc/rff Managed Nav alias fallback (#3611).
-     * {@code perc.nav} can drop the Hibernate mapping for FastForward ids
-     * 313–315 while {@link PSItemDefManager} still catalogs {@code rffNav*}
-     * editors. Those items share {@code RXS_CT_NAV*} with {@code percNav*}
-     * (1015–1017), so the registered sibling mapping loads the node.
+     * Exact JCR type map lookup with no perc/rff alias.
+     */
+    static PSTypeConfiguration lookupTypeConfigurationExact(long contentTypeId)
+    {
+        return ms_configuration.get(new PSContentTypeKey(contentTypeId));
+    }
+
+    /**
+     * JCR type map lookup with perc/rff Managed Nav alias fallback (#3611) for
+     * read/load/query/evict. {@code perc.nav} can drop the Hibernate mapping for
+     * FastForward ids 313–315 while {@link PSItemDefManager} still catalogs
+     * {@code rffNav*} editors. Those items share {@code RXS_CT_NAV*} with
+     * {@code percNav*} (1015–1017), so the registered sibling mapping loads the
+     * node. Do not use this for persist/write of the content-type id.
      */
     static PSTypeConfiguration lookupTypeConfiguration(long contentTypeId)
     {
-        PSTypeConfiguration config = ms_configuration.get(new PSContentTypeKey(contentTypeId));
+        PSTypeConfiguration config = lookupTypeConfigurationExact(contentTypeId);
         if (config != null)
         {
             return config;
@@ -527,16 +550,42 @@ public class PSContentRepository
 
     static PSTypeConfiguration lookupNavAliasTypeConfiguration(long contentTypeId)
     {
+        Long cached = ms_navAliasTypeIdCache.get(contentTypeId);
+        if (cached != null)
+        {
+            return cached == NO_NAV_ALIAS ? null : lookupTypeConfigurationExact(cached);
+        }
+        Long wellKnown = PSNavNameAliases.wellKnownNavAliasTypeId(contentTypeId);
+        if (wellKnown != null)
+        {
+            PSTypeConfiguration wellKnownConfig = lookupTypeConfigurationExact(wellKnown);
+            if (wellKnownConfig != null)
+            {
+                ms_navAliasTypeIdCache.put(contentTypeId, wellKnown);
+                ms_log.debug(
+                    "Using JCR type configuration {} as perc/rff alias for content type id {}",
+                    wellKnown,
+                    contentTypeId);
+                return wellKnownConfig;
+            }
+        }
         Long aliasId =
-            resolveNavAliasTypeId(
+            ms_navAliasTypeIdCache.computeIfAbsent(
                 contentTypeId,
-                ms_configuration.keySet(),
-                PSContentRepository::contentTypeNameQuietly);
-        if (aliasId == null)
+                id ->
+                {
+                    Long resolved =
+                        resolveNavAliasTypeId(
+                            id,
+                            ms_configuration.keySet(),
+                            PSContentRepository::contentTypeNameQuietly);
+                    return resolved == null ? NO_NAV_ALIAS : resolved;
+                });
+        if (aliasId == null || aliasId == NO_NAV_ALIAS)
         {
             return null;
         }
-        PSTypeConfiguration alias = ms_configuration.get(new PSContentTypeKey(aliasId));
+        PSTypeConfiguration alias = lookupTypeConfigurationExact(aliasId);
         if (alias != null)
         {
             ms_log.debug(
@@ -545,6 +594,16 @@ public class PSContentRepository
                 contentTypeId);
         }
         return alias;
+    }
+
+    static void clearNavAliasTypeIdCache()
+    {
+        ms_navAliasTypeIdCache.clear();
+    }
+
+    static boolean navAliasTypeIdCacheContains(long contentTypeId)
+    {
+        return ms_navAliasTypeIdCache.containsKey(contentTypeId);
     }
 
     /**
@@ -559,6 +618,17 @@ public class PSContentRepository
         if (registeredKeys == null)
         {
             return null;
+        }
+        Long wellKnown = PSNavNameAliases.wellKnownNavAliasTypeId(missingTypeId);
+        if (wellKnown != null)
+        {
+            for (IPSTypeKey k : registeredKeys)
+            {
+                if (k instanceof PSContentTypeKey && k.getContentType() == wellKnown)
+                {
+                    return wellKnown;
+                }
+            }
         }
         Set<Long> registered = new HashSet<>();
         for (IPSTypeKey k : registeredKeys)
@@ -584,6 +654,7 @@ public class PSContentRepository
         }
         catch (RuntimeException e)
         {
+            ms_log.debug("Content type name lookup failed for id {}", typeId, e);
             return null;
         }
     }
@@ -959,6 +1030,8 @@ public class PSContentRepository
             long type = s.getContentTypeId();
             if (typeToClassMap.get(type) == null)
             {
+                // Alias mapping is Hibernate class only; the map key stays the
+                // requested type id (e.g. 315) so loads cannot re-stamp 1017.
                 PSTypeConfiguration config = lookupTypeConfiguration(type);
                 if (config == null)
                 {
@@ -1319,6 +1392,7 @@ public class PSContentRepository
         }
         finally
         {
+            clearNavAliasTypeIdCache();
             m_rwlock.writeLock().unlock();
         }
     }

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -28,6 +28,7 @@ import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemChild;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.PSKey;
+import com.percussion.cms.objectstore.PSNavNameAliases;
 import com.percussion.cms.objectstore.server.IPSItemDefElementProcessor;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
@@ -149,6 +150,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import static com.percussion.services.utils.orm.PSDataCollectionHelper.clearIdSet;
 import static com.percussion.services.utils.orm.PSDataCollectionHelper.executeQuery;
@@ -503,10 +505,86 @@ public class PSContentRepository
      */
     public static PSTypeConfiguration getTypeConfiguration(int contenttypeid)
     {
-        synchronized (ms_configuration)
+        return lookupTypeConfiguration(contenttypeid);
+    }
+
+    /**
+     * JCR type map lookup with perc/rff Managed Nav alias fallback (#3611).
+     * {@code perc.nav} can drop the Hibernate mapping for FastForward ids
+     * 313–315 while {@link PSItemDefManager} still catalogs {@code rffNav*}
+     * editors. Those items share {@code RXS_CT_NAV*} with {@code percNav*}
+     * (1015–1017), so the registered sibling mapping loads the node.
+     */
+    static PSTypeConfiguration lookupTypeConfiguration(long contentTypeId)
+    {
+        PSTypeConfiguration config = ms_configuration.get(new PSContentTypeKey(contentTypeId));
+        if (config != null)
         {
-            PSContentTypeKey key = new PSContentTypeKey(contenttypeid);
-            return ms_configuration.get(key);
+            return config;
+        }
+        return lookupNavAliasTypeConfiguration(contentTypeId);
+    }
+
+    static PSTypeConfiguration lookupNavAliasTypeConfiguration(long contentTypeId)
+    {
+        Long aliasId =
+            resolveNavAliasTypeId(
+                contentTypeId,
+                ms_configuration.keySet(),
+                PSContentRepository::contentTypeNameQuietly);
+        if (aliasId == null)
+        {
+            return null;
+        }
+        PSTypeConfiguration alias = ms_configuration.get(new PSContentTypeKey(aliasId));
+        if (alias != null)
+        {
+            ms_log.debug(
+                "Using JCR type configuration {} as perc/rff alias for content type id {}",
+                aliasId,
+                contentTypeId);
+        }
+        return alias;
+    }
+
+    /**
+     * Package-visible so unit tests can pin perc/rff JCR alias selection
+     * without a live ItemDefManager (#3611).
+     */
+    static Long resolveNavAliasTypeId(
+        long missingTypeId,
+        Iterable<IPSTypeKey> registeredKeys,
+        Function<Long, String> typeIdToName)
+    {
+        if (registeredKeys == null)
+        {
+            return null;
+        }
+        Set<Long> registered = new HashSet<>();
+        for (IPSTypeKey k : registeredKeys)
+        {
+            if (k instanceof PSContentTypeKey)
+            {
+                registered.add(k.getContentType());
+            }
+        }
+        return PSNavNameAliases.findRegisteredNavAliasTypeId(
+            missingTypeId, typeIdToName, registered);
+    }
+
+    private static String contentTypeNameQuietly(long typeId)
+    {
+        try
+        {
+            return PSItemDefManager.getInstance().contentTypeIdToName(typeId);
+        }
+        catch (PSInvalidContentTypeException e)
+        {
+            return null;
+        }
+        catch (RuntimeException e)
+        {
+            return null;
         }
     }
 
@@ -674,9 +752,8 @@ public class PSContentRepository
                     if (summary == null)
                         continue;
                     GeneratedClassBase instance = loadedInstances.get(legacyguid);
-                    // Create type key
-                    IPSTypeKey key = new PSContentTypeKey(summary.getContentTypeId());
-                    PSTypeConfiguration config = ms_configuration.get(key);
+                    PSTypeConfiguration config =
+                            lookupTypeConfiguration(summary.getContentTypeId());
                     if (config == null)
                     {
                         throw new RepositoryException(
@@ -882,8 +959,7 @@ public class PSContentRepository
             long type = s.getContentTypeId();
             if (typeToClassMap.get(type) == null)
             {
-                IPSTypeKey key = new PSContentTypeKey(type);
-                PSTypeConfiguration config = ms_configuration.get(key);
+                PSTypeConfiguration config = lookupTypeConfiguration(type);
                 if (config == null)
                 {
                     ms_log.error("No content type info found for content type id: {}",type);
@@ -1644,8 +1720,12 @@ public class PSContentRepository
                 // level cache has already booted the data.
                 if (s == null)
                     continue;
-                IPSTypeKey key = new PSContentTypeKey(s.getContentTypeId());
-                PSTypeConfiguration config = ms_configuration.get(key);
+                PSTypeConfiguration config =
+                        lookupTypeConfiguration(s.getContentTypeId());
+                if (config == null)
+                {
+                    continue;
+                }
                 List<PSTypeConfiguration.ImplementingClass> classes = config
                         .getImplementingClasses();
                 for (PSTypeConfiguration.ImplementingClass ic : classes)
@@ -1839,8 +1919,7 @@ public class PSContentRepository
         // types
         for (Long typeid : typeids)
         {
-            IPSTypeKey key = new PSContentTypeKey(typeid);
-            PSTypeConfiguration type = ms_configuration.get(key);
+            PSTypeConfiguration type = lookupTypeConfiguration(typeid);
             if (type == null)
             {
                 throw new InvalidQueryException("Unknown content type id "
@@ -2014,8 +2093,7 @@ public class PSContentRepository
                                IPSQueryNode internalwhere, int maxresults,
                                Map<String, ? extends Object> params) throws InvalidQueryException
     {
-        IPSTypeKey key = new PSContentTypeKey(typeid);
-        PSTypeConfiguration type = ms_configuration.get(key);
+        PSTypeConfiguration type = lookupTypeConfiguration(typeid);
         if (type == null)
         {
             // Demoted from WARN in v8.1.7 PR #853 / GH-849: this fires frequently for obsolete

--- a/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
@@ -17,8 +17,10 @@
 package com.percussion.cms.objectstore;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -61,6 +63,104 @@ public final class PSNavNameAliases {
   /** {@code percNavon} or {@code rffNavon} (any case). */
   public static boolean isNavonTypeName(String typeName) {
     return "navon".equals(navRoleKey(typeName));
+  }
+
+  /** {@code percNavImage} or {@code rffNavImage} (any case). */
+  public static boolean isNavImageTypeName(String typeName) {
+    return "navimage".equals(navRoleKey(typeName));
+  }
+
+  /** True for perc/rff NavTree, Navon, or Nav Image type names. */
+  public static boolean isNavTypeName(String typeName) {
+    return isNavTreeTypeName(typeName)
+        || isNavonTypeName(typeName)
+        || isNavImageTypeName(typeName);
+  }
+
+  /**
+   * FastForward sample-site installer ids ({@code rffNavImage} / {@code rffNavon} / {@code
+   * rffNavTree}).
+   */
+  public static final long RFF_NAV_IMAGE_TYPE_ID = 313L;
+
+  public static final long RFF_NAVON_TYPE_ID = 314L;
+
+  public static final long RFF_NAV_TREE_TYPE_ID = 315L;
+
+  /**
+   * {@code perc.nav} package ids ({@code percNavImage} / {@code percNavon} / {@code percNavTree}).
+   */
+  public static final long PERC_NAV_IMAGE_TYPE_ID = 1015L;
+
+  public static final long PERC_NAVON_TYPE_ID = 1016L;
+
+  public static final long PERC_NAV_TREE_TYPE_ID = 1017L;
+
+  /**
+   * Role key for the well-known FastForward / perc.nav type ids when the catalog has no name for
+   * that id. Empty when {@code typeId} is not one of those ids.
+   */
+  public static String wellKnownNavRole(long typeId) {
+    if (typeId == RFF_NAV_IMAGE_TYPE_ID || typeId == PERC_NAV_IMAGE_TYPE_ID) {
+      return "navimage";
+    }
+    if (typeId == RFF_NAVON_TYPE_ID || typeId == PERC_NAVON_TYPE_ID) {
+      return "navon";
+    }
+    if (typeId == RFF_NAV_TREE_TYPE_ID || typeId == PERC_NAV_TREE_TYPE_ID) {
+      return "navtree";
+    }
+    return "";
+  }
+
+  /**
+   * When a FastForward {@code rffNav*} type (313–315) is missing from the JCR configuration map but
+   * a {@code percNav*} sibling is registered (1015–1017), or the inverse, return the registered
+   * alias id. Both pairs share {@code RXS_CT_NAV*} tables, so items of the missing id load with the
+   * alias mapping. Name lookup may return null when ItemDef dropped the FastForward catalog entry;
+   * well-known ids still match by role. Returns {@code null} when the missing id is not a nav type
+   * or no sibling is registered.
+   */
+  public static Long findRegisteredNavAliasTypeId(
+      long missingTypeId,
+      Function<Long, String> typeIdToName,
+      Collection<Long> registeredTypeIds) {
+    if (typeIdToName == null || registeredTypeIds == null || registeredTypeIds.isEmpty()) {
+      return null;
+    }
+    String missingRole = navRoleForType(missingTypeId, typeIdToName);
+    if (missingRole.isEmpty()) {
+      return null;
+    }
+    for (Long registered : registeredTypeIds) {
+      if (registered == null || registered.longValue() == missingTypeId) {
+        continue;
+      }
+      if (missingRole.equals(navRoleForType(registered, typeIdToName))) {
+        return registered;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Catalog name role, else well-known FastForward / perc.nav id role. Never {@code null}; empty
+   * when neither source identifies a nav type.
+   */
+  static String navRoleForType(long typeId, Function<Long, String> typeIdToName) {
+    String fromName = navRoleKey(typeNameQuietly(typeIdToName, typeId));
+    if (!fromName.isEmpty()) {
+      return fromName;
+    }
+    return wellKnownNavRole(typeId);
+  }
+
+  private static String typeNameQuietly(Function<Long, String> typeIdToName, long typeId) {
+    try {
+      return typeIdToName.apply(typeId);
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSNavNameAliases.java
@@ -22,12 +22,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * perc* and rff* names (and their {@code psx_ce*} content-editor apps) are the same Managed Nav
  * roles. Catalog, config, and CE registration must treat them as aliases.
  */
 public final class PSNavNameAliases {
+
+  private static final Logger log = LogManager.getLogger(PSNavNameAliases.class);
 
   private PSNavNameAliases() {}
 
@@ -114,6 +118,32 @@ public final class PSNavNameAliases {
   }
 
   /**
+   * Sibling FastForward / perc.nav type id that shares {@code RXS_CT_NAV*} tables. {@code 313↔1015},
+   * {@code 314↔1016}, {@code 315↔1017}. {@code null} when {@code typeId} is not one of those ids.
+   */
+  public static Long wellKnownNavAliasTypeId(long typeId) {
+    if (typeId == RFF_NAV_IMAGE_TYPE_ID) {
+      return PERC_NAV_IMAGE_TYPE_ID;
+    }
+    if (typeId == RFF_NAVON_TYPE_ID) {
+      return PERC_NAVON_TYPE_ID;
+    }
+    if (typeId == RFF_NAV_TREE_TYPE_ID) {
+      return PERC_NAV_TREE_TYPE_ID;
+    }
+    if (typeId == PERC_NAV_IMAGE_TYPE_ID) {
+      return RFF_NAV_IMAGE_TYPE_ID;
+    }
+    if (typeId == PERC_NAVON_TYPE_ID) {
+      return RFF_NAVON_TYPE_ID;
+    }
+    if (typeId == PERC_NAV_TREE_TYPE_ID) {
+      return RFF_NAV_TREE_TYPE_ID;
+    }
+    return null;
+  }
+
+  /**
    * When a FastForward {@code rffNav*} type (313–315) is missing from the JCR configuration map but
    * a {@code percNav*} sibling is registered (1015–1017), or the inverse, return the registered
    * alias id. Both pairs share {@code RXS_CT_NAV*} tables, so items of the missing id load with the
@@ -127,6 +157,10 @@ public final class PSNavNameAliases {
       Collection<Long> registeredTypeIds) {
     if (typeIdToName == null || registeredTypeIds == null || registeredTypeIds.isEmpty()) {
       return null;
+    }
+    Long wellKnownAlias = wellKnownNavAliasTypeId(missingTypeId);
+    if (wellKnownAlias != null && registeredTypeIds.contains(wellKnownAlias)) {
+      return wellKnownAlias;
     }
     String missingRole = navRoleForType(missingTypeId, typeIdToName);
     if (missingRole.isEmpty()) {
@@ -159,6 +193,7 @@ public final class PSNavNameAliases {
     try {
       return typeIdToName.apply(typeId);
     } catch (RuntimeException e) {
+      log.debug("Nav alias catalog name lookup failed for content type id {}", typeId, e);
       return null;
     }
   }

--- a/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
@@ -18,9 +18,11 @@ package com.percussion.cms.objectstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class PSNavNameAliasesTest {
@@ -58,6 +60,56 @@ class PSNavNameAliasesTest {
     assertTrue(PSNavNameAliases.isNavonTypeName("rffNavon"));
     assertTrue(PSNavNameAliases.isNavonTypeName("percNavon"));
     assertFalse(PSNavNameAliases.isNavonTypeName("rffNavTree"));
+    assertTrue(PSNavNameAliases.isNavImageTypeName("rffNavImage"));
+    assertTrue(PSNavNameAliases.isNavImageTypeName("percNavImage"));
+    assertTrue(PSNavNameAliases.isNavTypeName("rffNavTree"));
+    assertFalse(PSNavNameAliases.isNavTypeName("percPage"));
+    assertFalse(PSNavNameAliases.isNavTypeName(null));
+  }
+
+  @Test
+  void findRegisteredNavAliasTypeIdMapsRffNavTreeToPercNavTree() {
+    Map<Long, String> names =
+        Map.of(
+            315L, "rffNavTree",
+            1017L, "percNavTree",
+            314L, "rffNavon",
+            1016L, "percNavon",
+            1001L, "percPage");
+    assertEquals(
+        1017L, PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, names.keySet()));
+    assertEquals(
+        315L, PSNavNameAliases.findRegisteredNavAliasTypeId(1017L, names::get, names.keySet()));
+    assertEquals(
+        1016L, PSNavNameAliases.findRegisteredNavAliasTypeId(314L, names::get, names.keySet()));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(1001L, names::get, names.keySet()));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, List.of(315L, 1001L)));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names::get, List.of()));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, null, names.keySet()));
+  }
+
+  @Test
+  void findRegisteredNavAliasTypeIdUsesWellKnownIdsWhenCatalogNameMissing() {
+    assertEquals(
+        1017L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(
+            315L, id -> id == 1017L ? "percNavTree" : null, List.of(1017L, 1001L)));
+    assertEquals(
+        1016L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(
+            314L, id -> id == 1016L ? "percNavon" : null, List.of(1016L)));
+    assertEquals(
+        1015L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(
+            313L, id -> id == 1015L ? "percNavImage" : null, List.of(1015L)));
+    assertEquals(
+        1017L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(315L, id -> null, List.of(1017L, 1001L)));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(315L, id -> null, List.of(1001L)));
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(42L, id -> null, List.of(1017L)));
+    assertEquals("navtree", PSNavNameAliases.wellKnownNavRole(315L));
+    assertEquals("navtree", PSNavNameAliases.wellKnownNavRole(1017L));
+    assertEquals("", PSNavNameAliases.wellKnownNavRole(1001L));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSNavNameAliasesTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 class PSNavNameAliasesTest {
@@ -110,6 +112,38 @@ class PSNavNameAliasesTest {
     assertEquals("navtree", PSNavNameAliases.wellKnownNavRole(315L));
     assertEquals("navtree", PSNavNameAliases.wellKnownNavRole(1017L));
     assertEquals("", PSNavNameAliases.wellKnownNavRole(1001L));
+    assertEquals(1017L, PSNavNameAliases.wellKnownNavAliasTypeId(315L));
+    assertEquals(315L, PSNavNameAliases.wellKnownNavAliasTypeId(1017L));
+    assertEquals(1016L, PSNavNameAliases.wellKnownNavAliasTypeId(314L));
+    assertEquals(1015L, PSNavNameAliases.wellKnownNavAliasTypeId(313L));
+    assertNull(PSNavNameAliases.wellKnownNavAliasTypeId(1001L));
+  }
+
+  @Test
+  void findRegisteredNavAliasTypeIdShortCircuitsWellKnownWithoutNameScan() {
+    AtomicInteger nameLookups = new AtomicInteger();
+    Function<Long, String> names =
+        id -> {
+          nameLookups.incrementAndGet();
+          throw new IllegalStateException("catalog must not be scanned");
+        };
+    assertEquals(
+        1017L,
+        PSNavNameAliases.findRegisteredNavAliasTypeId(315L, names, List.of(1017L, 1001L)));
+    assertEquals(
+        1016L, PSNavNameAliases.findRegisteredNavAliasTypeId(314L, names, List.of(1016L)));
+    assertEquals(
+        1015L, PSNavNameAliases.findRegisteredNavAliasTypeId(313L, names, List.of(1015L)));
+    assertEquals(0, nameLookups.get());
+  }
+
+  @Test
+  void findRegisteredNavAliasTypeIdSwallowsNameLookupFailuresForUnknownIds() {
+    Function<Long, String> boom =
+        id -> {
+          throw new IllegalStateException("catalog down");
+        };
+    assertNull(PSNavNameAliases.findRegisteredNavAliasTypeId(42L, boom, List.of(1001L)));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
@@ -21,10 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.contentmgr.IPSContentPropertyConstants;
+import com.percussion.services.contentmgr.impl.IPSTypeKey;
 import com.percussion.system.utils.IPSHtmlParameters;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -92,5 +95,34 @@ class PSServicesContentmgrTypedTest {
     Map<String, Object> remapped = PSContentRepository.remapFolderId(raw);
     assertEquals(8, remapped.get("rx:sys_contentid"));
     assertNull(remapped.get(IPSContentPropertyConstants.RX_SYS_FOLDERID));
+  }
+
+  @Test
+  @DisplayName("rffNavTree 315 aliases to percNavTree 1017 JCR mapping")
+  void resolveNavAliasTypeIdMapsRffNavTreeToPerc() {
+    Set<IPSTypeKey> registered =
+        Set.of(new PSContentTypeKey(1017), new PSContentTypeKey(1001));
+    Map<Long, String> names =
+        Map.of(315L, "rffNavTree", 1017L, "percNavTree", 1001L, "percPage");
+    assertEquals(
+        1017L, PSContentRepository.resolveNavAliasTypeId(315L, registered, names::get));
+    assertNull(PSContentRepository.resolveNavAliasTypeId(1001L, registered, names::get));
+    assertNull(PSContentRepository.resolveNavAliasTypeId(315L, List.of(), names::get));
+  }
+
+  @Test
+  @DisplayName("rffNavTree 315 aliases to percNavTree 1017 when ItemDef has no name for 315")
+  void resolveNavAliasTypeIdMapsRffNavTreeWhenMissingNameUnknown() {
+    Set<IPSTypeKey> registered =
+        Set.of(new PSContentTypeKey(1017), new PSContentTypeKey(1001));
+    assertEquals(
+        1017L,
+        PSContentRepository.resolveNavAliasTypeId(
+            315L, registered, id -> id == 1017L ? "percNavTree" : null));
+    assertEquals(
+        1017L, PSContentRepository.resolveNavAliasTypeId(315L, registered, id -> null));
+    assertNull(
+        PSContentRepository.resolveNavAliasTypeId(
+            315L, Set.of(new PSContentTypeKey(1001)), id -> null));
   }
 }

--- a/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/impl/legacy/PSServicesContentmgrTypedTest.java
@@ -17,6 +17,7 @@
 package com.percussion.services.contentmgr.impl.legacy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,11 @@ import org.junit.jupiter.api.Test;
 @Tag("UnitTest")
 @DisplayName("services.contentmgr package generics")
 class PSServicesContentmgrTypedTest {
+
+  @AfterEach
+  void clearNavAliasCache() {
+    PSContentRepository.clearNavAliasTypeIdCache();
+  }
 
   @Test
   @DisplayName("asStringObjectMap copies keys as strings and skips null keys")
@@ -124,5 +131,28 @@ class PSServicesContentmgrTypedTest {
     assertNull(
         PSContentRepository.resolveNavAliasTypeId(
             315L, Set.of(new PSContentTypeKey(1001)), id -> null));
+  }
+
+  @Test
+  @DisplayName("public getTypeConfiguration is exact-match only (no perc/rff write alias)")
+  void publicGetTypeConfigurationDoesNotApplyNavAlias() {
+    assertNull(PSContentRepository.lookupTypeConfigurationExact(315L));
+    assertNull(PSContentRepository.getTypeConfiguration(315));
+    assertEquals(
+        1017L,
+        PSContentRepository.resolveNavAliasTypeId(
+            315L, Set.of(new PSContentTypeKey(1017)), id -> null));
+  }
+
+  @Test
+  @DisplayName("nav alias type-id cache memos negative lookups")
+  void lookupNavAliasTypeConfigurationCachesNegativeResult() {
+    PSContentRepository.clearNavAliasTypeIdCache();
+    assertFalse(PSContentRepository.navAliasTypeIdCacheContains(315L));
+    assertNull(PSContentRepository.lookupNavAliasTypeConfiguration(315L));
+    assertTrue(PSContentRepository.navAliasTypeIdCacheContains(315L));
+    assertNull(PSContentRepository.lookupNavAliasTypeConfiguration(315L));
+    PSContentRepository.clearNavAliasTypeIdCache();
+    assertFalse(PSContentRepository.navAliasTypeIdCacheContains(315L));
   }
 }


### PR DESCRIPTION
## Summary

H2 QA FastForward sample sites already have `rffNavTree` items (content type **315**). After `perc.nav` registers `percNavTree` at **1017**, the JCR type map often has no mapping for 315, and the running catalog may drop FastForward names (`Invalid content type id (313)`). `GET /Rhythmyx/services/sitemanage/section/tree/Corporate_Investments` then threw `No content type info found for content type id: 315` (HTTP 500), so Architecture never mounted `role="treeitem"` and Create section stayed dead.

This change:

1. Resolves perc/rff Managed Nav aliases in `PSContentRepository` so 313–315 items load through the registered 1015–1017 Hibernate mapping (shared `RXS_CT_NAV*` tables).
2. Falls back to **well-known id roles** (313–315 ↔ 1015–1017) when ItemDef has no name for the missing id.
3. Missing-NavTree still returns empty HTTP 200.

Does **not** seed a second NavTree. Does **not** allowlist 500.

Closed unmerged predecessor: #3614 (cluster absorb #3623 also closed). Related open sibling #3634 (#3612 bookmark console-clean) shares the same JCR alias class; this PR’s acceptance is Create-section no-skip.

Parent trackers: #3589 / #3092.

Fixes #3611
Partial #3589
Partial #3092

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (H2 cell HEALTH:healthy / HTTP 200).
2. Login as Admin. `GET /Rhythmyx/services/sitemanage/section/tree/Corporate_Investments` must be HTTP **200** with `SectionNode` children (not empty, not 500).
3. From `modules/perc-qa-automation/frontend`:
   `TEST_CMS_URL=<from qa-health> ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from cell> TEST_DB_TYPE=h2 TEST_PRODUCT=cms npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js`
   Expect 2 passed: treeitems visible, Create section enabled, Escape closes, console-clean via `isKnownArchitectureConsoleNoise`.
4. Always `python docker/scripts/perc-devctl.py qa-down`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (sample-site tree GET 200 + perc/rff JCR alias + Create section enabled)
- [x] **Unit / module tests** — `PSNavNameAliasesTest`, `PSServicesContentmgrTypedTest`, `PSSiteSectionServiceLoadTreeEmptyTest`, `PSSiteSectionRestServiceLoadTreeEmptyTest`
- [x] **WebUI + Playwright** — existing `architecture-create-section-noskip.spec.js` (no skip); C5 H2 surface 2 passed
- [x] **Build gates** — standalone `mvnw clean install` on changed modules
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `system`, `projects/sitemanage`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (01:51). Tests run: 2220, Failures: 0, Skipped: 238. `PSNavNameAliasesTest` Tests run: 6, Failures: 0. `PSServicesContentmgrTypedTest` Tests run: 7, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (58.7s). Tests run: 1266, Failures: 0, Skipped: 125. `PSSiteSectionServiceLoadTreeEmptyTest` Tests run: 8, Failures: 0. `PSSiteSectionRestServiceLoadTreeEmptyTest` Tests run: 6, Failures: 0.
- **downstream_checked:** none (no type made `final`/`sealed`; no existing public/protected method or ctor signature change). Additive `wellKnownNavRole` + public id constants. Grep `extends PSNavNameAliases` / `new PSNavNameAliases() {` / `extends PSContentRepository` / `new PSContentRepository() {` — no matches.

## C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`
- qa-health: RESULT:OK HTTP 200 / HEALTH:healthy
- Deploy: `docker cp` `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/WEB-INF/lib/`; in-cell `StopJetty.sh` / `StartJetty.sh` (not `docker restart`)
- After restart: qa-health RESULT:OK again
- Playwright: `npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js` → **2 passed** (3.4s)
- console-clean=yes (spec asserts `isKnownArchitectureConsoleNoise`)
- server.log-clean=yes for the post-restart test window (no type-315 ERROR)
- qa-down: RESULT:OK

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
