### PR TITLE
fix(webui): mount Explorer Dependencies for selected content row (#3571)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -744,7 +744,8 @@ function ContentExplorerShellInner({
     setSelection((prev) => ({ ...prev, item: bound }));
     setShowSubfolderCopy(false);
     // List rows that omit id / use a slug still resolve via path so
-    // View → Relationships can mount (#3546 / #2778).
+    // View → Relationships and View → Dependencies can mount
+    // (#3546 / #2778 / #3571).
     if (
       isFolder(bound) ||
       parseExplorerContentId(bound.id) != null ||
@@ -1178,15 +1179,14 @@ function ContentExplorerShellInner({
     [selection.folderPath, selection.item?.path, selection.item?.type],
   );
   const hasFolderContext = sourceFolderPathForCopy != null;
-  const hasDependencyItem =
-    selection.item != null &&
-    !isFolder(selection.item) &&
-    selection.item.id != null &&
-    String(selection.item.id).trim().length > 0;
   const hasRelationshipItem =
     selection.item != null &&
     !isFolder(selection.item) &&
     parseExplorerContentId(selection.item.id) != null;
+  // Same eligibility as Relationships: numeric id or GUID last-segment
+  // (host-type-uuid). A non-empty slug such as theme.css is not enough
+  // (#3571 / parent #2776).
+  const hasDependencyItem = hasRelationshipItem;
   const hasOpenSidePanel =
     showSearch ||
     showSecurity ||
@@ -1778,7 +1778,10 @@ function ContentExplorerShellInner({
           >
             <DependencyViewer
               item={{
-                id: String(selection.item!.id),
+                id: String(
+                  parseExplorerContentId(selection.item!.id) ??
+                    selection.item!.id,
+                ),
                 path: selection.item!.path,
                 folderPath: selection.folderPath ?? undefined,
               }}

--- a/WebUI/src/main/ts/contentExplorer/views/DependencyViewer.tsx
+++ b/WebUI/src/main/ts/contentExplorer/views/DependencyViewer.tsx
@@ -25,6 +25,7 @@ import {
   labelFor,
   totalKnownEdges,
 } from "./dependencyModel";
+import { parseExplorerContentId } from "../../api/contentExplorer/pathItemId";
 import { fetchNodeSummary } from "../../api/contentExplorer/relationshipsApi";
 
 export interface DependencyItem {
@@ -88,7 +89,11 @@ export function DependencyViewer(
   } = props;
   const summarise = composeSummary ?? defaultComposeSummary;
 
-  const itemId = item.id ?? "";
+  // REST /relationships/{id} needs a numeric content id. List rows often
+  // carry host-type-uuid (1-101-708); last segment is the content id (#3571).
+  const parsedId = parseExplorerContentId(item.id);
+  const itemId =
+    parsedId != null ? String(parsedId) : String(item.id ?? "").trim();
   const [state, setState] = React.useState<
     | { kind: "loading" }
     | { kind: "ok"; summary: PSNodeRelationshipSummary }

--- a/WebUI/src/main/ts/contentExplorer/views/DependencyViewer.tsx
+++ b/WebUI/src/main/ts/contentExplorer/views/DependencyViewer.tsx
@@ -91,9 +91,11 @@ export function DependencyViewer(
 
   // REST /relationships/{id} needs a numeric content id. List rows often
   // carry host-type-uuid (1-101-708); last segment is the content id (#3571).
+  // Unparseable ids must not fall back to the raw string (that 404s the REST
+  // path); shell already gates on parseExplorerContentId.
   const parsedId = parseExplorerContentId(item.id);
-  const itemId =
-    parsedId != null ? String(parsedId) : String(item.id ?? "").trim();
+  const itemId = parsedId != null ? String(parsedId) : "";
+  const rawId = String(item.id ?? "").trim();
   const [state, setState] = React.useState<
     | { kind: "loading" }
     | { kind: "ok"; summary: PSNodeRelationshipSummary }
@@ -103,6 +105,13 @@ export function DependencyViewer(
 
   React.useEffect(() => {
     let alive = true;
+    if (!itemId && rawId) {
+      setState({
+        kind: "error",
+        message: rawId,
+      });
+      return;
+    }
     if (!itemId) {
       // No item id → don't fire a network round-trip; the rest endpoint
       // would 404 on the empty path segment. Render the auth placeholder
@@ -136,7 +145,7 @@ export function DependencyViewer(
     return () => {
       alive = false;
     };
-  }, [itemId, loadServerSummary]);
+  }, [itemId, rawId, loadServerSummary]);
 
   if (state.kind === "loading") {
     return (

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -2282,7 +2282,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       });
     });
 
-    renderShell(
+    const { container } = renderShell(
       <ContentExplorerShell
         initialPath="/Sites/Corporate_Investments/web_resources/theme"
         loadDisplayFormats={async () => []}
@@ -2318,6 +2318,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       expect(loadDependencySummary).toHaveBeenCalledWith("708");
     });
     expect(screen.queryByTestId("explorer-dependencies-hint")).toBeNull();
+    await renderA11yGate(container);
   });
 
   it("dependencies toggle keeps select-item hint for a folder row (#3571)", async () => {
@@ -2351,7 +2352,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       });
     });
 
-    renderShell(
+    const { container } = renderShell(
       <ContentExplorerShell
         initialPath="/Sites/Corporate_Investments"
         loadDisplayFormats={async () => []}
@@ -2373,6 +2374,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
     expect(screen.queryByTestId("explorer-dependencies-panel")).toBeNull();
     expect(screen.queryByTestId("dependency-viewer")).toBeNull();
+    await renderA11yGate(container);
   });
 
   it("root initialPath does not call resolveFolderId (#3468)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -2162,6 +2162,219 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await renderA11yGate(container);
   });
 
+  it("dependencies panel mounts for a GUID-shaped content row (#3571)", async () => {
+    const loadDependencySummary = vi.fn(async () => ({
+      outgoing: { count: 0, byType: [] as { type: string; count: number }[] },
+      incoming: { count: 0, byType: [] as { type: string; count: number }[] },
+      taxonomy: { count: 0, nodes: [] as string[] },
+      local: { count: 0, links: [] as { type: string; targetId: string }[] },
+      reverse: { count: 0, byType: [] as { type: string; count: number }[] },
+    }));
+
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "1-101-708",
+                  name: "Home",
+                  path: "/Sites/Corporate_Investments/Pages/Home",
+                  type: "rffHome",
+                  category: "PAGE",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/Pages"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        loadDependencySummary={loadDependencySummary}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-1-101-708")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-1-101-708"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-dependencies"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-dependencies-panel"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("dependency-viewer")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(loadDependencySummary).toHaveBeenCalledWith("708");
+    });
+    expect(screen.queryByTestId("explorer-dependencies-hint")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("dependencies panel resolves omitted list id via path lookup (#3571)", async () => {
+    const loadDependencySummary = vi.fn(async () => ({
+      outgoing: { count: 0, byType: [] as { type: string; count: number }[] },
+      incoming: { count: 0, byType: [] as { type: string; count: number }[] },
+      taxonomy: { count: 0, nodes: [] as string[] },
+      local: { count: 0, links: [] as { type: string; targetId: string }[] },
+      reverse: { count: 0, byType: [] as { type: string; count: number }[] },
+    }));
+
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/path/item/")) {
+        return new Response(
+          JSON.stringify({
+            PathItem: {
+              id: "1-101-708",
+              name: "theme.css",
+              path: "/Sites/Corporate_Investments/web_resources/theme/theme.css",
+              type: "rffFile",
+              category: "ASSET",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  name: "theme.css",
+                  path: "/Sites/Corporate_Investments/web_resources/theme/theme.css",
+                  type: "rffFile",
+                  category: "ASSET",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments/web_resources/theme"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        loadDependencySummary={loadDependencySummary}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(
+          "detail-row-/Sites/Corporate_Investments/web_resources/theme/theme.css",
+        ),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByTestId(
+        "detail-row-/Sites/Corporate_Investments/web_resources/theme/theme.css",
+      ),
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-dependencies"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-dependencies-panel"),
+      ).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("dependency-viewer")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(loadDependencySummary).toHaveBeenCalledWith("708");
+    });
+    expect(screen.queryByTestId("explorer-dependencies-hint")).toBeNull();
+  });
+
+  it("dependencies toggle keeps select-item hint for a folder row (#3571)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "99",
+                  name: "Pages",
+                  path: "/Sites/Corporate_Investments/Pages/",
+                  type: "Folder",
+                  category: "FOLDER",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Corporate_Investments"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-99")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-99"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-dependencies"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-dependencies-hint"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("explorer-dependencies-panel")).toBeNull();
+    expect(screen.queryByTestId("dependency-viewer")).toBeNull();
+  });
+
   it("root initialPath does not call resolveFolderId (#3468)", async () => {
     stubPathFetch();
     const resolveFolderId = vi.fn(async () => "should-not-run");

--- a/WebUI/src/test/ts/contentExplorer/DependencyViewer.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DependencyViewer.test.tsx
@@ -145,6 +145,23 @@ describe("DependencyViewer", () => {
     await renderA11yGate(container);
   });
 
+  it("parses a GUID id before calling /relationships (#3571)", async () => {
+    const loader = vi.fn().mockResolvedValue(SYNTHETIC_SERVER);
+    render(
+      <DependencyViewer
+        item={{ id: "1-101-708", folderPath: "/Sites/Foo" }}
+        loadServerSummary={loader}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("dependency-viewer")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loader).toHaveBeenCalledWith("708");
+  });
+
   it("renders the auth placeholder and does not call loadServerSummary when item.id is missing", async () => {
     const loader = vi.fn();
     render(<DependencyViewer item={{}} loadServerSummary={loader} />);

--- a/WebUI/src/test/ts/contentExplorer/DependencyViewer.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DependencyViewer.test.tsx
@@ -41,7 +41,7 @@ describe("DependencyViewer", () => {
   it("renders the 6 dimension rows for a page item", async () => {
     render(
       <DependencyViewer
-        item={{ id: "p-1", folderPath: "/Sites/Foo" }}
+        item={{ id: "42", folderPath: "/Sites/Foo" }}
         aaLinkCount={2}
         loadServerSummary={mockLoad}
       />,
@@ -63,7 +63,7 @@ describe("DependencyViewer", () => {
   it("shows the AA count when known", async () => {
     render(
       <DependencyViewer
-        item={{ id: "x", folderPath: "/p" }}
+        item={{ id: "42", folderPath: "/p" }}
         aaLinkCount={5}
         loadServerSummary={mockLoad}
       />,
@@ -80,7 +80,7 @@ describe("DependencyViewer", () => {
 
   it("no longer renders the client-side preview banner (US8 ships)", async () => {
     render(
-      <DependencyViewer item={{ id: "x" }} loadServerSummary={mockLoad} />,
+      <DependencyViewer item={{ id: "42" }} loadServerSummary={mockLoad} />,
     );
     await waitFor(() =>
       expect(screen.queryByTestId("dependency-viewer")).toHaveAttribute(
@@ -95,7 +95,7 @@ describe("DependencyViewer", () => {
     const d = deferred<PSNodeRelationshipSummary>(SYNTHETIC_SERVER);
     render(
       <DependencyViewer
-        item={{ id: "x" }}
+        item={{ id: "42" }}
         loadServerSummary={() => d.promise}
       />,
     );
@@ -116,7 +116,7 @@ describe("DependencyViewer", () => {
     const denied = { status: 403, statusText: "Forbidden" };
     render(
       <DependencyViewer
-        item={{ id: "private" }}
+        item={{ id: "42" }}
         loadServerSummary={() => Promise.reject(denied)}
       />,
     );
@@ -131,7 +131,7 @@ describe("DependencyViewer", () => {
   it("passes the zero serious/critical axe-core gate", async () => {
     const { container } = render(
       <DependencyViewer
-        item={{ id: "x", folderPath: "/p" }}
+        item={{ id: "42", folderPath: "/p" }}
         aaLinkCount={3}
         loadServerSummary={mockLoad}
       />,
@@ -147,7 +147,7 @@ describe("DependencyViewer", () => {
 
   it("parses a GUID id before calling /relationships (#3571)", async () => {
     const loader = vi.fn().mockResolvedValue(SYNTHETIC_SERVER);
-    render(
+    const { container } = render(
       <DependencyViewer
         item={{ id: "1-101-708", folderPath: "/Sites/Foo" }}
         loadServerSummary={loader}
@@ -160,6 +160,22 @@ describe("DependencyViewer", () => {
       ),
     );
     expect(loader).toHaveBeenCalledWith("708");
+    await renderA11yGate(container);
+  });
+
+  it("renders error and does not call loadServerSummary for an unparseable id", async () => {
+    const loader = vi.fn();
+    const { container } = render(
+      <DependencyViewer item={{ id: "nope" }} loadServerSummary={loader} />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("dependency-viewer")).toHaveAttribute(
+        "data-testid-state",
+        "error",
+      ),
+    );
+    expect(loader).not.toHaveBeenCalled();
+    await renderA11yGate(container);
   });
 
   it("renders the auth placeholder and does not call loadServerSummary when item.id is missing", async () => {

--- a/docs/ai-generated/code-reviews/3571-explorer-dependencies-mount-erlang.md
+++ b/docs/ai-generated/code-reviews/3571-explorer-dependencies-mount-erlang.md
@@ -1,0 +1,66 @@
+# Erlang review — #3571 Explorer Dependencies mount
+
+**Branch:** `fix/issue-3571-explorer-dependencies-mount`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-08-19  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** missing behavioral tests (covered); incomplete change-class closure (WebUI screen → Playwright + product-docs companions present); CMS `/` URL paths are not OS file I/O (false-positive guard)
+
+## Summary
+
+Human QA on #2776 failed because View → Dependencies stayed on `explorer-dependencies-hint` after selecting a content row. `hasDependencyItem` treated any non-empty `selection.item.id` as eligible while Relationships already required `parseExplorerContentId` (numeric or GUID last-segment). Playwright accepted hint **or** viewer, so H2 QA could green without mounting.
+
+This slice:
+
+- Aligns `hasDependencyItem` with `hasRelationshipItem` (`parseExplorerContentId`)
+- Passes the parsed content id into `DependencyViewer` (and parses GUID inside the viewer)
+- Adds Vitest for GUID row, omitted-id path lookup (`theme.css`), and folder hint
+- Rewrites Playwright so a Sites content row **must** mount `explorer-dependencies-panel` / `dependency-viewer`
+- Updates `product-docs/8.2/admin/content-explorer.md` operator steps
+
+No Java API shape changes. No non-portable filesystem path joins.
+
+## Issues
+
+None blocking.
+
+### nit — Playwright console-clean listeners attach after `beforeEach` navigation
+
+`attachConsoleCleanGate` in the hint test runs after login/goto. Uncaught errors during the initial Explorer load are not asserted. The mount test navigates again after attach. Acceptable for this slice; pageerror on the mount path is still gated.
+
+### nit — `String(parseExplorerContentId(...) ?? selection.item!.id)` fallback is dead
+
+The panel only mounts when `hasDependencyItem` is true, so parse already succeeded. Harmless and matches the Relationships panel shape.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Shell eligibility + parsed id | `ContentExplorerShell.tsx` |
+| Viewer GUID parse | `DependencyViewer.tsx` + unit test |
+| Vitest selected-row mount | GUID, omitted id / path lookup, folder hint |
+| Playwright surface | `explorer-dependencies.spec.js` — no hint-or-panel skip when a content row exists |
+| Product docs | `product-docs/8.2/admin/content-explorer.md` |
+| QA README | `modules/perc-qa-automation/README.md` |
+
+## Cross-platform path checklist
+
+- No new `"/" +` / `"\\" +` filesystem construction
+- CMS Explorer paths and REST URLs correctly use `/`
+- Playwright `paginatedFolder` URL is HTTP, not OS I/O
+- N/A for installers / temp files
+
+## Tests / build (pre-PR)
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 2896 passed; Surefire Java 63 (17+7+15+11+6+7)
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (no Java tests)
+
+C5 Playwright (2026-08-19):
+
+- `perc-devctl qa-up --skip-image-build` → cell `perc-matrix-cms-h2` HEALTH:healthy HTTP:200; `qa-health` RESULT:FAIL `DETAIL:server_log_errors` FastForward `PSDbStorageService Could not import item` (BUG:#3592, not `Failed startup of context`)
+- Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
+- `npm run test:surface -- --path tests/explorer-dependencies.spec.js` — 2 passed
+- `npm run test:golden` — 2 passed
+- console-clean=yes (pageerror empty; network `Failed to load resource` filtered)
+- server.log-clean=yes for this feature (BUG:#3592 FastForward import + search-index at cell start; thin H2 relationship 403/auth viewer is in-scope)

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -702,11 +702,13 @@ npm run test:surface:list -- --path tests/explorer-relationships.spec.js
 npm run test:surface:list -- --tag explorer-relationships
 ```
 
-#### Explorer dependency viewer (#2768 / parent #2400)
+#### Explorer dependency viewer (#2768 / #3571 / parent #2400)
 
-View → Dependencies shell chrome + optional DependencyViewer mount for a
-selected content item (reuses relationship summary REST). Soft-skip deep
-relationship count assertions when the QA fixture has no selectable row.
+View → Dependencies shell chrome + DependencyViewer mount for a selected
+non-folder content row (numeric id or GUID last-segment). Empty / folder
+selection still shows the select-item hint. Do **not** treat the hint as a
+pass when a content row exists. Empty/error dimension states are OK on thin
+H2 fixtures once the viewer mounts.
 
 | Item | Value |
 |------|--------|

--- a/modules/perc-qa-automation/frontend/tests/explorer-dependencies.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-dependencies.spec.js
@@ -15,12 +15,13 @@
  */
 
 /**
- * Playwright surface: #2768 / parent #2400 — Explorer Dependency Viewer shell chrome.
+ * Playwright surface: #2768 / #3571 / parent #2400 — Explorer Dependency Viewer.
  *
- * <p>Verifies the modern React Content Explorer mounts View → Dependencies and
- * either shows the select-item hint or the DependencyViewer panel (reusing the
- * existing relationship summary REST loaders). Soft-skip deep relationship
- * assertions when the QA fixture has no selectable content item.</p>
+ * <p>Verifies the modern React Content Explorer mounts View → Dependencies.
+ * Empty selection shows the select-item hint. A selected non-folder content
+ * row (numeric or GUID last-segment) must mount {@code explorer-dependencies-panel}
+ * / {@code dependency-viewer} — do not treat the hint as a pass when a content
+ * row exists (H2 QA / parent #2776).</p>
  *
  * <p>Tags: {@code @explorer-dependencies} {@code @p-adv} {@code @smoke}</p>
  *
@@ -38,7 +39,29 @@ async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
 }
 
-test.describe("modern React Content Explorer — dependency viewer (#2768)", () => {
+function attachConsoleCleanGate(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") {
+      return;
+    }
+    const text = msg.text();
+    // Network 4xx/5xx on Explorer chrome / thin H2 relationship REST is
+    // console "error" but not an uncaught JS exception (C5d). Auth/error
+    // viewer states are in-scope for #3571.
+    if (/Failed to load resource/i.test(text)) {
+      return;
+    }
+    consoleErrors.push(text);
+  });
+  return { pageErrors, consoleErrors };
+}
+
+test.describe("modern React Content Explorer — dependency viewer (#2768 / #3571)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(45_000);
     await loginAsAdmin(page);
@@ -52,6 +75,7 @@ test.describe("modern React Content Explorer — dependency viewer (#2768)", () 
     "shell mounts dependencies toggle and select-item hint",
     { tag: ["@explorer-dependencies", "@p-adv", "@smoke"] },
     async ({ page }) => {
+      const { pageErrors, consoleErrors } = attachConsoleCleanGate(page);
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
@@ -77,90 +101,144 @@ test.describe("modern React Content Explorer — dependency viewer (#2768)", () 
       await expect(
         page.locator('[data-testid="dependency-viewer"]'),
       ).toHaveCount(0);
+      await expect(
+        page.locator('[data-testid="explorer-dependencies-panel"]'),
+      ).toHaveCount(0);
+      expect(pageErrors, "uncaught pageerror on dependencies hint").toEqual([]);
+      expect(consoleErrors, "console error on dependencies hint").toEqual([]);
     },
   );
 
   test(
-    "selecting a list row opens dependency viewer or select-item hint",
+    "selecting a content row mounts the dependency viewer (#3571)",
     { tag: ["@explorer-dependencies", "@p-adv"] },
     async ({ page }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(90_000);
+      const { pageErrors, consoleErrors } = attachConsoleCleanGate(page);
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
 
-      // Navigate into a structural root so the list has selectable children.
-      const tree = page.locator('[data-testid="explorer-tree"]');
-      await expect(tree).toBeVisible({ timeout: 15_000 });
-      const sitesNode = page
-        .locator(
-          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
-        )
-        .first();
-      if ((await sitesNode.count()) > 0) {
-        // No force:true / silent catch — surface navigation failures.
-        await sitesNode.click({ timeout: 10_000 });
-        await listWaitReady(page);
-        await page.waitForLoadState("networkidle").catch(() => {});
+      async function fetchChildren(folderPath) {
+        const suffix = String(folderPath || "")
+          .replace(/^\/+/, "")
+          .replace(/\/+$/, "");
+        const url = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/paginatedFolder/${suffix}?startIndex=0&maxResults=50`;
+        const res = await page.request.get(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok()) {
+          return [];
+        }
+        const body = await res.json();
+        return body?.PagedItemList?.childrenInPage ?? [];
       }
+
+      function isContentChild(child) {
+        const type = String(child?.type ?? "").trim().toLowerCase();
+        const category = String(child?.category ?? "").trim().toLowerCase();
+        if (
+          type === "folder" ||
+          type === "fsfolder" ||
+          type === "site" ||
+          category === "folder" ||
+          category === "site" ||
+          category === "section_folder"
+        ) {
+          return false;
+        }
+        if (
+          category === "page" ||
+          category === "asset" ||
+          category === "landing_page"
+        ) {
+          return true;
+        }
+        return type.length > 0 && type !== "folder";
+      }
+
+      async function findFolderWithContent(startPath, depth) {
+        const children = await fetchChildren(startPath);
+        const items = children.filter(isContentChild);
+        if (items.length > 0) {
+          return { folderPath: startPath, items };
+        }
+        if (depth <= 0) {
+          return null;
+        }
+        for (const child of children) {
+          const next =
+            child.folderPath ||
+            child.path ||
+            (child.name
+              ? `${startPath.replace(/\/+$/, "")}/${child.name}`
+              : null);
+          if (!next) continue;
+          const found = await findFolderWithContent(next, depth - 1);
+          if (found) return found;
+        }
+        return null;
+      }
+
+      const found = await findFolderWithContent("/Sites", 4);
+      expect(
+        found,
+        "H2 sample sites should list at least one page/asset under Sites",
+      ).toBeTruthy();
+
+      const folderPath = found.folderPath.replace(/\/+$/, "") || "/Sites";
+      await page.goto(
+        `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&path=${encodeURIComponent(folderPath)}&_=${Date.now()}`,
+      );
+      await page.waitForLoadState("networkidle");
+      await listWaitReady(page);
 
       const list = page.locator('[data-testid="detail-list"]');
       await expect(list).toBeVisible({ timeout: 15_000 });
 
-      const enabledRows = list.locator(
-        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      const itemRow = list.locator(
+        'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]:not([aria-disabled="true"])',
       );
-      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
-      const enabledCount = await enabledRows.count();
-      const anyCount = await anyRows.count();
-      if (enabledCount === 0 && anyCount === 0) {
-        // Soft path: empty list fixtures still prove chrome wiring via hint.
-        await page.locator('[data-testid="explorer-menu-view"]').click();
-        await page
-          .locator('[data-testid="explorer-toggle-dependencies"]')
-          .click();
-        await expect(
-          page.locator('[data-testid="explorer-dependencies-hint"]'),
-        ).toBeVisible({ timeout: 5_000 });
-        return;
-      }
 
-      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
-      try {
-        await target.click({ timeout: 10_000 });
-      } catch (err) {
-        const again = list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .first();
-        await again.click({ timeout: 10_000 });
+      if ((await itemRow.count()) === 0) {
+        const first = found.items[0];
+        const idKey = first.id ?? first.path;
+        const byId = list.locator(`[data-testid="detail-row-${idKey}"]`);
+        expect(
+          await byId.count(),
+          "content row from pathmanagement must appear in the detail list",
+        ).toBeGreaterThan(0);
+        await byId.first().click({ force: true, timeout: 10_000 });
+      } else {
+        await itemRow.first().click({ force: true, timeout: 10_000 });
       }
 
       await page.locator('[data-testid="explorer-menu-view"]').click();
       await page.locator('[data-testid="explorer-toggle-dependencies"]').click();
 
-      // Either full viewer (content id) or select-item hint (folder / no id).
+      const region = page.locator(
+        '[data-testid="explorer-dependencies-panel"]',
+      );
       const panel = page.locator('[data-testid="dependency-viewer"]');
-      const hint = page.locator('[data-testid="explorer-dependencies-hint"]');
-      await expect(panel.or(hint)).toBeVisible({ timeout: 15_000 });
-
-      if ((await panel.count()) > 0) {
-        await expect(panel).toHaveAttribute(
-          "data-testid-state",
-          /ok|loading|auth|error/,
-        );
-        // Soft-skip strict ok when relationships REST/fixture is thin.
-        await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
-          timeout: 20_000,
-        });
-        const state = await panel.getAttribute("data-testid-state");
-        if (state === "ok") {
-          await expect(
-            page.locator('[data-testid="dependency-dimensions"]'),
-          ).toBeVisible();
-          await expect(
-            page.locator('[data-testid="dependency-row-outgoing"]'),
-          ).toBeVisible();
-        }
-      }
+      await expect(region).toBeVisible({ timeout: 15_000 });
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-testid="explorer-dependencies-hint"]'),
+      ).toHaveCount(0);
+      await expect(panel).toHaveAttribute(
+        "data-testid-state",
+        /ok|loading|auth|error/,
+      );
+      await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+        timeout: 20_000,
+      });
+      expect(
+        pageErrors,
+        "uncaught pageerror on dependencies mount",
+      ).toEqual([]);
+      expect(
+        consoleErrors,
+        "console error on dependencies mount",
+      ).toEqual([]);
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/explorer-dependencies.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-dependencies.spec.js
@@ -239,6 +239,10 @@ test.describe("modern React Content Explorer — dependency viewer (#2768 / #357
         consoleErrors,
         "console error on dependencies mount",
       ).toEqual([]);
+
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
     },
   );
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -123,7 +123,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open the CM1 editor (`?view=editor`). |
 | **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`1-101-708`); the panel uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
-| **Impact Analysis** | Opens the Explorer **Dependencies** panel for the selected item. |
+| **Impact Analysis** | Opens the Explorer **Dependencies** panel for the **selected page or asset**. List row ids may be GUID-shaped (`1-101-708`); the viewer uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
 | **Revisions** | Opens the Revisions panel; restore is available when the selected revision is restorable. **Promote revision** opens the same chrome-less editor host (`mode=promote`) and restores the chosen revision through `GET /services/itemmanagement/item/restoreRevision/{revisionGuid}`. |
 | **Audit Trail** | Same Revisions panel, audit-trail tab. |
@@ -348,9 +348,11 @@ From the **View** menu you can also toggle:
   **page or asset** is selected (not a folder or site). On sample FastForward
   sites, expand a site in the tree, open a section folder (for example
   **AboutEnterpriseInvestments** — not only a `Pages` folder), and select a
-  content row. **View → Relationships** then mounts the relationships panel
-  (loading, results, empty, or an error). A folder-only or empty selection
-  keeps the select-item hint. See **Translations** below for locale variants.
+  content row. **View → Relationships** or **View → Dependencies** then mounts
+  the matching panel (loading, results, empty, or an error). List row ids may
+  be GUID-shaped (`1-101-708`); both panels use the last segment as the
+  content id. A folder-only or empty selection keeps the select-item hint.
+  See **Translations** below for locale variants.
 - **Clipboard** — copy/cut staging panel. **View → Clipboard** always opens
   the panel (even when empty) and shows a check mark while it is visible.
   Use **Content → Add to clipboard** after multi-select to put items on the


### PR DESCRIPTION
## Summary

Human QA on #2776 failed: after selecting a non-folder Explorer row (`theme.css` / content GUID), **View → Dependencies** stayed on `explorer-dependencies-hint`. `explorer-dependencies-panel` / `dependency-viewer` never mounted.

`hasDependencyItem` only required a non-empty `selection.item.id`. Relationships already requires `parseExplorerContentId` (numeric id or GUID `host-type-uuid` last segment) and path lookup when the list omits id. This PR aligns Dependencies with that gate, passes the parsed content id into `DependencyViewer`, and stops Playwright from treating the hint as a pass when a content row exists.

Parent: #2400 / implement #2768 / QA #2776. Residual implement: #3571.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3571

## Test plan

Env: QA H2 docker (`perc-devctl qa-up`) or installed CMS; user Admin.

1. Open modern Explorer: `/Rhythmyx/cm/app/spa.jsp?entry=explorer`
2. Open **View** and toggle **Dependencies** with no selection → `explorer-dependencies-hint`
3. Navigate under **Sites** to a folder with a page/asset row (GUID or numeric id is fine)
4. Select the **non-folder** row, toggle **Dependencies** → `explorer-dependencies-panel` + `dependency-viewer` (loading / ok / auth / error all acceptable)
5. Select a **folder** row with Dependencies open → hint, not viewer
6. Toggle Dependencies off → panel/hint hidden

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (Impact Analysis + View → Dependencies GUID last-segment)
- [x] **Unit / module tests** — Vitest GUID / omitted-id path lookup / folder hint; `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/explorer-dependencies.spec.js` requires mount when a content row exists
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation`
- [x] **Cross-platform** — N/A (no filesystem path I/O; CMS URL paths use `/`)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (01:38). Vitest 2896 passed. Surefire Java: Tests run 17+7+15+11+6+7 = 63, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (2.752 s; No tests to run)
- **downstream_checked:** none (no Java `final`/public API shape change; TS UI + Playwright only)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → cell `perc-matrix-cms-h2` `TEST_CMS_URL=http://127.0.0.1:9993` HEALTH:healthy HTTP:200
- `qa-health` RESULT:FAIL `DETAIL:server_log_errors` FastForward `PSDbStorageService Could not import item` — **BUG:#3592** (not `Failed startup of context` / not `rhythmyx_context_failed`)
- Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- `npm run test:surface -- --path tests/explorer-dependencies.spec.js` → **2 passed**
- `npm run test:golden` → **2 passed**
- **console-clean=yes** (no pageerror; network `Failed to load resource` 4xx/5xx filtered — thin H2 relationship 403/auth viewer is in-scope)
- **server.log-clean=yes** for this feature (BUG:#3592 FastForward import + search-index at cell start)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
