### PR TITLE
fix(webui): Explorer tree parent refresh after Delete/Rename (#3653 #3652)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -143,7 +143,11 @@ import {
   toDetailDisplayFormat,
 } from "./displayFormatMap";
 import { ExplorerMenuBar } from "./ExplorerMenuBar";
-import { ExplorerTree } from "./ExplorerTree";
+import {
+  ExplorerTree,
+  normalizeExplorerTreePathKey,
+  parentExplorerTreePath,
+} from "./ExplorerTree";
 import { FolderSecurityPanel } from "./FolderSecurityPanel";
 import type { ExplorerMenuCommandId } from "./menuBarModel";
 import { EXPLORER_MSG } from "./messages";
@@ -655,15 +659,26 @@ function ContentExplorerShellInner({
       const impl = actionHandlers?.onDelete ?? stockReducedHandlers.onDelete;
       await impl(item);
       setSelection((prev) => {
-        const deleted = String(item.path ?? "").replace(/\/+$/, "");
-        const selected = String(prev.item?.path ?? "").replace(/\/+$/, "");
+        const deleted = normalizeExplorerTreePathKey(item.path);
+        const deletedFolder = normalizeExplorerTreePathKey(
+          item.folderPath ?? item.path,
+        );
+        const selectedRow = normalizeExplorerTreePathKey(prev.item?.path);
+        const currentFolder = normalizeExplorerTreePathKey(prev.folderPath);
+        const deletingOpenFolder =
+          currentFolder !== "/" &&
+          (currentFolder === deleted || currentFolder === deletedFolder);
         return {
-          folderPath: prev.folderPath,
-          item: deleted && selected === deleted ? null : prev.item,
+          folderPath: deletingOpenFolder
+            ? parentExplorerTreePath(prev.folderPath) ?? prev.folderPath
+            : prev.folderPath,
+          item: deleted && selectedRow === deleted ? null : prev.item,
         };
       });
       // #3645 split folderTreeEpoch from the list epoch; list-only refresh
-      // would leave the deleted name in the tree.
+      // would leave the deleted name in the tree. ExplorerTree also reloads
+      // the parent node keyed by finder path when selectedPath is a
+      // repository folderPath (#3653).
       handleRefreshListAndTree();
     },
     // Product Copy folder (flag off) POSTs public REST copy/folder then

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -55,38 +55,125 @@ export interface ExplorerTreeProps {
   onActivate?: (path: string, folder: PSPathItem) => void;
   /**
    * When this value changes (and is non-zero), reload children of the
-   * selected folder even if they were already loaded. Used after Create
-   * Folder (#3640) and Rename (#3645) so the tree shows the new name
-   * without a manual Refresh. Hosts should pass a dedicated folder-mutation
-   * epoch, not the detail-list epoch.
+   * selected folder, its tree parent, and the tree root even if they were
+   * already loaded. Used after Create Folder (#3640), Rename (#3645 / #3652),
+   * and Delete (#3646 / #3653) so the tree shows the new name (or drops the
+   * deleted name) without a manual Refresh. Hosts should pass a dedicated
+   * folder-mutation epoch, not the detail-list epoch.
    */
   childrenEpoch?: number;
 }
 
 /**
- * Compare tree node keys with list paths that may differ only by a trailing
- * slash ({@code /Assets} vs {@code /Assets/}).
+ * Compare tree node keys with list paths that may differ by a trailing
+ * slash or a repository {@code //} prefix ({@code /Assets} vs
+ * {@code /Assets/} vs {@code //Assets}).
  */
 export function normalizeExplorerTreePathKey(
   path: string | null | undefined,
 ): string {
-  const raw = String(path ?? "").trim();
-  if (!raw || raw === "/") {
+  let p = String(path ?? "").trim().replace(/\\/g, "/");
+  if (!p || p === "/") {
     return "/";
   }
-  return raw.replace(/\/+$/, "") || "/";
+  p = p.replace(/^[A-Za-z]:/, "");
+  while (p.startsWith("//")) {
+    p = p.slice(1);
+  }
+  p = p.replace(/\/{2,}/g, "/");
+  if (!p.startsWith("/")) {
+    p = `/${p}`;
+  }
+  return p.replace(/\/+$/, "") || "/";
 }
 
-function resolveLoadedNodePath(
-  nodes: Record<string, NodeState>,
+/**
+ * Parent of a CMS tree path ({@code /Sites/Foo} → {@code /Sites}).
+ * Root {@code /} has no parent.
+ */
+export function parentExplorerTreePath(
+  path: string | null | undefined,
+): string | null {
+  const n = normalizeExplorerTreePathKey(path);
+  if (n === "/") {
+    return null;
+  }
+  const i = n.lastIndexOf("/");
+  if (i <= 0) {
+    return "/";
+  }
+  return n.slice(0, i) || "/";
+}
+
+function pathKeyMatches(
+  candidate: string | null | undefined,
+  wanted: ReadonlySet<string>,
+): boolean {
+  if (candidate == null || String(candidate).trim().length === 0) {
+    return false;
+  }
+  return wanted.has(normalizeExplorerTreePathKey(candidate));
+}
+
+/**
+ * Node keys to force-reload on a folder-mutation epoch.
+ *
+ * <p>Product Explorer seeds {@code initialPath="/"} while the selected list
+ * path may be a repository {@code folderPath} ({@code /Folders/$System$/Assets})
+ * and the visible tree node is keyed by finder {@code path} ({@code /Assets}).
+ * Reloading only {@code selectedPath} + root leaves the expanded parent's
+ * children stale after Delete/Rename (#3653 / #3652). Match loaded children
+ * by path <em>or</em> folderPath, and always include the tree parent of
+ * {@code selectedPath} so a tree-selected deleted folder drops from its
+ * parent without View → Refresh.</p>
+ *
+ * <p>Does not walk every loaded node — expanded siblings stay cached
+ * (#3645 review).</p>
+ */
+export function collectChildrenEpochReloadPaths(
+  nodes: Record<string, { children: ReadonlyArray<Pick<PSPathItem, "path" | "folderPath">> }>,
   selectedPath: string | null,
-  fallback: string,
-): string {
-  const target = normalizeExplorerTreePathKey(selectedPath ?? fallback);
-  const hit = Object.keys(nodes).find(
-    (key) => normalizeExplorerTreePathKey(key) === target,
-  );
-  return hit ?? selectedPath ?? fallback;
+  initialPath: string,
+): string[] {
+  const out = new Set<string>();
+  const hasNode = (key: string | null | undefined): boolean =>
+    key != null && Object.prototype.hasOwnProperty.call(nodes, key);
+  if (initialPath) {
+    out.add(initialPath);
+  }
+  const selectedKey = resolveLoadedNodePath(nodes, selectedPath, initialPath);
+  if (hasNode(selectedKey)) {
+    out.add(selectedKey);
+  }
+  const wanted = new Set<string>();
+  const addWanted = (p: string | null | undefined): void => {
+    const n = normalizeExplorerTreePathKey(p);
+    if (n !== "/") {
+      wanted.add(n);
+    }
+  };
+  addWanted(selectedPath);
+  addWanted(selectedKey);
+  addWanted(parentExplorerTreePath(selectedPath));
+  addWanted(parentExplorerTreePath(selectedKey));
+
+  for (const [key, state] of Object.entries(nodes)) {
+    if (pathKeyMatches(key, wanted)) {
+      out.add(key);
+    }
+    for (const child of state.children ?? []) {
+      if (
+        pathKeyMatches(child.path, wanted) ||
+        pathKeyMatches(child.folderPath, wanted)
+      ) {
+        out.add(key);
+        if (hasNode(child.path)) {
+          out.add(child.path);
+        }
+      }
+    }
+  }
+  return [...out];
 }
 
 interface NodeState {
@@ -102,6 +189,39 @@ const EMPTY_STATE: NodeState = {
   error: null,
   children: [],
 };
+
+function resolveLoadedNodePath(
+  nodes: Record<string, unknown>,
+  selectedPath: string | null,
+  fallback: string,
+): string {
+  const target = normalizeExplorerTreePathKey(selectedPath ?? fallback);
+  const hit = Object.keys(nodes).find(
+    (key) => normalizeExplorerTreePathKey(key) === target,
+  );
+  return hit ?? selectedPath ?? fallback;
+}
+
+function findFolderItemForPath(
+  nodes: Record<string, NodeState>,
+  path: string,
+): PSPathItem | null {
+  const target = normalizeExplorerTreePathKey(path);
+  for (const state of Object.values(nodes)) {
+    for (const child of state.children) {
+      if (normalizeExplorerTreePathKey(child.path) === target) {
+        return child;
+      }
+      if (
+        child.folderPath &&
+        normalizeExplorerTreePathKey(child.folderPath) === target
+      ) {
+        return child;
+      }
+    }
+  }
+  return null;
+}
 
 export function ExplorerTree({
   initialPath = "/",
@@ -155,19 +275,19 @@ export function ExplorerTree({
       return;
     }
     const snapshot = nodesRef.current;
-    const selected = resolveLoadedNodePath(
+    const toReload = collectChildrenEpochReloadPaths(
       snapshot,
       selectedPathRef.current,
       initialPath,
     );
-    const toReload = new Set<string>([selected, initialPath]);
     for (const path of toReload) {
-      void ensureLoaded(path, null, true);
+      // Pass the PathItem when we have it so force-reload uses
+      // folderPath (Assets → //Folders/$System$/Assets) not the finder key.
+      void ensureLoaded(path, findFolderItemForPath(snapshot, path), true);
     }
-    // Reload only the selected folder (and the tree root). Do not walk
-    // every loaded node — hosts used to pass listEpoch and that shotgun
-    // refetch (#3645 review). selectedPath is read from a ref so selection
-    // clicks after an epoch bump do not re-run this effect (#3640).
+    // Reload selected + its tree parent + root. selectedPath is read from
+    // a ref so selection clicks after an epoch bump do not re-run this
+    // effect (#3640). Do not walk every loaded node (#3645 review).
   }, [childrenEpoch, ensureLoaded, initialPath]);
 
   const toggle = useCallback(

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.delete.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.delete.test.tsx
@@ -119,4 +119,98 @@ describe("ContentExplorerShell delete folder (#3646)", () => {
     });
     await renderA11yGate(container);
   });
+
+  it("drops the deleted name from the tree when product initialPath is / (#3653)", async () => {
+    const SITES = {
+      id: "sites-root",
+      path: "/Sites",
+      name: "Sites",
+      type: "folder",
+      folderPath: "//Sites",
+      hasFolderChildren: true,
+    };
+    let deleted = false;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/pathmanagement/path/deleteFolder")) {
+        deleted = true;
+        return new Response("0", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      if (url.includes("/pathmanagement/path/delete/") && !url.includes("deleteFolder")) {
+        return new Response("missing", { status: 404 });
+      }
+      const pathOnly = url.split("?")[0];
+      const isRootList =
+        /\/path\/folder\/?$/.test(pathOnly) ||
+        /\/paginatedFolder\/?$/.test(pathOnly);
+      const isSitesList =
+        /\/folder\/Sites\/?$/.test(pathOnly) ||
+        /\/paginatedFolder\/Sites/.test(pathOnly);
+      const kids = isRootList
+        ? [SITES]
+        : isSitesList
+          ? deleted
+            ? []
+            : [DISPOSABLE]
+          : [];
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: kids,
+              childrenCount: kids.length,
+              startIndex: 0,
+            },
+            PathItem: kids,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const { container } = renderShell(
+      <ContentExplorerShell
+        initialPath="/"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        loadWorkflowMenuActions={async () => null}
+        actionHandlers={{
+          confirm: () => true,
+        }}
+      />,
+    );
+
+    const sitesNode = await screen.findByTestId("tree-node-/Sites");
+    const toggle = sitesNode.querySelector('[aria-hidden="true"]');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle!);
+    await waitFor(() => {
+      expect(screen.getByTestId("tree-node-/Sites/qa3646")).toBeInTheDocument();
+    });
+
+    const row = await screen.findByTestId("detail-row-n-3646");
+    fireEvent.click(row);
+
+    const deleteBtn = await screen.findByTestId("action-delete");
+    expect(deleteBtn).toBeEnabled();
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("detail-row-n-3646")).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("tree-node-/Sites/qa3646"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("qa3646")).not.toBeInTheDocument();
+    await renderA11yGate(container);
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -18,7 +18,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   ExplorerTree,
+  collectChildrenEpochReloadPaths,
   normalizeExplorerTreePathKey,
+  parentExplorerTreePath,
 } from "../../../main/ts/contentExplorer/ExplorerTree";
 import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
 import { mockFetch } from "./setup";
@@ -317,6 +319,64 @@ describe("ExplorerTree", () => {
     expect(normalizeExplorerTreePathKey("/Assets/")).toBe("/Assets");
     expect(normalizeExplorerTreePathKey("/")).toBe("/");
     expect(normalizeExplorerTreePathKey("")).toBe("/");
+    expect(normalizeExplorerTreePathKey("//Assets")).toBe("/Assets");
+    expect(normalizeExplorerTreePathKey("//Folders/$System$/Assets")).toBe(
+      "/Folders/$System$/Assets",
+    );
+  });
+
+  it("parentExplorerTreePath walks one segment", () => {
+    expect(parentExplorerTreePath("/Sites/Foo")).toBe("/Sites");
+    expect(parentExplorerTreePath("/Folders/$System$/Assets")).toBe(
+      "/Folders/$System$",
+    );
+    expect(parentExplorerTreePath("/Sites")).toBe("/");
+    expect(parentExplorerTreePath("/")).toBeNull();
+  });
+
+  it("collectChildrenEpochReloadPaths reloads finder parent for repository selectedPath (#3653)", () => {
+    const nodes = {
+      "/": {
+        children: [
+          {
+            path: "/Assets",
+            folderPath: "//Folders/$System$/Assets",
+          },
+          { path: "/Sites", folderPath: "//Sites" },
+        ],
+      },
+      "/Assets": {
+        children: [{ path: "/Assets/qa3653", folderPath: "//Folders/$System$/Assets/qa3653" }],
+      },
+      "/Sites": {
+        children: [{ path: "/Sites/Other", folderPath: "//Sites/Other" }],
+      },
+    };
+    const paths = collectChildrenEpochReloadPaths(
+      nodes,
+      "/Folders/$System$/Assets",
+      "/",
+    );
+    expect(paths).toContain("/");
+    expect(paths).toContain("/Assets");
+    expect(paths).not.toContain("/Sites");
+  });
+
+  it("collectChildrenEpochReloadPaths reloads tree parent when selected is the deleted child (#3653)", () => {
+    const nodes = {
+      "/": { children: [{ path: "/Sites", folderPath: "//Sites" }] },
+      "/Sites": {
+        children: [{ path: "/Sites/qa3653", folderPath: "//Sites/qa3653" }],
+      },
+    };
+    const paths = collectChildrenEpochReloadPaths(
+      nodes,
+      "/Sites/qa3653",
+      "/",
+    );
+    expect(paths).toContain("/");
+    expect(paths).toContain("/Sites");
+    expect(paths).not.toContain("/Sites/qa3653");
   });
 
   it("reloads selected folder children when childrenEpoch changes (#3640 #3645)", async () => {
@@ -446,6 +506,264 @@ describe("ExplorerTree", () => {
     );
     await waitFor(() => expect(sitesCalls).toBeGreaterThan(sitesAfterExpand));
     expect(fooCalls).toBe(1);
+    await renderA11yGate(container);
+  });
+
+  it("force-reloads Assets children when selectedPath is repository folderPath (#3653)", async () => {
+    const ASSETS: PSPathItem = {
+      id: "assets-root",
+      path: "/Assets",
+      name: "Assets",
+      type: "folder",
+      folderPath: "//Folders/$System$/Assets",
+      hasFolderChildren: true,
+    };
+    const DISPOSABLE: PSPathItem = {
+      id: "qa-3653",
+      path: "/Assets/qa3653",
+      name: "qa3653",
+      type: "folder",
+      folderPath: "//Folders/$System$/Assets/qa3653",
+      hasFolderChildren: false,
+    };
+    let assetsListCalls = 0;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (
+        url.endsWith("/pathmanagement/path/folder/") ||
+        /\/pathmanagement\/path\/folder\/?$/.test(url)
+      ) {
+        return pathItemListResponse([ASSETS]);
+      }
+      if (
+        url.includes("/pathmanagement/path/folder/Folders/") &&
+        url.includes("Assets")
+      ) {
+        assetsListCalls += 1;
+        return pathItemListResponse(assetsListCalls > 1 ? [] : [DISPOSABLE]);
+      }
+      return pathItemListResponse([]);
+    });
+    const { rerender, container } = render(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/"
+        onSelectFolder={() => undefined}
+        childrenEpoch={0}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Assets")).toBeInTheDocument(),
+    );
+    const assetsNode = screen.getByTestId("tree-node-/Assets");
+    const toggle = assetsNode.querySelector('[aria-hidden="true"]');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle!);
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Assets/qa3653")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("qa3653")).toBeInTheDocument();
+    rerender(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/Folders/$System$/Assets"
+        onSelectFolder={() => undefined}
+        childrenEpoch={1}
+      />,
+    );
+    await waitFor(() => expect(assetsListCalls).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(screen.queryByTestId("tree-node-/Assets/qa3653")).toBeNull(),
+    );
+    expect(screen.queryByText("qa3653")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("shows renamed child after childrenEpoch when selectedPath is repository folderPath (#3652)", async () => {
+    const ASSETS: PSPathItem = {
+      id: "assets-root",
+      path: "/Assets",
+      name: "Assets",
+      type: "folder",
+      folderPath: "//Folders/$System$/Assets",
+      hasFolderChildren: true,
+    };
+    const OLD_FOLDER: PSPathItem = {
+      id: "qa-3652",
+      path: "/Assets/OldFolder",
+      name: "OldFolder",
+      type: "folder",
+      folderPath: "//Folders/$System$/Assets/OldFolder",
+      hasFolderChildren: false,
+    };
+    const NEW_FOLDER: PSPathItem = {
+      id: "qa-3652",
+      path: "/Assets/qa3652r",
+      name: "qa3652r",
+      type: "folder",
+      folderPath: "//Folders/$System$/Assets/qa3652r",
+      hasFolderChildren: false,
+    };
+    let assetsListCalls = 0;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (
+        url.endsWith("/pathmanagement/path/folder/") ||
+        /\/pathmanagement\/path\/folder\/?$/.test(url)
+      ) {
+        return pathItemListResponse([ASSETS]);
+      }
+      if (
+        url.includes("/pathmanagement/path/folder/Folders/") &&
+        url.includes("Assets")
+      ) {
+        assetsListCalls += 1;
+        return pathItemListResponse(
+          assetsListCalls > 1 ? [NEW_FOLDER] : [OLD_FOLDER],
+        );
+      }
+      return pathItemListResponse([]);
+    });
+    const { rerender, container } = render(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/"
+        onSelectFolder={() => undefined}
+        childrenEpoch={0}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Assets")).toBeInTheDocument(),
+    );
+    const assetsNode = screen.getByTestId("tree-node-/Assets");
+    const toggle = assetsNode.querySelector('[aria-hidden="true"]');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle!);
+    await waitFor(() =>
+      expect(screen.getByText("OldFolder")).toBeInTheDocument(),
+    );
+    rerender(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/Folders/$System$/Assets"
+        onSelectFolder={() => undefined}
+        childrenEpoch={1}
+      />,
+    );
+    await waitFor(() => expect(assetsListCalls).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(screen.getByText("qa3652r")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("OldFolder")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("force-reloads parent children when selectedPath is the deleted folder (#3653)", async () => {
+    const DISPOSABLE: PSPathItem = {
+      id: "qa-3653b",
+      path: "/Sites/qa3653b",
+      name: "qa3653b",
+      type: "folder",
+      hasFolderChildren: false,
+    };
+    let sitesCalls = 0;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        sitesCalls += 1;
+        return pathItemListResponse(sitesCalls > 1 ? [] : [DISPOSABLE]);
+      }
+      return pathItemListResponse([]);
+    });
+    const { rerender, container } = render(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath="/Sites/qa3653b"
+        onSelectFolder={() => undefined}
+        childrenEpoch={0}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Sites/qa3653b")).toBeInTheDocument(),
+    );
+    rerender(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath="/Sites/qa3653b"
+        onSelectFolder={() => undefined}
+        childrenEpoch={1}
+      />,
+    );
+    await waitFor(() => expect(sitesCalls).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(screen.queryByTestId("tree-node-/Sites/qa3653b")).toBeNull(),
+    );
+    expect(screen.queryByText("qa3653b")).toBeNull();
+    await renderA11yGate(container);
+  });
+
+  it("force-reloads parent children after epoch when product root is / (#3653)", async () => {
+    const SITES: PSPathItem = {
+      id: "sites-root",
+      path: "/Sites",
+      name: "Sites",
+      type: "folder",
+      folderPath: "//Sites",
+      hasFolderChildren: true,
+    };
+    const DISPOSABLE: PSPathItem = {
+      id: "qa-3653c",
+      path: "/Sites/qa3653c",
+      name: "qa3653c",
+      type: "folder",
+      hasFolderChildren: false,
+    };
+    let sitesCalls = 0;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (
+        url.endsWith("/pathmanagement/path/folder/") ||
+        /\/pathmanagement\/path\/folder\/?$/.test(url)
+      ) {
+        return pathItemListResponse([SITES]);
+      }
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        sitesCalls += 1;
+        return pathItemListResponse(sitesCalls > 1 ? [] : [DISPOSABLE]);
+      }
+      return pathItemListResponse([]);
+    });
+    const { rerender, container } = render(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/"
+        onSelectFolder={() => undefined}
+        childrenEpoch={0}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Sites")).toBeInTheDocument(),
+    );
+    const sitesNode = screen.getByTestId("tree-node-/Sites");
+    const toggle = sitesNode.querySelector('[aria-hidden="true"]');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle!);
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Sites/qa3653c")).toBeInTheDocument(),
+    );
+    rerender(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath="/Sites/qa3653c"
+        onSelectFolder={() => undefined}
+        childrenEpoch={1}
+      />,
+    );
+    await waitFor(() => expect(sitesCalls).toBeGreaterThan(1));
+    await waitFor(() =>
+      expect(screen.queryByTestId("tree-node-/Sites/qa3653c")).toBeNull(),
+    );
+    expect(screen.queryByText("qa3653c")).toBeNull();
     await renderA11yGate(container);
   });
 });

--- a/docs/ai-generated/code-reviews/3653-explorer-tree-refresh-after-delete-erlang.md
+++ b/docs/ai-generated/code-reviews/3653-explorer-tree-refresh-after-delete-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — #3653 / #3652 Explorer tree refresh after Delete/Rename
+
+**Branch:** `fix/issue-3653-explorer-tree-parent-epoch`  
+**Base:** `origin/main` (`441025a626`, cluster #3651)  
+**Date:** 2026-08-20  
+**Reviewer:** Erlang (independent of implementer)
+
+## Summary
+
+After #3651, product-route Delete/Rename still left `[data-testid=explorer-tree]` stale. `folderTreeEpoch` bumped, but `ExplorerTree` reloaded only `selectedPath` + `initialPath`. Product Explorer seeds `initialPath="/"`. Selected list path is often a repository `folderPath` (`/Folders/$System$/Assets`) while the visible tree node is keyed by finder `path` (`/Assets`). Force-reload therefore created an unused node and left expanded parent children stale.
+
+The epoch collector now matches loaded children by `path` **or** `folderPath`, always includes the tree parent of `selectedPath`, and force-reloads using the original `PSPathItem` so `findChildren` hits `folderPath`. Expanded siblings stay cached (#3645). `onDelete` walks `folderPath` to the parent when the deleted folder is the open folder.
+
+Playwright H2 QA: delete 2 passed 0 skipped; rename 2 passed 0 skipped; golden 2 passed. Gap-matrix not flipped to Present. Product-docs already describe list+tree refresh without View → Refresh.
+
+Memory patterns hit: missing behavioral unit tests (now present for parent reload + repository `folderPath`); Playwright no-skip when H2 demo parent exists; WebUI screen companion; incomplete change-class closure (Vitest + existing Playwright specs); no Unix-only filesystem joins (CMS `/` paths only).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None (hard-gate).
+
+Cross-platform path checklist: N/A for filesystem I/O. Tree/list keys are CMS URL-style paths (`/`). `normalizeExplorerTreePathKey` collapses repository `//` and trailing slashes; it does not join OS file paths.
+
+## Tests / evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS. Vitest 2946 passed (387 files), including `ExplorerTree.test.tsx` (19) and `ContentExplorerShell.delete.test.tsx` (2).
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS. Tests run: 0 (Playwright is npm).
+- C5: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` TEST_CMS_URL=`http://127.0.0.1:9993` CONTAINER=`perc-matrix-cms-h2`; `qa-health` RESULT:OK HEALTH:healthy; hot-copy `WebUI/target/generated-webui/cm/modern/assets` → WAR `cm/modern/assets`; Jetty Stop/Start inside cell; `qa-health` again RESULT:OK HEALTH:healthy.
+- `npm run test:surface -- --path tests/explorer-delete-folder.spec.js` — 2 passed, 0 skipped. console-clean=yes.
+- `npm run test:surface -- --path tests/explorer-rename-folder.spec.js` — 2 passed, 0 skipped. console-clean=yes.
+- `npm run test:golden` — 2 passed.
+- server.log-clean=yes (no ERROR/FATAL after Jetty restart).
+
+downstream_checked: none (TypeScript-only; no Java `final`/`sealed` or public API signature change).


### PR DESCRIPTION
## Summary

After cluster #3651, product-route **Delete** and **Rename** (`spa.jsp?entry=explorer`, `rxFolderMutations` off) still left `[data-testid=explorer-tree]` stale: the detail list updated, but the expanded parent kept the old folder name until View → Refresh.

`folderTreeEpoch` was bumping, but `ExplorerTree` only force-reloaded `selectedPath` + `initialPath`. Product Explorer seeds `initialPath="/"`. The selected list path is often a repository `folderPath` (`/Folders/$System$/Assets`) while the visible tree node is keyed by finder `path` (`/Assets`). The epoch therefore reloaded the wrong key (or only `/`) and left parent children cached.

This PR reloads the **tree parent** of the mutation: match loaded children by `path` **or** `folderPath`, include the parent of `selectedPath`, and pass the original `PSPathItem` so `findChildren` uses `folderPath`. Expanded siblings stay cached (#3645). Delete also walks `folderPath` to the parent when the deleted folder is the open folder.

Parent tracker: #3102. Residual of #3646 / #3645 (cycle-verify #3653 / #3652).

Fixes #3653
Fixes #3652

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `perc-devctl qa-up` → `qa-health` (H2 Docker; use printed `TEST_CMS_URL`, do not hardcode `:9993`).
2. Hot-copy `WebUI/target/generated-webui/cm/modern/assets` into `perc-matrix-cms-h2` WAR `cm/modern/assets`; Jetty Stop/Start **inside** the cell; `qa-health` again.
3. From `modules/perc-qa-automation/frontend`:
   - `npm run test:surface -- --path tests/explorer-delete-folder.spec.js` — 2 passed, 0 skipped.
   - `npm run test:surface -- --path tests/explorer-rename-folder.spec.js` — 2 passed, 0 skipped.
   - `npm run test:golden` — 2 passed.
4. After Delete on the product route, the folder name is gone from `[data-testid=explorer-tree]` without View → Refresh.
5. After Rename, the new name is visible in the tree without View → Refresh.

## Checklist

- [x] **Product documentation** — N/A: `product-docs/8.2/admin/content-explorer.md` already states Delete/Rename refresh list **and** tree without a manual Refresh; this PR makes the SPA match that operator text.
- [x] **Unit / module tests** — Vitest for parent epoch reload (repository `folderPath` vs finder key; deleted child; product root `/`). `WebUI` and `modules/perc-qa-automation` standalone `mvnw clean install` green.
- [x] **WebUI + Playwright** — existing `explorer-delete-folder.spec.js` and `explorer-rename-folder.spec.js` (0 skipped) plus golden smoke.
- [x] **Build gates** — standalone clean install on changed modules; no Java API shape change.
- [x] **Cross-platform** — N/A for filesystem I/O; CMS URL-style `/` paths only.

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 2946 passed (387 files); `ExplorerTree.test.tsx` 19 tests; `ContentExplorerShell.delete.test.tsx` 2 tests.
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (Playwright is npm, Surefire Tests run: 0).
- **downstream_checked:** none (TypeScript-only; no Java `final`/`sealed` or public API signature change).

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — RESULT:OK; `TEST_CMS_URL=http://127.0.0.1:9993`; container `perc-matrix-cms-h2`.
- `qa-health` — RESULT:OK HTTP:200 HEALTH:healthy.
- Hot-copy `WebUI/target/generated-webui/cm/modern/assets` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`; `StopJetty.sh` / `StartJetty.sh` inside cell (not `docker restart`).
- `qa-health` after restart — RESULT:OK HEALTH:healthy.
- Playwright: delete 2 passed 0 skipped; rename 2 passed 0 skipped; golden 2 passed.
- console-clean=yes (specs assert no related pageerror/console error).
- server.log-clean=yes (no ERROR/FATAL after Jetty restart).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
