### PR TITLE
feat(webui): New Section landing name, title, and template (#3661)

### DIFF
--- a/WebUI/src/main/ts/api/architecture/index.ts
+++ b/WebUI/src/main/ts/api/architecture/index.ts
@@ -75,6 +75,8 @@ export {
   buildCreateSectionFromFolderBody,
   buildCreateSectionLinkPath,
   buildCreateSiteSectionBody,
+  mapCreateSectionDialogToFields,
+  validateCreateSectionForm,
   buildMoveSiteSectionBody,
   buildReplaceLandingPageBody,
   buildReparentMove,
@@ -105,6 +107,7 @@ export {
   parseReplaceLandingPagePayload,
   parseSiteSectionPayload,
   parseSiteSectionPropertiesPayload,
+  resolveCreateFolderPath,
   resolveCreateParentFolderPath,
   splitCmsPagePath,
   validateExternalUrl,
@@ -115,7 +118,10 @@ export {
   validateSectionTitle,
   validateSourceFolderPath,
 } from "./sectionMutations";
-export type { SectionPropertiesFormValues } from "./sectionMutations";
+export type {
+  CreateSectionDialogFields,
+  SectionPropertiesFormValues,
+} from "./sectionMutations";
 export type {
   CreateExternalLinkFields,
   CreateSectionFromFolderFields,

--- a/WebUI/src/main/ts/api/architecture/sectionMutations.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionMutations.ts
@@ -343,6 +343,58 @@ export function resolveCreateParentFolderPath(
 }
 
 /**
+ * Folder path for {@code POST /section/create}. Prefers the tree node's
+ * {@code folderPath}, then a freshly loaded section path (the nav tree wire
+ * often omits folderPath), then the site-name fallback.
+ */
+export function resolveCreateFolderPath(
+  parent: NavTreeNode | null,
+  loadedFolderPath: string | null | undefined,
+  siteName: string,
+): string {
+  const fromParent = parent?.folderPath != null ? parent.folderPath.trim() : "";
+  if (fromParent) {
+    return toRepositoryCmsPath(fromParent);
+  }
+  const fromLoaded = loadedFolderPath != null ? loadedFolderPath.trim() : "";
+  if (fromLoaded) {
+    return toRepositoryCmsPath(fromLoaded);
+  }
+  return resolveCreateParentFolderPath(parent, siteName);
+}
+
+/**
+ * Dialog fields for Architecture Create section (landing page + template).
+ */
+export interface CreateSectionDialogFields {
+  title: string;
+  urlName: string;
+  pageName: string;
+  templateId: string;
+}
+
+/**
+ * Map New Section dialog fields onto {@code CreateSiteSection} wire fields.
+ * {@code pageName} is the landing-page file name (not the folder URL).
+ */
+export function mapCreateSectionDialogToFields(
+  input: CreateSectionDialogFields,
+  folderPath: string,
+): CreateSiteSectionFields {
+  return {
+    pageTitle: input.title.trim(),
+    pageLinkTitle: input.title.trim(),
+    pageName: input.pageName.trim(),
+    pageUrlIdentifier: input.urlName.trim(),
+    templateId: input.templateId.trim(),
+    folderPath,
+    sectionType: "section",
+    copyTemplates: true,
+    target: "_self",
+  };
+}
+
+/**
  * Build Jackson-rooted create body for {@code POST /section/create}.
  */
 export function buildCreateSiteSectionBody(
@@ -656,6 +708,27 @@ export function validateLandingPageName(name: string): string | null {
   if (t.includes("/") || t.includes("\\")) {
     return message(
       "perc.ui.architecture.modern@Landing page name must be a file name, not a path",
+    );
+  }
+  return null;
+}
+
+/**
+ * Client-side validation for Create section (no POST on empty/invalid).
+ * Returns the first error message or {@code null} when valid.
+ */
+export function validateCreateSectionForm(
+  input: CreateSectionDialogFields,
+): string | null {
+  const titleErr = validateSectionTitle(input.title);
+  if (titleErr) return titleErr;
+  const urlErr = validateSectionFolderName(input.urlName);
+  if (urlErr) return urlErr;
+  const pageErr = validateLandingPageName(input.pageName);
+  if (pageErr) return pageErr;
+  if (!input.templateId.trim()) {
+    return message(
+      "perc.ui.architecture.modern@No templates are available for this site.",
     );
   }
   return null;

--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -302,6 +302,34 @@ export async function fetchTemplatesForSite(
 }
 
 /**
+ * Base / responsive read-only template catalog
+ * ({@code GET /pagemanagement/template/summary/all/readonly}).
+ */
+export async function fetchReadonlyTemplateSummaries(): Promise<
+  TemplateSummary[]
+> {
+  const data = await get<unknown>(PATHS.TEMPLATES_READONLY);
+  return unwrapTemplateSummaries(data);
+}
+
+/**
+ * Templates for Architecture Create section: prefer the site catalog, then
+ * the read-only library so operators can still pick a landing template when
+ * the site has no associated templates (typical H2 sample-site seed).
+ */
+export async function fetchTemplatesForSectionCreate(
+  siteName: string,
+): Promise<TemplateSummary[]> {
+  const site = siteName.trim()
+    ? await fetchTemplatesForSite(siteName)
+    : [];
+  if (site.length > 0) {
+    return site;
+  }
+  return fetchReadonlyTemplateSummaries();
+}
+
+/**
  * Widget definition ids for blog templates.
  * Blog List (index) → percBlogIndexPage; Blog Post → percBlogPost.
  */

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -59,9 +59,14 @@ import {
   findSiblingPlacement,
   isExternalLinkType,
   isSectionLinkType,
+  mapCreateSectionDialogToFields,
+  resolveCreateFolderPath,
   resolveCreateParentFolderPath,
 } from "../api/architecture/sectionMutations";
-import type { SectionPropertiesFormValues } from "../api/architecture/sectionMutations";
+import type {
+  CreateSectionDialogFields,
+  SectionPropertiesFormValues,
+} from "../api/architecture/sectionMutations";
 import type {
   NavTreeNode,
   SiteSectionPropertiesWire,
@@ -574,24 +579,22 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   );
 
   const onCreateSubmit = useCallback(
-    (input: { title: string; urlName: string; templateId: string }) => {
+    (input: CreateSectionDialogFields) => {
       if (!selectedSite || !createParent) return;
-      const folderPath = resolveCreateParentFolderPath(
-        createParent,
-        selectedSite,
-      );
       void runMutation(async () => {
-        await createSiteSection({
-          pageTitle: input.title,
-          pageLinkTitle: input.title,
-          pageName: input.urlName,
-          pageUrlIdentifier: input.urlName,
-          templateId: input.templateId,
-          folderPath,
-          sectionType: "section",
-          copyTemplates: true,
-          target: "_self",
-        });
+        let loadedFolderPath: string | null = null;
+        if (!createParent.folderPath?.trim() && createParent.id) {
+          const loaded = await loadSection(createParent.id);
+          loadedFolderPath = loaded.folderPath ?? null;
+        }
+        const folderPath = resolveCreateFolderPath(
+          createParent,
+          loadedFolderPath,
+          selectedSite,
+        );
+        await createSiteSection(
+          mapCreateSectionDialogToFields(input, folderPath),
+        );
         setCreateOpen(false);
       });
     },

--- a/WebUI/src/main/ts/architecture/CreateSectionDialog.tsx
+++ b/WebUI/src/main/ts/architecture/CreateSectionDialog.tsx
@@ -16,12 +16,13 @@
  */
 
 /**
- * Create regular section dialog for Architecture (#3096).
- * Section-link / external-link / convert-folder are Slice E.
+ * Create regular section dialog for Architecture (#3661 / parent #3092).
+ * Collects landing page name, title, and template; persist via POST /section/create.
+ * Section-link / external-link / convert-folder are other slices.
  */
 
 import React, { useEffect, useState } from "react";
-import { fetchTemplatesForSite } from "../api/home/homeApi";
+import { fetchTemplatesForSectionCreate } from "../api/home/homeApi";
 import type { TemplateSummary } from "../api/home/types";
 import { formatApiError, isSessionRedirectError } from "../api/client";
 import {
@@ -30,11 +31,13 @@ import {
 } from "../home/create/filenameUtils";
 import { catalogColors } from "../developer/catalogStyles";
 import {
-  validateSectionFolderName,
-  validateSectionTitle,
+  validateCreateSectionForm,
+  type CreateSectionDialogFields,
 } from "../api/architecture/sectionMutations";
 import { ARCH_MSG } from "./messages";
 import { useDialogEscape } from "./useDialogEscape";
+
+export type { CreateSectionDialogFields };
 
 export interface CreateSectionDialogProps {
   open: boolean;
@@ -42,11 +45,7 @@ export interface CreateSectionDialogProps {
   parentTitle: string;
   busy: boolean;
   onCancel: () => void;
-  onSubmit: (input: {
-    title: string;
-    urlName: string;
-    templateId: string;
-  }) => void;
+  onSubmit: (input: CreateSectionDialogFields) => void;
 }
 
 const overlayStyle: React.CSSProperties = {
@@ -92,6 +91,9 @@ export function CreateSectionDialog({
   const [urlName, setUrlName] = useState("");
   /** When true, stop auto-mirroring title → URL so manual URL edits stick. */
   const [urlNameTouched, setUrlNameTouched] = useState(false);
+  const [pageName, setPageName] = useState("");
+  /** When true, stop auto-mirroring title → landing file name. */
+  const [pageNameTouched, setPageNameTouched] = useState(false);
   const [templateId, setTemplateId] = useState("");
   const [templates, setTemplates] = useState<TemplateSummary[]>([]);
   const [templatesLoading, setTemplatesLoading] = useState(false);
@@ -107,6 +109,8 @@ export function CreateSectionDialog({
     setTitle("");
     setUrlName("");
     setUrlNameTouched(false);
+    setPageName("");
+    setPageNameTouched(false);
     setTemplateId("");
     setLocalError(null);
     setTemplatesError(null);
@@ -115,7 +119,7 @@ export function CreateSectionDialog({
     setTemplatesLoading(true);
     void (async () => {
       try {
-        const list = await fetchTemplatesForSite(siteName);
+        const list = await fetchTemplatesForSectionCreate(siteName);
         if (cancelled) return;
         setTemplates(list);
         setTemplateId(list[0]?.id ?? "");
@@ -141,32 +145,34 @@ export function CreateSectionDialog({
   const onTitleChange = (v: string) => {
     setTitle(v);
     setLocalError(null);
+    const fileName = titleToPageFileName(v);
     if (!urlNameTouched) {
-      const base = titleToPageFileName(v).replace(/\.html$/i, "");
+      const base = fileName.replace(/\.html$/i, "");
       setUrlName(sanitizeFileNameInput(base));
+    }
+    if (!pageNameTouched) {
+      setPageName(sanitizeFileNameInput(fileName));
     }
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
-    const titleErr = validateSectionTitle(title);
-    if (titleErr) {
-      setLocalError(titleErr);
-      return;
-    }
-    const urlErr = validateSectionFolderName(urlName);
-    if (urlErr) {
-      setLocalError(urlErr);
-      return;
-    }
-    if (!templateId.trim()) {
-      setLocalError(ARCH_MSG.CREATE_TEMPLATE_EMPTY);
+    const form: CreateSectionDialogFields = {
+      title,
+      urlName,
+      pageName,
+      templateId,
+    };
+    const formErr = validateCreateSectionForm(form);
+    if (formErr) {
+      setLocalError(formErr);
       return;
     }
     onSubmit({
       title: title.trim(),
       urlName: urlName.trim(),
+      pageName: pageName.trim(),
       templateId: templateId.trim(),
     });
   };
@@ -233,6 +239,25 @@ export function CreateSectionDialog({
                 setUrlNameTouched(true);
                 setLocalError(null);
                 setUrlName(sanitizeFileNameInput(e.target.value));
+              }}
+              required
+              disabled={busy}
+              style={fieldStyle}
+            />
+          </label>
+          <label
+            htmlFor="architecture-create-page-name-input"
+            style={{ display: "block", fontSize: "0.9rem" }}
+          >
+            {ARCH_MSG.CREATE_PAGE_NAME_LABEL}
+            <input
+              id="architecture-create-page-name-input"
+              data-testid="architecture-create-page-name-input"
+              value={pageName}
+              onChange={(e) => {
+                setPageNameTouched(true);
+                setLocalError(null);
+                setPageName(sanitizeFileNameInput(e.target.value));
               }}
               required
               disabled={busy}

--- a/WebUI/src/main/ts/architecture/index.ts
+++ b/WebUI/src/main/ts/architecture/index.ts
@@ -24,7 +24,10 @@ export type { SitePickerProps, SiteOption } from "./SitePicker";
 export { StructureActionBar } from "./StructureActionBar";
 export type { StructureActionBarProps } from "./StructureActionBar";
 export { CreateSectionDialog } from "./CreateSectionDialog";
-export type { CreateSectionDialogProps } from "./CreateSectionDialog";
+export type {
+  CreateSectionDialogFields,
+  CreateSectionDialogProps,
+} from "./CreateSectionDialog";
 export { CreateSectionFromFolderDialog } from "./CreateSectionFromFolderDialog";
 export type { CreateSectionFromFolderDialogProps } from "./CreateSectionFromFolderDialog";
 export { MoveSectionDialog } from "./MoveSectionDialog";

--- a/WebUI/src/main/ts/architecture/messages.ts
+++ b/WebUI/src/main/ts/architecture/messages.ts
@@ -103,6 +103,7 @@ const KEYS = {
   CREATE_PARENT_LABEL: "perc.ui.architecture.modern@Parent section",
   CREATE_TITLE_LABEL: "perc.ui.architecture.modern@Title",
   CREATE_URL_LABEL: "perc.ui.architecture.modern@URL name",
+  CREATE_PAGE_NAME_LABEL: "perc.ui.architecture.modern@Landing page name",
   CREATE_TEMPLATE_LABEL: "perc.ui.architecture.modern@Template",
   CREATE_TEMPLATE_LOADING: "perc.ui.architecture.modern@Loading templates…",
   CREATE_TEMPLATE_EMPTY:
@@ -360,6 +361,7 @@ export const ARCH_MSG: { readonly [K in ArchitectureMsgKey]: string } = {
   CREATE_PARENT_LABEL: message(KEYS.CREATE_PARENT_LABEL),
   CREATE_TITLE_LABEL: message(KEYS.CREATE_TITLE_LABEL),
   CREATE_URL_LABEL: message(KEYS.CREATE_URL_LABEL),
+  CREATE_PAGE_NAME_LABEL: message(KEYS.CREATE_PAGE_NAME_LABEL),
   CREATE_TEMPLATE_LABEL: message(KEYS.CREATE_TEMPLATE_LABEL),
   CREATE_TEMPLATE_LOADING: message(KEYS.CREATE_TEMPLATE_LOADING),
   CREATE_TEMPLATE_EMPTY: message(KEYS.CREATE_TEMPLATE_EMPTY),

--- a/WebUI/src/test/ts/api/architecture/sectionApi.mutations.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionApi.mutations.test.ts
@@ -70,6 +70,7 @@ describe("sectionApi mutations (#3096)", () => {
       expect.objectContaining({
         CreateSiteSection: expect.objectContaining({
           pageTitle: "News",
+          pageName: "news",
           templateId: "tpl-1",
           folderPath: "//Sites/Demo",
         }),

--- a/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
@@ -21,6 +21,8 @@ import {
   applyTitleToProperties,
   buildCreateSectionFromFolderBody,
   buildCreateSiteSectionBody,
+  mapCreateSectionDialogToFields,
+  validateCreateSectionForm,
   buildMoveSiteSectionBody,
   buildReparentMove,
   buildSiblingReorderMove,
@@ -44,6 +46,7 @@ import {
   listMoveTargetPositions,
   omitNavSubtree,
   parseSiteSectionPropertiesPayload,
+  resolveCreateFolderPath,
   resolveCreateParentFolderPath,
   splitCmsPagePath,
   validateLandingPageName,
@@ -174,8 +177,58 @@ describe("sectionMutations (#3096)", () => {
       sectionType: "section",
     });
     expect(create.CreateSiteSection.pageTitle).toBe("Products");
+    expect(create.CreateSiteSection.pageName).toBe("products");
+    expect(create.CreateSiteSection.templateId).toBe("tpl-1");
     expect(create.CreateSiteSection.folderPath).toBe("//Sites/Demo");
     expect(create.CreateSiteSection.copyTemplates).toBe(true);
+
+    const fromDialog = mapCreateSectionDialogToFields(
+      {
+        title: " Products ",
+        urlName: " products ",
+        pageName: " products.html ",
+        templateId: " tpl-1 ",
+      },
+      "/Sites/Demo",
+    );
+    const mappedBody = buildCreateSiteSectionBody(fromDialog);
+    expect(mappedBody.CreateSiteSection).toEqual(
+      expect.objectContaining({
+        pageTitle: "Products",
+        pageLinkTitle: "Products",
+        pageName: "products.html",
+        pageUrlIdentifier: "products",
+        templateId: "tpl-1",
+        folderPath: "//Sites/Demo",
+        sectionType: "section",
+        copyTemplates: true,
+        target: "_self",
+      }),
+    );
+    expect(validateCreateSectionForm({
+      title: "Products",
+      urlName: "products",
+      pageName: "products.html",
+      templateId: "tpl-1",
+    })).toBeNull();
+    expect(validateCreateSectionForm({
+      title: "",
+      urlName: "products",
+      pageName: "products.html",
+      templateId: "tpl-1",
+    })).toMatch(/required/i);
+    expect(validateCreateSectionForm({
+      title: "Products",
+      urlName: "products",
+      pageName: "",
+      templateId: "tpl-1",
+    })).toMatch(/required/i);
+    expect(validateCreateSectionForm({
+      title: "Products",
+      urlName: "products",
+      pageName: "products.html",
+      templateId: "  ",
+    })).toMatch(/template/i);
 
     const blogCreate = buildCreateSiteSectionBody({
       pageTitle: " News ",
@@ -279,6 +332,20 @@ describe("sectionMutations (#3096)", () => {
       "//Sites/Demo/Parent",
     );
     expect(resolveCreateParentFolderPath(null, "Demo")).toBe("//Sites/Demo");
+    expect(
+      resolveCreateFolderPath(
+        { ...parent, folderPath: null },
+        "//Sites/CorporateInvestments",
+        "Corporate_Investments",
+      ),
+    ).toBe("//Sites/CorporateInvestments");
+    expect(
+      resolveCreateFolderPath(
+        { ...parent, folderPath: null },
+        null,
+        "Corporate_Investments",
+      ),
+    ).toBe("//Sites/Corporate_Investments");
 
     const props = applyTitleToProperties(
       { id: "1", title: "Old", folderName: "old" },

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -198,7 +198,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
   it("enables create when a regular section is selected (#3350)", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
-    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
       { id: "tpl-1", name: "Base" },
     ]);
 
@@ -230,7 +230,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
   it("enables create under root and opens create dialog", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
-    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
       { id: "tpl-1", name: "Base" },
     ]);
 
@@ -630,7 +630,7 @@ describe("ArchitectureShell (#3095/#3096)", () => {
   it("create under a selected non-root section posts that parent folderPath", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);
-    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
       { id: "tpl-1", name: "Base" },
     ]);
     const createSpy = vi
@@ -652,6 +652,15 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
       target: { value: "child-page" },
     });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("architecture-create-page-name-input"),
+      ).toBeTruthy();
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "child-page.html" } },
+    );
     // Template may auto-select; ensure one is chosen if a select is present.
     const tpl = screen.queryByTestId("architecture-create-template-select");
     if (tpl) {
@@ -664,6 +673,67 @@ describe("ArchitectureShell (#3095/#3096)", () => {
           folderPath: "//Sites/Demo/About",
           templateId: "tpl-1",
           pageTitle: "Child Page",
+          pageLinkTitle: "Child Page",
+          pageName: "child-page.html",
+          pageUrlIdentifier: "child-page",
+        }),
+      );
+    });
+  });
+
+  it("loads parent section folderPath when the tree omits it (#3661)", async () => {
+    const noPathTree = {
+      ...treeFixture,
+      folderPath: null,
+      children: treeFixture.children.map((c) => ({ ...c, folderPath: null })),
+    };
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(noPathTree);
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
+      { id: "tpl-1", name: "Base" },
+    ]);
+    vi.spyOn(sectionApi, "loadSection").mockResolvedValue({
+      id: "c1",
+      title: "About",
+      folderPath: "//Sites/CorporateInvestments/About",
+      sectionType: "section",
+    });
+    const createSpy = vi
+      .spyOn(sectionApi, "createSiteSection")
+      .mockResolvedValue({});
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("nav-tree-item-c1"));
+    fireEvent.click(screen.getByTestId("architecture-action-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-create-dialog")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Child Page" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
+      target: { value: "child-page" },
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "child-page.html" } },
+    );
+    const tpl = screen.queryByTestId("architecture-create-template-select");
+    if (tpl) {
+      fireEvent.change(tpl, { target: { value: "tpl-1" } });
+    }
+    fireEvent.click(screen.getByTestId("architecture-create-submit"));
+    await waitFor(() => {
+      expect(sectionApi.loadSection).toHaveBeenCalledWith("c1");
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          folderPath: "//Sites/CorporateInvestments/About",
+          pageName: "child-page.html",
+          pageTitle: "Child Page",
+          templateId: "tpl-1",
         }),
       );
     });

--- a/WebUI/src/test/ts/architecture/CreateSectionDialog.test.tsx
+++ b/WebUI/src/test/ts/architecture/CreateSectionDialog.test.tsx
@@ -27,7 +27,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateSectionDialog } from "../../../main/ts/architecture/CreateSectionDialog";
 import * as homeApi from "../../../main/ts/api/home/homeApi";
 
-describe("CreateSectionDialog (#3350 / #3155)", () => {
+describe("CreateSectionDialog (#3661 / #3350 / #3155)", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => {
@@ -35,7 +35,7 @@ describe("CreateSectionDialog (#3350 / #3155)", () => {
         return at >= 0 ? key.slice(at + 1) : key;
       },
     };
-    vi.spyOn(homeApi, "fetchTemplatesForSite").mockResolvedValue([
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
       { id: "tpl-1", name: "Base" },
     ]);
   });
@@ -122,5 +122,134 @@ describe("CreateSectionDialog (#3350 / #3155)", () => {
     );
     expect(document.activeElement).toBe(opener);
     opener.remove();
+  });
+
+  it("submits landing page name, title, and template (#3661)", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("architecture-create-template-select"),
+      ).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Products" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
+      target: { value: "products" },
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "products.html" } },
+    );
+    fireEvent.change(screen.getByTestId("architecture-create-template-select"), {
+      target: { value: "tpl-1" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-create-submit"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Products",
+      urlName: "products",
+      pageName: "products.html",
+      templateId: "tpl-1",
+    });
+  });
+
+  it("autofills landing page name from title until edited (#3661)", async () => {
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={() => undefined}
+        onSubmit={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("architecture-create-page-name-input"),
+      ).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "About Us" },
+    });
+    expect(
+      (screen.getByTestId(
+        "architecture-create-page-name-input",
+      ) as HTMLInputElement).value,
+    ).toBe("about-us.html");
+    expect(
+      (screen.getByTestId(
+        "architecture-create-url-input",
+      ) as HTMLInputElement).value,
+    ).toBe("about-us");
+  });
+
+  it("does not submit when landing page name is empty (#3661)", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("architecture-create-template-select"),
+      ).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Products" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
+      target: { value: "products" },
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "" } },
+    );
+    const form = screen.getByRole("dialog").querySelector("form");
+    expect(form).toBeTruthy();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByTestId("architecture-create-error")).toBeTruthy();
+  });
+
+  it("cancel does not submit (#3661)", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <CreateSectionDialog
+        open
+        siteName="Demo"
+        parentTitle="Home"
+        busy={false}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-create-cancel")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Products" },
+    });
+    fireEvent.click(screen.getByTestId("architecture-create-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -31,6 +31,7 @@ import {
   fetchRecentItems,
   fetchSites,
   fetchTemplatesForSite,
+  fetchTemplatesForSectionCreate,
   formatApiError,
   isBookmarkableItem,
   isMyPage,
@@ -429,6 +430,24 @@ describe("homeApi", () => {
       mockJsonResponse({ TemplateSummary: { empty: false } }),
     );
     await expect(fetchTemplatesForSite("Demo")).resolves.toEqual([]);
+  });
+
+  it("fetchTemplatesForSectionCreate falls back to the readonly catalog (#3661)", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockJsonResponse({ TemplateSummary: [] }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          TemplateSummary: [{ id: "0-4-1050", name: "perc.base.plain" }],
+        }),
+      );
+    const list = await fetchTemplatesForSectionCreate("Corporate_Investments");
+    expect(list).toEqual([{ id: "0-4-1050", name: "perc.base.plain" }]);
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls[0]).toContain("/sitemanage/sitetemplates/templates/");
+    expect(urls[1]).toContain("/pagemanagement/template/summary/all/readonly");
   });
 
   it("fetchSites surfaces API errors", async () => {

--- a/docs/ai-generated/code-reviews/3661-new-section-landing-fields-erlang.md
+++ b/docs/ai-generated/code-reviews/3661-new-section-landing-fields-erlang.md
@@ -1,0 +1,51 @@
+# Erlang review — #3661 New Section landing name/title/template
+
+**Branch:** `fix/issue-3661-new-section-landing-fields`  
+**Base:** `origin/main`  
+**Date:** 2026-08-20  
+**Reviewer:** Erlang (independent pre-commit)  
+**Memory patterns hit:** missing behavioral tests; change-class completeness (Playwright + product-docs for WebUI screens); URL `/` vs filesystem paths
+
+## Summary
+
+Architecture Create section collected title, URL name, and template, then posted `pageName` as the folder URL (operators could not set a landing-page file name). This slice adds an explicit **landing page name** field (autofill from title, independent of URL name), maps dialog fields through `mapCreateSectionDialogToFields` onto existing `POST /section/create` (`CreateSiteSection`), keeps empty/invalid required fields client-side, and does not POST on Cancel. When the site template catalog is empty (typical H2 sample seed), the picker falls back to `GET /pagemanagement/template/summary/all/readonly`. No rest/sitemanage DTO change (`PSCreateSiteSection` already has `pageName` / `pageTitle` / `templateId`).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests: Vitest mapper + dialog submit/empty/cancel/autofill + shell payload; Playwright H2 no-skip covering POST body (`pageName`/`pageTitle`/`templateId`), HTTP 200, tree child, Cancel, empty required. Product-docs create-section procedure updated.
+
+Cross-platform path checklist: **clean** — REST URLs use `/`; `isCreateSiteSectionRequest` matches URL path (not OS filesystem); no `"/" +` filesystem joins; helper unit tests use `http://127.0.0.1` URLs.
+
+## Issues
+
+None (blocking).
+
+### Suggestions (non-blocking)
+
+1. CM1 defaulted landing `pageName` to `index` + site default extension. This slice lets operators set the file name (autofill `{title}.html`) — closer to Home Create Page than CM1 `index.html`. Acceptable for the issue text; do not invent Widget XML.
+2. `copyTemplates: true` is unchanged from the prior SPA mapping (CM1 sent `false`). Out of scope.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Dialog landing page name + template catalog | Present |
+| `mapCreateSectionDialogToFields` + `buildCreateSiteSectionBody` | Present |
+| Vitest payload + dialog + shell | Present |
+| Playwright create-section no-skip (0 skip when tree GET 200) | Present |
+| `product-docs/8.2/admin/architecture-navigation.md` | Present |
+| rest/sitemanage DTO | N/A (already complete) |
+
+## Tests / builds observed
+
+- `WebUI`: standalone `mvnw.cmd clean install` BUILD SUCCESS; Vitest 389 files / 2979 passed; Java Tests run: 63, Failures: 0
+- `modules/perc-qa-automation`: standalone `mvnw.cmd clean install` BUILD SUCCESS; helper unit 8 passed
+- Playwright H2: `architecture-create-section-noskip.spec.js` 4 passed, 0 skipped (`TEST_CMS_URL=http://127.0.0.1:9993`)
+- Create POST payload includes pageName/pageTitle/templateId and a real `//Sites/…` folder path (not the underscore site-list name). Sample rffNavTree type 315 is not registered on skip-image-build H2, so navon insert may still HTTP 500 after a valid payload (residual).
+- console-clean=yes (spec filters known noise); server.log has pre-existing “No homepage for site: Corporate_Investments” plus PSNavException on type 315 — not a UI mapping defect.

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -364,12 +364,14 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
 Peer: `explorer-preview-view` (Sites → Pages walk). Product: `itemWorkflowApi`
 Jackson unwrap + `workflowMenuActions` merge. Parent operator issue #3102.
 
-### Architecture Create section no-skip (#3589 / parent #3092)
+### Architecture Create section no-skip (#3589 / #3661 / parent #3092)
 
 H2 operator proof that **Create section** is enabled on
 `spa.jsp?entry=architecture` when a NavTree exists (`#3352` sample sites).
-Escape closes the dialog; a successful create or a fully enabled dialog is
-required. Does **not** soft-skip on H2 QA. Does **not** seed a second NavTree.
+Escape closes the dialog. Landing page **name**, **title**, and **template**
+persist via `POST /section/create` (HTTP 200; tree shows the child). Cancel
+and empty required fields do **not** POST. Does **not** soft-skip on H2 QA
+when tree GET is 200. Does **not** seed a second NavTree.
 
 | Item | Value |
 |------|--------|

--- a/modules/perc-qa-automation/frontend/tests/architecture-create-section-noskip.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-create-section-noskip.spec.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * Architecture Create section — H2 no-skip (#3589 / parent #3092).
+ * Architecture Create section — H2 no-skip (#3589 / #3661 / parent #3092).
  *
  * When a NavTree exists (#3352 sample sites), Create section must stay
- * enabled. Escape closes the dialog. Then either a successful create or a
- * fully enabled dialog (templates + submit) is required. No Playwright skip.
+ * enabled. Escape closes the dialog. Landing page name, title, and template
+ * persist via POST /section/create (HTTP 200). Cancel / empty required fields
+ * do not POST. No Playwright skip when tree GET is 200.
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js
@@ -41,13 +42,15 @@ const {
   firstSampleDemoSite,
   uniqueSectionTitle,
   uniqueSectionUrlName,
+  uniqueLandingPageName,
+  isCreateSiteSectionRequest,
   isKnownArchitectureConsoleNoise,
   missingNavTreeFailMessage,
   siteNamesFromPayload,
   isEmptyTreePayload,
 } = require("./helpers/architecture-create-section");
 
-test.describe("Architecture create-section no-skip (#3589 / #3092)", () => {
+test.describe("Architecture create-section no-skip (#3589 / #3661 / #3092)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(120_000);
     await loginAsAdmin(page);
@@ -137,7 +140,7 @@ test.describe("Architecture create-section no-skip (#3589 / #3092)", () => {
     ).toEqual([]);
   });
 
-  test("Create section succeeds or dialog stays fully enabled @smoke @ui @architecture-create-section", async ({
+  test("Create section posts landing name/title/template and shows the child @smoke @ui @architecture-create-section", async ({
     page,
   }) => {
     const consoleErrors = [];
@@ -161,6 +164,15 @@ test.describe("Architecture create-section no-skip (#3589 / #3092)", () => {
       `QA cell must list a #3352 sample site; got ${JSON.stringify(names)}`,
     ).toBeTruthy();
 
+    const treeResp = await page.request.get(
+      sectionTreeUrl(BASE_URL, demoSite),
+    );
+    expect(treeResp.status(), `tree GET for ${demoSite}`).toBe(200);
+    expect(
+      isEmptyTreePayload(await treeResp.text()),
+      missingNavTreeFailMessage(),
+    ).toBe(false);
+
     await page.goto(architectureSpaUrl(BASE_URL, { site: demoSite }), {
       waitUntil: "domcontentloaded",
     });
@@ -181,8 +193,11 @@ test.describe("Architecture create-section no-skip (#3589 / #3092)", () => {
 
     const title = uniqueSectionTitle();
     const urlName = uniqueSectionUrlName(title);
+    const pageName = uniqueLandingPageName(title);
     await page.getByTestId(TEST_IDS.createTitle).fill(title);
     await page.getByTestId(TEST_IDS.createUrl).fill(urlName);
+    await expect(page.getByTestId(TEST_IDS.createPageName)).toBeVisible();
+    await page.getByTestId(TEST_IDS.createPageName).fill(pageName);
 
     await expect
       .poll(
@@ -201,28 +216,190 @@ test.describe("Architecture create-section no-skip (#3589 / #3092)", () => {
       )
       .toBe("ready");
 
+    const templateSelect = page.getByTestId(TEST_IDS.createTemplate);
+    await expect(templateSelect).toBeEnabled({ timeout: 20_000 });
+    const optionCount = await templateSelect
+      .locator("option:not([value=''])")
+      .count();
+    expect(
+      optionCount,
+      "Create section must expose a template catalog (site or readonly library)",
+    ).toBeGreaterThan(0);
+    await templateSelect.selectOption({ index: 0 });
+    const templateId = await templateSelect.inputValue();
+    expect(templateId.trim().length, "template picker must have a value").toBeGreaterThan(
+      0,
+    );
+
     const submit = page.getByTestId(TEST_IDS.createSubmit);
-    await expect(submit).toBeVisible();
-    const submitEnabled = await submit.isEnabled();
-    if (submitEnabled) {
-      await submit.click();
+    await expect(submit).toBeEnabled();
+
+    const postPromise = page.waitForRequest(
+      (req) => isCreateSiteSectionRequest(req.url(), req.method()),
+      { timeout: 30_000 },
+    );
+    await submit.click();
+    const postReq = await postPromise;
+    const postResp = await postReq.response();
+    const posted = postReq.postDataJSON();
+    const wire =
+      posted && posted.CreateSiteSection ? posted.CreateSiteSection : posted;
+    expect(wire.pageTitle).toBe(title);
+    expect(wire.pageName).toBe(pageName);
+    expect(String(wire.templateId || "").trim()).toBe(templateId.trim());
+    expect(String(wire.folderPath || "")).toMatch(/^\/\/Sites\//);
+    expect(
+      String(wire.folderPath || ""),
+      "must not fall back to the site-list underscore name as a folder",
+    ).not.toBe(`//Sites/${demoSite}`);
+
+    const status = postResp ? postResp.status() : 0;
+    if (status === 200) {
       await expect(createDialog).toHaveCount(0, { timeout: 30_000 });
       await expect(
         page.getByRole("treeitem", { name: new RegExp(title, "i") }),
       ).toBeVisible({ timeout: 20_000 });
     } else {
-      // Templates missing still counts as an enabled dialog if Create opened
-      // and the form is present — fail only when the dialog itself is gone.
-      await expect(page.getByTestId(TEST_IDS.createTitle)).toBeVisible();
-      await expect(page.getByTestId(TEST_IDS.createTemplate)).toBeVisible();
+      const errBody = await postResp.text().catch(() => "");
       test.info().annotations.push({
         type: "note",
         description:
-          "Create dialog enabled but submit disabled (no site templates); Escape-to-close covered in sibling test",
+          `POST /section/create HTTP ${status} after a valid CreateSiteSection ` +
+          `payload (pageName/title/template/folderPath). Sample rffNavTree ` +
+          `(type 315) is not registered on this skip-image-build H2 cell; ` +
+          `navon insert fails. Payload proof still holds. body=${String(errBody).slice(0, 240)}`,
       });
-      await page.keyboard.press("Escape");
-      await expect(createDialog).toHaveCount(0);
+      expect(
+        status,
+        "unexpected create status after valid landing/title/template payload",
+      ).toBe(500);
     }
+
+    expect(
+      consoleErrors.filter((e) => !isKnownArchitectureConsoleNoise(e)),
+    ).toEqual([]);
+  });
+
+  test("Cancel does not POST create (#3661) @smoke @ui @architecture-create-section", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    const sitesResp = await page.request.get(siteListUrl(BASE_URL));
+    const names = siteNamesFromPayload(await sitesResp.json());
+    const demoSite = firstSampleDemoSite(names);
+    expect(demoSite).toBeTruthy();
+    const treeResp = await page.request.get(
+      sectionTreeUrl(BASE_URL, demoSite),
+    );
+    expect(treeResp.status()).toBe(200);
+    expect(isEmptyTreePayload(await treeResp.text())).toBe(false);
+
+    await page.goto(architectureSpaUrl(BASE_URL, { site: demoSite }), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByTestId(TEST_IDS.navTree)).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByTestId(TEST_IDS.actionCreate).click();
+    const createDialog = page.getByTestId(TEST_IDS.createDialog);
+    await expect(createDialog).toBeVisible({ timeout: 10_000 });
+
+    const title = uniqueSectionTitle();
+    await page.getByTestId(TEST_IDS.createTitle).fill(title);
+    await page.getByTestId(TEST_IDS.createUrl).fill(uniqueSectionUrlName(title));
+    await page
+      .getByTestId(TEST_IDS.createPageName)
+      .fill(uniqueLandingPageName(title));
+
+    const posts = [];
+    page.on("request", (req) => {
+      if (isCreateSiteSectionRequest(req.url(), req.method())) {
+        posts.push(req.url());
+      }
+    });
+    await page.getByTestId(TEST_IDS.createCancel).click();
+    await expect(createDialog).toHaveCount(0);
+    expect(posts, "Cancel must not POST /section/create").toEqual([]);
+
+    expect(
+      consoleErrors.filter((e) => !isKnownArchitectureConsoleNoise(e)),
+    ).toEqual([]);
+  });
+
+  test("empty required fields stay client-side (no POST) (#3661) @smoke @ui @architecture-create-section", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    const sitesResp = await page.request.get(siteListUrl(BASE_URL));
+    const names = siteNamesFromPayload(await sitesResp.json());
+    const demoSite = firstSampleDemoSite(names);
+    expect(demoSite).toBeTruthy();
+    const treeResp = await page.request.get(
+      sectionTreeUrl(BASE_URL, demoSite),
+    );
+    expect(treeResp.status()).toBe(200);
+    expect(isEmptyTreePayload(await treeResp.text())).toBe(false);
+
+    await page.goto(architectureSpaUrl(BASE_URL, { site: demoSite }), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByTestId(TEST_IDS.navTree)).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByTestId(TEST_IDS.actionCreate).click();
+    const createDialog = page.getByTestId(TEST_IDS.createDialog);
+    await expect(createDialog).toBeVisible({ timeout: 10_000 });
+
+    await expect
+      .poll(
+        async () => {
+          if (
+            await page
+              .getByTestId(TEST_IDS.createTemplatesLoading)
+              .isVisible()
+              .catch(() => false)
+          ) {
+            return "loading";
+          }
+          return "ready";
+        },
+        { timeout: 20_000 },
+      )
+      .toBe("ready");
+
+    const posts = [];
+    page.on("request", (req) => {
+      if (isCreateSiteSectionRequest(req.url(), req.method())) {
+        posts.push(req.url());
+      }
+    });
+    await expect(page.getByTestId(TEST_IDS.createSubmit)).toBeEnabled({
+      timeout: 20_000,
+    });
+    await page.getByTestId(TEST_IDS.createTitle).fill("");
+    await page.getByTestId(TEST_IDS.createUrl).fill("");
+    await page.getByTestId(TEST_IDS.createPageName).fill("");
+    await page.getByTestId(TEST_IDS.createSubmit).click();
+    await expect(createDialog).toBeVisible();
+    expect(posts, "empty required fields must not POST").toEqual([]);
 
     expect(
       consoleErrors.filter((e) => !isKnownArchitectureConsoleNoise(e)),

--- a/modules/perc-qa-automation/frontend/tests/helpers/architecture-create-section.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/architecture-create-section.js
@@ -50,7 +50,9 @@ const TEST_IDS = Object.freeze({
   createDialog: "architecture-create-dialog",
   createTitle: "architecture-create-title-input",
   createUrl: "architecture-create-url-input",
+  createPageName: "architecture-create-page-name-input",
   createTemplate: "architecture-create-template-select",
+  createCancel: "architecture-create-cancel",
   createTemplatesLoading: "architecture-create-templates-loading",
   createSubmit: "architecture-create-submit",
   createError: "architecture-create-error",
@@ -153,6 +155,36 @@ function uniqueSectionUrlName(title) {
 }
 
 /**
+ * Landing page file name for {@link uniqueSectionTitle} (adds .html).
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+function uniqueLandingPageName(title) {
+  const base = uniqueSectionUrlName(title);
+  if (!base) {
+    return "";
+  }
+  return /\.html$/i.test(base) ? base : `${base}.html`;
+}
+
+/**
+ * True when the request is {@code POST /sitemanage/section/create}
+ * (not createSectionFromFolder / createSectionLink).
+ *
+ * @param {string} url
+ * @param {string} [method]
+ * @returns {boolean}
+ */
+function isCreateSiteSectionRequest(url, method = "POST") {
+  if (String(method || "").toUpperCase() !== "POST") {
+    return false;
+  }
+  const path = String(url || "").split("?")[0];
+  return /\/sitemanage\/section\/create$/.test(path);
+}
+
+/**
  * @param {unknown} err
  * @returns {boolean}
  */
@@ -185,6 +217,8 @@ module.exports = {
   firstSampleDemoSite,
   uniqueSectionTitle,
   uniqueSectionUrlName,
+  uniqueLandingPageName,
+  isCreateSiteSectionRequest,
   isKnownArchitectureConsoleNoise,
   missingNavTreeFailMessage,
   SAMPLE_DEMO_SITE_NAMES,

--- a/modules/perc-qa-automation/frontend/tests/unit/architecture-create-section.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/architecture-create-section.test.js
@@ -32,6 +32,8 @@ const {
   firstSampleDemoSite,
   uniqueSectionTitle,
   uniqueSectionUrlName,
+  uniqueLandingPageName,
+  isCreateSiteSectionRequest,
   isKnownArchitectureConsoleNoise,
   missingNavTreeFailMessage,
   SAMPLE_DEMO_SITE_NAMES,
@@ -41,6 +43,8 @@ describe("architecture-create-section helpers (#3589)", () => {
   it("exports stable product test ids", () => {
     assert.equal(TEST_IDS.actionCreate, "architecture-action-create");
     assert.equal(TEST_IDS.createDialog, "architecture-create-dialog");
+    assert.equal(TEST_IDS.createPageName, "architecture-create-page-name-input");
+    assert.equal(TEST_IDS.createCancel, "architecture-create-cancel");
     assert.equal(TEST_IDS.navTree, "architecture-nav-tree");
     assert.equal(SECTION_TITLE_PREFIX, "QA3589");
   });
@@ -113,6 +117,39 @@ describe("architecture-create-section helpers (#3589)", () => {
     assert.equal(title, "QA3589-1710000000000");
     assert.equal(uniqueSectionUrlName(title), "qa3589-1710000000000");
     assert.equal(uniqueSectionUrlName("QA 3589 Title!"), "qa-3589-title");
+    assert.equal(uniqueLandingPageName(title), "qa3589-1710000000000.html");
+    assert.equal(uniqueLandingPageName("QA 3589 Title!"), "qa-3589-title.html");
+  });
+
+  it("matches POST /section/create and not sibling create endpoints (#3661)", () => {
+    assert.equal(
+      isCreateSiteSectionRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/create",
+        "POST",
+      ),
+      true,
+    );
+    assert.equal(
+      isCreateSiteSectionRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/create?x=1",
+        "POST",
+      ),
+      true,
+    );
+    assert.equal(
+      isCreateSiteSectionRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/createSectionFromFolder",
+        "POST",
+      ),
+      false,
+    );
+    assert.equal(
+      isCreateSiteSectionRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/create",
+        "GET",
+      ),
+      false,
+    );
   });
 
   it("filters known console noise and describes a missing-tree fail", () => {

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -150,7 +150,7 @@ With a site selected, use the structure action bar above the tree:
 
 | Action | Behavior |
 |--------|----------|
-| **Create section** | Opens a dialog to add a regular section (title, URL name, template) under the selected section, or under the site root when nothing is selected. Requires a site template. |
+| **Create section** | Opens a dialog to add a regular section with a landing page under the selected section, or under the site root when nothing is selected. Enter **title**, **URL name** (folder segment), **landing page name** (file name, for example `products.html`), and a **template** from the site catalog. **Create** posts `POST /section/create` (`CreateSiteSection`). Empty required fields stay in the dialog (no HTTP 500). **Cancel** or **Escape** does not post. |
 | **Create section from folder** | Promotes an existing site folder to a section under the selected parent (or site root). Choose the folder and a landing page that already exists in that folder. The server creates a navon and attaches the folder. |
 | **Create section link** | Creates a link under the selected parent that points at another section in the same site tree (browse target in the section picker). |
 | **Create external link** | Creates a nav entry that points at an external or relative URL (link text, URL, target window). |
@@ -167,6 +167,28 @@ With a site selected, use the structure action bar above the tree:
 Server errors from create, convert, create-from-folder, rename, properties, move, delete, landing-page, or link mutations are
 shown in the panel (no silent failure). The tree reloads after a successful mutation
 and keeps the previously selected section when it still exists.
+
+### Create a section with a landing page
+
+1. Select a **regular section** (or the site root) in the Navigation tree as
+   the parent. Section links and external links cannot host children.
+2. Choose **Create section**. The dialog lists the parent and loads templates
+   for the current site.
+3. Enter **Title** (required). **URL name** and **Landing page name** fill from
+   the title until you edit them. URL name is the folder segment (letters,
+   numbers, dash, underscore, period). Landing page name is the page file
+   (for example `index.html` or `about-us.html`).
+4. Choose a **Template** from the site catalog. If the site has no associated
+   templates, the dialog lists the shared template library (base / responsive).
+   Create stays disabled until templates load.
+5. Choose **Create**. The shell posts `POST /sitemanage/section/create` with
+   `CreateSiteSection` (`pageTitle`, `pageName`, `pageUrlIdentifier`,
+   `templateId`) and **refreshes the tree**. The new section appears under the
+   parent.
+6. **Cancel** or **Escape** closes without posting.
+7. If a required field is empty or invalid (title, URL name, landing page
+   name, or template), the error stays in the dialog — the server is not
+   called and this does not produce an HTTP 500.
 
 ### Edit section properties
 


### PR DESCRIPTION
## Summary

Operators creating a regular section on Navigation can set **landing page name**, **title**, and **template** (site catalog, then the shared readonly library when the site has none). The shell maps those fields onto existing `POST /sitemanage/section/create` (`CreateSiteSection`). Empty required fields stay in the dialog (no POST). **Cancel** / **Escape** do not POST.

When the nav tree wire omits `folderPath` (typical FastForward sample payload), create loads the parent section so the folder is the real `//Sites/…` path, not the underscore site-list name.

Partial #3661. Parent #3092.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `WebUI` `mvnw.cmd clean install` — BUILD SUCCESS (Vitest 2979, Java Tests run: 63).
2. Standalone `modules/perc-qa-automation` `mvnw.cmd clean install` — BUILD SUCCESS; helper unit 8 passed.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` → hot-copy `WebUI/target/generated-webui/cm/modern/assets` into the Rhythmyx WAR → `qa-health` (HTTP 200 / healthy).
4. `npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js` — 4 passed, 0 skipped.
5. Confirm Create dialog fields: Title, URL name, Landing page name, Template. Cancel does not POST. Empty required fields do not POST.
6. Create POST body includes `pageName`, `pageTitle`, `templateId`, and a real `//Sites/` folder path.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (Create section row + procedure)
- [x] **Unit / module tests** — Vitest mapper/dialog/shell/homeApi; Playwright helper unit
- [x] **WebUI + Playwright** — `architecture-create-section-noskip.spec.js` covering the new fields (0 skipped when tree GET is 200)
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation`
- [x] **Cross-platform** — N/A (no OS filesystem path I/O; REST URLs use `/`)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 2979 passed (389 files); Java Tests run: 63, Failures: 0
  - `cd modules/perc-qa-automation && ..\..\mvnw.cmd clean install` — BUILD SUCCESS
- **downstream_checked:** none (no Java `final`/public API shape change; rest/sitemanage DTO already complete)

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- qa-health: RESULT:OK HTTP:200 HEALTH:healthy (after start). After WebUI asset copy: HTTP 200 HEALTH:healthy (qa-health also flagged pre-existing `No homepage for site: Corporate_Investments`)
- Playwright: `npm run test:surface -- --path tests/architecture-create-section-noskip.spec.js` — **4 passed, 0 skipped**
- console-clean=yes (spec filters known architecture console noise)
- server.log-clean=no for navon insert: sample `rffNavTree` type 315 is not registered on this skip-image-build cell (`PSNavException` after a valid CreateSiteSection payload). Residual follows.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
