### PR TITLE
feat(perc-packages): perc.Baseline native page install (no dual-ship) (#3673)

### DIFF
--- a/docs/ai-generated/code-reviews/3673-baseline-native-page-install-erlang.md
+++ b/docs/ai-generated/code-reviews/3673-baseline-native-page-install-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — #3673 perc.Baseline native page install
+
+| Field | Value |
+|-------|--------|
+| **Branch** | `fix/issue-3673-baseline-native-page-install` |
+| **Scope** | uncommitted vs `HEAD` / `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | pass |
+| **May commit/push** | yes |
+| **Reviewed** | 2026-08-20 |
+
+## Summary
+
+Opt `perc.Baseline` into `page.installMode=native` (peer of `perc.baseTemplates` / `perc.responsiveTemplates`). Package-build stages archive `TemplateDef-N/` from modern `pages/` and does not dual-ship root `*.templateDef`. Mapping + ACL side-cars unchanged. Goldens extended in `PSPageXmlNativeInstallTest`. Dual-ship retirement checklist (and related inventory/ADR/implementer-guide) updated.
+
+Package-build log evidence: `native-install page TemplateDefs for perc.Baseline: 7 written`.
+
+## Issues
+
+None (no bugs, no missing behavioral tests for this change class, no non-portable path I/O).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Tests use `Path` / `Files` (`product.resolve(stem + ".templateDef.aclDef")` — `+` is filename suffix, not a path separator)
+- [x] Line-ending assertions use `normalizeNewlines` for dual-ship vs native XML parity
+- [x] No Unix-only absolute path shapes
+
+## Change-class companions
+
+| Kind | Present |
+|------|---------|
+| `package-install.properties` `page.installMode=native` | yes (peer copy) |
+| Mapping + ACL side-cars kept | yes (test asserts ACL files; mapping GUIDs) |
+| Native golden (`PSPageXmlNativeInstallTest`) | yes (7 stems, GUIDs, assemblers, no root dual-ship, perc.page XML parity) |
+| Dual-ship checklist row | yes |
+| Module `mvnw clean install` | BUILD SUCCESS, Tests run: 180, Failures: 0 |
+| Public API / `final` blast radius | N/A (properties + tests + docs) |
+| Product-docs | N/A (package-build internal; operator `.ppkg` wire format still TemplateDef XML) |
+| Playwright / WebUI | N/A |
+
+## Memory patterns hit
+
+- Incomplete change-class closure — checked peers (`perc.baseTemplates` native opt-in + `PSPageXmlNativeInstallTest`)
+- Non-portable path joins — none in this diff
+- Tests that only grep source strings — native test stages archive and parses XML
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -73,7 +73,7 @@ Compiler for upgrade-input Page / assembly `*.templateDef` → Component Package
 
 **#2786 (landed):** `perc.baseTemplates` and `perc.responsiveTemplates` **author** modern `pages/<id>/component-package.json` + sources.
 
-**#2806 (landed):** native package install — those packages set `page.installMode=native` so dual-ship root `*.templateDef` generation is off; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/` from modern pages. Dual-ship remains default for packages that have not opted in. Retirement checklist: [../dual-ship-page-template-retirement.md](../dual-ship-page-template-retirement.md). Baseline system templates remain residual under #2630.
+**#2806 / #3673 (landed):** native package install — `perc.baseTemplates`, `perc.responsiveTemplates`, and `perc.Baseline` set `page.installMode=native` so dual-ship root `*.templateDef` generation is off; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/` from modern pages. Dual-ship remains default for packages that have not opted in (widget leftover binary templateDefs). Retirement checklist: [../dual-ship-page-template-retirement.md](../dual-ship-page-template-retirement.md).
 
 ## Gadget registry compiler (slice #2771)
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -36,6 +36,7 @@ Policy code: `com.percussion.packages.pagexml.PSPageXmlInstallPolicy` (aligns wi
 |---------|-----------|-------|
 | `perc.baseTemplates` | `package-install.properties` → `native` | 20 page layouts |
 | `perc.responsiveTemplates` | `package-install.properties` → `native` | Banded / Basic / plain |
+| `perc.Baseline` | `package-install.properties` → `native` | 7 system templates (`perc.page`, `perc.pageDatabase`, `perc.pageDispatcher`, `perc.pageXml`, `perc.sys.resource`, `perc.widget`, `perc.widgetDispatcher`) — #3673 |
 
 ## Retirement checklist (per package)
 
@@ -53,7 +54,7 @@ Dual-ship **code path** can be deleted when **all** hold:
 
 - [x] Native install API + policy exist (`PSPageXmlNativeInstall` / `PSPageXmlInstallPolicy`) — #2806
 - [x] `perc.baseTemplates` / `perc.responsiveTemplates` use native mode — #2806
-- [ ] Remaining page layout packages on native (e.g. `perc.Baseline` system templates after #2805)
+- [x] Remaining page layout packages on native (`perc.Baseline` system templates — #3673)
 - [ ] Widget packages that still dual-ship any page-like templateDefs inventoried and converted or explicitly dual-ship-retained
 - [ ] CI / product package build has zero `dual-ship page templateDefs` log lines (or only waived packages)
 - [ ] Docs (this file + page inventory + ADR-004) mark dual-ship retired
@@ -69,7 +70,7 @@ Runtime install still uses `PSTemplateDefDependencyHandler` and assembly-templat
 |---------|-------|--------|
 | Dual-run **definition XML shim** | Runtime selection modern vs Widget/Page/Gadget XML | Time-boxed; Phase 5 #2632 — criteria: [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) |
 | Dual-ship **page templateDef** | Package-build install bridge for page layouts | Optional; native preferred for converted packages |
-| Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive |
+| Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive; #3673 for Baseline |
 
 ## See also
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/implementer-guide.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/implementer-guide.md
@@ -265,13 +265,13 @@ Dual-ship is a **package-build** bridge (materialize root `*.templateDef` for de
 | **dual-ship** (default) | Materialize root `*.templateDef` → reorganize into archive `TemplateDef-N/` |
 | **native** | Skip root dual-ship; stage `TemplateDef-N/` from modern `pages/` (`page.installMode=native`) |
 
-**Already native:** `perc.baseTemplates`, `perc.responsiveTemplates` (#2806). Remaining packages (e.g. Baseline system templates) stay on dual-ship until converted.
+**Already native:** `perc.baseTemplates`, `perc.responsiveTemplates` (#2806), `perc.Baseline` (#3673). Remaining dual-ship is widget leftover binary `*.templateDef` (#3674), not page-layout packages.
 
 | Concept | Layer | Status |
 |---------|-------|--------|
 | Dual-run **definition XML shim** | Runtime modern vs legacy XML | Time-boxed; Phase 5 #2632 |
 | Dual-ship **page templateDef** | Package-build install bridge | Optional; native preferred for converted packages |
-| Native **page install** | Build stages TemplateDef from modern pages | Landed for base/responsive |
+| Native **page install** | Build stages TemplateDef from modern pages | Landed for base/responsive/Baseline |
 
 ---
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -29,7 +29,7 @@ CM1 **page item** region trees / widget instances live in site storage (sitemana
 |---------|----------------------:|---------------------|---------------|-------|
 | `perc.baseTemplates` | 20 | `pageAssembler` | Page | **Modern authoring (#2786)**; **native install** (#2806) — dual-ship roots off |
 | `perc.responsiveTemplates` | 3 | `pageAssembler` | Page | **Modern authoring (#2786)**; **native install** (#2806); Banded / Basic / plain |
-| `perc.Baseline` | (still `*.templateDef`) | mix (`pageAssembler`, `velocityAssembler`, …) | Page / Global | System templates residual — convert carefully |
+| `perc.Baseline` | 7 | mix (`velocityAssembler`, `pageVariantAssembler`, `dispatchAssembler`, `resourceAssembler`, `pageDatabaseAssembler`) | Page / Global / Snippet | **Modern authoring (#2805)**; **native install** (#3673) — dual-ship roots off |
 
 Snippet-style `*.templateDef` files also appear inside **widget** packages (e.g. file/image binary templates). Those are **not** page layout packages; leave them to widget conversion residuals unless inventory shows Page `output-format`.
 
@@ -81,7 +81,7 @@ Native install (package build, #2806): archive `TemplateDef-N/<stem>.templateDef
 | Matching `id="…" class="perc-region perc-vertical …"` | `slots[].layout.orientation`, `slots[].styles.rootclass` (+ span hints) |
 | `catalog.kind` | always `page` for this compiler |
 
-**Install packaging (#2786 dual-ship + #2806 native):** product **authors** modern `pages/` only for `perc.baseTemplates` and `perc.responsiveTemplates`. Package-local `package-install.properties` sets `page.installMode=native` so dual-ship root `*.templateDef` generation is **off**; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/<stem>.templateDef` from modern pages (same XML/GUID semantics as dual-ship). Default for other packages remains dual-ship until they opt in. Policy: `PSPageXmlInstallPolicy`. Retirement checklist: [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md).
+**Install packaging (#2786 dual-ship + #2806 / #3673 native):** product **authors** modern `pages/` for `perc.baseTemplates`, `perc.responsiveTemplates`, and `perc.Baseline`. Package-local `package-install.properties` sets `page.installMode=native` so dual-ship root `*.templateDef` generation is **off**; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/<stem>.templateDef` from modern pages (same XML/GUID semantics as dual-ship). Default for other packages remains dual-ship until they opt in. Policy: `PSPageXmlInstallPolicy`. Retirement checklist: [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md).
 
 ## Golden fixtures
 
@@ -93,14 +93,14 @@ Native install (package build, #2806): archive `TemplateDef-N/<stem>.templateDef
 | Compiler tests | `com.percussion.packages.pagexml.PSPageXmlCompilerTest` |
 | Dual-ship tests | `com.percussion.packages.pagexml.PSPageXmlDualShipTest` |
 | Native install tests | `com.percussion.packages.pagexml.PSPageXmlNativeInstallTest` |
-| Product modern sources | `…/Packages/perc.baseTemplates/pages/`, `…/Packages/perc.responsiveTemplates/pages/` |
-| Native opt-in | `…/Packages/perc.baseTemplates/package-install.properties` (and responsive) |
+| Product modern sources | `…/Packages/perc.baseTemplates/pages/`, `…/Packages/perc.responsiveTemplates/pages/`, `…/Packages/perc.Baseline/pages/` |
+| Native opt-in | `…/Packages/perc.baseTemplates/package-install.properties` (and responsive + Baseline) |
 
 ## Residuals (not this PR)
 
 1. **Runtime deployer** reading `component-package.json` from archive (today native path is package-build staging into TemplateDef wire format).
 2. **Thumbnails / resources** wiring for template images into `resources[]`.
-3. **Baseline system templates** conversion matrix (Global / Xml / Database / Dispatcher) + native opt-in when ready.
+3. **Baseline system templates** conversion matrix landed (#2805) with native opt-in (#3673). Remaining: widget leftover binary `*.templateDef` (#3674) and CI dual-ship log gate (#3675).
 4. **Page item composition** (site storage region trees) → slot composition IR — depends on Phase 2 storage / REST (#2690 family).
 5. **Delete dual-ship code path** when all page packages use native (see retirement checklist).
 

--- a/modules/perc-packages/src/main/resources/Packages/perc.Baseline/package-install.properties
+++ b/modules/perc-packages/src/main/resources/Packages/perc.Baseline/package-install.properties
@@ -1,0 +1,4 @@
+# Native deployer install for modern page component packages (#3673 / parent #2630).
+# Dual-ship root *.templateDef generation is OFF for this package; package build
+# stages TemplateDef-N/ archive folders from pages/<id>/component-package.json.
+page.installMode=native

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
@@ -311,6 +311,125 @@ class PSPageXmlNativeInstallTest {
   }
 
   @Test
+  void productBaseline_nativeInstallMode_archiveParityWithoutDualShipRoots() throws Exception {
+    Path product = locatePackage("perc.Baseline");
+    if (product == null) {
+      System.err.println("WARN: perc.Baseline not found; skipping native product test");
+      return;
+    }
+
+    assertEquals(
+        PSPageXmlInstallMode.NATIVE,
+        PSPageXmlInstallPolicy.resolve(product),
+        "Baseline must opt into native install (#3673)");
+    assertFalse(PSPageXmlInstallPolicy.isDualShipEnabled(product));
+    assertTrue(PSPageXmlDualShip.hasModernPageSources(product));
+    assertTrue(
+        PSPageXmlPackageCompiler.listTemplateDefs(product).isEmpty(),
+        "must not author root *.templateDef");
+
+    for (String stem :
+        List.of(
+            "perc.page",
+            "perc.pageDatabase",
+            "perc.pageDispatcher",
+            "perc.pageXml",
+            "perc.sys.resource",
+            "perc.widget",
+            "perc.widgetDispatcher")) {
+      assertTrue(
+          Files.isRegularFile(product.resolve(stem + ".templateDef.aclDef")),
+          "ACL side-car must remain: " + stem);
+    }
+
+    Path staging = tempDir.resolve("baseline-native-src");
+    Path archive = tempDir.resolve("baseline-native-archive");
+    copyTree(product, staging);
+    Files.createDirectories(archive);
+
+    assertFalse(Files.isRegularFile(staging.resolve("perc.page.templateDef")));
+
+    int written = PSPageXmlNativeInstall.stageArchiveTemplateDefs(staging, archive);
+    assertEquals(7, written, "expected 7 Baseline system templates, got " + written);
+
+    Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
+    assertEquals("0-4-602", guids.get("perc.page"));
+    assertEquals("0-4-604", guids.get("perc.pagedatabase"));
+    assertEquals("0-4-606", guids.get("perc.pagedispatcher"));
+    assertEquals("0-4-608", guids.get("perc.pagexml"));
+    assertEquals("0-4-610", guids.get("perc.sys.resource"));
+    assertEquals("0-4-612", guids.get("perc.widget"));
+    assertEquals("0-4-614", guids.get("perc.widgetdispatcher"));
+
+    Path page =
+        archive.resolve("TemplateDef-602").resolve("perc.page.templateDef");
+    assertTrue(Files.isRegularFile(page), "archive TemplateDef-602/perc.page.templateDef");
+    PSPageXmlModel pageInstall = PSPageXmlParser.parse(page);
+    assertEquals("perc.page", pageInstall.getName());
+    assertEquals("0-4-602", pageInstall.getGuid());
+    assertEquals(
+        "Java/global/percussion/assembly/velocityAssembler", pageInstall.getAssembler());
+    assertEquals("Global", pageInstall.getOutputFormat());
+
+    Path pageXml =
+        archive.resolve("TemplateDef-608").resolve("perc.pageXml.templateDef");
+    assertTrue(Files.isRegularFile(pageXml), "archive TemplateDef-608/perc.pageXml.templateDef");
+    PSPageXmlModel xmlInstall = PSPageXmlParser.parse(pageXml);
+    assertEquals("perc.pageXml", xmlInstall.getName());
+    assertEquals("0-4-608", xmlInstall.getGuid());
+    assertEquals(
+        "Java/global/percussion/assembly/pageVariantAssembler", xmlInstall.getAssembler());
+    assertEquals("Snippet", xmlInstall.getOutputFormat());
+    assertEquals("text/xml", xmlInstall.getMimeType());
+    assertEquals(".xml", xmlInstall.getLocationSuffix());
+
+    Path widget =
+        archive.resolve("TemplateDef-612").resolve("perc.widget.templateDef");
+    assertTrue(Files.isRegularFile(widget), "archive TemplateDef-612/perc.widget.templateDef");
+    PSPageXmlModel widgetInstall = PSPageXmlParser.parse(widget);
+    assertEquals("perc.widget", widgetInstall.getName());
+    assertEquals("0-4-612", widgetInstall.getGuid());
+    assertEquals(
+        "Java/global/percussion/assembly/velocityAssembler", widgetInstall.getAssembler());
+    assertEquals("Snippet", widgetInstall.getOutputFormat());
+
+    Path resource =
+        archive.resolve("TemplateDef-610").resolve("perc.sys.resource.templateDef");
+    assertTrue(
+        Files.isRegularFile(resource), "archive TemplateDef-610/perc.sys.resource.templateDef");
+    PSPageXmlModel resourceInstall = PSPageXmlParser.parse(resource);
+    assertEquals("perc.sys.resource", resourceInstall.getName());
+    assertEquals("0-4-610", resourceInstall.getGuid());
+    assertEquals(
+        "Java/global/percussion/assembly/resourceAssembler", resourceInstall.getAssembler());
+    assertEquals("Page", resourceInstall.getOutputFormat());
+
+    for (String stem :
+        List.of(
+            "perc.page",
+            "perc.pageDatabase",
+            "perc.pageDispatcher",
+            "perc.pageXml",
+            "perc.sys.resource",
+            "perc.widget",
+            "perc.widgetDispatcher")) {
+      assertFalse(
+          Files.isRegularFile(staging.resolve(stem + ".templateDef")),
+          "native install must not dual-ship root " + stem + ".templateDef");
+    }
+
+    Path dualStaging = tempDir.resolve("baseline-dual-parity");
+    copyTree(product, dualStaging);
+    PSPageXmlDualShip.materializeInstallTemplateDefs(dualStaging);
+    String dualPageXml =
+        Files.readString(dualStaging.resolve("perc.page.templateDef"), StandardCharsets.UTF_8);
+    assertEquals(
+        normalizeNewlines(dualPageXml),
+        normalizeNewlines(Files.readString(page, StandardCharsets.UTF_8)),
+        "native perc.page archive XML must match dual-ship emit");
+  }
+
+  @Test
   void packageInstallProps_isCopiedAsRootFileInProductTree() throws Exception {
     Path product = locatePackage("perc.baseTemplates");
     if (product == null) {
@@ -318,6 +437,21 @@ class PSPageXmlNativeInstallTest {
     }
     Path props = product.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS);
     assertTrue(Files.isRegularFile(props));
+    Properties p = new Properties();
+    try (var in = Files.newInputStream(props)) {
+      p.load(in);
+    }
+    assertEquals("native", p.getProperty(PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE));
+  }
+
+  @Test
+  void packageInstallProps_baselineIsNative() throws Exception {
+    Path product = locatePackage("perc.Baseline");
+    if (product == null) {
+      return;
+    }
+    Path props = product.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS);
+    assertTrue(Files.isRegularFile(props), "perc.Baseline package-install.properties (#3673)");
     Properties p = new Properties();
     try (var in = Files.newInputStream(props)) {
       p.load(in);


### PR DESCRIPTION
## Summary

Parent tracker: **#2630**. Slice **#3673** opts `perc.Baseline` into native page install so package-build stages archive `TemplateDef-N/` from modern `pages/` and does **not** dual-ship root `*.templateDef`.

`perc.Baseline` already authored seven system templates under `pages/` (`perc.page`, `perc.pageDatabase`, `perc.pageDispatcher`, `perc.pageXml`, `perc.sys.resource`, `perc.widget`, `perc.widgetDispatcher`). This change adds package-root `package-install.properties` with `page.installMode=native` (peer of `perc.baseTemplates` / `perc.responsiveTemplates`). Mapping and ACL side-cars are unchanged. Root `*.templateDef` files were not re-authored.

Fixes #3673  
Partial #2630 (widget leftover binary templateDefs #3674, CI dual-ship log gate #3675, shim #2852 remain)

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-packages && ../../mvnw.cmd clean install` (or `../../mvnw clean install` on Unix)
2. Confirm Surefire: `PSPageXmlNativeInstallTest` (13 tests) and module suite green
3. Confirm package-build log: `native-install page TemplateDefs for perc.Baseline: 7 written` (no `dual-ship page templateDefs for perc.Baseline`)
4. Goldens assert GUID / name / assembler / body parity and no root dual-ship files for Baseline stems
5. Host-install smoke of `perc.Baseline.ppkg` is out of scope for this agent slice (human QA when a host install is available)

## Checklist

- [x] **Product documentation** — N/A (not product-facing): package-build install mode for an existing TemplateDef wire format; operators still install `.ppkg` assembly-template XML. Engineering checklist updated under `docs/ai-generated/tasks/template-assembler-normalization/`.
- [x] **Unit / module tests** — `PSPageXmlNativeInstallTest` Baseline goldens; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `modules/perc-packages` standalone clean install (tests included)
- [x] **Cross-platform** — tests use `Path` / `Files`; XML parity normalizes newlines

## C3 evidence

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 180, Failures: 0. `PSPageXmlNativeInstallTest` Tests run: 13. Package-build: `native-install page TemplateDefs for perc.Baseline: 7 written`.
- **downstream_checked:** none (C2 N/A — no public/protected API or `final`/`sealed` type changes)

## C5 UI proof

N/A — no WebUI / Playwright surface.

## Out of scope

- Widget leftover binary `*.templateDef` (#3674)
- CI dual-ship log gate (#3675)
- Deleting `PSPageXmlDualShip` / dual-run shim (#2852)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
