### PR TITLE
feat(perc-packages): fail-closed dual-ship page templateDef inventory (#3675)

### DIFF
--- a/docs/ai-generated/code-reviews/3675-dual-ship-page-templatedef-inventory-erlang.md
+++ b/docs/ai-generated/code-reviews/3675-dual-ship-page-templatedef-inventory-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review: #3675 dual-ship page templateDef CI inventory
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-20 |
+| **Branch** | `fix/issue-3675-dual-ship-page-templatedef-ci-gate` |
+| **Base** | `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: **yes** |
+
+## Summary
+
+Adds a fail-closed Surefire inventory so product package-build cannot silently re-introduce dual-ship page `*.templateDef` materialization (parent #2630). Peer of `PSPageDefinitionXmlInventory` / `PSWidgetDefinitionXmlInventory`. Scan uses committed `package-install.properties` only (JVM native override cannot hide a missing opt-in). Waiver is `perc.Test` only; #3674 leftover widget binaries are cited as **not** dual-ship-retained (empty retain list). `PSPackageBuilder` fails closed on non-waived dual-ship writes. Retirement checklist CI row marked done.
+
+## Scope
+
+- `modules/perc-packages` inventory API + Surefire + package-build fail-closed
+- Retirement checklist CI row + module/scripts README companions
+- Memory patterns: portable Path/Files; product-tree + TempDir fail-fast (G4 inventory peer)
+
+**Cross-platform path review:** package walking uses `DirectoryStream` + `Path.resolve` / `toAbsolutePath().normalize()`. Tests locate Packages via `Path.of("src", "main", "resources", "Packages")` and assert absolute finding paths / `startsWith` under TempDir. Log scan uses `Files.readAllLines` (UTF-8) and includes a `\r\n` fixture. No hardcoded `/` or `\` filesystem joins, no Unix-only roots, no `:`-only path lists.
+
+## Issues
+
+None (bug / missing tests / non-portable I/O).
+
+Behavioral tests cover: product tree clean + native page packages; leftover authored root templateDefs without `pages/` ignored; native modern pages clean; waived `perc.Test` dual-ship clean; dummy non-waived dual-ship fail; explicit `dual-ship` property fail; JVM native override ignored; relative packages root; mixed waived/non-waived; log format/parse; log waived vs fail; log file CRLF; materialization allowed helper; non-directory / missing log rejection.
+
+Change-class companions: inventory + tests + package-build hook + README + scripts README + retirement CI row. Product-docs N/A (not operator-facing). Playwright N/A.
+
+## Gate
+
+approve — no bug, missing behavioral tests, or non-portable path I/O.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -4,7 +4,7 @@
 |-------|--------|
 | **Status** | Active (#2806 native install path landed; dual-ship optional) |
 | **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
-| **Related** | #2786 dual-ship modern authoring · #2806 native package install · Phase 5 shim #2632 |
+| **Related** | #2786 dual-ship modern authoring · #2806 native package install · #3673 Baseline native · #3674 leftover binary conversion · #3675 CI dual-ship gate · Phase 5 shim #2632 |
 | **Code** | `PSPageXmlInstallPolicy`, `PSPageXmlNativeInstall`, `PSPageXmlDualShip`, `PSPackageBuilder` |
 
 ## Purpose
@@ -37,8 +37,7 @@ Policy code: `com.percussion.packages.pagexml.PSPageXmlInstallPolicy` (aligns wi
 | `perc.baseTemplates` | `package-install.properties` → `native` | 20 page layouts |
 | `perc.responsiveTemplates` | `package-install.properties` → `native` | Banded / Basic / plain |
 | `perc.Baseline` | `package-install.properties` → `native` | 7 system templates (`perc.page`, `perc.pageDatabase`, `perc.pageDispatcher`, `perc.pageXml`, `perc.sys.resource`, `perc.widget`, `perc.widgetDispatcher`) — #3673 |
-| `perc.FileAssetWidget` | `package-install.properties` → `native` | `perc.fileBinary` leftover binary TemplateDef (#3674) — assembly `pages/` peer, not Widget XML |
-| `perc.widgets.image` | `package-install.properties` → `native` | `perc.imageMainBinary` / `perc.imageThumbBinary` leftover binary TemplateDefs (#3674) |
+| `perc.FileAssetWidget` / `perc.widgets.image` | `package-install.properties` → `native` | Leftover binary TemplateDefs (`perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary`) converted to modern `pages/` — #3674 / #3680 |
 
 ## Retirement checklist (per package)
 
@@ -57,10 +56,20 @@ Dual-ship **code path** can be deleted when **all** hold:
 - [x] Native install API + policy exist (`PSPageXmlNativeInstall` / `PSPageXmlInstallPolicy`) — #2806
 - [x] `perc.baseTemplates` / `perc.responsiveTemplates` use native mode — #2806
 - [x] Remaining page layout packages on native (`perc.Baseline` system templates — #3673)
-- [x] Widget leftover binary TemplateDefs inventoried and converted (#3674): `perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary` are `output-format=Binary` / `binaryAssembler` (not page layouts). Converted to `pages/<id>/component-package.json` + native install (Widget XML emitter cannot emit TemplateDef). Product tree has zero authored root `*.templateDef`.
-- [ ] CI / product package build has zero `dual-ship page templateDefs` log lines (or only waived packages)
+- [x] Widget leftover binary TemplateDefs inventoried and converted (#3674 / #3680): `perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary` are `output-format=Binary` / `binaryAssembler` (not page layouts). Converted to `pages/<id>/component-package.json` + native install (Widget XML emitter cannot emit TemplateDef). Product tree has zero authored root `*.templateDef`.
+- [x] CI / product package build has zero `dual-ship page templateDefs` log lines (or only waived packages) — Surefire `PSDualShipPageTemplateDefInventory` / #3675. Waiver: **`perc.Test` only**. Leftover binaries are converted on `main` via #3680 (not dual-ship-retained). Package-build also fails closed via `assertDualShipMaterializationAllowed`.
 - [ ] Docs (this file + page inventory + ADR-004) mark dual-ship retired
 - [ ] Follow-up removes `PSPageXmlDualShip.materializeInstallTemplateDefs` call sites when unused
+
+### CI gate (#3675)
+
+| Piece | Class |
+|-------|--------|
+| Inventory + log parser + CLI | `com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` |
+| Surefire | `PSDualShipPageTemplateDefInventoryTest` |
+| Package-build fail-closed | `PSPackageBuilder.stageModernPageInstallArtifacts` |
+
+Scan is **committed** `package-install.properties` only (JVM `perc.packages.page.installMode` must not hide a missing native opt-in). Packages with modern `pages/` + native mode are not dual-ship emitters. Authored root `*.templateDef` without modern `pages/` is out of this gate; leftover binaries were converted (#3674 / #3680).
 
 ## Deployer note
 
@@ -72,7 +81,7 @@ Runtime install still uses `PSTemplateDefDependencyHandler` and assembly-templat
 |---------|-------|--------|
 | Dual-run **definition XML shim** | Runtime selection modern vs Widget/Page/Gadget XML | Time-boxed; Phase 5 #2632 — criteria: [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) |
 | Dual-ship **page templateDef** | Package-build install bridge for page layouts | Optional; native preferred for converted packages |
-| Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive; #3673 for Baseline |
+| Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive; #3673 for Baseline; #3674 / #3680 leftover binaries |
 
 ## See also
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -100,7 +100,7 @@ Native install (package build, #2806): archive `TemplateDef-N/<stem>.templateDef
 
 1. **Runtime deployer** reading `component-package.json` from archive (today native path is package-build staging into TemplateDef wire format).
 2. **Thumbnails / resources** wiring for template images into `resources[]`.
-3. **Baseline system templates** conversion matrix landed (#2805) with native opt-in (#3673). Remaining: widget leftover binary `*.templateDef` (#3674) and CI dual-ship log gate (#3675).
+3. **Baseline system templates** conversion matrix landed (#2805) with native opt-in (#3673). CI dual-ship log/path gate landed (#3675). Remaining: widget leftover binary `*.templateDef` (#3674).
 4. **Page item composition** (site storage region trees) → slot composition IR — depends on Phase 2 storage / REST (#2690 family).
 5. **Delete dual-ship code path** when all page packages use native (see retirement checklist).
 

--- a/modules/perc-packages/README.md
+++ b/modules/perc-packages/README.md
@@ -38,6 +38,21 @@ Do not delete `PSLegacyDefinitionXmlShim` (#2852 blocked).
 See root `scripts/README.md` (definition XML inventory gates) and
 `docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md`.
 
+## Dual-ship page templateDef inventory gate (#3675)
+
+Product packages with modern `pages/` must not re-introduce dual-ship root `*.templateDef`
+materialization except the explicit waiver **`perc.Test`**. Native packages
+(`package-install.properties` `page.installMode=native`) are not dual-ship emitters.
+#3674 leftover widget binaries are **not** dual-ship-retained (empty retain list).
+
+| Piece | Class |
+|-------|--------|
+| Inventory + log parser + CLI | `com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` |
+| Surefire | `PSDualShipPageTemplateDefInventoryTest` |
+| Package-build fail-closed | `PSPackageBuilder` |
+
+Committed policy ignores JVM `perc.packages.page.installMode` so CI reflects the source tree.
+
 ## Archive-manifest Widget XML paths (#3582)
 
 Non-waived product `psx_archiveInfo.xml` / `psx_archiveManifest.xml` must not author

--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -17,6 +17,7 @@
 
 package com.percussion.packages;
 
+import com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory;
 import com.percussion.packages.pagexml.PSPageXmlDualShip;
 import com.percussion.packages.pagexml.PSPageXmlException;
 import com.percussion.packages.pagexml.PSPageXmlInstallMode;
@@ -229,9 +230,11 @@ public final class PSPackageBuilder {
         if (mode != PSPageXmlInstallMode.DUAL_SHIP) {
           return;
         }
+        // Fail closed: non-waived product packages must not re-introduce dual-ship (#3675).
+        PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed(packageName);
         int n = PSPageXmlDualShip.materializeInstallTemplateDefs(stagingPackageDir);
         System.out.println(
-            "  dual-ship page templateDefs for " + packageName + ": " + n + " written");
+            PSDualShipPageTemplateDefInventory.formatDualShipLogLine(packageName, n));
         return;
       }
       // post-reorganize: native archive staging
@@ -241,7 +244,7 @@ public final class PSPackageBuilder {
       int n = PSPageXmlNativeInstall.stageArchiveTemplateDefs(stagingPackageDir, archiveRoot);
       System.out.println(
           "  native-install page TemplateDefs for " + packageName + ": " + n + " written");
-    } catch (PSPageXmlException e) {
+    } catch (PSPageXmlException | IllegalStateException e) {
       throw new IOException(
           "Page install staging failed for package "
               + packageName

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Fail-closed inventory for dual-ship page {@code *.templateDef} materialization (issue #3675 /
+ * parent #2630, ADR-004).
+ *
+ * <p>Peer of {@link PSPageDefinitionXmlInventory} / {@code PSWidgetDefinitionXmlInventory}. Pass
+ * condition: zero <em>non-waived</em> product packages that would emit dual-ship root templateDefs
+ * (modern {@code pages/} + committed {@code page.installMode} defaulting to dual-ship). Packages
+ * that opted into {@link PSPageXmlInstallMode#NATIVE} are not dual-ship emitters.
+ *
+ * <p>Committed policy is package-local {@code package-install.properties} only. JVM system
+ * properties ({@link PSPageXmlInstallPolicy#SYS_PROP_INSTALL_MODE} / {@link
+ * PSPageXmlInstallPolicy#SYS_PROP_DUAL_SHIP}) must not hide a missing native opt-in in CI.
+ *
+ * <p>Uses {@link Path#resolve(String)} / {@link Files} only — no hardcoded filesystem separators.
+ *
+ * @see PSPageXmlDualShip
+ * @see PSPageXmlInstallPolicy
+ */
+public final class PSDualShipPageTemplateDefInventory {
+
+  /**
+   * Marker substring of the package-build log line written by {@code PSPackageBuilder} when dual-ship
+   * root templateDefs are materialized.
+   */
+  public static final String DUAL_SHIP_LOG_MARKER = "dual-ship page templateDefs for ";
+
+  /**
+   * Widget leftover binary templateDef packages that remain <em>explicitly dual-ship-retained</em>
+   * from sibling #3674.
+   *
+   * <p>#3674 leftovers on {@code main} were authored root files (not modern {@code pages/}): {@code
+   * perc.FileAssetWidget/perc.fileBinary.templateDef}, {@code
+   * perc.widgets.image/perc.imageMainBinary.templateDef}, {@code
+   * perc.widgets.image/perc.imageThumbBinary.templateDef}. Sibling PR #3680 converts those to native
+   * {@code pages/} rather than dual-ship-retain. This set is therefore <strong>empty</strong> — do
+   * not add those package dirs here.
+   */
+  public static final Set<String> RETAINED_WIDGET_BINARY_PACKAGE_DIRS = Collections.emptySet();
+
+  /**
+   * Package directory names under {@code Packages/} allowed to still dual-ship page templateDefs.
+   * Explicit and minimal: {@code perc.Test} plus {@link #RETAINED_WIDGET_BINARY_PACKAGE_DIRS}.
+   */
+  public static final Set<String> WAIVED_PACKAGE_DIRS;
+
+  static {
+    LinkedHashSet<String> waived = new LinkedHashSet<>();
+    waived.add("perc.Test");
+    waived.addAll(RETAINED_WIDGET_BINARY_PACKAGE_DIRS);
+    WAIVED_PACKAGE_DIRS = Collections.unmodifiableSet(waived);
+  }
+
+  /**
+   * One package that would (or did) emit dual-ship page templateDefs.
+   *
+   * @param packageDirName immediate child name under the Packages root
+   * @param packageDir absolute normalized package directory, or {@code null} for log-only findings
+   * @param committedMode committed install mode that selected dual-ship
+   * @param modernPageCount modern {@code pages/} package count ({@code 0} when unknown from a log)
+   * @param waived whether {@code packageDirName} is in {@link #WAIVED_PACKAGE_DIRS}
+   */
+  public record Finding(
+      String packageDirName,
+      Path packageDir,
+      PSPageXmlInstallMode committedMode,
+      int modernPageCount,
+      boolean waived) {}
+
+  /**
+   * Inventory scan result.
+   *
+   * @param all all dual-ship findings (waived + non-waived), sorted
+   * @param nonWaived findings whose package is not waived
+   * @param waived findings whose package is waived
+   */
+  public record Report(List<Finding> all, List<Finding> nonWaived, List<Finding> waived) {
+
+    /**
+     * @return true when no non-waived dual-ship page templateDef emitters are present
+     */
+    public boolean isClean() {
+      return nonWaived.isEmpty();
+    }
+  }
+
+  private PSDualShipPageTemplateDefInventory() {
+    // utility
+  }
+
+  /**
+   * Scan every immediate package directory under {@code packagesRoot} for committed dual-ship page
+   * templateDef emitters (modern {@code pages/} + non-native committed install mode).
+   *
+   * @param packagesRoot non-null directory of package roots
+   * @return report of findings; never null
+   * @throws IOException on I/O failure
+   * @throws IllegalArgumentException if packagesRoot is null or not a directory
+   */
+  public static Report scan(Path packagesRoot) throws IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new IllegalArgumentException("Packages root is not a directory: " + packagesRoot);
+    }
+
+    List<Finding> all = new ArrayList<>();
+    try (DirectoryStream<Path> packages = Files.newDirectoryStream(packagesRoot)) {
+      for (Path packageDir : packages) {
+        if (!Files.isDirectory(packageDir)) {
+          continue;
+        }
+        Path namePath = packageDir.getFileName();
+        if (namePath == null) {
+          continue;
+        }
+        String packageDirName = namePath.toString();
+        Path absPkg = packageDir.toAbsolutePath().normalize();
+        if (!PSPageXmlDualShip.hasModernPageSources(absPkg)) {
+          continue;
+        }
+        PSPageXmlInstallMode mode = resolveCommittedInstallMode(absPkg);
+        if (mode != PSPageXmlInstallMode.DUAL_SHIP) {
+          continue;
+        }
+        Path pagesDir = absPkg.resolve(PSPageXmlDualShip.PAGES_DIR_NAME);
+        int modernCount = PSPageXmlDualShip.listModernPageDirs(pagesDir).size();
+        boolean waived = isWaivedPackage(packageDirName);
+        all.add(new Finding(packageDirName, absPkg, mode, modernCount, waived));
+      }
+    }
+
+    return toReport(all);
+  }
+
+  /**
+   * Parse package-build log lines for {@link #DUAL_SHIP_LOG_MARKER} and report dual-ship emitters.
+   *
+   * @param lines log lines (may be null entries); never null iterable
+   * @return report of dual-ship packages named in the log
+   */
+  public static Report scanLogLines(Iterable<String> lines) {
+    Objects.requireNonNull(lines, "lines");
+    List<Finding> all = new ArrayList<>();
+    LinkedHashSet<String> seen = new LinkedHashSet<>();
+    for (String line : lines) {
+      Optional<String> pkg = parseDualShipPackageFromLogLine(line);
+      if (pkg.isEmpty()) {
+        continue;
+      }
+      String packageDirName = pkg.get();
+      if (!seen.add(packageDirName)) {
+        continue;
+      }
+      boolean waived = isWaivedPackage(packageDirName);
+      all.add(new Finding(packageDirName, null, PSPageXmlInstallMode.DUAL_SHIP, 0, waived));
+    }
+    return toReport(all);
+  }
+
+  /**
+   * Scan a UTF-8 log file for dual-ship page templateDef lines.
+   *
+   * @param logFile existing text file
+   * @return report of dual-ship packages named in the log
+   * @throws IOException on I/O failure
+   */
+  public static Report scanLogFile(Path logFile) throws IOException {
+    Objects.requireNonNull(logFile, "logFile");
+    if (!Files.isRegularFile(logFile)) {
+      throw new IllegalArgumentException("Log file is not a regular file: " + logFile);
+    }
+    return scanLogLines(Files.readAllLines(logFile, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Format the package-build log line for dual-ship materialization (must stay in lockstep with
+   * {@code PSPackageBuilder}).
+   *
+   * @param packageName package directory name
+   * @param written number of templateDefs written
+   * @return log line including the {@link #DUAL_SHIP_LOG_MARKER}
+   */
+  public static String formatDualShipLogLine(String packageName, int written) {
+    Objects.requireNonNull(packageName, "packageName");
+    return "  " + DUAL_SHIP_LOG_MARKER + packageName + ": " + written + " written";
+  }
+
+  /**
+   * Parse a dual-ship package-build log line to the package directory name.
+   *
+   * @param line one log line; may be null
+   * @return package name when the line is a dual-ship templateDef write, else empty
+   */
+  public static Optional<String> parseDualShipPackageFromLogLine(String line) {
+    if (line == null || line.isBlank()) {
+      return Optional.empty();
+    }
+    int idx = line.indexOf(DUAL_SHIP_LOG_MARKER);
+    if (idx < 0) {
+      return Optional.empty();
+    }
+    String rest = line.substring(idx + DUAL_SHIP_LOG_MARKER.length());
+    int colon = rest.indexOf(':');
+    if (colon <= 0) {
+      return Optional.empty();
+    }
+    String pkg = rest.substring(0, colon).trim();
+    if (pkg.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(pkg);
+  }
+
+  /**
+   * Whether the package directory name is on the explicit waiver list.
+   *
+   * @param packageDirName package folder name under Packages
+   * @return true if waived
+   */
+  public static boolean isWaivedPackage(String packageDirName) {
+    if (packageDirName == null || packageDirName.isBlank()) {
+      return false;
+    }
+    return WAIVED_PACKAGE_DIRS.contains(packageDirName);
+  }
+
+  /**
+   * Fail-fast for package-build: non-waived packages must not materialize dual-ship page
+   * templateDefs.
+   *
+   * @param packageDirName package folder name
+   * @throws IllegalStateException when the package is not waived
+   */
+  public static void assertDualShipMaterializationAllowed(String packageDirName) {
+    if (isWaivedPackage(packageDirName)) {
+      return;
+    }
+    throw new IllegalStateException(
+        "Dual-ship page templateDefs CI gate (#3675): package "
+            + packageDirName
+            + " is not waived (waived package dirs: "
+            + WAIVED_PACKAGE_DIRS
+            + "). Set "
+            + PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE
+            + "=native in "
+            + PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS
+            + " or add an explicit waiver.");
+  }
+
+  /**
+   * Fail-fast assertion used by Surefire / CI: non-waived dual-ship page templateDef emitters must
+   * not reappear under the Packages tree.
+   *
+   * @param packagesRoot Packages tree root
+   * @throws IOException on I/O failure
+   * @throws IllegalStateException when non-waived dual-ship emitters are present
+   */
+  public static void assertNoNonWaivedDualShipPageTemplateDefs(Path packagesRoot)
+      throws IOException {
+    Report report = scan(packagesRoot);
+    failIfUnclean(report, "Packages tree " + packagesRoot);
+  }
+
+  /**
+   * Fail-fast assertion for package-build log lines.
+   *
+   * @param lines log lines
+   * @throws IllegalStateException when a non-waived dual-ship log line is present
+   */
+  public static void assertNoNonWaivedDualShipLogLines(Iterable<String> lines) {
+    Report report = scanLogLines(lines);
+    failIfUnclean(report, "package-build log");
+  }
+
+  /**
+   * Committed install mode from package-local properties only (default dual-ship). Ignores JVM
+   * system properties so CI reflects the source tree.
+   *
+   * @param packageDir package root
+   * @return non-null mode
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlInstallMode resolveCommittedInstallMode(Path packageDir)
+      throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Properties props = PSPageXmlInstallPolicy.loadPackageInstallProps(packageDir);
+    if (props != null) {
+      String mode = props.getProperty(PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE);
+      if (mode != null && !mode.isBlank()) {
+        return PSPageXmlInstallPolicy.parseMode(mode.trim());
+      }
+    }
+    return PSPageXmlInstallMode.DUAL_SHIP;
+  }
+
+  /**
+   * CLI entry for local / optional CI use (non-zero exit when non-waived dual-ship emitters exist).
+   *
+   * <p>Usage: {@code PSDualShipPageTemplateDefInventory <packagesRoot> [logFile]}
+   *
+   * @param args packages root and optional log file
+   * @throws IOException on I/O failure
+   */
+  public static void main(String[] args) throws IOException {
+    if (args == null || args.length < 1 || args[0] == null || args[0].isBlank()) {
+      System.err.println("Usage: PSDualShipPageTemplateDefInventory <packagesRoot> [logFile]");
+      System.err.println(
+          "  packagesRoot e.g. modules/perc-packages/src/main/resources/Packages");
+      System.exit(2);
+      return;
+    }
+    Path root = Path.of(args[0]).toAbsolutePath().normalize();
+    Report report = scan(root);
+    printReport("Committed dual-ship page templateDef inventory under " + root, report);
+    if (!report.isClean()) {
+      System.err.println(
+          "FAIL: non-waived dual-ship page templateDefs would be materialized (#3675)");
+      System.exit(1);
+      return;
+    }
+    if (args.length > 1 && args[1] != null && !args[1].isBlank()) {
+      Path logFile = Path.of(args[1]).toAbsolutePath().normalize();
+      Report logReport = scanLogFile(logFile);
+      printReport("Dual-ship page templateDef log inventory under " + logFile, logReport);
+      if (!logReport.isClean()) {
+        System.err.println("FAIL: non-waived dual-ship page templateDefs log lines (#3675)");
+        System.exit(1);
+        return;
+      }
+    }
+    System.out.println(
+        "PASS: zero non-waived dual-ship page templateDefs (#3675; waived="
+            + WAIVED_PACKAGE_DIRS
+            + ")");
+  }
+
+  private static Report toReport(List<Finding> all) {
+    all.sort(
+        Comparator.comparing((Finding f) -> f.packageDirName().toLowerCase(Locale.ROOT))
+            .thenComparing(f -> f.packageDir() == null ? "" : f.packageDir().toString()));
+    List<Finding> nonWaived = all.stream().filter(f -> !f.waived()).collect(Collectors.toList());
+    List<Finding> waivedOnly = all.stream().filter(Finding::waived).collect(Collectors.toList());
+    return new Report(
+        Collections.unmodifiableList(all),
+        Collections.unmodifiableList(nonWaived),
+        Collections.unmodifiableList(waivedOnly));
+  }
+
+  private static void failIfUnclean(Report report, String where) {
+    if (report.isClean()) {
+      return;
+    }
+    String detail =
+        report.nonWaived().stream()
+            .map(
+                f ->
+                    f.packageDirName()
+                        + " mode="
+                        + f.committedMode()
+                        + " modernPages="
+                        + f.modernPageCount()
+                        + (f.packageDir() != null ? " -> " + f.packageDir() : ""))
+            .collect(Collectors.joining(System.lineSeparator() + "  "));
+    throw new IllegalStateException(
+        "Dual-ship page templateDefs CI gate (#3675): non-waived dual-ship emitters under "
+            + where
+            + " (only waived package dirs: "
+            + WAIVED_PACKAGE_DIRS
+            + "):"
+            + System.lineSeparator()
+            + "  "
+            + detail);
+  }
+
+  private static void printReport(String title, Report report) {
+    System.out.println(
+        title
+            + ": total="
+            + report.all().size()
+            + " waived="
+            + report.waived().size()
+            + " nonWaived="
+            + report.nonWaived().size()
+            + " waivedPackages="
+            + WAIVED_PACKAGE_DIRS);
+    for (Finding f : report.all()) {
+      System.out.println(
+          (f.waived() ? "WAIVED " : "FAIL   ")
+              + f.packageDirName()
+              + " mode="
+              + f.committedMode()
+              + " modernPages="
+              + f.modernPageCount()
+              + (f.packageDir() != null ? " " + f.packageDir() : ""));
+    }
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventoryTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dual-ship page templateDef CI/inventory gate: zero non-waived emitters under Packages (issue
+ * #3675 / parent #2630). Explicit waiver: {@code perc.Test} only (#3674 leftover binaries were
+ * converted, not dual-ship-retained).
+ *
+ * <p>Cross-platform: all path construction uses {@link Path#resolve(String)} / {@link Files}.
+ */
+class PSDualShipPageTemplateDefInventoryTest {
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void clearInstallModeSystemProperties() {
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_INSTALL_MODE);
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_DUAL_SHIP);
+  }
+
+  @Test
+  void waivedPackageSet_isExplicitlyPercTestOnly_retainListEmpty() {
+    assertEquals(Set.of(), PSDualShipPageTemplateDefInventory.RETAINED_WIDGET_BINARY_PACKAGE_DIRS);
+    assertEquals(Set.of("perc.Test"), PSDualShipPageTemplateDefInventory.WAIVED_PACKAGE_DIRS);
+    assertTrue(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.Test"));
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.baseTemplates"));
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.FileAssetWidget"));
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.widgets.image"));
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage(null));
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage(""));
+  }
+
+  @Test
+  void productPackagesTree_hasZeroNonWaivedDualShipPageTemplateDefs() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    assertNotNull(
+        packagesRoot,
+        "Packages root must be visible when running module Surefire from perc-packages "
+            + "(src/main/resources/Packages)");
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packagesRoot);
+    assertTrue(
+        report.isClean(),
+        () ->
+            "non-waived dual-ship page templateDefs must not reappear; found: "
+                + report.nonWaived());
+    assertEquals(0, report.nonWaived().size());
+
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packagesRoot);
+  }
+
+  @Test
+  void productNativePagePackages_areNotDualShipEmitters() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    assertNotNull(packagesRoot);
+    for (String pkg : List.of("perc.baseTemplates", "perc.responsiveTemplates", "perc.Baseline")) {
+      Path dir = packagesRoot.resolve(pkg);
+      assertTrue(Files.isDirectory(dir), () -> "missing product package " + pkg);
+      assertTrue(PSPageXmlDualShip.hasModernPageSources(dir), pkg + " must have modern pages/");
+      assertEquals(
+          PSPageXmlInstallMode.NATIVE,
+          PSDualShipPageTemplateDefInventory.resolveCommittedInstallMode(dir),
+          pkg + " must commit page.installMode=native");
+    }
+  }
+
+  @Test
+  void leftoverAuthoredRootTemplateDefWithoutModernPages_isNotDualShip() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path fileWidget = packages.resolve("perc.FileAssetWidget");
+    Files.createDirectories(fileWidget);
+    Files.writeString(
+        fileWidget.resolve("perc.fileBinary.templateDef"),
+        "<AssemblyTemplate/>",
+        StandardCharsets.UTF_8);
+    Path image = packages.resolve("perc.widgets.image");
+    Files.createDirectories(image);
+    Files.writeString(
+        image.resolve("perc.imageMainBinary.templateDef"),
+        "<AssemblyTemplate/>",
+        StandardCharsets.UTF_8);
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertTrue(report.isClean());
+    assertEquals(0, report.all().size());
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packages);
+  }
+
+  @Test
+  void tempTree_nativeModernPages_isClean() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.baseTemplates");
+    writeModernPage(pkg, "perc.base.plain");
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=native\n",
+        StandardCharsets.UTF_8);
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertTrue(report.isClean());
+    assertEquals(0, report.all().size());
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packages);
+  }
+
+  @Test
+  void tempTree_onlyWaivedDualShip_isClean() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.Test");
+    writeModernPage(pkg, "PSPage_TestProperties");
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertEquals(1, report.all().size());
+    assertEquals(0, report.nonWaived().size());
+    assertEquals(1, report.waived().size());
+    assertTrue(report.isClean());
+    assertEquals("perc.Test", report.waived().get(0).packageDirName());
+    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, report.waived().get(0).committedMode());
+    assertEquals(1, report.waived().get(0).modernPageCount());
+    Path expectedAbs = pkg.toAbsolutePath().normalize();
+    assertEquals(expectedAbs, report.waived().get(0).packageDir());
+    assertTrue(report.waived().get(0).packageDir().isAbsolute());
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packages);
+  }
+
+  @Test
+  void tempTree_dummyNonWaivedDualShip_failsGate() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.baseTemplates");
+    writeModernPage(pkg, "perc.base.plain");
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertFalse(report.isClean());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals("perc.baseTemplates", report.nonWaived().get(0).packageDirName());
+    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, report.nonWaived().get(0).committedMode());
+    assertEquals(1, report.nonWaived().get(0).modernPageCount());
+    assertTrue(report.nonWaived().get(0).packageDir().isAbsolute());
+    assertEquals(pkg.toAbsolutePath().normalize(), report.nonWaived().get(0).packageDir());
+
+    IllegalStateException err =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(
+                    packages));
+    assertTrue(err.getMessage().contains("#3675"));
+    assertTrue(err.getMessage().contains("perc.baseTemplates"));
+  }
+
+  @Test
+  void tempTree_explicitDualShipProperty_failsGate() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.responsiveTemplates");
+    writeModernPage(pkg, "perc.resp.plain");
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=dual-ship\n",
+        StandardCharsets.UTF_8);
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertFalse(report.isClean());
+    assertEquals("perc.responsiveTemplates", report.nonWaived().get(0).packageDirName());
+  }
+
+  @Test
+  void committedScan_ignoresJvmNativeOverride() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.baseTemplates");
+    writeModernPage(pkg, "perc.base.plain");
+    System.setProperty(PSPageXmlInstallPolicy.SYS_PROP_INSTALL_MODE, "native");
+    System.setProperty(PSPageXmlInstallPolicy.SYS_PROP_DUAL_SHIP, "false");
+
+    assertEquals(PSPageXmlInstallMode.NATIVE, PSPageXmlInstallPolicy.resolve(pkg));
+    assertEquals(
+        PSPageXmlInstallMode.DUAL_SHIP,
+        PSDualShipPageTemplateDefInventory.resolveCommittedInstallMode(pkg));
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertFalse(report.isClean(), "JVM native override must not hide missing package-local opt-in");
+    assertEquals(1, report.nonWaived().size());
+  }
+
+  @Test
+  void findingPackageDir_relativePackagesRoot_isAbsolute() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path pkg = packages.resolve("perc.Test");
+    writeModernPage(pkg, "PSPage_TestProperties");
+
+    Path relativePackages =
+        Path.of(".").toAbsolutePath().normalize().relativize(packages.toAbsolutePath().normalize());
+    assertFalse(relativePackages.isAbsolute(), "precondition: packages root is relative");
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(relativePackages);
+    assertEquals(1, report.all().size());
+    Path found = report.all().get(0).packageDir();
+    assertTrue(found.isAbsolute());
+    assertEquals(pkg.toAbsolutePath().normalize(), found);
+    assertTrue(Files.isDirectory(found));
+  }
+
+  @Test
+  void tempTree_mixedWaivedAndNonWaived_reportsOnlyNonWaivedAsFailures() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    writeModernPage(packages.resolve("perc.Test"), "PSPage_TestProperties");
+    writeModernPage(packages.resolve("perc.baseTemplates"), "perc.base.plain");
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scan(packages);
+    assertEquals(2, report.all().size());
+    assertEquals(1, report.waived().size());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals("perc.baseTemplates", report.nonWaived().get(0).packageDirName());
+    assertFalse(report.isClean());
+  }
+
+  @Test
+  void logLine_formatAndParse_roundTrip() {
+    String line = PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.baseTemplates", 20);
+    assertTrue(line.contains(PSDualShipPageTemplateDefInventory.DUAL_SHIP_LOG_MARKER));
+    assertEquals(
+        Optional.of("perc.baseTemplates"),
+        PSDualShipPageTemplateDefInventory.parseDualShipPackageFromLogLine(line));
+    assertEquals(
+        Optional.empty(),
+        PSDualShipPageTemplateDefInventory.parseDualShipPackageFromLogLine(
+            "  native-install page TemplateDefs for perc.baseTemplates: 20 written"));
+    assertEquals(
+        Optional.empty(), PSDualShipPageTemplateDefInventory.parseDualShipPackageFromLogLine(null));
+    assertEquals(
+        Optional.empty(), PSDualShipPageTemplateDefInventory.parseDualShipPackageFromLogLine(""));
+  }
+
+  @Test
+  void scanLogLines_nonWaivedFails_waivedIsClean() {
+    String waived =
+        PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.Test", 1);
+    String nativeLine = "  native-install page TemplateDefs for perc.baseTemplates: 20 written";
+    PSDualShipPageTemplateDefInventory.Report waivedOnly =
+        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(waived, nativeLine));
+    assertTrue(waivedOnly.isClean());
+    assertEquals(1, waivedOnly.waived().size());
+    assertEquals("perc.Test", waivedOnly.waived().get(0).packageDirName());
+    assertNull(waivedOnly.waived().get(0).packageDir());
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(List.of(waived));
+
+    String bad = PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.baseTemplates", 20);
+    PSDualShipPageTemplateDefInventory.Report fail =
+        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(nativeLine, bad, waived));
+    assertFalse(fail.isClean());
+    assertEquals(1, fail.nonWaived().size());
+    assertEquals("perc.baseTemplates", fail.nonWaived().get(0).packageDirName());
+    IllegalStateException err =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(
+                    List.of(bad)));
+    assertTrue(err.getMessage().contains("perc.baseTemplates"));
+  }
+
+  @Test
+  void scanLogFile_readsUtf8Lines() throws Exception {
+    Path log = tempDir.resolve("package-build.log");
+    String content =
+        PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.baseTemplates", 3)
+            + "\r\n"
+            + "Package build complete: 1 built, 0 up-to-date\n";
+    Files.writeString(log, content, StandardCharsets.UTF_8);
+
+    PSDualShipPageTemplateDefInventory.Report report =
+        PSDualShipPageTemplateDefInventory.scanLogFile(log);
+    assertFalse(report.isClean());
+    assertEquals("perc.baseTemplates", report.nonWaived().get(0).packageDirName());
+  }
+
+  @Test
+  void assertDualShipMaterializationAllowed_waivesPercTestOnly() {
+    PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed("perc.Test");
+    IllegalStateException err =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed(
+                    "perc.baseTemplates"));
+    assertTrue(err.getMessage().contains("#3675"));
+    assertTrue(err.getMessage().contains("perc.baseTemplates"));
+    assertTrue(err.getMessage().contains("native"));
+  }
+
+  @Test
+  void scan_rejectsNonDirectoryRoot() {
+    Path missing = tempDir.resolve("does-not-exist");
+    assertThrows(
+        IllegalArgumentException.class, () -> PSDualShipPageTemplateDefInventory.scan(missing));
+  }
+
+  @Test
+  void scanLogFile_rejectsMissingFile() {
+    Path missing = tempDir.resolve("missing.log");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSDualShipPageTemplateDefInventory.scanLogFile(missing));
+  }
+
+  private static void writeModernPage(Path packageDir, String templateId) throws Exception {
+    Path page = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve(templateId);
+    Files.createDirectories(page);
+    Files.writeString(
+        page.resolve("component-package.json"),
+        "{\"id\":\"" + templateId + "\"}",
+        StandardCharsets.UTF_8);
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt = cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,6 +79,16 @@ Shared Page/Gadget scanner: `com.percussion.packages.inventory.PSDefinitionXmlSh
 under a non-waived package. Explicit waiver: **`perc.Test` only**. Cross-platform: `Path` /
 `Files` only (no hardcoded separators).
 
+### Dual-ship page templateDef inventory gate (#3675)
+
+**Not a Python script.** Fail-closed Surefire gate so product package-build cannot silently
+re-introduce dual-ship page `*.templateDef` materialization (modern `pages/` + non-native
+committed `page.installMode`). Waiver: **`perc.Test` only**. Sibling #3674 leftover widget
+binaries are not dual-ship-retained. API:
+`com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` /
+`PSDualShipPageTemplateDefInventoryTest`. Retirement checklist:
+`docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md`.
+
 Optional CLI (after compiling the module):
 
 ```bat
@@ -94,6 +104,10 @@ cd modules\perc-packages
 ..\..\mvnw.cmd -q exec:java -Dexec.classpathScope=compile ^
   -Dexec.mainClass=com.percussion.packages.gadgetxml.PSGadgetDefinitionXmlInventory ^
   -Dexec.args="src\main\resources\Packages"
+
+..\..\mvnw.cmd -q exec:java -Dexec.classpathScope=compile ^
+  -Dexec.mainClass=com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory ^
+  -Dexec.args="src\main\resources\Packages"
 ```
 
 ```bash
@@ -108,6 +122,10 @@ cd modules/perc-packages
 
 ../../mvnw -q exec:java -Dexec.classpathScope=compile \
   -Dexec.mainClass=com.percussion.packages.gadgetxml.PSGadgetDefinitionXmlInventory \
+  -Dexec.args="src/main/resources/Packages"
+
+../../mvnw -q exec:java -Dexec.classpathScope=compile \
+  -Dexec.mainClass=com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory \
   -Dexec.args="src/main/resources/Packages"
 ```
 


### PR DESCRIPTION
## Summary

Fail-closed Surefire / package-build inventory so product packages cannot silently re-introduce dual-ship page `*.templateDef` materialization (parent #2630 / grandparent #2626).

`PSDualShipPageTemplateDefInventory` scans `Packages/` for modern `pages/` + committed `page.installMode` defaulting to dual-ship. Native packages (`perc.baseTemplates`, `perc.responsiveTemplates`, `perc.Baseline`) are not emitters. JVM `perc.packages.page.installMode` cannot hide a missing package-local opt-in. Waiver is **`perc.Test` only**. Sibling #3674 leftover binaries (`perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary`) are **not** dual-ship-retained (empty retain list; PR #3680 converts them; on `main` they have no modern `pages/`). `PSPackageBuilder` fails closed on non-waived dual-ship writes and uses a shared log-line formatter.

Fixes #3675
Parent #2630 (grandparent #2626)

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. From `modules/perc-packages`, run `..\..\mvnw.cmd clean install` (already green).
2. Confirm Surefire: `PSDualShipPageTemplateDefInventoryTest` (17 tests).
3. Confirm package-build logs have **no** `dual-ship page templateDefs` lines; native-install only for Baseline / baseTemplates / responsiveTemplates.
4. Optional: `exec:java` CLI `PSDualShipPageTemplateDefInventory` against `src/main/resources/Packages` → PASS.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): CI/Surefire inventory for package-build dual-ship materialization; operators still install the same `.ppkg` TemplateDef wire format
- [x] **Unit / module tests** — inventory + log parser + product-tree gate; perc-packages standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd modules/perc-packages && ../../mvnw.cmd clean install` **BUILD SUCCESS**; Tests run: 197, Failures: 0
- [x] **Cross-platform** — inventory/tests use `Path` / `Files` / `DirectoryStream`; no hardcoded OS separators

### C3 evidence

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 197, Failures: 0, Errors: 0, Skipped: 0; package-build: native-install Baseline:7 / baseTemplates:20 / responsiveTemplates:3; zero `dual-ship page templateDefs` log lines
- **downstream_checked:** none (new inventory type is perc-packages-only; no `final`/`sealed` on existing types; no public signature change consumed by other modules)

### C5 UI proof

N/A — no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
