### PR TITLE
fix(explorer): open REST-listed site so workflow spec can run (#3684)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -143,13 +143,16 @@ export function renderDisplayFormatCell(
   };
 
   switch (column) {
-    case "name":
-      return (
-        fromProps(["sys_title", "name", "Name"]) ||
-        item.name ||
-        item.path ||
-        ""
-      );
+    case "name": {
+      const fromSys = fromProps(["sys_title", "name", "Name"]);
+      const type = (item.type ?? "").trim().toLowerCase();
+      // Site rows must expose finder SITENAME (Corporate_Investments), not
+      // a GUID path from PSSitePathItemService.convert (#3684 / #3001).
+      if (type === "site") {
+        return item.name || fromSys || item.path || "";
+      }
+      return fromSys || item.name || item.path || "";
+    }
     case "type":
       return (
         fromProps(["sys_contenttypename", "sys_contenttype", "type", "Type"]) ||
@@ -535,6 +538,7 @@ export function DetailList({
                 key={idKey}
                 data-testid={`detail-row-${idKey}`}
                 data-row-kind={folderish ? "folder" : "item"}
+                data-item-name={item.name || ""}
                 data-item-type={item.type ?? ""}
                 data-previewable={isPreviewableItem(item) ? "true" : "false"}
                 data-selected={selected ? "true" : undefined}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -496,8 +496,13 @@ export function ExplorerTree({
         selectedNorm === normalizeExplorerTreePathKey(listPath));
     const folderish = isFolder(folder);
 
+    // data-node-name is the finder SITENAME; path may be a GUID (#3684 / #3001).
     return (
-      <div key={pathKey} data-testid={`tree-node-${path}`}>
+      <div
+        key={pathKey}
+        data-testid={`tree-node-${path}`}
+        data-node-name={folder.name || ""}
+      >
         <div
           role="treeitem"
           aria-expanded={folderish ? isOpen : undefined}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -538,6 +538,7 @@ export function ExplorerTree({
               if (folderish) toggle(path, folder);
             }}
             aria-hidden="true"
+            data-testid={folderish ? `tree-toggle-${path}` : undefined}
           >
             {folderish ? (isOpen ? "▾" : "▸") : " "}
           </span>

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -694,6 +694,10 @@ describe("DetailList folder row chrome (#3328)", () => {
       "data-row-kind",
       "folder",
     );
+    expect(screen.getByTestId("detail-row-sys-1")).toHaveAttribute(
+      "data-item-name",
+      "$System$",
+    );
 
     const userIcon = screen.getByTestId("detail-folder-icon-uf-1");
     expect(userIcon).toHaveAttribute("data-kind", "folder");
@@ -845,6 +849,35 @@ describe("T092b / FR-027: display-format column resolution", () => {
     const minimal: PSPathItem = { id: "x", name: "X", path: "/x" };
     expect(renderDisplayFormatCell("title", minimal)).toBe("X"); // falls back to name
     expect(renderDisplayFormatCell("modified", minimal)).toBe("");
+  });
+
+  it("site folder rows expose finder name, not GUID path (#3684)", async () => {
+    const site: PSPathItem = {
+      id: "16777215-101-703",
+      path: "/Sites/16777215-101-703/",
+      name: "Corporate_Investments",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+      displayProperties: { sys_title: "16777215-101-703" },
+    };
+    expect(renderDisplayFormatCell("name", site)).toBe("Corporate_Investments");
+    mockFolderPage([site]);
+    render(
+      <DetailList
+        folderPath="/Sites"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("detail-row-16777215-101-703")).toBeInTheDocument(),
+    );
+    const row = screen.getByTestId("detail-row-16777215-101-703");
+    expect(row).toHaveAttribute("data-row-kind", "folder");
+    expect(row).toHaveAttribute("data-item-name", "Corporate_Investments");
+    expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
   });
 
   it("columnHeaderLabel returns translated headers", () => {

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -863,7 +863,7 @@ describe("T092b / FR-027: display-format column resolution", () => {
     };
     expect(renderDisplayFormatCell("name", site)).toBe("Corporate_Investments");
     mockFolderPage([site]);
-    render(
+    const { container } = render(
       <DetailList
         folderPath="/Sites"
         selectedItemId={null}
@@ -878,6 +878,7 @@ describe("T092b / FR-027: display-format column resolution", () => {
     expect(row).toHaveAttribute("data-row-kind", "folder");
     expect(row).toHaveAttribute("data-item-name", "Corporate_Investments");
     expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
+    await renderA11yGate(container);
   });
 
   it("columnHeaderLabel returns translated headers", () => {

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -161,6 +161,9 @@ describe("ExplorerTree", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tree-node-/Sites/16777215-101-703/"),
+    ).toHaveAttribute("data-node-name", "Corporate_Investments");
   });
 
   it("loads children on first expand (lazy)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -181,7 +181,7 @@ describe("ExplorerTree", () => {
       }
       return pathItemListResponse([]);
     });
-    render(
+    const { container } = render(
       <ExplorerTree
         initialPath="/Sites"
         selectedPath={null}
@@ -194,16 +194,15 @@ describe("ExplorerTree", () => {
     expect(rootCalls).toBe(1);
     expect(childCalls).toBe(0);
     // Expand is on the toggle control (not the row select handler).
-    const node = screen.getByTestId("tree-node-/Sites/Foo");
-    const toggle = node.querySelector('[aria-hidden="true"]');
-    expect(toggle).toBeTruthy();
-    fireEvent.click(toggle!);
+    const toggle = screen.getByTestId("tree-toggle-/Sites/Foo");
+    fireEvent.click(toggle);
     await waitFor(() =>
       expect(
         screen.getByTestId("tree-node-/Sites/Foo/Bar"),
       ).toBeInTheDocument(),
     );
     expect(childCalls).toBe(1);
+    await renderA11yGate(container);
   });
 
   it("lists site children using folderPath not sitename (#3326)", async () => {

--- a/docs/ai-generated/code-reviews/3684-explorer-sites-open-erlang.md
+++ b/docs/ai-generated/code-reviews/3684-explorer-sites-open-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review: #3684 Explorer Sites UI opens REST-listed site
+
+**Branch:** `fix/issue-3684-explorer-sites-open`  
+**Base:** `origin/main`  
+**Scope:** WebUI Explorer tree/list site-name attributes + perc-qa-automation Playwright `openSitesThenPages`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** Playwright companion for WebUI screen; behavioral unit tests for new match helper; CMS URL paths use `/` (not OS separators); product-docs for operator-visible Sites name column
+
+## Summary
+
+Cycle Verify residual of parent #2732 / epic #2400. `explorer-workflow-transitions.spec.js` walked Sites **detail-row** `innerText` and threw when REST listed `Corporate Investments Home` but no matching folder row with item children was opened. Sample sites use finder `SITENAME` `Corporate_Investments` and pathmanagement path `/Sites/{guid}/` (#3001). Peer preview/editor specs expand the Sites **tree** and click `tree-node-/Sites/…`.
+
+Product: `data-node-name` on tree nodes and `data-item-name` on detail rows; site-type Name column prefers `item.name` over GUID `sys_title`. Spec: expand Sites (only if not already expanded), match tree nodes by folded testid + label + `data-node-name`, folder-row fallback, open Pages only when the listed item is not already visible.
+
+## Issues
+
+None (no bugs, missing behavioral tests, or non-portable path I/O).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` **filesystem** path construction
+- [x] URL / REST / CMS folder paths correctly use `/`
+- [x] Helper unit tests assert folded site names and testids, not OS path strings
+- [x] Temp files: none
+- [x] Line-ending assertions: none (testid / JSON strings)
+
+## Tests
+
+- WebUI Vitest: `ExplorerTree.test.tsx` (`data-node-name` on GUID site path), `DetailList.test.tsx` (site folder `data-item-name` + Name column `Corporate_Investments`)
+- perc-qa-automation Node: `treeNodeMatchesFoldedSite` (finder path, GUID+name, space title, negative); workflow spec source asserts tree-node open (#3684)
+- Playwright H2 C5: `explorer-workflow-transitions.spec.js` (required before PR)
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Sites tree `data-node-name` | done |
+| Sites list `data-item-name` + site Name column | done |
+| Vitest for tree + list | done |
+| Playwright `openSitesThenPages` tree-node match | done |
+| Helper + unit tests | done |
+| `product-docs/8.2/admin/content-explorer.md` | done (Name column shows site name) |
+
+## Notes
+
+- `downstream_checked`: none — no `final`/`sealed` or public signature break.
+- Do not steal assigned QA #2743. Do not re-work Expire HTTP 500 (#3668 / PR #3683).

--- a/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
@@ -31,7 +31,7 @@
  * from {@code modules/perc-qa-automation/frontend}.</p>
  */
 
-const { test, expect } = require("@playwright/test");
+const { test, expect, errors } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 const {
@@ -214,7 +214,11 @@ async function openSitesThenPages(page, listed) {
   const treeitem = sitesNode.locator('[role="treeitem"]').first();
   const expanded = await treeitem.getAttribute("aria-expanded");
   if (expanded !== "true") {
-    const toggle = sitesNode.locator('[aria-hidden="true"]').first();
+    const toggle = sitesNode
+      .locator(
+        '[data-testid="tree-toggle-/Sites/"], [data-testid="tree-toggle-/Sites"]',
+      )
+      .first();
     if ((await toggle.count()) > 0) {
       await toggle.click();
     }
@@ -289,7 +293,8 @@ async function openSitesThenPages(page, listed) {
   if (wanted.size > 0) {
     throw new Error(
       `REST listed page ${listedName || listed.id} but UI did not open a ` +
-        `matching site among ${[...wanted].join(", ")}`,
+        `matching site among ${[...wanted].join(", ")} ` +
+        `(tree=${seen.join("; ") || "none"})`,
     );
   }
 }
@@ -310,20 +315,25 @@ async function listHasListedOrItemRow(list, listedName) {
   if (!listedName) {
     return false;
   }
-  const byName = list
-    .locator('tbody tr[data-testid^="detail-row-"]')
-    .filter({ hasText: listedName });
-  if ((await byName.count()) > 0) {
-    return true;
+  const rows = list.locator('tbody tr[data-testid^="detail-row-"]');
+  const rowCount = await rows.count();
+  for (let i = 0; i < rowCount; i += 1) {
+    const itemName = (await rows.nth(i).getAttribute("data-item-name")) || "";
+    if (itemName === listedName) {
+      return true;
+    }
   }
   const homeAlias = /\bHome\b/i.test(listedName) ? "Home" : "";
   if (!homeAlias) {
     return false;
   }
-  const homeRow = list
-    .locator('tbody tr[data-testid^="detail-row-"]')
-    .filter({ hasText: homeAlias });
-  return (await homeRow.count()) > 0;
+  for (let i = 0; i < rowCount; i += 1) {
+    const itemName = (await rows.nth(i).getAttribute("data-item-name")) || "";
+    if (itemName === homeAlias) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -335,7 +345,10 @@ async function openDetailFolderRow(row) {
   try {
     await icon.waitFor({ state: "attached", timeout: 1_000 });
     await icon.click();
-  } catch {
+  } catch (err) {
+    if (!(err instanceof errors.TimeoutError)) {
+      throw err;
+    }
     await row.dblclick({ force: true });
   }
   const page = row.page();

--- a/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Playwright surface: #3639 / parent #3102 / #2732 — Explorer Workflow
- * transition no-skip on H2.
+ * Playwright surface: #3639 / parent #3102 / #2732 / #3684 — Explorer
+ * Workflow transition no-skip on H2.
  *
  * <p>Selecting a content row on {@code spa.jsp?entry=explorer} must show
  * {@code action-toolbar-group-workflow} and an invokable
@@ -56,6 +56,7 @@ const {
   foldSiteName,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
+  treeNodeMatchesFoldedSite,
 } = require("./helpers/explorer-preview-view");
 
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -190,7 +191,11 @@ async function findEligibleWorkflowItemViaRest(request) {
 }
 
 /**
- * Open Sites → the site that owns {@code listed} → Pages when present.
+ * Open Sites → the site that owns {@code listed} via the explorer tree
+ * (peer #3575 / #3684; detail-list folder-icon open can leave the Sites
+ * root selected) → Pages when the listed item is not already visible.
+ * Tree matching uses finder path testids, {@code data-node-name}, and
+ * visible label so GUID site paths still open Corporate_Investments.
  * @param {import("@playwright/test").Page} page
  * @param {object} [listed]
  */
@@ -206,55 +211,119 @@ async function openSitesThenPages(page, listed) {
   await listWaitReady(page);
   await page.waitForLoadState("networkidle").catch(() => {});
 
-  const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
-  const siteRows = list.locator(
-    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  const treeitem = sitesNode.locator('[role="treeitem"]').first();
+  const expanded = await treeitem.getAttribute("aria-expanded");
+  if (expanded !== "true") {
+    const toggle = sitesNode.locator('[aria-hidden="true"]').first();
+    if ((await toggle.count()) > 0) {
+      await toggle.click();
+    }
+  }
+  const siteTreeNodes = tree.locator(
+    '[data-testid^="tree-node-/Sites/"]:not([data-testid="tree-node-/Sites/"])',
   );
-  await expect(siteRows.first()).toBeVisible({ timeout: 15_000 });
+  await expect(siteTreeNodes.first()).toBeVisible({ timeout: 15_000 });
 
   const wanted = new Set(
     listedPageSiteNames(listed).map((n) => foldSiteName(n)),
   );
   const listedName = listed && listed.name ? String(listed.name) : "";
-  const siteCount = await siteRows.count();
-  let opened = false;
+  const siteCount = await siteTreeNodes.count();
+  let clicked = false;
+  const seen = [];
   for (let i = 0; i < siteCount; i += 1) {
-    if (i > 0) {
-      await sitesNode.click({ force: true });
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
-    }
-    const row = siteRows.nth(i);
-    const rowText = ((await row.innerText().catch(() => "")) || "").trim();
+    const node = siteTreeNodes.nth(i);
+    const testid = (await node.getAttribute("data-testid")) || "";
+    const nodeName = (await node.getAttribute("data-node-name")) || "";
+    const label = ((await node.innerText().catch(() => "")) || "").trim();
+    seen.push(`${testid}|${nodeName || label}`);
     const nameMatch =
-      wanted.size === 0 || detailRowMatchesFoldedSite(rowText, wanted);
+      wanted.size === 0 ||
+      treeNodeMatchesFoldedSite(testid, label, nodeName, wanted);
     if (!nameMatch) continue;
-    await openDetailFolderRow(row);
-    await openPagesFolderIfPresent(page, list);
-
-    const itemRows = list.locator(
-      'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+    await node.click({ force: true });
+    clicked = true;
+    break;
+  }
+  if (!clicked) {
+    const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
+    const siteRows = list.locator(
+      'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
     );
-    const byName = listedName
-      ? list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .filter({ hasText: listedName })
-      : itemRows;
-    if ((await itemRows.count()) > 0 || (await byName.count()) > 0) {
-      opened = true;
+    const rowCount = await siteRows.count();
+    for (let i = 0; i < rowCount; i += 1) {
+      const row = siteRows.nth(i);
+      const rowText = ((await row.innerText().catch(() => "")) || "").trim();
+      const itemName = (await row.getAttribute("data-item-name")) || "";
+      const nameMatch =
+        wanted.size === 0 ||
+        detailRowMatchesFoldedSite(rowText, wanted) ||
+        treeNodeMatchesFoldedSite("", rowText, itemName, wanted);
+      if (!nameMatch) continue;
+      await openDetailFolderRow(row);
+      clicked = true;
       break;
     }
   }
-  if (!opened && wanted.size > 0) {
+  if (!clicked && wanted.size > 0) {
+    throw new Error(
+      `REST listed page ${listedName || listed.id} but UI did not open a ` +
+        `matching site among ${[...wanted].join(", ")} ` +
+        `(tree=${seen.join("; ") || "none"})`,
+    );
+  }
+  if (!clicked) {
+    await siteTreeNodes.first().click({ force: true });
+  }
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+
+  const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
+  if (await listHasListedOrItemRow(list, listedName)) {
+    return;
+  }
+  await openPagesFolderIfPresent(page, list);
+  if (await listHasListedOrItemRow(list, listedName)) {
+    return;
+  }
+  if (wanted.size > 0) {
     throw new Error(
       `REST listed page ${listedName || listed.id} but UI did not open a ` +
         `matching site among ${[...wanted].join(", ")}`,
     );
   }
-  if (!opened) {
-    await openDetailFolderRow(siteRows.first());
-    await openPagesFolderIfPresent(page, list);
+}
+
+/**
+ * True when the detail list shows the listed page or any content item row.
+ * @param {import("@playwright/test").Locator} list
+ * @param {string} listedName
+ * @returns {Promise<boolean>}
+ */
+async function listHasListedOrItemRow(list, listedName) {
+  const itemRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  if ((await itemRows.count()) > 0) {
+    return true;
   }
+  if (!listedName) {
+    return false;
+  }
+  const byName = list
+    .locator('tbody tr[data-testid^="detail-row-"]')
+    .filter({ hasText: listedName });
+  if ((await byName.count()) > 0) {
+    return true;
+  }
+  const homeAlias = /\bHome\b/i.test(listedName) ? "Home" : "";
+  if (!homeAlias) {
+    return false;
+  }
+  const homeRow = list
+    .locator('tbody tr[data-testid^="detail-row-"]')
+    .filter({ hasText: homeAlias });
+  return (await homeRow.count()) > 0;
 }
 
 /**
@@ -262,10 +331,11 @@ async function openSitesThenPages(page, listed) {
  * @param {import("@playwright/test").Locator} row
  */
 async function openDetailFolderRow(row) {
-  const icon = row.locator('[data-testid^="detail-folder-icon-"]');
-  if ((await icon.count()) > 0) {
+  const icon = row.locator('[data-testid^="detail-folder-icon-"]').first();
+  try {
+    await icon.waitFor({ state: "attached", timeout: 1_000 });
     await icon.click();
-  } else {
+  } catch {
     await row.dblclick({ force: true });
   }
   const page = row.page();

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -377,6 +377,24 @@ function detailRowMatchesFoldedSite(rowText, wantedFolded) {
   return wanted.some((n) => folded.includes(n));
 }
 
+/**
+ * Match a Sites tree node to REST-listed site names. Finder path testids
+ * ({@code tree-node-/Sites/Corporate_Investments/}) and GUID path + visible
+ * name ({@code tree-node-/Sites/16777215-101-703/} + Corporate_Investments
+ * / {@code data-node-name}) both match (#3684 / #3001).
+ * @param {string} testid
+ * @param {string} innerText
+ * @param {string} [nodeName]
+ * @param {Iterable<string>} wantedFolded
+ * @returns {boolean}
+ */
+function treeNodeMatchesFoldedSite(testid, innerText, nodeName, wantedFolded) {
+  const wanted = [...(wantedFolded || [])].filter(Boolean);
+  if (wanted.length === 0) return true;
+  const haystacks = [testid, innerText, nodeName].map((s) => foldSiteName(s));
+  return wanted.some((n) => haystacks.some((h) => h.includes(n)));
+}
+
 module.exports = {
   TEST_IDS,
   explorerEntryUrl,
@@ -397,4 +415,5 @@ module.exports = {
   foldSiteName,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
+  treeNodeMatchesFoldedSite,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -31,6 +31,7 @@ const {
   foldSiteName,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
+  treeNodeMatchesFoldedSite,
 } = require("../helpers/explorer-preview-view");
 
 describe("explorer-preview-view helpers (#2733)", () => {
@@ -316,6 +317,54 @@ describe("explorer-preview-view helpers (#2733)", () => {
     );
     assert.equal(
       detailRowMatchesFoldedSite(rowText, ["enterpriseinvestments"]),
+      false,
+    );
+  });
+
+  it("treeNodeMatchesFoldedSite matches finder path and GUID+name (#3684)", () => {
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/Corporate_Investments/",
+        "Corporate_Investments",
+        "Corporate_Investments",
+        ["corporateinvestments"],
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "Corporate_Investments",
+        "Corporate_Investments",
+        ["corporateinvestments"],
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "Corporate Investments",
+        "Corporate Investments",
+        ["corporateinvestments"],
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "",
+        "",
+        ["corporateinvestments"],
+      ),
+      false,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/Enterprise_Investments/",
+        "Enterprise_Investments",
+        "Enterprise_Investments",
+        ["corporateinvestments"],
+      ),
       false,
     );
   });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
@@ -208,6 +208,9 @@ describe("explorer-workflow-transitions helpers (#3639)", () => {
       src,
       /\[data-testid\^="tree-node-\/Sites\/"\]:not\(\[data-testid="tree-node-\/Sites\/"\]\)/,
     );
-    assert.match(src, /aria-hidden="true"/);
+    assert.match(src, /tree-toggle-\/Sites/);
+    assert.match(src, /errors\.TimeoutError/);
+    assert.match(src, /getAttribute\("data-item-name"\)/);
+    assert.match(src, /tree=\$\{seen\.join/);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
@@ -25,6 +25,8 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   TEST_IDS,
   JSON_ACCEPT_HEADERS,
@@ -191,5 +193,21 @@ describe("explorer-workflow-transitions helpers (#3639)", () => {
       ),
       false,
     );
+  });
+
+  it("workflow spec opens REST-listed site via tree-node name or testid (#3684)", () => {
+    const specPath = path.join(
+      __dirname,
+      "..",
+      "explorer-workflow-transitions.spec.js",
+    );
+    const src = fs.readFileSync(specPath, "utf8");
+    assert.match(src, /treeNodeMatchesFoldedSite/);
+    assert.match(src, /data-node-name/);
+    assert.match(
+      src,
+      /\[data-testid\^="tree-node-\/Sites\/"\]:not\(\[data-testid="tree-node-\/Sites\/"\]\)/,
+    );
+    assert.match(src, /aria-hidden="true"/);
   });
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -165,9 +165,10 @@ Editor HTML (`checkoutedit.xml`, `contenteditorurls.html`, `?view=editor`).
 ## Sites list and Create Site
 
 Under the tree root **Sites** you see traditional site folders available to your community
-(sample sites after a demo-sites install, plus any sites you create). Expand **Sites** and
-select a sample site to browse FastForward folders and pages (About…, Files, Images,
-and the site NavTree).
+(sample sites after a demo-sites install, plus any sites you create). The tree label and
+the list **Name** column show the **site name** (for example `Corporate_Investments`),
+not an internal identifier. Expand **Sites** and select a sample site to browse
+FastForward folders and pages (About…, Files, Images, and the site NavTree).
 
 To create a new Site from Explorer:
 


### PR DESCRIPTION
## Summary

Cycle Verify residual of parent [#2732](https://github.com/intersoftdatalabs-in/percussioncms/issues/2732) / epic [#2400](https://github.com/intersoftdatalabs-in/percussioncms/issues/2400) / QA fail [#2743](https://github.com/intersoftdatalabs-in/percussioncms/issues/2743) (do not steal the qa-task). **Fixes #3684.**

`explorer-workflow-transitions.spec.js` listed FastForward page **Corporate Investments Home** via REST, then `openSitesThenPages` walked Sites **detail-row** `innerText` and threw when no matching folder row had item children. Sample sites use finder `SITENAME` `Corporate_Investments` with pathmanagement path `/Sites/{guid}/` (#3001). Peer preview/editor specs expand the Sites **tree** and click `tree-node-/Sites/…`.

This PR:

- Adds `data-node-name` on Explorer tree nodes and `data-item-name` on detail rows.
- Site-type Name column prefers finder `item.name` over a GUID `sys_title`.
- Playwright opens the REST-listed site via tree-node match (testid + label + `data-node-name`), with folder-row fallback; opens Pages only when the listed item is not already visible.

Does **not** re-work Hibernate Expire HTTP 500 ([#3668](https://github.com/intersoftdatalabs-in/percussioncms/issues/3668) / PR [#3683](https://github.com/intersoftdatalabs-in/percussioncms/pull/3683)).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2984, Failures: 0).
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `frontend npm run test:unit` — 428 pass.
3. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `qa-health` RESULT:OK HTTP:200 HEALTH:healthy `TEST_CMS_URL=http://127.0.0.1:9993`.
4. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`; `qa-health` again.
5. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/explorer-workflow-transitions.spec.js` — **2 passed, 0 skipped**.
6. `npm run test:golden` — 2 passed.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md`: Sites tree label and list Name column show the site name (for example `Corporate_Investments`), not an internal identifier.
- [x] **Unit / module tests** — Vitest `ExplorerTree` / `DetailList`; Node `treeNodeMatchesFoldedSite` + workflow spec tree-node open; standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation`.
- [x] **WebUI + Playwright** — `tests/explorer-workflow-transitions.spec.js` (2 passed, 0 skipped) + golden smoke (2 passed).
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests).
- [x] **Cross-platform** — CMS/URL paths use `/`; no OS filesystem path joins.

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` BUILD SUCCESS (02:34 min). Vitest: Tests 2984 passed (390 files).
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` BUILD SUCCESS (13.8s). `npm run test:unit`: tests 428 pass, 0 fail.
- **downstream_checked:** none — no `final`/`sealed` or public signature break.

### C5 UI proof

- `perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy (before and after asset copy)
- Hot-copy WebUI `cm/modern/assets/` into Rhythmyx WAR (not `deploy-jar --target cms`)
- `npm run test:surface -- --path tests/explorer-workflow-transitions.spec.js` — 2 passed, 0 skipped
- `npm run test:golden` — 2 passed
- **console-clean:** yes (spec asserts no page/console errors)
- **server.log-clean:** BUG:#3668 — Expire trigger on Public FastForward page 551 logs `PSRuntimeExceptionMapper` failed transition (honest 500; not re-worked here)

Fixes #3684

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
