### PR TITLE
feat(system): csv-filesystem Virtual Site source SPI (#3685)

### DIFF
--- a/docs/ai-generated/code-reviews/3685-csv-filesystem-virtual-site-source-erlang.md
+++ b/docs/ai-generated/code-reviews/3685-csv-filesystem-virtual-site-source-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review: #3685 csv-filesystem IPSVirtualSiteSource
+
+**Date:** 2026-08-20  
+**Branch:** `feat/issue-3685-csv-filesystem-virtual-site-source`  
+**Scope:** uncommitted vs `HEAD` / `origin/main` (system virtualsite SPI + product-docs 8.2)  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** pass
+
+Memory patterns hit: portable Path/Files; behavioral tests for validation/rejection; change-class companions (SPI + factory + tests + product-docs); no REST/UI companions required (explicitly out of scope #3686/#3687).
+
+## Summary
+
+Adds `VirtualSiteSourceType.CSV_FILESYSTEM` (`csv-filesystem`), `PSCsvFilesystemVirtualSiteSource` (discover+load), RFC 4180 `VirtualCsvParser`, and `PSVirtualSiteSourceFactory` wired through `PSVirtualSiteBuildService.forSourceType` / CLI 4th arg. Required CSV columns `id`, `title`, `body`; optional `path`/`order`; fail-closed on missing columns, blank id/title, duplicates, unsafe paths. Product-docs 8.2 admin/developer/reference describe offline CSV build; REST Build remains git-filesystem.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction (logical CSV `path` uses `/` as href-style separators then `Path.of`/`resolve`)
+- [x] Discover/load uses `Path` / `Files.readString` / `Files.walk`
+- [x] Temp trees via JUnit `@TempDir`
+- [x] Windows vs Unix absolute path assertions behind `@EnabledOnOs`
+- [x] Containment: CSV files and version roots `startsWith` normalized site root; `path` column rejects `..`, NUL, drive letters, leading `/`
+- [x] Line endings: parser normalizes `\r\n` / `\r`; tests cover CRLF
+
+## Issues
+
+None blocking.
+
+### Notes (non-blocking)
+
+- REST `SitesAdaptor` still rejects non-`git-filesystem` on Build. Documented and in-scope for #3686, not this slice.
+- Adding an enum constant expands `PSVirtualSiteHelper` allow-list, so `PUT …/virtual` can persist `csv-filesystem`. That is the SPI allow-list, not REST Build.
+
+## Tests
+
+- `VirtualCsvParserTest` — required columns, quotes/newlines, CRLF, BOM, ragged/unclosed
+- `PSCsvFilesystemVirtualSiteSourceTest` — discover/load temp tree, fail-closed paths, no cache, factory + build HTML, OS-specific roots
+- `PSVirtualSiteHelperTest` — allow-list includes both kinds; csv remoteUrl rejected
+
+## Change-class companions
+
+New Virtual Site source adapter: enum + impl + factory + build-service selection + CLI + helper allow-list + product-docs + unit tests. REST/UI slices filed separately.

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -71,7 +71,7 @@ and Markdown tooling, not the classic page editor.
 
 | Property | Required | Example | Notes |
 |----------|----------|---------|-------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Phase 1 allow-list: **`git-filesystem` only**. Blank or `repository` = traditional Site. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**. Blank or `repository` = traditional Site. CMS Build/UI still use git-filesystem; `csv-filesystem` is the offline CSV adapter (see [Virtual Sites](id:developer-virtual-sites)). |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` | Local tree when `virtual.remoteUrl` is blank. Prefer absolute portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. When a remote is set, use a **relative** folder inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones or fetches into a contained server work directory, then discovers Markdown as usual. Blank = local-path mode. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. |
 | `virtual.branch` | No | `main` | Branch to checkout when a remote is set. Default `main`. |

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -10,7 +10,9 @@ tags: [developer, virtual-sites]
 # Virtual Sites
 
 **Virtual Sites** are Sites whose content originates outside the traditional Percussion content
-repository. Phase 1 delivers a **Git / filesystem** adapter aimed at product documentation.
+repository. Phase 1 delivers a **Git / filesystem** adapter aimed at product documentation. A
+**CSV / filesystem** adapter (`csv-filesystem`) can discover the same assemble pipeline from
+CSV files (offline CLI; REST Build remains git-filesystem).
 
 Operators can create a **Virtual** type from **Content Explorer → Create Site** or
 **Navigation → New Site**. That flow does not prompt for managed navigation or a page template.
@@ -88,7 +90,7 @@ treated as a safe Virtual Site source.
 
 | Property | Required | Example | Meaning |
 |----------|----------|---------|---------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem` only. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. CMS **Build** REST is still git-filesystem only; `csv-filesystem` is the offline SPI/CLI adapter. |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` (or install-relative) | Local filesystem root when `virtual.remoteUrl` is blank. When a remote is set, optional **relative** path inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. When set, **Build** clones or fetches into a contained work directory, then reuses git-filesystem discover. Blank keeps local-path mode. Allowed: `https://`, `ssh://`, `file://`, or `git@host:path`. `http` and other schemes are rejected. |
 | `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. Simple ref name only (no `..` or leading `-`). |
@@ -100,8 +102,9 @@ Empty / missing `virtual.sourceKind` (or value `repository`) means a traditional
 ### Validation rules
 
 - **Source kind allow-list** — only registered adapter wire names are accepted for Virtual Sites
-  (Phase 1: `git-filesystem`). Values such as future `sql` / `api` kinds are rejected until
-  implemented.
+  (`git-filesystem`, `csv-filesystem`). Values such as future `sql` / `api` kinds are rejected until
+  implemented. `csv-filesystem` does not accept `virtual.remoteUrl` (Git remotes apply to
+  `git-filesystem` only).
 - **Required root** — when `virtual.sourceKind` is virtual and `virtual.remoteUrl` is blank,
   `virtual.rootPath` must be non-blank.
 - **Optional Git remote** — `virtual.remoteUrl` + `virtual.branch` fetch or clone before Build.
@@ -128,6 +131,37 @@ scripts/build-cms-docs.sh
 
 Default output: `tmp/product-docs-site/`. The build fails non-zero when internal `id:` or relative
 Markdown links cannot be resolved.
+
+### Offline build from CSV (`csv-filesystem`)
+
+The `csv-filesystem` adapter discovers pages from `*.csv` files under each version folder in
+`_config.yaml` (the same `_config.yaml` / `_theme` contract as git-filesystem). Git remains
+optional; operators can assemble a static site from a spreadsheet export without ingesting rows
+as CMS content items.
+
+Required CSV columns (header row, case-insensitive):
+
+| Column | Required | Meaning |
+|--------|----------|---------|
+| `id` | Yes | Stable page id within the version (same role as Markdown frontmatter `id`) |
+| `title` | Yes | Page title |
+| `body` | Yes | Markdown body (quote the field when it contains commas or newlines) |
+| `path` | No | Site-relative page path (`getting-started/install` or `8.2/getting-started/install.md`). Omitted ⇒ `{version}/{id}.md`. Must be relative (no `..`, no `C:\…` / `/…`). |
+| `order` | No | Integer nav order; default `0` |
+
+Missing required columns, blank `id`/`title`, duplicate ids, or an unsafe `path` fail the build
+(`VirtualSiteException`). Each discover/load re-reads the current CSV bytes (no process-lifetime
+parse cache).
+
+CLI (from a tree that already has `_config.yaml`):
+
+```text
+PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey] csv-filesystem
+```
+
+REST `PUT /sites/{nameOrId}/virtual` may store `sourceKind=csv-filesystem` (allow-listed), but
+**Build Virtual Site** (`POST …/virtual/build`) and the Developer Sites UI still run the
+git-filesystem adapter only. Use the offline CLI for CSV trees until the REST/UI slices land.
 
 ## CMS-integrated build (REST and WebUI)
 
@@ -255,6 +289,7 @@ silent no-op). See [Publishing](id:admin-publishing).
 
 - CMS UI editing of Virtual items as normal content types
 - Automatic migration of the full legacy help site
+- REST/UI Build for `csv-filesystem` (offline CLI only in this slice)
 - SQL/API adapters
 - Fake classic content-list generators for virtual items
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -111,7 +111,7 @@ When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` co
 
 | Property name | Required | Example | Meaning |
 |---------------|----------|---------|---------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. `csv-filesystem` is the offline CSV source (required columns `id`, `title`, `body`); REST Build remains git-filesystem. |
 | `virtual.rootPath` | Yes when remote is blank | absolute or install-relative path to tree | Local filesystem source root when `virtual.remoteUrl` is blank. NIO `Path` normalize; no empty path / remaining `..`. When a remote is set, optional relative path inside the checkout. |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones/fetches into `{install}/tmp/virtual-site-checkouts/{siteKey}`. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. Fail-closed on `..`, `http`, option injection. Credentials are never logged. |
 | `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. |

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 /**
  * SPI for Virtual Site content sources. Phase 1: {@link PSGitFilesystemVirtualSiteSource}.
+ * CSV / flat-file adapter: {@link PSCsvFilesystemVirtualSiteSource} ({@code csv-filesystem}).
  * Future adapters (SQL, API, …) implement this interface.
  *
  * <p>Filesystem implementations must read <em>current</em> file contents on every {@link

--- a/system/services/src/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSource.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.virtualsite.VirtualSiteConfig.VersionSpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Virtual Site source: CSV files (or a directory of CSVs) under each version path.
+ *
+ * <p>Column contract: required {@code id}, {@code title}, {@code body} (Markdown); optional {@code
+ * path} and {@code order}. Missing required columns or blank {@code id}/{@code title} fail closed
+ * with {@link VirtualSiteException}.
+ *
+ * <p>Stateless: {@link #discover} and {@link #load} always {@link Files#readString} the current
+ * CSV bytes. No parse cache is kept on the instance or in statics.
+ *
+ * <p>Filesystem I/O uses portable NIO {@link Path} / {@link Files} only.
+ */
+public class PSCsvFilesystemVirtualSiteSource implements IPSVirtualSiteSource {
+
+  @Override
+  public String sourceType() {
+    return VirtualSiteSourceType.CSV_FILESYSTEM.wireName();
+  }
+
+  @Override
+  public List<VirtualItemRef> discover(VirtualSiteConfig config)
+      throws IOException, VirtualSiteException {
+    List<LoadedRow> rows = loadAllRows(config);
+    List<VirtualItemRef> refs = new ArrayList<>(rows.size());
+    for (LoadedRow row : rows) {
+      refs.add(row.ref());
+    }
+    refs.sort(
+        Comparator.comparing(VirtualItemRef::versionId)
+            .thenComparingInt(VirtualItemRef::order)
+            .thenComparing(r -> r.relativePath().toString().replace('\\', '/')));
+    return refs;
+  }
+
+  @Override
+  public VirtualItem load(VirtualSiteConfig config, VirtualItemRef ref)
+      throws IOException, VirtualSiteException {
+    if (ref == null) {
+      throw new VirtualSiteException("CSV item ref is required");
+    }
+    List<LoadedRow> rows = loadAllRows(config);
+    for (LoadedRow row : rows) {
+      if (row.ref().versionId().equals(ref.versionId()) && row.ref().id().equals(ref.id())) {
+        Path csvAbs = row.csvFile();
+        Path safeRoot = config.root().normalize();
+        Path safeCsv = csvAbs.normalize();
+        if (!safeCsv.startsWith(safeRoot)) {
+          throw new VirtualSiteException("CSV file escapes site root: " + csvAbs);
+        }
+        return new VirtualItem(row.ref(), row.frontmatter(), row.body(), csvAbs);
+      }
+    }
+    throw new VirtualSiteException(
+        "Unknown CSV page id '" + ref.id() + "' in version " + ref.versionId());
+  }
+
+  private static List<LoadedRow> loadAllRows(VirtualSiteConfig config)
+      throws IOException, VirtualSiteException {
+    if (config == null) {
+      throw new VirtualSiteException("Virtual Site config is required");
+    }
+    Path root = config.root();
+    if (root == null || !PSVirtualSiteHelper.isSafeRootPath(root)) {
+      throw new VirtualSiteException("CSV site root is missing or unsafe");
+    }
+    Path safeRoot = root.normalize();
+    List<LoadedRow> rows = new ArrayList<>();
+    Map<String, Path> seenIds = new HashMap<>();
+
+    for (VersionSpec version : config.versions()) {
+      Path versionRoot = safeRoot.resolve(version.path()).normalize();
+      if (!versionRoot.startsWith(safeRoot)) {
+        throw new VirtualSiteException("Version path escapes site root: " + version.path());
+      }
+      if (!Files.isDirectory(versionRoot)) {
+        throw new VirtualSiteException("Version path not found: " + versionRoot);
+      }
+      try (Stream<Path> walk = Files.walk(versionRoot)) {
+        List<Path> csvFiles =
+            walk.filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".csv"))
+                .sorted(Comparator.comparing(p -> p.toString().replace('\\', '/')))
+                .toList();
+        for (Path abs : csvFiles) {
+          Path csvAbs = abs.normalize();
+          if (!csvAbs.startsWith(safeRoot)) {
+            throw new VirtualSiteException("CSV file escapes site root: " + abs);
+          }
+          Path relCsv = safeRoot.relativize(csvAbs);
+          String label = relCsv.toString().replace('\\', '/');
+          String text = Files.readString(csvAbs, StandardCharsets.UTF_8);
+          List<Map<String, String>> parsed = VirtualCsvParser.parse(text, label);
+          for (int i = 0; i < parsed.size(); i++) {
+            LoadedRow loaded = toLoadedRow(parsed.get(i), version, csvAbs, label, i + 2);
+            String idKey = version.id() + "\0" + loaded.ref().id();
+            Path previous = seenIds.put(idKey, loaded.ref().relativePath());
+            if (previous != null) {
+              throw new VirtualSiteException(
+                  "Duplicate CSV id '"
+                      + loaded.ref().id()
+                      + "' in version "
+                      + version.id()
+                      + ": "
+                      + previous
+                      + " and "
+                      + loaded.ref().relativePath());
+            }
+            rows.add(loaded);
+          }
+        }
+      }
+    }
+    return rows;
+  }
+
+  private static LoadedRow toLoadedRow(
+      Map<String, String> cells, VersionSpec version, Path csvFile, String label, int line)
+      throws VirtualSiteException {
+    String id = VirtualCsvParser.cell(cells, VirtualCsvParser.COL_ID).trim();
+    String title = VirtualCsvParser.cell(cells, VirtualCsvParser.COL_TITLE).trim();
+    String body = VirtualCsvParser.cell(cells, VirtualCsvParser.COL_BODY);
+    String pathRaw = VirtualCsvParser.cell(cells, VirtualCsvParser.COL_PATH).trim();
+    String orderRaw = VirtualCsvParser.cell(cells, VirtualCsvParser.COL_ORDER).trim();
+    String where = label + ":" + line;
+    if (id.isEmpty()) {
+      throw new VirtualSiteException("CSV 'id' is required in " + where);
+    }
+    if (title.isEmpty()) {
+      throw new VirtualSiteException("CSV 'title' is required in " + where);
+    }
+    int order = parseOrder(orderRaw, where);
+    Path relative = resolvePagePath(pathRaw, id, version.path(), where);
+    VirtualItemRef ref = new VirtualItemRef(id, version.id(), relative, order, title);
+    VirtualFrontmatter fm =
+        new VirtualFrontmatter(id, title, "", version.id(), true, order, List.of(), false);
+    return new LoadedRow(ref, fm, body != null ? body : "", csvFile);
+  }
+
+  private static int parseOrder(String raw, String where) throws VirtualSiteException {
+    if (raw == null || raw.isBlank()) {
+      return 0;
+    }
+    try {
+      return Integer.parseInt(raw.trim());
+    } catch (NumberFormatException e) {
+      throw new VirtualSiteException("CSV 'order' must be an integer in " + where, e);
+    }
+  }
+
+  /**
+   * Map the optional CSV {@code path} column to a site-root-relative Markdown path using NIO {@link
+   * Path#resolve} (logical {@code /} in the column is a href-style separator, not a filesystem
+   * join).
+   */
+  static Path resolvePagePath(String pathRaw, String id, String versionPath, String where)
+      throws VirtualSiteException {
+    List<String> segments;
+    if (pathRaw == null || pathRaw.isBlank()) {
+      segments = List.of(versionPath, id + ".md");
+    } else {
+      if (pathRaw.indexOf('\0') >= 0) {
+        throw new VirtualSiteException("CSV 'path' must not contain NUL in " + where);
+      }
+      String logical = pathRaw.trim().replace('\\', '/');
+      if (logical.startsWith("/") || looksAbsoluteWindows(logical)) {
+        throw new VirtualSiteException("CSV 'path' must be relative in " + where);
+      }
+      segments = new ArrayList<>();
+      for (String seg : logical.split("/")) {
+        if (seg.isEmpty() || ".".equals(seg)) {
+          continue;
+        }
+        if ("..".equals(seg) || seg.indexOf('\0') >= 0 || seg.indexOf(':') >= 0) {
+          throw new VirtualSiteException(
+              "CSV 'path' must not contain '..', drive, or NUL segments in " + where);
+        }
+        segments.add(seg);
+      }
+      if (segments.isEmpty()) {
+        throw new VirtualSiteException("CSV 'path' is empty after normalize in " + where);
+      }
+      if (!segments.get(0).equals(versionPath)) {
+        segments.add(0, versionPath);
+      }
+      String last = segments.get(segments.size() - 1);
+      if (!last.toLowerCase(Locale.ROOT).endsWith(".md")) {
+        segments.set(segments.size() - 1, last + ".md");
+      }
+    }
+    Path p = Path.of(segments.get(0));
+    for (int i = 1; i < segments.size(); i++) {
+      p = p.resolve(segments.get(i));
+    }
+    Path normalized = p.normalize();
+    if (!PSVirtualSiteHelper.isSafeRootPath(normalized)
+        || normalized.isAbsolute()
+        || remainingParent(normalized)) {
+      throw new VirtualSiteException("CSV 'path' is not a safe relative path in " + where);
+    }
+    return normalized;
+  }
+
+  private static boolean looksAbsoluteWindows(String logical) {
+    return logical.length() >= 2
+        && Character.isLetter(logical.charAt(0))
+        && logical.charAt(1) == ':';
+  }
+
+  private static boolean remainingParent(Path path) {
+    for (Path part : path) {
+      if ("..".equals(part.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private record LoadedRow(
+      VirtualItemRef ref, VirtualFrontmatter frontmatter, String body, Path csvFile) {}
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildMain.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildMain.java
@@ -21,7 +21,10 @@ import java.nio.file.Path;
 /**
  * CLI entry for offline Virtual Site builds.
  *
- * <p>Usage: {@code PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey]}
+ * <p>Usage: {@code PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey] [sourceKind]}
+ *
+ * <p>{@code sourceKind} defaults to {@code git-filesystem}. Pass {@code csv-filesystem} for a
+ * CSV tree (see product-docs Virtual Sites).
  */
 public final class PSVirtualSiteBuildMain {
 
@@ -30,18 +33,30 @@ public final class PSVirtualSiteBuildMain {
   public static void main(String[] args) throws Exception {
     if (args.length < 2) {
       System.err.println(
-          "Usage: PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey]");
+          "Usage: PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey] [sourceKind]");
       System.exit(2);
     }
     Path siteRoot = Path.of(args[0]);
     Path outputRoot = Path.of(args[1]);
     String siteKey = args.length >= 3 ? args[2] : "product-docs";
+    VirtualSiteSourceType sourceType = VirtualSiteSourceType.GIT_FILESYSTEM;
+    if (args.length >= 4) {
+      sourceType = VirtualSiteSourceType.fromWireName(args[3]);
+      if (sourceType == null) {
+        System.err.println(
+            "Unknown sourceKind '"
+                + args[3]
+                + "'. Allowed: "
+                + String.join(", ", PSVirtualSiteHelper.allowedSourceKindWireNames()));
+        System.exit(2);
+      }
+    }
 
     Path participantDir = outputRoot.resolve("_meta");
     IPSVirtualParticipantService participants =
         new PSInMemoryVirtualParticipantService(participantDir);
     PSVirtualSiteBuildService service =
-        new PSVirtualSiteBuildService(new PSGitFilesystemVirtualSiteSource(), participants);
+        PSVirtualSiteBuildService.forSourceType(sourceType, participants);
 
     PSVirtualSiteBuildResult result = service.build(siteRoot, outputRoot, siteKey);
     System.out.println(

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -61,6 +61,35 @@ public class PSVirtualSiteBuildService {
   }
 
   /**
+   * Build service for a registered adapter kind ({@code git-filesystem}, {@code csv-filesystem}).
+   *
+   * @param type source kind; null defaults to {@link VirtualSiteSourceType#GIT_FILESYSTEM}
+   * @param participants participant registry; null uses an in-memory registry
+   * @return service wired to {@link PSVirtualSiteSourceFactory}
+   */
+  public static PSVirtualSiteBuildService forSourceType(
+      VirtualSiteSourceType type, IPSVirtualParticipantService participants) {
+    VirtualSiteSourceType resolved =
+        type != null ? type : VirtualSiteSourceType.GIT_FILESYSTEM;
+    return new PSVirtualSiteBuildService(
+        PSVirtualSiteSourceFactory.create(resolved), participants);
+  }
+
+  /**
+   * Build service for a registered adapter kind with an in-memory participant registry.
+   *
+   * @param type source kind; null defaults to git-filesystem
+   * @return service
+   */
+  public static PSVirtualSiteBuildService forSourceType(VirtualSiteSourceType type) {
+    return forSourceType(type, new PSInMemoryVirtualParticipantService());
+  }
+
+  IPSVirtualSiteSource source() {
+    return source;
+  }
+
+  /**
    * Build a Virtual Site from a filesystem root into {@code outputRoot}.
    *
    * <p>Every invocation reloads {@code _config.yaml}, optional {@code _redirects.yaml}, and

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
@@ -38,8 +38,8 @@ import org.apache.commons.lang3.StringUtils;
  * <p>Property keys:
  *
  * <ul>
- *   <li>{@code virtual.sourceKind} — allow-listed adapter wire name (e.g. {@code git-filesystem});
- *       blank or {@code repository} ⇒ traditional repository Site
+ *   <li>{@code virtual.sourceKind} — allow-listed adapter wire name ({@code git-filesystem},
+ *       {@code csv-filesystem}); blank or {@code repository} ⇒ traditional repository Site
  *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root when no remote is set
  *       (required when virtual and {@code virtual.remoteUrl} is blank); when a remote is set,
  *       an optional relative path inside the checkout
@@ -71,8 +71,8 @@ public final class PSVirtualSiteHelper {
   private PSVirtualSiteHelper() {}
 
   /**
-   * Allow-listed {@link #PROP_SOURCE_KIND} wire names for Virtual adapters (Phase 1:
-   * {@code git-filesystem} only). Does not include {@link #SOURCE_KIND_REPOSITORY}.
+   * Allow-listed {@link #PROP_SOURCE_KIND} wire names for Virtual adapters ({@code git-filesystem},
+   * {@code csv-filesystem}). Does not include {@link #SOURCE_KIND_REPOSITORY}.
    *
    * @return unmodifiable list of wire names in enum declaration order
    */
@@ -170,7 +170,8 @@ public final class PSVirtualSiteHelper {
    * repository}) always pass. Virtual Sites must:
    *
    * <ul>
-   *   <li>use an allow-listed {@code virtual.sourceKind} (see {@link #allowedSourceKindWireNames()})
+   *   <li>use an allow-listed {@code virtual.sourceKind} (see {@link #allowedSourceKindWireNames()};
+   *       {@code csv-filesystem} does not accept {@code virtual.remoteUrl})
    *   <li>when {@code virtual.remoteUrl} is blank: provide a non-blank safe {@code virtual.rootPath}
    *   <li>when {@code virtual.remoteUrl} is set: a safe Git URL (https / ssh / file / {@code
    *       git@host:path}); optional {@code virtual.branch}; optional relative {@code
@@ -207,6 +208,15 @@ public final class PSVirtualSiteHelper {
     }
 
     Optional<String> remoteRaw = remoteUrl(site);
+    if (type == VirtualSiteSourceType.CSV_FILESYSTEM && remoteRaw.isPresent()) {
+      throw new VirtualSiteException(
+          PROP_REMOTE_URL
+              + " is not supported for "
+              + VirtualSiteSourceType.CSV_FILESYSTEM.wireName()
+              + " (Git remotes apply to "
+              + VirtualSiteSourceType.GIT_FILESYSTEM.wireName()
+              + " only).");
+    }
     if (remoteRaw.isPresent()) {
       PSGitRemoteCheckout.requireSafeRemoteUrl(remoteRaw.get());
       String branchRaw = findProperty(site, PROP_BRANCH).orElse("");

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteSourceFactory.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteSourceFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Selects an {@link IPSVirtualSiteSource} for a registered {@link VirtualSiteSourceType}.
+ *
+ * <p>Used by {@link PSVirtualSiteBuildService} so offline / CLI builds can switch adapters
+ * without the REST Sites UI (csv-filesystem REST expose is a later slice).
+ */
+public final class PSVirtualSiteSourceFactory {
+
+  private PSVirtualSiteSourceFactory() {}
+
+  /**
+   * Create the adapter for {@code type}.
+   *
+   * @param type registered source kind, not null
+   * @return new stateless source instance
+   */
+  public static IPSVirtualSiteSource create(VirtualSiteSourceType type) {
+    Objects.requireNonNull(type, "type");
+    return switch (type) {
+      case GIT_FILESYSTEM -> new PSGitFilesystemVirtualSiteSource();
+      case CSV_FILESYSTEM -> new PSCsvFilesystemVirtualSiteSource();
+    };
+  }
+
+  /**
+   * Create the adapter for a property / CLI wire name.
+   *
+   * @param wireName e.g. {@code git-filesystem} or {@code csv-filesystem}
+   * @return new source
+   * @throws VirtualSiteException when the name is blank or unknown
+   */
+  public static IPSVirtualSiteSource createFromWireName(String wireName)
+      throws VirtualSiteException {
+    VirtualSiteSourceType type = VirtualSiteSourceType.fromWireName(wireName);
+    if (type == null) {
+      throw new VirtualSiteException(
+          "Unsupported virtual source kind '"
+              + (wireName == null ? "" : wireName)
+              + "'. Allowed: "
+              + Stream.of(VirtualSiteSourceType.values())
+                  .map(VirtualSiteSourceType::wireName)
+                  .collect(Collectors.joining(", ")));
+    }
+    return create(type);
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualCsvParser.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualCsvParser.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * RFC 4180-style CSV reader for Virtual Site {@code csv-filesystem} sources.
+ *
+ * <p>Required header columns (case-insensitive): {@code id}, {@code title}, {@code body}. Optional:
+ * {@code path}, {@code order}. Missing required columns fail closed.
+ */
+public final class VirtualCsvParser {
+
+  public static final String COL_ID = "id";
+  public static final String COL_TITLE = "title";
+  public static final String COL_BODY = "body";
+  public static final String COL_PATH = "path";
+  public static final String COL_ORDER = "order";
+
+  private VirtualCsvParser() {}
+
+  /**
+   * Parse UTF-8 CSV text into rows keyed by lowercase header names.
+   *
+   * @param text full file content, never null
+   * @param sourceLabel path label for error messages
+   * @return row list (empty when only a header is present)
+   * @throws VirtualSiteException when the header or row contract is violated
+   */
+  public static List<Map<String, String>> parse(String text, String sourceLabel)
+      throws VirtualSiteException {
+    Objects.requireNonNull(text, "text");
+    String label = sourceLabel != null ? sourceLabel : "csv";
+    String normalized = stripBom(text).replace("\r\n", "\n").replace('\r', '\n');
+    List<List<String>> records = parseRecords(normalized, label);
+    if (records.isEmpty()) {
+      throw new VirtualSiteException("CSV has no header row: " + label);
+    }
+    List<String> header = records.get(0);
+    Map<String, Integer> indexByName = headerIndex(header, label);
+    requireColumn(indexByName, COL_ID, label);
+    requireColumn(indexByName, COL_TITLE, label);
+    requireColumn(indexByName, COL_BODY, label);
+
+    List<Map<String, String>> rows = new ArrayList<>();
+    for (int r = 1; r < records.size(); r++) {
+      List<String> fields = records.get(r);
+      if (isEmptyRecord(fields)) {
+        continue;
+      }
+      if (fields.size() != header.size()) {
+        throw new VirtualSiteException(
+            "CSV row "
+                + (r + 1)
+                + " has "
+                + fields.size()
+                + " field(s) but header has "
+                + header.size()
+                + " in "
+                + label);
+      }
+      Map<String, String> row = new LinkedHashMap<>();
+      for (Map.Entry<String, Integer> e : indexByName.entrySet()) {
+        int idx = e.getValue();
+        String value = idx < fields.size() ? fields.get(idx) : "";
+        row.put(e.getKey(), value);
+      }
+      rows.add(Collections.unmodifiableMap(row));
+    }
+    return rows;
+  }
+
+  static String cell(Map<String, String> row, String column) {
+    if (row == null || column == null) {
+      return "";
+    }
+    String v = row.get(column.toLowerCase(Locale.ROOT));
+    return v != null ? v : "";
+  }
+
+  private static Map<String, Integer> headerIndex(List<String> header, String label)
+      throws VirtualSiteException {
+    Map<String, Integer> index = new LinkedHashMap<>();
+    for (int i = 0; i < header.size(); i++) {
+      String raw = header.get(i);
+      String name = raw != null ? raw.trim().toLowerCase(Locale.ROOT) : "";
+      if (name.isEmpty()) {
+        throw new VirtualSiteException("CSV header column " + (i + 1) + " is blank in " + label);
+      }
+      if (index.containsKey(name)) {
+        throw new VirtualSiteException("Duplicate CSV header '" + name + "' in " + label);
+      }
+      index.put(name, i);
+    }
+    return index;
+  }
+
+  private static void requireColumn(Map<String, Integer> index, String name, String label)
+      throws VirtualSiteException {
+    if (!index.containsKey(name)) {
+      throw new VirtualSiteException(
+          "CSV missing required column '" + name + "' in " + label);
+    }
+  }
+
+  private static boolean isEmptyRecord(List<String> fields) {
+    for (String f : fields) {
+      if (f != null && !f.isBlank()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String stripBom(String text) {
+    if (!text.isEmpty() && text.charAt(0) == '\uFEFF') {
+      return text.substring(1);
+    }
+    return text;
+  }
+
+  private static List<List<String>> parseRecords(String text, String label)
+      throws VirtualSiteException {
+    List<List<String>> records = new ArrayList<>();
+    List<String> fields = new ArrayList<>();
+    StringBuilder field = new StringBuilder();
+    boolean inQuotes = false;
+    int line = 1;
+    int i = 0;
+    int n = text.length();
+    while (i < n) {
+      char c = text.charAt(i);
+      if (inQuotes) {
+        if (c == '"') {
+          if (i + 1 < n && text.charAt(i + 1) == '"') {
+            field.append('"');
+            i += 2;
+            continue;
+          }
+          inQuotes = false;
+          i++;
+          continue;
+        }
+        if (c == '\n') {
+          line++;
+        }
+        field.append(c);
+        i++;
+        continue;
+      }
+      if (c == '"') {
+        inQuotes = true;
+        i++;
+        continue;
+      }
+      if (c == ',') {
+        fields.add(field.toString());
+        field.setLength(0);
+        i++;
+        continue;
+      }
+      if (c == '\n') {
+        fields.add(field.toString());
+        field.setLength(0);
+        records.add(fields);
+        fields = new ArrayList<>();
+        line++;
+        i++;
+        continue;
+      }
+      field.append(c);
+      i++;
+    }
+    if (inQuotes) {
+      throw new VirtualSiteException("Unclosed quoted CSV field starting near line " + line + " in " + label);
+    }
+    // Trailing content or a last record without a terminating newline.
+    if (field.length() > 0 || !fields.isEmpty()) {
+      fields.add(field.toString());
+      records.add(fields);
+    }
+    return records;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
@@ -17,10 +17,13 @@
 package com.percussion.services.virtualsite;
 
 /**
- * Registered Virtual Site adapter kinds. Phase 1 implements {@link #GIT_FILESYSTEM} only.
+ * Registered Virtual Site adapter kinds. Phase 1 implements {@link #GIT_FILESYSTEM}; {@link
+ * #CSV_FILESYSTEM} is the next filesystem adapter (offline discover/load from CSV).
  */
 public enum VirtualSiteSourceType {
-  GIT_FILESYSTEM("git-filesystem");
+  GIT_FILESYSTEM("git-filesystem"),
+  /** Local CSV / directory of CSVs (stable {@code id} column; Markdown in {@code body}). */
+  CSV_FILESYSTEM("csv-filesystem");
 
   private final String wireName;
 

--- a/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+class PSCsvFilesystemVirtualSiteSourceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void discoverAndLoadFromTempCsvTree() throws Exception {
+    Path root = writeSite(tempDir.resolve("csv-site"));
+    Path version = root.resolve("8.2");
+    Files.writeString(
+        version.resolve("pages.csv"),
+        """
+        id,title,body,path,order
+        csv-home,Home,"Welcome **CSV**.",index.md,1
+        csv-install,Install,"See [Home](id:csv-home).",getting-started/install.md,2
+        """,
+        StandardCharsets.UTF_8);
+
+    PSCsvFilesystemVirtualSiteSource source = new PSCsvFilesystemVirtualSiteSource();
+    assertEquals(VirtualSiteSourceType.CSV_FILESYSTEM.wireName(), source.sourceType());
+
+    VirtualSiteConfig config = config(root);
+    List<VirtualItemRef> refs = source.discover(config);
+    assertEquals(2, refs.size());
+    assertEquals("csv-home", refs.get(0).id());
+    assertEquals("Home", refs.get(0).title());
+    assertEquals(1, refs.get(0).order());
+    assertEquals(
+        Path.of("8.2", "index.md"),
+        refs.get(0).relativePath());
+    assertEquals(
+        Path.of("8.2", "getting-started", "install.md"),
+        refs.get(1).relativePath());
+
+    VirtualItem home = source.load(config, refs.get(0));
+    assertEquals("csv-home", home.frontmatter().id());
+    assertEquals("Home", home.frontmatter().title());
+    assertTrue(home.markdownBody().contains("Welcome **CSV**."));
+    assertTrue(Files.isRegularFile(home.absolutePath()));
+    assertEquals("pages.csv", home.absolutePath().getFileName().toString());
+
+    VirtualItem install = source.load(config, refs.get(1));
+    assertTrue(install.markdownBody().contains("id:csv-home"));
+  }
+
+  @Test
+  void omittedPathDefaultsToIdMarkdownUnderVersion() throws Exception {
+    Path root = writeSite(tempDir.resolve("default-path"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body\nplain-id,Plain,Body text\n",
+        StandardCharsets.UTF_8);
+
+    List<VirtualItemRef> refs =
+        new PSCsvFilesystemVirtualSiteSource().discover(config(root));
+    assertEquals(1, refs.size());
+    assertEquals(Path.of("8.2", "plain-id.md"), refs.get(0).relativePath());
+  }
+
+  @Test
+  void missingRequiredColumnFailsClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("missing-col"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title\nx,Y\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root)));
+    assertTrue(ex.getMessage().contains("body"), ex.getMessage());
+  }
+
+  @Test
+  void blankIdOrTitleFailsClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("blank-id"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body\n,MissingId,body\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException idEx =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root)));
+    assertTrue(idEx.getMessage().contains("id"), idEx.getMessage());
+
+    Path root2 = writeSite(tempDir.resolve("blank-title"));
+    Files.writeString(
+        root2.resolve("8.2").resolve("pages.csv"),
+        "id,title,body\nhas-id,,body\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException titleEx =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root2)));
+    assertTrue(titleEx.getMessage().contains("title"), titleEx.getMessage());
+  }
+
+  @Test
+  void unknownIdOnLoadFailsClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("unknown-id"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body\nknown,Known,Body\n",
+        StandardCharsets.UTF_8);
+    PSCsvFilesystemVirtualSiteSource source = new PSCsvFilesystemVirtualSiteSource();
+    VirtualSiteConfig config = config(root);
+    source.discover(config);
+    VirtualItemRef fake =
+        new VirtualItemRef("missing-id", "8.2", Path.of("8.2", "missing-id.md"), 0, "x");
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> source.load(config, fake));
+    assertTrue(ex.getMessage().contains("Unknown"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("missing-id"), ex.getMessage());
+  }
+
+  @Test
+  void pathTraversalAndAbsolutePathFailClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("escape"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nesc,Esc,body,../outside.md\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException rel =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root)));
+    assertTrue(rel.getMessage().contains("path"), rel.getMessage());
+
+    Path rootAbs = writeSite(tempDir.resolve("abs"));
+    Files.writeString(
+        rootAbs.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nesc,Esc,body,/etc/passwd.md\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException abs =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(rootAbs)));
+    assertTrue(abs.getMessage().toLowerCase().contains("relative"), abs.getMessage());
+
+    Path rootWin = writeSite(tempDir.resolve("winabs"));
+    Files.writeString(
+        rootWin.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nesc,Esc,body,C:/docs/evil.md\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException win =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(rootWin)));
+    assertTrue(win.getMessage().toLowerCase().contains("relative"), win.getMessage());
+  }
+
+  @Test
+  void duplicateIdsFailClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("dup"));
+    Path version = root.resolve("8.2");
+    Files.writeString(
+        version.resolve("a.csv"),
+        "id,title,body\nsame,A,a\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        version.resolve("b.csv"),
+        "id,title,body\nsame,B,b\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root)));
+    assertTrue(ex.getMessage().toLowerCase().contains("duplicate"), ex.getMessage());
+  }
+
+  @Test
+  void loadRereadsCurrentCsvBytesWithoutCache() throws Exception {
+    Path root = writeSite(tempDir.resolve("live"));
+    Path csv = root.resolve("8.2").resolve("pages.csv");
+    Files.writeString(
+        csv, "id,title,body\nlive,First,token-AAA\n", StandardCharsets.UTF_8);
+    PSCsvFilesystemVirtualSiteSource source = new PSCsvFilesystemVirtualSiteSource();
+    VirtualSiteConfig config = config(root);
+    VirtualItem first = source.load(config, source.discover(config).get(0));
+    assertTrue(first.markdownBody().contains("token-AAA"));
+
+    Files.writeString(
+        csv, "id,title,body\nlive,Second,token-BBB\n", StandardCharsets.UTF_8);
+    VirtualItem second = source.load(config, source.discover(config).get(0));
+    assertEquals("Second", second.frontmatter().title());
+    assertTrue(second.markdownBody().contains("token-BBB"));
+    assertFalse(second.markdownBody().contains("token-AAA"));
+  }
+
+  @Test
+  void invalidOrderFailsClosed() throws Exception {
+    Path root = writeSite(tempDir.resolve("bad-order"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,order\nx,T,b,not-an-int\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSCsvFilesystemVirtualSiteSource().discover(config(root)));
+    assertTrue(ex.getMessage().contains("order"), ex.getMessage());
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void windowsPathColumnAndTempRoot() throws Exception {
+    Path root = writeSite(tempDir.resolve("win-root"));
+    assertTrue(root.isAbsolute());
+    assertTrue(root.toString().contains(":"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nwin,Win,body,getting-started\\install\n",
+        StandardCharsets.UTF_8);
+    List<VirtualItemRef> refs =
+        new PSCsvFilesystemVirtualSiteSource().discover(config(root));
+    assertEquals(1, refs.size());
+    assertEquals(Path.of("8.2", "getting-started", "install.md"), refs.get(0).relativePath());
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void unixPathColumnAndTempRoot() throws Exception {
+    Path root = writeSite(tempDir.resolve("unix-root"));
+    assertTrue(root.isAbsolute());
+    assertTrue(root.toString().startsWith("/"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nunix,Unix,body,getting-started/install\n",
+        StandardCharsets.UTF_8);
+    List<VirtualItemRef> refs =
+        new PSCsvFilesystemVirtualSiteSource().discover(config(root));
+    assertEquals(1, refs.size());
+    assertEquals(Path.of("8.2", "getting-started", "install.md"), refs.get(0).relativePath());
+  }
+
+  @Test
+  void factorySelectsCsvFilesystem() throws Exception {
+    IPSVirtualSiteSource source =
+        PSVirtualSiteSourceFactory.create(VirtualSiteSourceType.CSV_FILESYSTEM);
+    assertTrue(source instanceof PSCsvFilesystemVirtualSiteSource);
+    assertEquals("csv-filesystem", source.sourceType());
+    IPSVirtualSiteSource git =
+        PSVirtualSiteSourceFactory.createFromWireName("git-filesystem");
+    assertTrue(git instanceof PSGitFilesystemVirtualSiteSource);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteSourceFactory.createFromWireName("sql-api"));
+    assertTrue(ex.getMessage().contains("sql-api"));
+  }
+
+  @Test
+  void buildServiceFactoryWiresCsvAndEmitsHtml() throws Exception {
+    Path root = writeSite(tempDir.resolve("build-csv"));
+    Files.writeString(
+        root.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${pageTitle}</h1>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path,order\nhome,CSV Home,Hello from CSV.,index.md,1\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("build-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.CSV_FILESYSTEM);
+    assertTrue(service.source() instanceof PSCsvFilesystemVirtualSiteSource);
+
+    PSVirtualSiteBuildResult result = service.build(root, out, "csv-docs");
+    assertEquals(1, result.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String body = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(body.contains("CSV Home"), body);
+    assertTrue(body.contains("Hello from CSV"), body);
+  }
+
+  private static Path writeSite(Path root) throws Exception {
+    Files.createDirectories(root.resolve("8.2"));
+    Files.createDirectories(root.resolve("_theme"));
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: CSV Docs
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    return root;
+  }
+
+  private static VirtualSiteConfig config(Path root) {
+    return new VirtualSiteConfig(
+        root,
+        "CSV Docs",
+        "",
+        "page.html",
+        List.of(new VirtualSiteConfig.VersionSpec("8.2", "8.2", "8.2", true)),
+        List.of(),
+        "csv-docs");
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
@@ -129,9 +129,9 @@ class PSVirtualSiteHelperTest {
   }
 
   @Test
-  void allowedSourceKindsIncludeGitFilesystemOnlyInPhase1() {
+  void allowedSourceKindsIncludeGitAndCsvFilesystem() {
     List<String> allowed = PSVirtualSiteHelper.allowedSourceKindWireNames();
-    assertEquals(List.of("git-filesystem"), allowed);
+    assertEquals(List.of("git-filesystem", "csv-filesystem"), allowed);
   }
 
   @Test
@@ -154,6 +154,31 @@ class PSVirtualSiteHelperTest {
             prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"),
             prop(PSVirtualSiteHelper.PROP_CONFIG_FILE, "_config.yaml"));
     assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(site));
+  }
+
+  @Test
+  void validatePassesForCsvFilesystemWithSafeRoot() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "csv-docs"));
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(site));
+    assertEquals(
+        VirtualSiteSourceType.CSV_FILESYSTEM,
+        PSVirtualSiteHelper.virtualSourceType(site).orElseThrow());
+  }
+
+  @Test
+  void validateRejectsRemoteUrlForCsvFilesystem() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "csv-docs"),
+            prop(PSVirtualSiteHelper.PROP_REMOTE_URL, "https://git.example.com/org/docs.git"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_REMOTE_URL));
+    assertTrue(ex.getMessage().contains("csv-filesystem"));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualCsvParserTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualCsvParserTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class VirtualCsvParserTest {
+
+  @Test
+  void parsesRequiredAndOptionalColumnsCaseInsensitive() throws Exception {
+    String csv =
+        """
+        ID,Title,Body,Path,Order
+        home,Welcome,"Hello, world",index.md,10
+        """;
+    List<Map<String, String>> rows = VirtualCsvParser.parse(csv, "pages.csv");
+    assertEquals(1, rows.size());
+    Map<String, String> row = rows.get(0);
+    assertEquals("home", VirtualCsvParser.cell(row, "id"));
+    assertEquals("Welcome", VirtualCsvParser.cell(row, "title"));
+    assertEquals("Hello, world", VirtualCsvParser.cell(row, "body"));
+    assertEquals("index.md", VirtualCsvParser.cell(row, "path"));
+    assertEquals("10", VirtualCsvParser.cell(row, "order"));
+  }
+
+  @Test
+  void quotedBodyMayContainNewlinesAndEscapedQuotes() throws Exception {
+    String csv =
+        "id,title,body\n"
+            + "p1,Page,\"Line 1\nSee \"\"quoted\"\".\"\n";
+    List<Map<String, String>> rows = VirtualCsvParser.parse(csv, "pages.csv");
+    assertEquals(1, rows.size());
+    assertEquals("Line 1\nSee \"quoted\".", VirtualCsvParser.cell(rows.get(0), "body"));
+  }
+
+  @Test
+  void crlfRecordsAreAccepted() throws Exception {
+    String csv = "id,title,body\r\na,A,alpha\r\nb,B,beta\r\n";
+    List<Map<String, String>> rows = VirtualCsvParser.parse(csv, "win.csv");
+    assertEquals(2, rows.size());
+    assertEquals("alpha", VirtualCsvParser.cell(rows.get(0), "body"));
+    assertEquals("beta", VirtualCsvParser.cell(rows.get(1), "body"));
+  }
+
+  @Test
+  void missingRequiredColumnFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualCsvParser.parse("id,title\nx,y\n", "bad.csv"));
+    assertTrue(ex.getMessage().contains("body"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("bad.csv"), ex.getMessage());
+  }
+
+  @Test
+  void missingIdColumnFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualCsvParser.parse("title,body\nT,B\n", "noid.csv"));
+    assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+  }
+
+  @Test
+  void missingTitleColumnFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualCsvParser.parse("id,body\nx,B\n", "notitle.csv"));
+    assertTrue(ex.getMessage().contains("title"), ex.getMessage());
+  }
+
+  @Test
+  void unclosedQuoteFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualCsvParser.parse("id,title,body\na,b,\"c\n", "open.csv"));
+    assertTrue(ex.getMessage().toLowerCase().contains("quoted"), ex.getMessage());
+  }
+
+  @Test
+  void raggedRowFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualCsvParser.parse("id,title,body\na,b\n", "ragged.csv"));
+    assertTrue(ex.getMessage().contains("field"), ex.getMessage());
+  }
+
+  @Test
+  void emptyFileFailsClosed() {
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> VirtualCsvParser.parse("", "empty.csv"));
+    assertTrue(ex.getMessage().toLowerCase().contains("header"), ex.getMessage());
+  }
+
+  @Test
+  void headerOnlyYieldsNoRows() throws Exception {
+    List<Map<String, String>> rows = VirtualCsvParser.parse("id,title,body\n", "header.csv");
+    assertTrue(rows.isEmpty());
+  }
+
+  @Test
+  void utf8BomIsStripped() throws Exception {
+    String csv = "\uFEFFid,title,body\nh,Home,Hi\n";
+    List<Map<String, String>> rows = VirtualCsvParser.parse(csv, "bom.csv");
+    assertEquals(1, rows.size());
+    assertEquals("h", VirtualCsvParser.cell(rows.get(0), "id"));
+  }
+}


### PR DESCRIPTION
## Summary

Parent: #2678. Slice #3685 implements the **csv-filesystem** Virtual Site source SPI so offline builds can discover and load pages from CSV files (or a directory of CSVs) with stable ids.

- `VirtualSiteSourceType.CSV_FILESYSTEM` (`csv-filesystem`)
- `PSCsvFilesystemVirtualSiteSource` (`IPSVirtualSiteSource` discover + load)
- Column contract: required `id`, `title`, `body` (Markdown); optional `path` / `order`. Missing required columns, blank id/title, duplicates, or unsafe paths fail closed (`VirtualSiteException`)
- Portable NIO `Path` / `Files` only
- Source selection via `PSVirtualSiteSourceFactory` and `PSVirtualSiteBuildService.forSourceType`
- CLI: `PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey] csv-filesystem`

REST `virtual.sourceKind` expose (#3686) and Developer Sites UI (#3687) are out of scope. CMS **Build** still runs git-filesystem only.

Fixes #3685

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (this PR)
2. Unit tests: `VirtualCsvParserTest`, `PSCsvFilesystemVirtualSiteSourceTest` (temp CSV tree, Windows path roots, fail-closed missing columns / unknown id), helper allow-list includes `csv-filesystem`
3. Factory wires csv-filesystem into `PSVirtualSiteBuildService` and emits HTML from a temp CSV site
4. Review product-docs 8.2 developer Virtual Sites CSV section, admin Sites, and site-config allow-list

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (developer Virtual Sites CSV offline build, admin Sites allow-list, reference site-config)
- [x] **Unit / module tests** — behavioral tests for parser, discover/load, helper, factory/build; `system` standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST/UI slices #3686/#3687)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS; tests run 2317, failures 0
- [x] **Cross-platform** — NIO `Path`/`Files`; CSV `path` is href-style then `Path.resolve`; Windows vs Unix `@EnabledOnOs` root tests

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-20). Tests run: 2317, Failures: 0, Errors: 0, Skipped: 242. Focused: VirtualCsvParserTest 11/0, PSCsvFilesystemVirtualSiteSourceTest 13/0 (1 skipped Unix-only on Windows), PSVirtualSiteHelperTest 29/0 (1 skipped Unix-only).
- **downstream_checked:** grep `VirtualSiteSourceType` — no `extends` / anonymous subclass; additive enum constant + new factory methods (no existing ctor/method signature change). `SitesAdaptor` still `!= GIT_FILESYSTEM` for REST Build (intentional; #3686). sitemanage rebuild not required.

### C5 UI proof

N/A — no WebUI / Playwright surface in this slice.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
