### PR TITLE
fix(explorer): open REST-listed Corporate Investments site (#3684)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -43,6 +43,10 @@ import {
 } from "../api/contentExplorer/pathApi";
 import type { PSPathItem, PSPagedResult } from "../api/contentExplorer/types";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
+import {
+  explorerSiteDisplayName,
+  isExplorerSiteRootItem,
+} from "./sitePath";
 
 /**
  * Public display-format column contract. Maps to the live
@@ -143,13 +147,15 @@ export function renderDisplayFormatCell(
   };
 
   switch (column) {
-    case "name":
-      return (
-        fromProps(["sys_title", "name", "Name"]) ||
-        item.name ||
-        item.path ||
-        ""
-      );
+    case "name": {
+      const fromSys = fromProps(["sys_title", "name", "Name"]);
+      // Site rows must expose finder SITENAME (Corporate_Investments) or
+      // the repository folder leaf, not a GUID sys_title / path (#3684).
+      if (isExplorerSiteRootItem(item)) {
+        return explorerSiteDisplayName(item) || fromSys || item.path || "";
+      }
+      return fromSys || item.name || item.path || "";
+    }
     case "type":
       return (
         fromProps(["sys_contenttypename", "sys_contenttype", "type", "Type"]) ||
@@ -530,11 +536,14 @@ export function DetailList({
             const visible = canRead(item);
             const folderish = isFolder(item);
             const folderOpen = folderish && selected;
+            const itemName =
+              explorerSiteDisplayName(item) || item.name || "";
             return (
               <tr
                 key={idKey}
                 data-testid={`detail-row-${idKey}`}
                 data-row-kind={folderish ? "folder" : "item"}
+                data-item-name={itemName}
                 data-item-type={item.type ?? ""}
                 data-previewable={isPreviewableItem(item) ? "true" : "false"}
                 data-selected={selected ? "true" : undefined}

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -29,7 +29,7 @@ import type { PSPathItem } from "../api/contentExplorer/types";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
 import { message } from "../i18n/message";
 import { isSafeExplorerTreeChild } from "./folderPath";
-import { resolveExplorerListPath } from "./sitePath";
+import { explorerSiteDisplayName, resolveExplorerListPath } from "./sitePath";
 import { isFolder } from "./selection";
 import {
   emptyStateStyle,
@@ -495,9 +495,18 @@ export function ExplorerTree({
       (listPath != null &&
         selectedNorm === normalizeExplorerTreePathKey(listPath));
     const folderish = isFolder(folder);
+    const nodeName = explorerSiteDisplayName(folder) || folder.name || "";
 
+    // data-node-name is finder SITENAME / folder leaf; path may be a GUID
+    // (#3684 / #3001). Playwright matches folded names against testid,
+    // visible label, data-node-name, and data-folder-path.
     return (
-      <div key={pathKey} data-testid={`tree-node-${path}`}>
+      <div
+        key={pathKey}
+        data-testid={`tree-node-${path}`}
+        data-node-name={nodeName}
+        data-folder-path={folder.folderPath || ""}
+      >
         <div
           role="treeitem"
           aria-expanded={folderish ? isOpen : undefined}
@@ -533,6 +542,7 @@ export function ExplorerTree({
               if (folderish) toggle(path, folder);
             }}
             aria-hidden="true"
+            data-testid={folderish ? `tree-toggle-${path}` : undefined}
           >
             {folderish ? (isOpen ? "▾" : "▸") : " "}
           </span>
@@ -541,7 +551,7 @@ export function ExplorerTree({
             title={folder.path}
             {...{ [MKD_LANG_IGNORE_ATTR]: "1" as const }}
           >
-            {folder.name || folder.path}
+            {nodeName || folder.path}
           </span>
         </div>
         {folderish &&

--- a/WebUI/src/main/ts/contentExplorer/sitePath.ts
+++ b/WebUI/src/main/ts/contentExplorer/sitePath.ts
@@ -89,3 +89,84 @@ export function resolveExplorerListPath(
   }
   return normalizeExplorerFolderPath(fallback);
 }
+
+/**
+ * Percussion content ids (revision-revision-content), not site names.
+ * Sample site paths may still use this shape under {@code /Sites/{guid}/}
+ * (#3001).
+ */
+const CONTENT_GUID_TOKEN = /^\d+-\d+-\d+$/;
+
+function lastCmsPathSegment(raw: string | null | undefined): string {
+  const normalized = normalizeExplorerFolderPath(raw);
+  if (normalized == null) return "";
+  const trimmed = normalized.replace(/\/+$/, "");
+  const slash = trimmed.lastIndexOf("/");
+  return (slash >= 0 ? trimmed.slice(slash + 1) : trimmed).trim();
+}
+
+function isContentGuidToken(value: string | null | undefined): boolean {
+  const token = String(value ?? "").trim();
+  return token.length > 0 && CONTENT_GUID_TOKEN.test(token);
+}
+
+/**
+ * True when the path item is a site root (type=site or {@code /Sites/{name}}).
+ */
+export function isExplorerSiteRootItem(
+  item: Pick<PSPathItem, "type" | "path" | "folderPath"> | null | undefined,
+): boolean {
+  if (!item) return false;
+  const type = String(item.type ?? "")
+    .trim()
+    .toLowerCase();
+  if (type === "site") return true;
+  for (const raw of [item.path, item.folderPath]) {
+    const normalized = normalizeExplorerFolderPath(raw);
+    if (normalized == null) continue;
+    const segs = normalized
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "")
+      .split("/")
+      .filter(Boolean);
+    if (segs.length === 2 && segs[0].toLowerCase() === "sites") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Operator-visible site name for Explorer tree labels and list Name cells.
+ *
+ * <p>Prefers finder {@code SITENAME} ({@code Corporate_Investments}) and
+ * repository folder leaf ({@code CorporateInvestments}) over a GUID
+ * {@code sys_title} or {@code /Sites/{guid}/} path (#3684 / #3001). REST
+ * listings and Playwright fold spaces/underscores so {@code Corporate
+ * Investments} still matches.</p>
+ */
+export function explorerSiteDisplayName(
+  item:
+    | (Pick<PSPathItem, "name" | "path" | "folderPath" | "type"> & {
+        title?: string;
+      })
+    | null
+    | undefined,
+): string {
+  if (!item) return "";
+  const candidates = [
+    item.name,
+    lastCmsPathSegment(item.folderPath),
+    item.title,
+    resolveSiteNameFromExplorerPath(item.folderPath),
+    resolveSiteNameFromExplorerPath(item.path),
+    lastCmsPathSegment(item.path),
+  ];
+  for (const candidate of candidates) {
+    const token = String(candidate ?? "").trim();
+    if (token.length > 0 && !isContentGuidToken(token)) {
+      return token;
+    }
+  }
+  return String(item.name || lastCmsPathSegment(item.path) || "").trim();
+}

--- a/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/DetailList.test.tsx
@@ -847,6 +847,51 @@ describe("T092b / FR-027: display-format column resolution", () => {
     expect(renderDisplayFormatCell("modified", minimal)).toBe("");
   });
 
+  it("site folder rows expose finder name, not GUID path (#3684)", async () => {
+    const site: PSPathItem = {
+      id: "16777215-101-703",
+      path: "/Sites/16777215-101-703/",
+      folderPath: "//Sites/CorporateInvestments",
+      name: "Corporate_Investments",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+      displayProperties: { sys_title: "16777215-101-703" },
+    };
+    expect(renderDisplayFormatCell("name", site)).toBe("Corporate_Investments");
+    mockFolderPage([site]);
+    const { container } = render(
+      <DetailList
+        folderPath="/Sites"
+        selectedItemId={null}
+        onSelectItem={() => undefined}
+        onActivateItem={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("detail-row-16777215-101-703"),
+      ).toBeInTheDocument(),
+    );
+    const row = screen.getByTestId("detail-row-16777215-101-703");
+    expect(row).toHaveAttribute("data-row-kind", "folder");
+    expect(row).toHaveAttribute("data-item-name", "Corporate_Investments");
+    expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
+    await renderA11yGate(container);
+  });
+
+  it("site Name column uses folderPath leaf when name is a GUID (#3684)", () => {
+    const site: PSPathItem = {
+      id: "16777215-101-703",
+      path: "/Sites/16777215-101-703/",
+      folderPath: "//Sites/CorporateInvestments",
+      name: "16777215-101-703",
+      type: "site",
+      displayProperties: { sys_title: "16777215-101-703" },
+    };
+    expect(renderDisplayFormatCell("name", site)).toBe("CorporateInvestments");
+  });
+
   it("columnHeaderLabel returns translated headers", () => {
     expect(columnHeaderLabel("name", EXPLORER_MSG)).toContain("Name");
     expect(columnHeaderLabel("modified", EXPLORER_MSG)).toContain("Modified");

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -161,6 +161,50 @@ describe("ExplorerTree", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tree-node-/Sites/16777215-101-703/"),
+    ).toHaveAttribute("data-node-name", "Corporate_Investments");
+  });
+
+  it("exposes folderPath leaf when site name is a GUID (#3684)", async () => {
+    const SITE_CHILD: PSPathItem = {
+      id: "16777215-101-703",
+      path: "/Sites/16777215-101-703/",
+      folderPath: "//Sites/CorporateInvestments",
+      name: "16777215-101-703",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        return pathItemListResponse([SITE_CHILD]);
+      }
+      return pathItemListResponse([]);
+    });
+    render(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath={null}
+        onSelectFolder={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/16777215-101-703/"),
+      ).toBeInTheDocument(),
+    );
+    const node = screen.getByTestId("tree-node-/Sites/16777215-101-703/");
+    expect(node).toHaveAttribute("data-node-name", "CorporateInvestments");
+    expect(node).toHaveAttribute(
+      "data-folder-path",
+      "//Sites/CorporateInvestments",
+    );
+    expect(screen.getByText("CorporateInvestments")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tree-toggle-/Sites/16777215-101-703/"),
+    ).toBeInTheDocument();
   });
 
   it("loads children on first expand (lazy)", async () => {
@@ -191,10 +235,7 @@ describe("ExplorerTree", () => {
     expect(rootCalls).toBe(1);
     expect(childCalls).toBe(0);
     // Expand is on the toggle control (not the row select handler).
-    const node = screen.getByTestId("tree-node-/Sites/Foo");
-    const toggle = node.querySelector('[aria-hidden="true"]');
-    expect(toggle).toBeTruthy();
-    fireEvent.click(toggle!);
+    fireEvent.click(screen.getByTestId("tree-toggle-/Sites/Foo"));
     await waitFor(() =>
       expect(
         screen.getByTestId("tree-node-/Sites/Foo/Bar"),

--- a/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/sitePath.test.ts
@@ -16,6 +16,8 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  explorerSiteDisplayName,
+  isExplorerSiteRootItem,
   resolveExplorerListPath,
   resolveSiteNameFromExplorerPath,
   resolveSiteNameFromSelection,
@@ -76,6 +78,60 @@ describe("resolveSiteNameFromSelection (#2767)", () => {
     expect(
       resolveSiteNameFromSelection("/Sites/FolderSite/sub", "/Assets/x"),
     ).toBe("FolderSite");
+  });
+});
+
+describe("explorerSiteDisplayName / isExplorerSiteRootItem (#3684)", () => {
+  it("prefers finder SITENAME over a GUID path and sys_title", () => {
+    expect(
+      explorerSiteDisplayName({
+        name: "Corporate_Investments",
+        path: "/Sites/16777215-101-703/",
+        type: "site",
+      }),
+    ).toBe("Corporate_Investments");
+  });
+
+  it("uses repository folder leaf when name is a content GUID", () => {
+    expect(
+      explorerSiteDisplayName({
+        name: "16777215-101-703",
+        path: "/Sites/16777215-101-703/",
+        folderPath: "//Sites/CorporateInvestments",
+        type: "site",
+      }),
+    ).toBe("CorporateInvestments");
+  });
+
+  it("keeps space titles that fold to the finder name", () => {
+    expect(
+      explorerSiteDisplayName({
+        name: "Corporate Investments",
+        path: "/Sites/Corporate Investments/",
+        type: "site",
+      }),
+    ).toBe("Corporate Investments");
+  });
+
+  it("detects site roots by type or /Sites/{name} path", () => {
+    expect(
+      isExplorerSiteRootItem({
+        type: "site",
+        path: "/Sites/16777215-101-703/",
+      }),
+    ).toBe(true);
+    expect(
+      isExplorerSiteRootItem({
+        type: "folder",
+        path: "/Sites/Corporate_Investments/",
+      }),
+    ).toBe(true);
+    expect(
+      isExplorerSiteRootItem({
+        type: "page",
+        path: "/Sites/Corporate_Investments/Home",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/docs/ai-generated/code-reviews/3684-sites-name-match-erlang.md
+++ b/docs/ai-generated/code-reviews/3684-sites-name-match-erlang.md
@@ -1,0 +1,53 @@
+# Erlang review: #3684 Explorer Sites open for REST-listed Corporate Investments
+
+**Branch:** `fix/issue-3684-sites-name-match`  
+**Base:** `origin/main`  
+**Scope:** WebUI Explorer tree/list site-name attributes + perc-qa-automation Playwright `openSitesThenPages`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** Playwright companion for WebUI screen; behavioral unit tests for new match helper; CMS URL paths use `/` (not OS separators); product-docs for operator-visible Sites name column; do not treat sibling PR #3689 as done when Cycle Verify still failed
+
+## Summary
+
+Cycle Verify residual of parent #2732 / QA #2743. REST lists FastForward page `Corporate Investments Home` under finder `SITENAME` `Corporate_Investments` and repository `//Sites/CorporateInvestments`. PR #3689 added `data-node-name` and tree-node matching but Cycle Verify on `ea6184f` still failed `openSitesThenPages` (Sites expand used `tree-toggle` only; folder-icon open can leave Sites selected; Pages-first walk missed site-root `rffHome` items).
+
+This change:
+
+- Resolves operator-visible site names via `explorerSiteDisplayName` (finder name / folderPath leaf, never a content GUID).
+- Exposes `data-node-name`, `data-folder-path`, and `tree-toggle-*` on Explorer tree nodes; site Name column + `data-item-name` on the list.
+- Playwright expands Sites with tree-toggle **or** aria-hidden peer; matches site-root testids only; falls back to detail rows then every sample site until the listed page or an item row is visible.
+
+## Issues
+
+None (no bugs, missing behavioral tests, or non-portable path/file I/O).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` **filesystem** path construction
+- [x] URL / REST / CMS folder paths correctly use `/`
+- [x] Helper unit tests assert folded site names and testids, not OS path strings
+- [x] Temp files: none
+- [x] Line-ending assertions: none (testid / JSON strings)
+
+## Tests
+
+- WebUI Vitest: `sitePath.test.ts` (`explorerSiteDisplayName` / `isExplorerSiteRootItem`), `ExplorerTree.test.tsx` (GUID path + folderPath leaf + tree-toggle), `DetailList.test.tsx` (site Name column + `data-item-name` + a11y gate)
+- perc-qa-automation Node: `listedPageSiteNames` page-title hint, `treeNodeMatchesFoldedSite` + `isExplorerSiteRootTestId`; workflow spec source lock
+- Playwright H2 C5: `explorer-workflow-transitions.spec.js` 2 passed, 0 skipped; golden 2 passed
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Sites tree name attributes | done |
+| Sites list Name column + `data-item-name` | done |
+| Vitest for tree + list + sitePath | done |
+| Playwright `openSitesThenPages` | done |
+| Helper + unit tests | done |
+| `product-docs/8.2/admin/content-explorer.md` | done |
+
+## Notes
+
+- `downstream_checked`: none — no `final`/`sealed` or public signature break.
+- Do not steal assigned QA #2743. Do not re-work Expire HTTP 500 (#3668 / PR #3683).
+- Leave #3684 open for later Cycle Verify.

--- a/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Playwright surface: #3639 / parent #3102 / #2732 — Explorer Workflow
- * transition no-skip on H2.
+ * Playwright surface: #3639 / parent #3102 / #2732 / #3684 — Explorer
+ * Workflow transition no-skip on H2.
  *
  * <p>Selecting a content row on {@code spa.jsp?entry=explorer} must show
  * {@code action-toolbar-group-workflow} and an invokable
@@ -31,7 +31,7 @@
  * from {@code modules/perc-qa-automation/frontend}.</p>
  */
 
-const { test, expect } = require("@playwright/test");
+const { test, expect, errors } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 const {
@@ -56,6 +56,8 @@ const {
   foldSiteName,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
+  treeNodeMatchesFoldedSite,
+  isExplorerSiteRootTestId,
 } = require("./helpers/explorer-preview-view");
 
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -190,7 +192,90 @@ async function findEligibleWorkflowItemViaRest(request) {
 }
 
 /**
- * Open Sites → the site that owns {@code listed} → Pages when present.
+ * Expand the Sites tree node (tree-toggle testid, else aria-hidden peer).
+ * @param {import("@playwright/test").Locator} sitesNode
+ */
+async function expandSitesTreeNode(sitesNode) {
+  const treeitem = sitesNode.locator('[role="treeitem"]').first();
+  const expanded = await treeitem.getAttribute("aria-expanded");
+  if (expanded === "true") {
+    return;
+  }
+  const toggle = sitesNode
+    .locator(
+      '[data-testid="tree-toggle-/Sites/"], [data-testid="tree-toggle-/Sites"]',
+    )
+    .first();
+  if ((await toggle.count()) > 0) {
+    await toggle.click();
+    return;
+  }
+  const ariaToggle = sitesNode.locator('[aria-hidden="true"]').first();
+  if ((await ariaToggle.count()) > 0) {
+    await ariaToggle.click();
+  }
+}
+
+/**
+ * True when the detail list shows the listed page or any content item row.
+ * @param {import("@playwright/test").Locator} list
+ * @param {string} listedName
+ * @returns {Promise<boolean>}
+ */
+async function listHasListedOrItemRow(list, listedName) {
+  const itemRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  if ((await itemRows.count()) > 0) {
+    return true;
+  }
+  if (!listedName) {
+    return false;
+  }
+  const aliases = [listedName];
+  if (/\bHome\b/i.test(listedName) && listedName !== "Home") {
+    aliases.push("Home");
+  }
+  const rows = list.locator('tbody tr[data-testid^="detail-row-"]');
+  const rowCount = await rows.count();
+  for (let i = 0; i < rowCount; i += 1) {
+    const row = rows.nth(i);
+    const itemName = (await row.getAttribute("data-item-name")) || "";
+    const text = ((await row.innerText().catch(() => "")) || "").trim();
+    if (
+      aliases.some(
+        (alias) => itemName === alias || detailRowHasExactName(text, alias),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * After opening a site, succeed if items (or the listed page) are visible,
+ * otherwise open Pages chrome and re-check.
+ * @param {import("@playwright/test").Page} page
+ * @param {import("@playwright/test").Locator} list
+ * @param {string} listedName
+ * @returns {Promise<boolean>}
+ */
+async function siteListingHasContent(page, list, listedName) {
+  if (await listHasListedOrItemRow(list, listedName)) {
+    return true;
+  }
+  await openPagesFolderIfPresent(page, list);
+  return listHasListedOrItemRow(list, listedName);
+}
+
+/**
+ * Open Sites → the site that owns {@code listed} via the explorer tree
+ * (peer #3575 / #3684). GUID path testids still match when
+ * {@code data-node-name} / {@code data-folder-path} / visible label fold
+ * to Corporate_Investments. If names do not match, try every site node
+ * until the listed page (or any item row) is visible — FastForward has
+ * two sample sites.
  * @param {import("@playwright/test").Page} page
  * @param {object} [listed]
  */
@@ -205,56 +290,102 @@ async function openSitesThenPages(page, listed) {
   await sitesNode.click({ force: true });
   await listWaitReady(page);
   await page.waitForLoadState("networkidle").catch(() => {});
+  await expandSitesTreeNode(sitesNode);
 
-  const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
-  const siteRows = list.locator(
-    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  const siteTreeNodes = tree.locator(
+    '[data-testid^="tree-node-/Sites/"]:not([data-testid="tree-node-/Sites/"])',
   );
-  await expect(siteRows.first()).toBeVisible({ timeout: 15_000 });
+  await expect(siteTreeNodes.first()).toBeVisible({ timeout: 15_000 });
 
   const wanted = new Set(
     listedPageSiteNames(listed).map((n) => foldSiteName(n)),
   );
   const listedName = listed && listed.name ? String(listed.name) : "";
-  const siteCount = await siteRows.count();
-  let opened = false;
+  const list = page.locator(`[data-testid="${TEST_IDS.list}"]`);
+  const seen = [];
+  const siteCount = await siteTreeNodes.count();
+
+  const trySiteNode = async (node) => {
+    await node.click({ force: true });
+    await listWaitReady(page);
+    await page.waitForLoadState("networkidle").catch(() => {});
+    return siteListingHasContent(page, list, listedName);
+  };
+
+  /** @type {string[]} */
+  const matchingTestIds = [];
+  /** @type {string[]} */
+  const allSiteTestIds = [];
   for (let i = 0; i < siteCount; i += 1) {
-    if (i > 0) {
-      await sitesNode.click({ force: true });
-      await listWaitReady(page);
-      await page.waitForLoadState("networkidle").catch(() => {});
+    const node = siteTreeNodes.nth(i);
+    const testid = (await node.getAttribute("data-testid")) || "";
+    if (!isExplorerSiteRootTestId(testid)) {
+      continue;
     }
+    const nodeName = (await node.getAttribute("data-node-name")) || "";
+    const folderPath = (await node.getAttribute("data-folder-path")) || "";
+    const label = ((await node.innerText().catch(() => "")) || "").trim();
+    seen.push(`${testid}|${nodeName || label}|${folderPath}`);
+    allSiteTestIds.push(testid);
+    const nameMatch =
+      wanted.size === 0 ||
+      treeNodeMatchesFoldedSite(
+        testid,
+        label,
+        nodeName,
+        wanted,
+        folderPath,
+      );
+    if (nameMatch) {
+      matchingTestIds.push(testid);
+    }
+  }
+
+  for (const testid of matchingTestIds) {
+    const node = tree.locator(`[data-testid="${testid}"]`).first();
+    if (await trySiteNode(node)) {
+      return;
+    }
+  }
+
+  const siteRows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="folder"]',
+  );
+  await sitesNode.click({ force: true });
+  await listWaitReady(page);
+  const rowCount = await siteRows.count();
+  for (let i = 0; i < rowCount; i += 1) {
     const row = siteRows.nth(i);
     const rowText = ((await row.innerText().catch(() => "")) || "").trim();
+    const itemName = (await row.getAttribute("data-item-name")) || "";
     const nameMatch =
-      wanted.size === 0 || detailRowMatchesFoldedSite(rowText, wanted);
+      wanted.size === 0 ||
+      detailRowMatchesFoldedSite(rowText, wanted) ||
+      treeNodeMatchesFoldedSite("", rowText, itemName, wanted);
     if (!nameMatch) continue;
     await openDetailFolderRow(row);
-    await openPagesFolderIfPresent(page, list);
+    if (await siteListingHasContent(page, list, listedName)) {
+      return;
+    }
+    await sitesNode.click({ force: true });
+    await listWaitReady(page);
+  }
 
-    const itemRows = list.locator(
-      'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
-    );
-    const byName = listedName
-      ? list
-          .locator('tbody tr[data-testid^="detail-row-"]')
-          .filter({ hasText: listedName })
-      : itemRows;
-    if ((await itemRows.count()) > 0 || (await byName.count()) > 0) {
-      opened = true;
-      break;
+  // GUID-only tree labels: still open each sample site until the listed
+  // page appears (peer explorer-content-editor, #3684 Cycle Verify).
+  for (const testid of allSiteTestIds) {
+    if (matchingTestIds.includes(testid)) continue;
+    const node = tree.locator(`[data-testid="${testid}"]`).first();
+    if (await trySiteNode(node)) {
+      return;
     }
   }
-  if (!opened && wanted.size > 0) {
-    throw new Error(
-      `REST listed page ${listedName || listed.id} but UI did not open a ` +
-        `matching site among ${[...wanted].join(", ")}`,
-    );
-  }
-  if (!opened) {
-    await openDetailFolderRow(siteRows.first());
-    await openPagesFolderIfPresent(page, list);
-  }
+
+  throw new Error(
+    `REST listed page ${listedName || (listed && listed.id)} but UI did ` +
+      `not open a matching site among ${[...wanted].join(", ") || "none"} ` +
+      `(tree=${seen.join("; ") || "none"})`,
+  );
 }
 
 /**
@@ -262,10 +393,14 @@ async function openSitesThenPages(page, listed) {
  * @param {import("@playwright/test").Locator} row
  */
 async function openDetailFolderRow(row) {
-  const icon = row.locator('[data-testid^="detail-folder-icon-"]');
-  if ((await icon.count()) > 0) {
+  const icon = row.locator('[data-testid^="detail-folder-icon-"]').first();
+  try {
+    await icon.waitFor({ state: "attached", timeout: 1_000 });
     await icon.click();
-  } else {
+  } catch (err) {
+    if (!(err instanceof errors.TimeoutError)) {
+      throw err;
+    }
     await row.dblclick({ force: true });
   }
   const page = row.page();

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -325,23 +325,36 @@ function foldSiteName(name) {
 
 /**
  * Site folder names for a listed page (finder underscore + repository).
- * @param {{ path?: string, folderPath?: string }} listed
+ * Also derives a site hint from page titles such as
+ * {@code Corporate Investments Home} (#3684).
+ * @param {{ path?: string, folderPath?: string, name?: string }} listed
  * @returns {string[]}
  */
 function listedPageSiteNames(listed) {
   if (!listed) return [];
   const names = [];
   const seen = new Set();
+  const addName = (raw) => {
+    const name = String(raw || "").trim();
+    if (!name) return;
+    const key = foldSiteName(name);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    names.push(name);
+  };
   for (const raw of [listed.folderPath, listed.path]) {
     if (!raw) continue;
     const p = resolveExplorerListPath({ path: String(raw) });
     const parts = p.replace(/^\/+/, "").split("/").filter(Boolean);
     if (parts.length < 2 || parts[0].toLowerCase() !== "sites") continue;
-    const name = parts[1];
-    const key = foldSiteName(name);
-    if (!name || seen.has(key)) continue;
-    seen.add(key);
-    names.push(name);
+    addName(parts[1]);
+  }
+  const pageName = listed.name ? String(listed.name).trim() : "";
+  if (pageName) {
+    const stripped = pageName.replace(/\s+Home$/i, "").trim();
+    if (stripped && foldSiteName(stripped).length >= 8) {
+      addName(stripped);
+    }
   }
   return names;
 }
@@ -377,6 +390,52 @@ function detailRowMatchesFoldedSite(rowText, wantedFolded) {
   return wanted.some((n) => folded.includes(n));
 }
 
+/**
+ * Match a Sites tree node to REST-listed site names. Finder path testids
+ * ({@code tree-node-/Sites/Corporate_Investments/}), GUID path + visible
+ * name, {@code data-node-name}, and {@code data-folder-path} (repository
+ * {@code CorporateInvestments}) all match (#3684 / #3001).
+ * @param {string} testid
+ * @param {string} innerText
+ * @param {string} [nodeName]
+ * @param {Iterable<string>} wantedFolded
+ * @param {string} [folderPath]
+ * @returns {boolean}
+ */
+/**
+ * True when a tree testid is a Sites <em>root</em> child
+ * ({@code tree-node-/Sites/Corporate_Investments/}), not a nested
+ * {@code /Sites/{site}/Pages} node.
+ * @param {string} testid
+ * @returns {boolean}
+ */
+function isExplorerSiteRootTestId(testid) {
+  const rest = String(testid || "")
+    .replace(/^tree-node-/i, "")
+    .replace(/\\/g, "/");
+  const segs = rest
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .split("/")
+    .filter(Boolean);
+  return segs.length === 2 && segs[0].toLowerCase() === "sites";
+}
+
+function treeNodeMatchesFoldedSite(
+  testid,
+  innerText,
+  nodeName,
+  wantedFolded,
+  folderPath,
+) {
+  const wanted = [...(wantedFolded || [])].filter(Boolean);
+  if (wanted.length === 0) return true;
+  const haystacks = [testid, innerText, nodeName, folderPath].map((s) =>
+    foldSiteName(s),
+  );
+  return wanted.some((n) => haystacks.some((h) => h.includes(n)));
+}
+
 module.exports = {
   TEST_IDS,
   explorerEntryUrl,
@@ -397,4 +456,6 @@ module.exports = {
   foldSiteName,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
+  treeNodeMatchesFoldedSite,
+  isExplorerSiteRootTestId,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -29,6 +29,8 @@ const {
   isProductPagePreviewUrl,
   listedPageSiteNames,
   foldSiteName,
+  treeNodeMatchesFoldedSite,
+  isExplorerSiteRootTestId,
   detailRowHasExactName,
   detailRowMatchesFoldedSite,
 } = require("../helpers/explorer-preview-view");
@@ -291,6 +293,23 @@ describe("explorer-preview-view helpers (#2733)", () => {
     assert.equal(foldSiteName("Corporate_Investments"), "corporateinvestments");
   });
 
+  it("listedPageSiteNames adds a site hint from Corporate Investments Home (#3684)", () => {
+    assert.deepEqual(
+      listedPageSiteNames({
+        name: "Corporate Investments Home",
+        path: "/Sites/16777215-101-703/Home",
+      }),
+      ["16777215-101-703", "Corporate Investments"],
+    );
+    assert.deepEqual(
+      listedPageSiteNames({
+        name: "Home",
+        path: "/Assets/x",
+      }),
+      [],
+    );
+  });
+
   it("noPreviewableItemSkipMessage is stable and cites issue", () => {
     assert.match(noPreviewableItemSkipMessage(), /#2733/);
   });
@@ -316,6 +335,71 @@ describe("explorer-preview-view helpers (#2733)", () => {
     );
     assert.equal(
       detailRowMatchesFoldedSite(rowText, ["enterpriseinvestments"]),
+      false,
+    );
+  });
+
+  it("isExplorerSiteRootTestId rejects nested Pages nodes", () => {
+    assert.equal(
+      isExplorerSiteRootTestId("tree-node-/Sites/Corporate_Investments/"),
+      true,
+    );
+    assert.equal(
+      isExplorerSiteRootTestId("tree-node-/Sites/16777215-101-703/"),
+      true,
+    );
+    assert.equal(isExplorerSiteRootTestId("tree-node-/Sites/"), false);
+    assert.equal(
+      isExplorerSiteRootTestId("tree-node-/Sites/Corporate_Investments/Pages/"),
+      false,
+    );
+  });
+
+  it("treeNodeMatchesFoldedSite matches finder path, GUID+name, and folderPath (#3684)", () => {
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/Corporate_Investments/",
+        "Corporate_Investments",
+        "Corporate_Investments",
+        ["corporateinvestments"],
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "16777215-101-703",
+        "16777215-101-703",
+        ["corporateinvestments"],
+        "//Sites/CorporateInvestments",
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "Corporate Investments",
+        "Corporate Investments",
+        ["corporateinvestments"],
+      ),
+      true,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/16777215-101-703/",
+        "",
+        "",
+        ["corporateinvestments"],
+      ),
+      false,
+    );
+    assert.equal(
+      treeNodeMatchesFoldedSite(
+        "tree-node-/Sites/Enterprise_Investments/",
+        "Enterprise_Investments",
+        "Enterprise_Investments",
+        ["corporateinvestments"],
+      ),
       false,
     );
   });

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-workflow-transitions.test.js
@@ -193,3 +193,19 @@ describe("explorer-workflow-transitions helpers (#3639)", () => {
     );
   });
 });
+
+describe("explorer-workflow-transitions spec (#3684)", () => {
+  it("opens Sites via tree-node match including folderPath and GUID fallback", () => {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const src = fs.readFileSync(
+      path.join(__dirname, "..", "explorer-workflow-transitions.spec.js"),
+      "utf8",
+    );
+    assert.match(src, /treeNodeMatchesFoldedSite/);
+    assert.match(src, /isExplorerSiteRootTestId/);
+    assert.match(src, /data-folder-path/);
+    assert.match(src, /expandSitesTreeNode/);
+    assert.match(src, /errors\.TimeoutError/);
+  });
+});

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -165,7 +165,9 @@ Editor HTML (`checkoutedit.xml`, `contenteditorurls.html`, `?view=editor`).
 ## Sites list and Create Site
 
 Under the tree root **Sites** you see traditional site folders available to your community
-(sample sites after a demo-sites install, plus any sites you create). Expand **Sites** and
+(sample sites after a demo-sites install, plus any sites you create). The tree label and
+list **Name** column show the **site name** (for example `Corporate_Investments` or
+`Corporate Investments`), not an internal identifier. Expand **Sites** and
 select a sample site to browse FastForward folders and pages (About…, Files, Images,
 and the site NavTree).
 


### PR DESCRIPTION
## Summary

Cycle Verify residual of parent [#2732](https://github.com/intersoftdatalabs-in/percussioncms/issues/2732) / QA fail [#2743](https://github.com/intersoftdatalabs-in/percussioncms/issues/2743) (do not steal the qa-task). **Fixes remaining acceptance on [#3684](https://github.com/intersoftdatalabs-in/percussioncms/issues/3684).** Supersedes the remaining Cycle Verify gap on open PR [#3689](https://github.com/intersoftdatalabs-in/percussioncms/pull/3689) (`ea6184f` still failed `openSitesThenPages`).

H2 REST lists FastForward page **Corporate Investments Home** under finder `SITENAME` `Corporate_Investments` (`path=/Sites/Corporate_Investments/`, `folderPath=//Sites/CorporateInvestments`). The homepage is an `rffHome` **item at the site root** (also injected under Pages chrome). Prior helpers either walked Sites **detail-row** `innerText` (folder-icon open can leave Sites selected) or expanded Sites only via `tree-toggle` (missing on a skip-image-build cell) and then treated an empty Pages list as “no matching site.”

This PR:

- Resolves operator-visible site names via `explorerSiteDisplayName` (finder SITENAME / repository folder leaf, never a content GUID `sys_title`).
- Adds `data-node-name`, `data-folder-path`, and `tree-toggle-*` on Explorer tree nodes; site-type Name column + `data-item-name` on detail rows.
- Playwright expands Sites with tree-toggle **or** aria-hidden peer; matches **site-root** testids only (not nested `/Pages`); falls back to detail rows then every sample site until the listed page or any item row is visible.

Does **not** re-work Hibernate Expire HTTP 500 ([#3668](https://github.com/intersoftdatalabs-in/percussioncms/issues/3668) / PR [#3683](https://github.com/intersoftdatalabs-in/percussioncms/pull/3683)).

Operator: Grok: night-issue-prs (model grok-4.6)

Leave #3684 open for later Cycle Verify.

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `frontend npm run test:unit` — 430 pass.
3. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `qa-health` RESULT:OK HTTP:200 HEALTH:healthy `TEST_CMS_URL=http://127.0.0.1:9993`.
4. Hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (not `deploy-jar --target cms`).
5. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/explorer-workflow-transitions.spec.js` — **2 passed, 0 skipped**.
6. `npm run test:golden` — 2 passed.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md`: Sites tree label and list Name column show the site name (for example `Corporate_Investments` or `Corporate Investments`), not an internal identifier.
- [x] **Unit / module tests** — Vitest `sitePath` / `ExplorerTree` / `DetailList`; Node `listedPageSiteNames` + `treeNodeMatchesFoldedSite` + `isExplorerSiteRootTestId`; standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation`.
- [x] **WebUI + Playwright** — `tests/explorer-workflow-transitions.spec.js` (2 passed, 0 skipped) + golden smoke (2 passed).
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests).
- [x] **Cross-platform** — CMS/URL paths use `/`; no OS filesystem path joins.

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` BUILD SUCCESS (02:42 min).
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` BUILD SUCCESS (3.6s). `npm run test:unit`: tests 430 pass, 0 fail.
- **downstream_checked:** none — no `final`/`sealed` or public signature break.

### C5 UI proof

- `perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- Container `Health=healthy`; REST `GET …/path/folder/Sites` returns `Corporate_Investments` + `Enterprise_Investments`
- Hot-copy WebUI `cm/modern/assets/` into Rhythmyx WAR (not `deploy-jar --target cms`)
- `npm run test:surface -- --path tests/explorer-workflow-transitions.spec.js` — 2 passed, 0 skipped
- `npm run test:golden` — 2 passed
- **console-clean:** yes (spec asserts no page/console errors)
- **server.log-clean:** BUG:#3668 — Expire trigger on Public FastForward page 551 logs `PSRuntimeExceptionMapper` failed transition (honest 500; not re-worked here)

Addresses #3684 (leave open for Cycle Verify; do not auto-close on merge). Parent: #2732. Existing human QA: #2743.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
