### PR TITLE
fix(sitemanage): map bare numeric checkIn ids to LEGACY_CONTENT (#3688)

### DIFF
--- a/docs/ai-generated/code-reviews/3688-numeric-checkin-guid-erlang.md
+++ b/docs/ai-generated/code-reviews/3688-numeric-checkin-guid-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #3688 numeric checkIn GUID
+
+**Branch:** `fix/issue-3688-numeric-checkin-guid`  
+**Scope:** uncommitted vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for new GUID mapping; URL paths correctly use `/`; no public API signature change; product-docs N/A (Preview already documented)
+
+## Summary
+
+Explorer Preview `GET …/itemmanagement/workflow/checkIn/594` passed a bare FastForward content id into `PSIdMapper.getGuid(String)`, which called untyped `guidMgr.makeGuid(id)`. `PSGuid.assemble` throws `Type is undetermined` when type bits 32–39 are zero. The mapper now routes those tokens through existing `getGuidFromContentId` / `makeGuid(raw, PSTypeEnum.LEGACY_CONTENT)`. Hyphenated `host-type-uuid` strings and packed longs that already carry a type still use untyped `makeGuid(String)`.
+
+No operator-visible Preview contract change — product-docs Preview row already describes listed-page view-mode preview.
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new filesystem `".../" +` or `"...\\" +` joins (CMS URL helpers use `/` for HTTP)
+- [x] Tests do not assert OS path strings
+- [x] N/A temp files / line endings / scripts
+
+## Tests
+
+- `PSIdMapperNumericContentIdTest` — bare `594`, hyphenated GUID, packed long with type bits, `getGuids` / `getItemGuid`
+- `PSItemSummaryServiceNumericIdTest` — `find("594")` uses `makeGuid(594L, LEGACY_CONTENT)`
+- `PSItemWorkflowServiceNumericCheckInTest` — REST/service checkIn with numeric id
+- Playwright helper unit tests for checkIn path + prefer content id 594
+- Live C5: `perc-devctl qa-up` TEST_CMS_URL=http://127.0.0.1:50758; docker cp sitemanage + perc-system; in-cell StopJetty/StartJetty; qa-health RESULT:OK HTTP:200 HEALTH:healthy; Playwright `explorer-preview-view.spec.js` **3 passed 0 skipped**; console-clean=yes (pageerror); server.log-clean=yes (no `Failed to load: 594` / `Type is undetermined`)
+
+## Change-class companions
+
+Numeric-id mapping in sitemanage share DAO; no REST URL shape change; Playwright surface spec extended; product-docs N/A.

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Playwright surface: #2733 / #3456 / #3463 / #3627 — Explorer preview
+ * Playwright surface: #2733 / #3456 / #3463 / #3627 / #3688 — Explorer preview
  * for a listed page on {@code spa.jsp?entry=explorer}.
  *
  * <p>Verifies product shell chrome for Preview + Refresh, then opens
@@ -47,6 +47,8 @@ const {
   listedPageSiteNames,
   foldSiteName,
   detailRowHasExactName,
+  workflowCheckInPath,
+  numericContentIdFromItemId,
 } = require("./helpers/explorer-preview-view");
 
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -309,6 +311,16 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
       test.setTimeout(90_000);
       const pageErrors = [];
       page.on("pageerror", (err) => pageErrors.push(String(err)));
+      const checkInFailures = [];
+      page.on("response", (res) => {
+        const u = res.url();
+        if (
+          /\/itemmanagement\/workflow\/checkIn\//i.test(u) &&
+          res.status() >= 500
+        ) {
+          checkInFailures.push(`${res.status()} ${u}`);
+        }
+      });
 
       // Use the logged-in page request (session cookies). Isolated
       // APIRequestContext basic-auth is often redirected to login.
@@ -425,6 +437,39 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
       expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
         [],
       );
+      expect(
+        checkInFailures,
+        `checkIn must not 500 for listed page (#3688): ${checkInFailures.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
+
+  test(
+    "numeric checkIn for listed page content id does not 500 (#3688)",
+    { tag: ["@explorer-preview-view", "@preview"] },
+    async ({ request }) => {
+      test.setTimeout(30_000);
+      const auth = {
+        ...adminBasicAuthHeaders(),
+        Accept: "application/json",
+      };
+      const listed = await findListedPageViaRest(request);
+      const numericIds = [
+        "594",
+        numericContentIdFromItemId(listed && listed.id),
+      ].filter((id, i, all) => id && all.indexOf(id) === i);
+      for (const numericId of numericIds) {
+        const checkInUrl = `${BASE_URL}${workflowCheckInPath(
+          "/Rhythmyx/services",
+          numericId,
+        )}`;
+        const res = await request.get(checkInUrl, { headers: auth });
+        const body = (await res.text()).slice(0, 400);
+        expect(
+          res.status(),
+          `GET ${checkInUrl} must not 500 for bare numeric content id; body=${body}`,
+        ).toBeLessThan(500);
+      }
     },
   );
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-preview-view.js
@@ -48,6 +48,54 @@ function explorerEntryUrl(baseUrl, opts = {}) {
 }
 
 /**
+ * Workflow checkIn path for a content id (mirrors WebUI ITEM_WORKFLOW_CHECKIN).
+ * Bare numeric ids such as FastForward {@code 594} are valid (#3688).
+ * @param {string} servicesRoot e.g. /Rhythmyx/services or /services
+ * @param {string} contentId
+ * @returns {string}
+ */
+function workflowCheckInPath(servicesRoot, contentId) {
+  const root = String(servicesRoot || "/services").replace(/\/+$/, "");
+  const id = String(contentId || "").trim();
+  if (!id) return "";
+  return `${root}/itemmanagement/workflow/checkIn/${encodeURIComponent(id)}`;
+}
+
+/**
+ * Bare numeric content id from a path item id or hyphenated GUID.
+ * @param {unknown} id
+ * @returns {string} empty when no numeric uuid is present
+ */
+function numericContentIdFromItemId(id) {
+  const s = String(id || "").trim();
+  if (/^\d+$/.test(s)) return s;
+  const parts = s.split("-");
+  const last = parts[parts.length - 1];
+  if (parts.length >= 3 && /^\d+$/.test(last)) {
+    return last;
+  }
+  return "";
+}
+
+/**
+ * Prefer FastForward Corporate Investments listed page (content id 594).
+ * @param {object[]} pages
+ * @returns {object|null}
+ */
+function pickPreferredListedPage(pages) {
+  const list = Array.isArray(pages) ? pages.filter(Boolean) : [];
+  if (list.length === 0) return null;
+  const by594 = list.find((p) => numericContentIdFromItemId(p.id) === "594");
+  if (by594) return by594;
+  const bySite = list.find((p) =>
+    listedPageSiteNames(p)
+      .map(foldSiteName)
+      .some((n) => n.includes("corporateinvestments")),
+  );
+  return bySite || list[0];
+}
+
+/**
  * Page render preview path for a content id (mirrors WebUI PAGE_PREVIEW).
  * @param {string} servicesRoot e.g. /Rhythmyx/services or /services
  * @param {string} contentId
@@ -381,6 +429,9 @@ module.exports = {
   TEST_IDS,
   explorerEntryUrl,
   pageRenderPreviewPath,
+  workflowCheckInPath,
+  numericContentIdFromItemId,
+  pickPreferredListedPage,
   sitePathPreviewUrl,
   noPreviewableItemSkipMessage,
   noListedPageSkipMessage,

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -15,6 +15,9 @@ const {
   TEST_IDS,
   explorerEntryUrl,
   pageRenderPreviewPath,
+  workflowCheckInPath,
+  numericContentIdFromItemId,
+  pickPreferredListedPage,
   sitePathPreviewUrl,
   noPreviewableItemSkipMessage,
   noListedPageSkipMessage,
@@ -39,6 +42,28 @@ describe("explorer-preview-view helpers (#2733)", () => {
     assert.equal(TEST_IDS.preview, "action-preview");
     assert.equal(TEST_IDS.refresh, "explorer-refresh-list");
     assert.equal(TEST_IDS.viewTools, "explorer-view-tools");
+  });
+
+  it("workflowCheckInPath encodes bare numeric content ids (#3688)", () => {
+    assert.equal(
+      workflowCheckInPath("/Rhythmyx/services", "594"),
+      "/Rhythmyx/services/itemmanagement/workflow/checkIn/594",
+    );
+    assert.equal(workflowCheckInPath("/services/", ""), "");
+  });
+
+  it("numericContentIdFromItemId accepts bare and hyphenated GUIDs", () => {
+    assert.equal(numericContentIdFromItemId("594"), "594");
+    assert.equal(numericContentIdFromItemId("0-101-594"), "594");
+    assert.equal(numericContentIdFromItemId(""), "");
+  });
+
+  it("pickPreferredListedPage prefers FastForward content id 594", () => {
+    const pages = [
+      { id: "501", name: "Other", path: "/Sites/EnterpriseInvestments/Pages/x" },
+      { id: "594", name: "Dow futures", path: "/Sites/CorporateInvestments/Pages/y" },
+    ];
+    assert.equal(pickPreferredListedPage(pages).id, "594");
   });
 
   it("explorerEntryUrl builds spa.jsp explorer entry with cache-buster", () => {

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSIdMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSIdMapper.java
@@ -55,6 +55,10 @@ public class PSIdMapper implements IPSIdMapper {
   public IPSGuid getGuid(String id) {
     notNull(id);
     notEmpty(id);
+    Long contentId = parseBareNumericContentId(id);
+    if (contentId != null) {
+      return getGuidFromContentId(contentId);
+    }
     return guidMgr.makeGuid(id);
   }
 
@@ -81,13 +85,13 @@ public class PSIdMapper implements IPSIdMapper {
   @Override
   public int getContentId(String guid) {
     notEmpty(guid);
-    return ((PSLegacyGuid) guidMgr.makeGuid(guid)).getContentId();
+    return getContentId(getGuid(guid));
   }
 
   @Override
   public IPSGuid getItemGuid(String id) {
     notEmpty(id);
-    var guid = guidMgr.makeGuid(id);
+    var guid = getGuid(id);
     return contentDesignWs.getItemGuid(guid);
   }
 
@@ -147,5 +151,36 @@ public class PSIdMapper implements IPSIdMapper {
   @Override
   public IPSGuid getGuidFromContentId(long id) {
     return guidMgr.makeGuid(id, PSTypeEnum.LEGACY_CONTENT);
+  }
+
+  /**
+   * Explorer Preview / editor view call {@code GET .../workflow/checkIn/{id}} with a
+   * bare numeric content id (FastForward sample {@code 594}). {@link
+   * com.percussion.services.guidmgr.data.PSGuid} treats a single numeric token with
+   * type bits 32–39 equal to zero as undetermined unless a {@link PSTypeEnum} is
+   * supplied. Those tokens are legacy content ids.
+   *
+   * @param id never {@code null}
+   * @return the content id, or {@code null} when {@code id} is a hyphenated GUID
+   *     string or a packed long that already carries a type
+   */
+  static Long parseBareNumericContentId(String id) {
+    var trimmed = id.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    for (int i = 0; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (c < '0' || c > '9') {
+        return null;
+      }
+    }
+    try {
+      long raw = Long.parseLong(trimmed);
+      int type = (int) ((raw >>> 32) & 0xFFL);
+      return type == 0 ? raw : null;
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/service/IPSIdMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/service/IPSIdMapper.java
@@ -79,6 +79,10 @@ public interface IPSIdMapper {
   /**
    * Gets the content ID from the string representation of an item GUID.
    *
+   * <p>Accepts the same forms as {@link #getGuid(String)}, including a
+   * <strong>bare numeric content id</strong> (for example {@code 594}), because
+   * this method routes through {@link #getGuid(String)}.
+   *
    * @param guid the string representation of an item GUID, not blank
    * @return the content ID
    */
@@ -86,6 +90,10 @@ public interface IPSIdMapper {
 
   /**
    * Converts string to {@link IPSGuid} for an item ID.
+   *
+   * <p>Accepts the same forms as {@link #getGuid(String)}, including a
+   * <strong>bare numeric content id</strong> (for example {@code 594}), because
+   * this method routes through {@link #getGuid(String)}.
    *
    * @param id the item ID, never blank
    * @return the item GUID with "correct" version number, never {@code null}

--- a/projects/sitemanage/src/main/java/com/percussion/share/service/IPSIdMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/service/IPSIdMapper.java
@@ -38,6 +38,12 @@ public interface IPSIdMapper {
   /**
    * Performs string to {@link IPSGuid} translation.
    *
+   * <p>Accepts a hyphenated {@code host-type-uuid} GUID, a packed long that already
+   * carries a type, or a <strong>bare numeric content id</strong> (for example
+   * {@code 594} from Explorer Preview {@code GET .../workflow/checkIn/594}). Bare
+   * numeric tokens with no GUID type bits are mapped as {@link
+   * PSTypeEnum#LEGACY_CONTENT} via {@link #getGuidFromContentId(long)}.
+   *
    * @param id the string representation of the id, never blank
    * @return the id as an {@link IPSGuid}, never {@code null}
    */

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowServiceNumericCheckInTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowServiceNumericCheckInTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.services.sitemgr.IPSSiteManager;
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.share.async.IPSAsyncJobService;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.data.PSDataItemSummary;
+import com.percussion.share.service.IPSDataItemSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.sitemanage.dao.IPSiteDao;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.security.IPSSecurityWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@code GET .../itemmanagement/workflow/checkIn/594} must not fail before
+ * GUID mapping (#3688).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSItemWorkflowServiceNumericCheckInTest {
+
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSSecurityWs securityWs;
+  @Mock private IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+  @Mock private IPSPageDao pageDao;
+  @Mock private IPSSystemService systemService;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSAssetDao assetDao;
+  @Mock private IPSDataItemSummaryService dataItemSummaryService;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSWorkflowService workflowService;
+  @Mock private IPSiteDao siteDao;
+  @Mock private IPSSiteManager siteMgr;
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSAsyncJobService asyncJobService;
+  @Mock private IPSRecycleService recycleService;
+  @Mock private IPSGuid contentGuid;
+
+  private PSItemWorkflowService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSItemWorkflowService(
+            contentWs,
+            idMapper,
+            securityWs,
+            widgetAssetRelationshipService,
+            pageDao,
+            systemService,
+            workflowHelper,
+            assetDao,
+            dataItemSummaryService,
+            folderHelper,
+            workflowService,
+            siteDao,
+            siteMgr,
+            systemWs,
+            asyncJobService,
+            recycleService);
+  }
+
+  @Test
+  void checkInNumericContentIdWhenItemMissingIsNoOp() throws Exception {
+    when(dataItemSummaryService.find("594")).thenReturn(null);
+
+    var result = service.checkIn("594", false);
+
+    assertEquals("checkIn", result.getOperation());
+  }
+
+  @Test
+  void checkInNumericContentIdPassesBareIdToGuidMapper() throws Exception {
+    var sum = new PSDataItemSummary();
+    sum.setName("Dow futures higher; chip stocks");
+    sum.setType("percAsset");
+    when(dataItemSummaryService.find("594")).thenReturn(sum);
+    when(idMapper.getGuids(anyList())).thenReturn(List.of(contentGuid));
+
+    var result = service.checkIn("594", false);
+
+    assertEquals("checkIn", result.getOperation());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> ids = ArgumentCaptor.forClass(List.class);
+    verify(idMapper).getGuids(ids.capture());
+    assertEquals(List.of("594"), ids.getValue());
+    verify(contentWs).checkinItems(eq(List.of(contentGuid)), isNull(), eq(false));
+  }
+
+  @Test
+  void checkInRestPathAcceptsBareNumericContentId() throws PSDataServiceException {
+    when(dataItemSummaryService.find("594")).thenReturn(null);
+
+    var result = service.checkIn("594");
+
+    assertEquals("checkIn", result.getOperation());
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSIdMapperNumericContentIdTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSIdMapperNumericContentIdTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import java.util.List;
@@ -128,6 +129,14 @@ class PSIdMapperNumericContentIdTest {
     when(contentDesignWs.getItemGuid(contentGuid)).thenReturn(itemGuid);
 
     assertSame(itemGuid, mapper.getItemGuid("594"));
+  }
+
+  @Test
+  void getContentIdUsesLegacyContentForBareNumeric() {
+    var legacy = new PSLegacyGuid((int) FASTFORWARD_CONTENT_ID, -1);
+    when(guidMgr.makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT)).thenReturn(legacy);
+
+    assertEquals((int) FASTFORWARD_CONTENT_ID, mapper.getContentId("594"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSIdMapperNumericContentIdTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSIdMapperNumericContentIdTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Explorer Preview {@code GET .../workflow/checkIn/594} sends a bare content id.
+ * {@link PSIdMapper#getGuid(String)} must use {@link PSTypeEnum#LEGACY_CONTENT}
+ * instead of untyped {@code makeGuid(String)} (#3688).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSIdMapperNumericContentIdTest {
+
+  private static final long FASTFORWARD_CONTENT_ID = 594L;
+
+  @Mock private IPSGuidManager guidMgr;
+  @Mock private IPSContentDesignWs contentDesignWs;
+  @Mock private IPSGuid contentGuid;
+  @Mock private IPSGuid hyphenatedGuid;
+  @Mock private IPSGuid packedGuid;
+  @Mock private IPSGuid itemGuid;
+
+  private PSIdMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new PSIdMapper(guidMgr, contentDesignWs);
+  }
+
+  @Test
+  void parseBareNumericContentIdRecognizesFastForwardSample() {
+    assertEquals(FASTFORWARD_CONTENT_ID, PSIdMapper.parseBareNumericContentId("594"));
+    assertEquals(FASTFORWARD_CONTENT_ID, PSIdMapper.parseBareNumericContentId(" 594 "));
+    assertNull(PSIdMapper.parseBareNumericContentId("0-101-594"));
+    assertNull(PSIdMapper.parseBareNumericContentId("host-type-uuid"));
+    assertNull(PSIdMapper.parseBareNumericContentId(""));
+  }
+
+  @Test
+  void parseBareNumericContentIdIgnoresPackedLongWithTypeBits() {
+    long packed = ((long) PSTypeEnum.LEGACY_CONTENT.getOrdinal() << 32) | FASTFORWARD_CONTENT_ID;
+    assertNull(PSIdMapper.parseBareNumericContentId(Long.toString(packed)));
+  }
+
+  @Test
+  void getGuidMapsBareNumericToLegacyContent() {
+    when(guidMgr.makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT))
+        .thenReturn(contentGuid);
+
+    assertSame(contentGuid, mapper.getGuid("594"));
+
+    verify(guidMgr).makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT);
+    verify(guidMgr, never()).makeGuid(anyString());
+  }
+
+  @Test
+  void getGuidLeavesHyphenatedGuidUntypedMakeGuid() {
+    when(guidMgr.makeGuid("0-101-594")).thenReturn(hyphenatedGuid);
+
+    assertSame(hyphenatedGuid, mapper.getGuid("0-101-594"));
+
+    verify(guidMgr).makeGuid("0-101-594");
+    verify(guidMgr, never()).makeGuid(anyLong(), eq(PSTypeEnum.LEGACY_CONTENT));
+  }
+
+  @Test
+  void getGuidLeavesPackedLongWithTypeBitsUntypedMakeGuid() {
+    long packed = ((long) PSTypeEnum.LEGACY_CONTENT.getOrdinal() << 32) | FASTFORWARD_CONTENT_ID;
+    String packedText = Long.toString(packed);
+    when(guidMgr.makeGuid(packedText)).thenReturn(packedGuid);
+
+    assertSame(packedGuid, mapper.getGuid(packedText));
+
+    verify(guidMgr).makeGuid(packedText);
+    verify(guidMgr, never()).makeGuid(anyLong(), eq(PSTypeEnum.LEGACY_CONTENT));
+  }
+
+  @Test
+  void getGuidsMapsBareNumericContentId() {
+    when(guidMgr.makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT))
+        .thenReturn(contentGuid);
+
+    assertEquals(List.of(contentGuid), mapper.getGuids(List.of("594")));
+
+    verify(guidMgr).makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT);
+  }
+
+  @Test
+  void getItemGuidUsesLegacyContentForBareNumeric() {
+    when(guidMgr.makeGuid(FASTFORWARD_CONTENT_ID, PSTypeEnum.LEGACY_CONTENT))
+        .thenReturn(contentGuid);
+    when(contentDesignWs.getItemGuid(contentGuid)).thenReturn(itemGuid);
+
+    assertSame(itemGuid, mapper.getItemGuid("594"));
+  }
+
+  @Test
+  void getGuidRejectsBlank() {
+    assertThrows(IllegalArgumentException.class, () -> mapper.getGuid(""));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemSummaryServiceNumericIdTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemSummaryServiceNumericIdTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.share.service.IPSDataService.DataServiceLoadException;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.IPSContentWs;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link PSItemSummaryService#find(String)} is on the Explorer Preview checkIn
+ * path. A bare numeric content id must map as {@link PSTypeEnum#LEGACY_CONTENT}
+ * (#3688).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSItemSummaryServiceNumericIdTest {
+
+  @Mock private IPSGuidManager guidMgr;
+  @Mock private IPSContentDesignWs contentDesignWs;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSGuid contentGuid;
+
+  @Test
+  void findAcceptsBareNumericContentIdWithoutUntypedMakeGuid() throws DataServiceLoadException {
+    when(guidMgr.makeGuid(594L, PSTypeEnum.LEGACY_CONTENT)).thenReturn(contentGuid);
+    when(contentWs.findItems(anyList(), anyBoolean())).thenReturn(Collections.emptyList());
+
+    var mapper = new PSIdMapper(guidMgr, contentDesignWs);
+    var sut =
+        new PSItemSummaryService(
+            contentWs, mock(PSItemDefManager.class), mapper, mock(IPSManagedNavService.class));
+
+    assertNull(sut.find("594"));
+
+    verify(guidMgr).makeGuid(594L, PSTypeEnum.LEGACY_CONTENT);
+    verify(guidMgr, never()).makeGuid(anyString());
+  }
+}


### PR DESCRIPTION
## Summary

Explorer Preview of FastForward **Corporate Investments** listed pages called `GET …/itemmanagement/workflow/checkIn/{numericContentId}` (e.g. `594`). `PSIdMapper.getGuid(String)` forwarded that token to untyped `guidMgr.makeGuid(id)`, and `PSGuid.assemble` threw `Type is undetermined` (`Failed to load: 594`).

Bare numeric ids with no GUID type bits now map through existing `getGuidFromContentId` / `makeGuid(raw, PSTypeEnum.LEGACY_CONTENT)`. Hyphenated `host-type-uuid` strings and packed longs that already carry a type are unchanged. No new REST URL shape.

Parent: #2400 (Explorer DCE ↔ web Explorer parity). Distinct from #3684 (Sites-row open).

Fixes #3688

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS; Tests run: 1293, Failures: 0, Skipped: 125 (includes 8+1+3 new numeric-id tests).
2. `npm run test:unit` in `modules/perc-qa-automation/frontend` — 429 passed.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up` → `TEST_CMS_URL=http://127.0.0.1:50758` → docker cp `sitemanage-8.2.0-SNAPSHOT.jar` + `perc-system-8.2.0-SNAPSHOT.jar` into `webapps/Rhythmyx/WEB-INF/lib/` → in-cell StopJetty/StartJetty → `qa-health` RESULT:OK HTTP:200 HEALTH:healthy.
4. `npm run test:surface -- --path tests/explorer-preview-view.spec.js` — **3 passed, 0 skipped**.
5. In-cell `GET /Rhythmyx/services/itemmanagement/workflow/checkIn/594` with `RX_USEBASICAUTH` → HTTP 200 `{"NoContent":{"operation":"checkIn"}}`.
6. `server.log`: no `Failed to load: 594` / `Type is undetermined`.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): Preview host/view-mode behavior is already documented; this only stops a 500 on the existing checkIn contract
- [x] **Unit / module tests** — behavioral tests for mapper / find / checkIn; sitemanage standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `explorer-preview-view.spec.js` surface on H2 QA (preview host 200 + numeric checkIn)
- [x] **Build gates** — `projects/sitemanage` standalone clean install; no public signature/`final` change
- [x] **Cross-platform** — N/A (no filesystem path/file I/O; HTTP paths use `/`)

### C3 evidence

- `modules_built=projects/sitemanage`
- `build_evidence=cd projects/sitemanage && ../../mvnw.cmd clean install → BUILD SUCCESS; Tests run: 1293, Failures: 0, Errors: 0, Skipped: 125. Focused: PSIdMapperNumericContentIdTest (8), PSItemSummaryServiceNumericIdTest (1), PSItemWorkflowServiceNumericCheckInTest (3). perc-qa-automation JS: npm run test:unit → 429 passed.`
- `downstream_checked=none` (C2 did not apply: no `final`/`sealed` and no public/protected signature change; `extends PSIdMapper` grep empty)

### C5 UI proof

- `qa-up` TEST_CMS_URL=`http://127.0.0.1:50758` QA_CMS_HOST_PORT=50758 (freeport)
- Deploy: docker cp sitemanage + perc-system SNAPSHOTs to WAR `WEB-INF/lib`; in-cell `./StopJetty.sh` / `./StartJetty.sh`; `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/explorer-preview-view.spec.js` — 3 passed, 0 skipped
- console-clean=yes (pageerror listeners on preview tests)
- server.log-clean=yes (no `Failed to load: 594` / `Type is undetermined` / ERROR in test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
