### PR TITLE
feat(sitemanage): REST csv-filesystem Virtual Site build (#3698)

### DIFF
--- a/docs/ai-generated/code-reviews/3698-csv-filesystem-virtual-build-erlang.md
+++ b/docs/ai-generated/code-reviews/3698-csv-filesystem-virtual-build-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review: #3698 REST csv-filesystem virtual/build
+
+**Date:** 2026-08-21  
+**Branch:** `fix/issue-3698-csv-filesystem-virtual-build`  
+**Scope:** uncommitted vs `HEAD` / `origin/main` (sitemanage SitesAdaptor, system config fallback, rest OpenAPI, product-docs 8.2)  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** pass
+
+Memory patterns hit: portable Path/Files; behavioral tests for validation/rejection; change-class companions (adaptor + resource tests + product-docs REST/admin); no WebUI/Playwright required (explicitly out of scope #3697).
+
+## Summary
+
+Removes the git-only gate on `SitesAdaptor.buildVirtualSite`. `runBuild` uses `PSVirtualSiteBuildService.forSourceType` (`PSVirtualSiteSourceFactory`). CSV trees may omit `_config.yaml` (`VirtualSiteConfigLoader.loadOrDefault` infers version folders). Unknown `sourceKind` still 400. git-filesystem build unchanged. Product-docs 8.2 REST/admin/developer/reference state CSV Virtual Sites can be built.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Config fallback uses `Path` / `Files.newDirectoryStream` / `Path.normalize` / `startsWith`
+- [x] Temp trees via JUnit `@TempDir`
+- [x] CSV fixture paths via `Path.resolve` (not OS separator concatenation)
+- [x] Containment: inferred version dirs must `startsWith` normalized site root
+- [x] Line-ending: CSV parser already normalizes; tests do not assert raw `\n` file bytes
+
+## Issues
+
+None blocking.
+
+### Notes (non-blocking)
+
+- Publish (`POST …/virtual/publish`) now inherits CSV build because it calls `buildVirtualSite`. Documented CSV **publish** remains slice #3699 (no extra UI/docs claim here).
+- REST resource tests mock the adaptor; real CSV HTML emit is covered in `SitesAdaptorTest` and system `PSCsvFilesystemVirtualSiteSourceTest`.
+
+## Tests
+
+- `SitesAdaptorTest` — CSV real-filesystem build (`pagesWritten > 0`), optional `_config.yaml`, missing column 400, unsafe path 400, unknown kind 400; existing git-filesystem tests
+- `SitesResourceTest` — temp CSV fixture delegation, unknown kind 400, OpenAPI `csv-filesystem` mention
+- `VirtualSiteConfigLoaderTest` — `loadOrDefault` infers versions / fails empty / uses YAML when present
+- `PSCsvFilesystemVirtualSiteSourceTest` — CLI/service build without `_config.yaml`
+
+## Change-class companions
+
+REST virtual/build for a new source kind: adaptor gate + factory wiring + config fallback + resource OpenAPI + sitemanage + rest + system tests + product-docs 8.2. No WebUI (later #3697). No publish docs as complete (#3699).
+
+## Builds
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -31,13 +31,13 @@ channels (static files, FTP, database, custom locations).
 
 ## Virtual Sites and docs builds
 
-For Git/filesystem Virtual Sites such as product documentation:
+For Git/filesystem or CSV/filesystem Virtual Sites such as product documentation:
 
-- Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session.
+- Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session. CSV trees can use `PSVirtualSiteBuildMain … csv-filesystem`.
 - **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
   `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`). Each build re-reads the
-  current Git/filesystem tree. After `git pull` or a local Markdown edit, run Build (or Publish)
-  again — no CMS restart.
+  current Git/filesystem or CSV tree (`csv-filesystem`). After `git pull`, a local Markdown
+  edit, or a CSV change, run Build (or Publish) again — no CMS restart.
 - **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
   assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
   publishing root). Staging `_meta` files are not copied. Redirect HTML and `redirects.json`

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -71,7 +71,7 @@ and Markdown tooling, not the classic page editor.
 
 | Property | Required | Example | Notes |
 |----------|----------|---------|-------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**. Blank or `repository` = traditional Site. CMS Build/UI still use git-filesystem; `csv-filesystem` is the offline CSV adapter (see [Virtual Sites](id:developer-virtual-sites)). |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**. Blank or `repository` = traditional Site. REST **Build Virtual Site** runs the matching adapter. CSV trees may omit `_config.yaml` (see [Virtual Sites](id:developer-virtual-sites)). |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` | Local tree when `virtual.remoteUrl` is blank. Prefer absolute portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. When a remote is set, use a **relative** folder inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones or fetches into a contained server work directory, then discovers Markdown as usual. Blank = local-path mode. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. |
 | `virtual.branch` | No | `main` | Branch to checkout when a remote is set. Default `main`. |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -132,7 +132,7 @@ Explorer chrome does not probe the named preference. A blank list entry (or no e
 | List | `GET /services/sites` | All CMS Sites (traditional, page-based, Virtual). JSON is a Jackson root wrap `{ "SiteList": [ { "name", "description", "baseUrl", … } ] }` or a bare array — **not** `{ "empty": false }`. Each entry includes a plain string `name` when the Site has one. |
 | Detail | `GET /services/sites/{nameOrId}` | Site detail including `virtual.*` when configured |
 | Virtual properties | `GET` / `PUT /services/sites/{nameOrId}/virtual` | Virtual Site source bag. PUT JSON is `{ "VirtualSiteProperties": { "sourceKind", "rootPath", "remoteUrl", "branch", "configFile", "siteKey" } }` (Jackson/JAXB root wrap). A flat `{ "sourceKind": … }` body returns **400** unexpected element `sourceKind`. Optional `remoteUrl` + `branch` clone/fetch before Build; omit `remoteUrl` to keep a stored remote; send `""` to clear. |
-| Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; Git-filesystem Virtual Sites. Fetches `remoteUrl` when set, else reads local `rootPath`. |
+| Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; `git-filesystem` or `csv-filesystem`. Git fetches `remoteUrl` when set; CSV reads a local CSV tree (`rootPath`; optional `_config.yaml`). Unknown `sourceKind` is **400**. |
 | Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
 | Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root. Same action as **Developer → Sites → Publish Virtual Site** |

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -11,8 +11,9 @@ tags: [developer, virtual-sites]
 
 **Virtual Sites** are Sites whose content originates outside the traditional Percussion content
 repository. Phase 1 delivers a **Git / filesystem** adapter aimed at product documentation. A
-**CSV / filesystem** adapter (`csv-filesystem`) can discover the same assemble pipeline from
-CSV files (offline CLI; REST Build remains git-filesystem).
+**CSV / filesystem** adapter (`csv-filesystem`) discovers the same assemble pipeline from
+CSV files. Operators can run it offline (CLI) or from CMS REST
+`POST /sites/{nameOrId}/virtual/build`. Developer Sites Build chrome for CSV is a later slice.
 
 Operators can create a **Virtual** type from **Content Explorer → Create Site** or
 **Navigation → New Site**. That flow does not prompt for managed navigation or a page template.
@@ -90,7 +91,7 @@ treated as a safe Virtual Site source.
 
 | Property | Required | Example | Meaning |
 |----------|----------|---------|---------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. CMS **Build** REST is still git-filesystem only; `csv-filesystem` is the offline SPI/CLI adapter. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. CMS **Build** REST (`POST …/virtual/build`) runs the matching adapter. |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` (or install-relative) | Local filesystem root when `virtual.remoteUrl` is blank. When a remote is set, optional **relative** path inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. When set, **Build** clones or fetches into a contained work directory, then reuses git-filesystem discover. Blank keeps local-path mode. Allowed: `https://`, `ssh://`, `file://`, or `git@host:path`. `http` and other schemes are rejected. |
 | `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. Simple ref name only (no `..` or leading `-`). |
@@ -134,10 +135,11 @@ Markdown links cannot be resolved.
 
 ### Offline build from CSV (`csv-filesystem`)
 
-The `csv-filesystem` adapter discovers pages from `*.csv` files under each version folder in
-`_config.yaml` (the same `_config.yaml` / `_theme` contract as git-filesystem). Git remains
-optional; operators can assemble a static site from a spreadsheet export without ingesting rows
-as CMS content items.
+The `csv-filesystem` adapter discovers pages from `*.csv` files under each version folder.
+`_config.yaml` is **optional** (when omitted, each immediate child folder other than `_theme` /
+`assets` is a version). `_theme` is optional (built-in layout). Do not require a Markdown docs
+tree — CSV `body` is the page source. Git remotes are not used (`virtual.remoteUrl` is rejected
+for this kind).
 
 Required CSV columns (header row, case-insensitive):
 
@@ -153,20 +155,21 @@ Missing required columns, blank `id`/`title`, duplicate ids, or an unsafe `path`
 (`VirtualSiteException`). Each discover/load re-reads the current CSV bytes (no process-lifetime
 parse cache).
 
-CLI (from a tree that already has `_config.yaml`):
+CLI (optional `_config.yaml`):
 
 ```text
 PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey] csv-filesystem
 ```
 
-REST `PUT /sites/{nameOrId}/virtual` may store `sourceKind=csv-filesystem` (allow-listed), but
-**Build Virtual Site** (`POST …/virtual/build`) and the Developer Sites UI still run the
-git-filesystem adapter only. Use the offline CLI for CSV trees until the REST/UI slices land.
+REST `PUT /sites/{nameOrId}/virtual` stores `sourceKind=csv-filesystem`. **Build Virtual Site**
+(`POST …/virtual/build`) then discovers CSV rows under `virtual.rootPath` and writes HTML
+(`pagesWritten` in the JSON result). Unknown kinds remain **400**. Developer Sites Build
+button for CSV is a later UI slice.
 
 ## CMS-integrated build (REST and WebUI)
 
-When a CMS Site has Virtual properties configured, an **Admin** can trigger the same build path
-from the running server:
+When a CMS Site has Virtual properties configured (`git-filesystem` or `csv-filesystem`), an
+**Admin** can trigger the matching build path from the running server:
 
 ```http
 POST /sites/{nameOrId}/virtual/build
@@ -289,7 +292,7 @@ silent no-op). See [Publishing](id:admin-publishing).
 
 - CMS UI editing of Virtual items as normal content types
 - Automatic migration of the full legacy help site
-- REST/UI Build for `csv-filesystem` (offline CLI only in this slice)
+- Developer Sites Build chrome for `csv-filesystem` (REST Build is available)
 - SQL/API adapters
 - Fake classic content-list generators for virtual items
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -111,7 +111,7 @@ When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` co
 
 | Property name | Required | Example | Meaning |
 |---------------|----------|---------|---------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. `csv-filesystem` is the offline CSV source (required columns `id`, `title`, `body`); REST Build remains git-filesystem. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. REST **Build** (`POST …/virtual/build`) runs the matching adapter. `csv-filesystem` required columns: `id`, `title`, `body`; optional `_config.yaml`. |
 | `virtual.rootPath` | Yes when remote is blank | absolute or install-relative path to tree | Local filesystem source root when `virtual.remoteUrl` is blank. NIO `Path` normalize; no empty path / remaining `..`. When a remote is set, optional relative path inside the checkout. |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones/fetches into `{install}/tmp/virtual-site-checkouts/{siteKey}`. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. Fail-closed on `..`, `http`, option injection. Credentials are never logged. |
 | `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. |
@@ -169,11 +169,18 @@ remote is blank, safe remote URL/branch, portable path safety).
 
 #### Build Virtual Site (`POST …/virtual/build`)
 
-Runs the Phase 1 static build for a Site configured with `virtual.sourceKind=git-filesystem`.
-When `virtual.remoteUrl` is set, the server clones or fetches that branch into a contained
-work directory, then discovers Markdown from the checkout (optional relative `virtual.rootPath`).
-When remote is blank, `virtual.rootPath` must be an existing directory on the CMS host.
-Requires **Admin**. `git` must be on the CMS `PATH` for remotes.
+Runs the static build for a Site configured with `virtual.sourceKind=git-filesystem` or
+`csv-filesystem`. Unknown kinds return **400**.
+
+- **git-filesystem** — when `virtual.remoteUrl` is set, the server clones or fetches that branch
+  into a contained work directory, then discovers Markdown from the checkout (optional relative
+  `virtual.rootPath`). When remote is blank, `virtual.rootPath` must be an existing directory on
+  the CMS host. `git` must be on the CMS `PATH` for remotes.
+- **csv-filesystem** — `virtual.rootPath` is a CSV tree (version folders with `*.csv`).
+  `_config.yaml` is optional. Required columns `id`, `title`, `body`; unsafe `path` values and
+  missing columns fail closed (**400**). Git remotes are not used.
+
+Requires **Admin**.
 
 | Status | When |
 |--------|------|

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -37,7 +37,6 @@ import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.services.sitemgr.PSSiteManagerLocator;
 import com.percussion.services.sitemgr.data.PSSite;
-import com.percussion.services.virtualsite.PSGitFilesystemVirtualSiteSource;
 import com.percussion.services.virtualsite.PSGitRemoteCheckout;
 import com.percussion.services.virtualsite.PSInMemoryVirtualParticipantService;
 import com.percussion.services.virtualsite.PSVirtualSiteBuildResult;
@@ -351,17 +350,9 @@ public class SitesAdaptor implements ISiteAdaptor {
             .orElseThrow(
                 () ->
                     new WebApplicationException(
-                        "Unsupported virtual.sourceKind for build",
+                        "Unsupported virtual.sourceKind for build. Allowed: "
+                            + String.join(", ", PSVirtualSiteHelper.allowedSourceKindWireNames()),
                         Response.Status.BAD_REQUEST));
-    if (type != VirtualSiteSourceType.GIT_FILESYSTEM) {
-      throw new WebApplicationException(
-          "Build is only supported for virtual.sourceKind="
-              + VirtualSiteSourceType.GIT_FILESYSTEM.wireName()
-              + " (got "
-              + type.wireName()
-              + ")",
-          Response.Status.BAD_REQUEST);
-    }
 
     Path siteRoot;
     try {
@@ -369,14 +360,17 @@ public class SitesAdaptor implements ISiteAdaptor {
     } catch (VirtualSiteException e) {
       throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
     } catch (IOException e) {
+      boolean remote = PSVirtualSiteHelper.hasRemote(site);
       log.error(
-          "Virtual Site Git checkout I/O failed for '{}' ({}): {}",
+          "Virtual Site {} I/O failed for '{}' ({}): {}",
+          remote ? "Git checkout" : "root path",
           nameOrId,
           e.getClass().getName(),
           e.getMessage(),
           e);
       throw new WebApplicationException(
-          "Virtual Site Git checkout failed: " + PSGitRemoteCheckout.redact(e.getMessage()),
+          (remote ? "Virtual Site Git checkout failed: " : "Virtual Site root path failed: ")
+              + PSGitRemoteCheckout.redact(e.getMessage()),
           Response.Status.INTERNAL_SERVER_ERROR);
     }
     if (!Files.isDirectory(siteRoot)) {
@@ -401,8 +395,8 @@ public class SitesAdaptor implements ISiteAdaptor {
       Path metaDir = outputRoot.resolve("_meta"); // codeql[java/path-injection]
       Files.createDirectories(metaDir); // codeql[java/path-injection]
 
-      VirtualSiteConfig config = VirtualSiteConfigLoader.load(siteRoot, configFile, siteKey);
-      PSVirtualSiteBuildResult built = runBuild(config, outputRoot, metaDir);
+      VirtualSiteConfig config = loadBuildConfig(type, siteRoot, configFile, siteKey);
+      PSVirtualSiteBuildResult built = runBuild(type, config, outputRoot, metaDir);
       recordLastOutputRoot(siteKey, outputRoot);
       return toWireResult(site.getName(), siteKey, built);
     } catch (VirtualSiteException e) {
@@ -499,15 +493,28 @@ public class SitesAdaptor implements ISiteAdaptor {
     }
   }
 
+  /**
+   * Load {@code _config.yaml} (required for git-filesystem). CSV trees may omit the file and
+   * infer versions from child directories.
+   */
+  static VirtualSiteConfig loadBuildConfig(
+      VirtualSiteSourceType type, Path siteRoot, String configFile, String siteKey)
+      throws IOException, VirtualSiteException {
+    if (type == VirtualSiteSourceType.CSV_FILESYSTEM) {
+      return VirtualSiteConfigLoader.loadOrDefault(siteRoot, configFile, siteKey);
+    }
+    return VirtualSiteConfigLoader.load(siteRoot, configFile, siteKey);
+  }
+
   private PSVirtualSiteBuildResult runBuild(
-      VirtualSiteConfig config, Path outputRoot, Path metaDir) throws Exception {
+      VirtualSiteSourceType type, VirtualSiteConfig config, Path outputRoot, Path metaDir)
+      throws Exception {
     if (buildRunner != null) {
       return buildRunner.build(config, outputRoot);
     }
     PSVirtualSiteBuildService service =
-        new PSVirtualSiteBuildService(
-            new PSGitFilesystemVirtualSiteSource(),
-            new PSInMemoryVirtualParticipantService(metaDir));
+        PSVirtualSiteBuildService.forSourceType(
+            type, new PSInMemoryVirtualParticipantService(metaDir));
     return service.build(config, outputRoot);
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -541,6 +541,144 @@ class SitesAdaptorTest {
   }
 
   @Test
+  void buildVirtualSite_csvFilesystemWritesHtml() throws Exception {
+    Path siteRoot = createMinimalCsvTree(tempDir.resolve("csv-src"));
+    Path out = tempDir.resolve("csv-out");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "csv-docs");
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+
+    VirtualSiteBuildResult result = adaptor.buildVirtualSite("CsvHelp", req);
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertFalse(Boolean.TRUE.equals(result.getHasLinkProblems()));
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String body = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(body.contains("CSV Home"), body);
+    assertTrue(body.contains("Hello from CSV"), body);
+  }
+
+  @Test
+  void buildVirtualSite_csvFilesystemOptionalConfigYaml() throws Exception {
+    Path siteRoot = tempDir.resolve("csv-noconfig");
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.writeString(
+        siteRoot.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path,order\nhome,No Config,Body from CSV.,index.md,1\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("csv-noconfig-out");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "csv-docs");
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+
+    VirtualSiteBuildResult result = adaptor.buildVirtualSite("CsvHelp", req);
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(Files.isRegularFile(out.resolve("8.2").resolve("index.html")));
+  }
+
+  @Test
+  void buildVirtualSite_csvFilesystemMissingColumn400() throws Exception {
+    Path siteRoot = tempDir.resolve("csv-missing-col");
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.writeString(
+        siteRoot.resolve("_config.yaml"),
+        """
+        site:
+          title: CSV
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("8.2").resolve("pages.csv"),
+        "id,title\nx,Y\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("csv-missing-col-out");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.buildVirtualSite("CsvHelp", req));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).contains("body"), String.valueOf(ex.getMessage()));
+  }
+
+  @Test
+  void buildVirtualSite_csvFilesystemUnsafePath400() throws Exception {
+    Path siteRoot = tempDir.resolve("csv-unsafe");
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.writeString(
+        siteRoot.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nesc,Esc,body,../outside.md\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("csv-unsafe-out");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.buildVirtualSite("CsvHelp", req));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(
+        String.valueOf(ex.getMessage()).toLowerCase().contains("path"),
+        String.valueOf(ex.getMessage()));
+  }
+
+  @Test
+  void buildVirtualSite_unknownSourceKind400() {
+    Path siteRoot = tempDir.resolve("sql-root");
+    PSSite site = new PSSite();
+    site.setName("Help");
+    site.setGUID(siteGuid);
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "sql-api");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toString());
+    when(siteManager.findSite("Help")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.buildVirtualSite("Help", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    String msg = String.valueOf(ex.getMessage()).toLowerCase();
+    assertTrue(msg.contains("unsupported") || msg.contains("sql-api"), msg);
+  }
+
+  @Test
   void publishVirtualSite_rejectsRepositorySite() {
     PSSite site = new PSSite();
     site.setName("Corp");
@@ -849,6 +987,34 @@ class SitesAdaptorTest {
 
         Welcome.
         """,
+        StandardCharsets.UTF_8);
+    return siteRoot;
+  }
+
+  private static Path createMinimalCsvTree(Path siteRoot) throws Exception {
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Files.writeString(
+        siteRoot.resolve("_config.yaml"),
+        """
+        site:
+          title: CSV Docs
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${pageTitle}</h1>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path,order\ncsv-home,CSV Home,Hello from CSV.,index.md,1\n",
         StandardCharsets.UTF_8);
     return siteRoot;
   }

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -95,13 +95,14 @@ public interface ISiteAdaptor {
   VirtualSiteProperties updateVirtualSiteProperties(String nameOrId, VirtualSiteProperties props);
 
   /**
-   * Builds a Virtual Site from configured {@code virtual.*} properties (Phase 1:
-   * {@code git-filesystem}).
+   * Builds a Virtual Site from configured {@code virtual.*} properties ({@code git-filesystem} or
+   * {@code csv-filesystem}).
    *
    * <p>Loads the site, validates via {@code PSVirtualSiteHelper}, optionally clones/fetches {@code
-   * virtual.remoteUrl} into a contained work directory, runs {@code PSVirtualSiteBuildService} with
-   * portable NIO {@code Path} I/O, and returns pages-written plus link-problem summary. Requires
-   * Admin (or equivalent site-manage) authorization.
+   * virtual.remoteUrl} into a contained work directory (git-filesystem only), runs {@code
+   * PSVirtualSiteBuildService.forSourceType} with portable NIO {@code Path} I/O, and returns
+   * pages-written plus link-problem summary. Unknown source kinds return 400. Requires Admin (or
+   * equivalent site-manage) authorization.
    *
    * @param nameOrId site name or GUID string, not blank
    * @param request optional body (output root override); may be null

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -255,11 +255,13 @@ public class SitesResource {
   @Operation(
       summary = "Build Virtual Site",
       description =
-          "Runs the Phase 1 Virtual Site static build for a site configured with"
-              + " virtual.sourceKind=git-filesystem. When virtual.remoteUrl is set, the server"
-              + " clones or fetches that branch into a contained work directory, then reuses the"
-              + " git-filesystem discover path. Blank remote keeps local virtual.rootPath. Uses"
-              + " PSVirtualSiteBuildService with portable NIO Path I/O. Requires"
+          "Runs the Virtual Site static build for a site configured with"
+              + " virtual.sourceKind=git-filesystem or csv-filesystem. git-filesystem: when"
+              + " virtual.remoteUrl is set, the server clones or fetches that branch into a"
+              + " contained work directory, then discovers Markdown. csv-filesystem: rootPath is a"
+              + " CSV tree (optional _config.yaml; required columns id, title, body; fail-closed on"
+              + " unsafe paths). Unknown source kinds return 400. Uses"
+              + " PSVirtualSiteBuildService.forSourceType with portable NIO Path I/O. Requires"
               + " Admin. Traditional repository Sites and invalid source kinds/paths return 4xx."
               + " Optional body may set outputRoot; otherwise the server writes under"
               + " {install}/tmp/virtual-sites/{siteKey}. Link problems are reported in the result"

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @Tag("UnitTest")
 public class SitesResourceTest {
@@ -46,6 +47,8 @@ public class SitesResourceTest {
   private SitesResource resource;
   private Logger previousLog;
   private Logger mockLog;
+
+  @TempDir Path tempDir;
 
   @BeforeEach
   public void setUp() {
@@ -178,6 +181,47 @@ public class SitesResourceTest {
   }
 
   @Test
+  public void buildVirtualSiteCsvFilesystemFixtureDelegates() throws Exception {
+    Path csvRoot = tempDir.resolve("csv-site");
+    Files.createDirectories(csvRoot.resolve("8.2"));
+    Files.writeString(
+        csvRoot.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path,order\ncsv-home,CSV Home,Hello from CSV.,index.md,1\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("csv-out");
+    Files.createDirectories(out);
+
+    VirtualSiteBuildResult built = new VirtualSiteBuildResult();
+    built.setSiteName("CsvHelp");
+    built.setPagesWritten(1);
+    built.setLinkProblemCount(0);
+    built.setHasLinkProblems(false);
+    built.setOutputPath(out.toAbsolutePath().toString());
+    VirtualSiteBuildRequest req = new VirtualSiteBuildRequest();
+    req.setOutputRoot(out.toAbsolutePath().toString());
+    when(adaptor.buildVirtualSite(eq("CsvHelp"), same(req))).thenReturn(built);
+
+    VirtualSiteBuildResult result = resource.buildVirtualSite("CsvHelp", req);
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertEquals(out.toAbsolutePath().toString(), result.getOutputPath());
+    assertTrue(Files.isRegularFile(csvRoot.resolve("8.2").resolve("pages.csv")));
+    verify(adaptor).buildVirtualSite("CsvHelp", req);
+  }
+
+  @Test
+  public void buildVirtualSiteUnknownKindPropagates400() {
+    when(adaptor.buildVirtualSite(eq("Help"), any()))
+        .thenThrow(
+            new WebApplicationException(
+                "Unsupported virtual.sourceKind", Response.Status.BAD_REQUEST));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.buildVirtualSite("Help", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor).buildVirtualSite("Help", null);
+  }
+
+  @Test
   public void buildVirtualSiteAllowsNullBody() {
     VirtualSiteBuildResult built = new VirtualSiteBuildResult();
     built.setPagesWritten(1);
@@ -283,6 +327,9 @@ public class SitesResourceTest {
         text.contains(
             "return requireAdaptor().buildVirtualSite(nameOrId, request); // codeql[java/xss]"),
         "buildVirtualSite return sink must carry same-line codeql[java/xss]");
+    assertTrue(
+        text.contains("csv-filesystem"),
+        "buildVirtualSite OpenAPI description must mention csv-filesystem");
     assertTrue(
         text.contains(
             "return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]"),

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -97,15 +97,24 @@ public class PSVirtualSiteBuildService {
    * {@code _redirects.yaml} is a no-op. The same service instance does not reuse parsed pages from
    * a previous build — operators do not need a JVM restart after {@code git pull} or a local edit.
    *
-   * @param siteRoot source tree (contains {@code _config.yaml})
+   * @param siteRoot source tree ({@code _config.yaml} required for git-filesystem; optional for
+   *     csv-filesystem)
    * @param outputRoot destination for HTML + assets
    * @param siteKey participant key
    * @return build result
    */
   public PSVirtualSiteBuildResult build(Path siteRoot, Path outputRoot, String siteKey)
       throws IOException, VirtualSiteException {
-    VirtualSiteConfig config =
-        VirtualSiteConfigLoader.load(siteRoot, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, siteKey);
+    VirtualSiteConfig config;
+    if (VirtualSiteSourceType.CSV_FILESYSTEM.wireName().equals(source.sourceType())) {
+      config =
+          VirtualSiteConfigLoader.loadOrDefault(
+              siteRoot, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, siteKey);
+    } else {
+      config =
+          VirtualSiteConfigLoader.load(
+              siteRoot, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, siteKey);
+    }
     List<VirtualRedirect> redirects =
         VirtualRedirectsLoader.loadOptional(siteRoot, config.siteUrl());
     return build(config, outputRoot, redirects);

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteSourceFactory.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteSourceFactory.java
@@ -23,8 +23,9 @@ import java.util.stream.Stream;
 /**
  * Selects an {@link IPSVirtualSiteSource} for a registered {@link VirtualSiteSourceType}.
  *
- * <p>Used by {@link PSVirtualSiteBuildService} so offline / CLI builds can switch adapters
- * without the REST Sites UI (csv-filesystem REST expose is a later slice).
+ * <p>Used by {@link PSVirtualSiteBuildService} (CLI and CMS REST {@code POST
+ * /sites/{nameOrId}/virtual/build}) so git-filesystem and csv-filesystem share one assemble
+ * pipeline.
  */
 public final class PSVirtualSiteSourceFactory {
 

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
@@ -20,16 +20,19 @@ import com.percussion.services.virtualsite.VirtualSiteConfig.NavSpec;
 import com.percussion.services.virtualsite.VirtualSiteConfig.VersionSpec;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
-/** Loads {@code _config.yaml} from a Virtual Site root. */
+/** Loads {@code _config.yaml} from a Virtual Site root (optional fallback for CSV trees). */
 public final class VirtualSiteConfigLoader {
 
   public static final String DEFAULT_CONFIG_FILE = "_config.yaml";
@@ -60,6 +63,87 @@ public final class VirtualSiteConfigLoader {
     try (InputStream in = Files.newInputStream(configPath)) {
       return parse(root, in, siteKey, configPath.toString());
     }
+  }
+
+  /**
+   * Load {@code _config.yaml} when present; otherwise synthesize a CSV-friendly default from
+   * immediate child version directories (no Markdown tree required).
+   *
+   * <p>Missing config is allowed only for this fallback. A present but invalid YAML still fails
+   * closed. Child folders named {@code assets}, or whose names start with {@code _} or {@code .},
+   * are skipped. Empty trees (no version folder) fail closed.
+   *
+   * @param root Virtual Site root directory
+   * @param configFileName config file name, may be null for default
+   * @param siteKey participant/site key
+   * @return config
+   */
+  public static VirtualSiteConfig loadOrDefault(Path root, String configFileName, String siteKey)
+      throws IOException, VirtualSiteException {
+    if (root == null) {
+      throw new VirtualSiteException("Virtual Site root is null");
+    }
+    String name =
+        configFileName == null || configFileName.isBlank() ? DEFAULT_CONFIG_FILE : configFileName;
+    Path configPath = root.resolve(name);
+    if (Files.isRegularFile(configPath)) {
+      return load(root, name, siteKey);
+    }
+    return defaultFromVersionDirectories(root, siteKey);
+  }
+
+  /**
+   * Infer versions from immediate child directories of {@code root} when {@code _config.yaml} is
+   * omitted (CSV trees).
+   *
+   * @param root site root, not null
+   * @param siteKey participant key
+   * @return config with at least one version
+   */
+  static VirtualSiteConfig defaultFromVersionDirectories(Path root, String siteKey)
+      throws IOException, VirtualSiteException {
+    if (!Files.isDirectory(root)) {
+      throw new VirtualSiteException("CSV site root is not a directory: " + root);
+    }
+    if (!PSVirtualSiteHelper.isSafeRootPath(root)) {
+      throw new VirtualSiteException("CSV site root is missing or unsafe");
+    }
+    Path safeRoot = root.normalize();
+    List<String> folders = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(safeRoot)) {
+      for (Path child : stream) {
+        if (!Files.isDirectory(child)) {
+          continue;
+        }
+        Path normalized = child.normalize();
+        if (!normalized.startsWith(safeRoot)) {
+          throw new VirtualSiteException("Version path escapes site root: " + child);
+        }
+        String folder = child.getFileName().toString();
+        if (folder.startsWith("_")
+            || folder.startsWith(".")
+            || "assets".equalsIgnoreCase(folder)) {
+          continue;
+        }
+        folders.add(folder);
+      }
+    }
+    folders.sort(Comparator.comparing(s -> s.toLowerCase(Locale.ROOT)));
+    if (folders.isEmpty()) {
+      throw new VirtualSiteException(
+          "CSV source has no _config.yaml and no version folder (add _config.yaml or a version"
+              + " directory such as 8.2)");
+    }
+    boolean prefer82 = folders.contains("8.2");
+    List<VersionSpec> versions = new ArrayList<>();
+    boolean first = true;
+    for (String folder : folders) {
+      boolean def = prefer82 ? "8.2".equals(folder) : first;
+      versions.add(new VersionSpec(folder, folder, folder, def));
+      first = false;
+    }
+    String title = siteKey != null && !siteKey.isBlank() ? siteKey : "CSV Site";
+    return new VirtualSiteConfig(safeRoot, title, "", "page.html", versions, List.of(), siteKey);
   }
 
   @SuppressWarnings("unchecked")

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
@@ -17,8 +17,8 @@
 package com.percussion.services.virtualsite;
 
 /**
- * Registered Virtual Site adapter kinds. Phase 1 implements {@link #GIT_FILESYSTEM}; {@link
- * #CSV_FILESYSTEM} is the next filesystem adapter (offline discover/load from CSV).
+ * Registered Virtual Site adapter kinds. {@link #GIT_FILESYSTEM} and {@link #CSV_FILESYSTEM} are
+ * both wired through {@link PSVirtualSiteSourceFactory} for CMS REST Build.
  */
 public enum VirtualSiteSourceType {
   GIT_FILESYSTEM("git-filesystem"),

--- a/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
@@ -306,6 +306,25 @@ class PSCsvFilesystemVirtualSiteSourceTest {
     assertTrue(body.contains("Hello from CSV"), body);
   }
 
+  @Test
+  void buildServiceOptionalConfigYamlEmitsHtml() throws Exception {
+    Path root = tempDir.resolve("build-csv-noconfig");
+    Files.createDirectories(root.resolve("8.2"));
+    Files.writeString(
+        root.resolve("8.2").resolve("pages.csv"),
+        "id,title,body,path\nhome,Bare CSV,Hello.,index.md\n",
+        StandardCharsets.UTF_8);
+    Path out = tempDir.resolve("build-csv-noconfig-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.CSV_FILESYSTEM);
+    PSVirtualSiteBuildResult result = service.build(root, out, "csv-docs");
+    assertEquals(1, result.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String body = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(body.contains("Bare CSV"), body);
+  }
+
   private static Path writeSite(Path root) throws Exception {
     Files.createDirectories(root.resolve("8.2"));
     Files.createDirectories(root.resolve("_theme"));

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -65,6 +65,40 @@ class VirtualSiteConfigLoaderTest {
   }
 
   @Test
+  void loadOrDefaultInfersVersionFoldersWhenYamlMissing() throws Exception {
+    Path root = tempDir.resolve("csv-default");
+    Files.createDirectories(root.resolve("8.2"));
+    Files.createDirectories(root.resolve("_theme"));
+    Files.createDirectories(root.resolve("assets"));
+    VirtualSiteConfig config = VirtualSiteConfigLoader.loadOrDefault(root, null, "csv-docs");
+    assertEquals("csv-docs", config.siteTitle());
+    assertEquals(1, config.versions().size());
+    assertEquals("8.2", config.versions().get(0).id());
+    assertTrue(config.versions().get(0).defaultVersion());
+    assertEquals(root.normalize(), config.root());
+  }
+
+  @Test
+  void loadOrDefaultFailsWhenNoVersionFolders() throws Exception {
+    Path root = tempDir.resolve("csv-empty");
+    Files.createDirectories(root.resolve("_theme"));
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualSiteConfigLoader.loadOrDefault(root, "_config.yaml", "k"));
+    assertTrue(ex.getMessage().toLowerCase().contains("version"), ex.getMessage());
+  }
+
+  @Test
+  void loadOrDefaultUsesYamlWhenPresent() throws Exception {
+    Path sampleRoot = resolveSampleDocs();
+    VirtualSiteConfig config =
+        VirtualSiteConfigLoader.loadOrDefault(sampleRoot, null, "sample");
+    assertEquals("Sample Docs", config.siteTitle());
+    assertEquals("8.2", config.versions().get(0).id());
+  }
+
+  @Test
   void nullRootFails() {
     assertThrows(
         VirtualSiteException.class,


### PR DESCRIPTION
## Summary

Parent: #2678. Slice: REST `csv-filesystem` Virtual Site **Build**.

`POST /sites/{nameOrId}/virtual/build` now runs for `virtual.sourceKind=csv-filesystem`, not git-filesystem only. `SitesAdaptor` no longer rejects non-git kinds; `runBuild` uses `PSVirtualSiteBuildService.forSourceType` / `PSVirtualSiteSourceFactory`. CSV `rootPath` is a CSV tree (`_config.yaml` optional; missing required columns / unsafe `path` values fail closed as 400). git-filesystem build is unchanged. Unknown `sourceKind` remains 400.

Out of scope: Developer Sites Build chrome (#3697), publish copy to `IPSSite.root` (#3699).

Fixes #3698.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `SitesAdaptorTest` CSV real-filesystem build (`pagesWritten > 0`), optional `_config.yaml`, missing column 400, unsafe path 400, unknown kind 400; existing git-filesystem tests.
2. Unit: `SitesResourceTest` temp CSV fixture delegation + OpenAPI `csv-filesystem`.
3. Unit: `VirtualSiteConfigLoaderTest` / `PSCsvFilesystemVirtualSiteSourceTest` optional config fallback.
4. Standalone `mvnw clean install` on `system`, `projects/sitemanage`, `rest` (see C3).
5. `scripts/ci-smoke-product-docs.bat` — OK, 8.2/index.html present.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md`, `developer/virtual-sites.md`, `admin/sites.md`, `admin/publishing.md`, `reference/site-config.md`)
- [x] **Unit / module tests** — behavioral tests for new/changed logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; UI slice is #3697)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when `final`/API shape changes
- [x] **Cross-platform** — path/file I/O uses portable `Path`/`Files`; `@TempDir` fixtures

## C3 evidence

- **modules_built:** `system`, `projects/sitemanage`, `rest`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Surefire Tests run: 2277, Failures: 0, Errors: 0, Skipped: 239)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Surefire Tests run: 1299, Failures: 0, Errors: 0, Skipped: 125)
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Surefire Tests run: 541, Failures: 0, Errors: 0, Skipped: 0)
  - `scripts/ci-smoke-product-docs.bat` — OK
- **downstream_checked:** C2 did not apply (no `final`/`sealed` or public signature break). Installed `system` first then `sitemanage` and `rest`. Grep: no anonymous subclasses of `VirtualSiteConfigLoader` / `SitesAdaptor`.

## C5 UI proof

N/A — REST/adaptor/backend only; no WebUI chrome in this slice.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
