### PR TITLE
feat(sites): csv-filesystem Virtual Site publish REST/UI (#3699)

### DIFF
--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -142,8 +142,8 @@ function validationMessage(
 /**
  * Site detail section: view/edit Virtual Site source fields via public Site REST
  * ({@code GET|PUT /services/sites/{name}/virtual}) and trigger a CMS-integrated
- * build ({@code POST …/virtual/build}) for git-filesystem and csv-filesystem, or
- * publish ({@code POST …/virtual/publish}) for git-filesystem.
+ * build ({@code POST …/virtual/build}) or publish ({@code POST …/virtual/publish})
+ * for git-filesystem and csv-filesystem.
  */
 export function VirtualSiteSourcePanel({
   siteName,
@@ -332,7 +332,7 @@ export function VirtualSiteSourcePanel({
   const csvMode = isCsvFilesystemSourceKind(form.sourceKind);
   /** Build chrome: git-filesystem and csv-filesystem (never repository). */
   const showBuildChrome = shouldShowVirtualBuildChrome(form.sourceKind);
-  /** Publish chrome: git-filesystem only (CSV publish is a later slice). */
+  /** Publish chrome: git-filesystem and csv-filesystem (never repository). */
   const showPublishChrome = shouldShowVirtualPublishChrome(form.sourceKind);
   const busy = saving || building || publishing;
   const buildSummary = buildResult ? formatVirtualSiteBuildSummary(buildResult) : null;

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -770,7 +770,7 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_KIND_GIT_FILESYSTEM: "perc.ui.developer@Git filesystem",
   SITE_VIRT_KIND_CSV_FILESYSTEM: "perc.ui.developer@CSV filesystem",
   SITE_VIRT_CSV_HINT:
-    "perc.ui.developer@CSV filesystem uses the root path only (no Git remote). Save, then Build Virtual Site. Publish remains Git filesystem.",
+    "perc.ui.developer@CSV filesystem uses the root path only (no Git remote). Save, then Build or Publish Virtual Site.",
   SITE_VIRT_STATUS_REPO: "perc.ui.developer@Mode: traditional repository Site",
   SITE_VIRT_STATUS_VIRTUAL: "perc.ui.developer@Mode: Virtual Site",
   SITE_VIRT_ERR_ROOT_REQUIRED:

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -34,12 +34,13 @@ export function shouldShowVirtualBuildChrome(
 
 /**
  * True when the Publish Virtual Site control should be shown.
- * Publish remains git-filesystem only until the CSV publish slice.
+ * Git-filesystem and csv-filesystem both run POST /virtual/publish (build then
+ * copy to IPSSite.root). Repository / blank / unknown kinds stay hidden.
  */
 export function shouldShowVirtualPublishChrome(
   sourceKind: string | null | undefined,
 ): boolean {
-  return (sourceKind ?? "").trim().toLowerCase() === "git-filesystem";
+  return shouldShowVirtualBuildChrome(sourceKind);
 }
 
 /**

--- a/WebUI/src/main/ts/developer/virtualSiteForm.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteForm.ts
@@ -71,7 +71,7 @@ export function isVirtualSourceKind(kind: string | null | undefined): boolean {
   return v.length > 0 && v !== SOURCE_KIND_REPOSITORY;
 }
 
-/** True when source kind is the Git filesystem adapter (Build/Publish chrome). */
+/** True when source kind is the Git filesystem adapter (remote URL/branch fields). */
 export function isGitFilesystemSourceKind(kind: string | null | undefined): boolean {
   return (kind ?? "").trim().toLowerCase() === SOURCE_KIND_GIT_FILESYSTEM;
 }

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -279,7 +279,7 @@ describe("VirtualSiteSourcePanel", () => {
     ).toBe("https://git.example.com/org/docs.git");
   });
 
-  it("loads csv-filesystem values with root path and Build chrome (no Git remotes or Publish)", async () => {
+  it("loads csv-filesystem values with root path and Build/Publish chrome (no Git remotes)", async () => {
     getVirtual.mockResolvedValue({
       sourceKind: "csv-filesystem",
       rootPath: "C:/csv-docs",
@@ -302,7 +302,7 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-build-section")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
-    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
       DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
     );
@@ -357,7 +357,7 @@ describe("VirtualSiteSourcePanel", () => {
     ).toBe("C:/csv-docs");
     expect(screen.getByTestId("developer-site-virtual-build-section")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
-    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
     expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
       DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
     );
@@ -382,6 +382,7 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.queryByTestId("developer-site-virtual-csv-hint")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
   });
 
   it("saves repository mode to clear virtual configuration", async () => {
@@ -483,7 +484,7 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.queryByTestId("developer-site-virtual-build-link-list")).toBeNull();
   });
 
-  it("shows Build chrome for csv-filesystem and success result without Publish", async () => {
+  it("shows Build chrome for csv-filesystem and success result", async () => {
     getVirtual.mockResolvedValue({
       sourceKind: "csv-filesystem",
       rootPath: "C:/csv-docs",
@@ -502,7 +503,7 @@ describe("VirtualSiteSourcePanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
     });
-    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
     fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-site-virtual-build-result")).toBeTruthy();
@@ -514,6 +515,37 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-build-pages").textContent).toBe("2");
     expect(screen.getByTestId("developer-site-virtual-build-output").textContent).toContain(
       "csv-docs",
+    );
+  });
+
+  it("shows Publish chrome for csv-filesystem and success dest path", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "csv-filesystem",
+      rootPath: "C:/csv-docs",
+      virtual: true,
+    });
+    publishVirtual.mockResolvedValue({
+      siteName: "Help",
+      publishPath: "C:/inetpub/wwwroot/csv-help",
+      filesCopied: 4,
+      pagesWritten: 2,
+      hasLinkProblems: false,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-publish"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-publish-result")).toBeTruthy();
+    });
+    expect(publishVirtual).toHaveBeenCalledWith("Help");
+    expect(screen.getByTestId("developer-site-virtual-publish-success").textContent).toContain(
+      DEV_MSG.SITE_VIRT_PUBLISH_SUCCESS,
+    );
+    expect(screen.getByTestId("developer-site-virtual-publish-files").textContent).toBe("4");
+    expect(screen.getByTestId("developer-site-virtual-publish-dest").textContent).toContain(
+      "csv-help",
     );
   });
 

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -25,13 +25,16 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualBuildChrome("CSV-Filesystem")).toBe(true);
   });
 
-  it("shouldShowVirtualPublishChrome only for git-filesystem", () => {
+  it("shouldShowVirtualPublishChrome for git-filesystem and csv-filesystem", () => {
     expect(shouldShowVirtualPublishChrome(null)).toBe(false);
     expect(shouldShowVirtualPublishChrome("")).toBe(false);
     expect(shouldShowVirtualPublishChrome("repository")).toBe(false);
     expect(shouldShowVirtualPublishChrome("Repository")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("sql-api")).toBe(false);
     expect(shouldShowVirtualPublishChrome("git-filesystem")).toBe(true);
-    expect(shouldShowVirtualPublishChrome("csv-filesystem")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("  git-filesystem  ")).toBe(true);
+    expect(shouldShowVirtualPublishChrome("csv-filesystem")).toBe(true);
+    expect(shouldShowVirtualPublishChrome("CSV-Filesystem")).toBe(true);
   });
 
   it("formatVirtualSitePublishSummary reports files copied and dest path", () => {

--- a/docs/ai-generated/code-reviews/3699-csv-filesystem-virtual-publish-erlang.md
+++ b/docs/ai-generated/code-reviews/3699-csv-filesystem-virtual-publish-erlang.md
@@ -1,0 +1,51 @@
+# Erlang review — #3699 REST/UI csv-filesystem virtual/publish
+
+**Branch:** `feat/issue-3699-csv-filesystem-virtual-publish`  
+**Stacked on:** cluster #3705 (`cluster/night-issue-20260821-csv-virtual-site`)  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve  
+**Memory patterns hit:** change-class closure (adaptor tests + Playwright + product-docs); portable Path/Files; fail-closed unsafe roots; WebUI Playwright HARD GATE
+
+## Summary
+
+Parent #2678 slice. `POST /sites/{nameOrId}/virtual/publish` already built-then-copied for any Virtual Site; this slice proves **csv-filesystem**, shows Developer Sites **Publish** chrome (hidden for repository), and documents it.
+
+Relative `IPSSite.root` values (H2 demo `../CI_Home`) are resolved against the CMS install directory with NIO `Path` before the remaining-`..` check — peer of `PSRxPublisherService` archive location resolution. Fail-closed when relative and no install root.
+
+## Change class
+
+REST/UI Virtual Site publish for csv-filesystem (peer git-filesystem #3301 / UI #3366).
+
+## Companions
+
+| Kind | Present |
+|------|---------|
+| Adaptor tests (CSV fixture + injected `buildRunner`) | yes — `SitesAdaptorTest` |
+| REST OpenAPI notes | yes — `SitesResource` publish description |
+| WebUI chrome + Vitest | yes — `shouldShowVirtualPublishChrome` |
+| Playwright surface spec | yes — intercept + live H2 |
+| product-docs 8.2 | yes — admin Sites/Publishing, developer REST/virtual-sites, reference site-config |
+| Cross-platform Path I/O | yes — `Path.of` / `resolve` / `normalize`; no hardcoded separators |
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] Relative Site root resolved with `Path.resolve` against install dir
+- [x] Tests do not assert Unix-only absolute path strings
+- [x] CSV QA fixture still uses POSIX in-container path (URL/container path, not OS join)
+
+## Issues
+
+None.
+
+## Tests / evidence
+
+- `system` clean install — BUILD SUCCESS; `PSVirtualSiteFilesystemPublisherTest` Tests run: 13, Failures: 0
+- `rest` clean install — BUILD SUCCESS; Tests run: 544, Failures: 0
+- `projects/sitemanage` clean install — BUILD SUCCESS; `SitesAdaptorTest` Tests run: 51, Failures: 0
+- `WebUI` clean install — BUILD SUCCESS; Vitest Tests 2997 passed
+- Playwright `developer-site-virtual-source.spec.js` 10/10 on H2 QA (`TEST_CMS_URL=http://127.0.0.1:9993`)
+- console-clean=yes; server.log-clean=yes (no virtual/publish ERROR/FATAL)
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -19,11 +19,11 @@
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
  * with source-kind control (repository default, git-filesystem, csv-filesystem),
- * save chrome, Build chrome for git-filesystem and csv-filesystem (never repository),
- * and Publish chrome for git-filesystem only (CSV publish is a later slice).
- * Also intercepts build REST to prove link-problem detail lines render on HTTP 200
- * and publish REST to prove dest path + files copied on HTTP 200. Live H2 QA
- * deploys a CSV tree into the cell and asserts POST /virtual/build completes.
+ * save chrome, Build and Publish chrome for git-filesystem and csv-filesystem
+ * (never repository). Also intercepts build REST to prove link-problem detail
+ * lines render on HTTP 200 and publish REST to prove dest path + files copied
+ * on HTTP 200 (including csv-filesystem). Live H2 QA deploys a CSV tree into the
+ * cell and asserts POST /virtual/build and POST /virtual/publish complete.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -134,7 +134,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
       }
 
-      // Switch to csv-filesystem reveals root path + Build (no Git remotes / Publish)
+      // Switch to csv-filesystem reveals root path + Build / Publish (no Git remotes)
       await kind.selectOption("csv-filesystem");
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-csv-hint"]')).toBeVisible();
@@ -143,7 +143,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
-      await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
 
       // Switch to git-filesystem reveals root path, optional remote, + Build / Publish
       await kind.selectOption("git-filesystem");
@@ -159,15 +159,22 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-publish-hint"]')).toBeVisible();
 
-      // Preview without a last build: in-panel empty/error (no 500 / no crash)
+      // Preview: empty/error when no last build, or a same-origin popup when a prior
+      // live CSV build left output on this site. Either is fail-closed (no 500 / crash).
+      const previewPopupPromise = page.waitForEvent("popup", { timeout: 20_000 }).catch(() => null);
       await page.locator('[data-testid="developer-site-virtual-preview"]').click();
-      const previewChrome = page.locator(
-        [
-          '[data-testid="developer-site-virtual-preview-error"]',
-          '[data-testid="developer-site-virtual-build-error"]',
-        ].join(", "),
-      );
-      await expect(previewChrome.first()).toBeVisible({ timeout: 20_000 });
+      const previewPopup = await previewPopupPromise;
+      if (previewPopup) {
+        await previewPopup.close();
+      } else {
+        const previewChrome = page.locator(
+          [
+            '[data-testid="developer-site-virtual-preview-error"]',
+            '[data-testid="developer-site-virtual-build-error"]',
+          ].join(", "),
+        );
+        await expect(previewChrome.first()).toBeVisible({ timeout: 20_000 });
+      }
 
       // Optional: click Build without save — expect client validation or API error chrome
       // (H2 QA rarely has a saved virtual root; do not require full build success)
@@ -269,7 +276,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     );
     await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
-    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
 
     await kind.selectOption("repository");
     await page.locator('[data-testid="developer-site-virtual-save"]').click();
@@ -838,7 +845,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(page.locator('[data-testid="developer-site-virtual-csv-hint"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
-    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
 
     await page.locator('[data-testid="developer-site-virtual-root-path"]').fill("C:/csv-docs");
     await page.locator('[data-testid="developer-site-virtual-save"]').click();
@@ -859,7 +866,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     );
     await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
-    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
 
     await kind.selectOption("repository");
     lastPutBody = null;
@@ -869,6 +876,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     });
     expect(lastPutBody.VirtualSiteProperties.sourceKind).toBe("repository");
     await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 
@@ -977,7 +985,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
     await page.locator('[data-testid="developer-site-virtual-build"]').click();
     await expect(page.locator('[data-testid="developer-site-virtual-build-result"]')).toBeVisible({
       timeout: 20_000,
@@ -1034,7 +1042,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       timeout: 20_000,
     });
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
-    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
 
     const buildRespPromise = page.waitForResponse(
       (resp) =>
@@ -1061,6 +1069,209 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
       timeout: 15_000,
     });
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
+
+  test("csv-filesystem publish result shows files copied on HTTP 200 (#3699)", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      if (/Failed to load resource:.*404/.test(text)) {
+        return;
+      }
+      consoleErrors.push(text);
+    });
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual/publish", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          siteName: "Help",
+          siteKey: "csv-docs",
+          publishPath: "C:/inetpub/wwwroot/csv-help",
+          buildOutputPath: "C:/tmp/virtual-sites/csv-docs",
+          pagesWritten: 2,
+          filesCopied: 4,
+          linkProblemCount: 0,
+          hasLinkProblems: false,
+        }),
+      });
+    });
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/virtual/publish") || url.includes("/virtual/build")) {
+        await route.fallback();
+        return;
+      }
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sourceKind: "csv-filesystem",
+          rootPath: "C:/csv-docs",
+          virtual: true,
+        }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+
+    const empty = page.locator('[data-testid="developer-site-empty"]');
+    if (await empty.isVisible().catch(() => false)) {
+      throw new Error(
+        "No sites in catalog — CSV Virtual Site publish intercept requires a site row",
+      );
+    }
+    const err = page.locator('[data-testid="developer-site-error"]');
+    if (await err.isVisible().catch(() => false)) {
+      throw new Error(`Sites catalog error: ${await err.textContent()}`);
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.locator('[data-testid="developer-site-virtual-publish"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-result"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-success"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-files"]')).toHaveText(
+      "4",
+    );
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-dest"]')).toContainText(
+      "csv-help",
+    );
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("csv-filesystem live Publish Virtual Site completes on H2 QA (#3699)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    const csvRoot = deployCsvVirtualFixtureToQaCell();
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      throw new Error("No sites in catalog — live CSV Publish requires a site row");
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const kind = page.locator('[data-testid="developer-site-virtual-source-kind"]');
+    await kind.selectOption("csv-filesystem");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill(csvRoot);
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
+
+    const publishRespPromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" && /\/virtual\/publish(\?|$)/.test(resp.url()),
+    );
+    await page.locator('[data-testid="developer-site-virtual-publish"]').click();
+    const publishResp = await publishRespPromise;
+    const publishBody = await publishResp.text();
+    expect(
+      publishResp.ok(),
+      `POST /virtual/publish HTTP ${publishResp.status()}: ${publishBody}`,
+    ).toBeTruthy();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-result"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-publish-success"]')).toBeVisible();
+    const filesText = (
+      await page.locator('[data-testid="developer-site-virtual-publish-files"]').textContent()
+    ).trim();
+    expect(Number.parseInt(filesText, 10), `files copied: ${filesText}`).toBeGreaterThan(0);
+
+    await kind.selectOption("repository");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/helpers/csv-virtual-qa-fixture.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/csv-virtual-qa-fixture.js
@@ -16,7 +16,8 @@
 
 /**
  * Copy the CSV Virtual Site QA fixture into the H2 Docker cell so
- * Developer Sites Build can POST /virtual/build against a real tree.
+ * Developer Sites Build/Publish can POST /virtual/build and /virtual/publish
+ * against a real tree.
  */
 
 const { execFileSync } = require("node:child_process");

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -46,12 +46,13 @@ For Git/filesystem or CSV/filesystem Virtual Sites such as product documentation
 ### Publish a Virtual Site to the Site filesystem target
 
 1. Sign in as **Admin**.
-2. Configure the Site as a Git-filesystem Virtual Site (see [Sites](id:admin-sites)).
+2. Configure the Site as a Git-filesystem or CSV-filesystem Virtual Site (see [Sites](id:admin-sites)).
 3. Set the Site **publishing filesystem root** (Site root) to a dedicated directory on the CMS
-   host. Do **not** point it at `virtual.rootPath` (the Markdown source tree).
+   host. Relative roots (legacy values such as `../CI_Home`) are resolved against the CMS
+   install directory. Do **not** point it at `virtual.rootPath` (the Markdown or CSV source tree).
 4. Confirm the source root exists on the host and that the publish directory is writable.
-5. From **Developer → Sites → Site detail**, choose **Publish Virtual Site** (visible only
-   when source kind is Virtual). The panel reports files copied and the destination path,
+5. From **Developer → Sites → Site detail**, choose **Publish Virtual Site** (visible for
+   **Git filesystem** and **CSV filesystem**; hidden for repository). The panel reports files copied and the destination path,
    or a clear error. Integrators can call `POST /services/sites/{nameOrId}/virtual/publish`
    instead. Run **Build Virtual Site** first if you only want staging output.
 6. On success, the result includes `publishPath`, `filesCopied`, `pagesWritten`, and any

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -71,7 +71,7 @@ and Markdown tooling, not the classic page editor.
 
 | Property | Required | Example | Notes |
 |----------|----------|---------|-------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**. Blank or `repository` = traditional Site. Developer Sites can save either kind. **Build Virtual Site** (REST and Developer Sites) runs the matching adapter. CSV trees may omit `_config.yaml` (see [Virtual Sites](id:developer-virtual-sites)). Unknown kinds are rejected. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**. Blank or `repository` = traditional Site. Developer Sites can save either kind. **Build Virtual Site** and **Publish Virtual Site** (REST and Developer Sites) run the matching adapter. CSV trees may omit `_config.yaml` (see [Virtual Sites](id:developer-virtual-sites)). Unknown kinds are rejected. |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` | Local tree when `virtual.remoteUrl` is blank. Prefer absolute portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. When a remote is set, use a **relative** folder inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones or fetches into a contained server work directory, then discovers Markdown as usual. Blank = local-path mode. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. |
 | `virtual.branch` | No | `main` | Branch to checkout when a remote is set. Default `main`. |
@@ -155,9 +155,8 @@ blank). Load failures show **Could not load sites** rather than the empty state.
    `sourceKind` object). For CSV it sends `{ "VirtualSiteProperties": {
    "sourceKind": "csv-filesystem", "rootPath": "…" } }` (no `remoteUrl`). After
    a successful save the panel reloads properties from GET so the kind and root
-   persist without a full page reload. **Build Virtual Site** appears for
-   **Git filesystem** and **CSV filesystem**. **Publish Virtual Site** remains
-   Git filesystem only.
+   persist without a full page reload. **Build Virtual Site** and **Publish
+   Virtual Site** appear for **Git filesystem** and **CSV filesystem**.
 6. To return a Virtual Site to traditional repository mode, set source kind back to
    **Repository (traditional)** and save (clears `virtual.*` properties). Switching
    the select back to Repository hides virtual fields immediately; Save is still
@@ -184,10 +183,9 @@ require a Git remote; `_config.yaml` is optional.
 
 ### Build a Virtual Site from the product UI
 
-When **Source kind** is **Git filesystem** or **CSV filesystem**, the Site detail panel shows a
-**Build Virtual Site** control. Traditional **Repository** Sites do **not** show this control
-(no misleading virtual-build chrome). **Publish Virtual Site** still appears for Git
-filesystem only.
+When **Source kind** is **Git filesystem** or **CSV filesystem**, the Site detail panel shows
+**Build Virtual Site** and **Publish Virtual Site**. Traditional **Repository** Sites do **not**
+show these controls (no misleading virtual-build or virtual-publish chrome).
 
 1. Sign in as an **Admin** (the build REST operation requires Admin).
 2. Open **Developer** → **Sites** and open the Virtual Site detail.
@@ -250,8 +248,9 @@ site to the Site's configured filesystem publish location:
 1. Set the Site **publishing filesystem root** (Site root / `IPSSite.root`) to a dedicated
    directory on the CMS host (not the Markdown `virtual.rootPath`).
 2. As **Admin**, open **Developer → Sites → Site detail** for the Virtual Site.
-3. Confirm **Source kind** is **Git filesystem** and **Save Virtual Site source** if you
-   changed properties. Traditional **Repository** Sites never show Publish chrome.
+3. Confirm **Source kind** is **Git filesystem** or **CSV filesystem** and **Save Virtual
+   Site source** if you changed properties. Traditional **Repository** Sites never show
+   Publish chrome.
 4. Choose **Publish Virtual Site**. The panel shows a busy state, then success with
    **files copied** and the **destination path**, or a clear error (not Admin, still a
    repository Site on the server, missing or unsafe Site root).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -135,7 +135,7 @@ Explorer chrome does not probe the named preference. A blank list entry (or no e
 | Virtual build | `POST /services/sites/{nameOrId}/virtual/build` | Admin-only; `git-filesystem` or `csv-filesystem`. Git fetches `remoteUrl` when set; CSV reads a local CSV tree (`rootPath`; optional `_config.yaml`). Same action as **Developer → Sites → Build Virtual Site**. Unknown `sourceKind` is **400**. |
 | Virtual preview status | `GET /services/sites/{nameOrId}/virtual/preview` | Admin-only; last build availability |
 | Virtual preview file | `GET /services/sites/{nameOrId}/virtual/preview/{relPath}` | Admin-only; assembled file stream |
-| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; build then copy to Site filesystem root. Same action as **Developer → Sites → Publish Virtual Site** |
+| Virtual publish | `POST /services/sites/{nameOrId}/virtual/publish` | Admin-only; `git-filesystem` or `csv-filesystem`. Builds then copies assembled files to the Site filesystem root (`IPSSite.root`). Same action as **Developer → Sites → Publish Virtual Site**. Repository / unknown kinds are **400**. |
 
 An HTTP 200 list with Site entries must bind in **Developer → Sites**. Empty catalog chrome
 appears only when this list **and** the sitemanage `GET /sitemanage/site/` `SiteSummary` fallback

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -13,8 +13,9 @@ tags: [developer, virtual-sites]
 repository. Phase 1 delivers a **Git / filesystem** adapter aimed at product documentation. A
 **CSV / filesystem** adapter (`csv-filesystem`) discovers the same assemble pipeline from
 CSV files. Operators can run it offline (CLI) or from CMS REST
-`POST /sites/{nameOrId}/virtual/build`. Developer **Sites** shows **Build Virtual Site**
-for **CSV filesystem** as well as Git filesystem.
+`POST /sites/{nameOrId}/virtual/build` and `POST /sites/{nameOrId}/virtual/publish`.
+Developer **Sites** shows **Build Virtual Site** and **Publish Virtual Site** for
+**CSV filesystem** as well as Git filesystem.
 
 Operators can create a **Virtual** type from **Content Explorer → Create Site** or
 **Navigation → New Site**. That flow does not prompt for managed navigation or a page template.
@@ -166,8 +167,9 @@ REST `PUT /sites/{nameOrId}/virtual` may store `sourceKind=csv-filesystem` (allo
 Developer Sites can select **CSV filesystem** and save a root path. **Build Virtual Site**
 (`POST …/virtual/build`) discovers CSV rows under `virtual.rootPath` and writes HTML
 (`pagesWritten` in the JSON result). Developer **Sites** shows the same **Build Virtual Site**
-control for **CSV filesystem** (and Git filesystem). Unknown kinds remain **400**.
-Publish to the Site filesystem for CSV is a later slice.
+control for **CSV filesystem** (and Git filesystem). **Publish Virtual Site**
+(`POST …/virtual/publish`) then copies assembled HTML to the Site filesystem root.
+Unknown kinds remain **400**.
 
 ## CMS-integrated build (REST and WebUI)
 
@@ -218,8 +220,8 @@ without reloading the page.
 
 CSV trees use the same envelope with `"sourceKind": "csv-filesystem"` and a portable-safe
 `rootPath` (no remaining `..` after NIO normalize). `GET` after `PUT` returns `csv-filesystem`.
-`virtual.remoteUrl` is not valid for CSV (HTTP 400). In-product `POST …/virtual/build` remains
-`git-filesystem` only.
+`virtual.remoteUrl` is not valid for CSV (HTTP 400). In-product `POST …/virtual/build` and
+`POST …/virtual/publish` run for both `git-filesystem` and `csv-filesystem`.
 
 ### Git remote fetch before Build
 
@@ -286,7 +288,7 @@ POST /sites/{nameOrId}/virtual/publish
 
 The server:
 
-1. Validates the Site is a Git-filesystem Virtual Site.
+1. Validates the Site is a Git-filesystem or CSV-filesystem Virtual Site.
 2. Selects the Site filesystem publish root (must be configured, safe after NIO normalize, and
    distinct from `virtual.rootPath`).
 3. Runs the same build as `POST …/virtual/build`.
@@ -300,7 +302,6 @@ silent no-op). See [Publishing](id:admin-publishing).
 
 - CMS UI editing of Virtual items as normal content types
 - Automatic migration of the full legacy help site
-- Publish assembled CSV output to the Site filesystem (`POST …/virtual/publish`)
 - SQL/API adapters
 - Fake classic content-list generators for virtual items
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -111,7 +111,7 @@ When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` co
 
 | Property name | Required | Example | Meaning |
 |---------------|----------|---------|---------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. REST **Build** (`POST …/virtual/build`) runs the matching adapter. `csv-filesystem` required columns: `id`, `title`, `body`; optional `_config.yaml`. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` or `csv-filesystem` | Adapter wire name. **Allow-list:** `git-filesystem`, `csv-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. REST **Build** (`POST …/virtual/build`) and **Publish** (`POST …/virtual/publish`) run the matching adapter. `csv-filesystem` required columns: `id`, `title`, `body`; optional `_config.yaml`. |
 | `virtual.rootPath` | Yes when remote is blank | absolute or install-relative path to tree | Local filesystem source root when `virtual.remoteUrl` is blank. NIO `Path` normalize; no empty path / remaining `..`. When a remote is set, optional relative path inside the checkout. |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones/fetches into `{install}/tmp/virtual-site-checkouts/{siteKey}`. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. Fail-closed on `..`, `http`, option injection. Credentials are never logged. |
 | `virtual.branch` | No | `main` | Branch to checkout when `remoteUrl` is set. Default `main`. |
@@ -219,8 +219,10 @@ the preview prefix so the assembled site is navigable in the browser. Missing fi
 
 #### Publish Virtual Site (`POST …/virtual/publish`)
 
-Runs the same build, then copies the assembled tree to the Site **filesystem publish location**
-(`IPSSite.root`). Requires **Admin**. Staging `_meta` is not copied.
+Runs the same build for `git-filesystem` or `csv-filesystem`, then copies the assembled tree
+to the Site **filesystem publish location** (`IPSSite.root`) using portable NIO `Path` /
+`Files`. Relative Site roots are resolved against the CMS install directory, then rejected if
+any `..` remains. Requires **Admin**. Staging `_meta` is not copied.
 
 | Status | When |
 |--------|------|
@@ -229,9 +231,10 @@ Runs the same build, then copies the assembled tree to the Site **filesystem pub
 | `403` | Caller is not Admin |
 | `404` | Site not found |
 
-Configure a dedicated Site root (not the Markdown source path). Operators can run the same
-action from **Developer → Sites → Site detail → Publish Virtual Site** (Admin; hidden for
-repository Sites). See [Publishing](id:admin-publishing).
+Configure a dedicated Site root (not the Markdown or CSV source path). Operators can run the
+same action from **Developer → Sites → Site detail → Publish Virtual Site** (Admin; **Git
+filesystem** and **CSV filesystem**; hidden for repository Sites). See
+[Publishing](id:admin-publishing).
 
 ## Related
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SitesAdaptor.java
@@ -424,6 +424,10 @@ public class SitesAdaptor implements ISiteAdaptor {
     }
   }
 
+  /**
+   * Build then NIO-copy assembled files to {@link IPSSite#getRoot()} for git-filesystem and
+   * csv-filesystem Virtual Sites. Fail-closed on blank/unsafe/overlapping publish roots.
+   */
   @Override
   public VirtualSitePublishResult publishVirtualSite(String nameOrId) {
     requireAdmin();

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SitesAdaptorTest.java
@@ -825,6 +825,100 @@ class SitesAdaptorTest {
   }
 
   @Test
+  void publishVirtualSite_csvFilesystemInjectedBuildRunnerCopiesToSiteRoot() throws Exception {
+    Path siteRoot = createMinimalCsvTree(tempDir.resolve("csv-pub-src"));
+    Path staging = tempDir.resolve("csv-pub-staging");
+    Path publishTo = tempDir.resolve("csv-pub-target");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    site.setRoot(publishTo.toString());
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "csv-docs");
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    SitesAdaptor.BuildRunner runner =
+        (config, outputRoot) -> {
+          Files.createDirectories(outputRoot.resolve("8.2"));
+          Files.writeString(
+              outputRoot.resolve("8.2").resolve("index.html"),
+              "<html>CSV published</html>",
+              StandardCharsets.UTF_8);
+          Files.createDirectories(outputRoot.resolve("_meta"));
+          Files.writeString(
+              outputRoot.resolve("_meta").resolve("skip.txt"),
+              "not published",
+              StandardCharsets.UTF_8);
+          return new PSVirtualSiteBuildResult(
+              outputRoot, 1, List.of(), List.of("8.2/index.html"));
+        };
+
+    SitesAdaptor publishing =
+        new SitesAdaptor(siteManager, () -> true, key -> staging, runner);
+
+    VirtualSitePublishResult result = publishing.publishVirtualSite("CsvHelp");
+    assertEquals("CsvHelp", result.getSiteName());
+    assertEquals("csv-docs", result.getSiteKey());
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(result.getFilesCopied() >= 1);
+    Path html = publishTo.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    assertTrue(
+        Files.readString(html, StandardCharsets.UTF_8).contains("CSV published"),
+        Files.readString(html, StandardCharsets.UTF_8));
+    assertFalse(Files.exists(publishTo.resolve("_meta")));
+    assertTrue(result.getPublishPath() != null && !result.getPublishPath().isBlank());
+  }
+
+  @Test
+  void publishVirtualSite_csvFilesystemBuildsThenCopiesToSiteRoot() throws Exception {
+    Path siteRoot = createMinimalCsvTree(tempDir.resolve("csv-real-pub-src"));
+    Path staging = tempDir.resolve("csv-real-pub-staging");
+    Path publishTo = tempDir.resolve("csv-real-pub-target");
+
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    site.setRoot(publishTo.toString());
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, siteRoot.toAbsolutePath().toString());
+    put(site, PSVirtualSiteHelper.PROP_SITE_KEY, "csv-docs");
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    SitesAdaptor publishing =
+        new SitesAdaptor(siteManager, () -> true, key -> staging, null);
+
+    VirtualSitePublishResult result = publishing.publishVirtualSite("CsvHelp");
+    assertEquals("CsvHelp", result.getSiteName());
+    assertEquals(1, result.getPagesWritten().intValue());
+    assertTrue(result.getFilesCopied() >= 1);
+    Path html = publishTo.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String body = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(body.contains("CSV Home"), body);
+    assertTrue(body.contains("Hello from CSV"), body);
+    assertFalse(Files.exists(publishTo.resolve("_meta")));
+  }
+
+  @Test
+  void publishVirtualSite_csvFilesystemRejectsUnsafeSiteRoot() {
+    PSSite site = new PSSite();
+    site.setName("CsvHelp");
+    site.setGUID(siteGuid);
+    site.setRoot(Path.of("a", "..", "..", "etc").toString());
+    put(site, PSVirtualSiteHelper.PROP_SOURCE_KIND, "csv-filesystem");
+    put(site, PSVirtualSiteHelper.PROP_ROOT_PATH, tempDir.resolve("csv-src").toString());
+    when(siteManager.findSite("CsvHelp")).thenReturn(site);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.publishVirtualSite("CsvHelp"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
   void publishVirtualSite_buildsThenCopiesToSiteRoot() throws Exception {
     Path siteRoot = createMinimalVirtualTree(tempDir.resolve("pub-src"));
     Path staging = tempDir.resolve("pub-staging");

--- a/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sites/ISiteAdaptor.java
@@ -139,8 +139,8 @@ public interface ISiteAdaptor {
   VirtualSitePreviewFile previewVirtualSiteFile(String nameOrId, String relativePath);
 
   /**
-   * Builds a Virtual Site and copies the static output to the Site filesystem publish root ({@code
-   * IPSSite.getRoot()}).
+   * Builds a Virtual Site ({@code git-filesystem} or {@code csv-filesystem}) and copies the static
+   * output to the Site filesystem publish root ({@code IPSSite.getRoot()}).
    *
    * <p>Publish-includes-build: operators get a published docs tree at the configured Site
    * publishing location, not only {@code tmp/virtual-sites}. Failures are operator-facing 4xx (not

--- a/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
+++ b/rest/src/main/java/com/percussion/rest/sites/SitesResource.java
@@ -410,11 +410,12 @@ public class SitesResource {
   @Operation(
       summary = "Publish Virtual Site to Site filesystem target",
       description =
-          "Runs the Phase 1 Virtual Site static build (same as POST …/virtual/build) then copies"
-              + " assembled HTML/assets to the Site publishing filesystem location (IPSSite.root)."
-              + " Requires Admin. Traditional repository Sites, missing/unsafe Site root, or"
-              + " overlap with virtual.rootPath return 4xx with an operator-readable message"
-              + " (never a silent no-op).",
+          "Runs the Virtual Site static build (same as POST …/virtual/build) for git-filesystem"
+              + " or csv-filesystem, then copies assembled HTML/assets to the Site publishing"
+              + " filesystem location (IPSSite.root) using portable NIO Path I/O. Requires Admin."
+              + " Traditional repository Sites, missing/unsafe Site root, or overlap with"
+              + " virtual.rootPath return 4xx with an operator-readable message (never a silent"
+              + " no-op).",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sites/SitesResourceTest.java
@@ -363,6 +363,11 @@ public class SitesResourceTest {
     assertTrue(
         text.contains("csv-filesystem"),
         "buildVirtualSite OpenAPI description must mention csv-filesystem");
+    String publishBlock =
+        text.substring(text.indexOf("@Path(\"/{nameOrId}/virtual/publish\")"));
+    assertTrue(
+        publishBlock.contains("csv-filesystem"),
+        "publishVirtualSite OpenAPI description must mention csv-filesystem");
     assertTrue(
         text.contains(
             "return requireAdaptor().getVirtualSitePreviewStatus(nameOrId); // codeql[java/xss]"),

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisher.java
@@ -17,6 +17,8 @@
 package com.percussion.services.virtualsite;
 
 import com.percussion.services.sitemgr.IPSSite;
+import com.percussion.utils.io.PathUtils;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -42,11 +44,28 @@ public final class PSVirtualSiteFilesystemPublisher {
   /**
    * Resolve the Site filesystem publish target from {@link IPSSite#getRoot()}.
    *
+   * <p>Relative roots (legacy demo values such as {@code ../CI_Home}) are resolved against the CMS
+   * install directory with portable NIO {@link Path}, then re-checked for remaining {@code ..}.
+   *
    * @param site CMS Site, not null
    * @return normalized target path (not required to exist yet)
    * @throws VirtualSiteException when root is blank, unsafe, or overlaps the Virtual source tree
    */
   public static Path selectFilesystemTarget(IPSSite site) throws VirtualSiteException {
+    return selectFilesystemTarget(site, detectInstallRoot());
+  }
+
+  /**
+   * Resolve the Site filesystem publish target, using {@code installRoot} for relative Site roots.
+   *
+   * @param site CMS Site, not null
+   * @param installRoot CMS install directory used to resolve relative {@link IPSSite#getRoot()}
+   *     values; may be null (relative roots then fail closed)
+   * @return normalized target path (not required to exist yet)
+   * @throws VirtualSiteException when root is blank, unsafe, or overlaps the Virtual source tree
+   */
+  public static Path selectFilesystemTarget(IPSSite site, Path installRoot)
+      throws VirtualSiteException {
     if (site == null) {
       throw new VirtualSiteException("Site is required to select a filesystem publish target.");
     }
@@ -58,11 +77,22 @@ public final class PSVirtualSiteFilesystemPublisher {
     }
     Path target;
     try {
-      target = Path.of(raw.trim()).normalize();
+      target = Path.of(raw.trim());
     } catch (InvalidPathException e) {
       throw new VirtualSiteException(
           "Site filesystem publish root is not a valid path: '" + raw.trim() + "'.", e);
     }
+    if (!target.isAbsolute()) {
+      if (installRoot == null || !PSVirtualSiteHelper.isSafeRootPath(installRoot)) {
+        throw new VirtualSiteException(
+            "Site filesystem publish root is relative and cannot be resolved against the CMS"
+                + " install directory. Rejected: '"
+                + raw.trim()
+                + "'.");
+      }
+      target = installRoot.toAbsolutePath().normalize().resolve(target);
+    }
+    target = target.normalize();
     if (!PSVirtualSiteHelper.isSafeRootPath(target)) {
       throw new VirtualSiteException(
           "Site filesystem publish root must be a non-empty path with no '..' segments after"
@@ -163,6 +193,26 @@ public final class PSVirtualSiteFilesystemPublisher {
   public static int copyBuildFileCountToTarget(Path buildOutput, Path target)
       throws VirtualSiteException, IOException {
     return copyBuildToTarget(buildOutput, target).filesCopied();
+  }
+
+  /**
+   * CMS install directory for resolving relative {@link IPSSite#getRoot()} values. Fail-closed
+   * ({@code null}) when the install root is missing or unsafe.
+   */
+  static Path detectInstallRoot() {
+    try {
+      File rx = PathUtils.getRxDir();
+      if (rx == null) {
+        return null;
+      }
+      Path install = rx.toPath().toAbsolutePath().normalize();
+      if (!PSVirtualSiteHelper.isSafeRootPath(install)) {
+        return null;
+      }
+      return install;
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   static boolean isMetaTree(Path relative) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteFilesystemPublisherTest.java
@@ -52,8 +52,31 @@ class PSVirtualSiteFilesystemPublisherTest {
     VirtualSiteException ex =
         assertThrows(
             VirtualSiteException.class,
-            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site));
-    assertTrue(ex.getMessage().contains(".."));
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site, null));
+    assertTrue(
+        ex.getMessage().toLowerCase().contains("relative")
+            || ex.getMessage().contains(".."),
+        ex.getMessage());
+  }
+
+  @Test
+  void selectFilesystemTarget_resolvesRelativeRootAgainstInstallDir() throws Exception {
+    Path install = tempDir.resolve("install").normalize();
+    Path virtualSrc = tempDir.resolve("src").normalize();
+    PSSite site = virtualSite(virtualSrc, Path.of("..", "CI_Home").toString());
+    Path selected = PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site, install);
+    assertEquals(install.getParent().resolve("CI_Home").normalize(), selected);
+    assertFalse(selected.toString().contains(".."));
+  }
+
+  @Test
+  void selectFilesystemTarget_relativeRootWithoutInstallFailsClosed() {
+    PSSite site = virtualSite(tempDir.resolve("src"), "../CI_Home");
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSVirtualSiteFilesystemPublisher.selectFilesystemTarget(site, null));
+    assertTrue(ex.getMessage().toLowerCase().contains("relative"), ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## Summary

CSV-filesystem Virtual Sites can **Publish** to the Site filesystem target, peer of git-filesystem (#3301 / UI #3366).

`POST /sites/{nameOrId}/virtual/publish` already ran build-then-NIO-copy for any Virtual Site. This slice:

- Proves **csv-filesystem** with adaptor tests (CSV fixture + injected `buildRunner`)
- Shows Developer Sites **Publish Virtual Site** chrome for csv-filesystem; hides it for repository
- Resolves relative `IPSSite.root` values (H2 demo `../CI_Home`) against the CMS install directory with portable `Path`, then fail-closes if `..` remains
- Updates product-docs 8.2 admin Sites + Publishing, developer REST + Virtual Sites, and site-config reference

Stacked on cluster **#3705** (`cluster/night-issue-20260821-csv-virtual-site`) because csv save/build is not on `main` yet. Do not merge before #3705.

Parent: #2678.

Fixes #3699

## Test plan

1. Standalone `mvnw clean install` on `system`, `rest`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation` (see C3).
2. `scripts/ci-smoke-product-docs.bat` — 23 pages OK.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health`.
4. Hot-deploy `perc-system`, `rest`, `sitemanage` into `WEB-INF/lib` plus `WebUI/target/generated-webui/cm/modern/assets`; `StopJetty.sh` / `StartJetty.sh` inside the cell (not `docker restart`); `qa-health` again.
5. `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` with printed `TEST_CMS_URL`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md`, `admin/publishing.md`, `developer/rest.md`, `developer/virtual-sites.md`, `reference/site-config.md`
- [x] **Unit / module tests** — adaptor CSV publish tests; publisher relative-root tests; Vitest chrome; REST OpenAPI guard
- [x] **WebUI + Playwright** — `developer-site-virtual-source.spec.js` intercept + live H2 Publish
- [x] **Build gates** — standalone clean install on each changed module; no skipTests
- [x] **Cross-platform** — NIO `Path.of` / `resolve` / `normalize`; no hardcoded separators

### C3 evidence

- **modules_built:** `system,rest,projects/sitemanage,WebUI,modules/perc-qa-automation`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS** (01:46 min). Tests run: 2280, Failures: 0, Errors: 0, Skipped: 239 (`PSVirtualSiteFilesystemPublisherTest` 13 passed)
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS** (23.756 s). Tests run: 544, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (56.397 s). Tests run: 1305, Failures: 0, Errors: 0, Skipped: 125 (`SitesAdaptorTest` 51 passed)
  - `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS** (02:01 min). Vitest Tests 2997 passed (390 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (3.071 s). `npm run test:unit` — 437 passed, 0 failed
  - `scripts/ci-smoke-product-docs.bat` — OK (23 pages)
- **downstream_checked:** no `final`/`sealed`/signature break. Added overload `selectFilesystemTarget(IPSSite, Path)` (existing one-arg still present). Grep `extends PSVirtualSiteFilesystemPublisher` / `extends SitesAdaptor` — none. `ISiteAdaptor` javadoc-only.

### C5 UI proof

- `perc-devctl qa-up --skip-image-build`; `qa-health` **RESULT:OK HTTP:200 HEALTH:healthy** `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Deploy: docker cp `perc-system-8.2.0-SNAPSHOT.jar`, `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar` → WAR `WEB-INF/lib`; copy WebUI `cm/modern/assets`; in-cell `StopJetty.sh` / `StartJetty.sh`; `qa-health` again **RESULT:OK**
- `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — **10 passed** (38.2s)
- console-clean=yes (pageerror listeners)
- server.log-clean=yes (no virtual/publish ERROR/FATAL)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
