### PR TITLE
feat(WebUI): CSV Virtual Site Preview chrome after Build (#3707)

### DIFF
--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -42,6 +42,7 @@ import {
   formatVirtualSitePublishSummary,
   sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
+  shouldShowVirtualPreviewChrome,
   shouldShowVirtualPublishChrome,
 } from "./virtualSiteBuild";
 import {
@@ -332,6 +333,8 @@ export function VirtualSiteSourcePanel({
   const csvMode = isCsvFilesystemSourceKind(form.sourceKind);
   /** Build chrome: git-filesystem and csv-filesystem (never repository). */
   const showBuildChrome = shouldShowVirtualBuildChrome(form.sourceKind);
+  /** Preview chrome: same kinds as Build (last-output REST, not git-only). */
+  const showPreviewChrome = shouldShowVirtualPreviewChrome(form.sourceKind);
   /** Publish chrome: git-filesystem and csv-filesystem (never repository). */
   const showPublishChrome = shouldShowVirtualPublishChrome(form.sourceKind);
   const busy = saving || building || publishing;
@@ -553,15 +556,17 @@ export function VirtualSiteSourcePanel({
                 >
                   {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
                 </button>
-                <button
-                  type="button"
-                  data-testid="developer-site-virtual-preview"
-                  style={busy || previewBusy ? disabledSecondaryButton : secondaryButton}
-                  disabled={busy || previewBusy}
-                  onClick={() => void onPreview()}
-                >
-                  {DEV_MSG.SITE_VIRT_PREVIEW}
-                </button>
+                {showPreviewChrome ? (
+                  <button
+                    type="button"
+                    data-testid="developer-site-virtual-preview"
+                    style={busy || previewBusy ? disabledSecondaryButton : secondaryButton}
+                    disabled={busy || previewBusy}
+                    onClick={() => void onPreview()}
+                  >
+                    {DEV_MSG.SITE_VIRT_PREVIEW}
+                  </button>
+                ) : null}
                 {showPublishChrome ? (
                   <button
                     type="button"
@@ -574,12 +579,14 @@ export function VirtualSiteSourcePanel({
                   </button>
                 ) : null}
               </div>
-              <p
-                style={{ ...mutedHintText, margin: "8px 0 0" }}
-                data-testid="developer-site-virtual-preview-hint"
-              >
-                {DEV_MSG.SITE_VIRT_PREVIEW_HINT}
-              </p>
+              {showPreviewChrome ? (
+                <p
+                  style={{ ...mutedHintText, margin: "8px 0 0" }}
+                  data-testid="developer-site-virtual-preview-hint"
+                >
+                  {DEV_MSG.SITE_VIRT_PREVIEW_HINT}
+                </p>
+              ) : null}
               {showPublishChrome ? (
                 <>
                   <p
@@ -613,7 +620,7 @@ export function VirtualSiteSourcePanel({
                 </div>
               ) : null}
 
-              {previewError ? (
+              {showPreviewChrome && previewError ? (
                 <div
                   role="alert"
                   data-testid="developer-site-virtual-preview-error"

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -770,7 +770,7 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_KIND_GIT_FILESYSTEM: "perc.ui.developer@Git filesystem",
   SITE_VIRT_KIND_CSV_FILESYSTEM: "perc.ui.developer@CSV filesystem",
   SITE_VIRT_CSV_HINT:
-    "perc.ui.developer@CSV filesystem uses the root path only (no Git remote). Save, then Build or Publish Virtual Site.",
+    "perc.ui.developer@CSV filesystem uses the root path only (no Git remote). Save, then Build Virtual Site, then Preview assembled site. Publish is also available after a successful Build.",
   SITE_VIRT_STATUS_REPO: "perc.ui.developer@Mode: traditional repository Site",
   SITE_VIRT_STATUS_VIRTUAL: "perc.ui.developer@Mode: Virtual Site",
   SITE_VIRT_ERR_ROOT_REQUIRED:
@@ -797,7 +797,7 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
   SITE_VIRT_PREVIEW: "perc.ui.developer@Preview assembled site",
   SITE_VIRT_PREVIEW_HINT:
-    "perc.ui.developer@Opens the last assembled documentation home in a new tab (same-origin preview of the build output). Requires Admin.",
+    "perc.ui.developer@Opens the last assembled home in a new tab after Build (Git filesystem or CSV filesystem). Same-origin preview of the build output. Requires Admin.",
   SITE_VIRT_PREVIEW_MISSING:
     "perc.ui.developer@No assembled site to preview. Run Build Virtual Site first.",
   SITE_VIRT_PREVIEW_ERROR: "perc.ui.developer@Could not open Virtual Site preview.",

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -33,6 +33,17 @@ export function shouldShowVirtualBuildChrome(
 }
 
 /**
+ * True when Preview assembled site should be shown.
+ * Same allow-list as Build: last-output preview for git-filesystem and
+ * csv-filesystem. Repository / blank / unknown kinds stay hidden.
+ */
+export function shouldShowVirtualPreviewChrome(
+  sourceKind: string | null | undefined,
+): boolean {
+  return shouldShowVirtualBuildChrome(sourceKind);
+}
+
+/**
  * True when the Publish Virtual Site control should be shown.
  * Git-filesystem and csv-filesystem both run POST /virtual/publish (build then
  * copy to IPSSite.root). Repository / blank / unknown kinds stay hidden.

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -694,6 +694,38 @@ describe("VirtualSiteSourcePanel", () => {
     expect(open.mock.calls[0][1]).toBe("_blank");
   });
 
+  it("shows Preview chrome for csv-filesystem and opens last-build home", async () => {
+    const open = vi.fn();
+    window.open = open;
+    getVirtual.mockResolvedValue({
+      sourceKind: "csv-filesystem",
+      rootPath: "C:/csv-docs",
+      virtual: true,
+    });
+    previewStatus.mockResolvedValue({
+      available: true,
+      homePath: "8.2/index.html",
+    });
+    render(<VirtualSiteSourcePanel siteName="CsvHelp" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-preview")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-csv-hint").textContent).toContain(
+      DEV_MSG.SITE_VIRT_CSV_HINT,
+    );
+    expect(screen.getByTestId("developer-site-virtual-preview-hint").textContent).toContain(
+      DEV_MSG.SITE_VIRT_PREVIEW_HINT,
+    );
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
+    await waitFor(() => {
+      expect(open).toHaveBeenCalled();
+    });
+    expect(previewStatus).toHaveBeenCalledWith("CsvHelp");
+    expect(String(open.mock.calls[0][0])).toContain("8.2/index.html");
+    expect(open.mock.calls[0][1]).toBe("_blank");
+  });
+
   it("shows empty preview state when no assembled site exists", async () => {
     window.open = vi.fn();
     getVirtual.mockResolvedValue({

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -716,7 +716,6 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-preview-hint").textContent).toContain(
       DEV_MSG.SITE_VIRT_PREVIEW_HINT,
     );
-    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
     fireEvent.click(screen.getByTestId("developer-site-virtual-preview"));
     await waitFor(() => {
       expect(open).toHaveBeenCalled();

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeVirtualSiteLinkProblems,
   sanitizeVirtualPreviewHomePath,
   shouldShowVirtualBuildChrome,
+  shouldShowVirtualPreviewChrome,
   shouldShowVirtualPublishChrome,
 } from "../../../main/ts/developer/virtualSiteBuild";
 
@@ -23,6 +24,16 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualBuildChrome("  git-filesystem  ")).toBe(true);
     expect(shouldShowVirtualBuildChrome("csv-filesystem")).toBe(true);
     expect(shouldShowVirtualBuildChrome("CSV-Filesystem")).toBe(true);
+  });
+
+  it("shouldShowVirtualPreviewChrome matches Build (git and csv, never repository)", () => {
+    expect(shouldShowVirtualPreviewChrome(null)).toBe(false);
+    expect(shouldShowVirtualPreviewChrome("")).toBe(false);
+    expect(shouldShowVirtualPreviewChrome("repository")).toBe(false);
+    expect(shouldShowVirtualPreviewChrome("sql-api")).toBe(false);
+    expect(shouldShowVirtualPreviewChrome("git-filesystem")).toBe(true);
+    expect(shouldShowVirtualPreviewChrome("csv-filesystem")).toBe(true);
+    expect(shouldShowVirtualPreviewChrome("  CSV-Filesystem  ")).toBe(true);
   });
 
   it("shouldShowVirtualPublishChrome for git-filesystem and csv-filesystem", () => {

--- a/docs/ai-generated/code-reviews/3707-csv-virtual-preview-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/3707-csv-virtual-preview-chrome-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: #3707 Developer Sites CSV virtual preview chrome
+
+**Branch:** `feat/issue-3707-csv-virtual-preview-chrome`  
+**Parent:** #2678 (slice 2 of 3; consumes REST #3709 / #3711)  
+**Change class:** WebUI product screen (Developer Sites Preview chrome for `csv-filesystem`) + Playwright live H2 QA + product-docs admin Sites
+
+## Scope
+
+- `shouldShowVirtualPreviewChrome` matches Build allow-list (`git-filesystem` | `csv-filesystem`); repository / unknown hide Preview.
+- CSV hint and Preview hint are i18n keys (not bare English).
+- Playwright live path: save CSV source, Build, GET `/virtual/preview` available, home HTML contains fixture title/body.
+- Consumes last-output Preview REST (no second assembler; no publish/rebuild).
+
+## Bugs
+
+None found. Preview URL uses `sanitizeVirtualPreviewHomePath` then encoded path segments. Playwright fallback `page.request.get` uses the same encoded relative home path (no `..`). CSV QA fixture is copied with `docker cp` + POSIX in-container root (`/opt/Percussion/tmp/csv-virtual-qa-3697`).
+
+## Tests
+
+- Vitest: `shouldShowVirtualPreviewChrome`; panel opens CSV last-build home; repository still hides Preview.
+- Playwright: repository hides Preview; CSV hint names Preview; live Build then Preview home HTML.
+
+## Cross-platform
+
+- No new filesystem `"/"` concatenations. Fixture helper already uses `path.join` on the host and POSIX strings only inside the Linux QA cell.
+- Preview REST paths are URL/relative (`8.2/index.html`), not OS file joins.
+
+## Product-docs
+
+`product-docs/8.2/admin/sites.md` Preview section: CSV after Build; repository hides Preview/Build.
+
+## Hard gates
+
+- Behavioral tests present for new helper + panel + live Playwright.
+- Portable paths: pass.
+- Companions: Vitest + Playwright + product-docs (change-class closure).

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -15,15 +15,17 @@
  */
 
 /**
- * Developer Sites → Virtual Site source panel (#2956 / #3020 / #3300 / #3687 / #3697 / epic #2678).
+ * Developer Sites → Virtual Site source panel
+ * (#2956 / #3020 / #3300 / #3687 / #3697 / #3699 / #3707 / epic #2678).
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
  * with source-kind control (repository default, git-filesystem, csv-filesystem),
- * save chrome, Build and Publish chrome for git-filesystem and csv-filesystem
+ * save chrome, Build + Preview + Publish chrome for git-filesystem and csv-filesystem
  * (never repository). Also intercepts build REST to prove link-problem detail
  * lines render on HTTP 200 and publish REST to prove dest path + files copied
  * on HTTP 200 (including csv-filesystem). Live H2 QA deploys a CSV tree into the
- * cell and asserts POST /virtual/build and POST /virtual/publish complete.
+ * cell and asserts POST /virtual/build, GET /virtual/preview home HTML, and
+ * POST /virtual/publish complete.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -131,6 +133,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         await expect(
           page.locator('[data-testid="developer-site-virtual-build-section"]'),
         ).toHaveCount(0);
+        await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
         await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
       }
 
@@ -138,6 +141,9 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await kind.selectOption("csv-filesystem");
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-csv-hint"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-csv-hint"]')).toContainText(
+        "Preview assembled site",
+      );
       await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveCount(0);
       await expect(page.locator('[data-testid="developer-site-virtual-branch"]')).toHaveCount(0);
       await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
@@ -203,6 +209,7 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       // Restore repository to avoid leaving QA site dirty when save is not exercised
       await kind.selectOption("repository");
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
       await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
     }
 
@@ -1272,6 +1279,153 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       timeout: 15_000,
     });
     await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
+
+  test("csv-filesystem live Preview assembled site after Build (#3707)", async ({ page }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    const csvRoot = deployCsvVirtualFixtureToQaCell();
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      throw new Error("No sites in catalog — live CSV Preview requires a site row");
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const siteName = (
+      await page.locator('[data-testid="developer-site-detail-title"]').textContent()
+    ).trim();
+    expect(siteName, "Site detail title required for preview URL").toBeTruthy();
+
+    const kind = page.locator('[data-testid="developer-site-virtual-source-kind"]');
+    await kind.selectOption("csv-filesystem");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-preview-hint"]')).toBeVisible();
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill(csvRoot);
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
+
+    const buildRespPromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" && /\/virtual\/build(\?|$)/.test(resp.url()),
+    );
+    await page.locator('[data-testid="developer-site-virtual-build"]').click();
+    const buildResp = await buildRespPromise;
+    const buildBody = await buildResp.text();
+    expect(
+      buildResp.ok(),
+      `POST /virtual/build HTTP ${buildResp.status()}: ${buildBody}`,
+    ).toBeTruthy();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-result"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build-success"]')).toBeVisible();
+
+    const previewStatusPromise = page.waitForResponse((resp) => {
+      if (resp.request().method() !== "GET") {
+        return false;
+      }
+      const url = resp.url();
+      return /\/virtual\/preview(\?|$)/.test(url) && !/\/virtual\/preview\/.+/.test(url);
+    });
+    const popupPromise = page.waitForEvent("popup", { timeout: 20_000 }).catch(() => null);
+    await page.locator('[data-testid="developer-site-virtual-preview"]').click();
+    const statusResp = await previewStatusPromise;
+    const statusBody = await statusResp.text();
+    expect(
+      statusResp.ok(),
+      `GET /virtual/preview HTTP ${statusResp.status()}: ${statusBody}`,
+    ).toBeTruthy();
+    let statusJson = {};
+    try {
+      statusJson = JSON.parse(statusBody);
+    } catch {
+      throw new Error(`Preview status was not JSON: ${statusBody}`);
+    }
+    const statusRoot =
+      statusJson.VirtualSitePreviewStatus ||
+      statusJson.virtualSitePreviewStatus ||
+      statusJson;
+    expect(
+      statusRoot.available === true || statusRoot.available === "true",
+      `preview available: ${statusBody}`,
+    ).toBeTruthy();
+    const homePath = String(statusRoot.homePath || "").replace(/\\/g, "/").replace(/^\/+/, "");
+    expect(homePath, `homePath in ${statusBody}`).toMatch(/index\.html$/);
+
+    const popup = await popupPromise;
+    let html = "";
+    if (popup) {
+      await popup.waitForLoadState("domcontentloaded").catch(() => {});
+      html = await popup.content().catch(() => "");
+      if (!html || /about:blank/i.test(popup.url())) {
+        const probeUrl = popup.url();
+        if (probeUrl && !/about:blank/i.test(probeUrl)) {
+          const probe = await page.request.get(probeUrl);
+          html = await probe.text();
+        }
+      }
+      if (!popup.isClosed()) {
+        await popup.close().catch(() => {});
+      }
+    }
+    if (!/CSV QA Home|Hello from CSV Virtual Site/.test(html)) {
+      const fileUrl = `${BASE_URL}/Rhythmyx/services/sites/${encodeURIComponent(siteName)}/virtual/preview/${homePath
+        .split("/")
+        .filter((seg) => seg.length > 0 && seg !== "." && seg !== "..")
+        .map((seg) => encodeURIComponent(seg))
+        .join("/")}`;
+      const fileResp = await page.request.get(fileUrl);
+      expect(
+        fileResp.ok(),
+        `GET preview home HTTP ${fileResp.status()} ${fileUrl}`,
+      ).toBeTruthy();
+      html = await fileResp.text();
+    }
+    expect(
+      html,
+      "assembled CSV home HTML should contain fixture title or body",
+    ).toMatch(/CSV QA Home|Hello from CSV Virtual Site/);
+
+    await kind.selectOption("repository");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -218,10 +218,11 @@ show these controls (no misleading virtual-build or virtual-publish chrome).
 
 ### Preview the assembled Virtual Site
 
-After a successful **Build Virtual Site**, operators can open the assembled documentation
-home from the same Site detail panel (no CLI, no `file://` path). This includes
-**`csv-filesystem`** last-build output as well as **`git-filesystem`** — preview is not
-git-only. In-product REST Build records the last output path (including a custom
+After a successful **Build Virtual Site**, operators can open the assembled home from the
+same Site detail panel (no CLI, no `file://` path). Preview is last-output based: it works
+for **Git filesystem** and **CSV filesystem** (not git-only). Traditional **Repository**
+Sites hide **Build Virtual Site**, **Preview assembled site**, and **Publish Virtual Site**.
+In-product REST Build records the last output path (including a custom
 `outputRoot`), so `GET /services/sites/{name}/virtual/preview` reports `available` +
 `homePath` and `GET …/virtual/preview/{path}` streams the HTML.
 
@@ -232,7 +233,9 @@ when the install root is unavailable). A custom CLI output directory is not prev
 until REST Build records it.
 
 1. Stay on **Developer → Sites → Site detail** for the Virtual Site (Admin).
-2. Choose **Preview assembled site**.
+2. For **CSV filesystem**, confirm **Source kind** is **CSV filesystem**, the **Root path**
+   is saved, and **Build Virtual Site** completed. Then choose **Preview assembled site**.
+   Git filesystem uses the same Preview control after its Build.
 3. The CMS opens the last build’s home (typically `8.2/index.html`, or root `index.html`
    when present) in a new tab. Navigation stays on the same-origin preview URL
    (`GET /services/sites/{name}/virtual/preview/{path}`).
@@ -241,9 +244,9 @@ until REST Build records it.
    does not return HTTP 500.
 
 The preview stream reads the last recorded `outputPath` from the build (default
-`{install}/tmp/virtual-sites/{siteKey}`). It is **Admin-only**, path-traversal safe, and
-does not invent a second assembler. Traditional **Repository** Sites do not show Preview
-chrome. Git and CSV Virtual Sites both show Preview next to **Build Virtual Site**.
+`{install}/tmp/virtual-sites/{siteKey}`). After a CSV assemble, `GET /services/sites/{name}/virtual/preview`
+reports `available` + `homePath`, and `GET …/virtual/preview/{path}` streams the HTML.
+It is **Admin-only**, path-traversal safe, and does not invent a second assembler.
 
 Integrators can call the same operation over REST:
 `POST /sites/{nameOrId}/virtual/build` (optional JSON body `outputRoot`). See


### PR DESCRIPTION
## Summary

Parent: #2678 (slice 2 of 3). **Fixes #3707.** Consumes REST csv-filesystem last-build preview (#3709 / #3711). Does not re-implement publish (#3699) or rebuild (#3708).

Developer Sites **Preview assembled site** is visible and invokable for `csv-filesystem` after Build (peer git-filesystem #3299). Repository still hides Preview/Build/Publish. After a live H2 QA CSV Build, `GET /virtual/preview` reports available and home HTML is reachable.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 544, Failures: 0) on REST preview consume.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1377, Failures: 0, Skipped: 125) on adaptor preview tests.
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest 3008 passed; Java Tests run: 63, Failures: 0).
4. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
5. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`; deploy rest + sitemanage + perc-system jars + full `cm/modern/assets`; in-cell Jetty restart; `qa-health` RESULT:OK HTTP:200 HEALTH:healthy.
6. `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — 10 passed including live CSV Preview after Build (#3707). One pre-existing live Publish (#3699) 400 on this H2 cell (`Site filesystem publish root … Rejected: '../CI_Home'`) — out of this slice. Dedicated `--grep #3707` **1 passed**. console-clean=yes; server.log-clean=yes for the Preview path.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md` Preview section (CSV after Build; repository hides Preview/Build); REST/developer/site-config last-output preview for both kinds
- [x] **Unit / module tests** — Vitest `shouldShowVirtualPreviewChrome` + csv panel open-home; adaptor preview tests from #3709; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — live Preview home HTML on H2 QA (`#3707` 1/1; spec chrome + live Preview passed)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); C2 N/A (no `final` / public signature change)
- [x] **Cross-platform** — Preview URLs are REST paths; CSV QA fixture uses `path.join` on host and POSIX in-container roots

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest; ../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 544, Failures: 0)
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 1377, Failures: 0, Skipped: 125)
  - `cd WebUI; ../mvnw.cmd clean install` → **BUILD SUCCESS** (Vitest Tests 3008 passed; Java Tests run: 63, Failures: 0)
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **downstream_checked:** none (C2 did not apply — no `final` / public method/ctor signature change). `projects/sitemanage` still clean-installed as adaptor implementer of `rest`.

## C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → **TEST_CMS_URL=http://127.0.0.1:9993** container `perc-matrix-cms-h2`
- Deploy: `docker cp` `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, `perc-system-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; full `WebUI/target/generated-webui/cm/modern/assets`; in-cell `StopJetty.sh` + `StartJetty.sh` (not `docker restart`)
- qa-health: `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy URL:http://127.0.0.1:9993/Rhythmyx/rest/mimetypes`
- Playwright: `npm run test:surface -- --grep #3707` → **1 passed** (`csv-filesystem live Preview assembled site after Build (#3707)`). Full spec path 10 passed / 1 failed (#3699 live Publish unsafe sample-site root `../CI_Home`, not this slice)
- console-clean=yes
- server.log-clean=yes (no ERROR/FATAL matching virtual/preview/csv in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
