### PR TITLE
fix(virtualsite): csv-filesystem rebuild reads current CSV (#3708)

### DIFF
--- a/docs/ai-generated/code-reviews/3708-csv-filesystem-rebuild-current-csv-erlang.md
+++ b/docs/ai-generated/code-reviews/3708-csv-filesystem-rebuild-current-csv-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3708 csv-filesystem rebuild reads current CSV
+
+**Branch:** `fix/issue-3708-csv-filesystem-rebuild-current`  
+**Date:** 2026-08-21  
+**Reviewer:** Erlang (pre-commit, independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for changed logic; portable `Path`/`Files` (no Unix-only roots); product-docs companion for operator-facing rebuild note; no incomplete rest/sitemanage adaptor cache (none present)
+
+## Summary
+
+`PSCsvFilesystemVirtualSiteSource` / `VirtualCsvParser` already `Files.readString` + parse on every discover/load (no path/mtime cache). `VirtualSiteConfigLoader` always opens `_config.yaml` from disk. `SitesAdaptor.runBuild` constructs a new `PSVirtualSiteBuildService` per REST build. This change locks the no-stale-parse-cache contract in Javadoc, proves same-JVM CSV/`_config.yaml` edit→rebuild emits new HTML, and documents that operators rebuild after a CSV edit without a CMS restart.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Test I/O uses `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`
+- [x] No Unix-only `/tmp` or Windows-only `C:\` hardcodes
+- [x] No raw OS `toString()` path equality assertions
+- [x] Line-ending sensitive checks use `contains` tokens, not whole-file `\n` equality
+
+## Issues
+
+None (hard-gate).
+
+## Nits
+
+- Two nearly parallel `secondBuildAfterCsvAndConfigEditEmitsUpdatedHtmlWithoutRestart` tests (`PSVirtualSiteBuildServiceTest` factory wiring vs `PSCsvFilesystemVirtualSiteSourceTest` same-instance source). Acceptable as the SPI + assemble proofs for peer #3367.
+
+## C2 API shape
+
+Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change. Reverse-deps (`rest` / `sitemanage`) not required.
+
+## Build
+
+Standalone `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**.  
+Focused: `PSCsvFilesystemVirtualSiteSourceTest` Tests run: 15, Failures: 0, Skipped: 1 (Unix-only path). `PSVirtualSiteBuildServiceTest` Tests run: 11, Failures: 0. `VirtualSiteConfigLoaderTest` Tests run: 10, Failures: 0.  
+Module Surefire: Tests run: 2339, Failures: 0, Errors: 0, Skipped: 242.

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -37,7 +37,8 @@ For Git/filesystem or CSV/filesystem Virtual Sites such as product documentation
 - **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
   `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`). Each build re-reads the
   current Git/filesystem or CSV tree (`csv-filesystem`). After `git pull`, a local Markdown
-  edit, or a CSV change, run Build (or Publish) again — no CMS restart.
+  edit, a CSV change, or a `_config.yaml` change, run Build (or Publish) again — no CMS
+  restart.
 - **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
   assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
   publishing root). Staging `_meta` files are not copied. Redirect HTML and `redirects.json`

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -200,9 +200,9 @@ show these controls (no misleading virtual-build or virtual-publish chrome).
    build uses the **saved** server properties, not unsaved form fields.
 4. Choose **Build Virtual Site**.
 5. After a `git pull` or a local Markdown/frontmatter edit on the host — or after the remote
-   branch moves — or after a CSV file change — choose **Build Virtual Site** again. The
-   build re-reads the current tree (and re-fetches when a Git remote is configured) —
-   **do not restart the CMS** just to pick up those edits. There is no file watcher; the
+   branch moves — or after a CSV file or `_config.yaml` change — choose **Build Virtual Site**
+   again. The build re-reads the current tree (and re-fetches when a Git remote is configured)
+   — **do not restart the CMS** just to pick up those edits. There is no file watcher; the
    next explicit build is the refresh.
 6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -79,7 +79,7 @@ HTML path in the **virtual participant registry** (`IPSVirtualParticipantService
 | **Process-scoped (default)** | Registrations live in memory until the process exits, or until `clear(siteKey)` / `clearAll()` is called (SPI reset API). Unit tests and one-shot builds use this mode when no store directory is supplied. |
 | **Path-backed (optional)** | Construct the registry with a portable `java.nio.file.Path` base (CLI uses `outputRoot/_meta`). Existing `participants-<siteKey>.jsonl` files are loaded on construct; `flush(siteKey)` rewrites that site’s file. Survives JVM restart when the same Path base is reused. |
 | **Full rebuild** | A complete site build **clears** that site key, then upserts every discovered page, then flushes. A second build therefore does not keep pages removed from the source tree, and does not lose current ids. |
-| **Current filesystem** | Each build reloads `_config.yaml` and re-reads every Markdown/frontmatter file from disk. The CMS process does **not** keep a parsed-page cache across builds. After `git pull` or a local edit under `virtual.rootPath`, run **Build Virtual Site** (or the offline docs script) again — **no JVM / CMS restart** is required. File watchers are not used; the next explicit build is the refresh. |
+| **Current filesystem** | Each build reloads `_config.yaml` and re-reads every Markdown/frontmatter file **and CSV row** from disk. The CMS process does **not** keep a parsed-page cache across builds. After `git pull`, a CSV/`_config.yaml` edit, or a local Markdown edit under `virtual.rootPath`, run **Build Virtual Site** (or the offline docs script) again — **no JVM / CMS restart** is required. File watchers are not used; the next explicit build is the refresh. |
 
 Operators can treat the JSONL under the build meta directory as a diagnostic dump of stable ids after
 an offline docs build. The registry is **not** a substitute for Git as the system of record.
@@ -155,7 +155,9 @@ Required CSV columns (header row, case-insensitive):
 
 Missing required columns, blank `id`/`title`, duplicate ids, or an unsafe `path` fail the build
 (`VirtualSiteException`). Each discover/load re-reads the current CSV bytes (no process-lifetime
-parse cache).
+parse cache). After you edit a CSV file or `_config.yaml` on the CMS host, run **Build Virtual
+Site** again (UI, `POST …/virtual/build`, or `PSVirtualSiteBuildMain … csv-filesystem`). The next
+build always sees the current files — **no CMS process restart**. File watchers are not used.
 
 CLI (optional `_config.yaml`):
 
@@ -257,13 +259,15 @@ local root from the panel until the remote is cleared.
 The CMS host must have `git` on `PATH`. Checkouts are server-managed; do not point `remoteUrl` at
 untrusted remotes.
 
-### Rebuild after git pull or a local edit (no CMS restart)
+### Rebuild after git pull, a CSV edit, or a local edit (no CMS restart)
 
-The Git/filesystem adapter always sees the **current** tree on the CMS host:
+The Git/filesystem and CSV/filesystem adapters always see the **current** tree on the CMS host:
 
-1. Update Markdown or frontmatter under `virtual.rootPath` (`git pull`, copy, or an editor),
-   **or** change the remote branch and Build again so the server fetches.
-2. Run **Build Virtual Site** again (UI, `POST …/virtual/build`, or `scripts/build-cms-docs.*`).
+1. Update Markdown or frontmatter, a CSV file, or `_config.yaml` under `virtual.rootPath`
+   (`git pull`, copy, or an editor), **or** change the remote branch and Build again so the
+   server fetches (Git only).
+2. Run **Build Virtual Site** again (UI, `POST …/virtual/build`, `scripts/build-cms-docs.*`,
+   or `PSVirtualSiteBuildMain … csv-filesystem`).
 3. Preview or publish the new output.
 
 You do **not** restart the CMS JVM for those file changes to appear. A restart is only needed

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -199,8 +199,9 @@ Optional body field `outputRoot` overrides the default output directory
 unavailable). Link problems are reported in the JSON result (and in `link-report.txt` under
 the output root) without failing the HTTP status when the build itself succeeds.
 
-Each build re-reads current Markdown/frontmatter from `virtual.rootPath` (no CMS restart after
-`git pull` or a local edit). The Developer Sites UI exposes this operation as **Build Virtual
+Each build re-reads current Markdown/frontmatter, CSV rows, and `_config.yaml` from
+`virtual.rootPath` (no CMS restart after `git pull`, a CSV/`_config.yaml` edit, or a local
+Markdown edit). The Developer Sites UI exposes this operation as **Build Virtual
 Site** when source kind is Virtual (never for traditional repository Sites). When
 `hasLinkProblems` is true, the result panel shows the problem **count** and an expandable list
 of `linkProblems` (same text as `link-report.txt`). A clean build does not show that banner.

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -27,8 +27,8 @@ import java.util.List;
  * <p>Filesystem implementations must read <em>current</em> file contents on every {@link
  * #discover} and {@link #load}. Process-lifetime parse caches that skip a file because its path
  * or mtime looks unchanged are not allowed — a second build in the same JVM (after {@code git
- * pull} or a local Markdown/frontmatter edit) must see the new bytes. File watchers are not
- * required; the next explicit build is the refresh.
+ * pull}, a CSV row edit, or a local Markdown/frontmatter edit) must see the new bytes. File
+ * watchers are not required; the next explicit build is the refresh.
  */
 public interface IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSource.java
@@ -37,7 +37,9 @@ import java.util.stream.Stream;
  * with {@link VirtualSiteException}.
  *
  * <p>Stateless: {@link #discover} and {@link #load} always {@link Files#readString} the current
- * CSV bytes. No parse cache is kept on the instance or in statics.
+ * CSV bytes. No path/mtime parse cache is kept on the instance or in statics — a second build
+ * in the same JVM after a CSV edit must see the new rows. {@code _config.yaml} is reloaded by
+ * {@link PSVirtualSiteBuildService}, not this source.
  *
  * <p>Filesystem I/O uses portable NIO {@link Path} / {@link Files} only.
  */

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -93,9 +93,10 @@ public class PSVirtualSiteBuildService {
    * Build a Virtual Site from a filesystem root into {@code outputRoot}.
    *
    * <p>Every invocation reloads {@code _config.yaml}, optional {@code _redirects.yaml}, and
-   * re-discovers and re-loads Markdown from the current tree, then overwrites emitted HTML. Missing
-   * {@code _redirects.yaml} is a no-op. The same service instance does not reuse parsed pages from
-   * a previous build — operators do not need a JVM restart after {@code git pull} or a local edit.
+   * re-discovers and re-loads Markdown or CSV rows from the current tree, then overwrites emitted
+   * HTML. Missing {@code _redirects.yaml} is a no-op. The same service instance does not reuse
+   * parsed pages from a previous build — operators do not need a JVM restart after {@code git
+   * pull}, a CSV/{@code _config.yaml} edit, or a local Markdown edit.
    *
    * @param siteRoot source tree ({@code _config.yaml} required for git-filesystem; optional for
    *     csv-filesystem)

--- a/system/services/src/com/percussion/services/virtualsite/VirtualCsvParser.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualCsvParser.java
@@ -28,7 +28,8 @@ import java.util.Objects;
  * RFC 4180-style CSV reader for Virtual Site {@code csv-filesystem} sources.
  *
  * <p>Required header columns (case-insensitive): {@code id}, {@code title}, {@code body}. Optional:
- * {@code path}, {@code order}. Missing required columns fail closed.
+ * {@code path}, {@code order}. Missing required columns fail closed. Stateless: each {@link
+ * #parse} call works from the supplied text only (no instance or static row cache).
  */
 public final class VirtualCsvParser {
 

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
@@ -32,7 +32,13 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
-/** Loads {@code _config.yaml} from a Virtual Site root (optional fallback for CSV trees). */
+/**
+ * Loads {@code _config.yaml} from a Virtual Site root (optional fallback for CSV trees).
+ *
+ * <p>Stateless: each {@link #load} / {@link #loadOrDefault} reads the current file (or current
+ * child directories). No process-lifetime YAML cache — a second build after a config edit sees
+ * the new title/versions without a JVM restart.
+ */
 public final class VirtualSiteConfigLoader {
 
   public static final String DEFAULT_CONFIG_FILE = "_config.yaml";

--- a/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSCsvFilesystemVirtualSiteSourceTest.java
@@ -18,6 +18,7 @@ package com.percussion.services.virtualsite;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -304,6 +305,85 @@ class PSCsvFilesystemVirtualSiteSourceTest {
     String body = Files.readString(html, StandardCharsets.UTF_8);
     assertTrue(body.contains("CSV Home"), body);
     assertTrue(body.contains("Hello from CSV"), body);
+  }
+
+  @Test
+  void secondBuildAfterCsvAndConfigEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path root = writeSite(tempDir.resolve("csv-rebuild"));
+    Files.writeString(
+        root.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: First Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Path csv = root.resolve("8.2").resolve("pages.csv");
+    Files.writeString(
+        csv,
+        "id,title,body,path\nlive-home,First Title,unique-token-AAA,index.md\n",
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("csv-rebuild-out");
+    PSCsvFilesystemVirtualSiteSource source = new PSCsvFilesystemVirtualSiteSource();
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(source, new PSInMemoryVirtualParticipantService());
+
+    PSVirtualSiteBuildResult first = service.build(root, out, "csv-docs");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        csv,
+        "id,title,body,path\nlive-home,Second Title,unique-token-BBB,index.md\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: Second Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+
+    VirtualSiteConfig reloaded =
+        VirtualSiteConfigLoader.load(root, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, "csv-docs");
+    assertEquals("Second Site Title", reloaded.siteTitle());
+    VirtualItem loaded = source.load(reloaded, source.discover(reloaded).get(0));
+    assertEquals("Second Title", loaded.frontmatter().title());
+    assertTrue(loaded.markdownBody().contains("unique-token-BBB"), loaded.markdownBody());
+
+    PSVirtualSiteBuildResult second = service.build(root, out, "csv-docs");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -195,6 +195,81 @@ class PSVirtualSiteBuildServiceTest {
   }
 
   @Test
+  void secondBuildAfterCsvAndConfigEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path siteRoot = tempDir.resolve("csv-live-site");
+    Path versionDir = siteRoot.resolve("8.2");
+    Files.createDirectories(versionDir);
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Path configYaml = siteRoot.resolve("_config.yaml");
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: First Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Path csv = versionDir.resolve("pages.csv");
+    Files.writeString(
+        csv,
+        "id,title,body,path\nlive-home,First Title,First body unique-token-AAA,index.md\n",
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("csv-live-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.CSV_FILESYSTEM);
+
+    PSVirtualSiteBuildResult first = service.build(siteRoot, out, "csv-live");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        csv,
+        "id,title,body,path\nlive-home,Second Title,Second body unique-token-BBB,index.md\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: Second Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+
+    PSVirtualSiteBuildResult second = service.build(siteRoot, out, "csv-live");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
+  }
+
+  @Test
   void linkReportListsProblemsWhenBrokenLinksPresent() throws Exception {
     Path siteRoot = tempDir.resolve("broken-site");
     Path versionDir = siteRoot.resolve("8.2");

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -99,6 +99,42 @@ class VirtualSiteConfigLoaderTest {
   }
 
   @Test
+  void secondLoadAfterConfigEditSeesCurrentTitleWithoutCache() throws Exception {
+    Path root = tempDir.resolve("live-config");
+    Files.createDirectories(root);
+    Path yaml = root.resolve("_config.yaml");
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: First Config Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig first = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("First Config Title", first.siteTitle());
+
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: Second Config Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig second = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("Second Config Title", second.siteTitle());
+  }
+
+  @Test
   void nullRootFails() {
     assertThrows(
         VirtualSiteException.class,


### PR DESCRIPTION
## Summary

csv-filesystem Virtual Site **Build** always reads the **current** CSV tree and `_config.yaml`. Operators editing those files on the CMS host do not need a CMS process restart for row/title/body/config changes to appear in assembled HTML.

Discover/load already `Files.readString`s on every call (`PSCsvFilesystemVirtualSiteSource` / `VirtualCsvParser`); `VirtualSiteConfigLoader` always opens the current YAML; `SitesAdaptor` constructs a new `PSVirtualSiteBuildService` per REST build. This PR locks that no-stale-parse-cache contract (Javadoc), proves same-JVM edit→rebuild emits new HTML, and documents the operator rebuild path.

Peer: git-filesystem rebuild #3367 / PR #3373. Parent epic: #2678. Slice of #3708.

Fixes #3708

## Test plan

1. Review `PSVirtualSiteBuildServiceTest.secondBuildAfterCsvAndConfigEditEmitsUpdatedHtmlWithoutRestart` and `PSCsvFilesystemVirtualSiteSourceTest.secondBuildAfterCsvAndConfigEditEmitsUpdatedHtmlWithoutRestart`: two builds against the same `@TempDir` root after CSV + `_config.yaml` edits change assembled HTML (portable `Path` / `Files`).
2. Review `VirtualSiteConfigLoaderTest.secondLoadAfterConfigEditSeesCurrentTitleWithoutCache`.
3. Standalone: `cd system && ../mvnw.cmd clean install` (already green in this session).
4. Operator docs: product-docs 8.2 developer Virtual Sites, admin Sites/Publishing, reference site-config — rebuild after CSV/`_config.yaml` edit, no JVM restart.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/virtual-sites.md`, `admin/sites.md`, `admin/publishing.md`, `reference/site-config.md`)
- [x] **Unit / module tests** — behavioral two-build HTML tests; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` **BUILD SUCCESS**
- [x] **Cross-platform** — tests use `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`; no Unix-only roots

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-21). Surefire: Tests run: 2339, Failures: 0, Errors: 0, Skipped: 242. Focused: `PSCsvFilesystemVirtualSiteSourceTest` 15/0/1 (Unix-only path skipped on Windows), `PSVirtualSiteBuildServiceTest` 11/0/0, `VirtualSiteConfigLoaderTest` 10/0/0. Product-docs: `scripts\ci-smoke-product-docs.bat` → **OK** (23 pages).
- **downstream_checked:** none (Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change). `rest` / `sitemanage` not touched.

## C5 UI proof

N/A — backend csv-filesystem rebuild contract + operator docs. No WebUI/Playwright.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
