### PR TITLE
fix(webui): Asset Picker search results selectable for CMS types (#3714)

### DIFF
--- a/WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx
+++ b/WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx
@@ -58,6 +58,7 @@ import {
   appendUniqueById,
   selectionItemFromSearchResult,
 } from "./selectionHelpers";
+import { passesFilters } from "./passesFilters";
 import {
   errorStateStyle,
   shellStyle,
@@ -132,26 +133,6 @@ function toSelectionItem(item: PSPathItem): SelectionItem {
     category: item.category,
     contentTypeIds: undefined,
   };
-}
-
-function passesFilters(
-  item: PSPathItem,
-  allowedTypes: ReadonlyArray<string> | null,
-  allowedCategories: ReadonlyArray<string> | null,
-): boolean {
-  if (allowedTypes && allowedTypes.length > 0) {
-    const t = (item.type ?? item.category ?? "").toLowerCase();
-    if (!allowedTypes.some((x) => x.toLowerCase() === t)) {
-      return false;
-    }
-  }
-  if (allowedCategories && allowedCategories.length > 0) {
-    const c = (item.category ?? item.type ?? "").toLowerCase();
-    if (!allowedCategories.some((x) => x.toLowerCase() === c)) {
-      return false;
-    }
-  }
-  return true;
 }
 
 export const ContentBrowser: React.FC<ContentBrowserProps> = (props) => {

--- a/WebUI/src/main/ts/contentBrowser/passesFilters.ts
+++ b/WebUI/src/main/ts/contentBrowser/passesFilters.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ContentBrowser client-side type / category filters (#3714).
+ *
+ * <p>Hosts such as the asset picker pass {@code allowedTypes: ['page', 'asset']}.
+ * CMS search and path rows often expose the <em>content-type name</em>
+ * ({@code Image}, {@code percPage}, {@code rffImage}) rather than those
+ * host tokens. Exact string equality rejected valid hits and left Confirm
+ * disabled. Folders and nav types stay excluded unless the host allows
+ * {@code folder}.</p>
+ */
+
+import type { PSPathItem } from "../api/contentExplorer/types";
+import {
+  isAssetContentType,
+  isFolder,
+  isPageOrAssetContentType,
+} from "../contentExplorer/selection";
+
+/**
+ * Host {@code page} token — stock / FastForward page content-type names.
+ * Customer types are accepted via {@link isPageOrAssetContentType} when the
+ * host allows both page and asset.
+ */
+const PAGE_KIND_ALIASES = new Set([
+  "page",
+  "percpage",
+  "landing_page",
+  "landingpage",
+  "rffhome",
+  "rffevent",
+  "rffgeneric",
+  "rffgenericword",
+  "rffbrief",
+  "rffcalendar",
+  "rffcontacts",
+  "rffpressrelease",
+  "rffexternallink",
+  "rffautoindex",
+]);
+
+/**
+ * Host {@code asset} token — stock / FastForward asset names plus CMS
+ * display names search returns ({@code Image}, {@code File}).
+ */
+const ASSET_KIND_ALIASES = new Set([
+  "asset",
+  "percasset",
+  "image",
+  "file",
+  "percimage",
+  "percfile",
+  "rffimage",
+  "rfffile",
+  "rffnavimage",
+]);
+
+function tokenSet(values: ReadonlyArray<string> | null): Set<string> {
+  const out = new Set<string>();
+  if (!values) {
+    return out;
+  }
+  for (const raw of values) {
+    const t = String(raw ?? "")
+      .trim()
+      .toLowerCase();
+    if (t) {
+      out.add(t);
+    }
+  }
+  return out;
+}
+
+function itemTypeTokens(item: PSPathItem): string[] {
+  const type = (item.type ?? "").trim().toLowerCase();
+  const category = (item.category ?? "").trim().toLowerCase();
+  const tokens: string[] = [];
+  if (type) {
+    tokens.push(type);
+  }
+  if (category && category !== type) {
+    tokens.push(category);
+  }
+  return tokens;
+}
+
+function hasAny(haystack: ReadonlySet<string>, needles: readonly string[]): boolean {
+  return needles.some((n) => haystack.has(n));
+}
+
+function isStockAssetKind(item: PSPathItem): boolean {
+  return hasAny(ASSET_KIND_ALIASES, itemTypeTokens(item));
+}
+
+function isStockPageKind(item: PSPathItem): boolean {
+  return hasAny(PAGE_KIND_ALIASES, itemTypeTokens(item));
+}
+
+/**
+ * Whether {@code item} matches a host {@code allowedTypes} list.
+ *
+ * <p>{@code page} / {@code asset} are object-class tokens. CMS content-type
+ * names map onto those classes. Exact type/category match is still accepted
+ * so a host that lists {@code Image} (or a customer type) keeps working.</p>
+ */
+export function matchesAllowedTypes(
+  item: PSPathItem,
+  allowedTypes: ReadonlyArray<string> | null,
+): boolean {
+  const allowed = tokenSet(allowedTypes);
+  if (allowed.size === 0) {
+    return true;
+  }
+
+  const itemTokens = itemTypeTokens(item);
+  if (itemTokens.some((t) => allowed.has(t))) {
+    return true;
+  }
+
+  const allowsFolder = allowed.has("folder");
+  if (isFolder(item)) {
+    return allowsFolder;
+  }
+
+  const allowsPage = allowed.has("page");
+  const allowsAsset = allowed.has("asset");
+
+  if (allowsPage && allowsAsset) {
+    return isPageOrAssetContentType(item);
+  }
+
+  if (allowsAsset && (isStockAssetKind(item) || isAssetContentType(item))) {
+    return true;
+  }
+
+  if (allowsPage) {
+    if (isStockAssetKind(item) || isAssetContentType(item)) {
+      return false;
+    }
+    return isStockPageKind(item) || isPageOrAssetContentType(item);
+  }
+
+  return false;
+}
+
+/**
+ * Client-side selection filter used by ContentBrowser toggle / activate /
+ * SearchPanel Open. Type mapping is in {@link matchesAllowedTypes}; category
+ * remains an exact (case-insensitive) match when the host sets
+ * {@code allowedCategories}.
+ */
+export function passesFilters(
+  item: PSPathItem,
+  allowedTypes: ReadonlyArray<string> | null,
+  allowedCategories: ReadonlyArray<string> | null,
+): boolean {
+  if (!matchesAllowedTypes(item, allowedTypes)) {
+    return false;
+  }
+  const categories = tokenSet(allowedCategories);
+  if (categories.size === 0) {
+    return true;
+  }
+  const c = (item.category ?? item.type ?? "").trim().toLowerCase();
+  return categories.has(c);
+}

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -540,6 +540,7 @@ function SearchStatusView(props: {
           <li
             key={`${r.id ?? r.title ?? "row"}-${idx}`}
             data-testid="search-panel-result-row"
+            data-item-type={r.type ?? ""}
             style={{
               display: "flex",
               gap: 8,

--- a/WebUI/src/test/ts/contentBrowser/ContentBrowser.test.tsx
+++ b/WebUI/src/test/ts/contentBrowser/ContentBrowser.test.tsx
@@ -251,6 +251,57 @@ describe("ContentBrowser", () => {
     });
   });
 
+  it("search Open of an Image with allowedTypes [page, asset] selects the item (#3714)", async () => {
+    const onConfirm = vi.fn();
+    const listSavedSearches = vi.fn().mockResolvedValue([]);
+    const search = vi.fn().mockResolvedValue({
+      children: [
+        {
+          id: "hit-img",
+          title: "hero.jpg",
+          name: "hero.jpg",
+          folderPath: "/Assets/uploads",
+          type: "Image",
+        },
+      ],
+      totalCount: 1,
+      startIndex: 1,
+    });
+    render(
+      <ContentBrowser
+        mode="select"
+        enableSearch
+        listSavedSearches={listSavedSearches}
+        search={search}
+        allowedTypes={["page", "asset"]}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("search-panel-input"), {
+      target: { value: "jpg" },
+    });
+    fireEvent.click(screen.getByTestId("search-panel-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-results")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("search-panel-open-hit-img"));
+    const confirm = screen.getByTestId("content-browser-confirm");
+    await waitFor(() => {
+      expect(confirm).not.toBeDisabled();
+    });
+    expect(screen.queryByTestId("content-browser-error")).not.toBeInTheDocument();
+    expect(screen.getByTestId("content-browser-selection-summary")).toHaveTextContent(
+      "1 selected",
+    );
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    const payload = onConfirm.mock.calls[0]?.[0];
+    expect(payload?.items?.[0]?.id).toBe("hit-img");
+    expect(payload?.items?.[0]?.type).toBe("Image");
+  });
+
   it("search Open selects the hit so Confirm can fire (#2793 host wiring)", async () => {
     const onConfirm = vi.fn();
     const listSavedSearches = vi.fn().mockResolvedValue([]);

--- a/WebUI/src/test/ts/contentBrowser/passesFilters.test.ts
+++ b/WebUI/src/test/ts/contentBrowser/passesFilters.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import {
+  matchesAllowedTypes,
+  passesFilters,
+} from "../../../main/ts/contentBrowser/passesFilters";
+
+function item(
+  type: string,
+  extra?: Partial<PSPathItem>,
+): PSPathItem {
+  return {
+    id: extra?.id ?? "1",
+    name: extra?.name ?? "row",
+    path: extra?.path ?? "/Assets/row",
+    type,
+    category: extra?.category,
+    ...extra,
+  };
+}
+
+describe("matchesAllowedTypes (#3714)", () => {
+  it("allows any item when the host lists no types", () => {
+    expect(matchesAllowedTypes(item("Image"), null)).toBe(true);
+    expect(matchesAllowedTypes(item("folder"), [])).toBe(true);
+  });
+
+  it("maps CMS Image / File / rffImage to host asset", () => {
+    const assetOnly = ["asset"];
+    expect(matchesAllowedTypes(item("Image"), assetOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("File"), assetOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("rffImage"), assetOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("rffFile"), assetOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("percAsset"), assetOnly)).toBe(true);
+  });
+
+  it("maps percPage / page / rffHome to host page", () => {
+    const pageOnly = ["page"];
+    expect(matchesAllowedTypes(item("percPage"), pageOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("page"), pageOnly)).toBe(true);
+    expect(matchesAllowedTypes(item("rffHome"), pageOnly)).toBe(true);
+    expect(
+      matchesAllowedTypes(item("CustomLanding", { category: "LANDING_PAGE" }), pageOnly),
+    ).toBe(true);
+  });
+
+  it("accepts Image when the asset picker allows page and asset", () => {
+    const picker = ["page", "asset"];
+    expect(matchesAllowedTypes(item("Image"), picker)).toBe(true);
+    expect(matchesAllowedTypes(item("percPage"), picker)).toBe(true);
+    expect(matchesAllowedTypes(item("rffImage"), picker)).toBe(true);
+    expect(matchesAllowedTypes(item("File"), picker)).toBe(true);
+    expect(
+      matchesAllowedTypes(
+        item("NewsArticle", { path: "/Sites/Demo/News/Q3" }),
+        picker,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects folders and nav types for page/asset hosts", () => {
+    const picker = ["page", "asset"];
+    expect(matchesAllowedTypes(item("folder"), picker)).toBe(false);
+    expect(matchesAllowedTypes(item("Folder"), picker)).toBe(false);
+    expect(matchesAllowedTypes(item("site"), picker)).toBe(false);
+    expect(matchesAllowedTypes(item("rffNavon"), picker)).toBe(false);
+    expect(matchesAllowedTypes(item("rffNavTree"), picker)).toBe(false);
+  });
+
+  it("does not treat Image as a page-only pick", () => {
+    expect(matchesAllowedTypes(item("Image"), ["page"])).toBe(false);
+    expect(matchesAllowedTypes(item("rffImage"), ["page"])).toBe(false);
+    expect(matchesAllowedTypes(item("File"), ["page"])).toBe(false);
+  });
+
+  it("does not treat percPage as an asset-only pick", () => {
+    expect(matchesAllowedTypes(item("percPage"), ["asset"])).toBe(false);
+    expect(matchesAllowedTypes(item("page"), ["asset"])).toBe(false);
+  });
+
+  it("keeps exact CMS type matches when the host lists that name", () => {
+    expect(matchesAllowedTypes(item("Image"), ["Image"])).toBe(true);
+    expect(matchesAllowedTypes(item("percPage"), ["percPage"])).toBe(true);
+  });
+});
+
+describe("passesFilters", () => {
+  it("still applies allowedCategories as an exact match", () => {
+    expect(
+      passesFilters(item("Image", { category: "ASSET" }), ["page", "asset"], ["asset"]),
+    ).toBe(true);
+    expect(
+      passesFilters(item("Image", { category: "ASSET" }), ["page", "asset"], ["page"]),
+    ).toBe(false);
+  });
+
+  it("passes Image with no category when allowedTypes is page+asset", () => {
+    expect(passesFilters(item("Image"), ["page", "asset"], null)).toBe(true);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
@@ -116,6 +116,10 @@ describe("SearchPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("search-panel-results")).toBeTruthy();
     });
+    expect(screen.getByTestId("search-panel-result-row")).toHaveAttribute(
+      "data-item-type",
+      "page",
+    );
     fireEvent.click(screen.getByTestId("search-panel-open-1"));
     fireEvent.click(screen.getByTestId("search-panel-reveal-1"));
     expect(onOpen).toHaveBeenCalledTimes(1);

--- a/docs/ai-generated/code-reviews/3714-asset-picker-search-type-erlang.md
+++ b/docs/ai-generated/code-reviews/3714-asset-picker-search-type-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review — #3714 Asset Picker search type mapping
+
+- **Branch:** `fix/issue-3714-asset-picker-search-type`
+- **Scope:** uncommitted vs `HEAD` / `origin/main`
+- **Reviewer:** Erlang (pre-commit)
+- **Date:** 2026-08-21
+- **Memory patterns hit:** behavioral tests; WebUI Playwright companion; change-class closure; no path I/O
+
+## Summary
+
+ContentBrowser `passesFilters` required an exact match between host `allowedTypes` (`page`, `asset`) and the item `type`/`category`. CMS search returns content-type names (`Image`, `percPage`, `rffImage`), so Open on a valid hit showed “Selected item type is not allowed” and Confirm stayed disabled.
+
+The mapping is extracted to `passesFilters.ts`, reuses Explorer `isFolder` / `isPageOrAssetContentType` / `isAssetContentType`, and adds stock aliases (`Image`/`File`/FastForward names). Folders and nav types still fail page/asset hosts. Search rows expose `data-item-type` for Playwright. Product-docs note the picker search behavior.
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None blocking.
+
+### Tests
+
+- `passesFilters.test.ts` — Image/File/rffImage → asset; percPage → page; `[page, asset]` accepts Image; folders/nav rejected; Image rejected for page-only.
+- `ContentBrowser.test.tsx` — search Open of Image with `allowedTypes: [page, asset]` enables Confirm and fires `onConfirm`.
+- Playwright `host-asset-picker.spec.js` — live Open + Confirm; skips folderish rows; prefers Image/file/asset hits; console/pageerror empty.
+
+### Change-class closure
+
+WebUI screen bug + Vitest + Playwright + `product-docs/8.2/admin/content-explorer.md` (Content Browser pickers). No Java API shape change.
+
+### Cross-platform path checklist
+
+N/A — no filesystem path I/O. CMS folder paths remain `/`-separated logical paths.
+
+## Re-review
+
+n/a (first pass; Playwright folder-row skip applied before this report).

--- a/modules/perc-qa-automation/frontend/tests/host-asset-picker.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/host-asset-picker.spec.js
@@ -200,4 +200,108 @@ test.describe("US2 host-asset-picker migration (SC-002)", () => {
       scope: '[data-testid="content-browser-search-panel"]',
     });
   });
+
+  /**
+   * #3714: CMS search returns content-type names (Image, percPage) while
+   * the host filter is allowedTypes [page, asset]. Open must select the
+   * hit so Confirm enables.
+   */
+  test("asset-picker search Open of a CMS type (Image/page) enables Confirm @content-browser-search @host-asset-picker @issue-3714", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        pageErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(DIALOG_URL, { waitUntil: "networkidle" });
+    const dialog = page.locator('[data-testid="content-browser"]');
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+    await expect(dialog).toHaveAttribute("data-enable-search", "true");
+
+    const input = page.locator('[data-testid="search-panel-input"]');
+    const submit = page.locator('[data-testid="search-panel-submit"]');
+    await expect(input).toBeVisible({ timeout: 10_000 });
+
+    const queries = ["jpg", "Image", "Home"];
+    let hasResults = false;
+    for (const q of queries) {
+      await input.fill(q);
+      await submit.click();
+      const settled = page
+        .locator(
+          '[data-testid="search-panel-results"], [data-testid="search-panel-empty"], [data-testid="search-panel-error"]',
+        )
+        .first();
+      await expect(settled).toBeVisible({ timeout: 20_000 });
+      if (await page.locator('[data-testid="search-panel-results"]').isVisible()) {
+        hasResults = true;
+        break;
+      }
+    }
+    expect(
+      hasResults,
+      "QA H2 cell must return at least one search hit (jpg/Image/Home)",
+    ).toBe(true);
+
+    const rows = page.locator('[data-testid="search-panel-result-row"]');
+    await expect(rows.first()).toBeVisible();
+    const rowCount = await rows.count();
+    const folderish = (type) =>
+      type === "folder" ||
+      type === "fsfolder" ||
+      type === "site" ||
+      type.includes("navon") ||
+      type.includes("navtree");
+    const isAssetish = (type) =>
+      type.includes("image") ||
+      type === "file" ||
+      type === "asset" ||
+      type === "rfffile" ||
+      type === "percasset";
+    let chosen = -1;
+    for (let i = 0; i < rowCount; i++) {
+      const type = (
+        (await rows.nth(i).getAttribute("data-item-type")) || ""
+      ).toLowerCase();
+      if (folderish(type)) {
+        continue;
+      }
+      if (isAssetish(type)) {
+        chosen = i;
+        break;
+      }
+      if (chosen < 0) {
+        chosen = i;
+      }
+    }
+    expect(chosen, "search results must include a non-folder page or asset").toBeGreaterThanOrEqual(
+      0,
+    );
+    await rows
+      .nth(chosen)
+      .locator("button[data-testid^='search-panel-open-']")
+      .click();
+
+    await expect(
+      page.locator('[data-testid="content-browser-error"]'),
+    ).toHaveCount(0);
+    const confirm = page.locator('[data-testid="content-browser-confirm"]');
+    await expect(confirm).toBeEnabled({ timeout: 10_000 });
+    const summary = page.locator(
+      '[data-testid="content-browser-selection-summary"]',
+    );
+    await expect(summary).not.toHaveText(/No items selected/i);
+    await confirm.click();
+    const result = page.locator('[data-testid="perc-content-browser-result"]');
+    await expect(result).toContainText("Confirmed:", { timeout: 10_000 });
+    await expect(result).toContainText("items");
+
+    expect(pageErrors, `browser errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -289,6 +289,19 @@ page (including a quiet or missing search index). A 500 error panel after Submit
 is a product defect — the input, Submit button, and optional saved-search picker
 stay available either way.
 
+## Content Browser pickers
+
+Slot **Add**, the modern **asset picker**, and the **page picker** open **Content Browser**
+(tree, list, and the same Search panel). Browse to a page or asset, or search, then
+**Open** a result and **Confirm**.
+
+Search hits use CMS content-type names (for example **Image**, **File**, **percPage**,
+or FastForward types such as **rffImage**). Those names match the picker's page/asset
+filter — **Open** selects the hit, the selection summary updates, and **Confirm**
+enables. Folders and navigation nodes are not selectable in the asset or page picker.
+A type that the picker does not allow still shows *Selected item type is not allowed*
+and leaves Confirm disabled.
+
 ## Display format
 
 Use the **display format** selector next to the menu bar to choose list columns for the


### PR DESCRIPTION
## Summary

Asset Picker search returned CMS content-type names such as `Image` while the host filter is `allowedTypes: [page, asset]`. Exact string match in ContentBrowser rejected the hit (`Selected item type is not allowed`), left the selection summary empty, and kept Confirm disabled.

This maps host `page`/`asset` onto CMS types (`percPage`, `Image`, `File`, FastForward `rffImage`/`rffFile`, and other non-folder items when both page and asset are allowed). Folders and nav types stay excluded.

Parent QA: #2799 (ContentBrowser host SearchPanel). Out of scope: dual React mount / folderPath JAXB (already fixed).

Fixes #3714

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Env: QA H2 docker (`perc-devctl qa-up`) as Admin.
2. Open `/Rhythmyx/cm/app/assetPickerModern.jsp`.
3. Search for an asset (e.g. `jpg` / `Image`).
4. Click **Open** on an Image (or other page/asset) hit.
5. Selection summary updates; Confirm enables; no “Selected item type is not allowed”.
6. Confirm returns JSON with the item id/type.
7. Folders remain unselectable.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/content-explorer.md` (Content Browser pickers: search Open maps CMS type names)
- [x] **Unit / module tests** — `passesFilters.test.ts`, ContentBrowser Image Open Vitest; `cd WebUI && ../mvnw clean install` BUILD SUCCESS (Vitest 3017 passed); `cd modules/perc-qa-automation && ../../mvnw clean install` BUILD SUCCESS
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/host-asset-picker.spec.js` (`@issue-3714`)
- [x] **Build gates** — standalone clean install on WebUI and perc-qa-automation; no skipTests
- [x] **Cross-platform** — N/A (no filesystem path I/O; CMS folder paths remain `/`)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests 3017 passed (Vitest)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (npm ci; no Java tests)
- **downstream_checked:** none (C2 N/A — no Java public API / `final` / signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- Hot-copy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- `QA_CMS_HOST_PORT=9993 python docker/scripts/perc-devctl.py qa-health` → `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy`
- `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/host-asset-picker.spec.js` → **7 passed** (13.4s), including search Open Confirm
- **console-clean:** yes (pageerror/console error listeners empty)
- **server.log-clean:** yes (no ERROR/FATAL in last 200 lines of `server.log` for the test window)
- `python docker/scripts/perc-devctl.py qa-down` → RESULT:OK

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
