### PR TITLE
fix(sitemanage): numeric GET checkIn must not HTTP 500 (#3722)

### DIFF
--- a/docs/ai-generated/code-reviews/3722-numeric-checkin-guid-erlang.md
+++ b/docs/ai-generated/code-reviews/3722-numeric-checkin-guid-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #3722 numeric checkIn GUID
+
+**Branch:** `fix/issue-3722-numeric-checkin-no-500`  
+**Scope:** uncommitted vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for remaining untyped GUID assemble; no public API signature change; REST checkIn no-op instead of 500; product-docs N/A (Preview already documented)
+
+## Summary
+
+Cycle Verify residual of Explorer Preview `GET …/itemmanagement/workflow/checkIn/594` HTTP 500 (`Type is undetermined`). Cluster #3695 already maps bare numeric ids in `PSIdMapper.getGuid`. Remaining untyped path is `PSGuid.assemble` for a single numeric token with type bits 0 (what stale `makeGuid(String)` still calls). Assemble now sets `LEGACY_CONTENT`. `PSItemSummaryService.find` retries `getGuidFromContentId` if getGuid still throws. REST `checkIn` returns 200 no-op instead of HTTP 500 when the cause chain contains undetermined type.
+
+No operator-visible Preview contract change.
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new filesystem `".../" +` or `"...\\" +` joins (CMS URL helpers use `/` for HTTP)
+- [x] Tests do not assert OS path strings
+- [x] N/A temp files / line endings / scripts
+
+## Tests
+
+- `PSGuidTest` — `new PSGuid("594")` is LEGACY_CONTENT; two-component still requires type
+- `PSItemSummaryServiceNumericIdTest` — find retries `getGuidFromContentId` on undetermined type
+- `PSItemWorkflowServiceNumericCheckInTest` — REST checkIn no-op on find IAE / DataServiceLoadException
+- Playwright `explorer-preview-view.spec.js` numeric checkIn case (#3688 / #3722)
+- Live C5: `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:9993; docker cp utils + sitemanage (+ perc-system); in-cell StopJetty/StartJetty; qa-health RESULT:OK HTTP:200 HEALTH:healthy; Playwright `explorer-preview-view.spec.js` **3 passed 0 skipped**; console-clean=yes (pageerror); server.log-clean=yes (0 ERROR/FATAL, 0 `Type is undetermined`)
+
+## Change-class companions
+
+Untyped GUID assemble in utils; sitemanage checkIn/find defense; Playwright surface spec title; product-docs N/A.

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -572,7 +572,7 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
   );
 
   test(
-    "numeric checkIn for listed page content id does not 500 (#3688)",
+    "numeric checkIn for listed page content id does not 500 (#3688 / #3722)",
     { tag: ["@explorer-preview-view", "@preview"] },
     async ({ request }) => {
       test.setTimeout(30_000);

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-preview-view.test.js
@@ -46,7 +46,7 @@ describe("explorer-preview-view helpers (#2733)", () => {
     assert.equal(TEST_IDS.viewTools, "explorer-view-tools");
   });
 
-  it("workflowCheckInPath encodes bare numeric content ids (#3688)", () => {
+  it("workflowCheckInPath encodes bare numeric content ids (#3688 / #3722)", () => {
     assert.equal(
       workflowCheckInPath("/Rhythmyx/services", "594"),
       "/Rhythmyx/services/itemmanagement/workflow/checkIn/594",

--- a/modules/utils/src/main/java/com/percussion/services/guidmgr/data/PSGuid.java
+++ b/modules/utils/src/main/java/com/percussion/services/guidmgr/data/PSGuid.java
@@ -246,10 +246,14 @@ public class PSGuid extends Number implements IPSGuid {
           m_guid = Long.parseLong(tokens[0]);
           if (getType() == 0) {
             if (type == null) {
-              throw new IllegalArgumentException(
-                  "Type is undetermined, expecting \"type\" argument");
+              // Bare numeric content ids (Explorer Preview
+              // GET .../workflow/checkIn/594) have no type bits. Untyped
+              // makeGuid(String) used to throw here; treat them as legacy
+              // content so REST checkIn cannot HTTP 500 (#3722 / #3688).
+              setType(PSTypeEnum.LEGACY_CONTENT.getOrdinal());
+            } else {
+              setType(type.getOrdinal());
             }
-            setType(type.getOrdinal());
           } else if ((type != null) && (getType() != type.getOrdinal()) && !forceType) {
             throw new IllegalArgumentException("Type does not match");
           } else if (type != null && getType() != type.getOrdinal()) {

--- a/modules/utils/src/test/java/com/percussion/services/guidmgr/data/PSGuidTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/guidmgr/data/PSGuidTest.java
@@ -49,4 +49,17 @@ public class PSGuidTest {
     assertThrows(
         IllegalArgumentException.class, () -> new PSGuid(PSTypeEnum.TEMPLATE, typed.longValue()));
   }
+
+  @Test
+  public void bareNumericStringIsLegacyContentNotUndetermined() {
+    PSGuid guid = new PSGuid("594");
+    assertEquals(PSTypeEnum.LEGACY_CONTENT.getOrdinal(), guid.getType());
+    assertEquals(594, guid.getUUID());
+    assertEquals(0L, guid.getHostId());
+  }
+
+  @Test
+  public void hyphenatedTwoComponentStillRequiresType() {
+    assertThrows(IllegalArgumentException.class, () -> new PSGuid("1-3"));
+  }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
@@ -191,10 +191,34 @@ public class PSItemWorkflowService implements IPSItemWorkflowService {
 
       return checkIn(id, false);
     } catch (PSItemWorkflowServiceException | PSDataServiceException e) {
+      if (isUndeterminedGuidType(e)) {
+        log.warn("checkIn skipping id {} with undetermined GUID type: {}", id, e.getMessage());
+        return new PSNoContent("checkIn");
+      }
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       throw new WebApplicationException(e.getMessage());
+    } catch (RuntimeException e) {
+      if (isUndeterminedGuidType(e)) {
+        log.warn("checkIn skipping id {} with undetermined GUID type: {}", id, e.getMessage());
+        return new PSNoContent("checkIn");
+      }
+      throw e;
     }
+  }
+
+  /**
+   * Explorer Preview {@code GET .../checkIn/{id}} must not HTTP 500 when a bare
+   * numeric content id hits untyped {@code PSGuid.assemble} (#3722 / #3688).
+   */
+  static boolean isUndeterminedGuidType(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      String msg = t.getMessage();
+      if (msg != null && msg.contains("Type is undetermined")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -211,7 +235,16 @@ public class PSItemWorkflowService implements IPSItemWorkflowService {
     var ids = new ArrayList<String>();
     ids.add(id);
 
-    var sum = dataItemSummaryService.find(id);
+    PSDataItemSummary sum;
+    try {
+      sum = dataItemSummaryService.find(id);
+    } catch (PSDataServiceException e) {
+      if (isUndeterminedGuidType(e)) {
+        log.warn("checkIn treating unloadable numeric id {} as missing: {}", id, e.getMessage());
+        return new PSNoContent("checkIn");
+      }
+      throw e;
+    }
     if (sum == null) {
       return new PSNoContent("checkIn");
     }

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSItemSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSItemSummaryService.java
@@ -151,7 +151,7 @@ public class PSItemSummaryService
   public List<PSDataItemSummary> findChildFolders(String id) throws DataServiceLoadException {
     notEmpty(id, "id");
     try {
-      var guid = idMapper.getGuid(id);
+      var guid = guidForItemId(id);
       var sums = contentWs.findChildFolders(guid);
       return convert(defaultItemSummaryFactory, sums, -1, PSRelationshipConfig.TYPE_FOLDER_CONTENT);
     } catch (Exception e) {
@@ -387,7 +387,7 @@ public class PSItemSummaryService
       isTrue(
           !StringUtils.startsWith(id, "//"),
           "findFolderChildren takes an id not a path. Use pathToId(path).");
-      var guid = idMapper.getGuid(id);
+      var guid = guidForItemId(id);
       var sums = contentWs.findFolderChildren(guid, false);
       var landingPageId = getLandingPageId(sums);
       return convert(factory, sums, landingPageId, PSRelationshipConfig.TYPE_FOLDER_CONTENT);
@@ -412,7 +412,7 @@ public class PSItemSummaryService
       IPSCatalogItemFactory<F, String> factory, String id, String relationshipTypeName)
       throws DataServiceLoadException {
     try {
-      var guid = idMapper.getGuid(id);
+      var guid = guidForItemId(id);
       var sums = contentWs.findItems(Collections.singletonList(guid), false);
       if (sums.isEmpty()) return null;
       var item = sums.get(0);
@@ -432,6 +432,36 @@ public class PSItemSummaryService
     var path = getIconFromSystem(id);
     if (path != null) path = path.replaceFirst("^\\.\\./", ICON_BASE_PATH);
     return path;
+  }
+
+  /**
+   * Map an Explorer / REST item id to a GUID. Bare numeric content ids such as
+   * FastForward {@code 594} must not fail with untyped {@code PSGuid.assemble}
+   * ({@code Type is undetermined}) — retry as {@code LEGACY_CONTENT} (#3722).
+   */
+  IPSGuid guidForItemId(String id) {
+    try {
+      return idMapper.getGuid(id);
+    } catch (IllegalArgumentException e) {
+      if (!isUndeterminedGuidType(e)) {
+        throw e;
+      }
+      try {
+        return idMapper.getGuidFromContentId(Long.parseLong(id.trim()));
+      } catch (NumberFormatException nfe) {
+        throw e;
+      }
+    }
+  }
+
+  static boolean isUndeterminedGuidType(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      String msg = t.getMessage();
+      if (msg != null && msg.contains("Type is undetermined")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   protected String getIconFromSystem(String id) {

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowServiceNumericCheckInTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowServiceNumericCheckInTest.java
@@ -37,6 +37,7 @@ import com.percussion.share.async.IPSAsyncJobService;
 import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.data.PSDataItemSummary;
 import com.percussion.share.service.IPSDataItemSummaryService;
+import com.percussion.share.service.IPSDataService.DataServiceLoadException;
 import com.percussion.share.service.IPSIdMapper;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.sitemanage.dao.IPSiteDao;
@@ -135,5 +136,38 @@ class PSItemWorkflowServiceNumericCheckInTest {
     var result = service.checkIn("594");
 
     assertEquals("checkIn", result.getOperation());
+  }
+
+  @Test
+  void checkInRestDoesNot500WhenFindReportsUndeterminedGuidType() throws Exception {
+    when(dataItemSummaryService.find("594"))
+        .thenThrow(
+            new DataServiceLoadException(
+                new IllegalArgumentException(
+                    "Type is undetermined, expecting \"type\" argument")));
+
+    var result = service.checkIn("594");
+
+    assertEquals("checkIn", result.getOperation());
+  }
+
+  @Test
+  void checkInRestDoesNot500WhenGuidAssembleThrowsUndeterminedType() throws Exception {
+    when(dataItemSummaryService.find("594"))
+        .thenThrow(
+            new IllegalArgumentException("Type is undetermined, expecting \"type\" argument"));
+
+    var result = service.checkIn("594");
+
+    assertEquals("checkIn", result.getOperation());
+  }
+
+  @Test
+  void isUndeterminedGuidTypeWalksCauseChain() {
+    var wrapped =
+        new DataServiceLoadException(
+            new IllegalArgumentException("Type is undetermined, expecting \"type\" argument"));
+    assertEquals(true, PSItemWorkflowService.isUndeterminedGuidType(wrapped));
+    assertEquals(false, PSItemWorkflowService.isUndeterminedGuidType(new IllegalArgumentException("other")));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemSummaryServiceNumericIdTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemSummaryServiceNumericIdTest.java
@@ -31,6 +31,7 @@ import com.percussion.fastforward.managednav.IPSManagedNavService;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.IPSGuidManager;
 import com.percussion.share.service.IPSDataService.DataServiceLoadException;
+import com.percussion.share.service.IPSIdMapper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.IPSContentWs;
@@ -67,5 +68,23 @@ class PSItemSummaryServiceNumericIdTest {
 
     verify(guidMgr).makeGuid(594L, PSTypeEnum.LEGACY_CONTENT);
     verify(guidMgr, never()).makeGuid(anyString());
+  }
+
+  @Test
+  void findRetriesLegacyContentWhenGetGuidThrowsUndeterminedType() throws DataServiceLoadException {
+    IPSIdMapper mapper = mock(IPSIdMapper.class);
+    when(mapper.getGuid("594"))
+        .thenThrow(
+            new IllegalArgumentException("Type is undetermined, expecting \"type\" argument"));
+    when(mapper.getGuidFromContentId(594L)).thenReturn(contentGuid);
+    when(contentWs.findItems(anyList(), anyBoolean())).thenReturn(Collections.emptyList());
+
+    var sut =
+        new PSItemSummaryService(
+            contentWs, mock(PSItemDefManager.class), mapper, mock(IPSManagedNavService.class));
+
+    assertNull(sut.find("594"));
+
+    verify(mapper).getGuidFromContentId(594L);
   }
 }


### PR DESCRIPTION
## Summary

Cycle Verify residual of Explorer Preview `GET /Rhythmyx/services/itemmanagement/workflow/checkIn/594` returning HTTP 500 (`Type is undetermined, expecting "type" argument`). Parent **#2400** / closed **#3688** / QA **#2745**.

Cluster #3695 already maps bare numeric ids in `PSIdMapper.getGuid` → `getGuidFromContentId` / `LEGACY_CONTENT`. That mapper is **not** re-landed here. The remaining untyped GUID path is `PSGuid.assemble` for a single numeric token with type bits 32–39 equal to zero (what untyped `makeGuid(String)` / stale mapper still calls). Assemble now sets `PSTypeEnum.LEGACY_CONTENT` instead of throwing.

Defense in sitemanage:

- `PSItemSummaryService.find` retries `getGuidFromContentId` when `getGuid` still throws undetermined type.
- REST `checkIn/{id}` returns a 200 no-op instead of HTTP 500 when the cause chain contains that message.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3722
Parent tracker: #2400

## Test plan

1. Standalone Maven: `cd modules/utils && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 392, Failures: 0, Skipped: 9 (`PSGuidTest` 5/0/0).
2. Standalone Maven: `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1393, Failures: 0, Skipped: 125 (`PSItemWorkflowServiceNumericCheckInTest` 6/0/0, `PSItemSummaryServiceNumericIdTest` 2/0/0).
3. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health` (RESULT:OK HTTP:200 HEALTH:healthy). TEST_CMS_URL from qa-up (this run `http://127.0.0.1:9993`).
4. Hot-deploy `utils-8.2.0-SNAPSHOT.jar` (WAR `WEB-INF/lib` + `jetty/defaults/lib/perc`) and `sitemanage-8.2.0-SNAPSHOT.jar` (WAR `WEB-INF/lib`); also copied `perc-system-8.2.0-SNAPSHOT.jar`. In-cell `StopJetty.sh` / `StartJetty.sh` (not `docker restart`). `qa-health` again RESULT:OK.
5. From `modules/perc-qa-automation/frontend`: `npm run test:surface -- --path tests/explorer-preview-view.spec.js` — **3 passed 0 skipped**, including `numeric checkIn for listed page content id does not 500 (#3688 / #3722)`.
6. console-clean=yes (pageerror). server.log-clean=yes (0 ERROR/FATAL, 0 `Type is undetermined` after hot-deploy restart).
7. `python docker/scripts/perc-devctl.py qa-down` after the run.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): no operator-visible Preview contract change; Preview/view behavior is unchanged; REST checkIn still exists and now avoids HTTP 500 for bare numeric content ids
- [x] **Unit / module tests** — `PSGuidTest`, `PSItemSummaryServiceNumericIdTest`, `PSItemWorkflowServiceNumericCheckInTest`; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — `tests/explorer-preview-view.spec.js` numeric checkIn case (title cites #3722); live H2 QA surface 3 passed
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O); CMS URL helpers keep `/`

### C3 evidence

- **modules_built:** `modules/utils`, `projects/sitemanage`
- **build_evidence:**
  - `cd modules/utils && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 392, Failures: 0, Skipped: 9
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1393, Failures: 0, Skipped: 125
- **downstream_checked:** C2 API shape did not apply (no `final`/`sealed`, no public/protected signature change). Grep `extends PSGuid` → `PSLegacyGuid`, `PSDesignGuid` only; no `new PSGuid() {` anonymous subclasses.

### C5 UI proof

- qa-up: `python docker/scripts/perc-devctl.py qa-up --skip-image-build`; TEST_CMS_URL=`http://127.0.0.1:9993`; container `perc-matrix-cms-h2`
- qa-health after up and after hot-deploy/Jetty restart: RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/explorer-preview-view.spec.js` → 3 passed
- console-clean=yes
- server.log-clean=yes

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
