### PR TITLE
fix(explorer): send full GUID on Translations GET (#3703)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/translationsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/translationsApi.ts
@@ -105,7 +105,8 @@ function rethrowAuthOrWrap(err: unknown, fallback: string): never {
 /**
  * List current locale + translation-category dependents for a content item.
  *
- * @param itemId legacy content id or guid string
+ * @param itemId hyphenated host-type-uuid GUID or bare numeric content id.
+ *   Do not strip a GUID to its last segment before calling.
  */
 export async function listItemTranslationVariants(
   itemId: string,

--- a/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/TranslationsPanel.tsx
@@ -86,14 +86,29 @@ async function defaultCreateVariants(body: {
 }
 
 /**
- * Resolve Explorer row id to a legacy content id.
+ * Resolve Explorer row id to a legacy content id for create-variant POST
+ * ({@code itemIds: number[]}).
  *
- * <p>List rows are usually Percussion GUIDs ({@code 1-101-708}); {@link
+ * <p>List rows are usually Percussion GUIDs ({@code 16777215-101-551}); {@link
  * Number}({@code itemId}) is NaN for those and must not be used (#3545 /
  * parent #2649). Folders/sites with no content id still return null.
+ *
+ * <p>Do <strong>not</strong> use this stripped id for variants GET (#3703):
+ * {@code GET …/translations/551} 404s while the full GUID succeeds.
  */
 function resolveTranslationsContentId(itemId: string): number | null {
   return parseExplorerContentId(itemId);
+}
+
+/**
+ * Path key for {@code GET /rest/content-explorer/translations/{itemId}}.
+ *
+ * <p>REST accepts a hyphenated GUID or a bare numeric content id. Prefer the
+ * raw Explorer row id so GUID selections are not reduced to the last
+ * segment (#3703 / parent #2649).
+ */
+export function translationsVariantsItemKey(itemId: string): string {
+  return itemId.trim();
 }
 
 function roleLabel(role: string | null | undefined): string {
@@ -137,12 +152,10 @@ export function TranslationsPanel(
       setState({ kind: "auth" });
       return;
     }
-    const resolvedId = resolveTranslationsContentId(itemId);
-    // GUID last segment (1-101-708 → 708). Parse-null does not skip GET:
-    // loadVariants still receives the raw itemId (unit tests / direct mounts).
-    // The Explorer shell never mounts this panel for folders/sites.
-    const variantsKey =
-      resolvedId != null ? String(resolvedId) : itemId;
+    // GET uses the raw row id (full GUID or numeric). Do not strip the last
+    // GUID segment — that 404s (#3703). Parse-null still GETs the raw id
+    // (unit tests / direct mounts). Create-variant POST uses numeric ids.
+    const variantsKey = translationsVariantsItemKey(itemId);
     setState({ kind: "loading" });
     setCreateError(null);
     setCreateSuccess(null);

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1494,9 +1494,11 @@ describe("ContentExplorerShell product composition (#2400)", () => {
   });
 
   it("GUID list row opens translations panel (not select-item hint) (#3545)", async () => {
+    const translationGets: string[] = [];
     mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;
       if (url.includes("/content-explorer/translations/")) {
+        translationGets.push(url);
         return new Response(
           JSON.stringify({
             itemId: 708,
@@ -1561,6 +1563,12 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       "en-us",
     );
     expect(screen.getByTestId("translations-variant-row-708")).toBeTruthy();
+    expect(translationGets.some((u) => u.includes("/translations/1-101-708"))).toBe(
+      true,
+    );
+    expect(translationGets.some((u) => /\/translations\/708(?:\?|$)/.test(u))).toBe(
+      false,
+    );
   });
 
   it("Content → Site Copy mounts wizard with source from /Sites/<name> (#2767)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/TranslationsPanel.test.tsx
@@ -17,7 +17,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TranslationAuthError } from "../../../main/ts/api/contentExplorer/translationsApi";
-import { TranslationsPanel } from "../../../main/ts/contentExplorer/TranslationsPanel";
+import {
+  TranslationsPanel,
+  translationsVariantsItemKey,
+} from "../../../main/ts/contentExplorer/TranslationsPanel";
 import { renderA11yGate } from "./a11y";
 
 const SAMPLE_VARIANTS = {
@@ -90,11 +93,11 @@ describe("TranslationsPanel", () => {
     ).toBeNull();
   });
 
-  it("resolves GUID Explorer row ids for variants GET (#3545)", async () => {
+  it("GETs hyphenated GUID without stripping last segment (#3703)", async () => {
     const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
     render(
       <TranslationsPanel
-        itemId="1-101-708"
+        itemId="16777215-101-551"
         itemLabel="Home"
         loadVariants={loadVariants}
         loadLocaleCatalog={async () => CATALOG}
@@ -106,12 +109,31 @@ describe("TranslationsPanel", () => {
         "ok",
       ),
     );
-    expect(loadVariants).toHaveBeenCalledWith("708");
+    expect(loadVariants).toHaveBeenCalledWith("16777215-101-551");
+    expect(loadVariants).not.toHaveBeenCalledWith("551");
     expect(screen.getByTestId("translations-current-locale-value")).toHaveTextContent(
       "en-us",
     );
     expect(screen.getByTestId("translations-variant-row-335")).toBeTruthy();
     expect(screen.getByTestId("translations-variant-row-900")).toBeTruthy();
+  });
+
+  it("GETs bare numeric content ids unchanged", async () => {
+    const loadVariants = vi.fn(async () => SAMPLE_VARIANTS);
+    render(
+      <TranslationsPanel
+        itemId="335"
+        loadVariants={loadVariants}
+        loadLocaleCatalog={async () => CATALOG}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("translations-panel")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      ),
+    );
+    expect(loadVariants).toHaveBeenCalledWith("335");
   });
 
   it("create-variant POSTs selected locales via injection seam", async () => {
@@ -178,7 +200,7 @@ describe("TranslationsPanel", () => {
         screen.getByTestId("translations-locale-option-de-de"),
       ).toBeInTheDocument(),
     );
-    expect(loadVariants).toHaveBeenCalledWith("708");
+    expect(loadVariants).toHaveBeenCalledWith("1-101-708");
     fireEvent.click(screen.getByTestId("translations-locale-option-de-de"));
     fireEvent.click(screen.getByTestId("translations-create-submit"));
     await waitFor(() => expect(createVariants).toHaveBeenCalledTimes(1));
@@ -298,5 +320,15 @@ describe("TranslationsPanel", () => {
       ),
     );
     await renderA11yGate(container);
+  });
+});
+
+describe("translationsVariantsItemKey", () => {
+  it("keeps GUID and numeric paths distinct", () => {
+    expect(translationsVariantsItemKey("16777215-101-551")).toBe(
+      "16777215-101-551",
+    );
+    expect(translationsVariantsItemKey(" 551 ")).toBe("551");
+    expect(translationsVariantsItemKey("1-101-708")).toBe("1-101-708");
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/translationsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/translationsApi.test.ts
@@ -67,6 +67,28 @@ describe("translationsApi", () => {
     );
   });
 
+  it("listItemTranslationVariants keeps hyphenated GUID in the path (#3703)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(SAMPLE), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+    await listItemTranslationVariants("16777215-101-551");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/Rhythmyx/rest/content-explorer/translations/16777215-101-551",
+      ),
+      expect.objectContaining({ method: "GET" }),
+    );
+    const url = String((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(url).not.toMatch(/\/translations\/551(?:\?|$)/);
+  });
+
   it("listItemTranslationVariants maps 403 to TranslationAuthError", async () => {
     vi.stubGlobal(
       "fetch",

--- a/docs/ai-generated/code-reviews/3703-translations-guid-erlang.md
+++ b/docs/ai-generated/code-reviews/3703-translations-guid-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — #3703 Translations GET GUID vs numeric
+
+**Branch:** `fix/issue-3703-translations-guid`  
+**Scope:** uncommitted vs `HEAD` (WebUI Translations panel + REST adaptor)  
+**Reviewer:** Erlang (strict, independent of implementer)  
+**Date:** 2026-08-21
+
+## Summary
+
+Explorer Translations GET was stripping hyphenated GUIDs (`16777215-101-551` → `551`), which 404s while the full GUID returns 200. The change keeps the raw row id on GET, still uses numeric ids for create-variant POST, and the adaptor resolves both hyphenated GUIDs and bare numeric content ids (numeric path skips untyped `getGuid`).
+
+Memory patterns hit: change-class closure (rest + sitemanage apibridge + WebUI + Playwright + product-docs); behavioral tests for new resolve logic; no non-portable path I/O.
+
+## Recommendation
+
+**approve** — May commit/push: yes
+
+## Gate
+
+No blocking bugs. Behavioral tests cover GUID vs numeric GET keys, adaptor dual-path, REST passthrough, and Playwright fail-closed GUID URL. Product-docs updated. Cross-platform path checklist N/A (no filesystem path construction).
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Create-variant POST remains numeric `itemIds` (REST contract). GET is the 404 surface.
+- Playwright console-error gate may be noisy on H2; treat feature-related errors only as C5 fail.
+- Duplicate #3704 not in this change.
+
+## Cross-platform path checklist
+
+N/A — no new file I/O, installers, or path assertions.

--- a/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-translations.spec.js
@@ -20,11 +20,13 @@
  * <p>Verifies the modern React Content Explorer shell exposes the Translations
  * panel chrome and loads item locale / variants from the public REST façade
  * ({@code GET /rest/content-explorer/translations/{itemId}}). Create-variant
- * is exercised when a content row is selectable (GUID last-segment ids such as
- * {@code 1-101-708} → {@code 708}, #3545 / parent #2649). The client must not
- * emit {@code Selected item does not have a numeric content id} for a
- * GUID-shaped row. Folders/sites keep the select-item hint. Chrome visibility
- * is the hard gate when no content row is listed.</p>
+ * is exercised when a content row is selectable. GUID-shaped list ids such as
+ * {@code 16777215-101-551} must be sent on GET as the full GUID (#3703 / parent
+ * #2649) — not stripped to {@code 551} (HTTP 404). Create-variant POST still
+ * uses the numeric content id. The client must not emit {@code Selected item
+ * does not have a numeric content id} for a GUID-shaped row. Folders/sites
+ * keep the select-item hint. A GUID content row that opens the panel must
+ * reach {@code ok} with locale + create-variant (fail closed).</p>
  *
  * <p>Tags: {@code @explorer-translations} {@code @p-trans} {@code @smoke}</p>
  *
@@ -49,6 +51,54 @@ async function clickFirstRowWithDetachRetry(rows) {
   await rows.first().click({ force: true, timeout: 10_000 }).catch(async () => {
     await rows.first().click({ force: true, timeout: 10_000 }).catch(() => {});
   });
+}
+
+/**
+ * Double-click a folder row by {@code data-item-name} or visible name.
+ * @returns {Promise<boolean>}
+ */
+async function openFolderByName(page, name) {
+  const list = page.locator('[data-testid="detail-list"]');
+  const named = list.locator(
+    `tbody tr[data-row-kind="folder"][data-item-name="${name}"]`,
+  );
+  const row =
+    (await named.count()) > 0
+      ? named.first()
+      : list
+          .locator("tbody tr[data-row-kind=\"folder\"]")
+          .filter({ hasText: name })
+          .first();
+  if ((await row.count()) === 0) {
+    return false;
+  }
+  await row.dblclick({ force: true, timeout: 10_000 }).catch(async () => {
+    await row.click({ force: true, timeout: 10_000 }).catch(() => {});
+  });
+  await listWaitReady(page);
+  await page.waitForLoadState("networkidle").catch(() => {});
+  return true;
+}
+
+/**
+ * Find a GUID-shaped content row ({@code detail-row-host-type-uuid}).
+ * @returns {Promise<string>}
+ */
+async function guidIdFromItemRows(page) {
+  const list = page.locator('[data-testid="detail-list"]');
+  const rows = list.locator(
+    'tbody tr[data-testid^="detail-row-"][data-row-kind="item"]',
+  );
+  const n = await rows.count();
+  for (let i = 0; i < n; i += 1) {
+    const testid = (await rows.nth(i).getAttribute("data-testid")) || "";
+    const m = testid.match(/^detail-row-(\d+-\d+-\d+)$/);
+    if (m) {
+      await rows.nth(i).click({ force: true, timeout: 10_000 }).catch(() => {});
+      return m[1];
+    }
+  }
+  return "";
 }
 
 /**
@@ -207,6 +257,128 @@ test.describe("modern React Content Explorer — translations (P-Trans #2430)", 
       } else {
         await expect(hint).toBeVisible();
       }
+    },
+  );
+
+  test(
+    "GUID content row GET uses full GUID and loads locale variants (#3703)",
+    { tag: ["@explorer-translations", "@p-trans"] },
+    async ({ page }) => {
+      test.setTimeout(75_000);
+      const pageErrors = [];
+      const consoleErrors = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() !== "error") {
+          return;
+        }
+        const text = msg.text();
+        // Explorer chrome often logs Failed to load resource 400/500 for
+        // unrelated catalog calls. Fail only on JS exceptions or translations.
+        if (
+          /Failed to load resource: the server responded with a status of \d+/i.test(
+            text,
+          ) &&
+          !/translations/i.test(text)
+        ) {
+          return;
+        }
+        consoleErrors.push(text);
+      });
+
+      /** @type {string[]} */
+      const translationGets = [];
+      await page.route(
+        "**/rest/content-explorer/translations/**",
+        async (route) => {
+          if (route.request().method() === "GET") {
+            translationGets.push(route.request().url());
+          }
+          await route.continue();
+        },
+      );
+
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const list = page.locator('[data-testid="detail-list"]');
+      await expect(list).toBeVisible({ timeout: 15_000 });
+
+      let guidRowId = await guidIdFromItemRows(page);
+      if (!guidRowId) {
+        // Sites list is site folders. Open Corporate Investments (or first
+        // site), then Pages — FastForward pages use host-type-uuid ids.
+        await openFolderByName(page, "Corporate Investments");
+        await openFolderByName(page, "CorporateInvestments");
+        await openFolderByName(page, "Corporate_Investments");
+        guidRowId = await guidIdFromItemRows(page);
+      }
+      if (!guidRowId) {
+        await openFolderByName(page, "Pages");
+        guidRowId = await guidIdFromItemRows(page);
+      }
+      if (!guidRowId) {
+        await selectFirstContentRow(page);
+        guidRowId = await guidIdFromItemRows(page);
+      }
+
+      expect(
+        guidRowId,
+        "H2 QA must list a GUID-shaped content row (host-type-uuid)",
+      ).toMatch(/^\d+-\d+-\d+$/);
+
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      await page.locator('[data-testid="explorer-toggle-translations"]').click();
+
+      const panel = page.locator('[data-testid="translations-panel"]');
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+        timeout: 20_000,
+      });
+      await expect(panel).toHaveAttribute("data-testid-state", "ok");
+      await expect(
+        page.locator('[data-testid="translations-current-locale-value"]'),
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-testid="translations-create"]'),
+      ).toBeVisible();
+
+      const lastSeg = guidRowId.split("-").pop();
+      const fullGuidGets = translationGets.filter((u) =>
+        u.includes(`/translations/${guidRowId}`),
+      );
+      const strippedGets = translationGets.filter((u) =>
+        new RegExp(`/translations/${lastSeg}(?:\\?|$)`).test(u),
+      );
+      expect(
+        fullGuidGets.length,
+        `GET must use full GUID ${guidRowId}; captured=${translationGets.join(" | ")}`,
+      ).toBeGreaterThan(0);
+      expect(
+        strippedGets.length,
+        `GET must not strip GUID to ${lastSeg}; captured=${translationGets.join(" | ")}`,
+      ).toBe(0);
+
+      expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+        [],
+      );
+      expect(
+        consoleErrors,
+        `console error: ${consoleErrors.join(" | ")}`,
+      ).toEqual([]);
     },
   );
 

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -128,7 +128,7 @@ The **Server actions** toolbar and the item **context menu** use the same catalo
 | **Workflow** | Allowed transitions run through itemmanagement (`GET …/workflow/transitionWithComments/{id}/{trigger}`, not `wfactionset.html`). Clicking a listed trigger — including **Expire** when it is listed — returns HTTP 200 and does not show an error toast. |
 | **Purge** | Confirm, then permanently purge a **page** or **asset** (`pagemanagement` / `assetmanagement` purge). Other types stay unavailable. Distinct from **Delete** (remove from folder / recycle). |
 | **Edit / Quick Edit / View content** | Select a **page** or **asset** row first. Opens a new Content Editor window (`spa.jsp?entry=editor`) that checkouts the item (Edit) and shows content-type fields. Explorer **Open** on that same selected row lands the same React editor host (HTTP 200). **Folders** stay non-editable: Edit / Quick Edit / View content stay hidden, and Open on a folder browses into it instead of opening the editor. Text, rich text (TinyMCE), keyword, and community controls save through `PUT /services/itemmanagement/item/fields/{id}`. File and image controls upload through `PUT /services/itemmanagement/item/binary/{id}/{field}`. Does not open leftover Content Editor HTML (`?view=editor`, `editAsset.jsp`, `rx_ce`, `checkoutedit.xml`). |
-| **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`1-101-708`); the panel uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
+| **Translate** | Opens the Explorer **Translations** panel for the **selected page or asset** (this item’s locale, related variants, and create-variant). List row ids may be GUID-shaped (`16777215-101-551`); the panel requests variants with that full GUID (`GET /rest/content-explorer/translations/{itemId}`) and uses the content-id segment only for create-variant. Folders and sites have no content id — Explorer shows a select-item hint. Does not open the legacy translate XSL wizard. |
 | **Impact Analysis** | Opens the Explorer **Dependencies** panel for the **selected page or asset**. List row ids may be GUID-shaped (`1-101-708`); the viewer uses the content-id segment. Folders and sites have no content id — Explorer shows a select-item hint. |
 | **Copy URL to Clipboard** | Copies the site-path preview URL (or CMS path) for the selected item. |
 | **Revisions** | Opens the Revisions panel; restore is available when the selected revision is restorable. **Promote revision** opens the same chrome-less editor host (`mode=promote`) and restores the chosen revision through `GET /services/itemmanagement/item/restoreRevision/{revisionGuid}`. |
@@ -391,9 +391,12 @@ Open **View → Translations** after selecting a **page or asset** in the list (
 The panel shows **this item’s current locale** and **related locale variants**, and lets
 an authorized user **Create variants** for catalog locales the item does not already
 have. Explorer list rows identify items with a Percussion content id. The id is often
-GUID-shaped (for example `1-101-708`); the panel uses the last segment (`708`) for
-both the variants request and create-variant. That GUID form must not fail with
-“Selected item does not have a numeric content id.”
+GUID-shaped (for example `16777215-101-551`). The panel sends that **full GUID** on
+`GET /rest/content-explorer/translations/{itemId}` (the REST façade also accepts a
+bare numeric content id such as `551`). Create-variant still posts the numeric
+content id. Stripping a GUID to its last segment for the GET (`…/translations/551`)
+fails with **Item not found**. That GUID form must not fail with “Selected item does
+not have a numeric content id.”
 
 **Folders and sites** have no content id. With Translations open and only a folder or
 site selected, Explorer shows a select-item hint instead of the live panel.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -687,6 +687,23 @@ warning in the Server actions error region.
 
 See [Content Explorer](id:admin-content-explorer) server actions.
 
+## Content Explorer translations
+
+Explorer **Translations** (View → Translations, or Translate on Server actions) lists locale
+variants and creates new ones through the public REST façade:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/rest/content-explorer/translations/{itemId}` | Current locale plus translation-category dependents |
+| `POST` | `/rest/content-explorer/translations` | Create locale variants (`itemIds` numeric content ids, optional `locales`) |
+
+`{itemId}` on GET may be a hyphenated Percussion GUID (`16777215-101-551`) **or** a bare numeric
+content id (`551`). Explorer list rows are usually GUID-shaped; clients must send that full GUID
+on GET. Stripping to the last segment (`GET …/translations/551`) can return **404 Item not found**
+while the GUID form returns **200**. Create-variant POST still uses numeric `itemIds`.
+
+See [Content Explorer](id:admin-content-explorer) → Translations.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
@@ -162,7 +162,9 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
 
     IPSGuid guid;
     try {
-      guid = guidResolver.apply(itemId.trim());
+      guid = resolveItemGuid(itemId.trim());
+    } catch (IllegalArgumentException e) {
+      throw e;
     } catch (RuntimeException e) {
       log.debug("Could not resolve item id {}: {}", itemId, e.getMessage());
       return null;
@@ -330,6 +332,57 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
     // Non-legacy guids: UUID is the best available numeric id for any type (item or
     // untyped). Callers still validate via loadComponentSummary (null → not found).
     return guid.getUUID();
+  }
+
+  /**
+   * Resolve {@code itemId} as either a hyphenated {@code host-type-uuid} GUID or a
+   * bare numeric content id.
+   *
+   * <p>Explorer Translations GET historically stripped GUIDs to the last segment
+   * ({@code 16777215-101-551} → {@code 551}). {@link
+   * com.percussion.share.service.IPSIdMapper#getGuid(String)} can throw on an
+   * untyped packed long, which the resource maps as HTTP 404. Bare numbers skip
+   * the mapper and become {@link PSLegacyGuid} content ids; GUID strings still
+   * go through {@code guidResolver}.
+   *
+   * @param itemId trimmed, non-blank key
+   * @return guid for summary load, never {@code null} on the numeric path
+   */
+  IPSGuid resolveItemGuid(String itemId) {
+    Long contentId = parseBareNumericContentId(itemId);
+    if (contentId != null) {
+      return new PSLegacyGuid(contentId.intValue(), -1);
+    }
+    return guidResolver.apply(itemId);
+  }
+
+  /**
+   * Bare decimal content id with no GUID type bits (Explorer last-segment or
+   * legacy numeric path). Hyphenated GUIDs return {@code null}.
+   */
+  static Long parseBareNumericContentId(String key) {
+    if (StringUtils.isBlank(key)) {
+      return null;
+    }
+    String trimmed = key.trim();
+    for (int i = 0; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (c < '0' || c > '9') {
+        return null;
+      }
+    }
+    try {
+      long raw = Long.parseLong(trimmed);
+      if (raw <= 0) {
+        return null;
+      }
+      if (raw > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("itemId content id out of range: " + key);
+      }
+      return raw;
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   /** Max path token length for content id / guid string (path-injection surface). */

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -186,9 +187,7 @@ class ContentTranslationsAdaptorTest {
 
   @Test
   void listItemVariantsIncludesSourceAndDependents() {
-    PSLegacyGuid sourceGuid = new PSLegacyGuid(100L);
-    when(idMapper.getGuid("100")).thenReturn(sourceGuid);
-    when(idMapper.getLocator(sourceGuid)).thenReturn(new PSLocator(100, 1));
+    when(idMapper.getLocator(any(IPSGuid.class))).thenReturn(new PSLocator(100, 1));
 
     PSComponentSummary source = mock(PSComponentSummary.class);
     when(source.getContentId()).thenReturn(100);
@@ -197,7 +196,7 @@ class ContentTranslationsAdaptorTest {
     when(objectMgr.loadComponentSummary(100)).thenReturn(source);
 
     PSLegacyGuid depGuid = new PSLegacyGuid(200L);
-    when(systemWs.findDependents(eq(sourceGuid), any(PSRelationshipFilter.class)))
+    when(systemWs.findDependents(any(IPSGuid.class), any(PSRelationshipFilter.class)))
         .thenReturn(List.of(depGuid));
 
     PSComponentSummary dep = mock(PSComponentSummary.class);
@@ -219,6 +218,65 @@ class ContentTranslationsAdaptorTest {
     assertEquals(ContentTranslationsAdaptor.ROLE_TRANSLATION, tr.getRole());
     assertEquals("fr-fr", tr.getLocale());
     assertEquals(Long.valueOf(100L), tr.getSourceContentId());
+    // Bare numeric must not go through untyped getGuid (Explorer last-segment 404).
+    verify(idMapper, never()).getGuid("100");
+  }
+
+  @Test
+  void listItemVariantsAcceptsHyphenatedGuid() {
+    PSLegacyGuid sourceGuid = new PSLegacyGuid(551, -1);
+    when(idMapper.getGuid("16777215-101-551")).thenReturn(sourceGuid);
+    when(idMapper.getLocator(any(IPSGuid.class))).thenReturn(new PSLocator(551, 1));
+
+    PSComponentSummary source = mock(PSComponentSummary.class);
+    when(source.getContentId()).thenReturn(551);
+    when(source.getLocale()).thenReturn("en-us");
+    when(source.getCurrentLocator()).thenReturn(new PSLocator(551, 1));
+    when(objectMgr.loadComponentSummary(551)).thenReturn(source);
+
+    when(systemWs.findDependents(any(IPSGuid.class), any(PSRelationshipFilter.class)))
+        .thenReturn(List.of());
+
+    ItemTranslationVariants out =
+        adaptor.listItemVariants(
+            URI.create("http://localhost/rest"), "16777215-101-551");
+
+    assertEquals(551L, out.getItemId());
+    assertEquals("en-us", out.getLocale());
+    assertEquals(1, out.getVariants().size());
+    verify(idMapper).getGuid("16777215-101-551");
+  }
+
+  @Test
+  void listItemVariantsBareNumericSkipsGuidResolver() {
+    when(idMapper.getLocator(any(IPSGuid.class))).thenReturn(new PSLocator(551, 1));
+
+    PSComponentSummary source = mock(PSComponentSummary.class);
+    when(source.getContentId()).thenReturn(551);
+    when(source.getLocale()).thenReturn("en-us");
+    when(source.getCurrentLocator()).thenReturn(new PSLocator(551, 1));
+    when(objectMgr.loadComponentSummary(551)).thenReturn(source);
+
+    when(systemWs.findDependents(any(IPSGuid.class), any(PSRelationshipFilter.class)))
+        .thenReturn(List.of());
+
+    ItemTranslationVariants out =
+        adaptor.listItemVariants(URI.create("http://localhost/rest"), "551");
+
+    assertEquals(551L, out.getItemId());
+    assertEquals("en-us", out.getLocale());
+    verify(idMapper, never()).getGuid("551");
+  }
+
+  @Test
+  void parseBareNumericContentIdRejectsGuidAndZero() {
+    assertEquals(Long.valueOf(551L), ContentTranslationsAdaptor.parseBareNumericContentId("551"));
+    assertNull(ContentTranslationsAdaptor.parseBareNumericContentId("16777215-101-551"));
+    assertNull(ContentTranslationsAdaptor.parseBareNumericContentId("1-101-708"));
+    assertNull(ContentTranslationsAdaptor.parseBareNumericContentId("0"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContentTranslationsAdaptor.parseBareNumericContentId(String.valueOf(1L + Integer.MAX_VALUE)));
   }
 
   @Test
@@ -264,8 +322,6 @@ class ContentTranslationsAdaptorTest {
   void listPropagatesLoadSummaryInfrastructureErrors() {
     // loadSummary used to swallow RuntimeException as null (404). Infrastructure failures must
     // now surface so the REST layer can map them to 500 instead of a false 404.
-    PSLegacyGuid sourceGuid = new PSLegacyGuid(100L);
-    when(idMapper.getGuid("100")).thenReturn(sourceGuid);
     when(objectMgr.loadComponentSummary(100))
         .thenThrow(new IllegalStateException("cms object manager unavailable"));
 

--- a/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
+++ b/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
@@ -137,8 +137,10 @@ public class ContentTranslationsResource {
   @Operation(
       summary = "List locale variants for a content item",
       description =
-          "Returns the item's current locale plus translation-category dependents. Does not include"
-              + " in-flight queue status or session content-locale context (product disposition).",
+          "Returns the item's current locale plus translation-category dependents. itemId may be a"
+              + " hyphenated host-type-uuid GUID (for example 16777215-101-551) or a bare numeric"
+              + " content id. Does not include in-flight queue status or session content-locale"
+              + " context (product disposition).",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/translations/IContentTranslationsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/translations/IContentTranslationsAdaptor.java
@@ -46,7 +46,7 @@ public interface IContentTranslationsAdaptor {
    * List the requested item's locale plus translation-category dependents.
    *
    * @param baseUri request base URI (may be null)
-   * @param itemId legacy content id or guid string
+   * @param itemId hyphenated host-type-uuid GUID or bare numeric content id
    * @return variants envelope; never null when the item is readable
    * @throws SecurityException / not-found mapped by the resource as 403/404
    */

--- a/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
@@ -124,6 +124,20 @@ class ContentTranslationsResourceTest {
   }
 
   @Test
+  void listPassesHyphenatedGuidToAdaptor() {
+    ItemTranslationVariants expected = new ItemTranslationVariants();
+    expected.setItemId(551L);
+    expected.setLocale("en-us");
+    when(adaptor.listItemVariants(any(), eq("16777215-101-551"))).thenReturn(expected);
+
+    ItemTranslationVariants out = resource.listItemVariants("16777215-101-551");
+
+    assertEquals(551L, out.getItemId());
+    assertEquals("en-us", out.getLocale());
+    verify(adaptor).listItemVariants(any(), eq("16777215-101-551"));
+  }
+
+  @Test
   void listNullFromAdaptorIs404() {
     when(adaptor.listItemVariants(any(), eq("missing"))).thenReturn(null);
 


### PR DESCRIPTION
## Summary

Explorer Translations GET used the last GUID segment (`16777215-101-551` → `551`), which 404s **Item not found**. The full GUID already returns 200 with `ItemTranslationVariants`. This PR:

- Sends the **raw Explorer row id** on `GET /rest/content-explorer/translations/{itemId}` (full GUID or numeric).
- Keeps create-variant **POST** on numeric `itemIds` (`parseExplorerContentId`).
- Resolves **both** hyphenated GUID and bare numeric content id in `ContentTranslationsAdaptor` (numeric path skips untyped `getGuid`).

Fixes #3703. Parent QA tracker: #2649 (do not close). Residual of #3545 / PR #3547. Duplicate #3704 not queued.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 QA (`perc-devctl qa-up`) as Admin.
2. Open Explorer → Sites → Corporate Investments → Pages (or Home).
3. Select **Corporate Investments Home**.
4. View → Translations.
5. Confirm GET uses `…/translations/16777215-101-551` (not `…/551`).
6. Panel shows current locale (or Unknown), variants table, and Create variant.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/content-explorer.md` (Translations / Translate action) and `product-docs/8.2/developer/rest.md` (GET GUID vs numeric)
- [x] **Unit / module tests** — Vitest GUID vs numeric GET keys; adaptor dual-path; REST GUID passthrough; Playwright `explorer-translations.spec.js`
- [x] **WebUI + Playwright** — `npm run test:surface -- --path tests/explorer-translations.spec.js` (4 passed on H2 QA)
- [x] **Build gates** — standalone `mvnw clean install` on `rest`, `WebUI`, `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** rest, WebUI, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 545, Failures: 0 (`ContentTranslationsResourceTest` 9)
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3009 passed; Java Tests run: 63, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1392, Failures: 0, Skipped: 125 (`ContentTranslationsAdaptorTest` 17)
- **downstream_checked:** rest public method signatures unchanged (javadoc only). sitemanage is the adaptor impl and was clean-installed after rest. No `final`/`sealed` type changes.

### C5 UI proof (H2 Docker QA)

- `python docker/scripts/perc-devctl.py qa-up` — TEST_CMS_URL=`http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Hot-deploy: `docker cp` rest + sitemanage SNAPSHOT jars into `…/webapps/Rhythmyx/WEB-INF/lib/`; full `cm/modern/assets` tree; Jetty StopJetty/StartJetty **inside** the cell (not `docker restart`)
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/rest/mimetypes` — RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/explorer-translations.spec.js` — **4 passed**
- console-clean=yes (pageerror empty; filtered unrelated Explorer 400/500 resource noise)
- server.log-clean=yes (no translations ERROR/FATAL; no Failed startup of context)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
