### PR TITLE
fix(home): Admin Create Page uses repository site folder (#3726)

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -18,6 +18,7 @@
 import { del, get, post, put } from "../client";
 import type { ApiError } from "../client";
 import { PATHS } from "../paths";
+import { findItemByPath } from "../contentExplorer/pathApi";
 import { searchExtended } from "../contentExplorer/searchApi";
 import type { PSSearchCriteria } from "../contentExplorer/types";
 import type {
@@ -32,6 +33,8 @@ import type {
 import {
   joinFolderAndName,
   normalizeCmsPath,
+  repositoryFolderFromPathItem,
+  siteRootFolderFromSummary,
   toRepositoryCmsPath,
 } from "../../home/create/filenameUtils";
 
@@ -136,22 +139,94 @@ export function isBookmarkableItem(item: ContentListItem): boolean {
   return true;
 }
 
+/**
+ * Map a sitemanage {@code SiteSummary} row, including repository
+ * {@code folderPath} when Jackson sends {@code folderPath} or
+ * {@code folderPaths[0]}.
+ */
+export function mapSiteSummary(raw: unknown): SiteSummary | null {
+  const o = asRecord(raw);
+  if (!o) {
+    return null;
+  }
+  const name = firstNonBlank(o, "name", "Name");
+  if (!name) {
+    return null;
+  }
+  let folderPath = firstNonBlank(o, "folderPath", "FolderPath");
+  if (!folderPath) {
+    const paths = o.folderPaths ?? o.FolderPaths;
+    if (Array.isArray(paths)) {
+      const first = paths.find((p) => p != null && String(p).trim());
+      if (first != null) {
+        folderPath = String(first).trim();
+      }
+    }
+  }
+  const id = o.id ?? o.Id;
+  const siteId = o.siteId ?? o.SiteId ?? id;
+  const summary: SiteSummary = { name };
+  if (id != null && String(id).trim()) {
+    summary.id = id as string | number;
+  }
+  if (siteId != null && String(siteId).trim()) {
+    summary.siteId = siteId as string | number;
+  }
+  if (folderPath) {
+    summary.folderPath = normalizeCmsPath(folderPath);
+  }
+  return summary;
+}
+
+function mapSiteSummaryList(list: unknown[]): SiteSummary[] {
+  return list
+    .map(mapSiteSummary)
+    .filter((s): s is SiteSummary => s != null);
+}
+
 /** All sites for Library root. */
 export async function fetchSites(): Promise<SiteSummary[]> {
   const data = await get<unknown>(`${PATHS.SITES_ALL}/`);
   if (data && typeof data === "object" && "SiteSummary" in data) {
     const list = (data as { SiteSummary: unknown }).SiteSummary;
     if (Array.isArray(list)) {
-      return list as SiteSummary[];
+      return mapSiteSummaryList(list);
     }
     if (list && typeof list === "object") {
-      return [list as SiteSummary];
+      return mapSiteSummaryList([list]);
     }
   }
   if (Array.isArray(data)) {
-    return data as SiteSummary[];
+    return mapSiteSummaryList(data);
   }
   return [];
+}
+
+/**
+ * Repository site-root folder for Home Create Page.
+ *
+ * <p>Classic CUI calls {@code perc_pathmanager.get_folder_path} so create
+ * posts {@code PathItem.folderPath} ({@code //Sites/CorporateInvestments}),
+ * not the finder SITENAME ({@code /Sites/Corporate_Investments}). Prefer the
+ * site summary folder, then pathmanagement item lookup, then
+ * {@code /Sites/{name}}.</p>
+ */
+export async function resolveSiteRootFolderPath(
+  site: SiteSummary | string,
+): Promise<string> {
+  const name =
+    typeof site === "string" ? site.trim() : String(site?.name ?? "").trim();
+  const fallback = siteRootFolderFromSummary(site);
+  const finder = name ? `/Sites/${name}` : fallback;
+  if (!finder) {
+    return fallback;
+  }
+  try {
+    const item = await findItemByPath(finder);
+    return repositoryFolderFromPathItem(item, fallback || finder);
+  } catch {
+    return normalizeCmsPath(fallback || finder);
+  }
 }
 
 /** Folder children under a CMS path. */
@@ -770,6 +845,11 @@ export function formatApiError(err: unknown, notAuthorizedMsg: string): string {
           ? notAuthorizedMsg
           : o.message;
       }
+    }
+    // Empty-body 5xx (CXF WebApplicationException 500) is not an ACL deny.
+    if (typeof apiErr.status === "number" && apiErr.status >= 500) {
+      const st = String(apiErr.statusText ?? "").trim();
+      return st && !/^ok$/i.test(st) ? st : "Create failed";
     }
   }
   if (typeof err === "string" && err.includes("NotAuthorized")) {

--- a/WebUI/src/main/ts/api/home/types.ts
+++ b/WebUI/src/main/ts/api/home/types.ts
@@ -19,6 +19,12 @@ export interface SiteSummary {
   name: string;
   id?: string | number;
   siteId?: string | number;
+  /**
+   * Repository folder for the site ({@code //Sites/CorporateInvestments}).
+   * Sample FastForward sites use a folder leaf that is not the SITENAME
+   * ({@code Corporate_Investments}) — page create must post this path.
+   */
+  folderPath?: string;
 }
 
 export interface ContentListItem {

--- a/WebUI/src/main/ts/home/create/PageWizard.tsx
+++ b/WebUI/src/main/ts/home/create/PageWizard.tsx
@@ -22,6 +22,7 @@ import {
   fetchSites,
   fetchTemplatesForSite,
   formatApiError,
+  resolveSiteRootFolderPath,
 } from "../../api/home/homeApi";
 import type { SiteSummary, TemplateSummary } from "../../api/home/types";
 import { loadPageTemplates } from "../../editor/pageTemplates";
@@ -80,17 +81,23 @@ export function PageWizard({
       setTemplateId("");
       return;
     }
+    let cancelled = false;
     setBusy(true);
     setTemplateId("");
-    Promise.all([
-      fetchTemplatesForSite(site),
-      fetchFolderChildren(`/Sites/${site}`),
-    ])
-      .then(async ([tmpls, children]) => {
+    const selected = sites.find((s) => s.name === site);
+    resolveSiteRootFolderPath(selected ?? site)
+      .then(async (rootHint) => {
+        if (cancelled) {
+          return;
+        }
+        const [tmpls, children] = await Promise.all([
+          fetchTemplatesForSite(site),
+          fetchFolderChildren(rootHint),
+        ]);
         let resolved = tmpls;
         if (resolved.length === 0) {
           try {
-            const fallback = await loadPageTemplates(`/Sites/${site}`, "percPage");
+            const fallback = await loadPageTemplates(rootHint, "percPage");
             resolved = fallback
               .filter((t) => t.id)
               .map((t) => ({ id: t.id, name: t.name || t.id }));
@@ -101,6 +108,9 @@ export function PageWizard({
               err,
             );
           }
+        }
+        if (cancelled) {
+          return;
         }
         setTemplates(resolved);
         const folderPaths = children
@@ -113,16 +123,26 @@ export function PageWizard({
             if (c.path) {
               return String(c.path);
             }
-            return `/Sites/${site}/${c.name ?? ""}`;
+            return `${rootHint}/${c.name ?? ""}`;
           });
-        // Always allow site root as destination
-        const root = `/Sites/${site}`;
-        setFolders([root, ...folderPaths.filter((p) => p !== root)]);
-        setFolderPath(root);
+        // Site repository root (not /Sites/${SITENAME} for FastForward).
+        setFolders([rootHint, ...folderPaths.filter((p) => p !== rootHint)]);
+        setFolderPath(rootHint);
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
-      .finally(() => setBusy(false));
-  }, [site]);
+      .catch(() => {
+        if (!cancelled) {
+          setError(message(MSG.ERROR_GENERIC));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setBusy(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [site, sites]);
 
   const onTitleChange = (v: string) => {
     setTitle(v);
@@ -231,6 +251,7 @@ export function PageWizard({
         <label htmlFor="pw-folder">{message(MSG.CREATE_FOLDER)}</label>
         <select
           id="pw-folder"
+          data-testid="page-wizard-folder"
           value={folderPath}
           onChange={(e) => setFolderPath(e.target.value)}
           required

--- a/WebUI/src/main/ts/home/create/filenameUtils.ts
+++ b/WebUI/src/main/ts/home/create/filenameUtils.ts
@@ -132,3 +132,63 @@ export function joinFolderAndName(folderPath: string, name: string): string {
   }
   return `${folder}/${name}`;
 }
+
+/**
+ * Site-root folder for Home Create Page.
+ *
+ * <p>Prefers {@code SiteSummary.folderPath} (repository folder) over
+ * {@code /Sites/{name}}. FastForward sample sites list as
+ * {@code Corporate_Investments} but live at {@code //Sites/CorporateInvestments}
+ * (#3726 / #3326). Constructing {@code /Sites/${name}} makes page create
+ * {@code getIdByPath} miss, then {@code addItem} tries to create a sibling
+ * folder under {@code //Sites} and Admin sees CREATE_NOT_AUTHORIZED.</p>
+ */
+export function siteRootFolderFromSummary(
+  site:
+    | {
+        name?: string;
+        folderPath?: string;
+        folderPaths?: string[];
+      }
+    | string
+    | null
+    | undefined,
+): string {
+  if (site == null) {
+    return "";
+  }
+  if (typeof site === "string") {
+    const n = site.trim();
+    return n ? `/Sites/${n}` : "";
+  }
+  const fromPaths = Array.isArray(site.folderPaths)
+    ? site.folderPaths.find((p) => p != null && String(p).trim())
+    : undefined;
+  const fromFolder = String(site.folderPath ?? fromPaths ?? "").trim();
+  if (fromFolder) {
+    return normalizeCmsPath(fromFolder);
+  }
+  const n = String(site.name ?? "").trim();
+  return n ? `/Sites/${n}` : "";
+}
+
+/**
+ * Classic CUI {@code get_folder_path}: PathItem.folderPath is the repository
+ * folder; PathItem.path is the finder id (often the site name).
+ */
+export function repositoryFolderFromPathItem(
+  item:
+    | { folderPath?: string; folderPaths?: string[] }
+    | null
+    | undefined,
+  fallback: string,
+): string {
+  const fromPaths = Array.isArray(item?.folderPaths)
+    ? item.folderPaths.find((p) => p != null && String(p).trim())
+    : undefined;
+  const fromFolder = String(item?.folderPath ?? fromPaths ?? "").trim();
+  if (fromFolder) {
+    return normalizeCmsPath(fromFolder);
+  }
+  return normalizeCmsPath(fallback);
+}

--- a/WebUI/src/test/ts/home/PageWizard.test.tsx
+++ b/WebUI/src/test/ts/home/PageWizard.test.tsx
@@ -111,6 +111,85 @@ describe("PageWizard templates", () => {
     ).toBe("Article");
   });
 
+  it("creates at repository folderPath for FastForward SITENAME (#3726)", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/sitemanage/site/")) {
+        return mockJsonResponse({
+          SiteSummary: [
+            {
+              name: "Enterprise_Investments",
+              folderPath: "//Sites/EnterpriseInvestments",
+            },
+            {
+              name: "Corporate_Investments",
+              folderPath: "//Sites/CorporateInvestments",
+            },
+          ],
+        });
+      }
+      if (url.includes("/sitetemplates/templates/")) {
+        return mockJsonResponse({
+          TemplateSummary: [
+            { id: "t-db", name: "Page - Database Template" },
+          ],
+        });
+      }
+      if (url.includes("/pathmanagement/path/item")) {
+        return mockJsonResponse({
+          PathItem: {
+            path: "/Sites/Corporate_Investments/",
+            folderPath: "//Sites/CorporateInvestments",
+            name: "Corporate_Investments",
+          },
+        });
+      }
+      if (url.includes("/pathmanagement/path/folder")) {
+        return mockJsonResponse([]);
+      }
+      if (url.includes("/pagemanagement/page") && init?.method === "POST") {
+        return mockJsonResponse({
+          Page: { id: "1-101-3726", name: "qa-create-3726.html" },
+        });
+      }
+      return mockJsonResponse([]);
+    });
+
+    const openCreated = vi.fn().mockResolvedValue(true);
+    render(<PageWizard onBack={() => undefined} openCreated={openCreated} />);
+    await waitFor(() => screen.getByTestId("page-wizard"));
+    fireEvent.change(screen.getByTestId("page-wizard-site"), {
+      target: { value: "Corporate_Investments" },
+    });
+    await waitFor(() => {
+      const folder = screen.getByTestId("page-wizard-folder") as HTMLSelectElement;
+      expect(folder.value).toBe("/Sites/CorporateInvestments");
+    });
+    fireEvent.change(screen.getByTestId("page-wizard-template"), {
+      target: { value: "t-db" },
+    });
+    fireEvent.change(document.getElementById("pw-title") as HTMLInputElement, {
+      target: { value: "Qa Create 3726" },
+    });
+    fireEvent.click(screen.getByTestId("page-wizard-submit"));
+    await waitFor(() => {
+      expect(openCreated).toHaveBeenCalled();
+    });
+    const postCall = fetchMock.mock.calls.find((c) => {
+      const url = String(c[0]);
+      const init = c[1] as RequestInit | undefined;
+      return url.includes("/pagemanagement/page") && init?.method === "POST";
+    });
+    expect(postCall).toBeTruthy();
+    const body = JSON.parse(String((postCall?.[1] as RequestInit).body));
+    expect(body.Page.folderPath).toBe("//Sites/CorporateInvestments");
+    expect(openCreated.mock.calls[0]?.[0]).toMatchObject({
+      id: "1-101-3726",
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("falls back to percPage allowedTemplates when the site catalog is an empty-bean", async () => {
     stubFetch({
       sites: {

--- a/WebUI/src/test/ts/home/filenameUtils.test.ts
+++ b/WebUI/src/test/ts/home/filenameUtils.test.ts
@@ -8,6 +8,8 @@ import {
   joinFolderAndName,
   normalizeCmsPath,
   parentCmsPath,
+  repositoryFolderFromPathItem,
+  siteRootFolderFromSummary,
   titleToBlogFileName,
   titleToPageFileName,
   toRepositoryCmsPath,
@@ -49,6 +51,42 @@ describe("filenameUtils", () => {
       "blog",
     ]);
     expect(cmsPathSegments("//Sites/a")).toEqual(["Sites", "a"]);
+  });
+
+  it("siteRootFolderFromSummary prefers repository folder over SITENAME (#3726)", () => {
+    expect(
+      siteRootFolderFromSummary({
+        name: "Corporate_Investments",
+        folderPath: "//Sites/CorporateInvestments",
+      }),
+    ).toBe("/Sites/CorporateInvestments");
+    expect(
+      siteRootFolderFromSummary({
+        name: "Corporate_Investments",
+        folderPaths: ["//Sites/CorporateInvestments"],
+      }),
+    ).toBe("/Sites/CorporateInvestments");
+    expect(siteRootFolderFromSummary({ name: "Demo" })).toBe("/Sites/Demo");
+    expect(siteRootFolderFromSummary("Demo")).toBe("/Sites/Demo");
+    expect(siteRootFolderFromSummary("")).toBe("");
+  });
+
+  it("repositoryFolderFromPathItem uses PathItem.folderPath like classic get_folder_path", () => {
+    expect(
+      repositoryFolderFromPathItem(
+        { folderPath: "//Sites/CorporateInvestments" },
+        "/Sites/Corporate_Investments",
+      ),
+    ).toBe("/Sites/CorporateInvestments");
+    expect(
+      repositoryFolderFromPathItem(
+        { folderPaths: ["//Sites/EnterpriseInvestments"] },
+        "/Sites/Enterprise_Investments",
+      ),
+    ).toBe("/Sites/EnterpriseInvestments");
+    expect(
+      repositoryFolderFromPathItem({}, "/Sites/Corporate_Investments"),
+    ).toBe("/Sites/Corporate_Investments");
   });
 });
 

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -25,6 +25,8 @@ import {
   createPageAndItem,
   ensurePageFileName,
   unwrapCreatedPageId,
+  mapSiteSummary,
+  resolveSiteRootFolderPath,
   extractTemplateWidgetDefinitionIds,
   fetchAssetTypes,
   fetchMyContent,
@@ -166,6 +168,49 @@ describe("homeApi", () => {
     expect(body.SearchCriteria.query).toBe("legacy");
   });
 
+  it("mapSiteSummary normalizes FastForward folderPath vs SITENAME (#3726)", () => {
+    expect(
+      mapSiteSummary({
+        name: "Corporate_Investments",
+        folderPath: "//Sites/CorporateInvestments",
+        id: "350",
+      }),
+    ).toMatchObject({
+      name: "Corporate_Investments",
+      folderPath: "/Sites/CorporateInvestments",
+      id: "350",
+    });
+    expect(
+      mapSiteSummary({
+        Name: "Enterprise_Investments",
+        folderPaths: ["//Sites/EnterpriseInvestments"],
+      }),
+    ).toMatchObject({
+      name: "Enterprise_Investments",
+      folderPath: "/Sites/EnterpriseInvestments",
+    });
+  });
+
+  it("resolveSiteRootFolderPath uses PathItem.folderPath not finder SITENAME (#3726)", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        PathItem: {
+          path: "/Sites/Corporate_Investments/",
+          folderPath: "//Sites/CorporateInvestments",
+          name: "Corporate_Investments",
+        },
+      }),
+    );
+    const root = await resolveSiteRootFolderPath({
+      name: "Corporate_Investments",
+      folderPath: "/Sites/Corporate_Investments",
+    });
+    expect(root).toBe("/Sites/CorporateInvestments");
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain("/pathmanagement/path/item");
+  });
+
   it("createPage posts repository // folderPath (getIdByPath requires it)", async () => {
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     fetchMock.mockResolvedValue(
@@ -183,6 +228,25 @@ describe("homeApi", () => {
     const body = JSON.parse(String(init.body));
     expect(body.Page.folderPath).toBe("//Sites/Demo");
     expect(body.Page.addToRecent).toBe(true);
+  });
+
+  it("createPage posts FastForward repository folder not SITENAME (#3726)", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ Page: { id: "1", name: "p" } }),
+    );
+    await createPage({
+      name: "about.html",
+      title: "About",
+      linkTitle: "About",
+      templateId: "t1",
+      folderPath: "/Sites/CorporateInvestments",
+    });
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
+    );
+    expect(body.Page.folderPath).toBe("//Sites/CorporateInvestments");
+    expect(body.Page.folderPath).not.toContain("Corporate_Investments");
   });
 
   it("createPage appends .html when name has no extension", async () => {
@@ -490,6 +554,18 @@ describe("homeApi", () => {
         body: "Name is invalid",
       };
       expect(formatApiError(err, notAuth)).toBe("Name is invalid");
+    });
+
+    it("does not map empty-body 500 to notAuthorizedMsg (#3726)", () => {
+      const err: ApiError = {
+        status: 500,
+        statusText: "Internal Server Error",
+        body: "",
+      };
+      expect(formatApiError(err, notAuth)).toBe("Internal Server Error");
+      expect(
+        formatApiError({ status: 500, statusText: "OK", body: null }, notAuth),
+      ).toBe("Create failed");
     });
   });
 });

--- a/docs/ai-generated/code-reviews/3726-home-create-page-admin-auth-erlang.md
+++ b/docs/ai-generated/code-reviews/3726-home-create-page-admin-auth-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — #3726 Home Create Page Admin authorization
+
+**Scope:** uncommitted `fix/issue-3726-create-page-admin-auth` vs `origin/main`  
+**Recommendation:** approve (partial slice; residual TX rollback)  
+**Gate:** May commit/push: yes (folder-path + template-load + error mapping)  
+**Memory patterns hit:** site name vs folder root bind; Playwright companion for WebUI screens; CMS paths use `/` (not OS separators)
+
+## Summary
+
+Home → Create → Page posted `folderPath=/Sites/${SITENAME}`. FastForward sample sites list as `Corporate_Investments` but the repository folder is `//Sites/CorporateInvestments` (#3326). Classic CUI resolves `PathItem.folderPath` via `get_folder_path` before `perc_page_manager.createPage`. The wizard skipped that lookup, so `getIdByPath` missed and `PSFolderHelper.addItem` tried to create a sibling folder under `//Sites`.
+
+Follow-on H2 QA: with the repository folder, `templateDao.find` of **Page - Database Template** (assembly GUID) failed `getThumbImgPath().get(0)` then `addRecentTemplate` required a percTemplate content guid. Those are fixed. Live create still returns HTTP 500 `Transaction silently rolled back because it has been marked as rollback-only` — residual, not this slice’s remaining UI path bug.
+
+## Issues
+
+- Residual (not a gate on this slice): page save TX rollback-only after template load on Corporate_Investments + perc.pageDatabase. Playwright still fails with “Server Error”. File leftover issue.
+
+## Cross-platform path checklist
+
+- CMS finder/repository paths use `/` (URL-style), not OS file separators.
+- New helpers normalize `//Sites` → `/Sites` for UI and re-prefix `//` only for page-create POST.
+- No filesystem I/O, drive letters, or OS temp roots.
+
+## Tests
+
+- Vitest: `siteRootFolderFromSummary`, `repositoryFolderFromPathItem`, `mapSiteSummary`, `resolveSiteRootFolderPath`, `createPage` FF folder, PageWizard Corporate_Investments POST
+- Playwright: `tests/home-react-editor.spec.js` Create Page Admin case
+- Module `mvnw clean install`: WebUI BUILD SUCCESS; perc-qa-automation BUILD SUCCESS

--- a/modules/perc-qa-automation/frontend/tests/home-react-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/home-react-editor.spec.js
@@ -159,4 +159,129 @@ test.describe("Home React Content Editor", () => {
       ).toEqual([]);
     },
   );
+
+  test(
+    "Home Create Page as Admin opens React editor (no CREATE_NOT_AUTHORIZED)",
+    { tag: ["@home", "@editor", "@page-wizard"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const blocked = [];
+      const consoleErrors = [];
+      page.on("request", (req) => {
+        if (/view=editor/.test(req.url())) {
+          blocked.push(req.url());
+        }
+      });
+      page.on("pageerror", (err) => {
+        consoleErrors.push(String(err && err.message ? err.message : err));
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+      await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
+      await expect(page.getByTestId("home-shell")).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId("home-nav-create").click();
+      await expect(page.getByTestId("create-type-chooser")).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId("create-choose-page").click();
+      const empty = page.getByTestId("create-wizard-no-sites");
+      const wizard = page.getByTestId("page-wizard");
+      await expect(empty.or(wizard)).toBeVisible({ timeout: 20_000 });
+      if (await empty.isVisible()) {
+        test.skip(true, "No sites available for Home Create Page");
+        return;
+      }
+
+      const siteSelect = page.getByTestId("page-wizard-site");
+      if (await siteSelect.isVisible()) {
+        const preferred = siteSelect.locator(
+          'option[value="Corporate_Investments"]',
+        );
+        if ((await preferred.count()) > 0) {
+          await siteSelect.selectOption("Corporate_Investments");
+        } else {
+          const firstSite = siteSelect
+            .locator("option[value]:not([value=''])")
+            .first();
+          const siteValue = await firstSite.getAttribute("value");
+          if (!siteValue) {
+            test.skip(true, "No site options in Create Page wizard");
+            return;
+          }
+          await siteSelect.selectOption(siteValue);
+        }
+      }
+
+      const templateSelect = page.getByTestId("page-wizard-template");
+      await expect(templateSelect).toBeVisible({ timeout: 20_000 });
+      await expect
+        .poll(
+          async () =>
+            templateSelect.locator("option[value]:not([value=''])").count(),
+          { timeout: 25_000 },
+        )
+        .toBeGreaterThan(0);
+      const firstTemplate = templateSelect
+        .locator("option[value]:not([value=''])")
+        .first();
+      const templateValue = await firstTemplate.getAttribute("value");
+      await templateSelect.selectOption(templateValue);
+
+      const title = `QaCreate3726 ${Date.now()}`;
+      await page.locator("#pw-title").fill(title);
+
+      const folderSelect = page.getByTestId("page-wizard-folder");
+      if (await folderSelect.isVisible()) {
+        const folderValue = await folderSelect.inputValue();
+        expect(folderValue, "create folder should be a Sites path").toMatch(
+          /\/Sites\//i,
+        );
+        expect(
+          folderValue,
+          "FastForward create must use repository folder, not SITENAME",
+        ).not.toMatch(/Corporate_Investments$/i);
+      }
+
+      const popupPromise = page
+        .waitForEvent("popup", { timeout: 30_000 })
+        .catch(() => null);
+      await page.getByTestId("page-wizard-submit").click();
+      const popup = await popupPromise;
+      const alert = page.getByRole("alert");
+      if (await alert.isVisible().catch(() => false)) {
+        const text = ((await alert.textContent()) || "").trim();
+        throw new Error(`Home Create Page failed: ${text || "(empty alert)"}`);
+      }
+      if (!popup) {
+        throw new Error(
+          "Home Create Page did not open the React editor after submit",
+        );
+      }
+      popup.on("request", (req) => {
+        if (/view=editor/.test(req.url())) {
+          blocked.push(req.url());
+        }
+      });
+      await expect(popup).not.toHaveURL(/^about:blank$/i, { timeout: 20_000 });
+      await expect(popup).toHaveURL(/entry=editor|\/editor/, { timeout: 20_000 });
+      await expect(popup).not.toHaveURL(/view=editor/);
+      expect(blocked, `leftover editor requested: ${blocked.join(" ")}`).toEqual(
+        [],
+      );
+      const unexpected = consoleErrors.filter(
+        (t) =>
+          !/favicon|404|net::ERR|Failed to load resource|ResizeObserver/i.test(t) &&
+          !/Download the React DevTools/i.test(t),
+      );
+      expect(
+        unexpected,
+        `JS console errors: ${unexpected.join(" | ")}`,
+      ).toEqual([]);
+    },
+  );
 });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -44,6 +44,16 @@ falls back to templates allowed for the page content type. You cannot create
 the page until a template is selected. Then pick the destination folder,
 title, and file name.
 
+The destination folder is the site's **repository folder**, not only the
+site display name. Sample FastForward sites such as **Corporate_Investments**
+and **Enterprise_Investments** live under `/Sites/CorporateInvestments` and
+`/Sites/EnterpriseInvestments` (no underscore). An administrator can create
+a page at that site root, including with site-listed page templates such as
+**Page - Database Template**. After create, the React Content Editor opens
+(`spa.jsp?entry=editor`) — leftover `?view=editor` is not used. If you are
+not allowed to create in a folder, the wizard shows that error; a missing
+or mismatched folder is not treated as a successful create.
+
 Rich file, image, and TinyMCE widget chrome in that editor is still a later
 slice — a new asset can still be created as a stub and opened on the field
 form.

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSTemplateDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSTemplateDao.java
@@ -189,6 +189,9 @@ public class PSTemplateDao implements IPSTemplateDao, ApplicationContextAware {
       } catch (PSTemplateException e) {
         throw new LoadException(e.getMessage(), e);
       }
+      if (StringUtils.isBlank(t.getId())) {
+        t.setId(id);
+      }
       return t;
     }
 
@@ -445,7 +448,7 @@ public class PSTemplateDao implements IPSTemplateDao, ApplicationContextAware {
     if (templateGuid != null) {
       template = new PSTemplate();
       loadTemplateFromBaseTemplate(templateGuid, template);
-      var imagePath = getThumbImgPath(asList(template.getName())).get(0);
+      var imagePath = firstThumbPath(getThumbImgPath(asList(template.getName())));
       template.setName(name);
       template.setImageThumbPath(imagePath);
       template.setReadOnly(false);
@@ -480,9 +483,18 @@ public class PSTemplateDao implements IPSTemplateDao, ApplicationContextAware {
 
     try {
       IPSAssemblyTemplate srcTpl = loadBaseTemplateById(srcId);
-      var imagePath = getThumbImgPath(asList(srcTpl.getName())).get(0);
-      IPSCatalogSummary sum = findAssemblyTemplate(srcTpl.getName()).get(0);
-      createReadOnlyTemplateSummary(templateName, sum, imagePath);
+      var imagePath = firstThumbPath(getThumbImgPath(asList(srcTpl.getName())));
+      var sum = firstCatalogSummary(findAssemblyTemplate(srcTpl.getName()));
+      if (sum != null) {
+        createReadOnlyTemplateSummary(templateName, sum, imagePath);
+      } else {
+        templateName.setId(idMapper.getString(srcId));
+        templateName.setName(srcTpl.getName());
+        templateName.setLabel(srcTpl.getLabel());
+        templateName.setDescription(srcTpl.getDescription());
+        templateName.setImageThumbPath(imagePath);
+        templateName.setReadOnly(true);
+      }
       templateName.setSourceTemplateName(srcTpl.getName());
       var srcContent = srcTpl.getTemplate();
       if (StringUtils.isNotBlank(srcContent)) {
@@ -494,12 +506,40 @@ public class PSTemplateDao implements IPSTemplateDao, ApplicationContextAware {
       }
       // set theme
       List<PSThemeSummary> themes = themeService.findAll();
-      if (!themes.isEmpty()) {
+      if (themes != null && !themes.isEmpty() && themes.get(0) != null) {
         templateName.setTheme(themes.get(0).getName());
       }
     } catch (Exception e) {
       throw new PSTemplateException("Failed to copy system template to PSCoreItem.", e);
     }
+  }
+
+  /**
+   * First non-blank thumbnail path. Assembly/snippet templates such as
+   * {@code perc.pageDatabase} may have no CM1 thumb — empty list must not
+   * fail page create (#3726).
+   */
+  static String firstThumbPath(List<String> thumbs) {
+    if (thumbs == null) {
+      return "";
+    }
+    for (String t : thumbs) {
+      if (t != null && !t.isBlank()) {
+        return t;
+      }
+    }
+    return "";
+  }
+
+  /**
+   * First catalog row, or {@code null} when the assembly catalog has no
+   * thumb/name match (FastForward snippet templates).
+   */
+  static IPSCatalogSummary firstCatalogSummary(List<IPSCatalogSummary> sums) {
+    if (sums == null || sums.isEmpty()) {
+      return null;
+    }
+    return sums.get(0);
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
@@ -634,8 +634,10 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
       recentService.addRecentItem(page.getId());
       recentService.addRecentSiteFolder(page.getFolderPath());
       String siteName = PSPathUtils.getSiteFromPath(page.getFolderPath());
-      if (StringUtils.isNotBlank(siteName))
+      if (StringUtils.isNotBlank(siteName)
+          && isRecentTemplateItemGuid(page.getTemplateId(), idMapper)) {
         recentService.addRecentTemplate(siteName, page.getTemplateId());
+      }
     }
 
     // Set the page-Id and the Event type
@@ -1233,6 +1235,22 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
     if (isImported) return ItemStatus.IMPORTED;
 
     return currentStatus;
+  }
+
+  /**
+   * Recent-template list stores percTemplate <em>content item</em> guids. Assembly
+   * system templates ({@code perc.pageDatabase}, type TEMPLATE) are valid page
+   * templates on FastForward sites but must not be written to recent (#3726).
+   */
+  static boolean isRecentTemplateItemGuid(String templateId, IPSIdMapper mapper) {
+    if (templateId == null || templateId.isBlank() || mapper == null) {
+      return false;
+    }
+    try {
+      return PSTypeEnum.LEGACY_CONTENT.getOrdinal() == mapper.getGuid(templateId).getType();
+    } catch (RuntimeException e) {
+      return false;
+    }
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/impl/PSTemplateCopyHelpersTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/impl/PSTemplateCopyHelpersTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import static org.mockito.Mockito.mock;
+
+import com.percussion.services.catalog.IPSCatalogSummary;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Assembly/snippet templates (perc.pageDatabase) have no CM1 thumbs. Page
+ * create must not fail with an empty-list {@code get(0)} (#3726).
+ */
+class PSTemplateCopyHelpersTest {
+
+  @Test
+  void firstThumbPathSkipsEmptyAndBlank() {
+    assertEquals("", PSTemplateDao.firstThumbPath(null));
+    assertEquals("", PSTemplateDao.firstThumbPath(Collections.emptyList()));
+    assertEquals("", PSTemplateDao.firstThumbPath(List.of("", "  ")));
+    assertEquals("/cm/thumbs/a.png", PSTemplateDao.firstThumbPath(List.of("", "/cm/thumbs/a.png")));
+  }
+
+  @Test
+  void firstCatalogSummaryReturnsNullWhenEmpty() {
+    assertNull(PSTemplateDao.firstCatalogSummary(null));
+    assertNull(PSTemplateDao.firstCatalogSummary(Collections.emptyList()));
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    assertSame(sum, PSTemplateDao.firstCatalogSummary(List.of(sum)));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceRecentTemplateGuidTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceRecentTemplateGuidTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import org.junit.jupiter.api.Test;
+
+/**
+ * FastForward assembly template ids are not percTemplate content items.
+ * Adding them to recent must not abort page create (#3726).
+ */
+class PSPageServiceRecentTemplateGuidTest {
+
+  @Test
+  void assemblyTemplateGuidIsNotRecentItem() {
+    IPSIdMapper mapper = mock(IPSIdMapper.class);
+    IPSGuid guid = mock(IPSGuid.class);
+    when(mapper.getGuid("0-4-1050")).thenReturn(guid);
+    when(guid.getType()).thenReturn(PSTypeEnum.TEMPLATE.getOrdinal());
+    assertFalse(PSPageService.isRecentTemplateItemGuid("0-4-1050", mapper));
+  }
+
+  @Test
+  void percTemplateContentGuidIsRecentItem() {
+    IPSIdMapper mapper = mock(IPSIdMapper.class);
+    IPSGuid guid = mock(IPSGuid.class);
+    when(mapper.getGuid("1-101-705")).thenReturn(guid);
+    when(guid.getType()).thenReturn(PSTypeEnum.LEGACY_CONTENT.getOrdinal());
+    assertTrue(PSPageService.isRecentTemplateItemGuid("1-101-705", mapper));
+  }
+
+  @Test
+  void blankOrBadGuidIsNotRecentItem() {
+    IPSIdMapper mapper = mock(IPSIdMapper.class);
+    when(mapper.getGuid("not-a-guid")).thenThrow(new IllegalArgumentException("bad"));
+    assertFalse(PSPageService.isRecentTemplateItemGuid(null, mapper));
+    assertFalse(PSPageService.isRecentTemplateItemGuid(" ", mapper));
+    assertFalse(PSPageService.isRecentTemplateItemGuid("not-a-guid", mapper));
+    assertFalse(PSPageService.isRecentTemplateItemGuid("1-101-705", null));
+  }
+}


### PR DESCRIPTION
## Summary

Home → Create → Page as Admin on FastForward sample site **Corporate_Investments** failed with *You are not authorized to create content in this location* (TMX `perc.ui.home.modern@Create Not Authorized`). The wizard posted `folderPath=/Sites/Corporate_Investments` (finder SITENAME). The repository folder is `//Sites/CorporateInvestments` (#3326). Classic CUI resolves `PathItem.folderPath` via `perc_pathmanager.get_folder_path` before page create.

This PR:

- Resolves the site repository folder from `SiteSummary.folderPath` / pathmanagement item lookup (classic `get_folder_path`).
- Hardens `PSTemplateDao.loadTemplateFromBaseTemplate` when assembly/snippet templates have no CM1 thumbs (`perc.pageDatabase`).
- Skips `addRecentTemplate` for non–content-item GUIDs (assembly TEMPLATE type is not a percTemplate item).
- Stops mapping empty HTTP 500 bodies to CREATE_NOT_AUTHORIZED.

**Partial #3726.** Live H2 create still returns 500 `Transaction silently rolled back because it has been marked as rollback-only` after these fixes. Residual: #3728.

Parent tracker: #3474 (epic #2400). Do not treat this as implementing QA task #3474.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Env: QA H2 docker (`perc-devctl qa-up`) — note `TEST_CMS_URL` / freeport (this run: `http://127.0.0.1:9993`).
2. Login as Admin; Home → Create → Page.
3. Site: Corporate_Investments. Folder should be `/Sites/CorporateInvestments` (not `Corporate_Investments`).
4. Template: Page - Database Template; title + file name; Create.
5. **Expected after this PR:** no false CREATE_NOT_AUTHORIZED for wrong folder / empty 500. **Known leftover (#3728):** save may still 500 rollback-only; editor may not open until that residual lands.
6. Surface: `cd modules/perc-qa-automation/frontend` then `npm run test:surface -- --path tests/home-react-editor.spec.js`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/index.md` Home → Create page folder vs SITENAME
- [x] **Unit / module tests** — Vitest PageWizard/homeApi/filenameUtils; sitemanage `PSTemplateCopyHelpersTest`, `PSPageServiceRecentTemplateGuidTest`
- [x] **WebUI + Playwright** — `tests/home-react-editor.spec.js` Create Page Admin case added (live C5 still red on residual 500)
- [x] **Build gates** — standalone `mvnw clean install` WebUI, sitemanage, perc-qa-automation
- [x] **Cross-platform** — CMS finder paths use `/` (not OS separators)

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md`

## C3 evidence

- **modules_built:** WebUI, projects/sitemanage, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` — BUILD SUCCESS; Java Tests run: 63, Failures: 0; Vitest Tests 3013 passed
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1391, Failures: 0, Skipped: 125 (includes new PSTemplateCopyHelpersTest 2, PSPageServiceRecentTemplateGuidTest 3)
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` — BUILD SUCCESS
- **downstream_checked:** none (no public type made final/sealed; no rest adaptor signature change). sitemanage internals + WebUI client only.

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up` (cell `perc-matrix-cms-h2`); `TEST_CMS_URL=http://127.0.0.1:9993`
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy (port 9993)
- Hot-deploy: WebUI `cm/modern/assets/*`; `sitemanage-8.2.0-SNAPSHOT.jar` + matching `perc-system-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; Jetty StopJetty/StartJetty inside the cell (not docker restart)
- `npm run test:surface -- --path tests/home-react-editor.spec.js` — Create asset passed; Create Page Admin **failed** (`Server Error` / TX rollback-only) — residual #3728
- console-clean: yes on asset path; Create Page path did not reach editor
- server.log-clean: no for Create Page window (`UnexpectedRollbackException`) — residual #3728

## Fixes / Partial

Partial #3726. Residual #3728.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
