### PR TITLE
fix(deployer): keep Baseline TemplateDef GUIDs 0-4-602..614 on first assign (#3727)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
@@ -676,9 +676,62 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
   // see base class
   @Override
   public void reserveNewId(PSDependency dep, PSIdMap idMap) throws PSDeployException {
+    if (dep == null) {
+      throw new IllegalArgumentException("dep may not be null");
+    }
+    if (idMap == null) {
+      throw new IllegalArgumentException("idMap may not be null");
+    }
+    if (!dep.getObjectType().equals(DEPENDENCY_TYPE)) {
+      throw new IllegalArgumentException("dep wrong type");
+    }
+
+    PSIdMapping mapping = idMap.getMapping(dep.getDependencyId(), dep.getObjectType());
+    if (mapping == null) {
+      Object[] args = {dep.getObjectType(), dep.getDependencyId(), idMap.getSourceServer()};
+      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+    }
+
+    // First assign of an unused archive UUID (TemplateDef-602 → 602) keeps the
+    // product GUID. Existing customer rows are matched by name before this runs
+    // (isNewObject=false) and are not remapped (#3727).
+    if (mapping.isNewObject() && mapping.getTargetId() == null) {
+      boolean claimed =
+          PSTemplateDefInstallUtils.isUuidReservedAsTarget(
+                  idMap, dep.getDependencyId(), DEPENDENCY_TYPE)
+              || isTemplateUuidPresentOnTarget(dep.getDependencyId());
+      if (PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, claimed)) {
+        log.info(
+            "TemplateDef install keeping archive UUID {} ({}) on first assign",
+            mapping.getTargetId(),
+            dep.getDisplayName());
+        return;
+      }
+    }
     PSDependencyUtils.reserveNewId(dep, idMap, getType());
-    // guids dont need ids, they are unique ids
-    return;
+  }
+
+  /**
+   * Whether a TemplateDef with this archive id already exists on the target.
+   *
+   * <p>Uses {@code findTemplate} (null if missing) so a fresh install does not log
+   * TEMPLATE_MISSING warnings for each unused archive UUID.
+   *
+   * @param sourceId archive dependency id, may be blank
+   * @return {@code true} when a template row is found, or the check cannot be completed
+   */
+  private boolean isTemplateUuidPresentOnTarget(String sourceId) {
+    if (sourceId == null || sourceId.isBlank()) {
+      return false;
+    }
+    init();
+    try {
+      IPSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, sourceId.trim());
+      return m_assemblySvc.findTemplate(guid) != null;
+    } catch (RuntimeException e) {
+      log.debug("TemplateDef UUID presence check failed for {}: {}", sourceId, e.toString());
+      return true;
+    }
   }
 
   /**

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
@@ -683,7 +683,8 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       throw new IllegalArgumentException("idMap may not be null");
     }
     if (!dep.getObjectType().equals(DEPENDENCY_TYPE)) {
-      throw new IllegalArgumentException("dep wrong type");
+      throw new IllegalArgumentException(
+          "dep wrong type: expected " + DEPENDENCY_TYPE + " but got " + dep.getObjectType());
     }
 
     PSIdMapping mapping = idMap.getMapping(dep.getDependencyId(), dep.getObjectType());
@@ -729,7 +730,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       IPSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, sourceId.trim());
       return m_assemblySvc.findTemplate(guid) != null;
     } catch (RuntimeException e) {
-      log.debug("TemplateDef UUID presence check failed for {}: {}", sourceId, e.toString());
+      log.debug("TemplateDef UUID presence check failed for {}: {}", sourceId, e);
       return true;
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtils.java
@@ -79,9 +79,7 @@ public final class PSTemplateDefInstallUtils {
       return null;
     }
     String trimmed = sourceId.trim();
-    try {
-      templateUuid(trimmed);
-    } catch (RuntimeException e) {
+    if (parseTemplateUuid(trimmed) == null) {
       return null;
     }
     if (sourceUuidInUse) {
@@ -162,11 +160,12 @@ public final class PSTemplateDefInstallUtils {
     if (left == null || right == null || left.isBlank() || right.isBlank()) {
       return false;
     }
-    try {
-      return templateUuid(left) == templateUuid(right);
-    } catch (RuntimeException e) {
-      return left.trim().equals(right.trim());
+    Integer leftUuid = parseTemplateUuid(left);
+    Integer rightUuid = parseTemplateUuid(right);
+    if (leftUuid == null || rightUuid == null) {
+      return false;
     }
+    return leftUuid.intValue() == rightUuid.intValue();
   }
 
   /**
@@ -180,6 +179,18 @@ public final class PSTemplateDefInstallUtils {
       throw new IllegalArgumentException("sourceId may not be null or empty");
     }
     return new PSGuid(PSTypeEnum.TEMPLATE, sourceId.trim()).toString();
+  }
+
+  /**
+   * Template UUID from a dependency id, or {@code null} when {@link PSGuid} rejects the string
+   * ({@link IllegalArgumentException}, including {@link NumberFormatException}).
+   */
+  static Integer parseTemplateUuid(String id) {
+    try {
+      return templateUuid(id);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
   }
 
   static int templateUuid(String id) {

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtils.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.server.dependencies;
+
+import com.percussion.deployer.objectstore.PSIdMap;
+import com.percussion.deployer.objectstore.PSIdMapping;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure helpers for TemplateDef package install ID reservation (issue #3727 / parent #2813).
+ *
+ * <p>Free of Spring so unit tests run without a CMS context. On a <em>first assign</em> (new
+ * mapping, unused UUID) the archive source UUID is kept so {@code perc.Baseline} system templates
+ * install as {@code 0-4-602}..{@code 0-4-614}. Existing customer/snapshot rows are matched by name
+ * before reservation and are never remapped here.
+ */
+public final class PSTemplateDefInstallUtils {
+
+  /**
+   * Expected assembly GUIDs for {@code perc.Baseline} system templates on a fresh 8.2 install
+   * ({@code TemplateDef-N} → {@code 0-4-N}). Existing databases keep whatever UUID was assigned on
+   * first install.
+   */
+  public static final Map<String, String> BASELINE_SYSTEM_TEMPLATE_GUIDS =
+      Map.of(
+          "perc.page", "0-4-602",
+          "perc.pageDatabase", "0-4-604",
+          "perc.pageDispatcher", "0-4-606",
+          "perc.pageXml", "0-4-608",
+          "perc.sys.resource", "0-4-610",
+          "perc.widget", "0-4-612",
+          "perc.widgetDispatcher", "0-4-614");
+
+  private PSTemplateDefInstallUtils() {
+    // utility
+  }
+
+  /**
+   * Whether a new TemplateDef mapping should keep the archive source UUID instead of allocating
+   * the next {@code variantid} from the GUID manager.
+   *
+   * @param sourceId archive dependency id (typically {@code 602} for {@code TemplateDef-602})
+   * @param sourceUuidInUse {@code true} when that UUID already exists on the target or is reserved
+   *     as another mapping's target
+   * @return {@code true} to keep {@code sourceId} as the target id
+   */
+  public static boolean shouldKeepSourceUuid(String sourceId, boolean sourceUuidInUse) {
+    return resolveKeptSourceId(sourceId, sourceUuidInUse) != null;
+  }
+
+  /**
+   * Source UUID to assign as the mapping target, or {@code null} when the caller must allocate a
+   * new sequential id.
+   *
+   * @param sourceId archive dependency id
+   * @param sourceUuidInUse whether the UUID is already claimed
+   * @return trimmed source id, or {@code null}
+   */
+  public static String resolveKeptSourceId(String sourceId, boolean sourceUuidInUse) {
+    if (sourceId == null || sourceId.isBlank()) {
+      return null;
+    }
+    String trimmed = sourceId.trim();
+    try {
+      templateUuid(trimmed);
+    } catch (RuntimeException e) {
+      return null;
+    }
+    if (sourceUuidInUse) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  /**
+   * First-assign path: if the mapping is a new object with no target yet and the source UUID is
+   * unused, set the target to the archive source id.
+   *
+   * @param mapping current id mapping, not {@code null}
+   * @param sourceUuidInUse whether the source UUID is already claimed
+   * @return {@code true} if the mapping target was set to the source UUID
+   */
+  public static boolean tryKeepSourceUuid(PSIdMapping mapping, boolean sourceUuidInUse) {
+    Objects.requireNonNull(mapping, "mapping");
+    if (!mapping.isNewObject() || mapping.getTargetId() != null) {
+      return false;
+    }
+    String kept = resolveKeptSourceId(mapping.getSourceId(), sourceUuidInUse);
+    if (kept == null) {
+      return false;
+    }
+    String name = mapping.getSourceName();
+    if (name == null || name.isBlank()) {
+      name = kept;
+    }
+    mapping.setTarget(kept, name);
+    return true;
+  }
+
+  /**
+   * Whether another mapping in {@code idMap} already reserved {@code sourceId} as a TemplateDef
+   * target (same UUID, including encoded {@link PSGuid#longValue()} forms).
+   *
+   * @param idMap current install id map, not {@code null}
+   * @param sourceId UUID being considered, may be blank
+   * @param objectType dependency type to match (typically {@code TemplateDef})
+   * @return {@code true} if another mapping already claims that UUID
+   */
+  public static boolean isUuidReservedAsTarget(PSIdMap idMap, String sourceId, String objectType) {
+    Objects.requireNonNull(idMap, "idMap");
+    if (objectType == null || objectType.isBlank()) {
+      throw new IllegalArgumentException("objectType may not be null or empty");
+    }
+    if (sourceId == null || sourceId.isBlank()) {
+      return false;
+    }
+    Iterator<PSIdMapping> mappings = idMap.getMappings();
+    while (mappings.hasNext()) {
+      PSIdMapping mapping = mappings.next();
+      if (mapping == null || mapping.getTargetId() == null) {
+        continue;
+      }
+      if (!objectType.equals(mapping.getObjectType())) {
+        continue;
+      }
+      if (sourceId.equals(mapping.getSourceId())) {
+        continue;
+      }
+      if (sameTemplateUuid(sourceId, mapping.getTargetId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Compare two TemplateDef ids as UUID values ({@code 602}, {@code 0-4-602}, or encoded longs).
+   *
+   * @param left first id
+   * @param right second id
+   * @return {@code true} when both parse and share the same template UUID
+   */
+  public static boolean sameTemplateUuid(String left, String right) {
+    if (left == null || right == null || left.isBlank() || right.isBlank()) {
+      return false;
+    }
+    try {
+      return templateUuid(left) == templateUuid(right);
+    } catch (RuntimeException e) {
+      return left.trim().equals(right.trim());
+    }
+  }
+
+  /**
+   * Assembly GUID string form ({@code 0-4-N}) for a TemplateDef dependency id.
+   *
+   * @param sourceId archive id such as {@code 602} or {@code 0-4-602}
+   * @return {@code host-type-uuid} string, never {@code null}
+   */
+  public static String assemblyGuidString(String sourceId) {
+    if (sourceId == null || sourceId.isBlank()) {
+      throw new IllegalArgumentException("sourceId may not be null or empty");
+    }
+    return new PSGuid(PSTypeEnum.TEMPLATE, sourceId.trim()).toString();
+  }
+
+  static int templateUuid(String id) {
+    return new PSGuid(PSTypeEnum.TEMPLATE, id.trim()).getUUID();
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtilsTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtilsTest.java
@@ -108,6 +108,29 @@ public class PSTemplateDefInstallUtilsTest {
   }
 
   @Test
+  public void sameTemplateUuidDoesNotTreatMalformedIdsAsCollisions() {
+    assertFalse(PSTemplateDefInstallUtils.sameTemplateUuid("not-a-guid", "not-a-guid"));
+    assertFalse(PSTemplateDefInstallUtils.sameTemplateUuid("602", "not-a-guid"));
+    assertFalse(PSTemplateDefInstallUtils.sameTemplateUuid("not-a-guid", "602"));
+    assertNull(PSTemplateDefInstallUtils.parseTemplateUuid("not-a-guid"));
+    assertEquals(Integer.valueOf(602), PSTemplateDefInstallUtils.parseTemplateUuid("602"));
+  }
+
+  @Test
+  public void malformedReservedTargetDoesNotBlockValidArchiveUuid() {
+    PSIdMap idMap = new PSIdMap("src:repo");
+    PSIdMapping other = newNewMapping("999", "other.template");
+    other.setTarget("not-a-guid", "other.template");
+    idMap.addMapping(other);
+
+    assertFalse(PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "602", TYPE));
+    PSIdMapping mapping = newNewMapping("602", "perc.page");
+    boolean reserved = PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "602", TYPE);
+    assertTrue(PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, reserved));
+    assertEquals("602", mapping.getTargetId());
+  }
+
+  @Test
   public void baselineSystemTemplateGuidsAreStableOnFreshInstall() {
     Map<String, String> expected =
         Map.of(

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtilsTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSTemplateDefInstallUtilsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSIdMap;
+import com.percussion.deployer.objectstore.PSIdMapping;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Install-path ID reservation for TemplateDef (issue #3727). Package emit tests already assert
+ * archive GUIDs {@code 0-4-602}..{@code 614}; this covers the deployer apply policy that previously
+ * allocated sequential type-4 UUIDs ({@code 0-4-1001}..) on fresh H2.
+ */
+public class PSTemplateDefInstallUtilsTest {
+
+  /** Same value as {@code PSTemplateDefDependencyHandler.DEPENDENCY_TYPE} — do not load that class (Spring locator). */
+  private static final String TYPE = "TemplateDef";
+
+  @Test
+  public void freshAssignKeepsArchiveUuid() {
+    PSIdMapping mapping = newNewMapping("602", "perc.page");
+    assertTrue(PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, false));
+    assertEquals("602", mapping.getTargetId());
+    assertEquals("0-4-602", PSTemplateDefInstallUtils.assemblyGuidString(mapping.getTargetId()));
+  }
+
+  @Test
+  public void existingCustomerRowIsNotRemapped() {
+    PSIdMapping mapping = new PSIdMapping("602", "perc.page", TYPE);
+    mapping.setIsNewObject(false);
+    mapping.setTarget("1001", "perc.page");
+
+    assertFalse(PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, false));
+    assertEquals("1001", mapping.getTargetId());
+    assertEquals(
+        "0-4-1001", PSTemplateDefInstallUtils.assemblyGuidString(mapping.getTargetId()));
+  }
+
+  @Test
+  public void takenSourceUuidFallsThroughToNextUuid() {
+    PSIdMapping mapping = newNewMapping("602", "perc.page");
+    assertFalse(PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, true));
+    assertNull(mapping.getTargetId());
+    assertFalse(PSTemplateDefInstallUtils.shouldKeepSourceUuid("602", true));
+    assertNull(PSTemplateDefInstallUtils.resolveKeptSourceId("602", true));
+  }
+
+  @Test
+  public void blankOrInvalidSourceDoesNotKeep() {
+    assertFalse(PSTemplateDefInstallUtils.shouldKeepSourceUuid(null, false));
+    assertFalse(PSTemplateDefInstallUtils.shouldKeepSourceUuid("  ", false));
+    assertFalse(PSTemplateDefInstallUtils.shouldKeepSourceUuid("not-a-guid", false));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSTemplateDefInstallUtils.assemblyGuidString(""));
+  }
+
+  @Test
+  public void reservedTargetUuidIsDetectedAcrossStringForms() {
+    PSIdMap idMap = new PSIdMap("src:repo");
+    PSIdMapping other = newNewMapping("999", "other.template");
+    other.setTarget("602", "other.template");
+    idMap.addMapping(other);
+
+    assertTrue(PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "602", TYPE));
+    assertTrue(PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "0-4-602", TYPE));
+    assertFalse(PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "604", TYPE));
+  }
+
+  @Test
+  public void selfMappingIsNotTreatedAsReserved() {
+    PSIdMap idMap = new PSIdMap("src:repo");
+    PSIdMapping self = newNewMapping("602", "perc.page");
+    self.setTarget("602", "perc.page");
+    idMap.addMapping(self);
+
+    assertFalse(PSTemplateDefInstallUtils.isUuidReservedAsTarget(idMap, "602", TYPE));
+  }
+
+  @Test
+  public void sameTemplateUuidAcceptsEncodedLong() {
+    String encoded = String.valueOf(new PSGuid(0, PSTypeEnum.TEMPLATE, 602).longValue());
+    assertTrue(PSTemplateDefInstallUtils.sameTemplateUuid("602", encoded));
+    assertTrue(PSTemplateDefInstallUtils.sameTemplateUuid("0-4-602", encoded));
+    assertFalse(PSTemplateDefInstallUtils.sameTemplateUuid("602", "604"));
+  }
+
+  @Test
+  public void baselineSystemTemplateGuidsAreStableOnFreshInstall() {
+    Map<String, String> expected =
+        Map.of(
+            "perc.page", "0-4-602",
+            "perc.pageDatabase", "0-4-604",
+            "perc.pageDispatcher", "0-4-606",
+            "perc.pageXml", "0-4-608",
+            "perc.sys.resource", "0-4-610",
+            "perc.widget", "0-4-612",
+            "perc.widgetDispatcher", "0-4-614");
+    assertEquals(expected, PSTemplateDefInstallUtils.BASELINE_SYSTEM_TEMPLATE_GUIDS);
+    expected.forEach(
+        (name, guid) -> {
+          String uuid = guid.substring("0-4-".length());
+          PSIdMapping mapping = newNewMapping(uuid, name);
+          assertTrue(
+              PSTemplateDefInstallUtils.tryKeepSourceUuid(mapping, false),
+              "first assign must keep " + name);
+          assertEquals(guid, PSTemplateDefInstallUtils.assemblyGuidString(mapping.getTargetId()));
+        });
+  }
+
+  @Test
+  public void tryKeepSourceUuidRejectsNullMapping() {
+    assertThrows(
+        NullPointerException.class, () -> PSTemplateDefInstallUtils.tryKeepSourceUuid(null, false));
+  }
+
+  private static PSIdMapping newNewMapping(String sourceId, String name) {
+    PSIdMapping mapping = new PSIdMapping(sourceId, name, TYPE, true);
+    mapping.setIsNewObject(true);
+    return mapping;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -49,7 +49,9 @@ import java.util.regex.Pattern;
  *
  * <p>Deployer runtime still consumes legacy assembly-template XML inside the {@code .ppkg}
  * (PSTemplateDefDependencyHandler). This class is the package-build / staging bridge that makes that
- * install path work from modern authoring alone.
+ * install path work from modern authoring alone. First-assign install keeps unused archive UUIDs
+ * ({@code TemplateDef-602} → {@code 0-4-602}); existing customer rows are not remapped (issue
+ * #3727).
  */
 public final class PSPageXmlNativeInstall {
 

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -46,6 +46,28 @@ The **Templates** tab lists assembly templates from `GET /services/templates`.
 | Empty | **No templates found.** Use **Create template**. |
 | Error | An operator-facing message. The rest of the Design shell stays usable. |
 
+## Baseline system templates (fresh 8.2)
+
+A new CMS install (including QA H2 via `perc-devctl qa-up`) loads `perc.Baseline` with seven
+system assembly templates. On **first assign** those templates keep the archive GUIDs:
+
+| Template | GUID (`stringValue`) |
+|----------|----------------------|
+| `perc.page` | `0-4-602` |
+| `perc.pageDatabase` | `0-4-604` |
+| `perc.pageDispatcher` | `0-4-606` |
+| `perc.pageXml` | `0-4-608` |
+| `perc.sys.resource` | `0-4-610` |
+| `perc.widget` | `0-4-612` |
+| `perc.widgetDispatcher` | `0-4-614` |
+
+**Existing databases are not remapped.** If an earlier install already assigned sequential type-4
+UUIDs (for example `0-4-1001` for `perc.page`), that row keeps its id. Package reinstall matches by
+template name. Do not rewrite GUIDs on customer or snapshot databases to force the table above.
+
+The Design catalog and `GET /services/templates` show the live id. On a fresh 8.2 host, `perc.page`
+is `0-4-602`.
+
 ## Create a template (no Widget XML)
 
 1. On the Templates library, choose **Create template**.

--- a/product-docs/8.2/developer/extensions.md
+++ b/product-docs/8.2/developer/extensions.md
@@ -35,6 +35,12 @@ and more). New extension code should:
 A **package** is a deployable unit of CMS components (content types, templates, apps, configs)
 distributed as a `.ppkg` (zip). Installers and startup packaging deploy packages into the CMS.
 
+`perc.Baseline` system templates (`perc.page`, `perc.pageDatabase`, `perc.pageDispatcher`,
+`perc.pageXml`, `perc.sys.resource`, `perc.widget`, `perc.widgetDispatcher`) install with stable
+GUIDs `0-4-602`..`0-4-614` on a **fresh** 8.2 instance. Existing databases keep the UUID assigned on
+first install; package apply does not rewrite customer template GUIDs. See
+[Design templates](id:admin-design-templates).
+
 When changing packaging:
 
 - Keep platform entry points (`.bat` / `.cmd` / `.sh`) in lockstep where operators need them.


### PR DESCRIPTION
## Summary

Fresh H2 installs of `perc.Baseline` assigned sequential type-4 UUIDs (`0-4-1001`..) to the seven system templates even though package emit already wrote `TemplateDef-602`..`614` / `0-4-602`..`614`. Deployer `reserveNewId` always called `guidMgr.createGuid(TEMPLATE)` for new mappings.

This keeps the **unused archive UUID** on first assign so a new 8.2 host (including QA H2) gets:

| Template | GUID |
|----------|------|
| perc.page | `0-4-602` |
| perc.pageDatabase | `0-4-604` |
| perc.pageDispatcher | `0-4-606` |
| perc.pageXml | `0-4-608` |
| perc.sys.resource | `0-4-610` |
| perc.widget | `0-4-612` |
| perc.widgetDispatcher | `0-4-614` |

**Existing customer/snapshot DBs are not remapped.** Reinstall matches by template name (`isNewObject=false`); this path only runs for unused UUIDs.

Parent: #2630. Residual of QA #2813 / closed #2805. Fixes #3727.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd deployer && ../mvnw clean install` — BUILD SUCCESS; `PSTemplateDefInstallUtilsTest` 9/9.
2. `cd modules/perc-packages && ../../mvnw clean install` — BUILD SUCCESS; Baseline native-install 7 TemplateDefs written.
3. After merge: fresh CMS / `perc-devctl qa-up` + `qa-health`. Design catalog or `GET /services/templates` lists `perc.page` as `0-4-602` (not `0-4-1001`).
4. Existing DBs: reinstall Baseline; `perc.page` keeps its previously assigned id.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/design-templates.md` and `product-docs/8.2/developer/extensions.md`
- [x] **Unit / module tests** — `PSTemplateDefInstallUtilsTest` (first assign, existing row, collision, Baseline 7 GUIDs); perc-packages native emit still asserts `0-4-602`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; installer/apply-path GUID policy)
- [x] **Build gates** — standalone `clean install` on `deployer` and `modules/perc-packages` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `deployer`, `modules/perc-packages`
- **build_evidence:**
  - `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 288, Failures: 0, Errors: 0, Skipped: 19 (`PSTemplateDefInstallUtilsTest` Tests run: 9, Failures: 0)
  - `cd modules/perc-packages && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 207, Failures: 0; `native-install page TemplateDefs for perc.Baseline: 7 written`
- **downstream_checked:** none (no existing public/protected signature change; additive `PSTemplateDefInstallUtils` + `reserveNewId` body only)

### C5 UI proof

N/A — not WebUI/SPA work. Live GUID proof requires a **fresh** package apply (hot-deploy after first start does not reinstall Baseline). Post-merge QA: `perc-devctl qa-up` + `qa-health` + template catalog.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
