### PR TITLE
feat(rest): Content Type design-session lock/unlock REST (#3742)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3742-content-type-design-session-lock-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3742-content-type-design-session-lock-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3742 Content Type design-session lock REST
+
+**Branch:** `feat/issue-3742-content-type-design-session-lock`  
+**Scope:** uncommitted vs `origin/main` (rest, sitemanage, product-docs)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** rest+sitemanage change-class companions (resource + IXxxAdaptor + Spring test stub + apibridge impl + adaptor unit tests); Workbench replacement via IPS*DesignWs; product-docs REST note for public surface.
+
+## Summary
+
+Adds explicit Admin-only, self-only Content Type design-session lock/unlock REST:
+
+- `POST /contenttypes/{idOrName}/lock` → `IPSContentDesignWs.loadContentTypes(..., lock=true, overrideLock=false)`
+- `POST /contenttypes/{idOrName}/unlock` → probe lock (409 if held by another user) then `IPSSystemDesignWs.releaseLocks` (no save)
+
+PUT save remains out of scope (existing lock-save-unlock PUT unchanged).
+
+## Issues
+
+None that block. Unlock briefly acquires/extends the lock when the object is free or already owned, then releases — matches Workbench self-only semantics and is covered by tests (no `saveContentTypes`).
+
+## Cross-platform path checklist
+
+N/A — no filesystem path I/O.
+
+## Tests / companions
+
+- Mockito: `ContentTypesResourceDetailTest` lock/unlock 2xx/403/404/409
+- Spring stub: `TestContentTypeAdaptor` (+ `ContentTypesTestAdaptor`)
+- Adaptor: `ContentTypeAdaptorLockTest`
+- product-docs/8.2/developer/rest.md Content types table
+- Standalone `rest` then `projects/sitemanage` `mvnw clean install` green

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -191,6 +191,21 @@ in the slot detail panel — use **Back** to return to the catalog.
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `designGaps` |
+| Lock | `POST /services/contenttypes/{idOrName}/lock` | **Admin.** Self-only design-session lock (`IPSContentDesignWs.loadContentTypes` with `lock=true`, `overrideLock=false`). Does **not** save. `200` + `ObjectLockSummary` (`session`, `locker`, `remainingTime` minutes). Re-lock by the same session user extends the lock. |
+| Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
+
+Lock/unlock status codes:
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | Lock acquired (body is `ObjectLockSummary`) |
+| `204` | Unlock success |
+| `403` | Caller is not Admin |
+| `404` | Content type not found |
+| `409` | Locked by another user (self-only; the lock is not stolen) |
+| `500` | Design service or server failure |
+
+`PUT /services/contenttypes/{idOrName}` still lock-saves-unlocks in one request. Use these lock/unlock endpoints when a client needs an explicit design session before a later save.
 
 JSON may wrap a single item as `ContentTypeDetail`. Integrators and the Developer
 SPA unwrap that envelope and read `guid.stringValue` (or synthesize

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -39,6 +39,7 @@ import com.percussion.design.objectstore.PSVisibilityRules;
 import com.percussion.design.objectstore.PSWorkflowInfo;
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeField;
@@ -49,6 +50,7 @@ import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
 import com.percussion.services.assembly.PSAssemblyException;
 import com.percussion.services.assembly.PSAssemblyServiceLocator;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.contentmgr.IPSContentMgr;
 import com.percussion.services.contentmgr.PSContentMgrLocator;
@@ -57,13 +59,21 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.workflow.IPSWorkflowService;
 import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.services.workflow.data.PSWorkflow;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.PSContentWsLocator;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import com.percussion.webservices.system.PSSystemWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,21 +82,47 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @PSSiteManageBean
 public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
   private static final Logger log = LogManager.getLogger(ContentTypeAdaptor.class);
 
+  /** Typical design-session lock duration reported by SOAP (minutes). */
+  static final long DESIGN_LOCK_MINUTES = 30L;
+
   private final IPSContentDesignWs designSvc;
   private final PSItemDefManager itemDefManager;
+  private final IPSSystemDesignWs systemDesign;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   public ContentTypeAdaptor() {
-    designSvc = PSContentWsLocator.getContentDesignWebservice();
-    itemDefManager = PSItemDefManager.getInstance();
+    this(
+        PSContentWsLocator.getContentDesignWebservice(),
+        PSItemDefManager.getInstance(),
+        PSSystemWsLocator.getSystemDesignWebservice(),
+        null);
+  }
+
+  /** Package-visible for unit tests that inject design web services and Admin gate. */
+  ContentTypeAdaptor(
+      IPSContentDesignWs designSvc,
+      PSItemDefManager itemDefManager,
+      IPSSystemDesignWs systemDesign,
+      BooleanSupplier adminChecker) {
+    this.designSvc = designSvc;
+    this.itemDefManager = itemDefManager;
+    this.systemDesign = systemDesign;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   /***
@@ -327,6 +363,58 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       log.error("Failed to update content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to update content type", e);
     }
+  }
+
+  @Override
+  public ObjectLockSummary lockContentType(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    requireSessionUserForLock();
+    IPSGuid ctGuid = resolveContentTypeGuid(idOrName.trim());
+    if (ctGuid == null) {
+      return null;
+    }
+    try {
+      List<PSItemDefinition> locked =
+          designSvc.loadContentTypes(Collections.singletonList(ctGuid), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      return toLockSummary(session, user, DESIGN_LOCK_MINUTES);
+    } catch (PSErrorResultsException e) {
+      throwLockOrNotFound(e, idOrName, true);
+      return null;
+    }
+  }
+
+  @Override
+  public Boolean unlockContentType(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    requireSessionUserForLock();
+    IPSGuid ctGuid = resolveContentTypeGuid(idOrName.trim());
+    if (ctGuid == null) {
+      return null;
+    }
+    // Detect another user's lock without stealing it (self-only, overrideLock=false).
+    try {
+      designSvc.loadContentTypes(Collections.singletonList(ctGuid), true, false, session, user);
+    } catch (PSErrorResultsException e) {
+      throwLockOrNotFound(e, idOrName, false);
+      return null;
+    }
+    if (systemDesign != null) {
+      systemDesign.releaseLocks(Collections.singletonList(ctGuid), session, user);
+    }
+    return Boolean.TRUE;
   }
 
   /**
@@ -898,5 +986,167 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         walkDisplayMapper(entry.getDisplayMapper(), map, controlPropsByField);
       }
     }
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(
+          "Admin role required to lock or unlock content types", Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(
+          "Admin role required to lock or unlock content types", Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  private static void requireSessionUserForLock() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new IllegalStateException(
+          "Request session/user required for content type design session");
+    }
+  }
+
+  /**
+   * Resolve a content type GUID from uuid, guid string, or unique name via content design find.
+   *
+   * @return guid or {@code null} when not found
+   */
+  IPSGuid resolveContentTypeGuid(String idOrName) {
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    if (StringUtils.isNumeric(idOrName)) {
+      return new PSGuid(PSTypeEnum.NODEDEF, Long.parseLong(idOrName));
+    }
+    if (idOrName.contains("-")) {
+      try {
+        PSGuid g = new PSGuid(idOrName);
+        if (g.getType() == 0) {
+          g = new PSGuid(PSTypeEnum.NODEDEF, g.getUUID());
+        }
+        return g;
+      } catch (RuntimeException ignore) {
+        // fall through to name lookup
+      }
+    }
+    List<IPSCatalogSummary> found = designSvc.findContentTypes(idOrName);
+    if (found == null || found.isEmpty()) {
+      return null;
+    }
+    for (IPSCatalogSummary sum : found) {
+      if (sum != null
+          && sum.getGUID() != null
+          && (idOrName.equalsIgnoreCase(sum.getName())
+              || idOrName.equalsIgnoreCase(sum.getLabel()))) {
+        return sum.getGUID();
+      }
+    }
+    if (found.size() == 1 && found.get(0) != null && found.get(0).getGUID() != null) {
+      return found.get(0).getGUID();
+    }
+    return null;
+  }
+
+  private void throwLockOrNotFound(PSErrorResultsException e, String idOrName, boolean acquiring) {
+    if (hasLockError(e)) {
+      String locker = firstLockLocker(e);
+      String verb = acquiring ? "acquire" : "release";
+      String msg =
+          locker != null
+              ? "Could not " + verb + " design lock for content type; locked by " + locker
+              : "Could not " + verb + " design lock for content type";
+      throw new IllegalStateException(msg, e);
+    }
+    if (isNotFoundError(e)) {
+      return;
+    }
+    throw new IllegalStateException(
+        "Failed to "
+            + (acquiring ? "open" : "close")
+            + " content type design session: "
+            + idOrName,
+        e);
+  }
+
+  /** Package-visible for unit tests. True when any collected error is a lock failure. */
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err instanceof PSLockErrorException) {
+        return true;
+      }
+      if (err != null && StringUtils.containsIgnoreCase(String.valueOf(err), "lock")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String firstLockLocker(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return null;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err instanceof PSLockErrorException lockErr
+          && StringUtils.isNotBlank(lockErr.getLocker())) {
+        return lockErr.getLocker();
+      }
+    }
+    return null;
+  }
+
+  static boolean isNotFoundError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null || e.getErrors().isEmpty()) {
+      return false;
+    }
+    if (hasLockError(e)) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err != null && StringUtils.containsIgnoreCase(String.valueOf(err), "not found")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static ObjectLockSummary toLockSummary(String session, String user, long remainingMinutes) {
+    ObjectLockSummary summary = new ObjectLockSummary();
+    summary.setSession(session);
+    summary.setLocker(user);
+    summary.setRemainingTime(remainingMinutes);
+    return summary;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorLockTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorLockTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.rest.ObjectLockSummary;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Content type design-session lock/unlock is a thin adaptor over {@link IPSContentDesignWs} (self
+ * only; Admin). Unlock releases via {@link IPSSystemDesignWs#releaseLocks} without saving.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorLockTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private ContentTypeAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    adaptor = new ContentTypeAdaptor(designWs, null, systemDesign, () -> true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void lockContentType_loadsWithLockTrueOverrideFalse() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+
+    ObjectLockSummary summary = adaptor.lockContentType(null, "311");
+
+    assertNotNull(summary);
+    assertEquals("Admin", summary.getLocker());
+    assertEquals("test-session", summary.getSession());
+    assertEquals(ContentTypeAdaptor.DESIGN_LOCK_MINUTES, summary.getRemainingTime());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
+    verify(designWs)
+        .loadContentTypes(ids.capture(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, ids.getValue().size());
+    assertEquals(guid, ids.getValue().get(0));
+  }
+
+  @Test
+  void lockContentType_resolvesNameViaFind() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn("percPage");
+    when(designWs.findContentTypes("percPage")).thenReturn(List.of(sum));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(mock(PSItemDefinition.class)));
+
+    ObjectLockSummary summary = adaptor.lockContentType(null, "percPage");
+    assertNotNull(summary);
+    verify(designWs).findContentTypes("percPage");
+  }
+
+  @Test
+  void lockContentType_unknownName_returnsNull() throws Exception {
+    when(designWs.findContentTypes("missing")).thenReturn(List.of());
+    assertNull(adaptor.lockContentType(null, "missing"));
+    verify(designWs, never()).loadContentTypes(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void lockContentType_conflictWhenLockedByOtherUser() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "CREATE_LOCK_FAILED", "stack", "editor2", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), any(), any())).thenThrow(errors);
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.lockContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+  }
+
+  @Test
+  void lockContentType_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied = new ContentTypeAdaptor(designWs, null, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.lockContentType(null, "311"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void lockContentType_requiresSessionUser() {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.lockContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void unlockContentType_releasesWithoutSave() throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(mock(PSItemDefinition.class)));
+
+    assertEquals(Boolean.TRUE, adaptor.unlockContentType(null, "311"));
+    verify(designWs).loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
+    verify(systemDesign).releaseLocks(ids.capture(), eq("test-session"), eq("Admin"));
+    assertEquals(new PSGuid(PSTypeEnum.NODEDEF, 311L), ids.getValue().get(0));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void unlockContentType_conflictWhenLockedByOtherUser() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "CREATE_LOCK_FAILED", "stack", "editor2", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), any(), any())).thenThrow(errors);
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.unlockContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(systemDesign, never()).releaseLocks(anyList(), any(), any());
+  }
+
+  @Test
+  void hasLockError_detectsLockException() {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 1L);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(guid, new PSLockErrorException(1, "locked", "stack", "u", 1));
+    assertTrue(ContentTypeAdaptor.hasLockError(errors));
+    assertEquals("u", ContentTypeAdaptor.firstLockLocker(errors));
+    assertFalse(ContentTypeAdaptor.isNotFoundError(errors));
+  }
+
+  @Test
+  void isNotFoundError_whenNoLockMetadata() {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 1L);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(guid, "object not found");
+    assertFalse(ContentTypeAdaptor.hasLockError(errors));
+    assertTrue(ContentTypeAdaptor.isNotFoundError(errors));
+    assertNull(ContentTypeAdaptor.firstLockLocker(errors));
+  }
+
+  @Test
+  void toLockSummary_setsSessionUserMinutes() {
+    ObjectLockSummary summary = ContentTypeAdaptor.toLockSummary("s", "Admin", 30);
+    assertEquals("s", summary.getSession());
+    assertEquals("Admin", summary.getLocker());
+    assertEquals(30, summary.getRemainingTime());
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.contenttypes;
 
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.system.utils.PSSiteManageBean;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -30,6 +31,7 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
@@ -890,6 +892,81 @@ public class ContentTypesResource {
       throw new WebApplicationException(e.getMessage(), 400);
     } catch (IllegalStateException e) {
       // lock / session problems surface as 409 when message indicates lock
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      if (msg.toLowerCase().contains("lock")) {
+        throw new WebApplicationException(msg, 409);
+      }
+      throw new WebApplicationException(e, 500);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @POST
+  @Path("/{idOrName}/lock")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Lock content type design session",
+      description =
+          "Acquires a self-only design-session lock for the current Admin user via the content"
+              + " design web service (IPSContentDesignWs.loadContentTypes with lock=true,"
+              + " overrideLock=false). Does not save. Re-lock by the same session user extends the"
+              + " lock.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Locked",
+            content = @Content(schema = @Schema(implementation = ObjectLockSummary.class))),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "409", description = "Locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ObjectLockSummary lockContentType(@PathParam("idOrName") String idOrName) {
+    try {
+      ObjectLockSummary summary =
+          requireAdaptor().lockContentType(uriInfo.getBaseUri(), idOrName);
+      if (summary == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return summary;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalStateException e) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      if (msg.toLowerCase().contains("lock")) {
+        throw new WebApplicationException(msg, 409);
+      }
+      throw new WebApplicationException(e, 500);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @POST
+  @Path("/{idOrName}/unlock")
+  @Operation(
+      summary = "Unlock content type design session",
+      description =
+          "Releases a design-session lock owned by the current Admin user/session. Does not save."
+              + " Locks held by another user are not stolen (409).",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Unlocked"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "409", description = "Locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response unlockContentType(@PathParam("idOrName") String idOrName) {
+    try {
+      Boolean released = requireAdaptor().unlockContentType(uriInfo.getBaseUri(), idOrName);
+      if (released == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalStateException e) {
       String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
       if (msg.toLowerCase().contains("lock")) {
         throw new WebApplicationException(msg, 409);

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.contenttypes;
 
+import com.percussion.rest.ObjectLockSummary;
 import java.net.URI;
 import java.util.List;
 
@@ -69,4 +70,23 @@ public interface IContentTypesAdaptor {
    * @return updated detail, or {@code null} when not found
    */
   ContentTypeDetail updateContentType(URI baseUri, String idOrName, ContentTypeDetail body);
+
+  /**
+   * Acquire a self-only design-session lock on the content type. Does not save.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return lock summary, or {@code null} when not found
+   */
+  ObjectLockSummary lockContentType(URI baseUri, String idOrName);
+
+  /**
+   * Release a design-session lock owned by the current user/session. Does not save.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return {@code Boolean.TRUE} when released; {@code null} when not found. Throws {@code
+   *     IllegalStateException} when locked by another user.
+   */
+  Boolean unlockContentType(URI baseUri, String idOrName);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.when;
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
 import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.ObjectLockSummary;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
@@ -195,6 +197,71 @@ public class ContentTypesResourceDetailTest {
         assertThrows(
             WebApplicationException.class,
             () -> resource.updateContentType("percPage", new ContentTypeDetail()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void lockContentTypeSuccess() {
+    ObjectLockSummary summary = new ObjectLockSummary();
+    summary.setLocker("Admin");
+    summary.setSession("sess-1");
+    summary.setRemainingTime(30);
+    when(adaptor.lockContentType(any(), eq("percPage"))).thenReturn(summary);
+    ObjectLockSummary out = resource.lockContentType("percPage");
+    assertEquals("Admin", out.getLocker());
+    assertEquals("sess-1", out.getSession());
+    assertEquals(30, out.getRemainingTime());
+  }
+
+  @Test
+  public void lockContentTypeNotFound() {
+    when(adaptor.lockContentType(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.lockContentType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void lockContentTypeConflictWhenLockedByOtherUser() {
+    when(adaptor.lockContentType(any(), eq("percPage")))
+        .thenThrow(
+            new IllegalStateException(
+                "Could not acquire design lock for content type; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.lockContentType("percPage"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void lockContentTypeForbidden() {
+    when(adaptor.lockContentType(any(), eq("percPage")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.lockContentType("percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void unlockContentTypeSuccess() {
+    when(adaptor.unlockContentType(any(), eq("percPage"))).thenReturn(Boolean.TRUE);
+    Response response = resource.unlockContentType("percPage");
+    assertEquals(204, response.getStatus());
+  }
+
+  @Test
+  public void unlockContentTypeNotFound() {
+    when(adaptor.unlockContentType(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.unlockContentType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void unlockContentTypeConflictWhenLockedByOtherUser() {
+    when(adaptor.unlockContentType(any(), eq("percPage")))
+        .thenThrow(new IllegalStateException("Could not release design lock; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.unlockContentType("percPage"));
     assertEquals(409, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.contenttypes;
 
 import com.percussion.rest.Guid;
+import com.percussion.rest.ObjectLockSummary;
 import java.net.URI;
 import java.util.List;
 
@@ -77,5 +78,15 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail updateContentType(URI baseUri, String idOrName, ContentTypeDetail body) {
     return null;
+  }
+
+  @Override
+  public ObjectLockSummary lockContentType(URI baseUri, String idOrName) {
+    return null;
+  }
+
+  @Override
+  public Boolean unlockContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -20,16 +20,19 @@
 package com.percussion.rest.test.apibridge;
 
 import com.percussion.rest.Guid;
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import java.net.URI;
 import java.util.List;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /** Test adaptor for ContentType API bridge (Spring MainTest companion stub). */
 @Component
+@Lazy
 public class TestContentTypeAdaptor implements IContentTypesAdaptor {
 
   public TestContentTypeAdaptor() {
@@ -89,5 +92,15 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail updateContentType(URI baseUri, String idOrName, ContentTypeDetail body) {
     return null;
+  }
+
+  @Override
+  public ObjectLockSummary lockContentType(URI baseUri, String idOrName) {
+    return null;
+  }
+
+  @Override
+  public Boolean unlockContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
   }
 }


### PR DESCRIPTION
## Summary

Adds public REST **lock/unlock** for a Content Type design session (parent **#1690** slice 1/3, CD-01). Thin adaptor over `IPSContentDesignWs.loadContentTypes(..., lock=true, overrideLock=false)` (self-only; no steal). Unlock uses Workbench `IPSSystemDesignWs.releaseLocks` and does **not** save.

Existing `PUT /contenttypes/{idOrName}` lock-save-unlock is unchanged. PUT save is slice 2; SPA chrome is slice 3.

| Method | Path | Status |
|--------|------|--------|
| `POST` | `/services/contenttypes/{idOrName}/lock` | **200** + `ObjectLockSummary` for Admin; **409** if locked by another user; **403** not Admin; **404** missing |
| `POST` | `/services/contenttypes/{idOrName}/unlock` | **204** for Admin; **409** if locked by another user; **403** / **404** |

Fixes #3742  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Mockito: `ContentTypesResourceDetailTest` lock/unlock 200/204/403/404/409.
2. Spring MainTest stub: `TestContentTypeAdaptor` implements new interface methods.
3. Adaptor: `ContentTypeAdaptorLockTest` (load with lock=true/overrideLock=false; 409 locker; Admin 403; unlock releaseLocks; no save).
4. Standalone `cd rest && ../mvnw clean install` then `cd projects/sitemanage && ../../mvnw clean install`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Content types (design catalog) lock/unlock table
- [x] **Unit / module tests** — behavioral tests for lock/unlock; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 551, Failures: 0 (`ContentTypesResourceDetailTest` 17 tests; `MainTest` green)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** Tests run: 1400, Failures: 0, Skipped: 125 (`ContentTypeAdaptorLockTest` 11 tests)
- **downstream_checked:** `IContentTypesAdaptor` gained methods (not made `final`). All implementors updated (`ContentTypeAdaptor`, `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`). Standalone sitemanage clean install (the rest reverse-dep). Grep `implements IContentTypesAdaptor` → 3 hits, all in this change set.

### C5 UI proof

N/A — REST/backend only; no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
