### PR TITLE
fix(perc-packages): empty perc.Test page dual-ship waive lists (#3737)

### DIFF
--- a/docs/ai-generated/code-reviews/3737-perc-test-page-dual-ship-exit-erlang.md
+++ b/docs/ai-generated/code-reviews/3737-perc-test-page-dual-ship-exit-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: #3737 perc.Test page dual-ship templateDef exit
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-22 |
+| **Branch** | `fix/issue-3737-page-templatedef-exit` |
+| **Scope** | uncommitted vs `HEAD` / `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | pass |
+| **May commit/push** | yes |
+
+## Summary
+
+`perc.Test` never authored page `pages/` or `*.templateDef`. This slice empties the dual-ship page templateDef waive list and the shared Page/Gadget G4 ship-path waive list so CI fails closed if dummy dual-ship `pages/` or `rxconfig/Pages|Gadgets` XML reappears, including under `perc.Test`. Widget G4 waiver is left for sibling #3736.
+
+Memory patterns hit: behavioral tests for changed inventory policy; portable `Path`/`Files` only; change-class companions (Page + Gadget tests because they share `WAIVED_PACKAGE_DIRS`); no invented dummy product pages.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Path logic uses `Path.resolve` / `Files`
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] Temp trees use JUnit `@TempDir`
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Nits (non-blocking)
+
+- Emptying Gadget G4 waive is slightly broader than the issue title; required because `PSPageDefinitionXmlInventory.WAIVED_PACKAGE_DIRS` aliases the shared scanner list. Product tree has zero Gadget XML.
+- Dual-ship **code path** (`PSPageXmlDualShip.materializeInstallTemplateDefs`) remains; out of scope (parent retirement checklist residual, not this slice).
+
+## Evidence
+
+`cd modules/perc-packages && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 209, Failures: 0. Package-build logged `Building package: perc.Test.ppkg` with **no** `dual-ship page templateDefs` line.

--- a/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
@@ -35,7 +35,7 @@ Re-verify against current `main` before any removal PR. Counts below were taken 
 | **G1** | `modules/perc-packages` clean install green after removal | **N/A (pre-removal)** | Module green on current dual-run code; deletion not started | Required only on the future removal PR |
 | **G2** | Behavioral modern-only selection tests | **PARTIAL** | `PSLegacyDefinitionXmlShimTest` + `PSWidgetDaoTest` modern/legacy/neither on main | Modern-only (no legacy fallback) tests belong on removal PR |
 | **G3** | No production refs to deleted dual-run APIs after removal | **N/A (pre-removal)** | Callers still **required**: `PSWidgetDao`, `GadgetRegistry` fallback | Pass only after deletion rewires consumers |
-| **G4** | CI fails if product definition XML reappears under Packages ship paths | **PASS** (Widget + Pages + Gadgets) | Widget: `PSWidgetDefinitionXmlInventory` + Surefire [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051) #3026; Pages/Gadgets: `PSPageDefinitionXmlInventory` / `PSGadgetDefinitionXmlInventory` / `PSDefinitionXmlShipPathInventory` #3581; waive `perc.Test` only | None for ship-path inventory; keep shim (#2852) |
+| **G4** | CI fails if product definition XML reappears under Packages ship paths | **PASS** (Widget + Pages + Gadgets) | Widget: `PSWidgetDefinitionXmlInventory` + Surefire [#3051](https://github.com/intersoftdatalabs-in/percussioncms/pull/3051) #3026 (waive `perc.Test` until #3736); Pages/Gadgets: `PSPageDefinitionXmlInventory` / `PSGadgetDefinitionXmlInventory` / `PSDefinitionXmlShipPathInventory` #3581; Page/Gadget waive **empty** after #3737 | None for ship-path inventory; keep shim (#2852) |
 | **G5** | Reverse-dep consumers green after removal | **N/A (pre-removal)** | sitemanage / WebUI dual-run tests green with shim present | Re-run sitemanage + WebUI on removal PR |
 | **G6** | Cross-platform Path/Files only in load paths | **PASS (current surfaces)** | Widget inventory + shim use `Path`/`Files`; DAO roots use `Path.of` | Re-check any replacement load path on removal PR |
 
@@ -218,7 +218,7 @@ Use these **CI-assertable** probes and log fields when collecting Phase 5 M2 evi
 | Page inventory API + CLI | `com.percussion.packages.pagexml.PSPageDefinitionXmlInventory` |
 | Gadget inventory API + CLI | `com.percussion.packages.gadgetxml.PSGadgetDefinitionXmlInventory` |
 | Surefire gates | `PSPageDefinitionXmlInventoryTest`, `PSGadgetDefinitionXmlInventoryTest`, `PSDefinitionXmlShipPathInventoryTest` (product tree zero non-waived; TempDir proves failure when dummy non-waived XML is introduced) |
-| Explicit waive | `perc.Test` only (`WAIVED_PACKAGE_DIRS`) |
+| Explicit waive | Empty after perc.Test page dual-ship exit (#3737) (`WAIVED_PACKAGE_DIRS`) |
 | Path I/O | `Path.resolve` / `Files` only (G6-aligned) |
 | Ship paths | `sys__UserDependency--rxconfig/Pages\|Gadgets` and `rxconfig/Pages\|Gadgets` (shim-recognized layouts). Modern `pages/` / catalog JSON is not definition XML. |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -38,6 +38,7 @@ Policy code: `com.percussion.packages.pagexml.PSPageXmlInstallPolicy` (aligns wi
 | `perc.responsiveTemplates` | `package-install.properties` → `native` | Banded / Basic / plain |
 | `perc.Baseline` | `package-install.properties` → `native` | 7 system templates (`perc.page`, `perc.pageDatabase`, `perc.pageDispatcher`, `perc.pageXml`, `perc.sys.resource`, `perc.widget`, `perc.widgetDispatcher`) — #3673 |
 | `perc.FileAssetWidget` / `perc.widgets.image` | `package-install.properties` → `native` | Leftover binary TemplateDefs (`perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary`) converted to modern `pages/` — #3674 / #3680 |
+| `perc.Test` | n/a (no `pages/`) | Never authored page `*.templateDef` / `pages/`; dual-ship and Page G4 waive lists emptied — #3737 |
 
 ## Retirement checklist (per package)
 
@@ -57,7 +58,7 @@ Dual-ship **code path** can be deleted when **all** hold:
 - [x] `perc.baseTemplates` / `perc.responsiveTemplates` use native mode — #2806
 - [x] Remaining page layout packages on native (`perc.Baseline` system templates — #3673)
 - [x] Widget leftover binary TemplateDefs inventoried and converted (#3674 / #3680): `perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary` are `output-format=Binary` / `binaryAssembler` (not page layouts). Converted to `pages/<id>/component-package.json` + native install (Widget XML emitter cannot emit TemplateDef). Product tree has zero authored root `*.templateDef`.
-- [x] CI / product package build has zero `dual-ship page templateDefs` log lines (or only waived packages) — Surefire `PSDualShipPageTemplateDefInventory` / #3675. Waiver: **`perc.Test` only**. Leftover binaries are converted on `main` via #3680 (not dual-ship-retained). Package-build also fails closed via `assertDualShipMaterializationAllowed`.
+- [x] CI / product package build has zero `dual-ship page templateDefs` log lines — Surefire `PSDualShipPageTemplateDefInventory` / #3675. Waiver is **empty** after perc.Test page dual-ship exit (#3737). Leftover binaries are converted on `main` via #3680 (not dual-ship-retained). Package-build also fails closed via `assertDualShipMaterializationAllowed`.
 - [ ] Docs (this file + page inventory + ADR-004) mark dual-ship retired
 - [ ] Follow-up removes `PSPageXmlDualShip.materializeInstallTemplateDefs` call sites when unused
 
@@ -69,7 +70,7 @@ Dual-ship **code path** can be deleted when **all** hold:
 | Surefire | `PSDualShipPageTemplateDefInventoryTest` |
 | Package-build fail-closed | `PSPackageBuilder.stageModernPageInstallArtifacts` |
 
-Scan is **committed** `package-install.properties` only (JVM `perc.packages.page.installMode` must not hide a missing native opt-in). Packages with modern `pages/` + native mode are not dual-ship emitters. Authored root `*.templateDef` without modern `pages/` is out of this gate; leftover binaries were converted (#3674 / #3680).
+Scan is **committed** `package-install.properties` only (JVM `perc.packages.page.installMode` must not hide a missing native opt-in). Packages with modern `pages/` + native mode are not dual-ship emitters. Authored root `*.templateDef` without modern `pages/` is out of this gate; leftover binaries were converted (#3674 / #3680). Waiver set is **empty** after perc.Test page dual-ship exit (#3737).
 
 ## Deployer note
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
@@ -97,7 +97,7 @@ Compiler for upgrade-input `GadgetRegistry.xml` → modern ship format (landed a
 
 **WebUI dual-load (#2788 / #3025):** runtime prefers `gadget-catalog.json` with legacy `GadgetRegistry.xml` fallback; INFO selection metrics and test-visible last-load source/entry count. **Still residual:** delete product/legacy `GadgetRegistry.xml` fallback only when Phase 5 criteria pass (#2852 / M2–M3) — not unattended mass-delete.
 
-**G4 Packages ship-path inventory (#3581):** `PSGadgetDefinitionXmlInventory` + Surefire fails CI if non-waived Gadget definition XML reappears under `Packages/**/sys__UserDependency--rxconfig/Gadgets` or `Packages/**/rxconfig/Gadgets` (waiver: `perc.Test` only). This does **not** cover WebUI `GadgetRegistry.xml` (outside Packages ship paths).
+**G4 Packages ship-path inventory (#3581 / #3737):** `PSGadgetDefinitionXmlInventory` + Surefire fails CI if Gadget definition XML reappears under `Packages/**/sys__UserDependency--rxconfig/Gadgets` or `Packages/**/rxconfig/Gadgets` (waiver set empty after perc.Test page dual-ship exit; shared Page/Gadget list). This does **not** cover WebUI `GadgetRegistry.xml` (outside Packages ship paths).
 
 ## Related docs
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -19,7 +19,7 @@ Unlike widgets (`rxconfig/Widgets/*.xml`), product **page layout** packaging is 
 | Thumbnail resources | `sys__UserDependency--rx_resources/images/TemplateImages/…` | Palette thumbs (not compiled in #2770) |
 | Package identity | `psx_archiveInfo.xml` | Version / publisher / CMS range for compiler context |
 
-There is **no** product tree under `rxconfig/Pages/*.xml` in `modules/perc-packages` today. The dual-run shim still recognizes `rxconfig/Pages` for customer installs (see [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)). **G4 ship-path inventory (#3581):** `PSPageDefinitionXmlInventory` + Surefire fails CI if non-waived Page definition XML reappears under `sys__UserDependency--rxconfig/Pages` or `rxconfig/Pages` (waiver: `perc.Test` only).
+There is **no** product tree under `rxconfig/Pages/*.xml` in `modules/perc-packages` today. The dual-run shim still recognizes `rxconfig/Pages` for customer installs (see [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)). **G4 ship-path inventory (#3581 / #3737):** `PSPageDefinitionXmlInventory` + Surefire fails CI if Page definition XML reappears under `sys__UserDependency--rxconfig/Pages` or `rxconfig/Pages` (waiver set empty after perc.Test page dual-ship exit).
 
 CM1 **page item** region trees / widget instances live in site storage (sitemanage domain), not as package `*.templateDef` files. This slice covers **packaged page templates** only; page-item composition upgrade remains a residual under #2630 when storage write-path is ready.
 

--- a/modules/perc-packages/README.md
+++ b/modules/perc-packages/README.md
@@ -20,7 +20,8 @@ From this module directory (standalone, preferred):
 
 Product packages must not reintroduce committed install definition XML under
 `sys__UserDependency--rxconfig/{Widgets,Pages,Gadgets}/` (or `rxconfig/{Pages,Gadgets}/`
-for Pages/Gadgets) except the explicit waiver **`perc.Test`**.
+for Pages/Gadgets). **Widget** waiver remains **`perc.Test` only** (widget ship-exit is
+#3736). **Pages/Gadgets** waiver is **empty** after perc.Test page dual-ship exit (#3737).
 
 | Piece | Class |
 |-------|--------|
@@ -41,7 +42,8 @@ See root `scripts/README.md` (definition XML inventory gates) and
 ## Dual-ship page templateDef inventory gate (#3675)
 
 Product packages with modern `pages/` must not re-introduce dual-ship root `*.templateDef`
-materialization except the explicit waiver **`perc.Test`**. Native packages
+materialization. Waiver is **empty** after perc.Test page dual-ship exit (#3737)
+(`perc.Test` never authored `pages/` / page `*.templateDef`). Native packages
 (`package-install.properties` `page.installMode=native`) are not dual-ship emitters.
 #3674 leftover widget binaries are **not** dual-ship-retained (empty retain list).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetDefinitionXmlInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetDefinitionXmlInventory.java
@@ -30,8 +30,8 @@ import java.util.Set;
  * {@code sys__UserDependency--rxconfig/Gadgets/*.xml} and {@code rxconfig/Gadgets/*.xml} (Phase 5
  * gate G4 / issue #3581, parent #2630, ADR-004).
  *
- * <p>Peer of {@code PSWidgetDefinitionXmlInventory}. Pass condition: zero <em>non-waived</em>
- * product Gadget definition XML. The only explicit waiver is {@code perc.Test}.
+ * <p>Peer of {@code PSWidgetDefinitionXmlInventory}. Pass condition: zero product Gadget definition
+ * XML. Waiver set is empty after perc.Test page dual-ship exit (#3737) (shared Page/Gadget list).
  *
  * <p>Modern {@code gadget-catalog.json} and per-gadget {@code component-package.json} are not
  * definition XML and are ignored. {@code GadgetRegistry.xml} lives outside Packages ship paths
@@ -43,7 +43,7 @@ public final class PSGadgetDefinitionXmlInventory {
 
   /**
    * Package directory names under {@code Packages/} allowed to still commit Gadget definition XML.
-   * Explicit and minimal — do not expand without an ADR / residual issue.
+   * Empty after #3737. Do not expand without an ADR / residual issue.
    */
   public static final Set<String> WAIVED_PACKAGE_DIRS =
       PSDefinitionXmlShipPathInventory.WAIVED_PACKAGE_DIRS;
@@ -65,7 +65,7 @@ public final class PSGadgetDefinitionXmlInventory {
   }
 
   /**
-   * Whether the package directory name is on the explicit waiver list ({@code perc.Test} only).
+   * Whether the package directory name is on the explicit waiver list (empty after #3737).
    *
    * @param packageDirName package folder name under Packages
    * @return true if waived

--- a/modules/perc-packages/src/main/java/com/percussion/packages/inventory/PSDefinitionXmlShipPathInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/inventory/PSDefinitionXmlShipPathInventory.java
@@ -46,10 +46,12 @@ public final class PSDefinitionXmlShipPathInventory {
 
   /**
    * Package directory names under {@code Packages/} allowed to still commit Page/Gadget definition
-   * XML. Explicit and minimal — do not expand without an ADR / residual issue.
+   * XML. Empty after perc.Test page dual-ship exit (#3737): {@code perc.Test} never authored {@code
+   * rxconfig/Pages} or {@code rxconfig/Gadgets} XML. Widget waiver is a separate list ({@code
+   * PSWidgetDefinitionXmlInventory}). Do not expand without an ADR / residual issue.
    */
   public static final Set<String> WAIVED_PACKAGE_DIRS =
-      Collections.unmodifiableSet(new LinkedHashSet<>(List.of("perc.Test")));
+      Collections.unmodifiableSet(new LinkedHashSet<>());
 
   /** Definition-XML kind under a Packages tree. */
   public enum Kind {
@@ -91,7 +93,7 @@ public final class PSDefinitionXmlShipPathInventory {
    * One committed definition XML file under a package ship path.
    *
    * @param kind Page or Gadget
-   * @param packageDirName immediate child name under the Packages root (e.g. {@code perc.Test})
+   * @param packageDirName immediate child name under the Packages root (e.g. {@code perc.baseTemplates})
    * @param xmlPath absolute normalized path to the {@code .xml} file
    * @param waived whether {@code packageDirName} is in {@link #WAIVED_PACKAGE_DIRS}
    */
@@ -172,7 +174,7 @@ public final class PSDefinitionXmlShipPathInventory {
   }
 
   /**
-   * Whether the package directory name is on the explicit waiver list ({@code perc.Test} only).
+   * Whether the package directory name is on the explicit waiver list (empty after #3737).
    *
    * @param packageDirName package folder name under Packages
    * @return true if waived

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
@@ -39,9 +39,10 @@ import java.util.stream.Collectors;
  * parent #2630, ADR-004).
  *
  * <p>Peer of {@link PSPageDefinitionXmlInventory} / {@code PSWidgetDefinitionXmlInventory}. Pass
- * condition: zero <em>non-waived</em> product packages that would emit dual-ship root templateDefs
- * (modern {@code pages/} + committed {@code page.installMode} defaulting to dual-ship). Packages
- * that opted into {@link PSPageXmlInstallMode#NATIVE} are not dual-ship emitters.
+ * condition: zero product packages that would emit dual-ship root templateDefs (modern {@code
+ * pages/} + committed {@code page.installMode} defaulting to dual-ship). Waiver set is empty after
+ * perc.Test page dual-ship exit (#3737). Packages that opted into {@link
+ * PSPageXmlInstallMode#NATIVE} are not dual-ship emitters.
  *
  * <p>Committed policy is package-local {@code package-install.properties} only. JVM system
  * properties ({@link PSPageXmlInstallPolicy#SYS_PROP_INSTALL_MODE} / {@link
@@ -75,16 +76,12 @@ public final class PSDualShipPageTemplateDefInventory {
 
   /**
    * Package directory names under {@code Packages/} allowed to still dual-ship page templateDefs.
-   * Explicit and minimal: {@code perc.Test} plus {@link #RETAINED_WIDGET_BINARY_PACKAGE_DIRS}.
+   * Empty after perc.Test page dual-ship exit (#3737): {@code perc.Test} never authored page {@code
+   * pages/} / {@code *.templateDef}. Plus {@link #RETAINED_WIDGET_BINARY_PACKAGE_DIRS} (also empty).
+   * Do not expand without an ADR / residual issue.
    */
-  public static final Set<String> WAIVED_PACKAGE_DIRS;
-
-  static {
-    LinkedHashSet<String> waived = new LinkedHashSet<>();
-    waived.add("perc.Test");
-    waived.addAll(RETAINED_WIDGET_BINARY_PACKAGE_DIRS);
-    WAIVED_PACKAGE_DIRS = Collections.unmodifiableSet(waived);
-  }
+  public static final Set<String> WAIVED_PACKAGE_DIRS =
+      Collections.unmodifiableSet(new LinkedHashSet<>(RETAINED_WIDGET_BINARY_PACKAGE_DIRS));
 
   /**
    * One package that would (or did) emit dual-ship page templateDefs.

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageDefinitionXmlInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageDefinitionXmlInventory.java
@@ -30,8 +30,8 @@ import java.util.Set;
  * {@code sys__UserDependency--rxconfig/Pages/*.xml} and {@code rxconfig/Pages/*.xml} (Phase 5 gate
  * G4 / issue #3581, parent #2630, ADR-004).
  *
- * <p>Peer of {@code PSWidgetDefinitionXmlInventory}. Pass condition: zero <em>non-waived</em>
- * product Page definition XML. The only explicit waiver is {@code perc.Test}.
+ * <p>Peer of {@code PSWidgetDefinitionXmlInventory}. Pass condition: zero product Page definition
+ * XML. Waiver set is empty after perc.Test page dual-ship exit (#3737).
  *
  * <p>Modern authoring under {@code pages/&lt;id&gt;/component-package.json} is not definition XML
  * and is ignored. Dual-ship / native {@code *.templateDef} install materialization is a separate
@@ -43,7 +43,7 @@ public final class PSPageDefinitionXmlInventory {
 
   /**
    * Package directory names under {@code Packages/} allowed to still commit Page definition XML.
-   * Explicit and minimal — do not expand without an ADR / residual issue.
+   * Empty after #3737. Do not expand without an ADR / residual issue.
    */
   public static final Set<String> WAIVED_PACKAGE_DIRS =
       PSDefinitionXmlShipPathInventory.WAIVED_PACKAGE_DIRS;
@@ -65,7 +65,7 @@ public final class PSPageDefinitionXmlInventory {
   }
 
   /**
-   * Whether the package directory name is on the explicit waiver list ({@code perc.Test} only).
+   * Whether the package directory name is on the explicit waiver list (empty after #3737).
    *
    * @param packageDirName package folder name under Packages
    * @return true if waived

--- a/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetDefinitionXmlInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetDefinitionXmlInventoryTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * G4 CI/inventory gate: zero non-waived product Gadget definition XML under Packages (issue #3581 /
- * parent #2630). Explicit waiver: {@code perc.Test} only.
+ * G4 CI/inventory gate: zero product Gadget definition XML under Packages (issue #3581 / #3737 /
+ * parent #2630). Waiver set is empty after perc.Test page dual-ship exit (shared Page/Gadget list).
  *
  * <p>Cross-platform: all path construction uses {@link Path#resolve(String)} / {@link Files}.
  */
@@ -42,9 +42,9 @@ class PSGadgetDefinitionXmlInventoryTest {
   @TempDir Path tempDir;
 
   @Test
-  void waivedPackageSet_isExplicitlyPercTestOnly() {
-    assertEquals(Set.of("perc.Test"), PSGadgetDefinitionXmlInventory.WAIVED_PACKAGE_DIRS);
-    assertTrue(PSGadgetDefinitionXmlInventory.isWaivedPackage("perc.Test"));
+  void waivedPackageSet_isEmptyAfterPercTestPageShipExit() {
+    assertEquals(Set.of(), PSGadgetDefinitionXmlInventory.WAIVED_PACKAGE_DIRS);
+    assertFalse(PSGadgetDefinitionXmlInventory.isWaivedPackage("perc.Test"));
     assertFalse(PSGadgetDefinitionXmlInventory.isWaivedPackage("perc.Baseline"));
     assertFalse(PSGadgetDefinitionXmlInventory.isWaivedPackage(null));
     assertFalse(PSGadgetDefinitionXmlInventory.isWaivedPackage(""));
@@ -65,13 +65,15 @@ class PSGadgetDefinitionXmlInventoryTest {
         () ->
             "G4: non-waived Gadget def XML must not reappear under product Packages; found: "
                 + report.nonWaived());
+    assertEquals(0, report.all().size(), "expected zero Gadget def XML including perc.Test");
+    assertEquals(0, report.waived().size());
     assertEquals(0, report.nonWaived().size());
 
     PSGadgetDefinitionXmlInventory.assertNoNonWaivedGadgetDefinitionXml(packagesRoot);
   }
 
   @Test
-  void tempTree_onlyWaivedXml_isClean() throws Exception {
+  void tempTree_percTestXml_failsGateAfterWaiverDrop() throws Exception {
     Path packages = tempDir.resolve("Packages");
     Path gadgets =
         packages
@@ -83,15 +85,17 @@ class PSGadgetDefinitionXmlInventoryTest {
     Files.writeString(xmlFile, "<Module id=\"PSGadget_TestProperties\"/>", StandardCharsets.UTF_8);
 
     PSDefinitionXmlShipPathInventory.Report report = PSGadgetDefinitionXmlInventory.scan(packages);
+    assertFalse(report.isClean());
     assertEquals(1, report.all().size());
-    assertEquals(0, report.nonWaived().size());
-    assertEquals(1, report.waived().size());
-    assertTrue(report.isClean());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals(0, report.waived().size());
     Path expectedAbs = xmlFile.toAbsolutePath().normalize();
-    assertEquals(expectedAbs, report.waived().get(0).xmlPath());
-    assertTrue(report.waived().get(0).xmlPath().isAbsolute());
-    assertTrue(report.waived().get(0).xmlPath().startsWith(gadgets.toAbsolutePath().normalize()));
-    PSGadgetDefinitionXmlInventory.assertNoNonWaivedGadgetDefinitionXml(packages);
+    assertEquals(expectedAbs, report.nonWaived().get(0).xmlPath());
+    assertTrue(report.nonWaived().get(0).xmlPath().isAbsolute());
+    assertTrue(report.nonWaived().get(0).xmlPath().startsWith(gadgets.toAbsolutePath().normalize()));
+    assertThrows(
+        IllegalStateException.class,
+        () -> PSGadgetDefinitionXmlInventory.assertNoNonWaivedGadgetDefinitionXml(packages));
   }
 
   @Test
@@ -175,16 +179,16 @@ class PSGadgetDefinitionXmlInventoryTest {
   }
 
   @Test
-  void tempTree_mixedWaivedAndNonWaived_reportsOnlyNonWaivedAsFailures() throws Exception {
+  void tempTree_percTestAndBaselineXml_bothFailAsNonWaived() throws Exception {
     Path packages = tempDir.resolve("Packages");
 
-    Path waived =
+    Path testGadgets =
         packages
             .resolve("perc.Test")
             .resolve("sys__UserDependency--rxconfig")
             .resolve("Gadgets");
-    Files.createDirectories(waived);
-    Files.writeString(waived.resolve("PSGadget_TestProperties.xml"), "<Module/>", StandardCharsets.UTF_8);
+    Files.createDirectories(testGadgets);
+    Files.writeString(testGadgets.resolve("PSGadget_TestProperties.xml"), "<Module/>", StandardCharsets.UTF_8);
 
     Path bad =
         packages
@@ -196,9 +200,8 @@ class PSGadgetDefinitionXmlInventoryTest {
 
     PSDefinitionXmlShipPathInventory.Report report = PSGadgetDefinitionXmlInventory.scan(packages);
     assertEquals(2, report.all().size());
-    assertEquals(1, report.waived().size());
-    assertEquals(1, report.nonWaived().size());
-    assertEquals("perc.Baseline", report.nonWaived().get(0).packageDirName());
+    assertEquals(0, report.waived().size());
+    assertEquals(2, report.nonWaived().size());
     assertFalse(report.isClean());
   }
 

--- a/modules/perc-packages/src/test/java/com/percussion/packages/inventory/PSDefinitionXmlShipPathInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/inventory/PSDefinitionXmlShipPathInventoryTest.java
@@ -27,6 +27,7 @@ import com.percussion.packages.inventory.PSDefinitionXmlShipPathInventory.Kind;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,6 +39,15 @@ import org.junit.jupiter.api.io.TempDir;
 class PSDefinitionXmlShipPathInventoryTest {
 
   @TempDir Path tempDir;
+
+  @Test
+  void waivedPackageSet_isEmptyAfterPercTestPageShipExit() {
+    assertEquals(Set.of(), PSDefinitionXmlShipPathInventory.WAIVED_PACKAGE_DIRS);
+    assertFalse(PSDefinitionXmlShipPathInventory.isWaivedPackage("perc.Test"));
+    assertFalse(PSDefinitionXmlShipPathInventory.isWaivedPackage("perc.baseTemplates"));
+    assertFalse(PSDefinitionXmlShipPathInventory.isWaivedPackage(null));
+    assertFalse(PSDefinitionXmlShipPathInventory.isWaivedPackage(""));
+  }
 
   @Test
   void productPackagesTree_pagesAndGadgets_areClean() throws Exception {

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventoryTest.java
@@ -35,9 +35,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Dual-ship page templateDef CI/inventory gate: zero non-waived emitters under Packages (issue
- * #3675 / parent #2630). Explicit waiver: {@code perc.Test} only (#3674 leftover binaries were
- * converted, not dual-ship-retained).
+ * Dual-ship page templateDef CI/inventory gate: zero dual-ship emitters under Packages (issue
+ * #3675 / #3737 / parent #2630). Waiver set is empty after perc.Test page dual-ship exit ({@code
+ * perc.Test} never authored {@code pages/}). #3674 leftover binaries were converted, not
+ * dual-ship-retained.
  *
  * <p>Cross-platform: all path construction uses {@link Path#resolve(String)} / {@link Files}.
  */
@@ -52,10 +53,10 @@ class PSDualShipPageTemplateDefInventoryTest {
   }
 
   @Test
-  void waivedPackageSet_isExplicitlyPercTestOnly_retainListEmpty() {
+  void waivedPackageSet_isEmptyAfterPercTestPageShipExit() {
     assertEquals(Set.of(), PSDualShipPageTemplateDefInventory.RETAINED_WIDGET_BINARY_PACKAGE_DIRS);
-    assertEquals(Set.of("perc.Test"), PSDualShipPageTemplateDefInventory.WAIVED_PACKAGE_DIRS);
-    assertTrue(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.Test"));
+    assertEquals(Set.of(), PSDualShipPageTemplateDefInventory.WAIVED_PACKAGE_DIRS);
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.Test"));
     assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.baseTemplates"));
     assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.FileAssetWidget"));
     assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.widgets.image"));
@@ -76,11 +77,24 @@ class PSDualShipPageTemplateDefInventoryTest {
     assertTrue(
         report.isClean(),
         () ->
-            "non-waived dual-ship page templateDefs must not reappear; found: "
-                + report.nonWaived());
+            "dual-ship page templateDefs must not reappear; found: " + report.nonWaived());
+    assertEquals(0, report.all().size(), "expected zero dual-ship emitters including perc.Test");
+    assertEquals(0, report.waived().size());
     assertEquals(0, report.nonWaived().size());
 
     PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packagesRoot);
+  }
+
+  @Test
+  void productPercTest_hasNoModernPagesAndIsNotWaived() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    assertNotNull(packagesRoot);
+    Path percTest = packagesRoot.resolve("perc.Test");
+    assertTrue(Files.isDirectory(percTest), "missing product package perc.Test");
+    assertFalse(
+        PSPageXmlDualShip.hasModernPageSources(percTest),
+        "perc.Test must not author pages/; do not reintroduce dual-ship page templateDefs");
+    assertFalse(PSDualShipPageTemplateDefInventory.isWaivedPackage("perc.Test"));
   }
 
   @Test
@@ -139,24 +153,28 @@ class PSDualShipPageTemplateDefInventoryTest {
   }
 
   @Test
-  void tempTree_onlyWaivedDualShip_isClean() throws Exception {
+  void tempTree_percTestDualShip_failsGateAfterWaiverDrop() throws Exception {
     Path packages = tempDir.resolve("Packages");
     Path pkg = packages.resolve("perc.Test");
     writeModernPage(pkg, "PSPage_TestProperties");
 
     PSDualShipPageTemplateDefInventory.Report report =
         PSDualShipPageTemplateDefInventory.scan(packages);
+    assertFalse(report.isClean());
     assertEquals(1, report.all().size());
-    assertEquals(0, report.nonWaived().size());
-    assertEquals(1, report.waived().size());
-    assertTrue(report.isClean());
-    assertEquals("perc.Test", report.waived().get(0).packageDirName());
-    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, report.waived().get(0).committedMode());
-    assertEquals(1, report.waived().get(0).modernPageCount());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals(0, report.waived().size());
+    assertEquals("perc.Test", report.nonWaived().get(0).packageDirName());
+    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, report.nonWaived().get(0).committedMode());
+    assertEquals(1, report.nonWaived().get(0).modernPageCount());
     Path expectedAbs = pkg.toAbsolutePath().normalize();
-    assertEquals(expectedAbs, report.waived().get(0).packageDir());
-    assertTrue(report.waived().get(0).packageDir().isAbsolute());
-    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(packages);
+    assertEquals(expectedAbs, report.nonWaived().get(0).packageDir());
+    assertTrue(report.nonWaived().get(0).packageDir().isAbsolute());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipPageTemplateDefs(
+                packages));
   }
 
   @Test
@@ -240,7 +258,7 @@ class PSDualShipPageTemplateDefInventoryTest {
   }
 
   @Test
-  void tempTree_mixedWaivedAndNonWaived_reportsOnlyNonWaivedAsFailures() throws Exception {
+  void tempTree_percTestAndBaseTemplates_bothFailAsNonWaived() throws Exception {
     Path packages = tempDir.resolve("Packages");
     writeModernPage(packages.resolve("perc.Test"), "PSPage_TestProperties");
     writeModernPage(packages.resolve("perc.baseTemplates"), "perc.base.plain");
@@ -248,9 +266,8 @@ class PSDualShipPageTemplateDefInventoryTest {
     PSDualShipPageTemplateDefInventory.Report report =
         PSDualShipPageTemplateDefInventory.scan(packages);
     assertEquals(2, report.all().size());
-    assertEquals(1, report.waived().size());
-    assertEquals(1, report.nonWaived().size());
-    assertEquals("perc.baseTemplates", report.nonWaived().get(0).packageDirName());
+    assertEquals(0, report.waived().size());
+    assertEquals(2, report.nonWaived().size());
     assertFalse(report.isClean());
   }
 
@@ -272,24 +289,27 @@ class PSDualShipPageTemplateDefInventoryTest {
   }
 
   @Test
-  void scanLogLines_nonWaivedFails_waivedIsClean() {
-    String waived =
+  void scanLogLines_percTestFailsAfterWaiverDrop() {
+    String percTest =
         PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.Test", 1);
     String nativeLine = "  native-install page TemplateDefs for perc.baseTemplates: 20 written";
-    PSDualShipPageTemplateDefInventory.Report waivedOnly =
-        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(waived, nativeLine));
-    assertTrue(waivedOnly.isClean());
-    assertEquals(1, waivedOnly.waived().size());
-    assertEquals("perc.Test", waivedOnly.waived().get(0).packageDirName());
-    assertNull(waivedOnly.waived().get(0).packageDir());
-    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(List.of(waived));
+    PSDualShipPageTemplateDefInventory.Report percTestOnly =
+        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(percTest, nativeLine));
+    assertFalse(percTestOnly.isClean());
+    assertEquals(1, percTestOnly.nonWaived().size());
+    assertEquals("perc.Test", percTestOnly.nonWaived().get(0).packageDirName());
+    assertNull(percTestOnly.nonWaived().get(0).packageDir());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(
+                List.of(percTest)));
 
     String bad = PSDualShipPageTemplateDefInventory.formatDualShipLogLine("perc.baseTemplates", 20);
     PSDualShipPageTemplateDefInventory.Report fail =
-        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(nativeLine, bad, waived));
+        PSDualShipPageTemplateDefInventory.scanLogLines(List.of(nativeLine, bad, percTest));
     assertFalse(fail.isClean());
-    assertEquals(1, fail.nonWaived().size());
-    assertEquals("perc.baseTemplates", fail.nonWaived().get(0).packageDirName());
+    assertEquals(2, fail.nonWaived().size());
     IllegalStateException err =
         assertThrows(
             IllegalStateException.class,
@@ -315,8 +335,15 @@ class PSDualShipPageTemplateDefInventoryTest {
   }
 
   @Test
-  void assertDualShipMaterializationAllowed_waivesPercTestOnly() {
-    PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed("perc.Test");
+  void assertDualShipMaterializationAllowed_rejectsAllPackagesIncludingPercTest() {
+    IllegalStateException percTest =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed(
+                    "perc.Test"));
+    assertTrue(percTest.getMessage().contains("#3675"));
+    assertTrue(percTest.getMessage().contains("perc.Test"));
     IllegalStateException err =
         assertThrows(
             IllegalStateException.class,

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageDefinitionXmlInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageDefinitionXmlInventoryTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * G4 CI/inventory gate: zero non-waived product Page definition XML under Packages (issue #3581 /
- * parent #2630). Explicit waiver: {@code perc.Test} only.
+ * G4 CI/inventory gate: zero product Page definition XML under Packages (issue #3581 / #3737 /
+ * parent #2630). Waiver set is empty after perc.Test page dual-ship exit.
  *
  * <p>Cross-platform: all path construction uses {@link Path#resolve(String)} / {@link Files}.
  */
@@ -42,9 +42,9 @@ class PSPageDefinitionXmlInventoryTest {
   @TempDir Path tempDir;
 
   @Test
-  void waivedPackageSet_isExplicitlyPercTestOnly() {
-    assertEquals(Set.of("perc.Test"), PSPageDefinitionXmlInventory.WAIVED_PACKAGE_DIRS);
-    assertTrue(PSPageDefinitionXmlInventory.isWaivedPackage("perc.Test"));
+  void waivedPackageSet_isEmptyAfterPercTestPageShipExit() {
+    assertEquals(Set.of(), PSPageDefinitionXmlInventory.WAIVED_PACKAGE_DIRS);
+    assertFalse(PSPageDefinitionXmlInventory.isWaivedPackage("perc.Test"));
     assertFalse(PSPageDefinitionXmlInventory.isWaivedPackage("perc.baseTemplates"));
     assertFalse(PSPageDefinitionXmlInventory.isWaivedPackage("perc.responsiveTemplates"));
     assertFalse(PSPageDefinitionXmlInventory.isWaivedPackage(null));
@@ -65,13 +65,15 @@ class PSPageDefinitionXmlInventoryTest {
         () ->
             "G4: non-waived Page def XML must not reappear under product Packages; found: "
                 + report.nonWaived());
+    assertEquals(0, report.all().size(), "expected zero Page def XML including perc.Test");
+    assertEquals(0, report.waived().size());
     assertEquals(0, report.nonWaived().size());
 
     PSPageDefinitionXmlInventory.assertNoNonWaivedPageDefinitionXml(packagesRoot);
   }
 
   @Test
-  void tempTree_onlyWaivedXml_isClean() throws Exception {
+  void tempTree_percTestXml_failsGateAfterWaiverDrop() throws Exception {
     Path packages = tempDir.resolve("Packages");
     Path pages =
         packages
@@ -85,15 +87,17 @@ class PSPageDefinitionXmlInventoryTest {
     Files.createDirectories(packages.resolve("perc.baseTemplates").resolve("pages"));
 
     PSDefinitionXmlShipPathInventory.Report report = PSPageDefinitionXmlInventory.scan(packages);
+    assertFalse(report.isClean());
     assertEquals(1, report.all().size());
-    assertEquals(0, report.nonWaived().size());
-    assertEquals(1, report.waived().size());
-    assertTrue(report.isClean());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals(0, report.waived().size());
     Path expectedAbs = xmlFile.toAbsolutePath().normalize();
-    assertEquals(expectedAbs, report.waived().get(0).xmlPath());
-    assertTrue(report.waived().get(0).xmlPath().isAbsolute());
-    assertTrue(report.waived().get(0).xmlPath().startsWith(pages.toAbsolutePath().normalize()));
-    PSPageDefinitionXmlInventory.assertNoNonWaivedPageDefinitionXml(packages);
+    assertEquals(expectedAbs, report.nonWaived().get(0).xmlPath());
+    assertTrue(report.nonWaived().get(0).xmlPath().isAbsolute());
+    assertTrue(report.nonWaived().get(0).xmlPath().startsWith(pages.toAbsolutePath().normalize()));
+    assertThrows(
+        IllegalStateException.class,
+        () -> PSPageDefinitionXmlInventory.assertNoNonWaivedPageDefinitionXml(packages));
   }
 
   @Test
@@ -184,16 +188,16 @@ class PSPageDefinitionXmlInventoryTest {
   }
 
   @Test
-  void tempTree_mixedWaivedAndNonWaived_reportsOnlyNonWaivedAsFailures() throws Exception {
+  void tempTree_percTestAndBaseTemplatesXml_bothFailAsNonWaived() throws Exception {
     Path packages = tempDir.resolve("Packages");
 
-    Path waivedPages =
+    Path testPages =
         packages
             .resolve("perc.Test")
             .resolve("sys__UserDependency--rxconfig")
             .resolve("Pages");
-    Files.createDirectories(waivedPages);
-    Files.writeString(waivedPages.resolve("PSPage_TestProperties.xml"), "<Page/>", StandardCharsets.UTF_8);
+    Files.createDirectories(testPages);
+    Files.writeString(testPages.resolve("PSPage_TestProperties.xml"), "<Page/>", StandardCharsets.UTF_8);
 
     Path badPages =
         packages
@@ -205,9 +209,8 @@ class PSPageDefinitionXmlInventoryTest {
 
     PSDefinitionXmlShipPathInventory.Report report = PSPageDefinitionXmlInventory.scan(packages);
     assertEquals(2, report.all().size());
-    assertEquals(1, report.waived().size());
-    assertEquals(1, report.nonWaived().size());
-    assertEquals("perc.baseTemplates", report.nonWaived().get(0).packageDirName());
+    assertEquals(0, report.waived().size());
+    assertEquals(2, report.nonWaived().size());
     assertFalse(report.isClean());
   }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,16 +75,17 @@ ship paths is enforced in Maven Surefire for `modules/perc-packages`:
 | Gadget | `sys__UserDependency--rxconfig/Gadgets/` and `rxconfig/Gadgets/` | `com.percussion.packages.gadgetxml.PSGadgetDefinitionXmlInventory` | `PSGadgetDefinitionXmlInventoryTest` |
 
 Shared Page/Gadget scanner: `com.percussion.packages.inventory.PSDefinitionXmlShipPathInventory`
-(combined `PAGE|GADGET|ALL` CLI). Tests fail if dummy non-waived fixture XML is introduced
-under a non-waived package. Explicit waiver: **`perc.Test` only**. Cross-platform: `Path` /
-`Files` only (no hardcoded separators).
+(combined `PAGE|GADGET|ALL` CLI). Tests fail if dummy fixture XML is introduced under a
+package. **Pages/Gadgets** waiver is **empty** after perc.Test page dual-ship exit (#3737).
+**Widget** waiver remains **`perc.Test` only** (#3736). Cross-platform: `Path` / `Files`
+only (no hardcoded separators).
 
 ### Dual-ship page templateDef inventory gate (#3675)
 
 **Not a Python script.** Fail-closed Surefire gate so product package-build cannot silently
 re-introduce dual-ship page `*.templateDef` materialization (modern `pages/` + non-native
-committed `page.installMode`). Waiver: **`perc.Test` only**. Sibling #3674 leftover widget
-binaries are not dual-ship-retained. API:
+committed `page.installMode`). Waiver is **empty** after perc.Test page dual-ship exit
+(#3737). Sibling #3674 leftover widget binaries are not dual-ship-retained. API:
 `com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` /
 `PSDualShipPageTemplateDefInventoryTest`. Retirement checklist:
 `docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md`.


### PR DESCRIPTION
## Summary

Parent: #2630 (slice 2/3). Peer dual-ship gates #3675 / #3674. Widget perc.Test ship-exit is sibling #3736 / PR #3750.

`perc.Test` never authored modern `pages/` or page `*.templateDef`. This slice **empties** the dual-ship page templateDef waive list (`PSDualShipPageTemplateDefInventory`) and the shared Page/Gadget G4 ship-path waive list (`PSDefinitionXmlShipPathInventory` / `PSPageDefinitionXmlInventory`). CI now fails if dummy dual-ship `pages/` or `rxconfig/Pages|Gadgets` XML reappears, including under `perc.Test`.

Widget XML waiver remains `perc.Test` until #3736. Dual-ship **code path** and runtime shim stay (out of scope; #2852 / customer GUID remap #3727).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3737
Parent: #2630

## Test plan

1. `cd modules/perc-packages && ../../mvnw.cmd clean install`
2. Confirm Surefire: `PSDualShipPageTemplateDefInventoryTest`, `PSPageDefinitionXmlInventoryTest`, `PSGadgetDefinitionXmlInventoryTest`, `PSDefinitionXmlShipPathInventoryTest`
3. Confirm package-build logs `Building package: perc.Test.ppkg` with **no** `dual-ship page templateDefs` line
4. Confirm waive sets are empty (`Set.of()`) and dummy perc.Test dual-ship / Pages XML fails the gate

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): CI/package-authoring inventory gate; no operator/UI/install-step change
- [x] **Unit / module tests** — behavioral inventory tests; perc-packages standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd modules/perc-packages && ../../mvnw.cmd clean install` **BUILD SUCCESS**; Tests run: 209, Failures: 0
- [x] **Cross-platform** — inventory tests use `Path.resolve` / `Files` / `@TempDir` only

### C3 evidence

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 209, Failures: 0, Errors: 0, Skipped: 0. Package-build: perc.Test.ppkg with no dual-ship page templateDefs log line.
- **downstream_checked:** grep monorepo for `PSDualShipPageTemplateDefInventory` / `PSPageDefinitionXmlInventory` / `PSDefinitionXmlShipPathInventory` — consumers are perc-packages tests only; no public signature / `final` / reverse-dep blast radius. C2 N/A.

Erlang: `docs/ai-generated/code-reviews/3737-perc-test-page-dual-ship-exit-erlang.md` (approve).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
