### PR TITLE
feat(deployer): retype catalog/client IPS*Errors to DeploymentErrorCodes (#3739)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
@@ -17,10 +17,10 @@
 
 package com.percussion.deployer.catalog;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.conn.PSServerException;
 import com.percussion.deployer.client.PSDeploymentServerConnection;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
@@ -163,7 +163,7 @@ public class PSCataloger {
     } catch (PSServerLockException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     PSCatalogResultSet set = null;
@@ -179,7 +179,7 @@ public class PSCataloger {
         respDoc.getDocumentElement().getTagName(),
         e.getLocalizedMessage()
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     return set;

--- a/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
@@ -29,8 +29,8 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.server.PSDependencyManager;
 import com.percussion.deployer.server.PSDeploymentHandler;
 import com.percussion.deployer.server.PSLogHandler;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
@@ -74,7 +74,7 @@ public class PSCatalogHandler {
     Document doc = request.getInputDocument();
     Element root = null;
     if (doc == null || (root = doc.getDocumentElement()) == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     /* verify this is the appropriate request type */
@@ -82,7 +82,7 @@ public class PSCatalogHandler {
     int length = PSCataloger.ROOT_PREFIX.length();
     if (!requestTag.startsWith(PSCataloger.ROOT_PREFIX)
         || !PSCataloger.ms_supportedReqTypes.contains(requestTag.substring(length))) {
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REQUEST_TYPE, root.getTagName());
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REQUEST_TYPE, root.getTagName());
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
@@ -306,7 +306,7 @@ public class PSCatalogHandler {
         }
       }
     } catch (PSUnknownNodeTypeException ex) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, ex.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, ex.getLocalizedMessage());
     }
     return descriptors;
   }
@@ -373,7 +373,7 @@ public class PSCatalogHandler {
     if (props == null
         || props.getProperty("type") == null
         || props.getProperty("type").trim().length() == 0)
-      throw new PSDeployException(IPSDeploymentErrors.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
+      throw new PSDeployException(DeploymentErrorCodes.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
 
     String type = props.getProperty("type");
     PSCatalogResultSet typeObjects = new PSCatalogResultSet();
@@ -496,7 +496,7 @@ public class PSCatalogHandler {
 
     if (!catalogDir.isDirectory() || !catalogDir.exists())
       throw new PSDeployException(
-          IPSDeploymentErrors.CATALOG_INVALID_DIRECTORY_SPECIFIED, new String[] {directory});
+          DeploymentErrorCodes.CATALOG_INVALID_DIRECTORY_SPECIFIED, new String[] {directory});
 
     PSCatalogResultSet resultSet = new PSCatalogResultSet();
     var dirFiles = Optional.ofNullable(catalogDir.listFiles()).orElse(new File[0]);

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.client;
 
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
@@ -199,7 +199,7 @@ public class PSDeployFileJobControl implements IPSDeployJobControl {
             ResourceBundle.getBundle("com.percussion.deployer.client.PSDeployStringResources");
       }
     } catch (MissingResourceException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return ms_bundle;

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
@@ -17,6 +17,8 @@
 
 package com.percussion.deployer.client;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.conn.PSServerException;
 import com.percussion.deployer.catalog.PSCataloger;
 import com.percussion.deployer.objectstore.IPSDeployComponent;
@@ -38,11 +40,9 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.objectstore.PSUserDependency;
 import com.percussion.deployer.objectstore.PSValidationResults;
 import com.percussion.deployer.server.PSDeploymentHandler;
-import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSFeatureSet;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
 import com.percussion.security.PSAuthenticationFailedException;
@@ -122,7 +122,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -155,7 +155,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -214,7 +214,7 @@ public class PSDeploymentManager {
         | PSAuthenticationFailedException
         | PSAuthorizationException e) {
       log.error(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -259,7 +259,7 @@ public class PSDeploymentManager {
       return results.iterator();
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -300,7 +300,7 @@ public class PSDeploymentManager {
       return results.iterator();
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -320,7 +320,7 @@ public class PSDeploymentManager {
       return respDoc.getDocumentElement().getAttribute("longvalue");
 
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -357,10 +357,10 @@ public class PSDeploymentManager {
       return types;
     } catch (PSUnknownNodeTypeException e) {
       Object args[] = {reqType, searchEl, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -438,7 +438,7 @@ public class PSDeploymentManager {
       Element childEl = tree.getNextElement(xmlNodeName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (childEl == null) {
         Object args[] = {reqType, xmlNodeName};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
       }
 
       Constructor<? extends IPSDeployComponent> compCtor =
@@ -447,11 +447,11 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException) {
         Object args[] = {reqType, xmlNodeName, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       } else if (e instanceof PSDeployException) {
         throw (PSDeployException) e;
       } else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
 
@@ -602,7 +602,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
     return respDoc;
@@ -669,7 +669,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -703,7 +703,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -729,7 +729,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -755,7 +755,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -796,7 +796,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -833,7 +833,7 @@ public class PSDeploymentManager {
       if (errors.isEmpty()) return null;
       return errors;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -898,7 +898,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
 
@@ -1245,7 +1245,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1306,7 +1306,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1395,7 +1395,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1458,7 +1458,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1478,7 +1478,7 @@ public class PSDeploymentManager {
       return runServerJob(desc, "export");
     } catch (PSServerLockException e) {
       // this is not expected, but helper method throws it
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1501,7 +1501,7 @@ public class PSDeploymentManager {
           tree.getNextElement(PSFeatureSet.ms_nodeName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (childEl == null) {
         Object args[] = {reqType, PSFeatureSet.ms_nodeName};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
       }
 
       PSXmlDocumentBuilder.replaceRoot(respDoc, childEl);
@@ -1511,11 +1511,11 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException || e instanceof PSUnknownDocTypeException) {
         Object args[] = {reqType, "PSXDeployGetFeatureSetRequest", e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       } else if (e instanceof PSDeployException) {
         throw (PSDeployException) e;
       } else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1560,7 +1560,7 @@ public class PSDeploymentManager {
       // this is not expected, but helper method throws it
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1595,7 +1595,7 @@ public class PSDeploymentManager {
       if (results == null) {
         // this would be a bug, just throw unexpected exeption
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Missing validation results for pkg: " + pkg.getPackage().getKey());
       }
       pkg.setValidationResults(results);
@@ -1654,7 +1654,7 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       String message = respRoot.getAttribute("message");
@@ -1664,7 +1664,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1702,14 +1702,14 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       return result;
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1749,7 +1749,7 @@ public class PSDeploymentManager {
     Element depEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (depEl == null) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
 
     return getDependencyFromElement(reqType, depEl);
@@ -1775,12 +1775,12 @@ public class PSDeploymentManager {
       else if (PSUserDependency.XML_NODE_NAME.equals(elName)) dep = new PSUserDependency(depEl);
     } catch (PSUnknownNodeTypeException e) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     if (dep == null) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
 
     return dep;
@@ -1833,7 +1833,7 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, root.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       return new PSDeployServerJobControl(jobId, this);
@@ -1841,7 +1841,7 @@ public class PSDeploymentManager {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else if (e instanceof PSServerLockException) throw (PSServerLockException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
@@ -28,7 +28,7 @@ import com.percussion.conn.PSServerException;
 import com.percussion.deployer.objectstore.PSDbmsInfo;
 import com.percussion.deployer.objectstore.PSDeploymentServerConnectionInfo;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
 import com.percussion.error.PSLockedException;
@@ -199,7 +199,7 @@ public final class PSDeploymentServerConnection {
       m_conn.setTimeout(0); // no timeout
       m_conn.addBasicAuthorization("", m_uid, m_password);
     } catch (ProtocolNotSuppException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     m_isConnected = true;
@@ -216,7 +216,7 @@ public final class PSDeploymentServerConnection {
     } catch (NumberFormatException e) {
       m_isConnected = false;
       Object[] args = {"connect", "deployVersion", deployVersion};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     // The client's deployment version must be greater than or equal to the
@@ -225,7 +225,7 @@ public final class PSDeploymentServerConnection {
     if (deployInterface > DEPLOYMENT_INTERFACE_VERSION) {
       m_isConnected = false;
       throw new PSDeployException(
-          IPSDeploymentErrors.SERVER_VERSION_INVALID, m_version.getVersionString());
+          DeploymentErrorCodes.SERVER_VERSION_INVALID, m_version.getVersionString());
     }
 
     String licensed = root.getAttribute("licensed");
@@ -237,13 +237,13 @@ public final class PSDeploymentServerConnection {
     if (versionEl == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSFormatVersion.NODE_TYPE};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
     m_version = PSFormatVersion.createFromXml(versionEl);
     if (m_version == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSFormatVersion.NODE_TYPE, "unknown"};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
     // This will have to be reworked once we allow remote install of the package manager for cougar.
     // It will need to know the difference of cougar and rhythmyx
@@ -252,7 +252,7 @@ public final class PSDeploymentServerConnection {
     if (m_version.getMajorVersion() < 6) {
       m_isConnected = false;
       throw new PSDeployException(
-          IPSDeploymentErrors.SERVER_VERSION_INVALID, m_version.getVersionString());
+          DeploymentErrorCodes.SERVER_VERSION_INVALID, m_version.getVersionString());
     }
 
     Element repositoryEl =
@@ -260,14 +260,14 @@ public final class PSDeploymentServerConnection {
     if (repositoryEl == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSDbmsInfo.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
     try {
       m_serverRepositoryInfo = new PSDbmsInfo(repositoryEl);
     } catch (PSUnknownNodeTypeException e) {
       m_isConnected = false;
       Object[] args = {"connect", PSDbmsInfo.XML_NODE_NAME, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     // locker thread tries to extend the lock 2 minutes before expiration.
@@ -311,7 +311,7 @@ public final class PSDeploymentServerConnection {
       doDisconnect();
     } catch (PSDeployException e) {
       Object[] args = {m_server + ":" + m_port, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.LOCK_NOT_RELEASED, args);
+      throw new PSDeployException(DeploymentErrorCodes.LOCK_NOT_RELEASED, args);
     } finally {
       if (m_lockerThread != null) m_lockerThread.interrupt();
       m_isConnected = false;
@@ -424,7 +424,7 @@ public final class PSDeploymentServerConnection {
     if (req == null) throw new IllegalArgumentException("req may not be null");
 
     if (!m_isConnected) {
-      throw new PSDeployException(IPSDeploymentErrors.NOT_CONNECTED_ERROR, m_server);
+      throw new PSDeployException(DeploymentErrorCodes.NOT_CONNECTED_ERROR, m_server);
     }
     return execute(type, req, params, true);
   }
@@ -500,7 +500,7 @@ public final class PSDeploymentServerConnection {
             log.debug(uee.getMessage(), uee);
           }
         }
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -517,7 +517,7 @@ public final class PSDeploymentServerConnection {
         }
       }
 
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (reqFile != null) reqFile.release();
     }
@@ -581,7 +581,7 @@ public final class PSDeploymentServerConnection {
     if (controller == null) throw new IllegalArgumentException("controller may not be null");
 
     if (!m_isConnected) {
-      throw new PSDeployException(IPSDeploymentErrors.NOT_CONNECTED_ERROR, m_server);
+      throw new PSDeployException(DeploymentErrorCodes.NOT_CONNECTED_ERROR, m_server);
     }
 
     return execute(type, params, body, controller, true, true);
@@ -663,12 +663,12 @@ public final class PSDeploymentServerConnection {
           log.error(ioe.getMessage());
           log.debug(ioe.getMessage(), ioe);
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR, ioe.getLocalizedMessage());
+              DeploymentErrorCodes.UNEXPECTED_ERROR, ioe.getLocalizedMessage());
         }
       } catch (Exception e) {
         log.error(PSExceptionUtils.getMessageForLog(e));
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } catch (IOException e) {
       if (repost) {
@@ -678,7 +678,7 @@ public final class PSDeploymentServerConnection {
       } else {
         log.error(PSExceptionUtils.getMessageForLog(e));
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
       }
     }
 
@@ -812,7 +812,7 @@ public final class PSDeploymentServerConnection {
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (in != null)
         try {
@@ -1049,7 +1049,7 @@ public final class PSDeploymentServerConnection {
    * Multipart Content-Type forced on XML request document parts so the server {@code
    * PSFormContentParser} classifies the part as XML and calls {@code setInputDocument}. Relying
    * only on {@code URLConnection.guessContentTypeFromName} can omit or mis-classify the type on
-   * some JREs/platforms and surfaces as {@code IPSDeploymentErrors.NULL_INPUT_DOC}.
+   * some JREs/platforms and surfaces as {@code DeploymentErrorCodes.NULL_INPUT_DOC}.
    */
   public static final String XML_REQUEST_CONTENT_TYPE = "application/xml";
 
@@ -1196,13 +1196,13 @@ public final class PSDeploymentServerConnection {
 
     // handle case if server is still starting
     if (status == 503) {
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_NOT_AVAILABLE);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_NOT_AVAILABLE);
     }
 
     // make sure we got back some kind of response
     if (response == null || response.length == 0) {
       Object[] args = {type, String.valueOf(status)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_EMPTY, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_EMPTY, args);
     }
 
     // try to parse the response as XML
@@ -1214,7 +1214,7 @@ public final class PSDeploymentServerConnection {
       if (status == 200) {
         // must have valid response for a 200 error.
         Object[] args = {type, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_PARSE_ERROR, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_PARSE_ERROR, args);
       }
     }
 
@@ -1233,7 +1233,7 @@ public final class PSDeploymentServerConnection {
       }
 
       Object[] args = {type, String.valueOf(status), msg};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_ERROR_RESPONSE, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_ERROR_RESPONSE, args);
     }
 
     // We must have an error that we can handle in some way.
@@ -1248,7 +1248,7 @@ public final class PSDeploymentServerConnection {
       } catch (PSUnknownNodeTypeException e) {
         // malformed exception xml (should not happen)
         Object[] args = {type, PSDeployException.XML_NODE_NAME, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       className = de.getOriginalExceptionClass();
@@ -1260,11 +1260,11 @@ public final class PSDeploymentServerConnection {
       PSJobException je = null;
       try {
         je = new PSJobException(root);
-        de = new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, je.getLocalizedMessage());
+        de = new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, je.getLocalizedMessage());
       } catch (PSUnknownNodeTypeException e) {
         // malformed exception xml (should not happen)
         Object[] args = {type, PSDeployException.XML_NODE_NAME, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       className = je.getOriginalExceptionClass();
@@ -1274,7 +1274,7 @@ public final class PSDeploymentServerConnection {
       }
     } else {
       Object[] args = {type, String.valueOf(status), PSXmlDocumentBuilder.toString(respDoc)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_ERROR_RESPONSE, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_ERROR_RESPONSE, args);
     }
 
     if (PSAuthenticationFailedException.class.getName().equals(className)) {

--- a/deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
@@ -24,7 +24,7 @@ import com.percussion.deployer.objectstore.PSDeployableElement;
 import com.percussion.deployer.objectstore.PSIdMap;
 import com.percussion.deployer.objectstore.PSIdMapping;
 import com.percussion.deployer.server.IPSJobHandle;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.utils.collections.PSIteratorUtils;
 import java.util.Collections;
@@ -143,7 +143,7 @@ public class PSFolderContentsDescriptorBuilder {
             .orElseThrow(
                 () ->
                     new PSDeployException(
-                        IPSDeploymentErrors.UNEXPECTED_ERROR, "Failed to find top-level folder"));
+                        DeploymentErrorCodes.UNEXPECTED_ERROR, "Failed to find top-level folder"));
 
     var previousMaxDeps = System.getProperty(IPSDeployConstants.PROP_MAX_DEPS);
     System.setProperty(IPSDeployConstants.PROP_MAX_DEPS, String.valueOf(MAX_DEPS));
@@ -247,7 +247,7 @@ public class PSFolderContentsDescriptorBuilder {
         if (mappings.hasNext()) {
           PSApplicationIDTypeMapping mapping = mappings.next();
           throw new PSDeployException(
-              IPSDeploymentErrors.INCOMPLETE_ID_TYPE_MAPPING,
+              DeploymentErrorCodes.INCOMPLETE_ID_TYPE_MAPPING,
               new Object[] {
                 mapping.getType(),
                 dep.getDependencyId(),

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.system.utils.PSArchiveFiles;
@@ -153,7 +153,7 @@ public final class PSArchive {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
 
     return m_archiveManifest;
@@ -236,7 +236,7 @@ public final class PSArchive {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
 
     return result;
@@ -340,7 +340,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_WRITE_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_WRITE_ERROR, args);
     }
   }
 
@@ -394,7 +394,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_WRITE_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_WRITE_ERROR, args);
     }
   }
 
@@ -436,7 +436,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
   }
 
@@ -462,7 +462,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -17,9 +17,9 @@
 
 package com.percussion.deployer.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -349,7 +349,7 @@ public final class PSIdMap implements IPSDeployComponent {
     PSIdMapping idMapping = getMapping(id, type, parentId, parentType);
     if (idMapping == null) {
       Object[] args = {type, id, getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     String newValue = idMapping.getTargetId();
@@ -357,7 +357,7 @@ public final class PSIdMap implements IPSDeployComponent {
       String errId = id;
       if (parentId != null) errId = id + ":" + parentId;
       Object[] args = {type, errId, getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.INCOMPLETE_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING, args);
     }
 
     return newValue;
@@ -395,7 +395,7 @@ public final class PSIdMap implements IPSDeployComponent {
       return Integer.parseInt(strId);
     } catch (NumberFormatException e) {
       Object[] args = {type, id, getSourceServer(), strId};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_ID_MAPPING_TARGET, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, args);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
+++ b/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
@@ -32,7 +32,7 @@ import com.percussion.deployer.server.dependencies.PSTemplateDefDependencyHandle
 import com.percussion.deployer.server.dependencies.PSVariantDefDependencyHandler;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.data.PSAssemblyTemplate;
@@ -199,14 +199,14 @@ public class PSDeployService implements IPSDeployService {
         existingByName = filterSvc.findFilterByName(filterName);
       } catch (IllegalArgumentException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             e,
             "Filter package has blank or invalid name while installing dependency "
                 + dep.getDependencyId());
       } catch (com.percussion.services.filter.PSFilterException e) {
         if (!PSFilterInstallUtils.isFilterMissingErrorCode(e.getErrorCode())) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               e,
               "Failed to resolve existing filter by name: " + filterName);
         }
@@ -222,7 +222,7 @@ public class PSDeployService implements IPSDeployService {
           existingByName = filterSvc.loadFilter(ids).get(0);
         } catch (PSNotFoundException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               "Could not load the existing filter: " + packageFilter.getName());
         }
         PSItemFilter managed = (PSItemFilter) existingByName;
@@ -232,7 +232,7 @@ public class PSDeployService implements IPSDeployService {
           managed.merge(packageFilter);
         } catch (com.percussion.services.filter.PSFilterException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               e,
               "Could not merge package filter onto existing filter: " + packageFilter.getName());
         }

--- a/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogClientTypedErrorCodeSliceTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogClientTypedErrorCodeSliceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.percussion.deployer.catalog.server.PSCatalogHandler;
+import com.percussion.deployer.objectstore.PSIdMap;
+import com.percussion.deployer.objectstore.PSIdMapping;
+import com.percussion.error.PSDeployException;
+import com.percussion.server.PSRequest;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Issue #3739 (parent #2616 slice 1): leftover deployer catalog / client / objectstore /
+ * PSDeployService production sites throw typed {@link DeploymentErrorCodes} (non-auditable leftover
+ * codes skip dual-write). Server/handlers remain on later slices.
+ */
+@Tag("UnitTest")
+public class PSDeployerCatalogClientTypedErrorCodeSliceTest {
+
+  @Test
+  public void catalogHandlerNullInputDocUsesTypedNonAuditableCode() throws Exception {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void catalogHandlerInvalidRequestTypeUsesTypedNonAuditableCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSXmlDocumentBuilder.createRoot(doc, "NotACatalogRequest");
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(doc);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(DeploymentErrorCodes.INVALID_REQUEST_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_REQUEST_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void idMapMissingAndIncompleteUseTypedNonAuditableCodes() throws Exception {
+    PSIdMap map = new PSIdMap("driver:server:db:origin");
+    PSDeployException missing =
+        assertThrows(PSDeployException.class, () -> map.getNewId("99", "widget"));
+    assertEquals(DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode(), missing.getErrorCode());
+    assertSame(DeploymentErrorCodes.MISSING_ID_MAPPING, missing.getTypedErrorCode());
+    assertFalse(missing.isAuditable());
+
+    map.addMapping(new PSIdMapping("1", "name", "widget"));
+    PSDeployException incomplete =
+        assertThrows(PSDeployException.class, () -> map.getNewId("1", "widget"));
+    assertEquals(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING.numericCode(), incomplete.getErrorCode());
+    assertSame(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING, incomplete.getTypedErrorCode());
+    assertFalse(incomplete.isAuditable());
+  }
+
+  @Test
+  public void idMapNonNumericTargetUsesTypedInvalidTarget() throws Exception {
+    PSIdMap map = new PSIdMap("driver:server:db:origin");
+    PSIdMapping mapping = new PSIdMapping("1", "name", "widget");
+    mapping.setTarget("not-an-int", "targetName");
+    map.addMapping(mapping);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> map.getNewIdInt("1", "widget"));
+    assertEquals(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
@@ -19,9 +19,12 @@ package com.percussion.deployer.error;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.conn.PSServerException;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
+import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -89,5 +92,52 @@ public class PSDeployExceptionTest {
           PSServerException sEx1 = new PSServerException(123, args3);
           new PSDeployNonUniqueException(sEx1);
         });
+  }
+
+  @Test
+  public void typedCatalogCodesRetainCodeAndSkipAudit() {
+    PSDeployException noArg = new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), noArg.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, noArg.getTypedErrorCode());
+    assertFalse(noArg.isAuditable());
+
+    PSDeployException single =
+        new PSDeployException(DeploymentErrorCodes.INVALID_REQUEST_TYPE, "PSXBad");
+    assertEquals(DeploymentErrorCodes.INVALID_REQUEST_TYPE.numericCode(), single.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_REQUEST_TYPE, single.getTypedErrorCode());
+    assertFalse(single.isAuditable());
+
+    Object[] args = {"widget", "99", "src"};
+    PSDeployException array = new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
+    assertEquals(DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode(), array.getErrorCode());
+    assertSame(DeploymentErrorCodes.MISSING_ID_MAPPING, array.getTypedErrorCode());
+    assertArrayEquals(args, array.getErrorArguments());
+    assertFalse(array.isAuditable());
+
+    IllegalStateException cause = new IllegalStateException("boom");
+    PSDeployException withCause =
+        new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, cause, "detail");
+    assertEquals(DeploymentErrorCodes.UNEXPECTED_ERROR.numericCode(), withCause.getErrorCode());
+    assertSame(DeploymentErrorCodes.UNEXPECTED_ERROR, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertFalse(withCause.isAuditable());
+  }
+
+  @Test
+  public void typedLockCodeIsAuditableAndCopiedFromPsException() {
+    PSDeployException lock = new PSDeployException(DeploymentErrorCodes.LOCK_ALREADY_HELD);
+    assertTrue(lock.isAuditable());
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, lock.getTypedErrorCode());
+
+    PSException pe = new PSException(DeploymentErrorCodes.LOCK_ALREADY_HELD);
+    PSDeployException wrapped = new PSDeployException(pe);
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, wrapped.getTypedErrorCode());
+    assertTrue(wrapped.isAuditable());
+    assertEquals(pe.getClass().getName(), wrapped.getOriginalExceptionClass());
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSDeployException((IPSErrorCode) null));
   }
 }

--- a/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
@@ -17,10 +17,13 @@
 package com.percussion.deployer.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.deployer.catalog.server.PSCatalogHandler;
 import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
@@ -44,6 +47,9 @@ public class PSNullInputDocHandlerTest {
     PSDeployException ex =
         assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
     assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   @Test

--- a/docs/ai-generated/code-reviews/3739-deployer-catalog-client-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3739-deployer-catalog-client-errorcodes-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3739 deployer catalog/client IPS*Errors typed ErrorCodes
+
+**Date:** 2026-08-23  
+**Branch:** `feat/issue-3739-deployer-catalog-client-errorcodes`  
+**Base:** `origin/main`  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Parent #2616 slice 1/3. Leftover deployer **catalog + client + objectstore + PSDeployService** production `IPSDeploymentErrors` int sites retyped to `DeploymentErrorCodes`. `PSDeployException` gained `IPSErrorCode` constructors, `getTypedErrorCode()`, and `isAuditable()` (peer of `PSException`). Residual allow-list shrunk by those exact paths. Server/handlers, DCE/TableFactory, and deleting `IPS*Errors` interfaces remain out of scope.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (typed construction, catalog/id-map production throws, dual-write skip)
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: exception typed ctors + production retype + allow-list shrink + dual-write tests
+- May commit/push: **yes** (after module `clean install` evidence)
+
+## Issues
+
+None.
+
+## Notes
+
+- Flat registry unchanged: leftover deploy ints 1–73 stay enum-only (WF/assembly/WS collision). Dual-write tests go through the enum, not `LegacyErrorCodeRegistry.find(int)`.
+- `PSDeployException` XML round-trip still drops typed metadata (legacy int only). Callers that reconstruct from XML keep int `getErrorCode()`; new tests cover typed construction, not XML restore.
+- C2: constructors are additive. Subclasses `PSLockedException` / `PSDeployNonUniqueException` still call `super(int, Object[])`. No anonymous `new PSDeployException() {` sites.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Dual-write skip tests live in `perc-auditlog` (`CapturingAuditLogSink` is test-scoped and not on the deployer test classpath).
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); collision-safe registry (do not flatten 1–73).

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -1200,6 +1200,36 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void deploymentCatalogClientLeftoverCodesSkipDualWriteViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    DeploymentErrorCodes[] leftovers = {
+      DeploymentErrorCodes.NULL_INPUT_DOC,
+      DeploymentErrorCodes.UNEXPECTED_ERROR,
+      DeploymentErrorCodes.INVALID_REQUEST_TYPE,
+      DeploymentErrorCodes.CATALOG_REQD_PROP_NOT_SPECIFIED,
+      DeploymentErrorCodes.CATALOG_INVALID_DIRECTORY_SPECIFIED,
+      DeploymentErrorCodes.ARCHIVE_READ_ERROR,
+      DeploymentErrorCodes.ARCHIVE_WRITE_ERROR,
+      DeploymentErrorCodes.MISSING_ID_MAPPING,
+      DeploymentErrorCodes.INCOMPLETE_ID_MAPPING,
+      DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET,
+      DeploymentErrorCodes.INCOMPLETE_ID_TYPE_MAPPING,
+      DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING,
+      DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID,
+      DeploymentErrorCodes.NOT_CONNECTED_ERROR,
+      DeploymentErrorCodes.LOCK_NOT_RELEASED
+    };
+    for (DeploymentErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      AuditLogId id = svc.log(code, AuditContext.empty());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED.value(), id.value(), code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
   void navigationCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(18001));
     assertSame(

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -6,6 +6,7 @@
 # Shrink this list as retype PRs merge:
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
+#   #3739 deployer catalog/client/objectstore/PSDeployService
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -14,15 +15,7 @@
 #
 # Tests, comment-only mentions, and the gate scripts themselves are ignored.
 
-deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
-deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
-deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
 deployer/src/main/java/com/percussion/deployer/jexl/PSDeployJexlUtils.java
-deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
-deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
 deployer/src/main/java/com/percussion/deployer/server/PSAppTransformer.java
 deployer/src/main/java/com/percussion/deployer/server/PSArchiveHandler.java
 deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
@@ -93,7 +86,6 @@ deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDef
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslationSettingsDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
 modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java

--- a/system/src/main/java/com/percussion/error/PSDeployException.java
+++ b/system/src/main/java/com/percussion/error/PSDeployException.java
@@ -102,6 +102,52 @@ public class PSDeployException extends Exception {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code DeploymentErrorCodes}).
+   * Sets the legacy numeric code for message lookup and retains the typed code for {@link
+   * #getTypedErrorCode()} / {@link #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSDeployException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    this(requireCode(code).numericCode(), cause, arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *
@@ -111,6 +157,7 @@ public class PSDeployException extends Exception {
   public PSDeployException(PSException ex) {
     this(ex.getErrorCode(), ex.getErrorArguments());
     m_originalExceptionClass = ex.getClass().getName();
+    m_typedErrorCode = ex.getTypedErrorCode();
   }
 
   /**
@@ -232,6 +279,29 @@ public class PSDeployException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link #PSDeployException(IPSErrorCode)}
+   * (or overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when present;
+   * legacy int construction returns {@code false} (handlers resolve auditability via the registry).
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -400,6 +470,12 @@ public class PSDeployException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed catalog code when constructed via {@link IPSErrorCode} overloads; otherwise {@code null}
+   * for legacy int construction. Not serialized in XML.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null


### PR DESCRIPTION
## Summary

Parent #2616 slice 1/3. Retype leftover **deployer catalog + client + objectstore + PSDeployService** production `IPSDeploymentErrors` int sites to typed `DeploymentErrorCodes`. `PSDeployException` now takes `IPSErrorCode` constructors and retains `getTypedErrorCode()` / `isAuditable()` (peer of `PSException` / #3585). Dual-write skip tests cover leftover non-auditable catalog/client codes; lock codes stay auditable via the enum. Collision-safe flat registry is unchanged (ints 1–73 remain enum-only). Shrunk `scripts/ipserrors-residual-allowlist.txt` by those exact paths.

Out of scope (already sliced): deployer server/handlers (#3740), DesktopContentExplorer / TableFactory (#3741), deleting `IPS*Errors` interfaces.

Fixes #3739
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
2. `cd system && ../mvnw.cmd clean install`
3. `cd deployer && ../mvnw.cmd clean install`
4. `python scripts/test_verify_no_bare_ipserrors.py` (17 passed; converted paths no longer on the residual allow-list)
5. Confirm catalog handler null-doc / invalid request and `PSIdMap` missing/incomplete/invalid-target throws retain typed `DeploymentErrorCodes` and `isAuditable()==false`

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — typed constructors, catalog/id-map production throws, dual-write skip; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); C2 additive constructors, subclasses still compile
- [x] **Cross-platform** — **N/A** (no path/file I/O)

## C3 evidence

- **modules_built:** `modules/perc-auditlog`, `system`, `deployer`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 296, Failures: 0 (`LegacyErrorCodeRegistryTest` 133)
  - `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2336, Failures: 0, Skipped: 242
  - `cd deployer && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 286, Failures: 0, Skipped: 19 (`PSDeployerCatalogClientTypedErrorCodeSliceTest` 4; `PSDeployExceptionTest` 5)
  - `python scripts/test_verify_no_bare_ipserrors.py` → 17 passed
- **downstream_checked:** C2 additive `PSDeployException(IPSErrorCode…)` overloads (existing int signatures unchanged). Grep: `extends PSDeployException` → `PSLockedException`, `PSDeployNonUniqueException` only (still `super(int, Object[])`). No `new PSDeployException() {` anonymous subclasses. Reverse-dep `deployer` standalone clean install green after installing `system` SNAPSHOT.

## C5 UI proof

N/A — Java backend error-catalog retype; no WebUI/Playwright surface.

Erlang: approve (`docs/ai-generated/code-reviews/3739-deployer-catalog-client-errorcodes-erlang.md`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
