### PR TITLE
feat(errorcodes): retype DCE/ContentUI/TableFactory IPS*Errors (#3741)

### DIFF
--- a/docs/ai-generated/code-reviews/3741-dce-contentui-tablefactory-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3741-dce-contentui-tablefactory-errorcodes-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — #3741 DCE/ContentUI/TableFactory IPS*Errors → typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3741-dce-contentui-tablefactory-errorcodes` vs `origin/main` (parent #2616 slice 3/3).
+
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; additive constructors (C2); portable `Path`/`@TempDir` in tests; do not delete `IPS*Errors` interfaces.
+
+## Summary
+
+Leftover production `IPSContentExplorerErrors` / `IPSCmsErrors` / `IPSSearchErrors` / `IPSServerErrors` / `IPSTableFactoryErrors` call-sites in DesktopContentExplorer, ContentUI search, and TableFactory now throw typed catalog enums. Additive `IPSErrorCode` constructors on `PSStandaloneException`, `PSContentExplorerException`, `PSExtensionProcessingException`, `PSWizardValidationError`, and `PSJdbcTableFactoryException` retain `getTypedErrorCode()` / `isAuditable()`. Allow-list shrunk by those exact paths. Dual-write skip tests cover HTML search missing-parameter (16053) and production throws.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (TableFactory 4, DCE 5, ContentUI 2; perc-auditlog dual-write skip)
+- Cross-platform paths: DCE cataloger test uses `@TempDir Path` + `Files.createDirectories` + `toUri().toURL()` (no hardcoded separators)
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## C2
+
+Constructors are additive. Subclasses of `PSStandaloneException` still compile (`PSOptionException`, `PSServletException`, inner `PSRequestException`). No `extends PSExtensionProcessingException` / `PSJdbcTableFactoryException`. Standalone reverse-dep installs: `system`, `modules/DesktopContentExplorer`, `modules/ContentUI`.

--- a/modules/ContentUI/pom.xml
+++ b/modules/ContentUI/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>extensions-main</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
+++ b/modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
@@ -17,6 +17,8 @@
 
 package com.percussion.content.ui.search;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSFolder;
@@ -30,7 +32,6 @@ import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.search.IPSExecutableSearch;
-import com.percussion.search.IPSSearchErrors;
 import com.percussion.search.IPSSearchResultRow;
 import com.percussion.search.PSExecutableSearchFactory;
 import com.percussion.search.PSSearchException;
@@ -40,7 +41,6 @@ import com.percussion.search.objectstore.PSWSSearchRequest;
 import com.percussion.search.ui.PSSearchAdvancedPanel;
 import com.percussion.search.ui.PSSearchSimplePanel;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
 import com.percussion.services.assembly.PSAssemblyException;
@@ -96,15 +96,15 @@ public class PSSearchResult {
 
     String locale = request.getUserLocale();
 
-    PSComponentProcessorProxy processor =
-        new PSComponentProcessorProxy(PSComponentProcessorProxy.PROCTYPE_SERVERLOCAL, request);
-
     String searchId = getParameter(IPSHtmlParameters.SYS_SEARCHID, null, parameters);
     if (searchId == null) {
       Object[] args = {"HTML", IPSHtmlParameters.SYS_SEARCHID};
 
-      throw new PSExtensionProcessingException(IPSSearchErrors.HTML_SEARCH_MISSING_PARAMETER, args);
+      throw new PSExtensionProcessingException(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, args);
     }
+
+    PSComponentProcessorProxy processor =
+        new PSComponentProcessorProxy(PSComponentProcessorProxy.PROCTYPE_SERVERLOCAL, request);
 
     PSSearch search = loadSearch(processor, searchId);
 
@@ -158,7 +158,7 @@ public class PSSearchResult {
         // validate length etc.
         String msg = PSSearchSimplePanel.validateFTSSearchQuery(fullTextQuery, null, locale);
         if (msg != null) {
-          throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+          throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
         }
 
         search.setProperty(PSSearch.PROP_FULLTEXTQUERY, fullTextQuery);
@@ -195,7 +195,7 @@ public class PSSearchResult {
         field.setFieldValues(op, values);
         String msg = PSSearchFieldOperators.validateSearchFieldValue(field, null, locale);
         if (msg != null) {
-          throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+          throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
         }
       }
     }

--- a/modules/ContentUI/src/test/java/com/percussion/content/ui/search/PSSearchResultTypedErrorCodeSliceTest.java
+++ b/modules/ContentUI/src/test/java/com/percussion/content/ui/search/PSSearchResultTypedErrorCodeSliceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.content.ui.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.server.IPSRequestContext;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover ContentUI search production {@code IPSSearchErrors}
+ * / {@code IPSServerErrors} sites throw typed {@link SearchErrorCodes} / {@link ServerErrorCodes}.
+ * Both leftover codes are non-auditable (dual-write skip).
+ */
+class PSSearchResultTypedErrorCodeSliceTest {
+
+  @Test
+  void missingSearchIdThrowsTypedHtmlSearchMissingParameter() throws Exception {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getParametersIterator()).thenReturn(Collections.emptyIterator());
+    when(request.getUserLocale()).thenReturn("en-us");
+
+    PSExtensionProcessingException ex =
+        assertThrows(
+            PSExtensionProcessingException.class,
+            () -> new PSSearchResult().getSearchResults(request));
+
+    assertEquals(
+        SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, ex.getTypedErrorCode());
+    assertFalse(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void rawDumpTypedConstructionSkipsDualWrite() {
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, "invalid query");
+
+    assertEquals(ServerErrorCodes.RAW_DUMP.numericCode(), ex.getErrorCode());
+    assertSame(ServerErrorCodes.RAW_DUMP, ex.getTypedErrorCode());
+    assertFalse(ServerErrorCodes.RAW_DUMP.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.border.PSFocusBorder;
 import com.percussion.cms.PSActionVisibilityChecker;
 import com.percussion.cms.PSActionVisibilityGlobalState;
@@ -42,7 +43,6 @@ import com.percussion.cx.catalogers.PSLocaleCataloger;
 import com.percussion.cx.catalogers.PSRoleCataloger;
 import com.percussion.cx.catalogers.PSSiteCataloger;
 import com.percussion.cx.catalogers.PSSubjectCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.javafx.PSBrowserUtils;
 import com.percussion.cx.javafx.PSDesktopExplorerWindow;
@@ -288,7 +288,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
       }
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -1113,7 +1113,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
     try {
       if (StringUtils.isBlank(url)) {
         throw new PSContentExplorerException(
-            IPSContentExplorerErrors.ACTION_GET_CHILDREN,
+            ContentExplorerErrorCodes.ACTION_GET_CHILDREN,
             m_applet.getResourceString(getClass(), "No url specified"));
       }
 
@@ -1158,7 +1158,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
           : resultChildList.iterator();
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.ACTION_GET_CHILDREN, ex.toString());
+          ContentExplorerErrorCodes.ACTION_GET_CHILDREN, ex.toString());
     }
   }
 
@@ -4895,7 +4895,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
       }
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
     return fm;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.util.PSXMLDomUtil;
@@ -77,7 +77,7 @@ public final class PSColumnWidthsOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
@@ -16,11 +16,11 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSUserInfo;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.guitools.ErrorDialogs;
@@ -104,10 +104,10 @@ public class PSDisplayFormatCatalog {
       }
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
 
     if (m_folderDisplayFormats.isEmpty()) {

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.HashMap;
@@ -72,7 +72,7 @@ public final class PSDisplayFormatOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSDisplayColumn;
 import com.percussion.cms.objectstore.PSDisplayFormat;
@@ -25,7 +26,6 @@ import com.percussion.cms.objectstore.PSSFields;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.cms.objectstore.ws.PSWSExecutableSearch;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.design.objectstore.PSLocator;
@@ -324,7 +324,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
       expandSynonyms = m_applet.getApplet().getSearchConfig().isSynonymExpansionRequired();
     } catch (PSCmsException cmsex) {
 
-      throw new PSContentExplorerException(IPSContentExplorerErrors.SEARCH_ERROR, cmsex.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, cmsex.toString());
     }
 
     String[][] advancedProps =
@@ -522,7 +522,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
           }
         }
 
-        throw new PSContentExplorerException(IPSContentExplorerErrors.SEARCH_ERROR, message);
+        throw new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, message);
       } else {
         throw new RuntimeException(ex.getLocalizedMessage());
       }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.Iterator;
@@ -77,7 +77,7 @@ public final class PSExpandedOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSCloningOptions;
@@ -37,7 +38,6 @@ import com.percussion.cx.catalogers.PSLocaleCataloger;
 import com.percussion.cx.catalogers.PSRoleCataloger;
 import com.percussion.cx.catalogers.PSSiteCataloger;
 import com.percussion.cx.catalogers.PSSubjectCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.cx.objectstore.PSProperties;
@@ -254,7 +254,7 @@ public class PSFolderActionManager {
       f.fromXml(els[0]);
       return f;
     } catch (PSException unte) {
-      throw new PSContentExplorerException(IPSContentExplorerErrors.GENERAL_ERROR, unte.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.GENERAL_ERROR, unte.toString());
     }
   }
 
@@ -365,7 +365,7 @@ public class PSFolderActionManager {
 
       return resList.iterator();
     } catch (PSException ex) {
-      throw new PSContentExplorerException(IPSContentExplorerErrors.GENERAL_ERROR, ex.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.GENERAL_ERROR, ex.toString());
     } catch (PSContentExplorerException ex) {
       throw ex;
     } finally {
@@ -592,7 +592,7 @@ public class PSFolderActionManager {
         options.addSiteMapping(Integer.valueOf(sourceId), Integer.valueOf(copyId));
       }
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.GENERAL_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.GENERAL_ERROR, e.getMessage());
     }
 
     // copy the specified folder
@@ -670,7 +670,7 @@ public class PSFolderActionManager {
         if (pos != -1) tmpCwd = tmpCwd.substring(0, pos);
         else {
           String[] args = {cwd, path};
-          throw new PSCmsException(IPSContentExplorerErrors.INCOMPATIBLE_PATHS, args);
+          throw new PSCmsException(ContentExplorerErrorCodes.INCOMPATIBLE_PATHS, args);
         }
       } else done = true;
     }
@@ -915,7 +915,7 @@ public class PSFolderActionManager {
         errorText += err;
         errorText += "\r\n";
       }
-      throw new PSCmsException(IPSContentExplorerErrors.SITEDEF_UPDATE_FAILURES, errorText);
+      throw new PSCmsException(ContentExplorerErrorCodes.SITEDEF_UPDATE_FAILURES, errorText);
     }
   }
 
@@ -956,7 +956,7 @@ public class PSFolderActionManager {
         error = handleErrorResult(root);
       }
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.GENERAL_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.GENERAL_ERROR, e.getMessage());
     }
     return error;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
@@ -17,7 +17,7 @@
 
 package com.percussion.cx;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummaries;
 import com.percussion.cms.objectstore.PSComponentSummary;
@@ -356,7 +356,7 @@ public class PSItemRelationshipsManager {
         cid = "" + loc.getId();
       } catch (Exception e) {
         Object[] args = new Object[] {e.getLocalizedMessage()};
-        throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+        throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
       }
       if (cid != null && isAllowedRelationshipSlot(slotId, regSlots, inlineSlots)) {
         contentIds.add(cid);
@@ -394,7 +394,7 @@ public class PSItemRelationshipsManager {
       }
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
     return regSlots;
   }
@@ -426,7 +426,7 @@ public class PSItemRelationshipsManager {
       }
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
 
     return inlineSlots;
@@ -460,7 +460,7 @@ public class PSItemRelationshipsManager {
 
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
 
     return doc;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -69,7 +69,7 @@ public class PSOptionManager {
       setDefaultOptions(new PSUserOptions(doc.getDocumentElement()));
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.OPTIONS_LOAD_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.OPTIONS_LOAD_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -189,7 +189,7 @@ public class PSOptionManager {
       m_applet.getActionManager().postData(appPath, params);
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.OPTIONS_SAVE_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.OPTIONS_SAVE_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
@@ -24,7 +25,6 @@ import com.percussion.cms.objectstore.PSSaveResults;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.cms.objectstore.client.PSRemoteCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.cx.objectstore.PSProperties;
@@ -224,7 +224,7 @@ public class PSSearchViewActionManager {
       return search;
     } catch (PSException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -454,10 +454,10 @@ public class PSSearchViewActionManager {
           searchEx.executeSearch(searchNode, includeFolders, true);
         } catch (IOException ioe) {
           throw new PSContentExplorerException(
-              IPSContentExplorerErrors.GENERAL_ERROR, ioe.getLocalizedMessage());
+              ContentExplorerErrorCodes.GENERAL_ERROR, ioe.getLocalizedMessage());
         } catch (SAXException sae) {
           throw new PSContentExplorerException(
-              IPSContentExplorerErrors.GENERAL_ERROR, sae.getLocalizedMessage());
+              ContentExplorerErrorCodes.GENERAL_ERROR, sae.getLocalizedMessage());
         }
       } else // If not initialized simply set empty children
       {
@@ -617,11 +617,11 @@ public class PSSearchViewActionManager {
     } catch (IOException ex) {
       ex.printStackTrace();
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (SAXException ex) {
       ex.printStackTrace();
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
 
     return ret;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
@@ -16,12 +16,12 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -132,10 +132,10 @@ public final class PSSearchViewCatalog {
         throw new IllegalStateException("Default search for Active Assembly is not found");
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -278,10 +278,10 @@ public final class PSSearchViewCatalog {
       }
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
     return emptySearchDoc;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSCommunityCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collCommunities = parseCommunities(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
@@ -66,7 +66,7 @@ public final class PSCommunityContentTypeMapperCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_commCtMapper = parseMapper(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -59,7 +59,7 @@ public final class PSGlobalTemplateCataloger {
 
       m_globalTemplates = parseGlobalTemplates(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSLocaleCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_locales = parseLocales(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSRoleCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collRoles = parseRoles(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSSite;
 import com.percussion.cx.PSFolderActionManager;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -58,7 +58,7 @@ public class PSSiteCataloger {
 
       fromXml(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSSubjectCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collSubjects = parseSubjects(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.cx.wizards;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.objectstore.PSSite;
 import com.percussion.cx.PSContentExplorerApplet;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.guitools.PSPropertyPanel;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
@@ -94,7 +94,7 @@ public final class PSCopySiteNamePage extends PSWizardPanel {
 
     if (errors.length() > 0)
       throw new PSWizardValidationError(
-          IPSContentExplorerErrors.WIZARD_VALIDATION_ERROR, errors.toString());
+          ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, errors.toString());
   }
 
   /* (non-Javadoc)

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.wizards;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.PSContentExplorerApplet;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.guitools.PSPropertyPanel;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import com.percussion.wizard.PSWizardPanel;
@@ -78,7 +78,7 @@ public class PSCopySiteSubfolderNamePage extends PSWizardPanel {
 
     if (errors.length() > 0)
       throw new PSWizardValidationError(
-          IPSContentExplorerErrors.WIZARD_VALIDATION_ERROR, errors.toString());
+          ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, errors.toString());
   }
 
   /* (non-Javadoc)

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.wizard;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -42,6 +43,26 @@ public final class PSWizardValidationError extends PSException {
    * @param args the arguments, may be <code>null</code>.
    */
   public PSWizardValidationError(int code, Object[] args) {
+    super(code, args);
+  }
+
+  /**
+   * Typed construction with a single argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arg the single argument, may be {@code null}
+   */
+  public PSWizardValidationError(IPSErrorCode code, Object arg) {
+    super(code, arg);
+  }
+
+  /**
+   * Typed construction with argument array.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param args the arguments, may be {@code null}
+   */
+  public PSWizardValidationError(IPSErrorCode code, Object[] args) {
     super(code, args);
   }
 

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerTypedErrorCodeSliceTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerTypedErrorCodeSliceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
+import com.percussion.cms.PSCmsException;
+import com.percussion.cx.catalogers.PSCommunityCataloger;
+import com.percussion.cx.error.PSContentExplorerException;
+import com.percussion.wizard.PSWizardValidationError;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover Desktop Content Explorer production {@code
+ * IPSContentExplorerErrors} / {@code IPSCmsErrors} sites throw typed {@link
+ * ContentExplorerErrorCodes} / {@link CmsErrorCodes}. Catalog codes are non-auditable (dual-write
+ * skip).
+ */
+class PSContentExplorerTypedErrorCodeSliceTest {
+
+  @Test
+  void typedContentExplorerExceptionSkipsDualWrite() {
+    PSContentExplorerException ex =
+        new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, "no hits");
+
+    assertEquals(ContentExplorerErrorCodes.SEARCH_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.SEARCH_ERROR, ex.getTypedErrorCode());
+    assertFalse(ContentExplorerErrorCodes.SEARCH_ERROR.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedWizardValidationErrorSkipsDualWrite() {
+    PSWizardValidationError ex =
+        new PSWizardValidationError(ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, "blank");
+
+    assertEquals(
+        ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void cmsUnexpectedErrorFromRelationshipsIsNonAuditable() {
+    PSCmsException ex = new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, "boom");
+
+    assertEquals(CmsErrorCodes.UNEXPECTED_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(CmsErrorCodes.UNEXPECTED_ERROR, ex.getTypedErrorCode());
+    assertFalse(CmsErrorCodes.UNEXPECTED_ERROR.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void columnWidthsFromXmlWrongRootThrowsTypedOptionsError() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = doc.createElement("not-column-widths");
+    PSColumnWidthsOption option = new PSColumnWidthsOption();
+
+    PSContentExplorerException ex =
+        assertThrows(PSContentExplorerException.class, () -> option.fromXml(wrong));
+
+    assertEquals(
+        ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void communityCatalogerMissingResourceThrowsTypedCatalogError(@TempDir Path tmp)
+      throws Exception {
+    Path base = tmp.resolve("cx-catalog-base");
+    Files.createDirectories(base);
+    URL urlBase = base.toUri().toURL();
+
+    PSCmsException ex =
+        assertThrows(PSCmsException.class, () -> new PSCommunityCataloger(urlBase));
+
+    assertEquals(ContentExplorerErrorCodes.CATALOG_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.CATALOG_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/TableFactory/pom.xml
+++ b/modules/TableFactory/pom.xml
@@ -17,6 +17,12 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>perc-security-utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCharSets;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -214,13 +215,13 @@ public class PSJdbcColumnData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
 
     m_name = PSJdbcTableComponent.getAttribute(tree, NAME_ATTR, true);
     if (m_name == null || m_name.trim().length() == 0)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.INVALID_COLUMN_NAME, NODE_NAME);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.INVALID_COLUMN_NAME, NODE_NAME);
 
     String externalAttr = PSJdbcTableComponent.getAttribute(tree, EXTERNAL_ATTR, false);
 
@@ -246,7 +247,7 @@ public class PSJdbcColumnData {
       } else if (!isEmptyNull.trim().equalsIgnoreCase(EMPTY_NULL_FALSE)) {
         // bad value for attribute
         Object[] args = {NODE_NAME, EMPTY_NULL_ATTR, isEmptyNull};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
   }
@@ -293,7 +294,7 @@ public class PSJdbcColumnData {
     File f = new File(external);
     if (!(f.exists() && f.canRead())) {
       Object[] args = {parentNodeName, EXTERNAL_ATTR, external};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     return external;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.utils.jdbc.PSJdbcUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -182,7 +183,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // allow base class to set its memebers
@@ -196,14 +197,14 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     // get the data type and set it
     String strJdbcType = walker.getElementData(JDBC_EL);
     if (strJdbcType == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, JDBC_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, JDBC_EL);
     // this will validate for us
     setType(strJdbcType);
 
     // get the allows null value
     String strAllowsNull = walker.getElementData(ALLOWS_NULL_EL);
     if (strAllowsNull == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, ALLOWS_NULL_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, ALLOWS_NULL_EL);
 
     if (strAllowsNull.equalsIgnoreCase("y")) m_allowsNull = true;
     else if (strAllowsNull.equalsIgnoreCase("yes")) m_allowsNull = true;
@@ -214,7 +215,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     if (size != null && size.trim().length() == 0) size = null;
     else if (!validateParams(size)) {
       Object[] args = {NODE_NAME, SIZE_EL, size};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     setSize(size);
 
@@ -223,7 +224,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     if (scale != null && scale.trim().length() == 0) scale = null;
     else if (!validateParams(scale)) {
       Object[] args = {NODE_NAME, SIZE_EL, size};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     setScale(scale);
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -87,13 +88,13 @@ public class PSJdbcDataTypeMap {
     String rootName = root.getNodeName();
     if (!rootName.equals(ROOT_EL)) {
       Object[] args = {ROOT_EL, rootName};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Walk the maps and select the first match we find
     Element map = tree.getNextElement(MAP_EL, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (map == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, MAP_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, MAP_EL);
 
     boolean found = false;
     while (map != null) {
@@ -136,7 +137,7 @@ public class PSJdbcDataTypeMap {
     // did we find any match?
     if (!found) {
       Object[] args = {dbAlias, driver, os};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DATA_TYPE_MAP_NOT_FOUND, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DATA_TYPE_MAP_NOT_FOUND, args);
     }
     setMaxIndexColSize(map);
     setCreateForeignKeyIndexes(map);
@@ -147,7 +148,7 @@ public class PSJdbcDataTypeMap {
             PSJdbcDataTypeMapping.NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (mapping == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcDataTypeMapping.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcDataTypeMapping.NODE_NAME);
 
     while (mapping != null) {
       PSJdbcDataTypeMapping dataType = new PSJdbcDataTypeMapping(mapping);
@@ -177,7 +178,7 @@ public class PSJdbcDataTypeMap {
         m_maxIndexColSize = Long.parseLong(sTemp);
       } catch (Exception e) {
         Object[] args = {ROOT_EL, MAXINDEXCOLSIZE_EL, sTemp};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
   }
@@ -422,13 +423,13 @@ public class PSJdbcDataTypeMap {
   public int convertJdbcString(String jdbcString) throws PSJdbcTableFactoryException {
     if (jdbcString == null || jdbcString.trim().length() == 0)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_INT_DATA_TYPE_CONVERSION,
+          TableFactoryErrorCodes.JDBC_INT_DATA_TYPE_CONVERSION,
           jdbcString == null ? "null" : jdbcString);
 
     Integer jdbcType = m_jdbcString2Int.get(jdbcString);
     if (jdbcType == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_STRING_DATA_TYPE_CONVERSION, jdbcString);
+          TableFactoryErrorCodes.JDBC_STRING_DATA_TYPE_CONVERSION, jdbcString);
 
     return jdbcType;
   }
@@ -444,7 +445,7 @@ public class PSJdbcDataTypeMap {
     String jdbcString = m_jdbcInt2String.get(jdbcType);
     if (jdbcString == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_INT_DATA_TYPE_CONVERSION, String.valueOf(jdbcType));
+          TableFactoryErrorCodes.JDBC_INT_DATA_TYPE_CONVERSION, String.valueOf(jdbcType));
 
     return jdbcString;
   }
@@ -518,7 +519,7 @@ public class PSJdbcDataTypeMap {
           jdbcType = Types.class.getField(jdbcStr).getInt(null);
         } catch (Exception e) {
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.INVALID_DATA_TYPE_MAPPING,
+              TableFactoryErrorCodes.INVALID_DATA_TYPE_MAPPING,
               new Object[] {jdbcStr, dataType.getNative()});
         }
         m_jdbcString2Int.put(jdbcStr, jdbcType);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -93,18 +94,18 @@ public class PSJdbcDataTypeMapping {
     String rootName = sourceNode.getNodeName();
     if (!rootName.equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, rootName};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     String jdbc = sourceNode.getAttribute(JDBC_AT);
     if (nullOrEmpty(jdbc))
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, JDBC_AT, ""});
+          TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, JDBC_AT, ""});
 
     String nativeStr = sourceNode.getAttribute(NATIVE_AT);
     if (nullOrEmpty(nativeStr))
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, NATIVE_AT, ""});
+          TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, NATIVE_AT, ""});
 
     String size = sourceNode.getAttribute(SIZE_AT);
     if (0 == size.trim().length()) size = null;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
@@ -15,6 +15,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
 import com.percussion.security.PSEncryptionException;
 import com.percussion.security.PSEncryptor;
@@ -467,13 +468,13 @@ public class PSJdbcDbmsDef implements IPSJdbcDbmsDefConstants {
     if (m_dataSource != null) {
       conn = m_dataSource.getConnection();
       if (conn == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED);
     } else {
       try {
         Class.forName(getDriverClassName());
       } catch (ClassNotFoundException | LinkageError cls) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.SQL_CONNECTION_FAILED, cls.getLocalizedMessage(), cls);
+            TableFactoryErrorCodes.SQL_CONNECTION_FAILED, cls.getLocalizedMessage(), cls);
       }
 
       String connStr = PSSqlHelper.getJdbcUrl(getDriver(), getServer());
@@ -513,7 +514,7 @@ public class PSJdbcDbmsDef implements IPSJdbcDbmsDefConstants {
         String message = connStr;
         if (sqe != null) message += (" - " + PSJdbcTableFactoryException.formatSqlException(sqe));
 
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED, message);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED, message);
       }
     }
     return conn;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -137,7 +138,7 @@ public class PSJdbcExecutionPlanLogsContainer {
       writer = new FileWriter(logFile);
       PSXmlDocumentBuilder.write(doc, writer, "UTF-8");
     } catch (Exception e) {
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.LOG_FILE_WRITE_ERROR);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.LOG_FILE_WRITE_ERROR);
     } finally {
       try {
         if (writer != null) writer.close();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -230,7 +231,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_columns.clear();
@@ -245,7 +246,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
     // make sure we get at least one
     do {
       if (fkcolumn == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, FK_COLUMN_EL);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, FK_COLUMN_EL);
 
       // load it's child elements
       String colName = getRequiredElement(walker, NAME_EL);
@@ -434,7 +435,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
     if (null == data || data.trim().length() == 0) {
       String parentName = tree.getCurrent().getNodeName();
       Object[] args = {parentName, elemName, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return data;
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -146,7 +147,7 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(nodeName)) {
       Object[] args = {nodeName, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     List<String> names = new ArrayList<>();
@@ -160,13 +161,13 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
     // make sure we get at least one
     do {
       if (nameEl == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, NAME_EL);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, NAME_EL);
 
       String name = PSXmlTreeWalker.getElementData(nameEl);
       if (name.trim().length() == 0) {
         Object[] args = {nodeName, NAME_EL, name};
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+            TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       names.add(name);
@@ -361,11 +362,11 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
       String colName = columnNames.next();
       if (colName == null || colName.trim().length() == 0)
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.INVALID_COLUMN_NAME, m_containerName);
+            TableFactoryErrorCodes.INVALID_COLUMN_NAME, m_containerName);
 
       if (newCols.contains(colName)) {
         Object[] args = {m_containerName, colName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DUPLICATE_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DUPLICATE_COLUMN, args);
       }
       newCols.add(colName);
     }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.sql.Connection;
@@ -107,7 +108,7 @@ public class PSJdbcPlanBuilder {
       // if no table and alter, error
       if (tableSchema.isAlter()) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.ALTER_NO_TABLE, tableSchema.getName());
+            TableFactoryErrorCodes.ALTER_NO_TABLE, tableSchema.getName());
       } else if (!tableSchema.isCreate()) {
         // no table and don't create, return empty plan
         PSJdbcTableFactory.logMessage("Table doesn't exist and create=n, no action taken");
@@ -685,7 +686,7 @@ public class PSJdbcPlanBuilder {
       dataTypeMap = new PSJdbcDataTypeMap(dbmsDef.getBackEndDB(), dbmsDef.getDriver(), null);
     } catch (Exception e) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+          TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
     }
     Iterator<?> childTables = row.getChildTables();
     while (childTables.hasNext()) {
@@ -981,13 +982,13 @@ public class PSJdbcPlanBuilder {
       if ((colFirst == null) || (colFirst.getValue() == null)) {
         Object[] args = {tableSchema.getName(), colName};
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE_IN_DB, args);
+            TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE_IN_DB, args);
       }
 
       colSecond = rowDataToCompare.getColumn(colName);
       if ((colSecond == null) || (colSecond.getValue() == null)) {
         Object[] args = {tableSchema.getName(), colName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE, args);
       }
 
       if (!colFirst.getValue().equals(colSecond.getValue())) return false;
@@ -1530,7 +1531,7 @@ public class PSJdbcPlanBuilder {
       return bakName;
     } catch (SQLException e) {
       Object[] args = {tablename, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SCHEMA_PROCESS_ERROR, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SCHEMA_PROCESS_ERROR, args, e);
     }
   }
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.util.PSPreparedStatement;
 import java.sql.Connection;
@@ -159,7 +160,7 @@ public class PSJdbcPreparedSqlStatement extends PSJdbcSqlStatement {
         // convert to SQLException
         Object[] args = {value.getValue(), value.getType(), e.toString()};
         PSJdbcTableFactoryException fe =
-            new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_BIND_PARAMETER, args, e);
+            new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_BIND_PARAMETER, args, e);
         throw new SQLException(fe.getLocalizedMessage(), e);
       }
     }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.util.PSSQLStatement;
 import java.io.IOException;
@@ -147,7 +148,7 @@ public class PSJdbcResultSetIteratorStep extends PSJdbcSqlStatement {
       }
     } catch (IOException e) {
       Object[] args = {m_tableSchema.getName(), "Column : " + colName + " " + e.getMessage()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CATALOG_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CATALOG_DATA, args, e);
     }
     return new PSJdbcRowData(colDataList.iterator(), m_rowAction);
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -378,7 +379,7 @@ public class PSJdbcRowData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -396,7 +397,7 @@ public class PSJdbcRowData {
         tree.getNextElement(PSJdbcColumnData.NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (colEl == null) {
       Object[] args = {NODE_NAME, PSJdbcColumnData.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (colEl != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -124,7 +125,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -144,7 +145,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, SRC_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String key = sTemp;
 
@@ -153,7 +154,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, DEST_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String value = sTemp;
         m_colMapping.put(key, value);
@@ -173,7 +174,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, DEST_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String colName = sTemp;
 
@@ -182,7 +183,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, VALUE_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String colValue = sTemp;
         PSJdbcColumnData colData = new PSJdbcColumnData(colName, colValue);
@@ -196,7 +197,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
    * Verifies that all the columns added to the column mapping Map though the <code>
    * addColumnMapping()</code> method are present in the input row parameter. If any column
    * specified in the mapping is not present then it throws <code>PSJdbcTableFactoryException</code>
-   * exception with error code <code>IPSTableFactoryErrors.COLUMN_NOT_FOUND</code>
+   * exception with error code <code>TableFactoryErrorCodes.COLUMN_NOT_FOUND</code>
    *
    * @param row the row data against which the column mapping is to be checked, may not be <code>
    *     null</code>
@@ -214,7 +215,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         String tableName = "";
         if (m_tblData != null) tableName = m_tblData.getName();
         Object[] args = {tableName, srcColName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
       }
     }
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Attr;
@@ -238,7 +239,7 @@ public abstract class PSJdbcTableComponent {
     if (required && (null == data || data.getValue().trim().length() == 0)) {
       String parentName = tree.getCurrent().getNodeName();
       Object[] args = {parentName, attrName, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return data == null ? null : data.getValue();
   }
@@ -289,7 +290,7 @@ public abstract class PSJdbcTableComponent {
       if (!found) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return index;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -208,7 +209,7 @@ public class PSJdbcTableData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_rows = new ArrayList<>();
     m_columnNames = new HashSet<>();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import static com.percussion.tablefactory.IPSLogger.LOG_CATEGORY;
 
 import com.percussion.security.error.PSExceptionUtils;
@@ -74,7 +75,7 @@ public class PSJdbcTableDataCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -89,7 +90,7 @@ public class PSJdbcTableDataCollection extends PSCollection {
 
     if (table == null) {
       Object[] args = {NODE_NAME, PSJdbcTableData.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, args);
     }
 
     while (table != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
@@ -17,6 +17,8 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.security.xml.PSSecureXMLUtils;
@@ -191,7 +193,7 @@ public class PSJdbcTableFactory {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
 
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SQL_CATALOG_TABLE_FAILED, args, e);
+          TableFactoryErrorCodes.SQL_CATALOG_TABLE_FAILED, args, e);
     }
 
     return tableSchema;
@@ -243,7 +245,7 @@ public class PSJdbcTableFactory {
       processTable(conn, dbmsDef, tableSchema, logOut, logDebug);
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED, args, e);
     } finally {
       if (conn != null)
         try {
@@ -331,7 +333,7 @@ public class PSJdbcTableFactory {
         // Schema changes for a view is not supported
         if (tableSchema.isView() || tmd.isView())
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.ALTER_VIEW_NOT_SUPPORTED, tableSchema.getName());
+              TableFactoryErrorCodes.ALTER_VIEW_NOT_SUPPORTED, tableSchema.getName());
 
         // Process schema changes
         PSJdbcExecutionPlan plan = new PSJdbcExecutionPlan();
@@ -401,10 +403,10 @@ public class PSJdbcTableFactory {
         processingData = false;
       }
     } catch (SQLException e) {
-      int errorCode =
+      IPSErrorCode errorCode =
           processingData
-              ? IPSTableFactoryErrors.DATA_PROCESS_ERROR
-              : IPSTableFactoryErrors.SCHEMA_PROCESS_ERROR;
+              ? TableFactoryErrorCodes.DATA_PROCESS_ERROR
+              : TableFactoryErrorCodes.SCHEMA_PROCESS_ERROR;
 
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
       PSJdbcTableFactoryException ex = new PSJdbcTableFactoryException(errorCode, args, e);
@@ -760,7 +762,7 @@ public class PSJdbcTableFactory {
         dataTypeMapObj = new PSJdbcDataTypeMap(dbmsDef.getBackEndDB(), dbmsDef.getDriver(), null);
       } catch (Exception e) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+            TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
       }
     } else {
       dataTypeMapObj =
@@ -797,7 +799,7 @@ public class PSJdbcTableFactory {
         }
       }
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           PSJdbcTableFactoryException.formatSqlException(e),
           e);
     } catch (PSJdbcTableFactoryException e1) {
@@ -1013,7 +1015,7 @@ public class PSJdbcTableFactory {
     File tableDefFile = new File(defDataFolder, "tableDef.xml");
     if (!tableDefFile.isFile()) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           "tableDef.xml not found under export storage: " + tableDefFile.getAbsolutePath());
     }
 
@@ -1062,7 +1064,7 @@ public class PSJdbcTableFactory {
             throw (PSJdbcTableFactoryException) e;
           }
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.DATA_PROCESS_ERROR,
+              TableFactoryErrorCodes.DATA_PROCESS_ERROR,
               new Object[] {tableName, e.getMessage()},
               e);
         }
@@ -1321,7 +1323,7 @@ public class PSJdbcTableFactory {
       return count > 0;
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.CHECK_EXISTING_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.CHECK_EXISTING_DATA, args, e);
     } finally {
       if (rsCount != null)
         try {
@@ -1406,7 +1408,7 @@ public class PSJdbcTableFactory {
       return new PSJdbcTableData(tableSchema.getName(), rowList.iterator());
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CATALOG_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CATALOG_DATA, args, e);
     } finally {
       if (step != null) step.close();
     }
@@ -1761,7 +1763,7 @@ public class PSJdbcTableFactory {
     URL xslUrl = PSJdbcTableFactory.class.getResource(xslFileName);
     if (xslUrl == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.STYLESHEET_NOT_FOUND, xslFileName);
+          TableFactoryErrorCodes.STYLESHEET_NOT_FOUND, xslFileName);
 
     DOMResult result = new DOMResult();
     try {
@@ -1771,7 +1773,7 @@ public class PSJdbcTableFactory {
       transformer.transform(new DOMSource(doc), result);
     } catch (Throwable t) {
       Object[] args = {xslFileName, t.getMessage()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.TRANSFORMATION_ERROR, args, t);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.TRANSFORMATION_ERROR, args, t);
     }
 
     return (Document) result.getNode();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactoryException.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactoryException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.percussion.error.IPSErrorCode;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -109,6 +110,62 @@ public class PSJdbcTableFactoryException extends Exception {
   }
 
   /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   * @param t the exception which this exception encapsulates, may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object singleArg, Throwable t) {
+    this(requireCode(code).numericCode(), singleArg, t);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param t the exception which this exception encapsulates, may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object[] arrayArgs, Throwable t) {
+    this(requireCode(code).numericCode(), arrayArgs, t);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Prints this Throwable's backtrace to the standard error stream. This method prints a stack
    * trace for this Throwable object on the error output stream that is the value of the field
    * System.err.
@@ -198,6 +255,29 @@ public class PSJdbcTableFactoryException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when constructed via {@link #PSJdbcTableFactoryException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when
+   * present; legacy int construction returns {@code false}.
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -370,6 +450,12 @@ public class PSJdbcTableFactoryException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed error code when constructed via {@link #PSJdbcTableFactoryException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -146,7 +147,7 @@ public class PSJdbcTableMapping {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.utils.collections.PSIteratorUtils;
@@ -120,7 +121,7 @@ public class PSJdbcTableMetaData {
       }
     } catch (SQLException e) {
       Object[] args = {tableName, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_TABLE_META_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_TABLE_META_DATA, args, e);
     }
   }
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -60,7 +61,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       PSJdbcColumnDef dupeCol = setColumn(column);
       if (dupeCol != null) {
         Object[] args = {m_name + " table", column.getName()};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DUPLICATE_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DUPLICATE_COLUMN, args);
       }
     }
   }
@@ -239,7 +240,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     int index = getColumnIndex(name);
     if (index > -1) {
       if (m_columns.size() == 1)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.REMOVE_LAST_COLUMN);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.REMOVE_LAST_COLUMN);
 
       oldCol = m_columns.get(index);
       m_columns.remove(index);
@@ -542,7 +543,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -555,7 +556,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     String sTemp = sourceNode.getAttribute(NAME_ATTR);
     if (sTemp.trim().length() == 0) {
       Object[] args = {NODE_NAME, NAME_ATTR, sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_name = sTemp;
 
@@ -587,12 +588,12 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     walker.setCurrent(sourceNode);
     Element row = walker.getNextElement(ROW_EL, firstFlags);
     if (row == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, ROW_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, ROW_EL);
 
     Element column = walker.getNextElement(PSJdbcColumnDef.NODE_NAME, firstFlags);
     if (column == null) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcColumnDef.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcColumnDef.NODE_NAME);
     }
 
     while (column != null) {
@@ -659,7 +660,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       Element index = walker.getNextElement(PSJdbcIndex.NODE_NAME, firstFlags);
       if (index == null) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcIndex.NODE_NAME);
+            TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcIndex.NODE_NAME);
       }
       while (index != null) {
         PSJdbcIndex indexDef = new PSJdbcIndex(index);
@@ -883,7 +884,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
   public void setAlter(boolean isAlter) throws PSJdbcTableFactoryException {
     // can't alter and have data
     if (isAlter && m_tableData != null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.ALTER_TABLE_SET_DATA, getName());
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.ALTER_TABLE_SET_DATA, getName());
 
     m_alter = isAlter;
   }
@@ -963,7 +964,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       // can't alter and have data
       if (isAlter())
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.ALTER_TABLE_SET_DATA, getName());
+            TableFactoryErrorCodes.ALTER_TABLE_SET_DATA, getName());
 
       validateTableData(tableData);
     }
@@ -982,7 +983,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(m_primaryKey.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcPrimaryKey.CONTAINER_NAME, badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
 
@@ -991,7 +992,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
         String badCols = checkColumns(foreignKey.getInternalColumns());
         if (badCols != null) {
           Object[] args = {getName(), PSJdbcForeignKey.CONTAINER_NAME, badCols};
-          throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+          throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
         }
       }
     }
@@ -1000,7 +1001,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(m_updateKey.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcUpdateKey.CONTAINER_NAME, badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
 
@@ -1008,7 +1009,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(index.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcIndex.CONTAINER_NAME + ": " + index.getName(), badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
   }
@@ -1033,7 +1034,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       if (columnDef == null
           || (columnDef.getAction() == PSJdbcTableComponent.ACTION_DELETE && isAlter())) {
         Object[] args = {tableData.getName(), columnName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
       }
     }
 
@@ -1043,7 +1044,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
      */
     if (tableData.hasUpdates()) {
       if (m_primaryKey == null && m_updateKey == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.UPDATE_DATA_NO_KEYS, getName());
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.UPDATE_DATA_NO_KEYS, getName());
 
       // walk each update row and be sure there's a value for each key column
       List<String> keyCols = getKeyColumns();
@@ -1056,7 +1057,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
           if (colData == null || colData.getValue() == null) {
             Object[] args = {getName(), keyCol};
             throw new PSJdbcTableFactoryException(
-                IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE, args);
+                TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE, args);
           }
         }
       }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -78,7 +79,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -92,7 +93,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
     Element table = walker.getNextElement(PSJdbcTableSchema.NODE_NAME, firstFlags);
     if (table == null) {
       Object[] args = {NODE_NAME, PSJdbcTableSchema.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (table != null) {
@@ -168,7 +169,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
       PSJdbcTableData tableData = (PSJdbcTableData) tables.next();
       if (!matchedTables.contains(tableData.getName())) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.TABLE_SCHEMA_NOT_FOUND, tableData.getName());
+            TableFactoryErrorCodes.TABLE_SCHEMA_NOT_FOUND, tableData.getName());
       }
     }
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
@@ -91,7 +92,7 @@ public class PSJdbcTableSchemaHandler {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -104,7 +105,7 @@ public class PSJdbcTableSchemaHandler {
     String sTemp = sourceNode.getAttribute(TYPE_ATTR);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {NODE_NAME, TYPE_ATTR, sTemp == null ? "null" : sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_type = getSchemaHandlerType(sTemp);
 
@@ -124,7 +125,7 @@ public class PSJdbcTableSchemaHandler {
             NODE_NAME, IPSJdbcTableDataHandler.CLASS_ATTR, sTemp == null ? "null" : sTemp
           };
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String className = sTemp;
 
@@ -136,13 +137,13 @@ public class PSJdbcTableSchemaHandler {
           dataHandler.fromXml(dataHandlerEl);
         } catch (ClassNotFoundException e) {
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.DATA_HANDLER_CLASS_NOT_FOUND, className);
+              TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND, className);
         } catch (PSJdbcTableFactoryException e) {
           throw e;
         } catch (Exception e) {
           Object[] args = {NODE_NAME, IPSJdbcTableDataHandler.CLASS_ATTR, e.getLocalizedMessage()};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         m_dataHandlers.add(dataHandler);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -60,7 +61,7 @@ public class PSJdbcTableSchemaHandlerCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -75,7 +76,7 @@ public class PSJdbcTableSchemaHandlerCollection extends PSCollection {
 
     if (schemaHandler == null) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcTableSchemaHandler.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcTableSchemaHandler.NODE_NAME);
     }
 
     while (schemaHandler != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
@@ -15,8 +15,8 @@
  */
 package com.percussion.tablefactory.tools;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcColumnDef;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
@@ -271,7 +271,7 @@ public class PSCatalogTableData {
     if (table == null) {
       // Do not System.exit — this path is used programmatically by migration (#548)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           "No tables found to export (empty tables document)");
     }
 

--- a/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
+++ b/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.tablefactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover TableFactory production {@code IPSTableFactoryErrors}
+ * sites throw typed {@link TableFactoryErrorCodes}. All catalog codes are non-auditable (dual-write
+ * skip).
+ */
+class PSJdbcTableFactoryTypedErrorCodeSliceTest {
+
+  @Test
+  void typedConstructionRetainsCatalogAndSkipsDualWrite() {
+    PSJdbcTableFactoryException ex =
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, new Object[] {"column", "row"});
+
+    assertEquals(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedConstructionRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSJdbcTableFactoryException(null, "arg"));
+  }
+
+  @Test
+  void columnDataWrongXmlElementThrowsTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = doc.createElement("row");
+
+    PSJdbcTableFactoryException ex =
+        assertThrows(PSJdbcTableFactoryException.class, () -> new PSJdbcColumnData(wrong));
+
+    assertEquals(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void schemaHandlerMissingClassThrowsTypedDataHandlerNotFound() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = doc.createElement(PSJdbcTableSchemaHandler.NODE_NAME);
+    handler.setAttribute("type", PSJdbcTableSchemaHandler.TYPE_STR_ON_CREATE);
+    Element handlersEl = doc.createElement("dataHandlers");
+    Element classEl = doc.createElement(IPSJdbcTableDataHandler.NODE_NAME);
+    classEl.setAttribute(IPSJdbcTableDataHandler.CLASS_ATTR, "com.percussion.does.not.ExistHandler");
+    handlersEl.appendChild(classEl);
+    handler.appendChild(handlersEl);
+
+    PSJdbcTableFactoryException ex =
+        assertThrows(PSJdbcTableFactoryException.class, () -> new PSJdbcTableSchemaHandler(handler));
+
+    assertEquals(
+        TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -773,6 +773,32 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void htmlSearchMissingParameterIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(16053));
+    assertSame(
+        SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER,
+        LegacyErrorCodeRegistry.find(16053).orElseThrow());
+    assertFalse(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.isAuditable());
+  }
+
+  @Test
+  void htmlSearchMissingParameterNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "HTML",
+            "sys_searchid");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
   void luceneIndexCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(16311));
     assertSame(
@@ -1316,6 +1342,7 @@ class LegacyErrorCodeRegistryTest {
     assertFalse(TableFactoryErrorCodes.XML_ELEMENT_NULL.isAuditable());
     assertEquals(1001, TableFactoryErrorCodes.XML_ELEMENT_NULL.numericCode());
     assertEquals(1310, TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
   }
 
   @Test

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -6,6 +6,7 @@
 # Shrink this list as retype PRs merge:
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
+#   #3741 DCE/ContentUI/TableFactory leftover call sites
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -94,51 +95,6 @@ deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslation
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
-modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java

--- a/system/src/main/java/com/percussion/cx/error/PSContentExplorerException.java
+++ b/system/src/main/java/com/percussion/cx/error/PSContentExplorerException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx.error;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSStandaloneException;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import java.text.MessageFormat;
@@ -57,6 +58,35 @@ public class PSContentExplorerException extends PSStandaloneException {
    */
   public PSContentExplorerException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSContentExplorerException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleMessage the sole argument to use as the arguments in the error message
+   */
+  public PSContentExplorerException(IPSErrorCode code, String singleMessage) {
+    super(code, singleMessage);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSContentExplorerException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /** See PSStandaloneException for details. */

--- a/system/src/main/java/com/percussion/error/PSStandaloneException.java
+++ b/system/src/main/java/com/percussion/error/PSStandaloneException.java
@@ -88,6 +88,40 @@ public abstract class PSStandaloneException extends Exception {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode}. Sets the legacy numeric code for
+   * message lookup and retains the typed code for {@link #getTypedErrorCode()} / {@link
+   * #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *
@@ -223,6 +257,30 @@ public abstract class PSStandaloneException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link
+   * #PSStandaloneException(IPSErrorCode)} (or overloads); otherwise {@code null} for legacy int
+   * construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when
+   * present; legacy int construction returns {@code false}.
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -430,6 +488,12 @@ public abstract class PSStandaloneException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed error code when constructed via {@link #PSStandaloneException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
 
@@ -68,6 +69,35 @@ public class PSExtensionProcessingException extends PSException {
    */
   public PSExtensionProcessingException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSExtensionProcessingException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**


### PR DESCRIPTION
## Summary

Parent **#2616** slice 3/3 (peers: **#3739** / PR **#3753**, **#3740** / PR **#3754**). Leftover **DesktopContentExplorer + ContentUI search + TableFactory** production `IPS*Errors` int sites now throw typed `ContentExplorerErrorCodes` / `CmsErrorCodes` / `SearchErrorCodes` / `ServerErrorCodes` / `TableFactoryErrorCodes` via additive `IPSErrorCode` constructors.

- Additive typed constructors: `PSStandaloneException`, `PSContentExplorerException`, `PSExtensionProcessingException`, `PSWizardValidationError`, `PSJdbcTableFactoryException` (`getTypedErrorCode()` / `isAuditable()`).
- Allow-list `scripts/ipserrors-residual-allowlist.txt` shrunk by the exact DCE / ContentUI / TableFactory paths.
- Dual-write: leftover catalog codes remain non-auditable (`isAuditable()==false`); HTML search missing-parameter (16053) skip test added.
- `PSSearchResult` checks missing `sys_searchid` before constructing the CMS processor (same throw, no extra server call).
- Out of scope: deployer (slices 1–2), javac/Xlint epics (#2045 / #2022), deleting `IPS*Errors` interfaces.

Fixes #3741  
Partial #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 297, Failures: 0 (`LegacyErrorCodeRegistryTest` 134)
2. `cd modules/TableFactory && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 52, Failures: 0, Skipped: 7 (`PSJdbcTableFactoryTypedErrorCodeSliceTest` 4)
3. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2336, Failures: 0, Skipped: 242
4. `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 215, Failures: 0 (`PSContentExplorerTypedErrorCodeSliceTest` 5)
5. `cd modules/ContentUI && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2, Failures: 0 (`PSSearchResultTypedErrorCodeSliceTest` 2)
6. `python scripts/verify-no-bare-ipserrors.py` — PASS; `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 17 passed

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — typed construction, production throws, dual-write skip; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when constructors added (system producer + DCE/ContentUI/TableFactory consumers)
- [x] **Cross-platform** — DCE cataloger test uses `@TempDir Path` + `Files.createDirectories` + `toUri().toURL()`; no hardcoded separators

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `modules/TableFactory`, `system`, `modules/DesktopContentExplorer`, `modules/ContentUI`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 297, Failures: 0
  - `cd modules/TableFactory && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 52, Failures: 0, Skipped: 7
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2336, Failures: 0, Skipped: 242
  - `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 215, Failures: 0
  - `cd modules/ContentUI && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2, Failures: 0
  - `python scripts/verify-no-bare-ipserrors.py` → PASS; pytest 17 passed
- **downstream_checked:** C2 constructors are additive (not `final` / signature-breaking). Grepped `extends PSStandaloneException` (`PSContentExplorerException`, `PSOptionException`, `PSServletException`, inner `PSRequestException` only); no `extends PSExtensionProcessingException` / `PSJdbcTableFactoryException`; no anonymous `new <Type>() {`. Standalone system + DCE + ContentUI + TableFactory install green.

### C5 UI proof

N/A — no WebUI / Playwright surface.

Erlang: approve (`docs/ai-generated/code-reviews/3741-dce-contentui-tablefactory-errorcodes-erlang.md`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
