### PR TITLE
cluster: IPS*Errors allowlist thrash (#3753 #3754 #3755)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
@@ -17,10 +17,10 @@
 
 package com.percussion.deployer.catalog;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.conn.PSServerException;
 import com.percussion.deployer.client.PSDeploymentServerConnection;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
@@ -163,7 +163,7 @@ public class PSCataloger {
     } catch (PSServerLockException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     PSCatalogResultSet set = null;
@@ -179,7 +179,7 @@ public class PSCataloger {
         respDoc.getDocumentElement().getTagName(),
         e.getLocalizedMessage()
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     return set;

--- a/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
@@ -29,8 +29,8 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.server.PSDependencyManager;
 import com.percussion.deployer.server.PSDeploymentHandler;
 import com.percussion.deployer.server.PSLogHandler;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
@@ -74,7 +74,7 @@ public class PSCatalogHandler {
     Document doc = request.getInputDocument();
     Element root = null;
     if (doc == null || (root = doc.getDocumentElement()) == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     /* verify this is the appropriate request type */
@@ -82,7 +82,7 @@ public class PSCatalogHandler {
     int length = PSCataloger.ROOT_PREFIX.length();
     if (!requestTag.startsWith(PSCataloger.ROOT_PREFIX)
         || !PSCataloger.ms_supportedReqTypes.contains(requestTag.substring(length))) {
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REQUEST_TYPE, root.getTagName());
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REQUEST_TYPE, root.getTagName());
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
@@ -306,7 +306,7 @@ public class PSCatalogHandler {
         }
       }
     } catch (PSUnknownNodeTypeException ex) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, ex.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, ex.getLocalizedMessage());
     }
     return descriptors;
   }
@@ -373,7 +373,7 @@ public class PSCatalogHandler {
     if (props == null
         || props.getProperty("type") == null
         || props.getProperty("type").trim().length() == 0)
-      throw new PSDeployException(IPSDeploymentErrors.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
+      throw new PSDeployException(DeploymentErrorCodes.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
 
     String type = props.getProperty("type");
     PSCatalogResultSet typeObjects = new PSCatalogResultSet();
@@ -496,7 +496,7 @@ public class PSCatalogHandler {
 
     if (!catalogDir.isDirectory() || !catalogDir.exists())
       throw new PSDeployException(
-          IPSDeploymentErrors.CATALOG_INVALID_DIRECTORY_SPECIFIED, new String[] {directory});
+          DeploymentErrorCodes.CATALOG_INVALID_DIRECTORY_SPECIFIED, new String[] {directory});
 
     PSCatalogResultSet resultSet = new PSCatalogResultSet();
     var dirFiles = Optional.ofNullable(catalogDir.listFiles()).orElse(new File[0]);

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.client;
 
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
@@ -199,7 +199,7 @@ public class PSDeployFileJobControl implements IPSDeployJobControl {
             ResourceBundle.getBundle("com.percussion.deployer.client.PSDeployStringResources");
       }
     } catch (MissingResourceException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return ms_bundle;

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
@@ -17,6 +17,8 @@
 
 package com.percussion.deployer.client;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.conn.PSServerException;
 import com.percussion.deployer.catalog.PSCataloger;
 import com.percussion.deployer.objectstore.IPSDeployComponent;
@@ -38,11 +40,9 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.objectstore.PSUserDependency;
 import com.percussion.deployer.objectstore.PSValidationResults;
 import com.percussion.deployer.server.PSDeploymentHandler;
-import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSFeatureSet;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
 import com.percussion.security.PSAuthenticationFailedException;
@@ -122,7 +122,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -155,7 +155,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -214,7 +214,7 @@ public class PSDeploymentManager {
         | PSAuthenticationFailedException
         | PSAuthorizationException e) {
       log.error(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -259,7 +259,7 @@ public class PSDeploymentManager {
       return results.iterator();
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -300,7 +300,7 @@ public class PSDeploymentManager {
       return results.iterator();
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -320,7 +320,7 @@ public class PSDeploymentManager {
       return respDoc.getDocumentElement().getAttribute("longvalue");
 
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -357,10 +357,10 @@ public class PSDeploymentManager {
       return types;
     } catch (PSUnknownNodeTypeException e) {
       Object args[] = {reqType, searchEl, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
-      else throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      else throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -438,7 +438,7 @@ public class PSDeploymentManager {
       Element childEl = tree.getNextElement(xmlNodeName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (childEl == null) {
         Object args[] = {reqType, xmlNodeName};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
       }
 
       Constructor<? extends IPSDeployComponent> compCtor =
@@ -447,11 +447,11 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException) {
         Object args[] = {reqType, xmlNodeName, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       } else if (e instanceof PSDeployException) {
         throw (PSDeployException) e;
       } else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
 
@@ -602,7 +602,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
     return respDoc;
@@ -669,7 +669,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -703,7 +703,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -729,7 +729,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -755,7 +755,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -796,7 +796,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -833,7 +833,7 @@ public class PSDeploymentManager {
       if (errors.isEmpty()) return null;
       return errors;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -898,7 +898,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
 
@@ -1245,7 +1245,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1306,7 +1306,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1395,7 +1395,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1458,7 +1458,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1478,7 +1478,7 @@ public class PSDeploymentManager {
       return runServerJob(desc, "export");
     } catch (PSServerLockException e) {
       // this is not expected, but helper method throws it
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1501,7 +1501,7 @@ public class PSDeploymentManager {
           tree.getNextElement(PSFeatureSet.ms_nodeName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (childEl == null) {
         Object args[] = {reqType, PSFeatureSet.ms_nodeName};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
       }
 
       PSXmlDocumentBuilder.replaceRoot(respDoc, childEl);
@@ -1511,11 +1511,11 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException || e instanceof PSUnknownDocTypeException) {
         Object args[] = {reqType, "PSXDeployGetFeatureSetRequest", e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       } else if (e instanceof PSDeployException) {
         throw (PSDeployException) e;
       } else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1560,7 +1560,7 @@ public class PSDeploymentManager {
       // this is not expected, but helper method throws it
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1595,7 +1595,7 @@ public class PSDeploymentManager {
       if (results == null) {
         // this would be a bug, just throw unexpected exeption
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Missing validation results for pkg: " + pkg.getPackage().getKey());
       }
       pkg.setValidationResults(results);
@@ -1654,7 +1654,7 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       String message = respRoot.getAttribute("message");
@@ -1664,7 +1664,7 @@ public class PSDeploymentManager {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1702,14 +1702,14 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, respRoot.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       return result;
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1749,7 +1749,7 @@ public class PSDeploymentManager {
     Element depEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (depEl == null) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
 
     return getDependencyFromElement(reqType, depEl);
@@ -1775,12 +1775,12 @@ public class PSDeploymentManager {
       else if (PSUserDependency.XML_NODE_NAME.equals(elName)) dep = new PSUserDependency(depEl);
     } catch (PSUnknownNodeTypeException e) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     if (dep == null) {
       Object args[] = {reqType, PSDependency.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
 
     return dep;
@@ -1833,7 +1833,7 @@ public class PSDeploymentManager {
             new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
         Object args[] = {reqType, root.getTagName(), une.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       return new PSDeployServerJobControl(jobId, this);
@@ -1841,7 +1841,7 @@ public class PSDeploymentManager {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else if (e instanceof PSServerLockException) throw (PSServerLockException) e;
       else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
@@ -28,7 +28,7 @@ import com.percussion.conn.PSServerException;
 import com.percussion.deployer.objectstore.PSDbmsInfo;
 import com.percussion.deployer.objectstore.PSDeploymentServerConnectionInfo;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
 import com.percussion.error.PSLockedException;
@@ -199,7 +199,7 @@ public final class PSDeploymentServerConnection {
       m_conn.setTimeout(0); // no timeout
       m_conn.addBasicAuthorization("", m_uid, m_password);
     } catch (ProtocolNotSuppException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     m_isConnected = true;
@@ -216,7 +216,7 @@ public final class PSDeploymentServerConnection {
     } catch (NumberFormatException e) {
       m_isConnected = false;
       Object[] args = {"connect", "deployVersion", deployVersion};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     // The client's deployment version must be greater than or equal to the
@@ -225,7 +225,7 @@ public final class PSDeploymentServerConnection {
     if (deployInterface > DEPLOYMENT_INTERFACE_VERSION) {
       m_isConnected = false;
       throw new PSDeployException(
-          IPSDeploymentErrors.SERVER_VERSION_INVALID, m_version.getVersionString());
+          DeploymentErrorCodes.SERVER_VERSION_INVALID, m_version.getVersionString());
     }
 
     String licensed = root.getAttribute("licensed");
@@ -237,13 +237,13 @@ public final class PSDeploymentServerConnection {
     if (versionEl == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSFormatVersion.NODE_TYPE};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
     m_version = PSFormatVersion.createFromXml(versionEl);
     if (m_version == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSFormatVersion.NODE_TYPE, "unknown"};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
     // This will have to be reworked once we allow remote install of the package manager for cougar.
     // It will need to know the difference of cougar and rhythmyx
@@ -252,7 +252,7 @@ public final class PSDeploymentServerConnection {
     if (m_version.getMajorVersion() < 6) {
       m_isConnected = false;
       throw new PSDeployException(
-          IPSDeploymentErrors.SERVER_VERSION_INVALID, m_version.getVersionString());
+          DeploymentErrorCodes.SERVER_VERSION_INVALID, m_version.getVersionString());
     }
 
     Element repositoryEl =
@@ -260,14 +260,14 @@ public final class PSDeploymentServerConnection {
     if (repositoryEl == null) {
       m_isConnected = false;
       Object[] args = {"connect", PSDbmsInfo.XML_NODE_NAME};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_MISSING, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING, args);
     }
     try {
       m_serverRepositoryInfo = new PSDbmsInfo(repositoryEl);
     } catch (PSUnknownNodeTypeException e) {
       m_isConnected = false;
       Object[] args = {"connect", PSDbmsInfo.XML_NODE_NAME, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
     }
 
     // locker thread tries to extend the lock 2 minutes before expiration.
@@ -311,7 +311,7 @@ public final class PSDeploymentServerConnection {
       doDisconnect();
     } catch (PSDeployException e) {
       Object[] args = {m_server + ":" + m_port, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.LOCK_NOT_RELEASED, args);
+      throw new PSDeployException(DeploymentErrorCodes.LOCK_NOT_RELEASED, args);
     } finally {
       if (m_lockerThread != null) m_lockerThread.interrupt();
       m_isConnected = false;
@@ -424,7 +424,7 @@ public final class PSDeploymentServerConnection {
     if (req == null) throw new IllegalArgumentException("req may not be null");
 
     if (!m_isConnected) {
-      throw new PSDeployException(IPSDeploymentErrors.NOT_CONNECTED_ERROR, m_server);
+      throw new PSDeployException(DeploymentErrorCodes.NOT_CONNECTED_ERROR, m_server);
     }
     return execute(type, req, params, true);
   }
@@ -500,7 +500,7 @@ public final class PSDeploymentServerConnection {
             log.debug(uee.getMessage(), uee);
           }
         }
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -517,7 +517,7 @@ public final class PSDeploymentServerConnection {
         }
       }
 
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (reqFile != null) reqFile.release();
     }
@@ -581,7 +581,7 @@ public final class PSDeploymentServerConnection {
     if (controller == null) throw new IllegalArgumentException("controller may not be null");
 
     if (!m_isConnected) {
-      throw new PSDeployException(IPSDeploymentErrors.NOT_CONNECTED_ERROR, m_server);
+      throw new PSDeployException(DeploymentErrorCodes.NOT_CONNECTED_ERROR, m_server);
     }
 
     return execute(type, params, body, controller, true, true);
@@ -663,12 +663,12 @@ public final class PSDeploymentServerConnection {
           log.error(ioe.getMessage());
           log.debug(ioe.getMessage(), ioe);
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR, ioe.getLocalizedMessage());
+              DeploymentErrorCodes.UNEXPECTED_ERROR, ioe.getLocalizedMessage());
         }
       } catch (Exception e) {
         log.error(PSExceptionUtils.getMessageForLog(e));
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } catch (IOException e) {
       if (repost) {
@@ -678,7 +678,7 @@ public final class PSDeploymentServerConnection {
       } else {
         log.error(PSExceptionUtils.getMessageForLog(e));
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
       }
     }
 
@@ -812,7 +812,7 @@ public final class PSDeploymentServerConnection {
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (in != null)
         try {
@@ -1049,7 +1049,7 @@ public final class PSDeploymentServerConnection {
    * Multipart Content-Type forced on XML request document parts so the server {@code
    * PSFormContentParser} classifies the part as XML and calls {@code setInputDocument}. Relying
    * only on {@code URLConnection.guessContentTypeFromName} can omit or mis-classify the type on
-   * some JREs/platforms and surfaces as {@code IPSDeploymentErrors.NULL_INPUT_DOC}.
+   * some JREs/platforms and surfaces as {@code DeploymentErrorCodes.NULL_INPUT_DOC}.
    */
   public static final String XML_REQUEST_CONTENT_TYPE = "application/xml";
 
@@ -1196,13 +1196,13 @@ public final class PSDeploymentServerConnection {
 
     // handle case if server is still starting
     if (status == 503) {
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_NOT_AVAILABLE);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_NOT_AVAILABLE);
     }
 
     // make sure we got back some kind of response
     if (response == null || response.length == 0) {
       Object[] args = {type, String.valueOf(status)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_EMPTY, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_EMPTY, args);
     }
 
     // try to parse the response as XML
@@ -1214,7 +1214,7 @@ public final class PSDeploymentServerConnection {
       if (status == 200) {
         // must have valid response for a 200 error.
         Object[] args = {type, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_PARSE_ERROR, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_PARSE_ERROR, args);
       }
     }
 
@@ -1233,7 +1233,7 @@ public final class PSDeploymentServerConnection {
       }
 
       Object[] args = {type, String.valueOf(status), msg};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_ERROR_RESPONSE, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_ERROR_RESPONSE, args);
     }
 
     // We must have an error that we can handle in some way.
@@ -1248,7 +1248,7 @@ public final class PSDeploymentServerConnection {
       } catch (PSUnknownNodeTypeException e) {
         // malformed exception xml (should not happen)
         Object[] args = {type, PSDeployException.XML_NODE_NAME, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       className = de.getOriginalExceptionClass();
@@ -1260,11 +1260,11 @@ public final class PSDeploymentServerConnection {
       PSJobException je = null;
       try {
         je = new PSJobException(root);
-        de = new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, je.getLocalizedMessage());
+        de = new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, je.getLocalizedMessage());
       } catch (PSUnknownNodeTypeException e) {
         // malformed exception xml (should not happen)
         Object[] args = {type, PSDeployException.XML_NODE_NAME, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_RESPONSE_ELEMENT_INVALID, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID, args);
       }
 
       className = je.getOriginalExceptionClass();
@@ -1274,7 +1274,7 @@ public final class PSDeploymentServerConnection {
       }
     } else {
       Object[] args = {type, String.valueOf(status), PSXmlDocumentBuilder.toString(respDoc)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_ERROR_RESPONSE, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_ERROR_RESPONSE, args);
     }
 
     if (PSAuthenticationFailedException.class.getName().equals(className)) {

--- a/deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
@@ -24,7 +24,7 @@ import com.percussion.deployer.objectstore.PSDeployableElement;
 import com.percussion.deployer.objectstore.PSIdMap;
 import com.percussion.deployer.objectstore.PSIdMapping;
 import com.percussion.deployer.server.IPSJobHandle;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.utils.collections.PSIteratorUtils;
 import java.util.Collections;
@@ -143,7 +143,7 @@ public class PSFolderContentsDescriptorBuilder {
             .orElseThrow(
                 () ->
                     new PSDeployException(
-                        IPSDeploymentErrors.UNEXPECTED_ERROR, "Failed to find top-level folder"));
+                        DeploymentErrorCodes.UNEXPECTED_ERROR, "Failed to find top-level folder"));
 
     var previousMaxDeps = System.getProperty(IPSDeployConstants.PROP_MAX_DEPS);
     System.setProperty(IPSDeployConstants.PROP_MAX_DEPS, String.valueOf(MAX_DEPS));
@@ -247,7 +247,7 @@ public class PSFolderContentsDescriptorBuilder {
         if (mappings.hasNext()) {
           PSApplicationIDTypeMapping mapping = mappings.next();
           throw new PSDeployException(
-              IPSDeploymentErrors.INCOMPLETE_ID_TYPE_MAPPING,
+              DeploymentErrorCodes.INCOMPLETE_ID_TYPE_MAPPING,
               new Object[] {
                 mapping.getType(),
                 dep.getDependencyId(),

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
@@ -17,7 +17,7 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.system.utils.PSArchiveFiles;
@@ -153,7 +153,7 @@ public final class PSArchive {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
 
     return m_archiveManifest;
@@ -236,7 +236,7 @@ public final class PSArchive {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
 
     return result;
@@ -340,7 +340,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_WRITE_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_WRITE_ERROR, args);
     }
   }
 
@@ -394,7 +394,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_WRITE_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_WRITE_ERROR, args);
     }
   }
 
@@ -436,7 +436,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
   }
 
@@ -462,7 +462,7 @@ public final class PSArchive {
       Object args[] = {m_archiveFile.getPath(), e.getLocalizedMessage()};
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new PSDeployException(IPSDeploymentErrors.ARCHIVE_READ_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.ARCHIVE_READ_ERROR, args);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -17,9 +17,9 @@
 
 package com.percussion.deployer.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -349,7 +349,7 @@ public final class PSIdMap implements IPSDeployComponent {
     PSIdMapping idMapping = getMapping(id, type, parentId, parentType);
     if (idMapping == null) {
       Object[] args = {type, id, getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     String newValue = idMapping.getTargetId();
@@ -357,7 +357,7 @@ public final class PSIdMap implements IPSDeployComponent {
       String errId = id;
       if (parentId != null) errId = id + ":" + parentId;
       Object[] args = {type, errId, getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.INCOMPLETE_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING, args);
     }
 
     return newValue;
@@ -395,7 +395,7 @@ public final class PSIdMap implements IPSDeployComponent {
       return Integer.parseInt(strId);
     } catch (NumberFormatException e) {
       Object[] args = {type, id, getSourceServer(), strId};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_ID_MAPPING_TARGET, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, args);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSAppTransformer.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSAppTransformer.java
@@ -86,7 +86,6 @@ import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUISet;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.PSVisibilityRules;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.system.utils.PSUrlUtils;
 import com.percussion.tablefactory.PSJdbcColumnData;
@@ -100,6 +99,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Handles discovery and transformations of literal ids specified in application and other
@@ -2796,7 +2796,7 @@ public class PSAppTransformer {
         newValue = Integer.parseInt(mapping.getValue());
       } catch (NumberFormatException e) {
         // should never happen, would be a bug
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } else {
       newValue =

--- a/deployer/src/main/java/com/percussion/deployer/server/PSArchiveHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSArchiveHandler.java
@@ -22,7 +22,6 @@ import com.percussion.deployer.objectstore.*;
 import com.percussion.deployer.server.dependencies.PSAclDefDependencyHandler;
 import com.percussion.deployer.server.dependencies.PSContentTypeDependencyHandler;
 import com.percussion.deployer.server.dependencies.PSSupportFileDependencyHandler;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +31,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Handling saving and retrieving IDTypes and dependencies to and from a <code>PSArchive</code>
@@ -194,7 +194,7 @@ public class PSArchiveHandler {
       if (hasDependencyFiles(dep)) m_archiveMan.addFiles(dep, dupFiles.iterator());
     } catch (RuntimeException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.ARCHIVE_WRITE_ERROR,
+          DeploymentErrorCodes.ARCHIVE_WRITE_ERROR,
           new Object[] {m_archive.getArchiveRef().getPath(), e.getLocalizedMessage()});
     } finally {
       tmpFiles.forEach(File::delete);

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
@@ -25,7 +25,6 @@ import com.percussion.deployer.objectstore.PSDeployComponentUtils;
 import com.percussion.deployer.server.dependencies.PSDependencyUtils;
 import com.percussion.design.objectstore.PSLockedException;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSNotLockedException;
 import com.percussion.security.PSAuthorizationException;
@@ -78,6 +77,7 @@ import javax.naming.NamingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Singleton class to provide common database read/write functionality. */
 public class PSDbmsHelper {
@@ -142,12 +142,12 @@ public class PSDbmsHelper {
 
         if (id == null || id.getValue() == null || id.getValue().isBlank()) {
           throw new PSDeployException(
-              IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE,
+              DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE,
               new Object[] {table, idCol, id.getValue()});
         }
         if (name == null || name.getValue() == null || name.getValue().isBlank()) {
           throw new PSDeployException(
-              IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE,
+              DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE,
               new Object[] {table, nameCol, name.getValue()});
         }
 
@@ -169,7 +169,7 @@ public class PSDbmsHelper {
       DataSourceInfo ds = getDataSourceInfo();
       if (ds == null) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not resolve datasource");
+            DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not resolve datasource");
       }
 
       IPSJndiDatasource dsSource = ds.getDataSource();
@@ -245,7 +245,7 @@ public class PSDbmsHelper {
         | PSNotLockedException
         | PSServerException
         | PSAuthorizationException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
 
     if (jndiSrcList == null || jndiSrcList.isEmpty())
@@ -270,7 +270,7 @@ public class PSDbmsHelper {
         | PSNotLockedException
         | PSLockedException
         | PSAuthorizationException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
     return dsResolver;
   }
@@ -287,7 +287,7 @@ public class PSDbmsHelper {
       return PSConnectionHelper.getDbConnection(null);
     } catch (SQLException | NamingException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.REPOSITORY_CONNECTION_ERROR, e.getLocalizedMessage());
+          DeploymentErrorCodes.REPOSITORY_CONNECTION_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -311,7 +311,7 @@ public class PSDbmsHelper {
       if (includeData) schema.setTableData(catalogTableData(schema, null, null));
     } catch (PSJdbcTableFactoryException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.REPOSITORY_READ_WRITE_ERROR, e.getLocalizedMessage());
+          DeploymentErrorCodes.REPOSITORY_READ_WRITE_ERROR, e.getLocalizedMessage());
     }
 
     return schema;
@@ -391,7 +391,7 @@ public class PSDbmsHelper {
       return PSJdbcTableFactory.catalogTableData(
           conn, dbmsDef, schema, columns, filter, PSJdbcRowData.ACTION_INSERT);
     } catch (SQLException | PSJdbcTableFactoryException e) {
-      throw new PSDeployException(IPSDeploymentErrors.REPOSITORY_READ_WRITE_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.REPOSITORY_READ_WRITE_ERROR, e.getMessage());
     }
   }
 
@@ -408,7 +408,7 @@ public class PSDbmsHelper {
       var dbmsDef = getDbmsDef();
       PSJdbcTableFactory.processTable(conn, dbmsDef, schema, null, false);
     } catch (PSJdbcTableFactoryException | SQLException e) {
-      throw new PSDeployException(IPSDeploymentErrors.REPOSITORY_READ_WRITE_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.REPOSITORY_READ_WRITE_ERROR, e.getMessage());
     }
   }
 
@@ -424,7 +424,7 @@ public class PSDbmsHelper {
     try {
       schema.setTableData(tableData);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
     processTable(schema);
   }
@@ -460,11 +460,11 @@ public class PSDbmsHelper {
         m_dbmsDef = new PSServerJdbcDbmsDef(info);
       } catch (SQLException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.REPOSITORY_CONNECTION_ERROR,
+            DeploymentErrorCodes.REPOSITORY_CONNECTION_ERROR,
             PSDeployException.formatSqlException(e));
       } catch (NamingException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.REPOSITORY_CONNECTION_ERROR, e.getLocalizedMessage());
+            DeploymentErrorCodes.REPOSITORY_CONNECTION_ERROR, e.getLocalizedMessage());
       }
     }
 
@@ -483,13 +483,13 @@ public class PSDbmsHelper {
       try {
         conn = PSConnectionHelper.getConnectionDetail();
       } catch (NamingException | SQLException nex) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, nex.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, nex.toString());
       }
 
       try {
         m_dataTypeMap = new PSJdbcDataTypeMap(null, conn.getDriver(), null);
       } catch (Exception e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     }
 
@@ -513,7 +513,7 @@ public class PSDbmsHelper {
       return PSIdGenerator.getNextId(tableName);
     } catch (SQLException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
     }
   }
 
@@ -535,7 +535,7 @@ public class PSDbmsHelper {
       return PSIdGenerator.getNextIdBlock(tableName, blockSize);
     } catch (SQLException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
     }
   }
 
@@ -560,7 +560,7 @@ public class PSDbmsHelper {
 
     if (cdata == null || cdata.getValue() == null || cdata.getValue().trim().length() == 0) {
       Object[] args = {table, column, cdata.getValue() == null ? "null" : cdata.getValue()};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
 
     return cdata.getValue();
@@ -589,7 +589,7 @@ public class PSDbmsHelper {
       dateTime = Timestamp.valueOf(sDate);
     } catch (IllegalArgumentException e) {
       Object[] args = {table, column, sDate};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
     return dateTime;
   }
@@ -616,7 +616,7 @@ public class PSDbmsHelper {
       number = Integer.parseInt(sNumber);
     } catch (NumberFormatException e) {
       Object[] args = {table, column, sNumber};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
     return number;
   }
@@ -648,7 +648,7 @@ public class PSDbmsHelper {
 
     if (appName == null || appName.trim().length() == 0) {
       Object[] args = {table, column, url};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
 
     return appName;
@@ -691,7 +691,7 @@ public class PSDbmsHelper {
       PSJdbcUpdateKey updKey = new PSJdbcUpdateKey(columns);
       schema.setUpdateKey(updKey);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -797,7 +797,7 @@ public class PSDbmsHelper {
       else iResult = rs.getInt(1) + 1;
     } catch (SQLException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSDeployException.formatSqlException(e));
     } finally {
       if (null != rs)
         try {
@@ -1003,7 +1003,7 @@ public class PSDbmsHelper {
           m_systemTables.add(schema.getName());
         }
       } catch (PSJdbcTableFactoryException e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1024,7 +1024,7 @@ public class PSDbmsHelper {
           m_tableTypes.put(key, Integer.valueOf(bundle.getString(key)));
         }
       } catch (NumberFormatException e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
       }
     }
   }
@@ -1071,7 +1071,7 @@ public class PSDbmsHelper {
     try (var in = new FileInputStream(file)) {
       return PSXmlDocumentBuilder.createXmlDocument(in, false);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1089,7 +1089,7 @@ public class PSDbmsHelper {
     if (schema == null) // table does not exist
     {
       Object[] args = {tableName};
-      throw new PSDeployException(IPSDeploymentErrors.UNABLE_FIND_TABLE, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNABLE_FIND_TABLE, args);
     }
 
     return schema;
@@ -1130,7 +1130,7 @@ public class PSDbmsHelper {
         }
       } catch (PSJdbcTableFactoryException | SQLException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.REPOSITORY_READ_WRITE_ERROR, e.getLocalizedMessage());
+            DeploymentErrorCodes.REPOSITORY_READ_WRITE_ERROR, e.getLocalizedMessage());
       }
 
       if (canCache && schema != null) {

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDbmsMapManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDbmsMapManager.java
@@ -18,13 +18,13 @@
 package com.percussion.deployer.server;
 
 import com.percussion.deployer.objectstore.PSDbmsMap;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * PSDbmsMapManager handles saving and retrieving <code>PSDbmsMap</code> objects from and to the
@@ -60,7 +60,7 @@ public class PSDbmsMapManager {
       var root = doc.getDocumentElement();
       return new PSDbmsMap(root);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -78,7 +78,7 @@ public class PSDbmsMapManager {
     try (var in = new FileInputStream(mapFile)) {
       return PSXmlDocumentBuilder.createXmlDocument(in, false);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -105,7 +105,7 @@ public class PSDbmsMapManager {
     try (var out = new FileOutputStream(mapFile)) {
       PSXmlDocumentBuilder.write(doc, out);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDependencyManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDependencyManager.java
@@ -25,7 +25,6 @@ import com.percussion.deployer.server.dependencies.PSAclDefDependencyHandler;
 import com.percussion.deployer.server.dependencies.PSCustomDependencyHandler;
 import com.percussion.deployer.server.dependencies.PSDependencyHandler;
 import com.percussion.deployer.server.dependencies.PSUserDependencyHandler;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.security.error.PSExceptionUtils;
@@ -50,6 +49,7 @@ import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Manager class for all dependency handlers. The {@link PSDeploymentHandler} creates and holds an
@@ -117,7 +117,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
       m_depMap = config.getDependencyMap();
       createTypeMappings();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.DEPENDENCY_MGR_INIT, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.DEPENDENCY_MGR_INIT, e.toString());
     }
   }
 
@@ -225,7 +225,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
           PSApplicationIDTypes idTypes = PSIdTypeManager.loadIdTypes(dependency.getKey());
           if (idTypes == null) {
             Object[] args = {dependency.getObjectTypeName(), dependency.getDependencyId()};
-            throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_TYPES, args);
+            throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_TYPES, args);
           }
 
           archiveHandler.addIdTypes(dependency, idTypes);
@@ -563,14 +563,14 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
             idTypes = archiveHandler.getIdTypes(dependency);
             if (idTypes == null) {
               Object[] args = {dependency.getObjectTypeName(), dependency.getDependencyId()};
-              throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_TYPES, args);
+              throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_TYPES, args);
             }
             ctx.setIdTypes(idTypes);
           }
           depHandler.installDependencyFiles(tok, archiveHandler, dependency, ctx);
           // Check for null pkgGuid
           if (ctx.getPkgGuid() == null) {
-            throw new PSDeployException(IPSDeploymentErrors.MISSING_PKG_GUID);
+            throw new PSDeployException(DeploymentErrorCodes.MISSING_PKG_GUID);
           }
 
           // Transform dependency id if necessary
@@ -937,7 +937,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
       var doc = PSXmlDocumentBuilder.createXmlDocument();
       PSXmlDocumentBuilder.write(dep.toXml(doc), out);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -1195,7 +1195,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
       if (targetId == null) {
         // must have id set
         Object[] args = {mapping.getObjectType(), mapping.getSourceId(), idMap.getSourceServer()};
-        throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+        throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
       }
 
       dep.setDependencyId(targetId);
@@ -1223,7 +1223,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
 
     PSDependencyDef def = m_depMap.getDependencyDef(type);
     if (def == null) {
-      throw new PSDeployException(IPSDeploymentErrors.DEPENDENCY_DEF_NOT_FOUND, type);
+      throw new PSDeployException(DeploymentErrorCodes.DEPENDENCY_DEF_NOT_FOUND, type);
     }
 
     return def;
@@ -1280,7 +1280,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
             if (!userDep.getPath().exists()) depFile.delete();
             else deps.add(userDep);
           } catch (Exception e) {
-            throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+            throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
           }
         }
       }
@@ -1747,7 +1747,7 @@ public class PSDependencyManager implements IPSDependencyManagerBaseline {
 
     List<String> depTypes = m_guidToDepTypeMap.get(type);
     if (depTypes == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NO_TYPE_MAPPING_FOR_GUID, type);
+      throw new PSDeployException(DeploymentErrorCodes.NO_TYPE_MAPPING_FOR_GUID, type);
     }
 
     return depTypes;

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDependencyMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDependencyMap.java
@@ -21,7 +21,6 @@ import com.percussion.cms.IPSConstants;
 import com.percussion.deployer.server.dependencies.PSDependencyHandler;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -33,6 +32,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Map that defines all supported dependency types, and maintains parent and child relations between
@@ -231,7 +231,7 @@ public final class PSDependencyMap {
                         if (childDef == null) {
                           var args = new Object[] {childType, defType};
                           throw new PSDeployException(
-                              IPSDeploymentErrors.CHILD_DEPENDENCY_TYPE_NOT_FOUND, args);
+                              DeploymentErrorCodes.CHILD_DEPENDENCY_TYPE_NOT_FOUND, args);
                         }
                         childList.add(childDef);
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
@@ -48,7 +48,6 @@ import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSFeatureSet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
 import com.percussion.error.PSException;
@@ -58,7 +57,6 @@ import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
 import com.percussion.rx.config.data.PSDescriptorSummaryReport;
 import com.percussion.rx.config.impl.PSConfigDefGenerator;
 import com.percussion.rx.config.impl.PSDefaultConfigGenerator;
-import com.percussion.security.IPSSecurityErrors;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.PSEncryptionException;
@@ -66,7 +64,6 @@ import com.percussion.security.PSEncryptor;
 import com.percussion.security.PSUserEntry;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSLoadableRequestHandler;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSResponse;
@@ -128,6 +125,9 @@ import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 
 /** Class to handle all requests from Deployment client. */
 @PSBaseBean("sys_deploymentHandler")
@@ -162,7 +162,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     var doc =
         Optional.ofNullable(req.getInputDocument())
-            .orElseThrow(() -> new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC));
+            .orElseThrow(() -> new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC));
 
     var root = doc.getDocumentElement();
     var uid = root.getAttribute("userId");
@@ -175,7 +175,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
             ? "yes"
             : "no";
     if (!licensed.equals("yes") && enforceLicense) {
-      throw new PSDeployException(IPSDeploymentErrors.MULTISERVER_MANAGER_DISABLED);
+      throw new PSDeployException(DeploymentErrorCodes.MULTISERVER_MANAGER_DISABLED);
     }
 
     req.setCgiVariable(IPSCgiVariables.CGI_AUTH_USER_NAME, uid);
@@ -185,7 +185,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       PSSecurityFilter.authenticate(req.getServletRequest(), req.getServletResponse(), uid, pwd);
     } catch (LoginException e) {
       throw new PSAuthenticationFailedException(
-          IPSSecurityErrors.GENERIC_AUTHENTICATION_FAILED, null);
+          SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED, null);
     }
 
     PSServer.checkAccessLevel(req, PSAclEntry.SACE_ADMINISTER_SERVER);
@@ -232,7 +232,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // get the element type
@@ -244,7 +244,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
           new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     // create the response
@@ -339,7 +339,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the root of the doc in request
     Document doc = req.getInputDocument();
-    if (doc == null) throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+    if (doc == null) throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     Element root = doc.getDocumentElement();
 
     String name = null;
@@ -424,7 +424,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       importDesc = new PSImportDescriptor(importDescEl);
     } catch (PSUnknownNodeTypeException une) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(une));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(une));
     }
 
     Document respDoc = PSXmlDocumentBuilder.createXmlDocument();
@@ -462,7 +462,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // Get the list of objects (typed as PSDependency so iterator assigns cleanly)
@@ -474,7 +474,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         depList.add(new PSDeployableObject(depEl));
       } catch (PSUnknownNodeTypeException une) {
         Object[] args = {depEl.getTagName(), PSExceptionUtils.getMessageForLog(une)};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       }
 
       depEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
@@ -525,7 +525,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // get the PSIdType Element
@@ -541,7 +541,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     while (idTypeEl != null) {
@@ -552,7 +552,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         idTypes = new PSApplicationIDTypes(idTypeEl);
       } catch (PSUnknownNodeTypeException ne) {
         Object[] args = {idTypeEl.getTagName(), ne.toString()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       }
 
       PSIdTypeManager.saveIdTypes(idTypes);
@@ -592,7 +592,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (req == null) throw new IllegalArgumentException(NULL_REQUEST_ERROR);
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
     PSXmlDecoder decoder = new PSXmlDecoder();
     PSXmlTreeWalker tree = new PSXmlTreeWalker(req.getInputDocument());
@@ -627,7 +627,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       }
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     }
   }
 
@@ -661,7 +661,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     try {
@@ -688,7 +688,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         Object[] args = {
           doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
         };
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       }
       PSArchiveInfo info = new PSArchiveInfo(infoEl);
 
@@ -724,7 +724,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         req.getInputDocument().getDocumentElement().getTagName(),
         PSExceptionUtils.getMessageForLog(une)
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
   }
 
@@ -808,7 +808,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
              Object[] args =
              {expDesc.getName()};
              message = new PSDeployException(
-                   IPSDeploymentErrors.PACKAGE_CREATED_ON_SYSTEM, args)
+                   DeploymentErrorCodes.PACKAGE_CREATED_ON_SYSTEM, args)
                    .getMessage();
              validationMap.put(IPSDeployConstants.ERROR_KEY, message);
           }
@@ -835,7 +835,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         if (false && isLowerVersion) {
           Object[] args = {expDesc.getVersion(), pkgInfo.getPackageVersion()};
           message =
-              new PSDeployException(IPSDeploymentErrors.VERSION_LOWER_THEN_INSTALLED, args)
+              new PSDeployException(DeploymentErrorCodes.VERSION_LOWER_THAN_INSTALLED, args)
                   .getMessage();
           validationMap.put(IPSDeployConstants.ERROR_KEY, message);
         }
@@ -852,21 +852,21 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (checkArchiveRef && getImportArchiveFile(info.getArchiveRef()).exists()) {
       message =
           new PSDeployNonUniqueException(
-                  IPSDeploymentErrors.ARCHIVE_REF_FOUND, info.getArchiveRef())
+                  DeploymentErrorCodes.ARCHIVE_REF_FOUND, info.getArchiveRef())
               .getMessage();
       validationMap.put(IPSDeployConstants.ERROR_KEY, message);
     }
 
     if (isLowerVersion(systemVersion, packageSystemMin)) {
       Object[] args = {systemVersion, packageSystemMin};
-      message = new PSDeployException(IPSDeploymentErrors.SERVER_VERSION_LOWER, args).getMessage();
+      message = new PSDeployException(DeploymentErrorCodes.SERVER_VERSION_MISMATCH, args).getMessage();
       if (warnOnBuildMismatch) validationMap.put(IPSDeployConstants.WARNING_KEY, message);
       else validationMap.put(IPSDeployConstants.ERROR_KEY, message);
     }
 
     if (message == null && isHigherVersion(systemVersion, packageSystemMax)) {
       Object[] args = {systemVersion, packageSystemMax};
-      message = new PSDeployException(IPSDeploymentErrors.SERVER_VERSION_HIGHER, args).getMessage();
+      message = new PSDeployException(DeploymentErrorCodes.SERVER_BUILD_MISMATCH, args).getMessage();
       if (warnOnBuildMismatch) validationMap.put(IPSDeployConstants.WARNING_KEY, message);
       else validationMap.put(IPSDeployConstants.ERROR_KEY, message);
     }
@@ -919,7 +919,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         sb.append("\n");
       }
       Object[] args = {sb.toString()};
-      message = new PSDeployException(IPSDeploymentErrors.PKG_DEP_VALIDATION, args).getMessage();
+      message = new PSDeployException(DeploymentErrorCodes.PKG_DEP_VALIDATION, args).getMessage();
       if (warnMissingPackageDep) validationMap.put(IPSDeployConstants.WARNING_KEY, message);
       else validationMap.put(IPSDeployConstants.ERROR_KEY, message);
     } else if (!pkgVersionMismatch.isEmpty()) {
@@ -930,7 +930,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       }
       Object[] args = {sb.toString()};
       message =
-          new PSDeployException(IPSDeploymentErrors.PKG_DEP_VERSION_VALIDATION, args).getMessage();
+          new PSDeployException(DeploymentErrorCodes.PKG_DEP_VERSION_VALIDATION, args).getMessage();
       validationMap.put(IPSDeployConstants.WARNING_KEY, message);
     }
   }
@@ -1083,7 +1083,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       throws PSDeployException {
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
     Element root = doc.getDocumentElement();
     String attrValue = root.getAttribute(attrName);
@@ -1093,7 +1093,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
           new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
     return attrValue;
   }
@@ -1123,7 +1123,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the root of the doc in request
     Document doc = req.getInputDocument();
-    if (doc == null) throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+    if (doc == null) throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     Element root = doc.getDocumentElement();
 
     int logId = -1;
@@ -1142,7 +1142,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (archiveSummary == null) // cannot find one
     {
       Object[] args = {"PSArchiveSummary", Integer.toString(logId)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
 
     // create the response document for the PSArchiveSummary
@@ -1207,7 +1207,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (archiveSummary == null) // cannot find one
     {
       Object[] args = {"PSArchiveSummary", Integer.toString(logId)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
 
     return archiveSummary;
@@ -1228,7 +1228,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     // make sure the archive file exists
     if (!archiveFile.exists()) {
       Object[] args = {"PSArchive", archiveRef};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
 
     PSArchive archive = new PSArchive(archiveFile);
@@ -1273,7 +1273,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
           new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {root.getTagName(), PSExceptionUtils.getMessageForLog(une)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     return number;
@@ -1307,7 +1307,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (logSummary == null) // cannot find one
     {
       Object[] args = {"PSLogSummary", Integer.toString(logId)};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
 
     String archiveRef = logSummary.getArchiveSummary().getArchiveInfo().getArchiveRef();
@@ -1451,7 +1451,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
     Element root = doc.getDocumentElement();
     String archiveRef = root.getAttribute("archiveRef");
@@ -1552,7 +1552,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       PSRequest req, Class<? extends IPSDeployComponent> compClass, String xmlNodeName)
       throws PSDeployException {
     Document doc = req.getInputDocument();
-    if (doc == null) throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+    if (doc == null) throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
 
     // get the component
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
@@ -1565,7 +1565,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     IPSDeployComponent comp = null;
@@ -1576,10 +1576,10 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException) {
         Object[] args = {compEl.getTagName(), e.toString()};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       } else
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+            DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     }
 
     return comp;
@@ -1612,7 +1612,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     File descFile = new File(EXPORT_DESC_DIR, name + ".xml");
     if (!descFile.exists()) {
       Object[] args = {"Export Descriptor", name};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
     descFile.delete();
 
@@ -1670,7 +1670,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         settings = new PSAppPolicySettings(policyDoc.getDocumentElement());
       } catch (PSUnknownNodeTypeException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+            DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
       }
     } else settings = new PSAppPolicySettings();
 
@@ -1735,7 +1735,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       PSXmlDocumentBuilder.write(doc, out);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     } finally {
       if (out != null)
         try {
@@ -1778,7 +1778,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
           else {
             String timeleft = String.valueOf((remainder) / oneMinute);
             Object[] args = new Object[] {m_lockedUser, timeleft};
-            throw new PSLockedException(IPSDeploymentErrors.LOCK_ALREADY_HELD, args);
+            throw new PSLockedException(DeploymentErrorCodes.LOCK_ALREADY_HELD, args);
           }
         } else {
           setLockedValues(userId, sessionId, System.currentTimeMillis() + LOCKING_DURATION);
@@ -1865,7 +1865,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         // lock has been aquired by someone else and released since this
         // user's last request
         Object args[] = new Object[] {m_lastLockedUser};
-        throw new PSLockedException(IPSDeploymentErrors.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, args);
+        throw new PSLockedException(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, args);
       } else {
         // lock held by another, check to see if expired
         long oneMinute = 1000 * 60; // one min of millisecs
@@ -1874,11 +1874,11 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
           // lock has been aquired by someone else and has expired since
           // this user's last request
           Object args[] = new Object[] {m_lastLockedUser};
-          throw new PSLockedException(IPSDeploymentErrors.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, args);
+          throw new PSLockedException(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, args);
         } else {
           String timeleft = String.valueOf((remainder) / oneMinute);
           Object args[] = new Object[] {m_lockedUser, timeleft};
-          throw new PSLockedException(IPSDeploymentErrors.LOCK_NOT_EXTENSIBLE_TAKEN, args);
+          throw new PSLockedException(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN, args);
         }
       }
     }
@@ -1931,7 +1931,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // get the credentials
@@ -1977,7 +1977,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // get the dependency
@@ -2022,7 +2022,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // get the dependency
@@ -2147,7 +2147,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     } catch (IOException e) {
       Object[] args = {"Archive File", name};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     } finally {
       if (in != null)
         try {
@@ -2191,7 +2191,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     } catch (Exception e) {
       Object[] args = {PSExceptionUtils.getMessageForLog(e)};
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, args);
     } finally {
       if (in != null)
         try {
@@ -2244,7 +2244,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     } catch (Exception e) {
       Object[] args = {PSExceptionUtils.getMessageForLog(e)};
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, args);
     } finally {
       if (in != null)
         try {
@@ -2288,7 +2288,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     } catch (Exception e) {
       Object[] args = {PSExceptionUtils.getMessageForLog(e)};
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, args);
     } finally {
       if (in != null)
         try {
@@ -2353,7 +2353,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     String archiveRef = req.getParameter("archiveRef");
     if (archiveRef == null || archiveRef.trim().length() == 0) {
       Object[] args = {"archiveRef", archiveRef == null ? "null" : archiveRef};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_PARAM_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_PARAM_INVALID, args);
     }
 
     File inFile = null;
@@ -2376,7 +2376,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     } catch (IOException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     } finally {
       if (in != null)
         try {
@@ -2420,7 +2420,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     String configRef = req.getParameter("configRef");
     if (configRef == null || configRef.trim().length() == 0) {
       Object[] args = {"configRef", configRef == null ? "null" : configRef};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_PARAM_INVALID, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_PARAM_INVALID, args);
     }
 
     File inFile = null;
@@ -2442,7 +2442,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       IOTools.copyStream(in, out);
     } catch (IOException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     } finally {
       if (in != null)
         try {
@@ -2484,7 +2484,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // build the response doc
@@ -2556,7 +2556,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     Document doc = req.getInputDocument();
     if (doc == null) {
-      throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
+      throw new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
     }
 
     // build the response doc
@@ -2695,7 +2695,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       m_logHandler = new PSLogHandler();
     } catch (PSDeployException e) {
       Object[] args = {getName(), PSExceptionUtils.getMessageForLog(e)};
-      throw new PSServerException(IPSServerErrors.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, args);
+      throw new PSServerException(ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, args);
     }
   }
 
@@ -2740,7 +2740,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     try {
       if (reqType == null || !reqType.startsWith("deploy-")) {
         throw new PSDeployException(
-            IPSDeploymentErrors.INVALID_REQUEST_TYPE, reqType == null ? "" : reqType);
+            DeploymentErrorCodes.INVALID_REQUEST_TYPE, reqType == null ? "" : reqType);
       } else {
         subReqType = reqType.substring("deploy-".length());
       }
@@ -2802,7 +2802,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         else if (subReqType.equals("createDescriptorSummary"))
           respDoc = createDescriptorSummary(request);
         else {
-          throw new PSDeployException(IPSDeploymentErrors.INVALID_REQUEST_TYPE, reqType);
+          throw new PSDeployException(DeploymentErrorCodes.INVALID_REQUEST_TYPE, reqType);
         }
       }
     } catch (PSAuthenticationFailedException af) {
@@ -2847,7 +2847,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         else {
           de =
               new PSDeployException(
-                  IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+                  DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
         }
 
         respDoc = PSXmlDocumentBuilder.createXmlDocument();
@@ -2947,7 +2947,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     if (!docFile.exists()) {
       Object[] args = {docDescription, docFile.getAbsolutePath()};
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
     }
 
     FileInputStream in = null;
@@ -2956,7 +2956,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       return PSXmlDocumentBuilder.createXmlDocument(in, false);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, PSExceptionUtils.getMessageForLog(e));
     } finally {
       if (in != null)
         try {
@@ -2976,7 +2976,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
   private void checkDepCount(int depCount, int maxCount) throws PSDeployException {
     if (depCount > maxCount) {
       throw new PSDeployException(
-          IPSDeploymentErrors.MAX_DEP_COUNT_EXCEEDED, String.valueOf(maxCount));
+          DeploymentErrorCodes.MAX_DEP_COUNT_EXCEEDED, String.valueOf(maxCount));
     }
   }
 
@@ -3024,7 +3024,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         Object[] args = {
           doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(e)
         };
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       }
     }
 
@@ -3037,7 +3037,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       Object[] args = {
         doc.getDocumentElement().getTagName(), PSExceptionUtils.getMessageForLog(une)
       };
-      throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     return dep;
@@ -3065,7 +3065,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
         exportDesc = new PSExportDescriptor(exportDescEl);
       } catch (PSUnknownNodeTypeException une) {
         Object[] args = {exportDescEl.getTagName(), PSExceptionUtils.getMessageForLog(une)};
-        throw new PSDeployException(IPSDeploymentErrors.SERVER_REQUEST_MALFORMED, args);
+        throw new PSDeployException(DeploymentErrorCodes.SERVER_REQUEST_MALFORMED, args);
       }
       exportDesc.clearMissingPackages();
     }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSExportJob.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSExportJob.java
@@ -34,7 +34,6 @@ import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
-import com.percussion.server.job.IPSJobErrors;
 import com.percussion.server.job.PSJobException;
 import com.percussion.services.pkginfo.PSPkgInfoServiceLocator;
 import com.percussion.services.pkginfo.data.PSPkgInfo;
@@ -45,6 +44,7 @@ import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 
 /**
  * Job to create a deployment archive from an export descriptor. Archive created will be named using
@@ -80,7 +80,7 @@ public class PSExportJob extends PSDeployJob {
         initDepCount(m_descriptor.getPackages());
       }
     } catch (PSDeployException | PSUnknownNodeTypeException e) {
-      throw new PSJobException(IPSJobErrors.INVALID_JOB_DESCRIPTOR, e.getMessage());
+      throw new PSJobException(JobErrorCodes.INVALID_JOB_DESCRIPTOR, e.getMessage());
     }
 
     m_serverVersion = new PSFormatVersion("com.percussion.util");
@@ -221,7 +221,7 @@ public class PSExportJob extends PSDeployJob {
       config = dh.getConfigTempFile(configRef);
       if (!config.exists() || !config.isFile()) {
         throw new PSJobException(
-            IPSJobErrors.CONFIG_FILE_NOT_FOUND, m_descriptor.getConfigDefFile());
+            JobErrorCodes.CONFIG_FILE_NOT_FOUND, m_descriptor.getConfigDefFile());
       }
       archive.storeFile(
           config, PSDescriptor.getConfigArchiveEntryPath(IPSConfigService.ConfigTypes.CONFIG_DEF));
@@ -231,7 +231,7 @@ public class PSExportJob extends PSDeployJob {
       config = dh.getConfigTempFile(configRef);
       if (!config.exists() || !config.isFile()) {
         throw new PSJobException(
-            IPSJobErrors.CONFIG_FILE_NOT_FOUND, m_descriptor.getLocalConfigFile());
+            JobErrorCodes.CONFIG_FILE_NOT_FOUND, m_descriptor.getLocalConfigFile());
       }
       archive.storeFile(
           config,

--- a/deployer/src/main/java/com/percussion/deployer/server/PSIdMapManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSIdMapManager.java
@@ -20,10 +20,10 @@ package com.percussion.deployer.server;
 
 import com.percussion.deployer.objectstore.PSIdMap;
 import com.percussion.deployer.objectstore.PSIdMapping;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import java.util.HashMap;
 import java.util.Map;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Manages saving and retrieving <code>PSIdMap</code> objects to and from memory. */
 public class PSIdMapManager {
@@ -77,7 +77,7 @@ public class PSIdMapManager {
       if (mapping.getTargetId() == null && !mapping.isNewObject()) {
         var args =
             new Object[] {map.getSourceServer(), mapping.getSourceId(), mapping.getSourceName()};
-        throw new PSDeployException(IPSDeploymentErrors.INVALID_SAVED_ID_MAP, args);
+        throw new PSDeployException(DeploymentErrorCodes.INVALID_SAVED_ID_MAP, args);
       }
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSIdTypeManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSIdTypeManager.java
@@ -24,7 +24,6 @@ import com.percussion.deployer.objectstore.idtypes.PSAppExtensionCallIdContext;
 import com.percussion.deployer.objectstore.idtypes.PSAppExtensionParamIdContext;
 import com.percussion.deployer.objectstore.idtypes.PSApplicationIdContext;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.IPSExtensionDef;
 import com.percussion.extension.PSExtensionDef;
@@ -42,6 +41,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to manage {@link PSApplicationIDTypes} maps for all applications. Handles saving and
@@ -72,7 +72,7 @@ public class PSIdTypeManager {
     try {
       return idTypeDoc != null ? new PSApplicationIDTypes(idTypeDoc.getDocumentElement()) : null;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -174,7 +174,7 @@ public class PSIdTypeManager {
         idTypes = new PSApplicationIDTypes(doc.getDocumentElement());
       } catch (PSUnknownNodeTypeException e) {
         Object[] args = {depKey, e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.ID_TYPE_MAP_LOAD, args);
+        throw new PSDeployException(DeploymentErrorCodes.ID_TYPE_MAP_LOAD, args);
       }
     } else {
       // if new map, create
@@ -224,7 +224,7 @@ public class PSIdTypeManager {
     try (var out = new FileOutputStream(mapFile)) {
       PSXmlDocumentBuilder.write(doc, out);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -302,7 +302,7 @@ public class PSIdTypeManager {
     try (var in = new FileInputStream(mapFile)) {
       return PSXmlDocumentBuilder.createXmlDocument(in, false);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSImportJob.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSImportJob.java
@@ -43,7 +43,6 @@ import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServerLockManager;
 import com.percussion.server.cache.PSCacheManager;
-import com.percussion.server.job.IPSJobErrors;
 import com.percussion.server.job.PSJobException;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -73,6 +72,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 
 /** Job to install objects from a deployment archive using an import descriptor. */
 public class PSImportJob extends PSDeployJob {
@@ -117,7 +117,7 @@ public class PSImportJob extends PSDeployJob {
       // init dependency count for status messages
       initDepCount();
     } catch (PSUnknownNodeTypeException | PSDeployException e) {
-      throw new PSJobException(IPSJobErrors.INVALID_JOB_DESCRIPTOR, e.getLocalizedMessage());
+      throw new PSJobException(JobErrorCodes.INVALID_JOB_DESCRIPTOR, e.getLocalizedMessage());
     }
   }
 
@@ -171,7 +171,7 @@ public class PSImportJob extends PSDeployJob {
     if (runException != null) {
       log.error("Install Archive error :", runException);
       PSJobException jobEx =
-          new PSJobException(IPSJobErrors.UNEXPECTED_ERROR, runException.getLocalizedMessage());
+          new PSJobException(JobErrorCodes.UNEXPECTED_ERROR, runException.getLocalizedMessage());
       runException = null;
       throw jobEx;
     }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSItemData.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSItemData.java
@@ -21,12 +21,12 @@ import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSTableRef;
 import com.percussion.design.objectstore.PSTableSet;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.tablefactory.PSJdbcTableData;
 import com.percussion.tablefactory.PSJdbcTableFactoryException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Iterator;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Encapsulates an item definition and Jdbc table data for a single table that is part of a content
@@ -56,7 +56,7 @@ public class PSItemData {
       var xmlDoc = PSXmlDocumentBuilder.createXmlDocument();
       m_tgtItemData = new PSJdbcTableData(itemData.toXml(xmlDoc));
     } catch (PSJdbcTableFactoryException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
@@ -34,7 +34,6 @@ import com.percussion.deployer.objectstore.PSLogSummary;
 import com.percussion.deployer.objectstore.PSTransactionLogSummary;
 import com.percussion.deployer.objectstore.PSTransactionSummary;
 import com.percussion.deployer.objectstore.PSValidationResults;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.server.PSServer;
 import com.percussion.tablefactory.PSJdbcColumnData;
@@ -55,6 +54,7 @@ import java.util.TreeMap;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Handles processing of all log table related operations for deployment. */
 public class PSLogHandler {
@@ -511,7 +511,7 @@ public class PSLogHandler {
       var compCtor = compClass.getConstructor(Element.class);
       return (IPSDeployComponent) compCtor.newInstance(root);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -529,7 +529,7 @@ public class PSLogHandler {
     var cdata = row.getColumn(column);
     if (cdata == null) {
       Object[] args = {table, column, "null"};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
     if (cdata.getValue() != null && !cdata.getValue().trim().isEmpty())
       return getColumnClob(table, column, row, compClass);
@@ -979,7 +979,7 @@ public class PSLogHandler {
 
     if (pkg.getValidationResults() == null) {
       Object[] args = {pkg.getPackage().getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_VALIDATION_RESULTS, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_VALIDATION_RESULTS, args);
     }
 
     PSIdMap idMap = importCtx.getCurrentIdMap();
@@ -1210,7 +1210,7 @@ public class PSLogHandler {
      boolean bEqualMan = srcManifest.equals(tgtManifest);
      if ((!bEqualMan) || (!bEqualPkgList) || asList.size()<=0)
      {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR,
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR,
            "Error retrieved archive info or manifest");
      }
 
@@ -1273,7 +1273,7 @@ public class PSLogHandler {
      List logList = PSDeployComponentUtils.cloneList(logIter);
      if (logList.size()<=0)
      {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR,
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR,
            "Error retrieved log summary (getLogSummarys()) <= 0");
      }
 
@@ -1283,7 +1283,7 @@ public class PSLogHandler {
      String archiveRef = srcInfo.getArchiveRef();
      lh.deleteAllLogs(archiveRef);
      if ( lh.doesArchiveRefExist(archiveRef) )
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR,
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR,
            "archiveRef should not exit in archive summary table");
   }
   */

--- a/deployer/src/main/java/com/percussion/deployer/server/PSPackageConfiguration.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSPackageConfiguration.java
@@ -20,7 +20,6 @@ package com.percussion.deployer.server;
 
 import com.percussion.deployer.server.dependencies.PSCustomDependencyHandler;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.ArrayList;
@@ -32,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * The configuration of the package tool. It contains all supported dependency mapping and the
@@ -97,7 +97,7 @@ public class PSPackageConfiguration {
     if (ignoreEl != null) {
       parseUninstallIgnoreTypes(ignoreEl);
     } else {
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_NUM_CHILD_DEFS);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_NUM_CHILD_DEFS);
     }
   }
 
@@ -187,18 +187,18 @@ public class PSPackageConfiguration {
       // make sure all deployable elements are included.
       Set<String> deployableTyeps = getDeplyableDefTypes();
       if (mi_deployableEls.size() != deployableTyeps.size()) {
-        throw new PSDeployException(IPSDeploymentErrors.INCOMPLATE_ORDER_DEF);
+        throw new PSDeployException(DeploymentErrorCodes.INCOMPLATE_ORDER_DEF);
       }
 
       // make sure all child of "Custom" element are included.
       if (mi_nonDepEls.keySet().size() != 1) {
-        throw new PSDeployException(IPSDeploymentErrors.INVALID_NUM_PARENT_DEFS);
+        throw new PSDeployException(DeploymentErrorCodes.INVALID_NUM_PARENT_DEFS);
       }
 
       String parentType = mi_nonDepEls.keySet().iterator().next();
       if (!parentType.equals(PSCustomDependencyHandler.DEPENDENCY_TYPE)) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_PARENT_TYPE,
+            DeploymentErrorCodes.UNEXPECTED_PARENT_TYPE,
             new String[] {parentType, PSCustomDependencyHandler.DEPENDENCY_TYPE});
       }
 
@@ -208,7 +208,7 @@ public class PSPackageConfiguration {
                 .size())
           {
              throw new PSDeployException(
-                   IPSDeploymentErrors.INVALID_NUM_CHILD_DEFS,
+                   DeploymentErrorCodes.INVALID_NUM_CHILD_DEFS,
                    PSCustomDependencyHandler.DEPENDENCY_TYPE);
           }
       */
@@ -274,7 +274,7 @@ public class PSPackageConfiguration {
 
     var objDef = m_depMap.getDependencyDef(objType);
     if (objDef == null) {
-      throw new PSDeployException(IPSDeploymentErrors.CANNOT_FIND_DEP_DEF, objType);
+      throw new PSDeployException(DeploymentErrorCodes.CANNOT_FIND_DEP_DEF, objType);
     }
 
     if (objDef.isDeployableElement()) {
@@ -282,16 +282,16 @@ public class PSPackageConfiguration {
     }
 
     if (StringUtils.isBlank(parentType)) {
-      throw new PSDeployException(IPSDeploymentErrors.DEP_DEF_NOT_DEPLOYABLE, objType);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_DEF_NOT_DEPLOYABLE, objType);
     }
 
     var parentDef = m_depMap.getDependencyDef(parentType);
     if (parentDef == null) {
-      throw new PSDeployException(IPSDeploymentErrors.CANNOT_FIND_PARENT_DEP_DEF, parentType);
+      throw new PSDeployException(DeploymentErrorCodes.CANNOT_FIND_PARENT_DEP_DEF, parentType);
     }
 
     if (!parentDef.isDeployableElement()) {
-      throw new PSDeployException(IPSDeploymentErrors.PARENT_DEP_DEF_NOT_DEPLOYABLE, parentType);
+      throw new PSDeployException(DeploymentErrorCodes.PARENT_DEP_DEF_NOT_DEPLOYABLE, parentType);
     }
 
     return new String[] {objType, parentType};

--- a/deployer/src/main/java/com/percussion/deployer/server/PSValidationJob.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSValidationJob.java
@@ -28,7 +28,6 @@ import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
-import com.percussion.server.job.IPSJobErrors;
 import com.percussion.server.job.PSJobException;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -39,6 +38,7 @@ import java.util.*;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 
 /**
  * Job to validate all packages in an import descriptor. Results are saved on the server and may be
@@ -79,7 +79,7 @@ public class PSValidationJob extends PSDeployJob {
       }
       initDepCount(pkgList.iterator(), false);
     } catch (PSUnknownNodeTypeException | PSDeployException e) {
-      throw new PSJobException(IPSJobErrors.INVALID_JOB_DESCRIPTOR, e.getLocalizedMessage());
+      throw new PSJobException(JobErrorCodes.INVALID_JOB_DESCRIPTOR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/IPSDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/IPSDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.PSAssemblyException;
@@ -36,6 +35,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Defines the contract for classes that discover, package, and install a single type of dependency
@@ -70,12 +70,12 @@ public interface IPSDependencyHandler {
         | IllegalAccessException
         | NoSuchMethodException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.DEPENDENCY_HANDLER_INIT,
+          DeploymentErrorCodes.DEPENDENCY_HANDLER_INIT,
           new Object[] {className, e.getLocalizedMessage()});
     } catch (InvocationTargetException e) {
       var origException = e.getTargetException();
       throw new PSDeployException(
-          IPSDeploymentErrors.DEPENDENCY_HANDLER_INIT,
+          DeploymentErrorCodes.DEPENDENCY_HANDLER_INIT,
           new Object[] {
             className,
             origException.getClass().getName() + ": " + origException.getLocalizedMessage()

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAclDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAclDefDependencyHandler.java
@@ -27,7 +27,6 @@ import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSDeploymentHandler;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSAclEntry;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.IPSTypedPrincipal;
 import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
@@ -51,6 +50,7 @@ import com.percussion.utils.guid.IPSGuid;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying an ACL definition. */
 public class PSAclDefDependencyHandler extends PSDependencyHandler {
@@ -164,7 +164,7 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
       acl = findAclByDependencyID(id);
     } catch (PSDeployException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for ACLEntry:" + id);
     }
     if (acl != null) {
@@ -218,7 +218,7 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
       str = acl.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for ACLEntry:" + acl.getName());
     }
 
@@ -270,7 +270,7 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -294,7 +294,7 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
     } catch (Exception e) {
       String err = e.getLocalizedMessage();
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create acl from file:" + depFile.getFile().getName() + " Error was:\n" + err);
     }
     return tmp;
@@ -402,7 +402,7 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
 
       } catch (NotOwnerException | PSServiceSecurityException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not install the ACL: " + tmp.getName());
+            DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not install the ACL: " + tmp.getName());
       }
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAppObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAppObjectDependencyHandler.java
@@ -37,7 +37,6 @@ import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
 import com.percussion.design.objectstore.server.PSXmlObjectStoreLockerId;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.error.PSNotLockedException;
@@ -66,6 +65,7 @@ import java.util.StringTokenizer;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Base class for handlers that deploy application objects. */
 public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHandler {
@@ -98,10 +98,10 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
     } catch (PSNotFoundException e) {
       // rethrow an exception
       Object[] args = {appName};
-      throw new PSDeployException(IPSDeploymentErrors.APP_DEFINITION_DOESNOT_EXIST, args);
+      throw new PSDeployException(DeploymentErrorCodes.APP_DEFINITION_DOESNOT_EXIST, args);
     } catch (Exception e) {
       // all others are bad
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
     return app;
   }
@@ -153,7 +153,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       try {
         call = new PSExtensionCall(callEl, null, null);
       } catch (PSUnknownNodeTypeException e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
 
       var ref = call.getExtensionRef();
@@ -216,7 +216,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       try {
         urlReq = new PSUrlRequest(urlEl, null, null);
       } catch (PSUnknownNodeTypeException e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
 
       var href = urlReq.getHref();
@@ -260,7 +260,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
         lit = new PSTextLiteral(litEl, null, null);
       } catch (PSUnknownNodeTypeException e) {
         // unlikely
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
 
       String litVal = lit.getText();
@@ -312,7 +312,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       rxGlobals = new PSRxGlobals(null);
     } catch (IOException | org.xml.sax.SAXException e) {
       // wrap in deploy exception so caller handles
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
     boolean hasGlobals = false;
     for (Element sheetEl : sheetNodeList) {
@@ -480,7 +480,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
     if (appName == null) {
       // couldn't have gotten here in this case, but in case its a bug...
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Cannot get appname from path: " + dep.getDependencyId());
     }
 
@@ -501,7 +501,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
         | PSNotLockedException e) {
 
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Cannot save application from path: "
               + dep.getDependencyId()
               + "Error: "
@@ -511,7 +511,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
         os.releaseApplicationLock(lockId, appName + "-" + origFile.getName());
       } catch (PSServerException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Cannot release Application lock  "
                 + dep.getDependencyId()
                 + "Error: "
@@ -563,7 +563,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
 
       return appFiles.iterator();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -592,7 +592,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       return createXmlDocument(os.getApplicationFile(appName, appFile, tok));
     } catch (Exception e) {
       Object[] args = {appFile, appName, e.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.APP_FILE_LOAD, args);
+      throw new PSDeployException(DeploymentErrorCodes.APP_FILE_LOAD, args);
     }
   }
 
@@ -622,7 +622,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       }
       return tmpFile;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandler.java
@@ -63,7 +63,6 @@ import com.percussion.design.objectstore.PSWhereClause;
 import com.percussion.design.objectstore.server.PSApplicationSummary;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
 import com.percussion.design.objectstore.server.PSXmlObjectStoreLockerId;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSServer;
@@ -79,6 +78,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying an application. */
 public class PSApplicationDependencyHandler extends PSContentEditorObjectDependencyHandler
@@ -253,7 +253,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
 
       return files.iterator();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -300,7 +300,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
 
       return infoList;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
   }
 
@@ -342,7 +342,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     PSServerXmlObjectStore os = PSServerXmlObjectStore.getInstance();
@@ -467,7 +467,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
     } catch (PSDeployException e) {
       throw e;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     } finally {
       if (lockId != null) {
         try {
@@ -661,7 +661,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
         }
       }
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return idTypes;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAssemblyServiceHelper.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAssemblyServiceHelper.java
@@ -16,7 +16,6 @@
  */
 package com.percussion.deployer.server.dependencies;
 
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.security.error.PSExceptionUtils;
@@ -43,6 +42,7 @@ import javax.jcr.RepositoryException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * A helper class for the new templates, slots, bindings, contentlists etc to use
@@ -115,7 +115,7 @@ public class PSAssemblyServiceHelper {
       templates = m_assemblySvc.findAllTemplates();
     } catch (PSAssemblyException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Assembly exception occurred while cataloging Templates");
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAuthTypeDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAuthTypeDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSEntry;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSException;
 import com.percussion.security.PSSecurityToken;
@@ -43,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying authtypes. */
 public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
@@ -166,7 +166,7 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
 
       return result;
     } catch (PSException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -234,7 +234,7 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
       props.load(in);
       return props;
     } catch (IOException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCmsObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCmsObjectDependencyHandler.java
@@ -33,7 +33,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
@@ -48,6 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Base class to provide utility methods for all handlers deploying cms objects. */
 public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHandler {
@@ -100,7 +100,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
 
     if (id == null || id.trim().length() == 0) {
       Object[] args = {name, comp.getComponentType()};
-      throw new PSDeployException(IPSDeploymentErrors.EXTRACT_ID_FROM_KEY, args);
+      throw new PSDeployException(DeploymentErrorCodes.EXTRACT_ID_FROM_KEY, args);
     }
 
     return id;
@@ -134,7 +134,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
     }
     if (mapping == null) {
       Object[] args = {dep.getObjectType(), dep.getDependencyId(), idMap.getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     if (mapping.isNewObject() && (mapping.getTargetId() == null)) {
@@ -145,7 +145,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         proc.assignKey(new IPSDbComponent[] {comp}, null);
       } catch (PSCmsException e) {
         Object[] args = {dep.getDisplayName(), dep.getObjectTypeName(), e.getLocalizedMessage()};
-        throw new PSDeployException(IPSDeploymentErrors.EXTRACT_ID_FROM_KEY, args);
+        throw new PSDeployException(DeploymentErrorCodes.EXTRACT_ID_FROM_KEY, args);
       }
 
       String id = getIdFromKey(comp, dep.getDisplayName());
@@ -155,7 +155,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         PSIdMapping parentMapping = idMap.getMapping(dep.getParentId(), dep.getParentType());
         if (parentMapping == null) {
           Object[] args = {dep.getParentType(), dep.getParentId(), idMap.getSourceServer()};
-          throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+          throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
         }
 
         mapping.setTarget(
@@ -210,7 +210,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     return files;
@@ -241,7 +241,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         PSDependencyFile.TYPE_ENUM[file.getType()],
         PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_COMPONENT_XML]
       };
-      throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+      throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
     }
 
     Element root = doc.getDocumentElement();
@@ -253,7 +253,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         dep.getDisplayName(),
         "Null document root"
       };
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_DEPENDENCY_FILE, args);
     }
 
     return root;
@@ -443,7 +443,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
         m_componentProcessor =
             new PSComponentProcessorProxy(PSComponentProcessorProxy.PROCTYPE_SERVERLOCAL, req);
       } catch (PSCmsException e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     } else {
       m_componentProcessor.setProcessorContext(req);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -57,6 +56,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.naming.NamingException;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a community definition. */
 public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandler {
@@ -273,7 +273,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
     } catch (Exception e) {
       Object[] args = {dep.getDisplayName()};
       throw new PSDeployException(
-          IPSDeploymentErrors.FAILED_TO_CREATE_COMPONENT_COMMUNITY_ASSNS, e, args);
+          DeploymentErrorCodes.FAILED_TO_CREATE_COMPONENT_COMMUNITY_ASSNS, e, args);
     }
   }
 
@@ -353,7 +353,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
     Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {
@@ -418,7 +418,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
     Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {
@@ -489,7 +489,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
     Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -40,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a component definition. */
 public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandler {
@@ -238,7 +238,7 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
     List<PSJdbcRowData> rows = PSDeployComponentUtils.cloneList(srcData.getRows());
 
     if (rows.isEmpty()) // not expecting no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     int[] ids = PSDbmsHelper.getNextIdBlock(COMPPROP_NEXTNUMBER_ID, rows.size());
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentSlotDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentSlotDependencyHandler.java
@@ -27,7 +27,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -39,6 +38,7 @@ import com.percussion.tablefactory.PSJdbcTableSchema;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a component slot */
 public class PSComponentSlotDependencyHandler extends PSPairIdDependencyHandler {
@@ -192,7 +192,7 @@ public class PSComponentSlotDependencyHandler extends PSPairIdDependencyHandler 
     List<PSJdbcRowData> rows = PSDeployComponentUtils.cloneList(srcData.getRows());
 
     if (rows.isEmpty()) // not expecting no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     // get the source row
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentDefDependencyHandler.java
@@ -44,7 +44,6 @@ import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.search.PSSearchIndexEventQueue;
 import com.percussion.security.PSSecurityToken;
@@ -72,6 +71,7 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a content definition. */
 public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
@@ -330,7 +330,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
           new Object[] {
             "Any", PSCEDependencyHandler.DEPENDENCY_TYPE, dep.getDependencyId(), dep.getObjectType()
           };
-      throw new PSDeployException(IPSDeploymentErrors.CHILD_DEP_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.CHILD_DEP_NOT_FOUND, args);
     }
 
     // tranform content type id if required
@@ -344,7 +344,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
           PSItemDefManager.getInstance()
               .getItemDef(ctypeId, PSRequest.getContextForRequest().getSecurityToken());
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // install the table schema and data for all item tables
@@ -415,7 +415,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
       String value = cacheData.get(CACHED_COLS[i]);
       if (value == null || value.trim().length() == 0) {
         String[] args = new String[] {newContentId, CACHED_COLS[i], CONTENT_TABLE};
-        throw new PSDeployException(IPSDeploymentErrors.MISSING_REQUIRED_CACHE_DATA, args);
+        throw new PSDeployException(DeploymentErrorCodes.MISSING_REQUIRED_CACHE_DATA, args);
       }
     }
 
@@ -461,7 +461,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
       itemDef =
           PSItemDefManager.getInstance().getItemDef(new PSLocator(dep.getDependencyId()), adminTok);
     } catch (PSInvalidContentTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // walk fields and check to ID type support, recurse into children
@@ -553,7 +553,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
 
       return tableData.iterator();
     } catch (PSInvalidContentTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -634,7 +634,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
       }
     } else // not expecting no rows
     {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     return new PSJdbcTableData(CONTENT_TABLE, tgtRowList.iterator());
@@ -656,7 +656,7 @@ public class PSContentDefDependencyHandler extends PSDataObjectDependencyHandler
     Iterator<PSJdbcRowData> rows = data.getRows();
 
     if (!rows.hasNext()) {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentEditorObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentEditorObjectDependencyHandler.java
@@ -30,7 +30,6 @@ import com.percussion.design.objectstore.PSTableRef;
 import com.percussion.design.objectstore.PSTableSet;
 import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUISet;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSServer;
@@ -38,6 +37,7 @@ import com.percussion.services.error.PSNotFoundException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Base class for handlers that deploy content editor objects. */
 public abstract class PSContentEditorObjectDependencyHandler extends PSAppObjectDependencyHandler {
@@ -192,7 +192,7 @@ public abstract class PSContentEditorObjectDependencyHandler extends PSAppObject
         String elementName = dep.getDisplayName();
         String controlName = ctrlDep.getDisplayName();
         Object[] args = {elementName, controlName};
-        throw new PSDeployException(IPSDeploymentErrors.CONTROL_NOT_PACKAGEABLE, args);
+        throw new PSDeployException(DeploymentErrorCodes.CONTROL_NOT_PACKAGEABLE, args);
       }
     }
   }
@@ -276,7 +276,7 @@ public abstract class PSContentEditorObjectDependencyHandler extends PSAppObject
       // result of shared def not loading, server will have already logged
       // an error for this.
       Object[] args = {"Cannot load shared def"};
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, args);
     }
     return sharedDef;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentListDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentListDefDependencyHandler.java
@@ -31,7 +31,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSParam;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.PSExtensionRef;
 import com.percussion.security.PSSecurityToken;
@@ -57,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a ContentList definition.
@@ -244,7 +244,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
         if (ruleDep != null && !childDeps.contains(ruleDep)) childDeps.add(ruleDep);
       } catch (PSFilterException | PSNotFoundException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "While creating the Filter dependency, "
                 + "a FilterException occurred: "
                 + e.getLocalizedMessage());
@@ -318,7 +318,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       str = cList.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Template:" + cList.getName());
     }
 
@@ -342,7 +342,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       m_publisherSvc.saveContentLists(lists);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not save or update the content list:"
               + cList.getName()
               + "\n"
@@ -416,7 +416,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       cList.fromXML(tmpStr);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not deserialize the ContentList");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not deserialize the ContentList");
     }
     return cList;
   }
@@ -447,7 +447,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -529,7 +529,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
     IPSContentList cList = findContentListByDependencyID(dep.getDependencyId());
     if (cList == null)
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not locate the content list for idTyping");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not locate the content list for idTyping");
     if (isLegacyContentList(cList)) return getIdTypesForLegacyContentList(tok, dep, cList);
 
     PSApplicationIDTypes idTypes = new PSApplicationIDTypes(dep);
@@ -589,7 +589,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       }
     } catch (PSFilterException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "While processing id types for contentlist encountered a" + "a filter exception");
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentRelationDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentRelationDependencyHandler.java
@@ -51,7 +51,6 @@ import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSRelationshipSet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
@@ -79,6 +78,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a content relation definition. */
 public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandler
@@ -382,11 +382,11 @@ public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandle
         }
       }
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSInternalRequestCallException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -526,7 +526,7 @@ public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandle
 
           if (newId == null) {
             Object[] args = {PSFolderDefDependencyHandler.DEPENDENCY_TYPE, value};
-            throw new PSDeployException(IPSDeploymentErrors.SERVER_OBJECT_NOT_FOUND, args);
+            throw new PSDeployException(DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND, args);
           }
         } else {
           PSIdMapping mapping = getIdMapping(ctx, value, type);
@@ -590,7 +590,7 @@ public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandle
 
       return modifiedSet;
     } catch (PSInvalidContentTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -751,7 +751,7 @@ public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandle
       }
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e.fillInStackTrace();
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -781,7 +781,7 @@ public class PSContentRelationDependencyHandler extends PSIdTypeDependencyHandle
 
       return relSet.iterator();
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
@@ -53,7 +53,6 @@ import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.PSWorkflowInfo;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.security.error.PSExceptionUtils;
@@ -93,6 +92,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a content type definition. */
 public class PSContentTypeDependencyHandler extends PSContentEditorObjectDependencyHandler
@@ -241,7 +241,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
         t = assemblySvc.loadTemplate(guid, false);
       } catch (PSAssemblyException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Unable to load template while catalogging ContentType "
                 + "dependencies\n"
                 + e.getLocalizedMessage());
@@ -276,7 +276,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
     var appName = PSDependencyUtils.getColumnAppName(((PSNodeDefinition) node).getNewRequest());
     if (appName == null || appName.isBlank()) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, "App name was null");
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, "App name was null");
     }
     childDeps.addAll(getCEChildDependencies(tok, appName));
 
@@ -321,7 +321,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       PSXmlDocumentBuilder.replaceRoot(doc, elem);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Template:" + item.getName());
     }
     return new PSDependencyFile(PSDependencyFile.TYPE_ITEM_DEFINITION, createXmlFile(doc));
@@ -342,7 +342,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       str = node.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for NodeDefinition:" + node.getName());
     }
 
@@ -376,7 +376,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -475,7 +475,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
         PSDependencyFile.TYPE_ENUM[depFile.getType()],
         PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_ITEM_DEFINITION]
       };
-      throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+      throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
     }
 
     try {
@@ -487,7 +487,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
     } catch (PSUnknownNodeTypeException e) {
       String err = e.getLocalizedMessage();
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create template from file:"
               + depFile.getFile().getName()
               + " Error was:\n"
@@ -524,7 +524,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
     } catch (Exception e) {
       String err = e.getLocalizedMessage();
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create NodeDefinition from file:" + f.getName() + " Error was:\n" + err);
     }
     return node;
@@ -556,7 +556,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       guidval = Integer.parseInt(clMapping.getTargetId());
     } catch (NumberFormatException ne) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, " was expecting an int value: ");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, " was expecting an int value: ");
     }
 
     item.setTypeId(guidval);
@@ -655,7 +655,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       mgr.saveNodeDefinitions(nodes);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not save or update the slot:" + s.getName() + "\n" + e1.getLocalizedMessage());
     }
   }
@@ -714,7 +714,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       tmpSet = aSvc.findAllTemplates();
     } catch (PSAssemblyException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "catalogging templates failed");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "catalogging templates failed");
     }
 
     for (IPSAssemblyTemplate tmp : tmpSet) tmpGuids.add(String.valueOf(tmp.getGUID().longValue()));
@@ -738,7 +738,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
     PSIdMap idMap = ctx.getCurrentIdMap();
     if (idMap == null)
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, "PSIdMap cannot be null");
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, "PSIdMap cannot be null");
 
     IPSGuid nodeGuid = new PSGuid(PSTypeEnum.NODEDEF, id);
     Set<String> tmpGuids = catalogTemplates();
@@ -924,7 +924,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       throws PSDeployException {
     if (itemFile == null)
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "could not locate the item definition file in the archive");
 
     boolean isNew = curVer == -1;
@@ -1031,7 +1031,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       String detail = PSExceptionUtils.getMessageForLog(e);
       log.error("Error occurred while installing content type:{} — {}", appname, detail, e);
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Error occurred while installing content type:" + appname + "\n Error was: " + detail);
     }
 
@@ -1087,7 +1087,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       item = PSContentTypeHelper.loadItemDef(node.getGUID());
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Error occurred while cataloging this contenttype:"
               + node.getName()
               + "Error was: "
@@ -1127,7 +1127,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
       } catch (Exception e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Error occurred while cataloging this contenttype:"
                 + node.getName()
                 + "Error was: "
@@ -1324,7 +1324,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
         }
       }
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
     return idTypes;
   }
@@ -1358,7 +1358,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       } catch (Exception e) {
         String msg = "\n Error was:" + e.getLocalizedMessage();
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Could not locate CE application:" + appName + msg);
       }
     return app;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeTemplateDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeTemplateDefDependencyHandler.java
@@ -22,7 +22,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import javax.jcr.RepositoryException;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a template definition. Adds relations to
@@ -83,7 +83,7 @@ public class PSContentTypeTemplateDefDependencyHandler extends PSDependencyHandl
       nodeDefs = contentMgr.findAllItemNodeDefinitions();
     } catch (RepositoryException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "RepositoryException occurred");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "RepositoryException occurred");
     }
 
     var def =
@@ -106,7 +106,7 @@ public class PSContentTypeTemplateDefDependencyHandler extends PSDependencyHandl
       return new PSGuid(type, guidValue);
     } catch (NumberFormatException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Expected a long value: " + id);
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Expected a long value: " + id);
     }
   }
 
@@ -173,7 +173,7 @@ public class PSContentTypeTemplateDefDependencyHandler extends PSDependencyHandl
       contentMgr.saveNodeDefinitions(List.of(nodeDef));
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Error installing dependency: " + e.getLocalizedMessage());
     }
   }
@@ -199,7 +199,7 @@ public class PSContentTypeTemplateDefDependencyHandler extends PSDependencyHandl
       tmp.fromXML(tmpStr);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create template from file:" + f.getName());
     }
     return tmp;
@@ -231,7 +231,7 @@ public class PSContentTypeTemplateDefDependencyHandler extends PSDependencyHandl
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -43,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a context definition. */
 public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
@@ -153,7 +153,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
     IPSPublishingContext context = findPublishingContext(depId);
     if (context == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     files.add(getDepFileFromContext(context));
@@ -216,7 +216,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
       depSvc.installDependencyFiles(tok, archive, dep, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing context: " + e.getLocalizedMessage());
     }
   }
@@ -271,7 +271,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
       addTransactionLogEntryByGuidType(dep, ctx, PSTypeEnum.CONTEXT, isNew);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing context: " + e.getLocalizedMessage());
     }
@@ -291,7 +291,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
     var context = findPublishingContext(dep.getDependencyId());
     if (context == null) {
       throw new PSDeployException(
-          IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+          DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
           new Object[] {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()});
     }
 
@@ -322,7 +322,7 @@ public class PSContextDefDependencyHandler extends PSDataObjectDependencyHandler
       str = ((PSPublishingContext) context).toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Context:" + context.getName());
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSControlDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSControlDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.design.objectstore.PSControlMeta;
 import com.percussion.design.objectstore.PSControlParameter;
 import com.percussion.design.objectstore.PSFileDescriptor;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSCustomControlManager;
@@ -40,6 +39,7 @@ import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a content editor control. */
 public class PSControlDependencyHandler extends PSAppObjectDependencyHandler {
@@ -283,7 +283,7 @@ public class PSControlDependencyHandler extends PSAppObjectDependencyHandler {
 
       return controls;
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataDependencyHandler.java
@@ -24,7 +24,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -40,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying both schema and data */
 public class PSDataDependencyHandler extends PSSchemaDependencyHandler {
@@ -144,7 +144,7 @@ public class PSDataDependencyHandler extends PSSchemaDependencyHandler {
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     // convert docs to objects
@@ -169,7 +169,7 @@ public class PSDataDependencyHandler extends PSSchemaDependencyHandler {
         dep.getDisplayName(),
         e.getLocalizedMessage()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     boolean exists = doesDependencyExist(tok, dep.getDependencyId());

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataObjectDependencyHandler.java
@@ -30,7 +30,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -56,6 +55,7 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * The parent class for all data object definition handlers. These are handlers for dependencies
@@ -574,7 +574,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     }
     if (mapping == null) {
       Object[] args = {dep.getObjectType(), dep.getDependencyId(), idMap.getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     if (mapping.isNewObject() && (mapping.getTargetId() == null)) {
@@ -583,7 +583,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
         PSIdMapping parentMapping = idMap.getMapping(dep.getParentId(), dep.getParentType());
         if (parentMapping == null) {
           Object[] args = {dep.getParentType(), dep.getParentId(), idMap.getSourceServer()};
-          throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+          throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
         }
 
         String tgtParentId = parentMapping.getTargetId();
@@ -727,7 +727,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
 
     if (isDataRequired && (data == null || !data.getRows().hasNext())) {
       throw new PSDeployException(
-          IPSDeploymentErrors.CANNOT_FIND_DATA, new Object[] {table, filter.toString()});
+          DeploymentErrorCodes.CANNOT_FIND_DATA, new Object[] {table, filter.toString()});
     }
 
     return data != null && data.getRows().hasNext() ? new PSDependencyData(schema, data) : null;
@@ -760,7 +760,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
         PSDependencyFile.TYPE_ENUM[file.getType()],
         PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_DBMS_DATA]
       };
-      throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+      throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
     }
 
     // convert docs to objects
@@ -769,7 +769,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     try {
       depData = new PSDependencyData(dataDoc.getDocumentElement(), typeMap);
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return depData;
@@ -916,7 +916,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
       tgtRowList.add(tgtRow);
     } else // no rows
     {
-      throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+      throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
     }
 
     PSJdbcTableData newData = new PSJdbcTableData(tableName, tgtRowList.iterator());
@@ -950,7 +950,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -1136,7 +1136,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     if (cdata == null) // the column not exist
     {
       Object[] args = {table, col, "null"};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
     if (cdata.getValue() != null && cdata.getValue().trim().length() == 0) return null;
     else return cdata.getValue();
@@ -1163,7 +1163,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     String val = getColumnValueNullable(table, col, row);
     if (val == null) {
       Object[] args = {table, col, "null"};
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_REPOSITORY_COLUMN_VALUE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_REPOSITORY_COLUMN_VALUE, args);
     }
 
     return val;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyHandler.java
@@ -19,7 +19,6 @@ package com.percussion.deployer.server.dependencies;
 
 import com.percussion.deployer.objectstore.*;
 import com.percussion.deployer.server.*;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.PSAssemblyException;
@@ -37,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Base class for all dependency handlers. A dependency handler is the runtime handler for an
@@ -111,12 +111,12 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
         | IllegalAccessException
         | NoSuchMethodException cnfe) {
       Object[] args = {className, cnfe.getLocalizedMessage()};
-      throw new PSDeployException(IPSDeploymentErrors.DEPENDENCY_HANDLER_INIT, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEPENDENCY_HANDLER_INIT, args);
     } catch (InvocationTargetException ite) {
       Throwable origException = ite.getTargetException();
       String msg = origException.getLocalizedMessage();
       Object[] args = {className, origException.getClass().getName() + ": " + msg};
-      throw new PSDeployException(IPSDeploymentErrors.DEPENDENCY_HANDLER_INIT, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEPENDENCY_HANDLER_INIT, args);
     } catch (IllegalArgumentException iae) {
       // this should never happen because we checked ahead of time
       throw new RuntimeException("Ctor args failed validation: " + iae.getLocalizedMessage());
@@ -334,7 +334,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
     try {
       acl = (PSAclImpl) m_aclSvc.loadAclForObject(guid);
     } catch (com.percussion.services.security.PSServiceSecurityException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e);
     }
 
     if (acl != null) {
@@ -777,7 +777,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
         return xmlFile;
       }
     } catch (IOException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
   }
 
@@ -807,7 +807,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
         return xmlFile;
       }
     } catch (IOException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
   }
 
@@ -846,7 +846,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
       if (sourceIdentity != null && !sourceIdentity.isBlank()) {
         msg = msg + " [archive file: " + sourceIdentity + "]";
       }
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, msg);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, msg);
     } finally {
       try {
         in.close();
@@ -940,7 +940,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
       mapping = getIdMapping(map, id, type, parentId, parentType);
       if (mapping.getTargetId() == null) {
         Object[] args = {mapping.getObjectType(), mapping.getSourceId(), map.getSourceServer()};
-        throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+        throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
       }
     }
 
@@ -995,7 +995,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
     mapping = idMap.getMapping(id, type, parentId, parentType);
     if (mapping == null) {
       Object[] args = {type, id, idMap.getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     return mapping;
@@ -1044,10 +1044,10 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
     // that is acceptable, set the idMapping and continue.
     // Any other exception should be rethrown.
     catch (PSDeployException de) {
-      if (de.getErrorCode() == IPSDeploymentErrors.MISSING_ID_MAPPING) {
+      if (de.getErrorCode() == DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode()) {
         idMapping = null;
       } else {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR);
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR);
       }
     } catch (PSNotFoundException e) {
       throw new PSDeployException(0);
@@ -1144,7 +1144,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
     if (childDep == null) {
       Object[] args = {childId, childObjType, dep.getDependencyId(), dep.getObjectType()};
 
-      throw new PSDeployException(IPSDeploymentErrors.CHILD_DEP_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.CHILD_DEP_NOT_FOUND, args);
     }
 
     return childDep;
@@ -1215,7 +1215,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
       PSDependency childDep = getChildDependency(dep, childId, childObjType);
       isIncluded = childDep.isIncluded();
     } catch (PSDeployException e) {
-      if (e.getErrorCode() != IPSDeploymentErrors.CHILD_DEP_NOT_FOUND) {
+      if (e.getErrorCode() != DeploymentErrorCodes.CHILD_DEP_NOT_FOUND.numericCode()) {
         throw e;
       }
     }
@@ -1321,7 +1321,7 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
       in = new FileInputStream(file);
       return PSXmlDocumentBuilder.createXmlDocument(in, false);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (in != null)
         try {

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyUtils.java
@@ -34,7 +34,6 @@ import com.percussion.design.objectstore.PSDataSet;
 import com.percussion.design.objectstore.PSSharedFieldGroup;
 import com.percussion.design.objectstore.PSTableRef;
 import com.percussion.design.objectstore.PSTableSet;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.security.error.PSExceptionUtils;
@@ -77,6 +76,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * A util class with ALL static methods to help in new GUID type create/install actions
@@ -110,7 +110,7 @@ public class PSDependencyUtils {
       guidval = Long.parseLong(depId);
     } catch (NumberFormatException ne) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           depTypeName + " was expecting a long value: " + depId);
     }
     return guidval;
@@ -170,7 +170,7 @@ public class PSDependencyUtils {
     }
     if (mapping == null) {
       Object[] args = {dep.getObjectType(), dep.getDependencyId(), idMap.getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     // this is a new mapping, but a target id was not chosen in the GUI
@@ -178,7 +178,7 @@ public class PSDependencyUtils {
       String nextId = PSDependencyUtils.getNextId(dep);
       if (nextId == null)
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "NextID generator returned null for " + dep.getDisplayName());
       mapping.setTarget(nextId, dep.getDisplayName());
     }
@@ -249,7 +249,7 @@ public class PSDependencyUtils {
       guidval = Long.parseLong(clMapping.getTargetId());
     } catch (NumberFormatException ne) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, " was expecting a long value: ");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, " was expecting a long value: ");
     }
 
     guid = new PSGuid(type, guidval);
@@ -273,7 +273,7 @@ public class PSDependencyUtils {
 
     if (appName == null || appName.trim().length() == 0) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not extract any application name");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not extract any application name");
     }
     return appName;
   }
@@ -336,7 +336,7 @@ public class PSDependencyUtils {
 
     } catch (IOException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Problem reading the dependency file: " + depFile.getArchiveLocation().getName());
     } finally {
       if (in != null) {
@@ -370,7 +370,7 @@ public class PSDependencyUtils {
     try {
       m = dep.getIdMapping(ctx, tmpId, PSTemplateDefDependencyHandler.DEPENDENCY_TYPE);
     } catch (PSDeployException dex) {
-      if (dex.getErrorCode() == IPSDeploymentErrors.MISSING_ID_MAPPING) {
+      if (dex.getErrorCode() == DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode()) {
         // try as a variant . . .
         m = dep.getIdMapping(ctx, tmpId, PSVariantDefDependencyHandler.DEPENDENCY_TYPE);
       }
@@ -474,7 +474,7 @@ public class PSDependencyUtils {
       // result of shared def not loading, server will have already logged
       // an error for this.
       Object[] args = {"Cannot load shared def"};
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, args);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, args);
     }
     return sharedDef;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDisplayFormatDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDisplayFormatDefDependencyHandler.java
@@ -33,7 +33,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -42,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a display format definition. */
 public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHandler {
@@ -69,7 +69,7 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
     var df = loadDisplayFormat(getComponentProcessor(tok), dep.getDependencyId());
     if (df == null) {
       throw new PSDeployException(
-          IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+          DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
           new Object[] {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()});
     }
 
@@ -199,7 +199,7 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
               : PSTransactionSummary.ACTION_MODIFIED;
       addTransactionLogEntry(dep, ctx, newDispFormat, action);
     } catch (PSCmsException | PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -229,9 +229,9 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
 
       return df;
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -283,7 +283,7 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
   //      }
   //      catch (Exception e)
   //      {
-  //         throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e
+  //         throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e
   //               .getLocalizedMessage());
   //      }
   //      return df;
@@ -322,7 +322,7 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
 
       return result.iterator();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -364,7 +364,7 @@ public class PSDisplayFormatDefDependencyHandler extends PSCmsObjectDependencyHa
       PSDisplayFormat df = new PSDisplayFormat();
       reserveNewId(dep, idMap, df);
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionDefDependencyHandler.java
@@ -29,7 +29,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -47,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a edition definition. */
 public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
@@ -208,7 +208,7 @@ public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
     IPSEdition edition = findEditionByDependencyID(edId);
     if (edition == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     files.add(getDepFileFromEdition(edition));
@@ -226,7 +226,7 @@ public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
       }
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "Unable to generate an edition content list dependency file "
               + "for Edition: "
@@ -257,7 +257,7 @@ public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
       depSvc.installDependencyFiles(tok, archive, dep, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing edition: " + e.getLocalizedMessage());
     }
   }
@@ -332,7 +332,7 @@ public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
       addTransactionLogEntryByGuidType(dep, ctx, PSTypeEnum.EDITION, isNew);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing edition: " + e.getLocalizedMessage());
     }
@@ -450,7 +450,7 @@ public class PSEditionDefDependencyHandler extends PSDataObjectDependencyHandler
       str = ((PSEdition) edition).toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Edition:" + edition.getName());
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionTaskDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionTaskDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.PSExtensionRef;
 import com.percussion.security.PSSecurityToken;
@@ -44,6 +43,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying an edition task. */
 public class PSEditionTaskDefDependencyHandler extends PSDataObjectDependencyHandler
@@ -191,7 +191,7 @@ public class PSEditionTaskDefDependencyHandler extends PSDataObjectDependencyHan
     IPSEditionTaskDef task = findEditionTask(dep.getDependencyId());
     if (task == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     files.add(getDepFileFromEditionTask(task));
@@ -216,7 +216,7 @@ public class PSEditionTaskDefDependencyHandler extends PSDataObjectDependencyHan
       depSvc.installDependencyFiles(tok, archive, dep, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing edition task: " + e.getLocalizedMessage());
     }
   }
@@ -257,7 +257,7 @@ public class PSEditionTaskDefDependencyHandler extends PSDataObjectDependencyHan
       str = ((PSEditionTaskDef) task).toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Edition Task:" + task.getExtensionName());
     }
 
@@ -353,7 +353,7 @@ public class PSEditionTaskDefDependencyHandler extends PSDataObjectDependencyHan
       addTransactionLogEntryByGuidType(dep, ctx, PSTypeEnum.EDITION_TASK_DEF, isNew);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing edition task: " + e.getLocalizedMessage());
     }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSExitDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSExitDefDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSExtensionDef;
@@ -49,6 +48,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying an exit defintion. */
 public class PSExitDefDependencyHandler extends PSDependencyHandler {
@@ -85,7 +85,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
     try {
       def = m_extMgr.getExtensionDef(new PSExtensionRef(dep.getDependencyId()));
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // Check for app deps
@@ -166,7 +166,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
     } catch (Exception e) {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return fileList.iterator();
@@ -212,7 +212,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     try {
@@ -240,7 +240,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
       if (e instanceof PSDeployException) throw (PSDeployException) e;
       else
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, e, e.getLocalizedMessage());
+            DeploymentErrorCodes.UNEXPECTED_ERROR, e, e.getLocalizedMessage());
     }
   }
 
@@ -264,9 +264,9 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
       }
 
     } catch (PSNotFoundException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSExtensionException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return deps.iterator();
@@ -290,9 +290,9 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
       }
     } catch (PSNotFoundException e) {
       // should not happen if doesDependencyExist returns true
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSExtensionException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return dep;
@@ -318,7 +318,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
         }
       }
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -357,7 +357,7 @@ public class PSExitDefDependencyHandler extends PSDependencyHandler {
     try {
       exists = m_extMgr.exists(new PSExtensionRef(id));
     } catch (PSExtensionException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return exists;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFileDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFileDependencyHandler.java
@@ -24,7 +24,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSServer;
@@ -36,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Base class for handlers that package and install files directly to and from the file system. */
 public abstract class PSFileDependencyHandler extends PSDependencyHandler {
@@ -83,7 +83,7 @@ public abstract class PSFileDependencyHandler extends PSDependencyHandler {
             PSDeployComponentUtils.getNormalizedPath(dep.getDependencyId()));
     if (!depFile.exists()) {
       throw new PSDeployException(
-          IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+          DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
           new Object[] {dep.getObjectTypeName(), dep.getDependencyId(), dep.getDisplayName()});
     }
 
@@ -106,7 +106,7 @@ public abstract class PSFileDependencyHandler extends PSDependencyHandler {
     Iterator<PSDependencyFile> files = archive.getFiles(dep);
     if (!files.hasNext()) {
       throw new PSDeployException(
-          IPSDeploymentErrors.MISSING_DEPENDENCY_FILE,
+          DeploymentErrorCodes.MISSING_DEPENDENCY_FILE,
           new Object[] {
             PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_SUPPORT_FILE],
             dep.getObjectType(),
@@ -136,7 +136,7 @@ public abstract class PSFileDependencyHandler extends PSDependencyHandler {
         var in = archive.getFileData(depFile)) {
       IOTools.copyStream(in, out);
     } catch (IOException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     addTransactionLogEntry(

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDefDependencyHandler.java
@@ -33,7 +33,6 @@ import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
 import com.percussion.design.objectstore.PSParam;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.PSExtensionRef;
 import com.percussion.security.PSSecurityToken;
@@ -56,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a Filter definition.
@@ -161,7 +161,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
         }
       } catch (PSFilterException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "While creating the Filter dependency, "
                 + "a FilterException occurred: "
                 + e.getLocalizedMessage());
@@ -234,7 +234,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
           PSDependencyFile.TYPE_SERVICEGENERATED_XML, createXmlFile(xmlContent));
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for filter: " + filter.getName());
     }
   }
@@ -251,12 +251,12 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
       depSvc.deserializeAndSaveFilter(tok, archive, dep, depFile, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing filter: " + e.getLocalizedMessage());
     } catch (RuntimeException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, e, PSFilterInstallUtils.formatInstallError(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, e, PSFilterInstallUtils.formatInstallError(e));
     }
 
     // add transaction log
@@ -293,7 +293,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
       m_filterSvc.saveFilter(f);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e1,
           "Could not save or update the filter:" + f.getName() + "\n" + e1.getLocalizedMessage());
     }
@@ -348,7 +348,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
       for (IPSItemFilterRuleDef def : rules) ((PSItemFilterRuleDef) def).setVersion(null);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not deserialize the ItemFilter");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not deserialize the ItemFilter");
     }
     return filter;
   }
@@ -379,7 +379,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -452,7 +452,7 @@ public class PSFilterDefDependencyHandler extends PSDependencyHandler implements
       }
     } catch (PSFilterException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "while looking for ID types, ruleDef did not provide a proper name");
     }
     return idTypes;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterInstallUtils.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterInstallUtils.java
@@ -17,6 +17,8 @@
 
 package com.percussion.deployer.server.dependencies;
 
+import com.intsof.percussioncms.auditlog.codes.FilterServiceErrorCodes;
+
 /**
  * Pure helpers for item-filter package install. Free of Spring so unit tests run without a CMS
  * context. Public so {@code PSDeployService} can share the FILTER_MISSING policy without
@@ -74,7 +76,7 @@ public final class PSFilterInstallUtils {
    * @return {@code true} only for FILTER_MISSING
    */
   public static boolean isFilterMissingErrorCode(int errorCode) {
-    return errorCode == com.percussion.services.filter.IPSFilterServiceErrors.FILTER_MISSING;
+    return errorCode == FilterServiceErrorCodes.FILTER_MISSING.numericCode();
   }
 
   /**

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderContentsDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderContentsDependencyHandler.java
@@ -33,7 +33,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.security.error.PSExceptionUtils;
@@ -48,6 +47,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a folder's relationships to its child content items. */
 public class PSFolderContentsDependencyHandler extends PSFolderObjectDependencyHandler {
@@ -201,7 +201,7 @@ public class PSFolderContentsDependencyHandler extends PSFolderObjectDependencyH
       PSComponentSummary tgtFolderSum = getFolderSummary(proc, path);
       if (tgtFolderSum == null) {
         Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-        throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+        throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
       }
       PSLocator tgtFolderLoc = tgtFolderSum.getCurrentLocator();
 
@@ -245,7 +245,7 @@ public class PSFolderContentsDependencyHandler extends PSFolderObjectDependencyH
               ctx.getCurrentIdMap().getSourceServer(),
               mapping.getTargetId()
             };
-            throw new PSDeployException(IPSDeploymentErrors.INVALID_ID_MAPPING_TARGET, args);
+            throw new PSDeployException(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, args);
           }
         }
         adds.add(new PSLocator(childId, srcLoc.getRevision()));
@@ -262,9 +262,9 @@ public class PSFolderContentsDependencyHandler extends PSFolderObjectDependencyH
           PSTransactionSummary.ACTION_CREATED);
 
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderObjectDependencyHandler.java
@@ -40,7 +40,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -51,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Base class for all dependency handlers dealing with <code>PSFolder</code> objects. Provides
@@ -121,7 +121,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
         parentSum = getParentFolderSummary(relProc, path);
         if (parentSum == null) {
           throw new PSDeployException(
-              IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+              DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
               new Object[] {
                 path, dep.getObjectTypeName(), path.substring(0, path.lastIndexOf(PATH_SEP))
               });
@@ -144,7 +144,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
 
       addTransactionLogEntry(dep, ctx, newFolder, action);
     } catch (PSCmsException | PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -181,9 +181,9 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
 
       return path;
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -451,7 +451,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
 
       return summaries.iterator();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getMessage());
     }
   }
 
@@ -479,7 +479,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
 
       return summaries.iterator();
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -504,7 +504,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
 
       return folder;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -609,7 +609,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
               new PSKey[] {PSDisplayFormat.createKey(new String[] {formatId})});
       if (els.length > 0) df = new PSDisplayFormat(els[0]);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     if (df != null) {
@@ -657,7 +657,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
             ctx.getSourceRepository(),
             strCommId
           };
-          throw new PSDeployException(IPSDeploymentErrors.INVALID_ID_MAPPING_TARGET, args);
+          throw new PSDeployException(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, args);
         }
       }
     }
@@ -670,7 +670,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
       Iterator<PSDependency> deps = dep.getDependencies(dfType);
       if (!deps.hasNext()) {
         Object[] args = {oldDfId, dfType, dep.getDependencyId(), dep.getObjectTypeName()};
-        throw new PSDeployException(IPSDeploymentErrors.CHILD_DEP_NOT_FOUND, args);
+        throw new PSDeployException(DeploymentErrorCodes.CHILD_DEP_NOT_FOUND, args);
       }
 
       PSDependency dfDep = (PSDependency) deps.next();
@@ -682,7 +682,7 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
         Object[] args = {
           dfDep.getDependencyId(), dfDep.getObjectTypeName(), dfDep.getDisplayName()
         };
-        throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+        throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
       }
 
       String newDfId = getIdFromKey(df, df.getComponentType());

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderTranslationsDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderTranslationsDependencyHandler.java
@@ -30,7 +30,6 @@ import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipSet;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -38,6 +37,7 @@ import com.percussion.utils.collections.PSIteratorUtils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a folder's translation. */
 public class PSFolderTranslationsDependencyHandler extends PSFolderObjectDependencyHandler {
@@ -163,7 +163,7 @@ public class PSFolderTranslationsDependencyHandler extends PSFolderObjectDepende
           dep.getObjectTypeName(),
           parentFolderPath.substring(parentFolderPath.lastIndexOf(PATH_SEP) + 1)
         };
-        throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+        throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
       }
 
       // delete all current translations
@@ -207,7 +207,7 @@ public class PSFolderTranslationsDependencyHandler extends PSFolderObjectDepende
             dep.getObjectTypeName(),
             childFolderPath.substring(childFolderPath.lastIndexOf(PATH_SEP) + 1)
           };
-          throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+          throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
         }
         list.add(childFolder.getLocator());
       }
@@ -274,7 +274,7 @@ public class PSFolderTranslationsDependencyHandler extends PSFolderObjectDepende
 
     if (!isValid) {
       Object[] args = {depId};
-      throw new PSDeployException(IPSDeploymentErrors.WRONG_FORMAT_FOR_PAIRID_DEP_ID, args);
+      throw new PSDeployException(DeploymentErrorCodes.WRONG_FORMAT_FOR_PAIRID_DEP_ID, args);
     }
 
     return new String[] {folderPath, relType};

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSKeywordDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSKeywordDependencyHandler.java
@@ -30,7 +30,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -47,6 +46,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a keyword definition. */
 public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
@@ -158,7 +158,7 @@ public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
     PSKeyword keyword = findKeywordByDependencyID(keyId);
     if (keyword == null) {
       Object[] args = {keyId, dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     files.add(getDepFileFromKeyword(keyword));
@@ -187,13 +187,13 @@ public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
       depSvc.installDependencyFiles(tok, archive, dep, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing keyword: " + e.getLocalizedMessage());
     } catch (RuntimeException e) {
       // UnexpectedRollbackException and similar often hide the real Hibernate failure
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, e, PSKeywordInstallUtils.formatInstallError(e));
+          DeploymentErrorCodes.UNEXPECTED_ERROR, e, PSKeywordInstallUtils.formatInstallError(e));
     }
   }
 
@@ -275,7 +275,7 @@ public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
       addTransactionLogEntryByGuidType(dep, ctx, PSTypeEnum.KEYWORD_DEF, isNew);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "error occurred while installing keyword: " + e.getLocalizedMessage());
     }
@@ -294,7 +294,7 @@ public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
     PSIdMapping mapping = idMap.getMapping(dep.getDependencyId(), dep.getObjectType());
     if (mapping == null) {
       Object[] args = {dep.getObjectType(), dep.getDependencyId(), idMap.getSourceServer()};
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
     }
 
     if (mapping.isNewObject() && mapping.getTargetId() == null) {
@@ -470,7 +470,7 @@ public class PSKeywordDependencyHandler extends PSDataObjectDependencyHandler
       str = keyword.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Keyword:" + keyword.getName());
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLoadableHandlerDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLoadableHandlerDependencyHandler.java
@@ -21,7 +21,6 @@ import com.percussion.conn.PSServerException;
 import com.percussion.deployer.objectstore.PSDependency;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequestHandlerConfiguration;
@@ -30,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle loadable handler dependencies */
 public class PSLoadableHandlerDependencyHandler extends PSDependencyHandler {
@@ -125,7 +125,7 @@ public class PSLoadableHandlerDependencyHandler extends PSDependencyHandler {
 
       return m_reqHandlerCfg;
     } catch (PSServerException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocSchemeDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocSchemeDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
@@ -44,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a location scheme definition. */
 public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandler
@@ -190,7 +190,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
     IPSLocationScheme scheme = findLocationScheme(dep.getDependencyId());
     if (scheme == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     files.add(getDepFileFromLocationScheme(scheme));
@@ -215,7 +215,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
       depSvc.installDependencyFiles(tok, archive, dep, ctx, this);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing context: " + e.getLocalizedMessage());
     }
   }
@@ -262,7 +262,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
       // Note: "transferIdsInLocationScheme" will try to map the ids for the
       // Location Scheme's Content Type and Template. If they are not
       // found on the target system an exception is thrown:
-      //     PSDeployException(IPSDeploymentErrors.MISSING_ID_MAPPING).
+      //     PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING).
       // This is acceptable for these associations, and the exception
       // is caught below. This skips over the call to save the scheme below,
       // and the Location Scheme is not added to target.
@@ -279,7 +279,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
       PSDeployException psde = (PSDeployException) e;
       Object[] errorArgs = psde.getErrorArguments();
       String obType = (String) errorArgs[0];
-      if ((psde.getErrorCode() == IPSDeploymentErrors.MISSING_ID_MAPPING)
+      if ((psde.getErrorCode() == DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode())
           && ((obType.equals(PSTemplateDefDependencyHandler.DEPENDENCY_TYPE))
               || (obType.equals(PSVariantDefDependencyHandler.DEPENDENCY_TYPE))
               || (obType.equals(PSCEDependencyHandler.DEPENDENCY_TYPE)))) {
@@ -290,7 +290,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
         // if they are.
       } else {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             e,
             "error occurred while installing location scheme: " + e.getLocalizedMessage());
       }
@@ -397,7 +397,7 @@ public class PSLocSchemeDefDependencyHandler extends PSDataObjectDependencyHandl
       str = ((PSLocationScheme) scheme).toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Location Scheme:" + scheme.getName());
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocaleDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocaleDefDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.i18n.PSLocale;
 import com.percussion.i18n.PSLocaleException;
@@ -56,6 +55,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a Locale definintion. */
 @SuppressWarnings(value = {"unchecked"})
@@ -77,7 +77,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
       m_localeMgr = PSLocaleManager.getInstance();
       initTmxTypes();
     } catch (PSLocaleException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -97,7 +97,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
       loc = m_localeMgr.getLocale(lStr);
     } catch (PSLocaleException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "could not locate the specified locale, " + lStr + "\n" + e.getLocalizedMessage());
     }
     return loc;
@@ -134,7 +134,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
     try {
       tmxDoc = PSTmxResourceBundle.getMasterResourceDoc(m_rxRoot);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     childDeps.addAll(getTmxDependencies(tok, tmxDoc));
@@ -171,7 +171,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
               deps.add(
                   createDependency(m_def, locale.getLanguageString(), locale.getDisplayName())));
     } catch (PSLocaleException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return deps.iterator();
@@ -268,7 +268,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
         files.add(new PSDependencyFile(PSDependencyFile.TYPE_DBMS_DATA, createXmlFile(keyDoc)));
       }
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return files.iterator();
@@ -312,7 +312,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
         dep.getDisplayName()
       };
 
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     // restore the objects
@@ -382,7 +382,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
       // save the bundle
       PSTmxResourceBundle.getInstance().saveMasterResourceBundle(masterTmxDoc, true);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // check to see if overwriting
@@ -748,7 +748,7 @@ public class PSLocaleDefDependencyHandler extends PSDependencyHandler {
       try {
         ms_mergeConfig = PSXmlDocumentBuilder.createXmlDocument(in, false);
       } catch (Exception e) {
-        throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionDefDependencyHandler.java
@@ -35,7 +35,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import java.util.ArrayList;
@@ -44,6 +43,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a menu action definition. This includes menu items and
@@ -192,9 +192,9 @@ public class PSMenuActionDefDependencyHandler extends PSMenuActionObjectDependen
         } else addTransactionLogEntry(txnDep, ctx, action, txnAction.intValue());
       }
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -239,7 +239,7 @@ public class PSMenuActionDefDependencyHandler extends PSMenuActionObjectDependen
         dep.getDisplayName()
       };
 
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     // try to restore the current action from the db

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionObjectDependencyHandler.java
@@ -37,7 +37,6 @@ import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -47,6 +46,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Base class for menu action dependency handlers, provides common functionality for deploying and
@@ -353,7 +353,7 @@ public abstract class PSMenuActionObjectDependencyHandler extends PSCmsObjectDep
     PSAction action = loadAction(proc, dep.getDependencyId(), loadLeaf);
     if (action == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     return action;
@@ -388,9 +388,9 @@ public abstract class PSMenuActionObjectDependencyHandler extends PSCmsObjectDep
 
       return result;
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -424,9 +424,9 @@ public abstract class PSMenuActionObjectDependencyHandler extends PSCmsObjectDep
 
       return result.iterator();
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPairDependencyId.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPairDependencyId.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.deployer.server.dependencies;
 
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Helper class to handle format the parent and child id combination for a dependency object, who
@@ -40,7 +40,7 @@ public class PSPairDependencyId {
     var sepPos = depId.indexOf(":");
     if (sepPos == -1 || sepPos == depId.length() - 1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.WRONG_FORMAT_FOR_PAIRID_DEP_ID, new Object[] {depId});
+          DeploymentErrorCodes.WRONG_FORMAT_FOR_PAIRID_DEP_ID, new Object[] {depId});
     }
 
     m_parentId = depId.substring(0, sepPos);
@@ -50,7 +50,7 @@ public class PSPairDependencyId {
       Integer.parseInt(m_parentId);
     } catch (NumberFormatException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.WRONG_FORMAT_FOR_PAIRID_DEP_ID, new Object[] {depId});
+          DeploymentErrorCodes.WRONG_FORMAT_FOR_PAIRID_DEP_ID, new Object[] {depId});
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPublisherServiceHelper.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPublisherServiceHelper.java
@@ -17,7 +17,6 @@
 package com.percussion.deployer.server.dependencies;
 
 import com.percussion.data.PSIdGenerator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.IPSExtensionManager;
 import com.percussion.extension.PSExtensionException;
@@ -36,6 +35,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * A util class to interface msm with the Publisher service
@@ -77,7 +77,7 @@ public class PSPublisherServiceHelper {
         m_guidContentList.put(c.getGUID(), c);
       }
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e);
     }
   }
 
@@ -103,7 +103,7 @@ public class PSPublisherServiceHelper {
       refs = emgr.getExtensionNames(null, context, interfacename, name);
     } catch (PSExtensionException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not locate extension:" + name);
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not locate extension:" + name);
     }
     PSExtensionRef ref = null;
     while (refs.hasNext() && !found) {
@@ -192,7 +192,7 @@ public class PSPublisherServiceHelper {
       Collections.sort(names);
       return names;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e);
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRelationshipDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRelationshipDefDependencyHandler.java
@@ -37,7 +37,6 @@ import com.percussion.design.objectstore.PSConfigurationFactory;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSRelationshipConfigSet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.config.PSConfigManager;
@@ -53,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a Relationship defintion. */
 public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHandler
@@ -189,7 +189,7 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
           cfgName,
           dep.getDisplayName()
         };
-        throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+        throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
       }
 
       Document doc = null;
@@ -201,7 +201,7 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
           PSDependencyFile.TYPE_ENUM[file.getType()],
           PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_COMPONENT_XML]
         };
-        throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+        throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
       }
 
       Element root = doc.getDocumentElement();
@@ -234,9 +234,9 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
           exists ? PSTransactionSummary.ACTION_MODIFIED : PSTransactionSummary.ACTION_CREATED;
       addTransactionLogEntry(dep, ctx, cfgName, PSTransactionSummary.TYPE_CMS_OBJECT, action);
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSErrorException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -264,7 +264,7 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
     PSRelationshipConfig cfg = cfgSet.getConfig(dep.getDependencyId());
     if (cfg == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     PSApplicationIDTypes idTypes = new PSApplicationIDTypes(dep);
@@ -373,7 +373,7 @@ public class PSRelationshipDefDependencyHandler extends PSAppObjectDependencyHan
 
       return cfgSet;
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRoleDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRoleDefDependencyHandler.java
@@ -27,7 +27,6 @@ import com.percussion.design.objectstore.PSRole;
 import com.percussion.design.objectstore.PSRoleConfiguration;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
 import com.percussion.design.objectstore.server.PSXmlObjectStoreLockerId;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSException;
 import com.percussion.security.PSSecurityToken;
@@ -38,6 +37,7 @@ import com.percussion.utils.collections.PSIteratorUtils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a role definition. */
 public class PSRoleDefDependencyHandler
@@ -155,7 +155,7 @@ public class PSRoleDefDependencyHandler
             PSTransactionSummary.ACTION_SKIPPED_NO_OVERWRITE);
       }
     } catch (PSException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } finally {
       if (lockId != null) {
         try {

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSchemaDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSchemaDependencyHandler.java
@@ -26,7 +26,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -47,6 +46,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a schema definition. */
 public class PSSchemaDependencyHandler extends PSDataObjectDependencyHandler {
@@ -116,7 +116,7 @@ public class PSSchemaDependencyHandler extends PSDataObjectDependencyHandler {
       return results.iterator();
     } catch (SQLException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.REPOSITORY_READ_WRITE_ERROR, PSDeployException.formatSqlException(e));
+          DeploymentErrorCodes.REPOSITORY_READ_WRITE_ERROR, PSDeployException.formatSqlException(e));
     }
   }
 
@@ -238,7 +238,7 @@ public class PSSchemaDependencyHandler extends PSDataObjectDependencyHandler {
         PSDependencyFile.TYPE_ENUM[file.getType()],
         PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_DBMS_SCHEMA]
       };
-      throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+      throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
     }
 
     // convert doc to schema object
@@ -249,7 +249,7 @@ public class PSSchemaDependencyHandler extends PSDataObjectDependencyHandler {
     try {
       schema = new PSJdbcTableSchema(doc.getDocumentElement(), typeMap);
     } catch (PSJdbcTableFactoryException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // handle flushing the dbmd cache on schema change

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSearchObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSearchObjectDependencyHandler.java
@@ -43,7 +43,6 @@ import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSProperty;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -57,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Base class to handle packaging and deploying search objects. */
 public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDependencyHandler
@@ -90,7 +90,7 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
     PSSearch search = loadSearch(proc, dep.getDependencyId());
     if (search == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     // get default display format
@@ -108,9 +108,9 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
         if (dfDep != null) childDeps.add(dfDep);
       }
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // get app
@@ -176,7 +176,7 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
       }
       return deps.iterator();
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -225,7 +225,7 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
       PSSearch search = new PSSearch();
       reserveNewId(dep, idMap, search);
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -312,9 +312,9 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
       addTransactionLogEntry(dep, ctx, newSearch, action);
 
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -334,7 +334,7 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
     PSSearch search = loadSearch(getComponentProcessor(tok), dep.getDependencyId());
     if (search == null) {
       Object[] args = {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     // convert to PSProperties so we can use an existing app transformer
@@ -468,9 +468,9 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
 
       return search;
     } catch (PSCmsException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -585,7 +585,7 @@ public abstract class PSSearchObjectDependencyHandler extends PSCmsObjectDepende
       Object[] args = {
         search.getDisplayFormatId(), dfDepType, dep.getDependencyId(), dep.getObjectTypeName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.CHILD_DEP_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.CHILD_DEP_NOT_FOUND, args);
     }
 
     //    Second - determine if the Display Format is:

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSharedGroupDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSharedGroupDependencyHandler.java
@@ -35,7 +35,6 @@ import com.percussion.design.objectstore.PSSharedFieldGroup;
 import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -51,6 +50,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a shared group */
 public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDependencyHandler
@@ -152,7 +152,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
     PSSharedFieldGroup group = getSharedGroup(dep.getDependencyId());
     if (group == null) {
       Object[] args = {dep.getObjectTypeName(), dep.getDependencyId(), dep.getDisplayName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     // use set to ensure we don't add dupes
@@ -200,7 +200,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
             .orElseThrow(
                 () ->
                     new PSDeployException(
-                        IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+                        DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
                         new Object[] {
                           dep.getObjectTypeName(), dep.getDependencyId(), dep.getDisplayName()
                         }));
@@ -249,7 +249,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     PSSharedFieldGroup group = null;
@@ -263,7 +263,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
         dep.getDisplayName(),
         e.getLocalizedMessage()
       };
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_DEPENDENCY_FILE, args);
     }
 
     // transform ids and dbms's in the group if necessary
@@ -349,7 +349,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
       addTransactionLogEntry(
           dep, ctx, defFile.getName(), PSTransactionSummary.TYPE_FILE, transAction);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.toString());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.toString());
     }
   }
 
@@ -382,7 +382,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
       // this should never happen
       if (sharedGroup == null) {
         Object[] args = {dep.getKey(), "Group not found"};
-        throw new PSDeployException(IPSDeploymentErrors.ID_TYPE_MAP_LOAD, args);
+        throw new PSDeployException(DeploymentErrorCodes.ID_TYPE_MAP_LOAD, args);
       }
 
       mappings.clear();
@@ -413,7 +413,7 @@ public class PSSharedGroupDependencyHandler extends PSContentEditorObjectDepende
           groupName, IPSDeployConstants.ID_TYPE_ELEMENT_CE_VALIDATION_RULES, mappings.iterator());
 
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return idTypes;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSiteDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSiteDefDependencyHandler.java
@@ -30,7 +30,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
@@ -62,6 +61,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a site definition. */
 public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
@@ -118,7 +118,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       }
     } catch (SAXException | IOException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e,
           "could not parse serialized Site data, due to :" + e.getMessage());
     }
@@ -401,7 +401,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       str = ((PSSite) site).toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Site:" + site.getName());
     }
 
@@ -421,7 +421,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
     var site = findSiteByDependencyID(dep.getDependencyId());
     if (site == null) {
       throw new PSDeployException(
-          IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+          DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
           new Object[] {dep.getDependencyId(), dep.getObjectTypeName(), dep.getDisplayName()});
     }
 
@@ -476,7 +476,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       // tmpStr remains unchanged
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Error occurred while generating site:" + e.getLocalizedMessage());
     }
     // deserialize on the mapped template idss
@@ -502,7 +502,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       ((PSSite) site).fromXML(tmpStr);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not deserialize site");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not deserialize site");
     }
     return site;
   }
@@ -533,7 +533,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }
@@ -558,7 +558,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
         site = m_siteMgr.loadSite(site.getGUID());
       } catch (PSNotFoundException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "Site Not Found: " + site.toString() + e.getLocalizedMessage());
       }
       ver = ((PSSite) site).getVersion();
@@ -576,7 +576,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       depSvc.deserializeAndSaveSite(tok, archive, dep, depFile, ctx, this, site, ver);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing site: " + e.getLocalizedMessage());
     }
 
@@ -599,7 +599,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
       m_siteMgr.saveSite(s);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not save or update the site:" + s.getName() + "\n" + e1.getLocalizedMessage());
     }
   }
@@ -613,7 +613,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
    * @param ctx the import context never <code>null</code>
    * @param tmpId the template id never <code>null</code>
    * @return the mapping if it exists else <code>null</code>
-   * @throws PSDeployException (other than IPSDeploymentErrors.MISSING_ID_MAPPING, which is handled
+   * @throws PSDeployException (other than DeploymentErrorCodes.MISSING_ID_MAPPING, which is handled
    *     by a <code>null</code> return.)
    */
   private PSIdMapping getTemplateOrVariantMapping(
@@ -625,7 +625,7 @@ public class PSSiteDefDependencyHandler extends PSDataObjectDependencyHandler {
         m = getIdMappingOfAssoc(tok, ctx, tmpId, PSVariantDefDependencyHandler.DEPENDENCY_TYPE);
       }
     } catch (PSDeployException dex) {
-      if (dex.getErrorCode() == IPSDeploymentErrors.MISSING_ID_MAPPING) {
+      if (dex.getErrorCode() == DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode()) {
         // try a variant . . .
         m = getIdMapping(ctx, tmpId, PSVariantDefDependencyHandler.DEPENDENCY_TYPE);
       }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSlotDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSlotDefDependencyHandler.java
@@ -31,7 +31,6 @@ import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.design.objectstore.PSParam;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.security.PSSecurityToken;
@@ -58,6 +57,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a Slot definition the new way.
@@ -152,7 +152,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
     IPSTemplateSlot slot = findSlotByDependencyID(dep.getDependencyId());
     if (slot == null)
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not find a slot with id: " + dep.getDependencyId());
     boolean isLegacy = isLegacySlot(slot);
 
@@ -195,7 +195,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
           t = m_assemblySvc.loadTemplate(String.valueOf(tmpList[i]), false);
         } catch (PSAssemblyException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               "Unable to load template while cataloging slot dependencies\n"
                   + e.getLocalizedMessage());
         }
@@ -246,7 +246,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
 
     if (slot == null)
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not find a slot with id: " + dep.getDependencyId());
 
     if (isLegacySlot(slot)) return idTypes;
@@ -323,7 +323,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
       str = slot.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Template:" + slot.getName());
     }
 
@@ -424,7 +424,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
       m_assemblySvc.saveSlot(s);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           e1,
           "Could not save or update the slot:" + s.getName() + "\n" + e1.getLocalizedMessage());
     }
@@ -484,7 +484,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
                   String.valueOf(a.getTemplateId()),
                   PSTemplateDefDependencyHandler.DEPENDENCY_TYPE);
         } catch (PSDeployException dex) {
-          if (dex.getErrorCode() == IPSDeploymentErrors.MISSING_ID_MAPPING) {
+          if (dex.getErrorCode() == DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode()) {
             tmpMap =
                 getIdMapping(
                     ctx,
@@ -690,7 +690,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
     } catch (Exception e) {
       m_log.error("Error ", e);
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create template from file:" + f.getName());
     }
     return slot;
@@ -722,7 +722,7 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSupportFileDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSupportFileDependencyHandler.java
@@ -24,7 +24,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -34,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a support file. */
 public class PSSupportFileDependencyHandler extends PSAppObjectDependencyHandler {
@@ -240,7 +240,7 @@ public class PSSupportFileDependencyHandler extends PSAppObjectDependencyHandler
         dep.getDisplayName()
       };
 
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     saveAppFile(tok, archive, dep, ctx, depFile);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefDependencyHandler.java
@@ -40,7 +40,6 @@ import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSServer;
@@ -54,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.w3c.dom.Document;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a system def */
 public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependencyHandler {
@@ -220,7 +220,7 @@ public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependenc
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     // restore the system def
@@ -228,7 +228,7 @@ public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependenc
     try {
       sysDef = new PSContentEditorSystemDef(doc);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     // transform ids and dbms's in the def if necessary
@@ -245,7 +245,7 @@ public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependenc
       addTransactionLogEntry(
           dep, ctx, dep.getDisplayName(), PSTransactionSummary.TYPE_FILE, transAction);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -360,7 +360,7 @@ public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependenc
           resource, IPSDeployConstants.ID_TYPE_ELEMENT_INIT_PARAMS, mappings.iterator());
 
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return idTypes;
@@ -494,7 +494,7 @@ public class PSSystemDefDependencyHandler extends PSContentEditorObjectDependenc
     PSContentEditorSystemDef def = PSServer.getContentEditorSystemDef();
     if (def == null) {
       Object[] args = {m_def.getObjectType(), m_def.getObjectType(), m_def.getObjectTypeName()};
-      throw new PSDeployException(IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND, args);
+      throw new PSDeployException(DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND, args);
     }
 
     return def;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefElementDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefElementDependencyHandler.java
@@ -35,7 +35,6 @@ import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSContentEditorSharedDef;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.error.PSNotFoundException;
@@ -49,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a system def override from a shared def */
 public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDependencyHandler {
@@ -196,7 +196,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
             .orElseThrow(
                 () ->
                     new PSDeployException(
-                        IPSDeploymentErrors.DEP_OBJECT_NOT_FOUND,
+                        DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
                         new Object[] {
                           dep.getObjectTypeName(), dep.getDependencyId(), dep.getDisplayName()
                         }));
@@ -244,7 +244,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
 
     PSApplicationFlow appFlow = null;
@@ -275,7 +275,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
         // Content editor apps won't target with no shared def, and
         // should have been caught by loading shared def above
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR, "no target shared def file");
+            DeploymentErrorCodes.UNEXPECTED_ERROR, "no target shared def file");
       }
 
       // see if original file exists.  Also if find a file that already
@@ -314,7 +314,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
       addTransactionLogEntry(
           dep, ctx, tgtFile.getName(), PSTransactionSummary.TYPE_FILE, transAction);
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -362,7 +362,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
       }
 
     } catch (Exception e) {
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     }
 
     return idTypes;
@@ -462,7 +462,7 @@ public class PSSystemDefElementDependencyHandler extends PSContentEditorObjectDe
         dep.getDisplayName(),
         e.getLocalizedMessage()
       };
-      throw new PSDeployException(IPSDeploymentErrors.INVALID_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.INVALID_DEPENDENCY_FILE, args);
     }
 
     return comp;

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateCommunityDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateCommunityDefDependencyHandler.java
@@ -23,7 +23,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -35,6 +34,7 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a **PART OF** template definition. Adds definitions to
@@ -80,7 +80,7 @@ public class PSTemplateCommunityDefDependencyHandler extends PSDataObjectDepende
         }
         catch ( NumberFormatException ne)
         {
-           throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR,
+           throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR,
                  "ContentTypeTemplate Definition was expecting a long value: "
                        + tempID);
         }
@@ -184,7 +184,7 @@ public class PSTemplateCommunityDefDependencyHandler extends PSDataObjectDepende
       tmpGuid = new PSGuid(PSTypeEnum.TEMPLATE, templateGuid);
     } catch (NumberFormatException ne) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "ContentTypeTemplate Definition was expecting a long value: " + dep.getDependencyId());
     }
 
@@ -197,7 +197,7 @@ public class PSTemplateCommunityDefDependencyHandler extends PSDataObjectDepende
       contentMgr.saveNodeDefinitions(newList);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Repository Exception occurred while installing a dependency" + dep.getDisplayName());
     }
   }
@@ -228,7 +228,7 @@ public class PSTemplateCommunityDefDependencyHandler extends PSDataObjectDepende
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
@@ -33,7 +33,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionRef;
@@ -63,6 +62,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying a template definition.
@@ -273,7 +273,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       bindingsList = handleExitsInJexlExp(tok, tmp);
     } catch (PSExtensionException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "Could not find an extension: ");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "Could not find an extension: ");
     }
     if (bindingsList.size() > 0) {
       for (PSDependency dependency : bindingsList) {
@@ -360,7 +360,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
               + t.getDescription()
               + "==>\n "
               + e.getLocalizedMessage();
-      throw new PSDeployException(IPSDeploymentErrors.UNEXPECTED_ERROR, err);
+      throw new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, err);
     }
   }
 
@@ -443,7 +443,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       str = tmp.toXML();
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for Template:" + tmp.getName());
     }
 
@@ -508,7 +508,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       depSvc.deserializeAndSaveTemplate(tok, archive, dep, depFile, ctx, this, tmp, ver, bVer);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing template: " + e.getLocalizedMessage());
     }
 
@@ -541,7 +541,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       m_assemblySvc.saveTemplate(t);
     } catch (Exception e1) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not save or update the template:" + t.getName() + "\n" + e1.getLocalizedMessage());
     }
   }
@@ -598,7 +598,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
       tmpStr = PSAssemblyTemplate.replaceSlotIdsFromTemplate(tmpStr, newGuids);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Error occurred while generating site:" + e.getLocalizedMessage());
     }
 
@@ -607,7 +607,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
     } catch (Exception e) {
       String err = e.getLocalizedMessage();
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Could not create template from file:" + f.getName() + " Error was:\n" + err);
     }
     return tmp;
@@ -639,7 +639,7 @@ public class PSTemplateDefDependencyHandler extends PSDependencyHandler {
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslationSettingsDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslationSettingsDefDependencyHandler.java
@@ -27,7 +27,6 @@ import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.i18n.PSLocale;
 import com.percussion.i18n.PSLocaleException;
@@ -49,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.SAXException;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /**
  * Class to handle packaging and deploying TranslationSettings definition for a particular locale.
@@ -112,7 +112,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
     List<PSAutoTranslation> xlnList = findTranslationSettingsByLocaleID(dep.getDependencyId());
     if (xlnList.isEmpty())
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "could not find a TranslationSettings for locale: " + dep.getDependencyId());
     // OK, we have the TranslationSettings, now package its dependencies..
     Set<PSDependency> childDeps = new HashSet<PSDependency>();
@@ -161,7 +161,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
       return deps.iterator();
     } catch (PSLocaleException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "could not retrieve locales");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "could not retrieve locales");
     }
   }
 
@@ -203,7 +203,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
           sb.append(at.toXML());
         } catch (IOException | SAXException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               "Unable to serialize auto translation: " + e.getLocalizedMessage());
         }
         sb.append(AUTOTRANSLATIONS_DELIM);
@@ -215,7 +215,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
           PSDependencyFile.TYPE_SERVICEGENERATED_XML, createXmlFile(sb.toString()));
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "Unable to generate a dependency file for translation settings");
     }
   }
@@ -261,7 +261,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
         m_svc.saveAutoTranslation(at);
       } catch (Exception e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             "could not save or update the TranslationSettings:" + e.getLocalizedMessage());
       }
     }
@@ -361,12 +361,12 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
           PSDependencyFile.TYPE_ENUM[depFile.getType()],
           PSDependencyFile.TYPE_ENUM[PSDependencyFile.TYPE_SERVICEGENERATED_XML]
         };
-        throw new PSDeployException(IPSDeploymentErrors.WRONG_DEPENDENCY_FILE_TYPE, args);
+        throw new PSDeployException(DeploymentErrorCodes.WRONG_DEPENDENCY_FILE_TYPE, args);
       }
       xlnList = fromXML(xlnStr);
     } catch (Exception e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR, "could not deserialize translation settings");
+          DeploymentErrorCodes.UNEXPECTED_ERROR, "could not deserialize translation settings");
     }
     return xlnList;
   }
@@ -426,7 +426,7 @@ public class PSTranslationSettingsDefDependencyHandler extends PSDependencyHandl
         dep.getDependencyId(),
         dep.getDisplayName()
       };
-      throw new PSDeployException(IPSDeploymentErrors.MISSING_DEPENDENCY_FILE, args);
+      throw new PSDeployException(DeploymentErrorCodes.MISSING_DEPENDENCY_FILE, args);
     }
     return files;
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSImportCtx;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
 import com.percussion.deployer.services.PSDeployServiceLocator;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
@@ -41,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a variant definition. */
 public class PSVariantDefDependencyHandler extends PSDataObjectDependencyHandler {
@@ -305,7 +305,7 @@ public class PSVariantDefDependencyHandler extends PSDataObjectDependencyHandler
       depSvc.deserializeAndSaveVariant(tok, archive, dep, depFile, ctx, this, tmp, ver);
     } catch (PSDeployServiceException e) {
       throw new PSDeployException(
-          IPSDeploymentErrors.UNEXPECTED_ERROR,
+          DeploymentErrorCodes.UNEXPECTED_ERROR,
           "error occurred while installing template: " + e.getLocalizedMessage());
     }
     // add transaction log

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
@@ -28,7 +28,6 @@ import com.percussion.deployer.server.PSDbmsHelper;
 import com.percussion.deployer.server.PSDependencyDef;
 import com.percussion.deployer.server.PSDependencyMap;
 import com.percussion.deployer.server.PSImportCtx;
-import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -52,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 
 /** Class to handle packaging and deploying a workflow definition. */
 public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandler {
@@ -328,7 +328,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -389,7 +389,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -502,7 +502,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -584,7 +584,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -655,7 +655,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -726,7 +726,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     PSIdMapping wfMapping = getIdMapping(ctx, wfDep);
 
@@ -805,7 +805,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     // transfer ids in all rows
 
@@ -885,7 +885,7 @@ public class PSWorkflowDefDependencyHandler extends PSDataObjectDependencyHandle
     Iterator<PSJdbcRowData> rows = depData.getData().getRows();
 
     if (!rows.hasNext()) // no rows
-    throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
+    throw new PSDeployException(DeploymentErrorCodes.NO_ROWS_TO_PROCESS);
 
     // transfer ids in all rows
 

--- a/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
+++ b/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
@@ -32,7 +32,7 @@ import com.percussion.deployer.server.dependencies.PSTemplateDefDependencyHandle
 import com.percussion.deployer.server.dependencies.PSVariantDefDependencyHandler;
 import com.percussion.deployer.services.IPSDeployService;
 import com.percussion.deployer.services.PSDeployServiceException;
-import com.percussion.error.IPSDeploymentErrors;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.error.PSDeployException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.services.assembly.data.PSAssemblyTemplate;
@@ -199,14 +199,14 @@ public class PSDeployService implements IPSDeployService {
         existingByName = filterSvc.findFilterByName(filterName);
       } catch (IllegalArgumentException e) {
         throw new PSDeployException(
-            IPSDeploymentErrors.UNEXPECTED_ERROR,
+            DeploymentErrorCodes.UNEXPECTED_ERROR,
             e,
             "Filter package has blank or invalid name while installing dependency "
                 + dep.getDependencyId());
       } catch (com.percussion.services.filter.PSFilterException e) {
         if (!PSFilterInstallUtils.isFilterMissingErrorCode(e.getErrorCode())) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               e,
               "Failed to resolve existing filter by name: " + filterName);
         }
@@ -222,7 +222,7 @@ public class PSDeployService implements IPSDeployService {
           existingByName = filterSvc.loadFilter(ids).get(0);
         } catch (PSNotFoundException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               "Could not load the existing filter: " + packageFilter.getName());
         }
         PSItemFilter managed = (PSItemFilter) existingByName;
@@ -232,7 +232,7 @@ public class PSDeployService implements IPSDeployService {
           managed.merge(packageFilter);
         } catch (com.percussion.services.filter.PSFilterException e) {
           throw new PSDeployException(
-              IPSDeploymentErrors.UNEXPECTED_ERROR,
+              DeploymentErrorCodes.UNEXPECTED_ERROR,
               e,
               "Could not merge package filter onto existing filter: " + packageFilter.getName());
         }

--- a/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogClientTypedErrorCodeSliceTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/catalog/PSDeployerCatalogClientTypedErrorCodeSliceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.percussion.deployer.catalog.server.PSCatalogHandler;
+import com.percussion.deployer.objectstore.PSIdMap;
+import com.percussion.deployer.objectstore.PSIdMapping;
+import com.percussion.error.PSDeployException;
+import com.percussion.server.PSRequest;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Issue #3739 (parent #2616 slice 1): leftover deployer catalog / client / objectstore /
+ * PSDeployService production sites throw typed {@link DeploymentErrorCodes} (non-auditable leftover
+ * codes skip dual-write). Server/handlers remain on later slices.
+ */
+@Tag("UnitTest")
+public class PSDeployerCatalogClientTypedErrorCodeSliceTest {
+
+  @Test
+  public void catalogHandlerNullInputDocUsesTypedNonAuditableCode() throws Exception {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void catalogHandlerInvalidRequestTypeUsesTypedNonAuditableCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSXmlDocumentBuilder.createRoot(doc, "NotACatalogRequest");
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(doc);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(DeploymentErrorCodes.INVALID_REQUEST_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_REQUEST_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void idMapMissingAndIncompleteUseTypedNonAuditableCodes() throws Exception {
+    PSIdMap map = new PSIdMap("driver:server:db:origin");
+    PSDeployException missing =
+        assertThrows(PSDeployException.class, () -> map.getNewId("99", "widget"));
+    assertEquals(DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode(), missing.getErrorCode());
+    assertSame(DeploymentErrorCodes.MISSING_ID_MAPPING, missing.getTypedErrorCode());
+    assertFalse(missing.isAuditable());
+
+    map.addMapping(new PSIdMapping("1", "name", "widget"));
+    PSDeployException incomplete =
+        assertThrows(PSDeployException.class, () -> map.getNewId("1", "widget"));
+    assertEquals(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING.numericCode(), incomplete.getErrorCode());
+    assertSame(DeploymentErrorCodes.INCOMPLETE_ID_MAPPING, incomplete.getTypedErrorCode());
+    assertFalse(incomplete.isAuditable());
+  }
+
+  @Test
+  public void idMapNonNumericTargetUsesTypedInvalidTarget() throws Exception {
+    PSIdMap map = new PSIdMap("driver:server:db:origin");
+    PSIdMapping mapping = new PSIdMapping("1", "name", "widget");
+    mapping.setTarget("not-an-int", "targetName");
+    map.addMapping(mapping);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> map.getNewIdInt("1", "widget"));
+    assertEquals(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
@@ -24,6 +24,7 @@ import com.percussion.conn.PSServerException;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
+import com.percussion.error.PSLockedException;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
@@ -139,5 +140,21 @@ public class PSDeployExceptionTest {
   @Test
   public void typedConstructorRejectsNullCode() {
     assertThrows(IllegalArgumentException.class, () -> new PSDeployException((IPSErrorCode) null));
+  }
+
+  @Test
+  public void typedLockedAndNonUniqueConstructorsRetainCodes() {
+    Object[] lockArgs = {"alice", "2"};
+    PSLockedException locked =
+        new PSLockedException(DeploymentErrorCodes.LOCK_ALREADY_HELD, lockArgs);
+    assertEquals(DeploymentErrorCodes.LOCK_ALREADY_HELD.numericCode(), locked.getErrorCode());
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, locked.getTypedErrorCode());
+    assertTrue(locked.isAuditable());
+
+    PSDeployNonUniqueException nonUnique =
+        new PSDeployNonUniqueException(DeploymentErrorCodes.ARCHIVE_REF_FOUND, "archive-1");
+    assertEquals(DeploymentErrorCodes.ARCHIVE_REF_FOUND.numericCode(), nonUnique.getErrorCode());
+    assertSame(DeploymentErrorCodes.ARCHIVE_REF_FOUND, nonUnique.getTypedErrorCode());
+    assertFalse(nonUnique.isAuditable());
   }
 }

--- a/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
@@ -121,6 +121,7 @@ public class PSDeployExceptionTest {
     assertEquals(DeploymentErrorCodes.UNEXPECTED_ERROR.numericCode(), withCause.getErrorCode());
     assertSame(DeploymentErrorCodes.UNEXPECTED_ERROR, withCause.getTypedErrorCode());
     assertSame(cause, withCause.getCause());
+    assertArrayEquals(new Object[] {"detail"}, withCause.getErrorArguments());
     assertFalse(withCause.isAuditable());
   }
 

--- a/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/error/PSDeployExceptionTest.java
@@ -19,9 +19,12 @@ package com.percussion.deployer.error;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.conn.PSServerException;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSDeployException;
 import com.percussion.error.PSDeployNonUniqueException;
+import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -89,5 +92,52 @@ public class PSDeployExceptionTest {
           PSServerException sEx1 = new PSServerException(123, args3);
           new PSDeployNonUniqueException(sEx1);
         });
+  }
+
+  @Test
+  public void typedCatalogCodesRetainCodeAndSkipAudit() {
+    PSDeployException noArg = new PSDeployException(DeploymentErrorCodes.NULL_INPUT_DOC);
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), noArg.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, noArg.getTypedErrorCode());
+    assertFalse(noArg.isAuditable());
+
+    PSDeployException single =
+        new PSDeployException(DeploymentErrorCodes.INVALID_REQUEST_TYPE, "PSXBad");
+    assertEquals(DeploymentErrorCodes.INVALID_REQUEST_TYPE.numericCode(), single.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_REQUEST_TYPE, single.getTypedErrorCode());
+    assertFalse(single.isAuditable());
+
+    Object[] args = {"widget", "99", "src"};
+    PSDeployException array = new PSDeployException(DeploymentErrorCodes.MISSING_ID_MAPPING, args);
+    assertEquals(DeploymentErrorCodes.MISSING_ID_MAPPING.numericCode(), array.getErrorCode());
+    assertSame(DeploymentErrorCodes.MISSING_ID_MAPPING, array.getTypedErrorCode());
+    assertArrayEquals(args, array.getErrorArguments());
+    assertFalse(array.isAuditable());
+
+    IllegalStateException cause = new IllegalStateException("boom");
+    PSDeployException withCause =
+        new PSDeployException(DeploymentErrorCodes.UNEXPECTED_ERROR, cause, "detail");
+    assertEquals(DeploymentErrorCodes.UNEXPECTED_ERROR.numericCode(), withCause.getErrorCode());
+    assertSame(DeploymentErrorCodes.UNEXPECTED_ERROR, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertFalse(withCause.isAuditable());
+  }
+
+  @Test
+  public void typedLockCodeIsAuditableAndCopiedFromPsException() {
+    PSDeployException lock = new PSDeployException(DeploymentErrorCodes.LOCK_ALREADY_HELD);
+    assertTrue(lock.isAuditable());
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, lock.getTypedErrorCode());
+
+    PSException pe = new PSException(DeploymentErrorCodes.LOCK_ALREADY_HELD);
+    PSDeployException wrapped = new PSDeployException(pe);
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, wrapped.getTypedErrorCode());
+    assertTrue(wrapped.isAuditable());
+    assertEquals(pe.getClass().getName(), wrapped.getOriginalExceptionClass());
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSDeployException((IPSErrorCode) null));
   }
 }

--- a/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerHandlersTypedErrorCodeSliceTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerHandlersTypedErrorCodeSliceTest.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.deployer.server;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -104,6 +105,11 @@ public class PSDeployerServerHandlersTypedErrorCodeSliceTest {
 
   @Test
   public void jobExceptionTypedCodesSkipAudit() {
+    PSJobException noArg = new PSJobException(JobErrorCodes.NULL_INPUT_DOC);
+    assertEquals(JobErrorCodes.NULL_INPUT_DOC.numericCode(), noArg.getErrorCode());
+    assertSame(JobErrorCodes.NULL_INPUT_DOC, noArg.getTypedErrorCode());
+    assertFalse(noArg.isAuditable());
+
     PSJobException invalid =
         new PSJobException(JobErrorCodes.INVALID_JOB_DESCRIPTOR, "bad-desc");
     assertEquals(JobErrorCodes.INVALID_JOB_DESCRIPTOR.numericCode(), invalid.getErrorCode());
@@ -118,6 +124,22 @@ public class PSDeployerServerHandlersTypedErrorCodeSliceTest {
         new PSJobException(JobErrorCodes.CONFIG_FILE_NOT_FOUND, "rxconfig.xml");
     assertSame(JobErrorCodes.CONFIG_FILE_NOT_FOUND, missingCfg.getTypedErrorCode());
     assertFalse(missingCfg.isAuditable());
+
+    IllegalStateException cause = new IllegalStateException("runner failed");
+    PSJobException withCause =
+        new PSJobException(JobErrorCodes.UNEXPECTED_ERROR, cause, "detail");
+    assertSame(JobErrorCodes.UNEXPECTED_ERROR, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertArrayEquals(new Object[] {"detail"}, withCause.getErrorArguments());
+    assertFalse(withCause.isAuditable());
+
+    PSJobException arrayCause =
+        new PSJobException(
+            JobErrorCodes.CONFIG_FILE_NOT_FOUND, new Object[] {"rxconfig.xml"}, cause);
+    assertSame(JobErrorCodes.CONFIG_FILE_NOT_FOUND, arrayCause.getTypedErrorCode());
+    assertSame(cause, arrayCause.getCause());
+    assertArrayEquals(new Object[] {"rxconfig.xml"}, arrayCause.getErrorArguments());
+    assertFalse(arrayCause.isAuditable());
 
     assertThrows(IllegalArgumentException.class, () -> new PSJobException((IPSErrorCode) null));
   }
@@ -150,6 +172,16 @@ public class PSDeployerServerHandlersTypedErrorCodeSliceTest {
         SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.numericCode(), auth.getErrorCode());
     assertSame(SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED, auth.getTypedErrorCode());
     assertTrue(auth.isAuditable());
+
+    IllegalStateException cause = new IllegalStateException("handler init");
+    PSServerException withCause =
+        new PSServerException(
+            ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, cause, "DeploymentHandler");
+    assertSame(
+        ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertArrayEquals(new Object[] {"DeploymentHandler"}, withCause.getErrorArguments());
+    assertFalse(withCause.isAuditable());
   }
 
   @Test

--- a/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerHandlersTypedErrorCodeSliceTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSDeployerServerHandlersTypedErrorCodeSliceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.FilterServiceErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.conn.PSServerException;
+import com.percussion.deployer.server.dependencies.PSFilterInstallUtils;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSDeployException;
+import com.percussion.error.PSDeployNonUniqueException;
+import com.percussion.error.PSLockedException;
+import com.percussion.security.PSAuthenticationFailedException;
+import com.percussion.server.job.PSJobException;
+import com.percussion.util.PSResourceUtils;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.File;
+import java.io.FileInputStream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Issue #3740 (parent #2616 slice 2): leftover deployer server / dependency-handler production
+ * sites throw typed {@code *ErrorCodes}. Lock codes remain auditable; leftover operational codes
+ * skip dual-write. Catalog/client remain on #3739; DCE/TableFactory on later slices.
+ */
+@Tag("UnitTest")
+public class PSDeployerServerHandlersTypedErrorCodeSliceTest {
+
+  @Test
+  public void packageConfigInvalidOrderUsesTypedNonAuditableCode() throws Exception {
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> loadConfig("sys_PkgConfig_MissDeployEl.xml"));
+    assertEquals(DeploymentErrorCodes.INCOMPLATE_ORDER_DEF.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INCOMPLATE_ORDER_DEF, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void packageConfigMissingChildUsesTypedNonAuditableCode() throws Exception {
+    PSDeployException ex =
+        assertThrows(
+            PSDeployException.class, () -> loadConfig("sys_PkgConfig_MissNonDeployEl.xml"));
+    assertEquals(DeploymentErrorCodes.INVALID_NUM_CHILD_DEFS.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.INVALID_NUM_CHILD_DEFS, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void packageConfigInvalidParentUsesTypedNonAuditableCode() throws Exception {
+    PSDeployException ex =
+        assertThrows(
+            PSDeployException.class,
+            () -> loadConfig("sys_PkgConfig_InvalidNonDeployElParent.xml"));
+    assertEquals(DeploymentErrorCodes.CANNOT_FIND_PARENT_DEP_DEF.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.CANNOT_FIND_PARENT_DEP_DEF, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void lockedExceptionTypedLockCodesAreAuditable() {
+    Object[] args = {"alice", "3"};
+    PSLockedException held = new PSLockedException(DeploymentErrorCodes.LOCK_ALREADY_HELD, args);
+    assertEquals(DeploymentErrorCodes.LOCK_ALREADY_HELD.numericCode(), held.getErrorCode());
+    assertSame(DeploymentErrorCodes.LOCK_ALREADY_HELD, held.getTypedErrorCode());
+    assertTrue(held.isAuditable());
+
+    PSLockedException taken =
+        new PSLockedException(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN);
+    assertSame(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN, taken.getTypedErrorCode());
+    assertTrue(taken.isAuditable());
+
+    PSLockedException released =
+        new PSLockedException(
+            DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, "bob");
+    assertSame(
+        DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED, released.getTypedErrorCode());
+    assertTrue(released.isAuditable());
+  }
+
+  @Test
+  public void jobExceptionTypedCodesSkipAudit() {
+    PSJobException invalid =
+        new PSJobException(JobErrorCodes.INVALID_JOB_DESCRIPTOR, "bad-desc");
+    assertEquals(JobErrorCodes.INVALID_JOB_DESCRIPTOR.numericCode(), invalid.getErrorCode());
+    assertSame(JobErrorCodes.INVALID_JOB_DESCRIPTOR, invalid.getTypedErrorCode());
+    assertFalse(invalid.isAuditable());
+
+    PSJobException unexpected = new PSJobException(JobErrorCodes.UNEXPECTED_ERROR, "boom");
+    assertSame(JobErrorCodes.UNEXPECTED_ERROR, unexpected.getTypedErrorCode());
+    assertFalse(unexpected.isAuditable());
+
+    PSJobException missingCfg =
+        new PSJobException(JobErrorCodes.CONFIG_FILE_NOT_FOUND, "rxconfig.xml");
+    assertSame(JobErrorCodes.CONFIG_FILE_NOT_FOUND, missingCfg.getTypedErrorCode());
+    assertFalse(missingCfg.isAuditable());
+
+    assertThrows(IllegalArgumentException.class, () -> new PSJobException((IPSErrorCode) null));
+  }
+
+  @Test
+  public void nonUniqueArchiveRefUsesTypedNonAuditableCode() {
+    PSDeployNonUniqueException ex =
+        new PSDeployNonUniqueException(DeploymentErrorCodes.ARCHIVE_REF_FOUND, "pkg-1");
+    assertEquals(DeploymentErrorCodes.ARCHIVE_REF_FOUND.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.ARCHIVE_REF_FOUND, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void serverAndAuthTypedConstructorsRetainCodes() {
+    Object[] args = {"DeploymentHandler", "init failed"};
+    PSServerException server =
+        new PSServerException(ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, args);
+    assertEquals(
+        ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION.numericCode(),
+        server.getErrorCode());
+    assertSame(
+        ServerErrorCodes.LOADABLE_HANDLER_UNEXPECTED_EXCEPTION, server.getTypedErrorCode());
+    assertFalse(server.isAuditable());
+
+    PSAuthenticationFailedException auth =
+        new PSAuthenticationFailedException(
+            SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED, null);
+    assertEquals(
+        SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.numericCode(), auth.getErrorCode());
+    assertSame(SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED, auth.getTypedErrorCode());
+    assertTrue(auth.isAuditable());
+  }
+
+  @Test
+  public void filterMissingUsesTypedNumericCode() {
+    assertTrue(
+        PSFilterInstallUtils.isFilterMissingErrorCode(
+            FilterServiceErrorCodes.FILTER_MISSING.numericCode()));
+    assertFalse(
+        PSFilterInstallUtils.isFilterMissingErrorCode(
+            FilterServiceErrorCodes.DATABASE.numericCode()));
+    assertFalse(FilterServiceErrorCodes.FILTER_MISSING.isAuditable());
+  }
+
+  private static PSPackageConfiguration loadConfig(String fileName) throws Exception {
+    String resource = "/com/percussion/config/" + fileName;
+    File f = PSResourceUtils.getFile(PSPackageConfigurationTest.class, resource, null);
+    try (FileInputStream in = new FileInputStream(f)) {
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(in, false);
+      return new PSPackageConfiguration(doc.getDocumentElement(), false);
+    }
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
@@ -17,10 +17,13 @@
 package com.percussion.deployer.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.percussion.deployer.catalog.server.PSCatalogHandler;
 import com.percussion.error.IPSDeploymentErrors;
 import com.percussion.error.PSDeployException;
@@ -44,6 +47,9 @@ public class PSNullInputDocHandlerTest {
     PSDeployException ex =
         assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
     assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+    assertEquals(DeploymentErrorCodes.NULL_INPUT_DOC.numericCode(), ex.getErrorCode());
+    assertSame(DeploymentErrorCodes.NULL_INPUT_DOC, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   @Test

--- a/docs/ai-generated/code-reviews/3739-deployer-catalog-client-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3739-deployer-catalog-client-errorcodes-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3739 deployer catalog/client IPS*Errors typed ErrorCodes
+
+**Date:** 2026-08-23  
+**Branch:** `feat/issue-3739-deployer-catalog-client-errorcodes`  
+**Base:** `origin/main`  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Parent #2616 slice 1/3. Leftover deployer **catalog + client + objectstore + PSDeployService** production `IPSDeploymentErrors` int sites retyped to `DeploymentErrorCodes`. `PSDeployException` gained `IPSErrorCode` constructors, `getTypedErrorCode()`, and `isAuditable()` (peer of `PSException`). Residual allow-list shrunk by those exact paths. Server/handlers, DCE/TableFactory, and deleting `IPS*Errors` interfaces remain out of scope.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (typed construction, catalog/id-map production throws, dual-write skip)
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: exception typed ctors + production retype + allow-list shrink + dual-write tests
+- May commit/push: **yes** (after module `clean install` evidence)
+
+## Issues
+
+None.
+
+## Notes
+
+- Flat registry unchanged: leftover deploy ints 1–73 stay enum-only (WF/assembly/WS collision). Dual-write tests go through the enum, not `LegacyErrorCodeRegistry.find(int)`.
+- `PSDeployException` XML round-trip still drops typed metadata (legacy int only). Callers that reconstruct from XML keep int `getErrorCode()`; new tests cover typed construction, not XML restore.
+- C2: constructors are additive. Subclasses `PSLockedException` / `PSDeployNonUniqueException` still call `super(int, Object[])`. No anonymous `new PSDeployException() {` sites.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Dual-write skip tests live in `perc-auditlog` (`CapturingAuditLogSink` is test-scoped and not on the deployer test classpath).
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); collision-safe registry (do not flatten 1–73).

--- a/docs/ai-generated/code-reviews/3740-deployer-server-handlers-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3740-deployer-server-handlers-errorcodes-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3740 deployer server/handlers IPS*Errors typed ErrorCodes
+
+**Date:** 2026-08-23  
+**Branch:** `fix/issue-3740-deployer-server-handlers-errorcodes`  
+**Base:** stacked on #3739 / PR #3753 (`origin/feat/issue-3739-deployer-catalog-client-errorcodes`); PR targets `main`  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Parent #2616 slice 2/3. Leftover deployer **server jobs/helpers + dependency handlers** production `IPS*Errors` int sites retyped to typed `*ErrorCodes` (`DeploymentErrorCodes`, `JobErrorCodes`, `SecurityErrorCodes`, `ServerErrorCodes`, `FilterServiceErrorCodes`). Additive `IPSErrorCode` constructors on `PSLockedException`, `PSDeployNonUniqueException`, `PSJobException`, `PSServerException`, and `PSAuthenticationFailedException`. Residual allow-list shrunk by those exact `deployer/.../server/` paths (70). Catalog/client remain on #3739; DCE/TableFactory and `PSDeployJexlUtils` remain later slices. No mass behavior change of deploy jobs.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (package-config production throws, typed lock/job/auth/server constructors, dual-write skip)
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: exception typed ctors + production retype + allow-list shrink + dual-write tests
+- May commit/push: **yes** (after module `clean install` evidence)
+
+## Issues
+
+None.
+
+## Notes
+
+- Flat registry unchanged: leftover deploy ints 1–73 stay enum-only (WF/assembly/WS collision). Dual-write tests go through the enum, not `LegacyErrorCodeRegistry.find(int)`.
+- Aliases mapped to existing enum names: `VERSION_LOWER_THEN_INSTALLED` → `VERSION_LOWER_THAN_INSTALLED`; `SERVER_VERSION_LOWER` → `SERVER_VERSION_MISMATCH`; `SERVER_VERSION_HIGHER` → `SERVER_BUILD_MISMATCH`. Numeric codes unchanged.
+- `getErrorCode() == IPS*Errors.X` comparisons became `== *ErrorCodes.X.numericCode()` so int equality still holds for mixed typed/legacy construction.
+- C2: constructors are additive. `PSAuthenticationFailedExException` extends `PSAuthenticationFailedException`; no anonymous `new <Type>() {` sites. system + deployer standalone install green.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Dual-write skip tests live in `perc-auditlog` (`CapturingAuditLogSink` is test-scoped and not on the deployer test classpath).
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); collision-safe registry (do not flatten 1–73).

--- a/docs/ai-generated/code-reviews/3741-dce-contentui-tablefactory-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3741-dce-contentui-tablefactory-errorcodes-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — #3741 DCE/ContentUI/TableFactory IPS*Errors → typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3741-dce-contentui-tablefactory-errorcodes` vs `origin/main` (parent #2616 slice 3/3).
+
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; additive constructors (C2); portable `Path`/`@TempDir` in tests; do not delete `IPS*Errors` interfaces.
+
+## Summary
+
+Leftover production `IPSContentExplorerErrors` / `IPSCmsErrors` / `IPSSearchErrors` / `IPSServerErrors` / `IPSTableFactoryErrors` call-sites in DesktopContentExplorer, ContentUI search, and TableFactory now throw typed catalog enums. Additive `IPSErrorCode` constructors on `PSStandaloneException`, `PSContentExplorerException`, `PSExtensionProcessingException`, `PSWizardValidationError`, and `PSJdbcTableFactoryException` retain `getTypedErrorCode()` / `isAuditable()`. Allow-list shrunk by those exact paths. Dual-write skip tests cover HTML search missing-parameter (16053) and production throws.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (TableFactory 4, DCE 5, ContentUI 2; perc-auditlog dual-write skip)
+- Cross-platform paths: DCE cataloger test uses `@TempDir Path` + `Files.createDirectories` + `toUri().toURL()` (no hardcoded separators)
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## C2
+
+Constructors are additive. Subclasses of `PSStandaloneException` still compile (`PSOptionException`, `PSServletException`, inner `PSRequestException`). No `extends PSExtensionProcessingException` / `PSJdbcTableFactoryException`. Standalone reverse-dep installs: `system`, `modules/DesktopContentExplorer`, `modules/ContentUI`.

--- a/modules/ContentUI/pom.xml
+++ b/modules/ContentUI/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>extensions-main</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
+++ b/modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
@@ -17,6 +17,8 @@
 
 package com.percussion.content.ui.search;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSFolder;
@@ -30,7 +32,6 @@ import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.search.IPSExecutableSearch;
-import com.percussion.search.IPSSearchErrors;
 import com.percussion.search.IPSSearchResultRow;
 import com.percussion.search.PSExecutableSearchFactory;
 import com.percussion.search.PSSearchException;
@@ -40,7 +41,6 @@ import com.percussion.search.objectstore.PSWSSearchRequest;
 import com.percussion.search.ui.PSSearchAdvancedPanel;
 import com.percussion.search.ui.PSSearchSimplePanel;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
 import com.percussion.services.assembly.PSAssemblyException;
@@ -96,15 +96,15 @@ public class PSSearchResult {
 
     String locale = request.getUserLocale();
 
-    PSComponentProcessorProxy processor =
-        new PSComponentProcessorProxy(PSComponentProcessorProxy.PROCTYPE_SERVERLOCAL, request);
-
     String searchId = getParameter(IPSHtmlParameters.SYS_SEARCHID, null, parameters);
     if (searchId == null) {
       Object[] args = {"HTML", IPSHtmlParameters.SYS_SEARCHID};
 
-      throw new PSExtensionProcessingException(IPSSearchErrors.HTML_SEARCH_MISSING_PARAMETER, args);
+      throw new PSExtensionProcessingException(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, args);
     }
+
+    PSComponentProcessorProxy processor =
+        new PSComponentProcessorProxy(PSComponentProcessorProxy.PROCTYPE_SERVERLOCAL, request);
 
     PSSearch search = loadSearch(processor, searchId);
 
@@ -158,7 +158,7 @@ public class PSSearchResult {
         // validate length etc.
         String msg = PSSearchSimplePanel.validateFTSSearchQuery(fullTextQuery, null, locale);
         if (msg != null) {
-          throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+          throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
         }
 
         search.setProperty(PSSearch.PROP_FULLTEXTQUERY, fullTextQuery);
@@ -195,7 +195,7 @@ public class PSSearchResult {
         field.setFieldValues(op, values);
         String msg = PSSearchFieldOperators.validateSearchFieldValue(field, null, locale);
         if (msg != null) {
-          throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+          throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
         }
       }
     }

--- a/modules/ContentUI/src/test/java/com/percussion/content/ui/search/PSSearchResultTypedErrorCodeSliceTest.java
+++ b/modules/ContentUI/src/test/java/com/percussion/content/ui/search/PSSearchResultTypedErrorCodeSliceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.content.ui.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.server.IPSRequestContext;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover ContentUI search production {@code IPSSearchErrors}
+ * / {@code IPSServerErrors} sites throw typed {@link SearchErrorCodes} / {@link ServerErrorCodes}.
+ * Both leftover codes are non-auditable (dual-write skip).
+ */
+class PSSearchResultTypedErrorCodeSliceTest {
+
+  @Test
+  void missingSearchIdThrowsTypedHtmlSearchMissingParameter() throws Exception {
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    when(request.getParametersIterator()).thenReturn(Collections.emptyIterator());
+    when(request.getUserLocale()).thenReturn("en-us");
+
+    PSExtensionProcessingException ex =
+        assertThrows(
+            PSExtensionProcessingException.class,
+            () -> new PSSearchResult().getSearchResults(request));
+
+    assertEquals(
+        SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, ex.getTypedErrorCode());
+    assertFalse(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void rawDumpTypedConstructionSkipsDualWrite() {
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, "invalid query");
+
+    assertEquals(ServerErrorCodes.RAW_DUMP.numericCode(), ex.getErrorCode());
+    assertSame(ServerErrorCodes.RAW_DUMP, ex.getTypedErrorCode());
+    assertFalse(ServerErrorCodes.RAW_DUMP.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.border.PSFocusBorder;
 import com.percussion.cms.PSActionVisibilityChecker;
 import com.percussion.cms.PSActionVisibilityGlobalState;
@@ -42,7 +43,6 @@ import com.percussion.cx.catalogers.PSLocaleCataloger;
 import com.percussion.cx.catalogers.PSRoleCataloger;
 import com.percussion.cx.catalogers.PSSiteCataloger;
 import com.percussion.cx.catalogers.PSSubjectCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.javafx.PSBrowserUtils;
 import com.percussion.cx.javafx.PSDesktopExplorerWindow;
@@ -288,7 +288,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
       }
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -1113,7 +1113,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
     try {
       if (StringUtils.isBlank(url)) {
         throw new PSContentExplorerException(
-            IPSContentExplorerErrors.ACTION_GET_CHILDREN,
+            ContentExplorerErrorCodes.ACTION_GET_CHILDREN,
             m_applet.getResourceString(getClass(), "No url specified"));
       }
 
@@ -1158,7 +1158,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
           : resultChildList.iterator();
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.ACTION_GET_CHILDREN, ex.toString());
+          ContentExplorerErrorCodes.ACTION_GET_CHILDREN, ex.toString());
     }
   }
 
@@ -4895,7 +4895,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
       }
     } catch (Exception ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
     return fm;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.util.PSXMLDomUtil;
@@ -77,7 +77,7 @@ public final class PSColumnWidthsOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
@@ -16,11 +16,11 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSUserInfo;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.guitools.ErrorDialogs;
@@ -104,10 +104,10 @@ public class PSDisplayFormatCatalog {
       }
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
 
     if (m_folderDisplayFormats.isEmpty()) {

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.HashMap;
@@ -72,7 +72,7 @@ public final class PSDisplayFormatOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSDisplayColumn;
 import com.percussion.cms.objectstore.PSDisplayFormat;
@@ -25,7 +26,6 @@ import com.percussion.cms.objectstore.PSSFields;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.cms.objectstore.ws.PSWSExecutableSearch;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.design.objectstore.PSLocator;
@@ -324,7 +324,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
       expandSynonyms = m_applet.getApplet().getSearchConfig().isSynonymExpansionRequired();
     } catch (PSCmsException cmsex) {
 
-      throw new PSContentExplorerException(IPSContentExplorerErrors.SEARCH_ERROR, cmsex.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, cmsex.toString());
     }
 
     String[][] advancedProps =
@@ -522,7 +522,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
           }
         }
 
-        throw new PSContentExplorerException(IPSContentExplorerErrors.SEARCH_ERROR, message);
+        throw new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, message);
       } else {
         throw new RuntimeException(ex.getLocalizedMessage());
       }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.Iterator;
@@ -77,7 +77,7 @@ public final class PSExpandedOption implements IPSClientObjects {
       }
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSCloningOptions;
@@ -37,7 +38,6 @@ import com.percussion.cx.catalogers.PSLocaleCataloger;
 import com.percussion.cx.catalogers.PSRoleCataloger;
 import com.percussion.cx.catalogers.PSSiteCataloger;
 import com.percussion.cx.catalogers.PSSubjectCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.cx.objectstore.PSProperties;
@@ -254,7 +254,7 @@ public class PSFolderActionManager {
       f.fromXml(els[0]);
       return f;
     } catch (PSException unte) {
-      throw new PSContentExplorerException(IPSContentExplorerErrors.GENERAL_ERROR, unte.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.GENERAL_ERROR, unte.toString());
     }
   }
 
@@ -365,7 +365,7 @@ public class PSFolderActionManager {
 
       return resList.iterator();
     } catch (PSException ex) {
-      throw new PSContentExplorerException(IPSContentExplorerErrors.GENERAL_ERROR, ex.toString());
+      throw new PSContentExplorerException(ContentExplorerErrorCodes.GENERAL_ERROR, ex.toString());
     } catch (PSContentExplorerException ex) {
       throw ex;
     } finally {
@@ -592,7 +592,7 @@ public class PSFolderActionManager {
         options.addSiteMapping(Integer.valueOf(sourceId), Integer.valueOf(copyId));
       }
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.GENERAL_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.GENERAL_ERROR, e.getMessage());
     }
 
     // copy the specified folder
@@ -670,7 +670,7 @@ public class PSFolderActionManager {
         if (pos != -1) tmpCwd = tmpCwd.substring(0, pos);
         else {
           String[] args = {cwd, path};
-          throw new PSCmsException(IPSContentExplorerErrors.INCOMPATIBLE_PATHS, args);
+          throw new PSCmsException(ContentExplorerErrorCodes.INCOMPATIBLE_PATHS, args);
         }
       } else done = true;
     }
@@ -915,7 +915,7 @@ public class PSFolderActionManager {
         errorText += err;
         errorText += "\r\n";
       }
-      throw new PSCmsException(IPSContentExplorerErrors.SITEDEF_UPDATE_FAILURES, errorText);
+      throw new PSCmsException(ContentExplorerErrorCodes.SITEDEF_UPDATE_FAILURES, errorText);
     }
   }
 
@@ -956,7 +956,7 @@ public class PSFolderActionManager {
         error = handleErrorResult(root);
       }
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.GENERAL_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.GENERAL_ERROR, e.getMessage());
     }
     return error;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
@@ -17,7 +17,7 @@
 
 package com.percussion.cx;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummaries;
 import com.percussion.cms.objectstore.PSComponentSummary;
@@ -356,7 +356,7 @@ public class PSItemRelationshipsManager {
         cid = "" + loc.getId();
       } catch (Exception e) {
         Object[] args = new Object[] {e.getLocalizedMessage()};
-        throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+        throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
       }
       if (cid != null && isAllowedRelationshipSlot(slotId, regSlots, inlineSlots)) {
         contentIds.add(cid);
@@ -394,7 +394,7 @@ public class PSItemRelationshipsManager {
       }
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
     return regSlots;
   }
@@ -426,7 +426,7 @@ public class PSItemRelationshipsManager {
       }
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
 
     return inlineSlots;
@@ -460,7 +460,7 @@ public class PSItemRelationshipsManager {
 
     } catch (Exception e) {
       Object[] args = new Object[] {e.getLocalizedMessage()};
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, args);
     }
 
     return doc;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cx;
 
-import com.percussion.cx.error.IPSContentExplorerErrors;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -69,7 +69,7 @@ public class PSOptionManager {
       setDefaultOptions(new PSUserOptions(doc.getDocumentElement()));
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.OPTIONS_LOAD_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.OPTIONS_LOAD_ERROR, e.getLocalizedMessage());
     }
   }
 
@@ -189,7 +189,7 @@ public class PSOptionManager {
       m_applet.getActionManager().postData(appPath, params);
     } catch (Exception e) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.OPTIONS_SAVE_ERROR, e.getLocalizedMessage());
+          ContentExplorerErrorCodes.OPTIONS_SAVE_ERROR, e.getLocalizedMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
@@ -24,7 +25,6 @@ import com.percussion.cms.objectstore.PSSaveResults;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.cms.objectstore.client.PSRemoteCataloger;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.cx.objectstore.PSProperties;
@@ -224,7 +224,7 @@ public class PSSearchViewActionManager {
       return search;
     } catch (PSException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -454,10 +454,10 @@ public class PSSearchViewActionManager {
           searchEx.executeSearch(searchNode, includeFolders, true);
         } catch (IOException ioe) {
           throw new PSContentExplorerException(
-              IPSContentExplorerErrors.GENERAL_ERROR, ioe.getLocalizedMessage());
+              ContentExplorerErrorCodes.GENERAL_ERROR, ioe.getLocalizedMessage());
         } catch (SAXException sae) {
           throw new PSContentExplorerException(
-              IPSContentExplorerErrors.GENERAL_ERROR, sae.getLocalizedMessage());
+              ContentExplorerErrorCodes.GENERAL_ERROR, sae.getLocalizedMessage());
         }
       } else // If not initialized simply set empty children
       {
@@ -617,11 +617,11 @@ public class PSSearchViewActionManager {
     } catch (IOException ex) {
       ex.printStackTrace();
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (SAXException ex) {
       ex.printStackTrace();
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
 
     return ret;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
@@ -16,12 +16,12 @@
  */
 package com.percussion.cx;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
 import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -132,10 +132,10 @@ public final class PSSearchViewCatalog {
         throw new IllegalStateException("Default search for Active Assembly is not found");
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -278,10 +278,10 @@ public final class PSSearchViewCatalog {
       }
     } catch (PSCmsException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     } catch (PSUnknownNodeTypeException ex) {
       throw new PSContentExplorerException(
-          IPSContentExplorerErrors.GENERAL_ERROR, ex.getLocalizedMessage());
+          ContentExplorerErrorCodes.GENERAL_ERROR, ex.getLocalizedMessage());
     }
     return emptySearchDoc;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSCommunityCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collCommunities = parseCommunities(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
@@ -66,7 +66,7 @@ public final class PSCommunityContentTypeMapperCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_commCtMapper = parseMapper(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -59,7 +59,7 @@ public final class PSGlobalTemplateCataloger {
 
       m_globalTemplates = parseGlobalTemplates(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSLocaleCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_locales = parseLocales(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSRoleCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collRoles = parseRoles(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSSite;
 import com.percussion.cx.PSFolderActionManager;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -58,7 +58,7 @@ public class PSSiteCataloger {
 
       fromXml(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
@@ -17,8 +17,8 @@
 
 package com.percussion.cx.catalogers;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.PSCmsException;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -60,7 +60,7 @@ public final class PSSubjectCataloger {
       Document doc = PSXmlDocumentBuilder.createXmlDocument(url.openStream(), false);
       m_collSubjects = parseSubjects(doc.getDocumentElement());
     } catch (Exception e) {
-      throw new PSCmsException(IPSContentExplorerErrors.CATALOG_ERROR, e.getMessage());
+      throw new PSCmsException(ContentExplorerErrorCodes.CATALOG_ERROR, e.getMessage());
     }
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.cx.wizards;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cms.objectstore.PSSite;
 import com.percussion.cx.PSContentExplorerApplet;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.objectstore.PSNode;
 import com.percussion.guitools.PSPropertyPanel;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
@@ -94,7 +94,7 @@ public final class PSCopySiteNamePage extends PSWizardPanel {
 
     if (errors.length() > 0)
       throw new PSWizardValidationError(
-          IPSContentExplorerErrors.WIZARD_VALIDATION_ERROR, errors.toString());
+          ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, errors.toString());
   }
 
   /* (non-Javadoc)

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.cx.wizards;
 
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.percussion.cx.PSContentExplorerApplet;
-import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.guitools.PSPropertyPanel;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import com.percussion.wizard.PSWizardPanel;
@@ -78,7 +78,7 @@ public class PSCopySiteSubfolderNamePage extends PSWizardPanel {
 
     if (errors.length() > 0)
       throw new PSWizardValidationError(
-          IPSContentExplorerErrors.WIZARD_VALIDATION_ERROR, errors.toString());
+          ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, errors.toString());
   }
 
   /* (non-Javadoc)

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardValidationError.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.wizard;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -42,6 +43,26 @@ public final class PSWizardValidationError extends PSException {
    * @param args the arguments, may be <code>null</code>.
    */
   public PSWizardValidationError(int code, Object[] args) {
+    super(code, args);
+  }
+
+  /**
+   * Typed construction with a single argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arg the single argument, may be {@code null}
+   */
+  public PSWizardValidationError(IPSErrorCode code, Object arg) {
+    super(code, arg);
+  }
+
+  /**
+   * Typed construction with argument array.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param args the arguments, may be {@code null}
+   */
+  public PSWizardValidationError(IPSErrorCode code, Object[] args) {
     super(code, args);
   }
 

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerTypedErrorCodeSliceTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerTypedErrorCodeSliceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
+import com.percussion.cms.PSCmsException;
+import com.percussion.cx.catalogers.PSCommunityCataloger;
+import com.percussion.cx.error.PSContentExplorerException;
+import com.percussion.wizard.PSWizardValidationError;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover Desktop Content Explorer production {@code
+ * IPSContentExplorerErrors} / {@code IPSCmsErrors} sites throw typed {@link
+ * ContentExplorerErrorCodes} / {@link CmsErrorCodes}. Catalog codes are non-auditable (dual-write
+ * skip).
+ */
+class PSContentExplorerTypedErrorCodeSliceTest {
+
+  @Test
+  void typedContentExplorerExceptionSkipsDualWrite() {
+    PSContentExplorerException ex =
+        new PSContentExplorerException(ContentExplorerErrorCodes.SEARCH_ERROR, "no hits");
+
+    assertEquals(ContentExplorerErrorCodes.SEARCH_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.SEARCH_ERROR, ex.getTypedErrorCode());
+    assertFalse(ContentExplorerErrorCodes.SEARCH_ERROR.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedWizardValidationErrorSkipsDualWrite() {
+    PSWizardValidationError ex =
+        new PSWizardValidationError(ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, "blank");
+
+    assertEquals(
+        ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.WIZARD_VALIDATION_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void cmsUnexpectedErrorFromRelationshipsIsNonAuditable() {
+    PSCmsException ex = new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, "boom");
+
+    assertEquals(CmsErrorCodes.UNEXPECTED_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(CmsErrorCodes.UNEXPECTED_ERROR, ex.getTypedErrorCode());
+    assertFalse(CmsErrorCodes.UNEXPECTED_ERROR.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void columnWidthsFromXmlWrongRootThrowsTypedOptionsError() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = doc.createElement("not-column-widths");
+    PSColumnWidthsOption option = new PSColumnWidthsOption();
+
+    PSContentExplorerException ex =
+        assertThrows(PSContentExplorerException.class, () -> option.fromXml(wrong));
+
+    assertEquals(
+        ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.MISC_PROCESSING_OPTIONS_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void communityCatalogerMissingResourceThrowsTypedCatalogError(@TempDir Path tmp)
+      throws Exception {
+    Path base = tmp.resolve("cx-catalog-base");
+    Files.createDirectories(base);
+    URL urlBase = base.toUri().toURL();
+
+    PSCmsException ex =
+        assertThrows(PSCmsException.class, () -> new PSCommunityCataloger(urlBase));
+
+    assertEquals(ContentExplorerErrorCodes.CATALOG_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(ContentExplorerErrorCodes.CATALOG_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/TableFactory/pom.xml
+++ b/modules/TableFactory/pom.xml
@@ -17,6 +17,12 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>perc-security-utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCharSets;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -214,13 +215,13 @@ public class PSJdbcColumnData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
 
     m_name = PSJdbcTableComponent.getAttribute(tree, NAME_ATTR, true);
     if (m_name == null || m_name.trim().length() == 0)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.INVALID_COLUMN_NAME, NODE_NAME);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.INVALID_COLUMN_NAME, NODE_NAME);
 
     String externalAttr = PSJdbcTableComponent.getAttribute(tree, EXTERNAL_ATTR, false);
 
@@ -246,7 +247,7 @@ public class PSJdbcColumnData {
       } else if (!isEmptyNull.trim().equalsIgnoreCase(EMPTY_NULL_FALSE)) {
         // bad value for attribute
         Object[] args = {NODE_NAME, EMPTY_NULL_ATTR, isEmptyNull};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
   }
@@ -293,7 +294,7 @@ public class PSJdbcColumnData {
     File f = new File(external);
     if (!(f.exists() && f.canRead())) {
       Object[] args = {parentNodeName, EXTERNAL_ATTR, external};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     return external;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.utils.jdbc.PSJdbcUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -182,7 +183,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // allow base class to set its memebers
@@ -196,14 +197,14 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     // get the data type and set it
     String strJdbcType = walker.getElementData(JDBC_EL);
     if (strJdbcType == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, JDBC_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, JDBC_EL);
     // this will validate for us
     setType(strJdbcType);
 
     // get the allows null value
     String strAllowsNull = walker.getElementData(ALLOWS_NULL_EL);
     if (strAllowsNull == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, ALLOWS_NULL_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, ALLOWS_NULL_EL);
 
     if (strAllowsNull.equalsIgnoreCase("y")) m_allowsNull = true;
     else if (strAllowsNull.equalsIgnoreCase("yes")) m_allowsNull = true;
@@ -214,7 +215,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     if (size != null && size.trim().length() == 0) size = null;
     else if (!validateParams(size)) {
       Object[] args = {NODE_NAME, SIZE_EL, size};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     setSize(size);
 
@@ -223,7 +224,7 @@ public class PSJdbcColumnDef extends PSJdbcTableComponent {
     if (scale != null && scale.trim().length() == 0) scale = null;
     else if (!validateParams(scale)) {
       Object[] args = {NODE_NAME, SIZE_EL, size};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     setScale(scale);
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSStringOperation;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -87,13 +88,13 @@ public class PSJdbcDataTypeMap {
     String rootName = root.getNodeName();
     if (!rootName.equals(ROOT_EL)) {
       Object[] args = {ROOT_EL, rootName};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Walk the maps and select the first match we find
     Element map = tree.getNextElement(MAP_EL, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (map == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, MAP_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, MAP_EL);
 
     boolean found = false;
     while (map != null) {
@@ -136,7 +137,7 @@ public class PSJdbcDataTypeMap {
     // did we find any match?
     if (!found) {
       Object[] args = {dbAlias, driver, os};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DATA_TYPE_MAP_NOT_FOUND, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DATA_TYPE_MAP_NOT_FOUND, args);
     }
     setMaxIndexColSize(map);
     setCreateForeignKeyIndexes(map);
@@ -147,7 +148,7 @@ public class PSJdbcDataTypeMap {
             PSJdbcDataTypeMapping.NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (mapping == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcDataTypeMapping.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcDataTypeMapping.NODE_NAME);
 
     while (mapping != null) {
       PSJdbcDataTypeMapping dataType = new PSJdbcDataTypeMapping(mapping);
@@ -177,7 +178,7 @@ public class PSJdbcDataTypeMap {
         m_maxIndexColSize = Long.parseLong(sTemp);
       } catch (Exception e) {
         Object[] args = {ROOT_EL, MAXINDEXCOLSIZE_EL, sTemp};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
   }
@@ -422,13 +423,13 @@ public class PSJdbcDataTypeMap {
   public int convertJdbcString(String jdbcString) throws PSJdbcTableFactoryException {
     if (jdbcString == null || jdbcString.trim().length() == 0)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_INT_DATA_TYPE_CONVERSION,
+          TableFactoryErrorCodes.JDBC_INT_DATA_TYPE_CONVERSION,
           jdbcString == null ? "null" : jdbcString);
 
     Integer jdbcType = m_jdbcString2Int.get(jdbcString);
     if (jdbcType == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_STRING_DATA_TYPE_CONVERSION, jdbcString);
+          TableFactoryErrorCodes.JDBC_STRING_DATA_TYPE_CONVERSION, jdbcString);
 
     return jdbcType;
   }
@@ -444,7 +445,7 @@ public class PSJdbcDataTypeMap {
     String jdbcString = m_jdbcInt2String.get(jdbcType);
     if (jdbcString == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.JDBC_INT_DATA_TYPE_CONVERSION, String.valueOf(jdbcType));
+          TableFactoryErrorCodes.JDBC_INT_DATA_TYPE_CONVERSION, String.valueOf(jdbcType));
 
     return jdbcString;
   }
@@ -518,7 +519,7 @@ public class PSJdbcDataTypeMap {
           jdbcType = Types.class.getField(jdbcStr).getInt(null);
         } catch (Exception e) {
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.INVALID_DATA_TYPE_MAPPING,
+              TableFactoryErrorCodes.INVALID_DATA_TYPE_MAPPING,
               new Object[] {jdbcStr, dataType.getNative()});
         }
         m_jdbcString2Int.put(jdbcStr, jdbcType);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -93,18 +94,18 @@ public class PSJdbcDataTypeMapping {
     String rootName = sourceNode.getNodeName();
     if (!rootName.equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, rootName};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     String jdbc = sourceNode.getAttribute(JDBC_AT);
     if (nullOrEmpty(jdbc))
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, JDBC_AT, ""});
+          TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, JDBC_AT, ""});
 
     String nativeStr = sourceNode.getAttribute(NATIVE_AT);
     if (nullOrEmpty(nativeStr))
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, NATIVE_AT, ""});
+          TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, new Object[] {NODE_NAME, NATIVE_AT, ""});
 
     String size = sourceNode.getAttribute(SIZE_AT);
     if (0 == size.trim().length()) size = null;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
@@ -15,6 +15,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
 import com.percussion.security.PSEncryptionException;
 import com.percussion.security.PSEncryptor;
@@ -467,13 +468,13 @@ public class PSJdbcDbmsDef implements IPSJdbcDbmsDefConstants {
     if (m_dataSource != null) {
       conn = m_dataSource.getConnection();
       if (conn == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED);
     } else {
       try {
         Class.forName(getDriverClassName());
       } catch (ClassNotFoundException | LinkageError cls) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.SQL_CONNECTION_FAILED, cls.getLocalizedMessage(), cls);
+            TableFactoryErrorCodes.SQL_CONNECTION_FAILED, cls.getLocalizedMessage(), cls);
       }
 
       String connStr = PSSqlHelper.getJdbcUrl(getDriver(), getServer());
@@ -513,7 +514,7 @@ public class PSJdbcDbmsDef implements IPSJdbcDbmsDefConstants {
         String message = connStr;
         if (sqe != null) message += (" - " + PSJdbcTableFactoryException.formatSqlException(sqe));
 
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED, message);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED, message);
       }
     }
     return conn;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -137,7 +138,7 @@ public class PSJdbcExecutionPlanLogsContainer {
       writer = new FileWriter(logFile);
       PSXmlDocumentBuilder.write(doc, writer, "UTF-8");
     } catch (Exception e) {
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.LOG_FILE_WRITE_ERROR);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.LOG_FILE_WRITE_ERROR);
     } finally {
       try {
         if (writer != null) writer.close();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -230,7 +231,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_columns.clear();
@@ -245,7 +246,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
     // make sure we get at least one
     do {
       if (fkcolumn == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, FK_COLUMN_EL);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, FK_COLUMN_EL);
 
       // load it's child elements
       String colName = getRequiredElement(walker, NAME_EL);
@@ -434,7 +435,7 @@ public class PSJdbcForeignKey extends PSJdbcTableComponent {
     if (null == data || data.trim().length() == 0) {
       String parentName = tree.getCurrent().getNodeName();
       Object[] args = {parentName, elemName, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return data;
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -146,7 +147,7 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
 
     if (!sourceNode.getNodeName().equals(nodeName)) {
       Object[] args = {nodeName, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     List<String> names = new ArrayList<>();
@@ -160,13 +161,13 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
     // make sure we get at least one
     do {
       if (nameEl == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, NAME_EL);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, NAME_EL);
 
       String name = PSXmlTreeWalker.getElementData(nameEl);
       if (name.trim().length() == 0) {
         Object[] args = {nodeName, NAME_EL, name};
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+            TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       names.add(name);
@@ -361,11 +362,11 @@ public abstract class PSJdbcKey extends PSJdbcTableComponent {
       String colName = columnNames.next();
       if (colName == null || colName.trim().length() == 0)
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.INVALID_COLUMN_NAME, m_containerName);
+            TableFactoryErrorCodes.INVALID_COLUMN_NAME, m_containerName);
 
       if (newCols.contains(colName)) {
         Object[] args = {m_containerName, colName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DUPLICATE_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DUPLICATE_COLUMN, args);
       }
       newCols.add(colName);
     }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.sql.Connection;
@@ -107,7 +108,7 @@ public class PSJdbcPlanBuilder {
       // if no table and alter, error
       if (tableSchema.isAlter()) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.ALTER_NO_TABLE, tableSchema.getName());
+            TableFactoryErrorCodes.ALTER_NO_TABLE, tableSchema.getName());
       } else if (!tableSchema.isCreate()) {
         // no table and don't create, return empty plan
         PSJdbcTableFactory.logMessage("Table doesn't exist and create=n, no action taken");
@@ -685,7 +686,7 @@ public class PSJdbcPlanBuilder {
       dataTypeMap = new PSJdbcDataTypeMap(dbmsDef.getBackEndDB(), dbmsDef.getDriver(), null);
     } catch (Exception e) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+          TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
     }
     Iterator<?> childTables = row.getChildTables();
     while (childTables.hasNext()) {
@@ -981,13 +982,13 @@ public class PSJdbcPlanBuilder {
       if ((colFirst == null) || (colFirst.getValue() == null)) {
         Object[] args = {tableSchema.getName(), colName};
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE_IN_DB, args);
+            TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE_IN_DB, args);
       }
 
       colSecond = rowDataToCompare.getColumn(colName);
       if ((colSecond == null) || (colSecond.getValue() == null)) {
         Object[] args = {tableSchema.getName(), colName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE, args);
       }
 
       if (!colFirst.getValue().equals(colSecond.getValue())) return false;
@@ -1530,7 +1531,7 @@ public class PSJdbcPlanBuilder {
       return bakName;
     } catch (SQLException e) {
       Object[] args = {tablename, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SCHEMA_PROCESS_ERROR, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SCHEMA_PROCESS_ERROR, args, e);
     }
   }
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.util.PSPreparedStatement;
 import java.sql.Connection;
@@ -159,7 +160,7 @@ public class PSJdbcPreparedSqlStatement extends PSJdbcSqlStatement {
         // convert to SQLException
         Object[] args = {value.getValue(), value.getType(), e.toString()};
         PSJdbcTableFactoryException fe =
-            new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_BIND_PARAMETER, args, e);
+            new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_BIND_PARAMETER, args, e);
         throw new SQLException(fe.getLocalizedMessage(), e);
       }
     }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.util.PSSQLStatement;
 import java.io.IOException;
@@ -147,7 +148,7 @@ public class PSJdbcResultSetIteratorStep extends PSJdbcSqlStatement {
       }
     } catch (IOException e) {
       Object[] args = {m_tableSchema.getName(), "Column : " + colName + " " + e.getMessage()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CATALOG_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CATALOG_DATA, args, e);
     }
     return new PSJdbcRowData(colDataList.iterator(), m_rowAction);
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -378,7 +379,7 @@ public class PSJdbcRowData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -396,7 +397,7 @@ public class PSJdbcRowData {
         tree.getNextElement(PSJdbcColumnData.NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (colEl == null) {
       Object[] args = {NODE_NAME, PSJdbcColumnData.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (colEl != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -124,7 +125,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -144,7 +145,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, SRC_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String key = sTemp;
 
@@ -153,7 +154,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, DEST_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String value = sTemp;
         m_colMapping.put(key, value);
@@ -173,7 +174,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, DEST_COLUMN_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String colName = sTemp;
 
@@ -182,7 +183,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         if (sTemp == null || sTemp.trim().length() == 0) {
           Object[] args = {NODE_NAME, VALUE_ATTR, sTemp == null ? "null" : sTemp};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String colValue = sTemp;
         PSJdbcColumnData colData = new PSJdbcColumnData(colName, colValue);
@@ -196,7 +197,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
    * Verifies that all the columns added to the column mapping Map though the <code>
    * addColumnMapping()</code> method are present in the input row parameter. If any column
    * specified in the mapping is not present then it throws <code>PSJdbcTableFactoryException</code>
-   * exception with error code <code>IPSTableFactoryErrors.COLUMN_NOT_FOUND</code>
+   * exception with error code <code>TableFactoryErrorCodes.COLUMN_NOT_FOUND</code>
    *
    * @param row the row data against which the column mapping is to be checked, may not be <code>
    *     null</code>
@@ -214,7 +215,7 @@ public class PSJdbcRowMapping implements IPSJdbcRowMapping {
         String tableName = "";
         if (m_tblData != null) tableName = m_tblData.getName();
         Object[] args = {tableName, srcColName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
       }
     }
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Attr;
@@ -238,7 +239,7 @@ public abstract class PSJdbcTableComponent {
     if (required && (null == data || data.getValue().trim().length() == 0)) {
       String parentName = tree.getCurrent().getNodeName();
       Object[] args = {parentName, attrName, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return data == null ? null : data.getValue();
   }
@@ -289,7 +290,7 @@ public abstract class PSJdbcTableComponent {
       if (!found) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
     return index;

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -208,7 +209,7 @@ public class PSJdbcTableData {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_rows = new ArrayList<>();
     m_columnNames = new HashSet<>();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import static com.percussion.tablefactory.IPSLogger.LOG_CATEGORY;
 
 import com.percussion.security.error.PSExceptionUtils;
@@ -74,7 +75,7 @@ public class PSJdbcTableDataCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -89,7 +90,7 @@ public class PSJdbcTableDataCollection extends PSCollection {
 
     if (table == null) {
       Object[] args = {NODE_NAME, PSJdbcTableData.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, args);
     }
 
     while (table != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
@@ -17,6 +17,8 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.security.xml.PSSecureXMLUtils;
@@ -191,7 +193,7 @@ public class PSJdbcTableFactory {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
 
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SQL_CATALOG_TABLE_FAILED, args, e);
+          TableFactoryErrorCodes.SQL_CATALOG_TABLE_FAILED, args, e);
     }
 
     return tableSchema;
@@ -243,7 +245,7 @@ public class PSJdbcTableFactory {
       processTable(conn, dbmsDef, tableSchema, logOut, logDebug);
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CONNECTION_FAILED, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CONNECTION_FAILED, args, e);
     } finally {
       if (conn != null)
         try {
@@ -331,7 +333,7 @@ public class PSJdbcTableFactory {
         // Schema changes for a view is not supported
         if (tableSchema.isView() || tmd.isView())
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.ALTER_VIEW_NOT_SUPPORTED, tableSchema.getName());
+              TableFactoryErrorCodes.ALTER_VIEW_NOT_SUPPORTED, tableSchema.getName());
 
         // Process schema changes
         PSJdbcExecutionPlan plan = new PSJdbcExecutionPlan();
@@ -401,10 +403,10 @@ public class PSJdbcTableFactory {
         processingData = false;
       }
     } catch (SQLException e) {
-      int errorCode =
+      IPSErrorCode errorCode =
           processingData
-              ? IPSTableFactoryErrors.DATA_PROCESS_ERROR
-              : IPSTableFactoryErrors.SCHEMA_PROCESS_ERROR;
+              ? TableFactoryErrorCodes.DATA_PROCESS_ERROR
+              : TableFactoryErrorCodes.SCHEMA_PROCESS_ERROR;
 
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
       PSJdbcTableFactoryException ex = new PSJdbcTableFactoryException(errorCode, args, e);
@@ -760,7 +762,7 @@ public class PSJdbcTableFactory {
         dataTypeMapObj = new PSJdbcDataTypeMap(dbmsDef.getBackEndDB(), dbmsDef.getDriver(), null);
       } catch (Exception e) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+            TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
       }
     } else {
       dataTypeMapObj =
@@ -797,7 +799,7 @@ public class PSJdbcTableFactory {
         }
       }
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           PSJdbcTableFactoryException.formatSqlException(e),
           e);
     } catch (PSJdbcTableFactoryException e1) {
@@ -1013,7 +1015,7 @@ public class PSJdbcTableFactory {
     File tableDefFile = new File(defDataFolder, "tableDef.xml");
     if (!tableDefFile.isFile()) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           "tableDef.xml not found under export storage: " + tableDefFile.getAbsolutePath());
     }
 
@@ -1062,7 +1064,7 @@ public class PSJdbcTableFactory {
             throw (PSJdbcTableFactoryException) e;
           }
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.DATA_PROCESS_ERROR,
+              TableFactoryErrorCodes.DATA_PROCESS_ERROR,
               new Object[] {tableName, e.getMessage()},
               e);
         }
@@ -1321,7 +1323,7 @@ public class PSJdbcTableFactory {
       return count > 0;
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.CHECK_EXISTING_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.CHECK_EXISTING_DATA, args, e);
     } finally {
       if (rsCount != null)
         try {
@@ -1406,7 +1408,7 @@ public class PSJdbcTableFactory {
       return new PSJdbcTableData(tableSchema.getName(), rowList.iterator());
     } catch (SQLException e) {
       Object[] args = {tableSchema.getName(), PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CATALOG_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CATALOG_DATA, args, e);
     } finally {
       if (step != null) step.close();
     }
@@ -1761,7 +1763,7 @@ public class PSJdbcTableFactory {
     URL xslUrl = PSJdbcTableFactory.class.getResource(xslFileName);
     if (xslUrl == null)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.STYLESHEET_NOT_FOUND, xslFileName);
+          TableFactoryErrorCodes.STYLESHEET_NOT_FOUND, xslFileName);
 
     DOMResult result = new DOMResult();
     try {
@@ -1771,7 +1773,7 @@ public class PSJdbcTableFactory {
       transformer.transform(new DOMSource(doc), result);
     } catch (Throwable t) {
       Object[] args = {xslFileName, t.getMessage()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.TRANSFORMATION_ERROR, args, t);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.TRANSFORMATION_ERROR, args, t);
     }
 
     return (Document) result.getNode();

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactoryException.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactoryException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.percussion.error.IPSErrorCode;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -109,6 +110,62 @@ public class PSJdbcTableFactoryException extends Exception {
   }
 
   /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   * @param t the exception which this exception encapsulates, may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object singleArg, Throwable t) {
+    this(requireCode(code).numericCode(), singleArg, t);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param t the exception which this exception encapsulates, may be {@code null}
+   */
+  public PSJdbcTableFactoryException(IPSErrorCode code, Object[] arrayArgs, Throwable t) {
+    this(requireCode(code).numericCode(), arrayArgs, t);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Prints this Throwable's backtrace to the standard error stream. This method prints a stack
    * trace for this Throwable object on the error output stream that is the value of the field
    * System.err.
@@ -198,6 +255,29 @@ public class PSJdbcTableFactoryException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when constructed via {@link #PSJdbcTableFactoryException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when
+   * present; legacy int construction returns {@code false}.
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -370,6 +450,12 @@ public class PSJdbcTableFactoryException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed error code when constructed via {@link #PSJdbcTableFactoryException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -146,7 +147,7 @@ public class PSJdbcTableMapping {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.SecureStringUtils;
 import com.percussion.util.PSSqlHelper;
 import com.percussion.utils.collections.PSIteratorUtils;
@@ -120,7 +121,7 @@ public class PSJdbcTableMetaData {
       }
     } catch (SQLException e) {
       Object[] args = {tableName, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_TABLE_META_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_TABLE_META_DATA, args, e);
     }
   }
 

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -60,7 +61,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       PSJdbcColumnDef dupeCol = setColumn(column);
       if (dupeCol != null) {
         Object[] args = {m_name + " table", column.getName()};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DUPLICATE_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DUPLICATE_COLUMN, args);
       }
     }
   }
@@ -239,7 +240,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     int index = getColumnIndex(name);
     if (index > -1) {
       if (m_columns.size() == 1)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.REMOVE_LAST_COLUMN);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.REMOVE_LAST_COLUMN);
 
       oldCol = m_columns.get(index);
       m_columns.remove(index);
@@ -542,7 +543,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -555,7 +556,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     String sTemp = sourceNode.getAttribute(NAME_ATTR);
     if (sTemp.trim().length() == 0) {
       Object[] args = {NODE_NAME, NAME_ATTR, sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_name = sTemp;
 
@@ -587,12 +588,12 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
     walker.setCurrent(sourceNode);
     Element row = walker.getNextElement(ROW_EL, firstFlags);
     if (row == null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, ROW_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, ROW_EL);
 
     Element column = walker.getNextElement(PSJdbcColumnDef.NODE_NAME, firstFlags);
     if (column == null) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcColumnDef.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcColumnDef.NODE_NAME);
     }
 
     while (column != null) {
@@ -659,7 +660,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       Element index = walker.getNextElement(PSJdbcIndex.NODE_NAME, firstFlags);
       if (index == null) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcIndex.NODE_NAME);
+            TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcIndex.NODE_NAME);
       }
       while (index != null) {
         PSJdbcIndex indexDef = new PSJdbcIndex(index);
@@ -883,7 +884,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
   public void setAlter(boolean isAlter) throws PSJdbcTableFactoryException {
     // can't alter and have data
     if (isAlter && m_tableData != null)
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.ALTER_TABLE_SET_DATA, getName());
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.ALTER_TABLE_SET_DATA, getName());
 
     m_alter = isAlter;
   }
@@ -963,7 +964,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       // can't alter and have data
       if (isAlter())
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.ALTER_TABLE_SET_DATA, getName());
+            TableFactoryErrorCodes.ALTER_TABLE_SET_DATA, getName());
 
       validateTableData(tableData);
     }
@@ -982,7 +983,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(m_primaryKey.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcPrimaryKey.CONTAINER_NAME, badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
 
@@ -991,7 +992,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
         String badCols = checkColumns(foreignKey.getInternalColumns());
         if (badCols != null) {
           Object[] args = {getName(), PSJdbcForeignKey.CONTAINER_NAME, badCols};
-          throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+          throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
         }
       }
     }
@@ -1000,7 +1001,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(m_updateKey.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcUpdateKey.CONTAINER_NAME, badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
 
@@ -1008,7 +1009,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       String badCols = checkColumns(index.getColumnNames());
       if (badCols != null) {
         Object[] args = {getName(), PSJdbcIndex.CONTAINER_NAME + ": " + index.getName(), badCols};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.MISSING_COLUMN, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.MISSING_COLUMN, args);
       }
     }
   }
@@ -1033,7 +1034,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
       if (columnDef == null
           || (columnDef.getAction() == PSJdbcTableComponent.ACTION_DELETE && isAlter())) {
         Object[] args = {tableData.getName(), columnName};
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
       }
     }
 
@@ -1043,7 +1044,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
      */
     if (tableData.hasUpdates()) {
       if (m_primaryKey == null && m_updateKey == null)
-        throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.UPDATE_DATA_NO_KEYS, getName());
+        throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.UPDATE_DATA_NO_KEYS, getName());
 
       // walk each update row and be sure there's a value for each key column
       List<String> keyCols = getKeyColumns();
@@ -1056,7 +1057,7 @@ public class PSJdbcTableSchema implements Comparable<PSJdbcTableSchema> {
           if (colData == null || colData.getValue() == null) {
             Object[] args = {getName(), keyCol};
             throw new PSJdbcTableFactoryException(
-                IPSTableFactoryErrors.UPDATE_DATA_NO_KEY_VALUE, args);
+                TableFactoryErrorCodes.UPDATE_DATA_NO_KEY_VALUE, args);
           }
         }
       }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -78,7 +79,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -92,7 +93,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
     Element table = walker.getNextElement(PSJdbcTableSchema.NODE_NAME, firstFlags);
     if (table == null) {
       Object[] args = {NODE_NAME, PSJdbcTableSchema.NODE_NAME, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (table != null) {
@@ -168,7 +169,7 @@ public class PSJdbcTableSchemaCollection extends PSCollection {
       PSJdbcTableData tableData = (PSJdbcTableData) tables.next();
       if (!matchedTables.contains(tableData.getName())) {
         throw new PSJdbcTableFactoryException(
-            IPSTableFactoryErrors.TABLE_SCHEMA_NOT_FOUND, tableData.getName());
+            TableFactoryErrorCodes.TABLE_SCHEMA_NOT_FOUND, tableData.getName());
       }
     }
   }

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
@@ -91,7 +92,7 @@ public class PSJdbcTableSchemaHandler {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -104,7 +105,7 @@ public class PSJdbcTableSchemaHandler {
     String sTemp = sourceNode.getAttribute(TYPE_ATTR);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {NODE_NAME, TYPE_ATTR, sTemp == null ? "null" : sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_type = getSchemaHandlerType(sTemp);
 
@@ -124,7 +125,7 @@ public class PSJdbcTableSchemaHandler {
             NODE_NAME, IPSJdbcTableDataHandler.CLASS_ATTR, sTemp == null ? "null" : sTemp
           };
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         String className = sTemp;
 
@@ -136,13 +137,13 @@ public class PSJdbcTableSchemaHandler {
           dataHandler.fromXml(dataHandlerEl);
         } catch (ClassNotFoundException e) {
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.DATA_HANDLER_CLASS_NOT_FOUND, className);
+              TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND, className);
         } catch (PSJdbcTableFactoryException e) {
           throw e;
         } catch (Exception e) {
           Object[] args = {NODE_NAME, IPSJdbcTableDataHandler.CLASS_ATTR, e.getLocalizedMessage()};
           throw new PSJdbcTableFactoryException(
-              IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+              TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         m_dataHandlers.add(dataHandler);

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.tablefactory;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import org.w3c.dom.Document;
@@ -60,7 +61,7 @@ public class PSJdbcTableSchemaHandlerCollection extends PSCollection {
 
     if (!sourceNode.getNodeName().equals(NODE_NAME)) {
       Object[] args = {NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     clear();
@@ -75,7 +76,7 @@ public class PSJdbcTableSchemaHandlerCollection extends PSCollection {
 
     if (schemaHandler == null) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcTableSchemaHandler.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcTableSchemaHandler.NODE_NAME);
     }
 
     while (schemaHandler != null) {

--- a/modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
+++ b/modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
@@ -15,8 +15,8 @@
  */
 package com.percussion.tablefactory.tools;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcColumnDef;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
@@ -271,7 +271,7 @@ public class PSCatalogTableData {
     if (table == null) {
       // Do not System.exit — this path is used programmatically by migration (#548)
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.SCHEMA_COLL_PROCESS_ERROR,
+          TableFactoryErrorCodes.SCHEMA_COLL_PROCESS_ERROR,
           "No tables found to export (empty tables document)");
     }
 

--- a/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
+++ b/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.tablefactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3741 / parent #2616 slice 3: leftover TableFactory production {@code IPSTableFactoryErrors}
+ * sites throw typed {@link TableFactoryErrorCodes}. All catalog codes are non-auditable (dual-write
+ * skip).
+ */
+class PSJdbcTableFactoryTypedErrorCodeSliceTest {
+
+  @Test
+  void typedConstructionRetainsCatalogAndSkipsDualWrite() {
+    PSJdbcTableFactoryException ex =
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, new Object[] {"column", "row"});
+
+    assertEquals(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedConstructionRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSJdbcTableFactoryException(null, "arg"));
+  }
+
+  @Test
+  void columnDataWrongXmlElementThrowsTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = doc.createElement("row");
+
+    PSJdbcTableFactoryException ex =
+        assertThrows(PSJdbcTableFactoryException.class, () -> new PSJdbcColumnData(wrong));
+
+    assertEquals(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void schemaHandlerMissingClassThrowsTypedDataHandlerNotFound() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = doc.createElement(PSJdbcTableSchemaHandler.NODE_NAME);
+    handler.setAttribute("type", PSJdbcTableSchemaHandler.TYPE_STR_ON_CREATE);
+    Element handlersEl = doc.createElement("dataHandlers");
+    Element classEl = doc.createElement(IPSJdbcTableDataHandler.NODE_NAME);
+    classEl.setAttribute(IPSJdbcTableDataHandler.CLASS_ATTR, "com.percussion.does.not.ExistHandler");
+    handlersEl.appendChild(classEl);
+    handler.appendChild(handlersEl);
+
+    PSJdbcTableFactoryException ex =
+        assertThrows(PSJdbcTableFactoryException.class, () -> new PSJdbcTableSchemaHandler(handler));
+
+    assertEquals(
+        TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
+++ b/modules/TableFactory/src/test/java/com/percussion/tablefactory/PSJdbcTableFactoryTypedErrorCodeSliceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
+import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -44,6 +45,21 @@ class PSJdbcTableFactoryTypedErrorCodeSliceTest {
     assertSame(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
     assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
     assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedConstructionWithCauseRetainsCatalogAndSkipsDualWrite() {
+    SQLException cause = new SQLException("meta lookup failed");
+    Object[] args = {"RXSYS", "CONTENTSTATUS"};
+    PSJdbcTableFactoryException ex =
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.SQL_TABLE_META_DATA, args, cause);
+
+    assertEquals(TableFactoryErrorCodes.SQL_TABLE_META_DATA.numericCode(), ex.getErrorCode());
+    assertSame(TableFactoryErrorCodes.SQL_TABLE_META_DATA, ex.getTypedErrorCode());
+    assertFalse(TableFactoryErrorCodes.SQL_TABLE_META_DATA.isAuditable());
+    assertFalse(ex.isAuditable());
+    assertSame(cause, ex.m_th);
   }
 
   @Test

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -1230,6 +1230,54 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void deploymentServerHandlerLeftoverCodesSkipDualWriteViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    DeploymentErrorCodes[] leftovers = {
+      DeploymentErrorCodes.SERVER_REQUEST_MALFORMED,
+      DeploymentErrorCodes.SERVER_OBJECT_NOT_FOUND,
+      DeploymentErrorCodes.DEPENDENCY_HANDLER_INIT,
+      DeploymentErrorCodes.DEPENDENCY_MGR_INIT,
+      DeploymentErrorCodes.MISSING_DEPENDENCY_FILE,
+      DeploymentErrorCodes.INVALID_DEPENDENCY_FILE,
+      DeploymentErrorCodes.DEP_OBJECT_NOT_FOUND,
+      DeploymentErrorCodes.NO_ROWS_TO_PROCESS,
+      DeploymentErrorCodes.INCOMPLATE_ORDER_DEF,
+      DeploymentErrorCodes.INVALID_NUM_CHILD_DEFS,
+      DeploymentErrorCodes.CANNOT_FIND_PARENT_DEP_DEF,
+      DeploymentErrorCodes.ARCHIVE_REF_FOUND,
+      DeploymentErrorCodes.MAX_DEP_COUNT_EXCEEDED,
+      DeploymentErrorCodes.MULTISERVER_MANAGER_DISABLED,
+      DeploymentErrorCodes.PACKAGE_CREATED_ON_SYSTEM
+    };
+    for (DeploymentErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      AuditLogId id = svc.log(code, AuditContext.empty());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED.value(), id.value(), code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void jobLeftoverCodesSkipDualWriteViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    JobErrorCodes[] leftovers = {
+      JobErrorCodes.INVALID_JOB_DESCRIPTOR,
+      JobErrorCodes.UNEXPECTED_ERROR,
+      JobErrorCodes.CONFIG_FILE_NOT_FOUND
+    };
+    for (JobErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      AuditLogId id = svc.log(code, AuditContext.empty());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED.value(), id.value(), code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
   void navigationCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(18001));
     assertSame(

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -773,6 +773,32 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void htmlSearchMissingParameterIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(16053));
+    assertSame(
+        SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER,
+        LegacyErrorCodeRegistry.find(16053).orElseThrow());
+    assertFalse(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.isAuditable());
+  }
+
+  @Test
+  void htmlSearchMissingParameterNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "HTML",
+            "sys_searchid");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
   void luceneIndexCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(16311));
     assertSame(
@@ -1316,6 +1342,7 @@ class LegacyErrorCodeRegistryTest {
     assertFalse(TableFactoryErrorCodes.XML_ELEMENT_NULL.isAuditable());
     assertEquals(1001, TableFactoryErrorCodes.XML_ELEMENT_NULL.numericCode());
     assertEquals(1310, TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
   }
 
   @Test

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -1200,6 +1200,36 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void deploymentCatalogClientLeftoverCodesSkipDualWriteViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    DeploymentErrorCodes[] leftovers = {
+      DeploymentErrorCodes.NULL_INPUT_DOC,
+      DeploymentErrorCodes.UNEXPECTED_ERROR,
+      DeploymentErrorCodes.INVALID_REQUEST_TYPE,
+      DeploymentErrorCodes.CATALOG_REQD_PROP_NOT_SPECIFIED,
+      DeploymentErrorCodes.CATALOG_INVALID_DIRECTORY_SPECIFIED,
+      DeploymentErrorCodes.ARCHIVE_READ_ERROR,
+      DeploymentErrorCodes.ARCHIVE_WRITE_ERROR,
+      DeploymentErrorCodes.MISSING_ID_MAPPING,
+      DeploymentErrorCodes.INCOMPLETE_ID_MAPPING,
+      DeploymentErrorCodes.INVALID_ID_MAPPING_TARGET,
+      DeploymentErrorCodes.INCOMPLETE_ID_TYPE_MAPPING,
+      DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_MISSING,
+      DeploymentErrorCodes.SERVER_RESPONSE_ELEMENT_INVALID,
+      DeploymentErrorCodes.NOT_CONNECTED_ERROR,
+      DeploymentErrorCodes.LOCK_NOT_RELEASED
+    };
+    for (DeploymentErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      AuditLogId id = svc.log(code, AuditContext.empty());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED.value(), id.value(), code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
   void navigationCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(18001));
     assertSame(

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -7,6 +7,7 @@
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
 #   #3739 deployer catalog/client/objectstore/PSDeployService
+#   #3740 deployer server/handlers + server/dependencies
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -16,76 +17,6 @@
 # Tests, comment-only mentions, and the gate scripts themselves are ignored.
 
 deployer/src/main/java/com/percussion/deployer/jexl/PSDeployJexlUtils.java
-deployer/src/main/java/com/percussion/deployer/server/PSAppTransformer.java
-deployer/src/main/java/com/percussion/deployer/server/PSArchiveHandler.java
-deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
-deployer/src/main/java/com/percussion/deployer/server/PSDbmsMapManager.java
-deployer/src/main/java/com/percussion/deployer/server/PSDependencyManager.java
-deployer/src/main/java/com/percussion/deployer/server/PSDependencyMap.java
-deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
-deployer/src/main/java/com/percussion/deployer/server/PSExportJob.java
-deployer/src/main/java/com/percussion/deployer/server/PSIdMapManager.java
-deployer/src/main/java/com/percussion/deployer/server/PSIdTypeManager.java
-deployer/src/main/java/com/percussion/deployer/server/PSImportJob.java
-deployer/src/main/java/com/percussion/deployer/server/PSItemData.java
-deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
-deployer/src/main/java/com/percussion/deployer/server/PSPackageConfiguration.java
-deployer/src/main/java/com/percussion/deployer/server/PSValidationJob.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/IPSDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAclDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAppObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAssemblyServiceHelper.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAuthTypeDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCmsObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentSlotDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentEditorObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentListDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentRelationDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeTemplateDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContextDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSControlDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyUtils.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDisplayFormatDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSEditionTaskDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSExitDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFileDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFilterInstallUtils.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderContentsDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderTranslationsDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSKeywordDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLoadableHandlerDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocSchemeDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSLocaleDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSMenuActionObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPairDependencyId.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPublisherServiceHelper.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRelationshipDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSRoleDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSchemaDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSearchObjectDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSharedGroupDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSiteDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSlotDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSupportFileDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSystemDefElementDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateCommunityDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslationSettingsDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
 modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -6,6 +6,7 @@
 # Shrink this list as retype PRs merge:
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
+#   #3739 deployer catalog/client/objectstore/PSDeployService
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -14,15 +15,7 @@
 #
 # Tests, comment-only mentions, and the gate scripts themselves are ignored.
 
-deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java
-deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java
-deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
-deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java
 deployer/src/main/java/com/percussion/deployer/jexl/PSDeployJexlUtils.java
-deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java
-deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
 deployer/src/main/java/com/percussion/deployer/server/PSAppTransformer.java
 deployer/src/main/java/com/percussion/deployer/server/PSArchiveHandler.java
 deployer/src/main/java/com/percussion/deployer/server/PSDbmsHelper.java
@@ -93,7 +86,6 @@ deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTemplateDef
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslationSettingsDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
-deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
 modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
 modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -6,6 +6,7 @@
 # Shrink this list as retype PRs merge:
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
+#   #3741 DCE/ContentUI/TableFactory leftover call sites
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -94,51 +95,6 @@ deployer/src/main/java/com/percussion/deployer/server/dependencies/PSTranslation
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSVariantDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/server/dependencies/PSWorkflowDefDependencyHandler.java
 deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
-modules/ContentUI/src/main/java/com/percussion/content/ui/search/PSSearchResult.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
-modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteSubfolderNamePage.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcColumnDef.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMap.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDataTypeMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcDbmsDef.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcExecutionPlanLogsContainer.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcForeignKey.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcKey.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPlanBuilder.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcPreparedSqlStatement.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcResultSetIteratorStep.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcRowMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableComponent.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableDataCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableFactory.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMapping.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableMetaData.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
-modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
 modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java

--- a/system/src/main/java/com/percussion/conn/PSServerException.java
+++ b/system/src/main/java/com/percussion/conn/PSServerException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.conn;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
 import java.lang.reflect.Constructor;
@@ -60,6 +61,35 @@ public class PSServerException extends PSException {
    */
   public PSServerException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction from a catalogued {@link IPSErrorCode}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSServerException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSServerException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSServerException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/system/src/main/java/com/percussion/conn/PSServerException.java
+++ b/system/src/main/java/com/percussion/conn/PSServerException.java
@@ -93,6 +93,17 @@ public class PSServerException extends PSException {
   }
 
   /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSServerException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    super(code, arrayArgs, cause);
+  }
+
+  /**
    * Construct a server exception when an unknown exception occurs while communicating with the
    * server.
    *

--- a/system/src/main/java/com/percussion/cx/error/PSContentExplorerException.java
+++ b/system/src/main/java/com/percussion/cx/error/PSContentExplorerException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cx.error;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSStandaloneException;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import java.text.MessageFormat;
@@ -57,6 +58,35 @@ public class PSContentExplorerException extends PSStandaloneException {
    */
   public PSContentExplorerException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSContentExplorerException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleMessage the sole argument to use as the arguments in the error message
+   */
+  public PSContentExplorerException(IPSErrorCode code, String singleMessage) {
+    super(code, singleMessage);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSContentExplorerException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /** See PSStandaloneException for details. */

--- a/system/src/main/java/com/percussion/error/PSDeployException.java
+++ b/system/src/main/java/com/percussion/error/PSDeployException.java
@@ -102,6 +102,52 @@ public class PSDeployException extends Exception {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code DeploymentErrorCodes}).
+   * Sets the legacy numeric code for message lookup and retains the typed code for {@link
+   * #getTypedErrorCode()} / {@link #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSDeployException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSDeployException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    this(requireCode(code).numericCode(), cause, arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *
@@ -111,6 +157,7 @@ public class PSDeployException extends Exception {
   public PSDeployException(PSException ex) {
     this(ex.getErrorCode(), ex.getErrorArguments());
     m_originalExceptionClass = ex.getClass().getName();
+    m_typedErrorCode = ex.getTypedErrorCode();
   }
 
   /**
@@ -232,6 +279,29 @@ public class PSDeployException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link #PSDeployException(IPSErrorCode)}
+   * (or overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when present;
+   * legacy int construction returns {@code false} (handlers resolve auditability via the registry).
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -400,6 +470,12 @@ public class PSDeployException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed catalog code when constructed via {@link IPSErrorCode} overloads; otherwise {@code null}
+   * for legacy int construction. Not serialized in XML.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/system/src/main/java/com/percussion/error/PSDeployNonUniqueException.java
+++ b/system/src/main/java/com/percussion/error/PSDeployNonUniqueException.java
@@ -70,6 +70,35 @@ public class PSDeployNonUniqueException extends PSDeployException {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSDeployNonUniqueException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSDeployNonUniqueException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSDeployNonUniqueException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * This constructor is not supported by this exception class. Use the {@link
    * PSDeployException#PSDeployException(PSException) ctor} from the base class.
    *

--- a/system/src/main/java/com/percussion/error/PSLockedException.java
+++ b/system/src/main/java/com/percussion/error/PSLockedException.java
@@ -56,6 +56,36 @@ public class PSLockedException extends PSDeployException {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code DeploymentErrorCodes}
+   * lock codes). Retains the typed code for {@link #getTypedErrorCode()} / {@link #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSLockedException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSLockedException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSLockedException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * This constructor is not supported by this exception class. Use the {@link
    * PSDeployException#PSDeployException(PSException) ctor} from the base class.
    *

--- a/system/src/main/java/com/percussion/error/PSStandaloneException.java
+++ b/system/src/main/java/com/percussion/error/PSStandaloneException.java
@@ -88,6 +88,40 @@ public abstract class PSStandaloneException extends Exception {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode}. Sets the legacy numeric code for
+   * message lookup and retains the typed code for {@link #getTypedErrorCode()} / {@link
+   * #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSStandaloneException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *
@@ -223,6 +257,30 @@ public abstract class PSStandaloneException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link
+   * #PSStandaloneException(IPSErrorCode)} (or overloads); otherwise {@code null} for legacy int
+   * construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when
+   * present; legacy int construction returns {@code false}.
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -430,6 +488,12 @@ public abstract class PSStandaloneException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed error code when constructed via {@link #PSStandaloneException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -101,6 +101,17 @@ public class PSExtensionProcessingException extends PSException {
   }
 
   /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    super(code, arrayArgs, cause);
+  }
+
+  /**
    * Construct an exception when an unknown exception occurs during processing.
    *
    * @param extName the name of the extension being processed

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
 
@@ -68,6 +69,35 @@ public class PSExtensionProcessingException extends PSException {
    */
   public PSExtensionProcessingException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSExtensionProcessingException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/system/src/main/java/com/percussion/security/PSAuthenticationFailedException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthenticationFailedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -50,5 +51,16 @@ public class PSAuthenticationFailedException extends PSException {
    */
   public PSAuthenticationFailedException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction from a catalogued {@link IPSErrorCode}.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message; may be
+   *     {@code null}
+   */
+  public PSAuthenticationFailedException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 }

--- a/system/src/main/java/com/percussion/server/job/PSJobException.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobException.java
@@ -114,6 +114,30 @@ public class PSJobException extends Exception {
   }
 
   /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSJobException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    this(code, arrayArgs);
+    initCause(cause);
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param cause causal throwable; may be {@code null}
+   */
+  public PSJobException(IPSErrorCode code, Object[] arrayArgs, Throwable cause) {
+    this(code, arrayArgs);
+    initCause(cause);
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *

--- a/system/src/main/java/com/percussion/server/job/PSJobException.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobException.java
@@ -19,6 +19,7 @@ package com.percussion.server.job;
 
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -79,6 +80,40 @@ public class PSJobException extends Exception {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code JobErrorCodes}). Sets
+   * the legacy numeric code for message lookup and retains the typed code for {@link
+   * #getTypedErrorCode()} / {@link #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSJobException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSJobException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSJobException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception from a class derived from PSException. The name of the original
    * exception class is saved.
    *
@@ -88,6 +123,7 @@ public class PSJobException extends Exception {
   public PSJobException(PSException ex) {
     this(ex.getErrorCode(), ex.getErrorArguments());
     m_originalExceptionClass = ex.getClass().getName();
+    m_typedErrorCode = ex.getTypedErrorCode();
   }
 
   /**
@@ -203,6 +239,29 @@ public class PSJobException extends Exception {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link #PSJobException(IPSErrorCode)}
+   * (or overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when present;
+   * legacy int construction returns {@code false} (handlers resolve auditability via the registry).
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -371,6 +430,12 @@ public class PSJobException extends Exception {
 
   /** The error code of this exception, set during ctor, never modified after that. */
   private int m_code;
+
+  /**
+   * Typed catalog code when constructed via {@link IPSErrorCode} overloads; otherwise {@code null}
+   * for legacy int construction. Not serialized in XML.
+   */
+  private transient IPSErrorCode m_typedErrorCode;
 
   /**
    * The array of arguments to use to format the message with. Set during ctor, may be <code>null

--- a/system/src/test/java/com/percussion/extension/PSExtensionProcessingExceptionTypedCauseTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionProcessingExceptionTypedCauseTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import org.junit.jupiter.api.Test;
+
+/** Typed cause+varargs construction for {@link PSExtensionProcessingException}. */
+class PSExtensionProcessingExceptionTypedCauseTest {
+
+  @Test
+  void typedCauseVarargsRetainsCatalogCauseAndArgs() {
+    IllegalStateException cause = new IllegalStateException("eval failed");
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException(
+            ExtensionErrorCodes.JEXL_EVALUATION_FAILED, cause, "expr");
+
+    assertEquals(
+        ExtensionErrorCodes.JEXL_EVALUATION_FAILED.numericCode(), ex.getErrorCode());
+    assertSame(ExtensionErrorCodes.JEXL_EVALUATION_FAILED, ex.getTypedErrorCode());
+    assertSame(cause, ex.getCause());
+    assertArrayEquals(new Object[] {"expr"}, ex.getErrorArguments());
+    assertFalse(ExtensionErrorCodes.JEXL_EVALUATION_FAILED.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+}


### PR DESCRIPTION
## Thrash problem

Overnight slices of parent #2616 (`#3739` / `#3740` / `#3741`) each shrink the same residual IPS*Errors allowlist and dual-write skip tests. Merging them independently against `main` would conflict on:

- `scripts/ipserrors-residual-allowlist.txt`
- `modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java`

#3753 and #3754 also overlap on deployer catalog/client/objectstore sources and `PSDeployException`. This cluster absorbs the three PRs oldest-first and applies **all** allowlist removals (intersection of remaining residuals, 620 → 496 paths). Unique adds from each slice are kept. Header comments union `#3739`, `#3740`, and `#3741`.

Conflict resolution on the allowlist: never restore a path that any absorbed slice retyped.

## Thrash files

- `scripts/ipserrors-residual-allowlist.txt`
- `modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java`
- `deployer/src/main/java/com/percussion/deployer/catalog/PSCataloger.java`
- `deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java`
- `deployer/src/main/java/com/percussion/deployer/client/PSDeployFileJobControl.java`
- `deployer/src/main/java/com/percussion/deployer/client/PSDeploymentManager.java`
- `deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java`
- `deployer/src/main/java/com/percussion/deployer/client/PSFolderContentsDescriptorBuilder.java`
- `deployer/src/main/java/com/percussion/deployer/objectstore/PSArchive.java`
- `deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java`
- `deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java`
- `system/src/main/java/com/percussion/error/PSDeployException.java`

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|---|---|---|---|---|
| yes | #3753 | `feat/issue-3739-deployer-catalog-client-errorcodes` | yes | Slice 1/3 catalog/client/objectstore → `DeploymentErrorCodes` |
| yes | #3754 | `fix/issue-3740-deployer-server-handlers-errorcodes` | yes | Slice 2/3 server/handlers → typed ErrorCodes |
| yes | #3755 | `fix/issue-3741-dce-contentui-tablefactory-errorcodes-2` | yes | Slice 3 leftover DCE/ContentUI/TableFactory; allowlist intersection |

Do **not** merge the superseded PRs.

Not absorbed: #3730 (Baseline TemplateDef GUIDs) shares one coincidental deployer handler file; different product scope. Residual #3756 (extensions-main) stays open.

## modules_built

`modules/perc-auditlog, modules/TableFactory, system, deployer, modules/ContentUI, modules/DesktopContentExplorer`

## build_evidence

Standalone `clean install` on cluster tip `be032c3893` (JDK 21, repo-root `mvnw.cmd`, no `-DskipTests`):

- `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 300, Failures: 0, Skipped: 0.
- `cd modules/TableFactory && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 52, Failures: 0, Skipped: 7.
- `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 2336, Failures: 0, Skipped: 242.
- `cd deployer && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 295, Failures: 0, Skipped: 19.
- `cd modules/ContentUI && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 2, Failures: 0, Skipped: 0.
- `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 215, Failures: 0, Skipped: 0.

Also: `python scripts/verify-no-bare-ipserrors.py` → **PASS**; `python scripts/test_verify_no_bare_ipserrors.py` → 17 passed.

C2: constructors are additive `IPSErrorCode` overloads (not final/sealed/signature-breaking). Reverse-deps rebuilt as the modules above.

No new warnings attributed to this union beyond existing javadoc/analyze baseline.

## Product documentation

- [x] N/A — internal error-catalog retype; no operator/WebUI/installer surface.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
