### PR TITLE
feat(errorcodes): retype extensions-main IPS*Errors (#3756)

### DIFF
--- a/docs/ai-generated/code-reviews/3756-extensions-main-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3756-extensions-main-errorcodes-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review: #3756 extensions-main IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted work on `fix/issue-3756-extensions-main-errorcodes` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Date:** 2026-08-23
+
+## Summary
+
+Leftover `modules/extensions-main` production `IPS*Errors` sites now construct typed `*ErrorCodes` via additive `IPSErrorCode` constructors on `PSExtensionException`, `PSExtensionProcessingException`, `PSConversionException`, `PSRequestValidationException`, and `PSInternalRequestCallException`. Allow-list shrunk by those exact 20 paths. Dual-write skip tests cover leftover non-auditable catalog codes. No product UI/config surface.
+
+Memory patterns hit: change-class closure (typed ctors + production retype + allow-list + dual-write skip + producer module install); portable `@TempDir Path` in new tests; additive constructors (not `final` / signature-breaking).
+
+## Gate
+
+No bugs. Behavioral tests cover typed construction, production throws (`PSFormEncode`, `PSPrepareInClause`, `PSSetArrayHtmlParameter`, `PSConcatAssemblyLocation`), and dual-write skip. Cross-platform path checklist: new tests use `Path` / `@TempDir`; no hardcoded separators. Existing assembly exits that swallow `PSExtensionException` were not changed.
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New path logic uses `Path` / `Files` (`@TempDir Path` + `toFile()` for legacy `init`)
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] N/A for product scripts / installers

--- a/modules/extensions-main/pom.xml
+++ b/modules/extensions-main/pom.xml
@@ -16,6 +16,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>perc-security-utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -123,6 +128,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.cas;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.server.PSAuthTypes;
 import com.percussion.data.PSInternalRequestCallException;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -72,7 +72,7 @@ public class PSAuthtypeDispatcher extends PSDefaultExtension implements IPSResul
     if (resource == null) {
       String[] args = {authtype, PSAuthTypes.getInstance().getConfigFile().getPath()};
       throw new PSExtensionProcessingException(
-          IPSExtensionErrors.AUTHTYPE_REGISTRATION_MISSING, args);
+          ExtensionErrorCodes.AUTHTYPE_REGISTRATION_MISSING, args);
     }
     // Make the current siteid as the originating siteid if originating siteid
     // is missing in the request.
@@ -94,7 +94,7 @@ public class PSAuthtypeDispatcher extends PSDefaultExtension implements IPSResul
       String[] args = {
         authtype, resource.toString(), PSAuthTypes.getInstance().getConfigFile().getPath()
       };
-      throw new PSExtensionProcessingException(IPSExtensionErrors.AUTHTYPE_RESOURCE_MISSING, args);
+      throw new PSExtensionProcessingException(ExtensionErrorCodes.AUTHTYPE_RESOURCE_MISSING, args);
     }
     try {
       Document doc = iReq.getResultDoc();

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.cas;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSAssemblyLocation;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
@@ -56,7 +56,7 @@ public class PSConcatAssemblyLocation implements IPSAssemblyLocation {
       request.printTraceMessage("Error: " + PSExceptionUtils.getMessageForLog(e));
 
       Object[] args = {m_def.getRef().getExtensionName(), PSExceptionUtils.getMessageForLog(e)};
-      throw new PSExtensionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
     } finally {
       request.printTraceMessage("Leaving " + exitName + ".createLocation");
     }

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.cas;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.extension.IPSAssemblyLocation;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
@@ -66,20 +66,20 @@ public class PSConcatWithIdAssemblyLocation implements IPSAssemblyLocation {
       // check the number of parameters provided is correct
       if (params.length < EXPECTED_NUMBER_OF_PARAMS) {
         Object[] args = {"" + EXPECTED_NUMBER_OF_PARAMS, "" + params.length};
-        throw new PSExtensionException(IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH, args);
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH, args);
       }
 
       // parameter 0 must be the index
       int index = Integer.parseInt(params[0].toString());
       if (index < 0 || index >= params.length) {
         Object[] args = {m_def.getRef().getExtensionName(), "Index out of bounds: " + index};
-        throw new PSExtensionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
       }
 
       String contentid = PSHtmlParameters.get(IPSHtmlParameters.SYS_CONTENTID, request);
       if (contentid == null) {
         Object[] args = {exitName, IPSHtmlParameters.SYS_CONTENTID};
-        throw new PSExtensionException(IPSExtensionErrors.MISSING_HTML_PARAMETER, args);
+        throw new PSExtensionException(ExtensionErrorCodes.MISSING_HTML_PARAMETER, args);
       }
 
       for (int i = 1; i < params.length; i++) {

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDefaultAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDefaultAssemblyLocation.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.cas;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.extension.IPSAssemblyLocation;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
@@ -69,7 +69,7 @@ public class PSDefaultAssemblyLocation implements IPSAssemblyLocation {
       // check the number of parameters provided is correct
       if (params.length < EXPECTED_NUMBER_OF_PARAMS) {
         Object[] args = {"" + EXPECTED_NUMBER_OF_PARAMS, "" + params.length};
-        throw new PSExtensionException(IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH, args);
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH, args);
       }
 
       String root = params[0].toString().replace('\\', '/');

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
@@ -17,8 +17,8 @@
 package com.percussion.cas;
 
 import com.icl.saxon.expr.XPathException;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.data.PSConversionException;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.PSExtensionParams;
 import com.percussion.extension.PSSimpleJavaUdfExtension;
 import com.percussion.server.IPSInternalRequest;
@@ -88,7 +88,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
     if (variantid == null) {
       Object[] args = {IPSHtmlParameters.SYS_VARIANTID, "VariantId is required"};
       throw new PSConversionException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
     }
     if ((contentid == null) ^ (revisionid == null)) {
       Object[] args = {
@@ -96,7 +96,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
         "Must provide both content id and revision id."
       };
       throw new PSConversionException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
     }
 
     // Obtain values from request context if not supplied explicitly
@@ -118,7 +118,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
         "Must provide both content id and revision id."
       };
       throw new PSConversionException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
     }
 
     // determine the base URL for the specified variant id
@@ -174,7 +174,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
           request);
     } catch (MalformedURLException mue) {
       Object[] args = {this.getClass().getName(), mue.getLocalizedMessage()};
-      throw new PSConversionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+      throw new PSConversionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
     }
   }
 
@@ -195,7 +195,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
         this.getClass().getName(),
         "Could not find the variant lookup resource at " + VARIANT_LOOKUP_URL
       };
-      throw new PSConversionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+      throw new PSConversionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
     }
     IPSRequestContext innerReqContext = ireq.getRequestContext();
     innerReqContext.setParameter(IPSHtmlParameters.SYS_VARIANTID, variantid);
@@ -209,20 +209,20 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
         Object[] args = {
           this.getClass().getName(), "Failed to extract the assembler URL from the variant lookup."
         };
-        throw new PSConversionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+        throw new PSConversionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
       }
     } catch (XPathException xpe) {
       Object[] args = {
         this.getClass().getName(),
         "Exception while evaluating the expression. " + xpe.getLocalizedMessage()
       };
-      throw new PSConversionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+      throw new PSConversionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
     } catch (TransformerException te) {
       Object[] args = {
         this.getClass().getName(),
         "Could not instantiate a XPathEvalutor class. " + te.getLocalizedMessage()
       };
-      throw new PSConversionException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+      throw new PSConversionException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
     }
     return assemblyURL;
   }

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
@@ -27,8 +27,8 @@ import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSAssemblyLocation;
 import com.percussion.extension.IPSExtension;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSExtensionManager;
 import com.percussion.extension.IPSUdfProcessor;
 import com.percussion.extension.PSExtensionException;
@@ -245,7 +245,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       }
       if (filtername != null && authtype != null) {
         Object args[] = {"Both filter and authtype can not both be set."};
-        throw new PSConversionException(IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, args);
+        throw new PSConversionException(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, args);
       }
 
       authtype = authtype_from_filter;
@@ -524,7 +524,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       } catch (Exception sme) {
         Object args[] = new Object[] {variantid, ctid.longValue(), contextid};
         PSExtensionException extExc =
-            new PSExtensionException(IPSExtensionErrors.SCHEME_CANT_BE_FOUND, sme, args);
+            new PSExtensionException(ExtensionErrorCodes.SCHEME_CANT_BE_FOUND, sme, args);
 
         log.error(extExc.getLocalizedMessage(), sme);
 
@@ -544,7 +544,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       IPSExtension exit = exitMgr.prepareExtension(ref, null);
       if (!(exit instanceof IPSAssemblyLocation)) {
         Object[] args = {exit.getClass().getName(), IPSAssemblyLocation.class.getName()};
-        throw new PSConversionException(IPSExtensionErrors.UNEXPECTED_EXT_TYPE_EXCEPTION, args);
+        throw new PSConversionException(ExtensionErrorCodes.UNEXPECTED_EXT_TYPE_EXCEPTION, args);
       }
 
       String[] callParams = new String[exitParams.length];

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.cas;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.extension.IPSAssemblyLocation;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.error.PSExceptionUtils;
@@ -80,7 +80,7 @@ public class PSGenericAssembly extends PSDefaultExtension implements IPSAssembly
           || (params[0] == null)
           || (params[0].toString().trim().length() < 1)) {
         Object[] args = {"" + EXPECTED_NUMBER_OF_PARAMS, "" + params.length};
-        throw new PSExtensionException(IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH, args);
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH, args);
       }
 
       String resource = params[0].toString().trim();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
@@ -20,10 +20,10 @@ import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSRelationshipProcessor;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
 import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSRelationshipSet;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -77,7 +77,7 @@ public class PSCheckIfVariantIsInUse implements IPSRequestPreProcessor {
         }
         Object errorargs[] = new Object[] {variantid, ownerids};
         throw new PSExtensionProcessingException(
-            IPSExtensionErrors.VARIANT_HAS_RELATIONSHIPS_ERROR, errorargs);
+            ExtensionErrorCodes.VARIANT_HAS_RELATIONSHIPS_ERROR, errorargs);
       }
     } catch (PSCmsException e) {
       throw new PSExtensionProcessingException("Fatal error", e);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -17,11 +17,11 @@
 
 package com.percussion.extensions.general;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.PSItemField;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.cms.objectstore.server.PSServerItem;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -282,7 +282,7 @@ public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProce
         }
       } catch (Exception e) {
         Object args = new Object[] {"sys_FileInfo", e.getMessage()};
-        throw new PSExtensionProcessingException(IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, args);
+        throw new PSExtensionProcessingException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
       }
     }
   }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
@@ -17,8 +17,8 @@
 
 package com.percussion.extensions.general;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -87,10 +87,10 @@ public class PSPrepareInClause implements IPSRequestPreProcessor {
           EXPECTED_NUMBER_OF_PARAMS, params == null ? 0 : params.length);
     } else if (null == params[0] || 0 == params[0].toString().trim().length()) {
       throw new PSExtensionProcessingException(
-          IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, "Base param name may not be null or empty");
+          ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, "Base param name may not be null or empty");
     } else if (request == null) {
       throw new PSRequestValidationException(
-          IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, "Request context may not be null");
+          ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, "Request context may not be null");
     }
 
     String baseName = params[0].toString();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.extensions.general;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -82,7 +82,7 @@ public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
     } else if (request == null) {
       m_log.debug("Request context is null");
       throw new PSRequestValidationException(
-          IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION, "Request context may not be null");
+          ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, "Request context may not be null");
     }
 
     String paramName = "";

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
@@ -17,8 +17,8 @@
 
 package com.percussion.extensions.publishing;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSWorkFlowContext;
 import com.percussion.extension.IPSWorkflowAction;
 import com.percussion.extension.PSDefaultExtension;
@@ -155,7 +155,7 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
       throw pse;
     } catch (Exception ex) {
       throw new PSExtensionException(
-          IPSExtensionErrors.BAD_PUBLISH_CONTENT_INITIALIZATION_DATA, ex.getMessage());
+          ExtensionErrorCodes.BAD_PUBLISH_CONTENT_INITIALIZATION_DATA, ex.getMessage());
     }
   }
 
@@ -309,21 +309,21 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
         key.mi_workflowId = Integer.parseInt(PSXMLDomUtil.getElementData(workflow));
       } catch (Exception th) {
         throw new PSExtensionException(
-            IPSExtensionErrors.BAD_PUBLISH_CONTENT_FILE_DATA,
+            ExtensionErrorCodes.BAD_PUBLISH_CONTENT_FILE_DATA,
             "Error while parsing value for workflow id");
       }
       try {
         key.mi_transitionId = Integer.parseInt(PSXMLDomUtil.getElementData(transition));
       } catch (Exception th) {
         throw new PSExtensionException(
-            IPSExtensionErrors.BAD_PUBLISH_CONTENT_FILE_DATA,
+            ExtensionErrorCodes.BAD_PUBLISH_CONTENT_FILE_DATA,
             "Error while parsing value for workflow id");
       }
       try {
         editionId = Integer.valueOf(PSXMLDomUtil.getElementData(edition));
       } catch (Exception th) {
         throw new PSExtensionException(
-            IPSExtensionErrors.BAD_PUBLISH_CONTENT_FILE_DATA,
+            ExtensionErrorCodes.BAD_PUBLISH_CONTENT_FILE_DATA,
             "Error while parsing value for workflow id");
       }
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncode.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.extensions.translations;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSFieldInputTransformer;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionParams;
@@ -52,7 +52,7 @@ public class PSFormEncode implements IPSFieldInputTransformer {
     String name = ep.getStringParam(0, null, false);
     if (StringUtils.isBlank(name)) {
       Object[] args = new Object[] {"name"};
-      throw new PSConversionException(IPSExtensionErrors.MISSING_REQUIRED_PARAM_NO, args);
+      throw new PSConversionException(ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO, args);
     }
     String value = request.getParameter(name);
     return PSFormEncodeDecodeHelper.encode(value);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapInputValue.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapInputValue.java
@@ -16,13 +16,13 @@
  */
 package com.percussion.extensions.translations;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.extension.IPSExtensionDef;
 import com.percussion.extension.IPSFieldInputTransformer;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionParams;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -74,7 +74,7 @@ public class PSMapInputValue implements IPSFieldInputTransformer {
       }
     } catch (UnsupportedEncodingException e) {
       throw new PSConversionException(
-          IPSServerErrors.UNEXPECTED_EXCEPTION_LOG, "Unsupported encoding", null);
+          ServerErrorCodes.UNEXPECTED_EXCEPTION_LOG, "Unsupported encoding", null);
     }
 
     return null;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapOutputValue.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapOutputValue.java
@@ -16,13 +16,13 @@
  */
 package com.percussion.extensions.translations;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.extension.IPSExtensionDef;
 import com.percussion.extension.IPSFieldOutputTransformer;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionParams;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -74,7 +74,7 @@ public class PSMapOutputValue implements IPSFieldOutputTransformer {
       }
     } catch (UnsupportedEncodingException e) {
       throw new PSConversionException(
-          IPSServerErrors.UNEXPECTED_EXCEPTION_LOG, "Unsupported encoding", null);
+          ServerErrorCodes.UNEXPECTED_EXCEPTION_LOG, "Unsupported encoding", null);
     }
 
     return null;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -17,7 +17,7 @@
 
 package com.percussion.extensions.usersearch;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.design.objectstore.PSSubject;
 import com.percussion.extension.IPSExtensionDef;
@@ -225,7 +225,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
 
     if (ret == null || ret.trim().length() == 0)
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, CMS_LOOKUP_CONTENTSTATUS);
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, CMS_LOOKUP_CONTENTSTATUS);
 
     return Integer.parseInt(ret);
   }
@@ -283,7 +283,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
 
     if (iReq == null)
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, COMMUNITY_ROLE_LOOKUP_URL);
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, COMMUNITY_ROLE_LOOKUP_URL);
 
     Document doc = null;
 

--- a/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
+++ b/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.relationship;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.error.PSSqlException;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -87,7 +87,7 @@ public class PSTranslationConstraint extends PSDefaultExtension implements IPSRe
         if (parameter.length() == 0) {
           Object[] args = {htmlParameters[i], "null or empty"};
           throw new PSExtensionProcessingException(
-              IPSExtensionErrors.EXT_MISSING_HTML_PARAMETER_ERROR, args);
+              ExtensionErrorCodes.EXT_MISSING_HTML_PARAMETER_ERROR, args);
         }
 
         parameters.put(htmlParameters[i], parameter);
@@ -98,7 +98,7 @@ public class PSTranslationConstraint extends PSDefaultExtension implements IPSRe
           parameters.get(IPSHtmlParameters.SYS_LANG),
           parameters.get(IPSHtmlParameters.SYS_CONTENTID)
         };
-        throw new PSRequestValidationException(IPSExtensionErrors.TRANSLATION_ALREADY_EXISTS, args);
+        throw new PSRequestValidationException(ExtensionErrorCodes.TRANSLATION_ALREADY_EXISTS, args);
       }
     } catch (PSException e) {
       if (e instanceof PSRequestValidationException) throw (PSRequestValidationException) e;

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
@@ -16,9 +16,10 @@
  */
 package com.percussion.uicontext;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import com.percussion.cx.PSOptionManagerConstants;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
@@ -29,7 +30,6 @@ import com.percussion.server.IPSRequestContext;
 import com.percussion.services.general.IPSRhythmyxInfo;
 import com.percussion.services.general.PSRhythmyxInfoLocator;
 import com.percussion.system.utils.IPSHtmlParameters;
-import com.percussion.xml.IPSXmlErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.File;
 import java.io.FileInputStream;
@@ -99,9 +99,9 @@ public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequ
 
       doc = PSXmlDocumentBuilder.createXmlDocument(inSource, false);
     } catch (IOException e) {
-      throw new PSExtensionProcessingException(IPSXmlErrors.XML_PROCESSING_ERROR);
+      throw new PSExtensionProcessingException(XmlErrorCodes.XML_PROCESSING_ERROR);
     } catch (SAXException e) {
-      throw new PSExtensionProcessingException(IPSXmlErrors.XML_PROCESSING_ERROR);
+      throw new PSExtensionProcessingException(XmlErrorCodes.XML_PROCESSING_ERROR);
     }
     return doc;
   }
@@ -238,12 +238,12 @@ public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequ
       // this message constant doesn't look right, however,
       // it does display the right message:
       throw new PSExtensionProcessingException(
-          IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR, e.getLocalizedMessage());
+          ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, e.getLocalizedMessage());
     } catch (SAXException e) {
-      throw new PSExtensionProcessingException(IPSXmlErrors.RAW_XML_DUMP, e.getLocalizedMessage());
+      throw new PSExtensionProcessingException(XmlErrorCodes.RAW_XML_DUMP, e.getLocalizedMessage());
     } catch (IOException e) {
       throw new PSExtensionProcessingException(
-          IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR, e.getLocalizedMessage());
+          ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, e.getLocalizedMessage());
     }
 
     return doc;

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.uicontext;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -79,7 +79,7 @@ public class PSTranslationKeyValueAccessor implements IPSResultDocumentProcessor
     if (keyValueMap == null) {
       Object[] errs = {getClass().getName(), theLang};
 
-      throw new PSExtensionProcessingException(IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR, errs);
+      throw new PSExtensionProcessingException(ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, errs);
     }
 
     PSI18NTranslationKeyValues keyVals = PSI18NTranslationKeyValues.getInstance();

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
@@ -17,9 +17,9 @@
 
 package com.percussion.validate;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -99,7 +99,7 @@ public class PSValidateSlotName implements IPSRequestPreProcessor {
       // Check validity of slotname
       if (!isValid()) {
         Object[] args = new Object[0];
-        throw new PSExtensionException(IPSExtensionErrors.VALIDATE_SLOTNAME_NOT_UNIQUE, args);
+        throw new PSExtensionException(ExtensionErrorCodes.VALIDATE_SLOTNAME_NOT_UNIQUE, args);
       }
 
     } catch (PSException e) {

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/PSExtensionsMainTypedErrorCodeSliceTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/PSExtensionsMainTypedErrorCodeSliceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.percussion.cas.PSConcatAssemblyLocation;
+import com.percussion.data.PSConversionException;
+import com.percussion.extension.IPSExtensionDef;
+import com.percussion.extension.PSExtensionException;
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.extensions.general.PSPrepareInClause;
+import com.percussion.extensions.general.PSSetArrayHtmlParameter;
+import com.percussion.extensions.translations.PSFormEncode;
+import com.percussion.server.IPSRequestContext;
+import com.percussion.server.PSRequestValidationException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+/**
+ * Leftover extensions-main production throw sites now construct typed {@link ExtensionErrorCodes}
+ * (non-auditable). File-root init uses a portable {@link Path} temp directory.
+ */
+@Tag("UnitTest")
+class PSExtensionsMainTypedErrorCodeSliceTest {
+
+  @TempDir Path tempRoot;
+
+  @Test
+  void formEncodeMissingNameThrowsTypedMissingRequiredParam() {
+    PSFormEncode encode = new PSFormEncode();
+    PSConversionException ex =
+        assertThrows(PSConversionException.class, () -> encode.processUdf(new Object[] {""}, null));
+    assertSame(ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO, ex.getTypedErrorCode());
+    assertEquals(ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO.numericCode(), ex.getErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void prepareInClauseNullRequestThrowsTypedProcessorException() {
+    PSPrepareInClause exit = new PSPrepareInClause();
+    PSRequestValidationException ex =
+        assertThrows(
+            PSRequestValidationException.class,
+            () -> exit.preProcessRequest(new Object[] {"inClause"}, null));
+    assertSame(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void setArrayHtmlParameterNullRequestThrowsTypedProcessorException() {
+    PSSetArrayHtmlParameter exit = new PSSetArrayHtmlParameter();
+    PSRequestValidationException ex =
+        assertThrows(
+            PSRequestValidationException.class,
+            () ->
+                exit.preProcessRequest(
+                    new Object[] {"param", "app/resource", "el", "10"}, null));
+    assertSame(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void concatAssemblyLocationParamToStringFailureThrowsTypedProcessorException() throws Exception {
+    PSConcatAssemblyLocation loc = new PSConcatAssemblyLocation();
+    loc.init(mockDef("sys_concat"), tempRoot.toFile());
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    Object boom =
+        new Object() {
+          @Override
+          public String toString() {
+            throw new IllegalStateException("boom");
+          }
+        };
+    PSExtensionException ex =
+        assertThrows(
+            PSExtensionException.class, () -> loc.createLocation(new Object[] {boom}, request));
+    assertSame(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void processingExceptionFromFileInfoArgsIsNonAuditable() {
+    Object args = new Object[] {"sys_FileInfo", "io"};
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, args);
+    assertSame(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  private static IPSExtensionDef mockDef(String name) {
+    IPSExtensionDef def = mock(IPSExtensionDef.class);
+    Mockito.when(def.getRef()).thenReturn(new PSExtensionRef("Java", "global/percussion/", name));
+    return def;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/ExtensionsMainResidualErrorCodesDualWriteTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/ExtensionsMainResidualErrorCodesDualWriteTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Dual-write skip coverage for leftover extensions-main catalog codes (#3756). All of these
+ * leftovers are non-auditable operational / validation noise.
+ */
+class ExtensionsMainResidualErrorCodesDualWriteTest {
+
+  @BeforeEach
+  void rebootstrap() {
+    LegacyErrorCodeRegistry.clearForTests();
+    LegacyErrorCodeRegistry.bootstrap();
+  }
+
+  @Test
+  void leftoverExtensionCodesSkipDualWrite() {
+    List<ExtensionErrorCodes> leftovers =
+        List.of(
+            ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
+            ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH,
+            ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID,
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+            ExtensionErrorCodes.EXT_MISSING_HTML_PARAMETER_ERROR,
+            ExtensionErrorCodes.MISSING_HTML_PARAMETER,
+            ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO,
+            ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR,
+            ExtensionErrorCodes.AUTHTYPE_REGISTRATION_MISSING,
+            ExtensionErrorCodes.AUTHTYPE_RESOURCE_MISSING,
+            ExtensionErrorCodes.VALIDATE_SLOTNAME_NOT_UNIQUE,
+            ExtensionErrorCodes.TRANSLATION_ALREADY_EXISTS,
+            ExtensionErrorCodes.VARIANT_HAS_RELATIONSHIPS_ERROR,
+            ExtensionErrorCodes.BAD_PUBLISH_CONTENT_INITIALIZATION_DATA,
+            ExtensionErrorCodes.BAD_PUBLISH_CONTENT_FILE_DATA,
+            ExtensionErrorCodes.SCHEME_CANT_BE_FOUND,
+            ExtensionErrorCodes.UNEXPECTED_EXT_TYPE_EXCEPTION);
+
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    for (ExtensionErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      assertSame(code, LegacyErrorCodeRegistry.find(code.numericCode()).orElseThrow());
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void leftoverXmlDataServerCodesSkipDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    assertFalse(XmlErrorCodes.XML_PROCESSING_ERROR.isAuditable());
+    assertFalse(XmlErrorCodes.RAW_XML_DUMP.isAuditable());
+    assertFalse(DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION.isAuditable());
+    assertFalse(ServerErrorCodes.UNEXPECTED_EXCEPTION_LOG.isAuditable());
+
+    for (int numeric :
+        new int[] {
+          XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(),
+          XmlErrorCodes.RAW_XML_DUMP.numericCode(),
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION.numericCode(),
+          ServerErrorCodes.UNEXPECTED_EXCEPTION_LOG.numericCode()
+        }) {
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, numeric, AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+}

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -6,6 +6,7 @@
 # Shrink this list as retype PRs merge:
 #   #3584 SiteManage IPSSiteManageErrors -> SiteManageErrorCodes
 #   #3585 webservices/transformation leftover call sites
+#   #3756 leftover extensions-main production IPS*Errors -> *ErrorCodes
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -139,26 +140,6 @@ modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchema
 modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandler.java
 modules/TableFactory/src/main/java/com/percussion/tablefactory/PSJdbcTableSchemaHandlerCollection.java
 modules/TableFactory/src/main/java/com/percussion/tablefactory/tools/PSCatalogTableData.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSDefaultAssemblyLocation.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
-modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
-modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
-modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
-modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
-modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
-modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
-modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncode.java
-modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapInputValue.java
-modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapOutputValue.java
-modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
-modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
-modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
-modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
-modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
 modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
 modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
 modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java

--- a/system/src/main/java/com/percussion/data/PSConversionException.java
+++ b/system/src/main/java/com/percussion/data/PSConversionException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.data;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -66,6 +67,36 @@ public class PSConversionException extends PSException {
    */
   public PSConversionException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSConversionException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with message arguments (varargs, matching the int ctor).
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the arguments to use as the arguments in the error message
+   */
+  public PSConversionException(IPSErrorCode code, Object... arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs the arguments to use as the arguments in the error message
+   */
+  public PSConversionException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    super(code, arrayArgs, cause);
   }
 
   /**

--- a/system/src/main/java/com/percussion/data/PSInternalRequestCallException.java
+++ b/system/src/main/java/com/percussion/data/PSInternalRequestCallException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.data;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -76,6 +77,35 @@ public class PSInternalRequestCallException extends PSConversionException {
    */
   public PSInternalRequestCallException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSInternalRequestCallException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSInternalRequestCallException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSInternalRequestCallException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/system/src/main/java/com/percussion/extension/PSExtensionException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import java.util.Objects;
 
@@ -89,6 +90,46 @@ public final class PSExtensionException extends PSException {
    */
   public PSExtensionException(int code, Object[] args) {
     super(code, args);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSExtensionException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arg the argument to use as the sole argument in the error message
+   */
+  public PSExtensionException(IPSErrorCode code, Object arg) {
+    super(code, arg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param args the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionException(IPSErrorCode code, Object[] args) {
+    super(code, args);
+  }
+
+  /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause the underlying cause, may be {@code null}
+   * @param args the arguments for the error message
+   */
+  public PSExtensionException(IPSErrorCode code, Throwable cause, Object... args) {
+    super(code, args, cause);
   }
 
   /**

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
 
@@ -68,6 +69,46 @@ public class PSExtensionProcessingException extends PSException {
    */
   public PSExtensionProcessingException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSExtensionProcessingException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with a cause and message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSExtensionProcessingException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    super(code, arrayArgs, cause);
   }
 
   /**

--- a/system/src/main/java/com/percussion/server/PSRequestValidationException.java
+++ b/system/src/main/java/com/percussion/server/PSRequestValidationException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.server;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 
@@ -58,6 +59,35 @@ public class PSRequestValidationException extends PSException {
    */
   public PSRequestValidationException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSRequestValidationException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSRequestValidationException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSRequestValidationException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/system/src/test/java/com/percussion/extension/PSExtensionTypedErrorCodeCtorTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionTypedErrorCodeCtorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
+import com.percussion.data.PSConversionException;
+import com.percussion.data.PSInternalRequestCallException;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.server.PSRequestValidationException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Additive {@link IPSErrorCode} constructors on extension-related exceptions (#3756). Leftover
+ * catalog codes used by extensions-main remain non-auditable.
+ */
+class PSExtensionTypedErrorCodeCtorTest {
+
+  @Test
+  void extensionExceptionTypedArrayCtorRetainsCodeAndSkipsAudit() {
+    Object[] args = {"expected", "actual"};
+    PSExtensionException ex =
+        new PSExtensionException(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH, args);
+    assertSame(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH, ex.getTypedErrorCode());
+    assertEquals(ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH.numericCode(), ex.getErrorCode());
+    assertFalse(ex.isAuditable());
+    assertEquals(2, ex.getErrorArguments().length);
+  }
+
+  @Test
+  void extensionExceptionTypedCauseCtorRetainsCode() {
+    RuntimeException cause = new RuntimeException("scheme");
+    Object[] args = {"variant", 1L, 2L};
+    PSExtensionException ex =
+        new PSExtensionException(ExtensionErrorCodes.SCHEME_CANT_BE_FOUND, cause, args);
+    assertSame(ExtensionErrorCodes.SCHEME_CANT_BE_FOUND, ex.getTypedErrorCode());
+    assertSame(cause, ex.getCause());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void extensionProcessingExceptionTypedCtors() {
+    PSExtensionProcessingException noArgs =
+        new PSExtensionProcessingException(XmlErrorCodes.XML_PROCESSING_ERROR);
+    assertEquals(XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(), noArgs.getErrorCode());
+    assertFalse(noArgs.isAuditable());
+
+    PSExtensionProcessingException single =
+        new PSExtensionProcessingException(
+            ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, "missing");
+    assertSame(ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, single.getTypedErrorCode());
+
+    Object[] args = {"authtype", "config"};
+    PSExtensionProcessingException array =
+        new PSExtensionProcessingException(
+            ExtensionErrorCodes.AUTHTYPE_REGISTRATION_MISSING, args);
+    assertEquals(2, array.getErrorArguments().length);
+    assertFalse(array.isAuditable());
+  }
+
+  @Test
+  void conversionExceptionTypedVarargsCtor() {
+    PSConversionException ex =
+        new PSConversionException(
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+            "sys_variantid",
+            "VariantId is required");
+    assertSame(
+        ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, ex.getTypedErrorCode());
+    assertEquals(2, ex.getErrorArguments().length);
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void requestValidationExceptionTypedCtor() {
+    Object[] args = {"en-us", "123"};
+    PSRequestValidationException ex =
+        new PSRequestValidationException(ExtensionErrorCodes.TRANSLATION_ALREADY_EXISTS, args);
+    assertSame(ExtensionErrorCodes.TRANSLATION_ALREADY_EXISTS, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void internalRequestCallExceptionTypedCtor() {
+    PSInternalRequestCallException ex =
+        new PSInternalRequestCallException(
+            DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, "sys_cmpUserCommunities/lookup.xml");
+    assertSame(DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void typedCtorsRejectNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSExtensionException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSExtensionProcessingException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSConversionException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSRequestValidationException((IPSErrorCode) null));
+  }
+}


### PR DESCRIPTION
## Summary

Parent **#2616** leftover slice after cluster **#3757** (DCE/ContentUI/TableFactory / deployer). Leftover **extensions-main** production `IPS*Errors` int sites now throw typed `ExtensionErrorCodes` / `XmlErrorCodes` / `DataErrorCodes` / `ServerErrorCodes` via additive `IPSErrorCode` constructors.

- Additive typed constructors: `PSExtensionException`, `PSExtensionProcessingException`, `PSConversionException`, `PSRequestValidationException`, `PSInternalRequestCallException` (`getTypedErrorCode()` / `isAuditable()`).
- Allow-list `scripts/ipserrors-residual-allowlist.txt` shrunk by the exact 20 extensions-main paths.
- Dual-write: leftover catalog codes remain non-auditable (`isAuditable()==false`); skip tests added in perc-auditlog.
- Out of scope: deployer / DCE / ContentUI / TableFactory (cluster #3757), remaining nav/sfp/workflow extension modules, deleting `IPS*Errors` interfaces.

Fixes #3756  
Partial #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 297, Failures: 0 (`ExtensionsMainResidualErrorCodesDualWriteTest` 2)
2. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2343, Failures: 0, Skipped: 242 (`PSExtensionTypedErrorCodeCtorTest` 7)
3. `cd modules/extensions-main && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 60, Failures: 0 (`PSExtensionsMainTypedErrorCodeSliceTest` 5)
4. `python scripts/verify-no-bare-ipserrors.py` — PASS; `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 17 passed

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — typed construction, production throws, dual-write skip; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when constructors added (system producer + extensions-main consumer)
- [x] **Cross-platform** — slice test uses `@TempDir Path` + `toFile()` for legacy `init`; no hardcoded separators

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `system`, `modules/extensions-main`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 297, Failures: 0
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2343, Failures: 0, Skipped: 242
  - `cd modules/extensions-main && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 60, Failures: 0
  - `python scripts/verify-no-bare-ipserrors.py` → PASS; pytest 17 passed
- **downstream_checked:** C2 constructors are additive (not `final` / signature-breaking). Grepped `extends PSConversionException` (`PSInternalRequestCallException`, `PSUnsupportedConversionException` only); no `extends PSExtensionProcessingException` / `PSRequestValidationException`; `PSExtensionException` already `final`; no anonymous `new <Type>() {`. Standalone system + extensions-main install green.

### C5 UI proof

N/A — no WebUI / Playwright surface.

Erlang: approve (`docs/ai-generated/code-reviews/3756-extensions-main-errorcodes-erlang.md`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.