### PR TITLE
fix(webui): unwrap Content Types catalog Jackson list (#3706)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -21,7 +21,6 @@ import { PATHS } from "../paths";
 import type {
   ContentTypeDetail,
   ContentTypeFieldSummary,
-  ContentTypeListEnvelope,
   ContentTypeSummary,
   NamedObjectRef,
 } from "./types";
@@ -40,28 +39,95 @@ function normalizeContentTypeSummary(item: ContentTypeSummary): ContentTypeSumma
   return normalizeDesignObjectGuid(item);
 }
 
+/** Jackson WRAP_ROOT / JAXB / ArrayList envelopes for GET /services/contenttypes. */
+const CONTENT_TYPE_LIST_WRAP_KEYS = [
+  "ContentTypeList",
+  "contentTypeList",
+  "ContentType",
+  "contentType",
+  "contentTypes",
+  "ArrayList",
+  "arrayList",
+  "items",
+] as const;
+
+const MAX_CONTENT_TYPE_LIST_DEPTH = 6;
+
+function looksLikeContentTypeSummary(obj: Record<string, unknown>): boolean {
+  return (
+    obj.name != null ||
+    obj.label != null ||
+    obj.guid != null ||
+    obj.guidString != null ||
+    typeof obj.hideFromMenu === "boolean"
+  );
+}
+
+function isEmptyCollectionBean(obj: Record<string, unknown>): boolean {
+  if (!("empty" in obj) || typeof obj.empty !== "boolean") {
+    return false;
+  }
+  return Object.keys(obj).every((k) => k === "empty");
+}
+
 /**
- * Normalize list responses that may be a bare array or a JAXB envelope.
+ * Flatten Jackson list envelopes so the catalog never receives a non-array.
+ *
+ * <p>Live WRAP_ROOT_VALUE serializes {@code ContentTypeList} as
+ * {@code {"ContentTypeList":[…]}} (class name) or {@code {"ContentType":[…]}}
+ * ({@code @XmlRootElement}). A one-level {@code env.ContentType} read misses
+ * the class-name root and can leave a truthy object for {@code [...items]} /
+ * {@code .map} — DeveloperSectionErrorBoundary (#3706 / peer searches #3576).
  */
-export function unwrapContentTypeList(payload: unknown): ContentTypeSummary[] {
-  if (payload == null) {
+function flattenContentTypeList(payload: unknown, depth = 0): unknown[] {
+  if (payload == null || depth > MAX_CONTENT_TYPE_LIST_DEPTH) {
     return [];
   }
   if (Array.isArray(payload)) {
-    return (payload as ContentTypeSummary[]).map(normalizeContentTypeSummary);
-  }
-  if (typeof payload === "object") {
-    const env = payload as ContentTypeListEnvelope & {
-      contentType?: ContentTypeSummary[] | ContentTypeSummary;
-    };
-    const raw = env.ContentType ?? env.contentType;
-    if (raw == null) {
-      return [];
+    const out: unknown[] = [];
+    for (const item of payload) {
+      if (item == null || typeof item !== "object") {
+        continue;
+      }
+      const rec = item as Record<string, unknown>;
+      const wrapped =
+        !looksLikeContentTypeSummary(rec) &&
+        CONTENT_TYPE_LIST_WRAP_KEYS.some((k) => rec[k] != null);
+      if (wrapped || !looksLikeContentTypeSummary(rec)) {
+        out.push(...flattenContentTypeList(item, depth + 1));
+      } else {
+        out.push(item);
+      }
     }
-    const list = Array.isArray(raw) ? raw : [raw];
-    return list.map(normalizeContentTypeSummary);
+    return out;
+  }
+  const obj = asRecord(payload);
+  if (!obj) {
+    return [];
+  }
+  if (isEmptyCollectionBean(obj)) {
+    return [];
+  }
+  for (const key of CONTENT_TYPE_LIST_WRAP_KEYS) {
+    if (obj[key] != null) {
+      return flattenContentTypeList(obj[key], depth + 1);
+    }
+  }
+  if (looksLikeContentTypeSummary(obj)) {
+    return [obj];
   }
   return [];
+}
+
+/**
+ * Normalize list responses: bare array, {@code ContentTypeList}/{@code ContentType}
+ * envelopes, nested wraps, singleton object, or empty-collection bean (#3706).
+ * Always returns an array.
+ */
+export function unwrapContentTypeList(payload: unknown): ContentTypeSummary[] {
+  return flattenContentTypeList(payload).map((item) =>
+    normalizeContentTypeSummary(item as ContentTypeSummary),
+  );
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -48,6 +48,9 @@ export interface ContentTypeSummary {
 /** Jackson / JAXB list envelope sometimes used by legacy REST resources. */
 export interface ContentTypeListEnvelope {
   ContentType?: ContentTypeSummary[] | ContentTypeSummary;
+  contentType?: ContentTypeSummary[] | ContentTypeSummary;
+  ContentTypeList?: ContentTypeSummary[] | ContentTypeSummary | ContentTypeListEnvelope;
+  contentTypeList?: ContentTypeSummary[] | ContentTypeSummary | ContentTypeListEnvelope;
 }
 
 /** Field row from {@code GET /services/contenttypes/{idOrName}}. */

--- a/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
@@ -17,20 +17,48 @@
 
 import React, { useEffect, useState } from "react";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
-import { listContentTypes } from "../api/developer/contentTypesApi";
+import {
+  listContentTypes,
+  unwrapContentTypeList,
+} from "../api/developer/contentTypesApi";
 import type { ContentTypeSummary } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
 import { monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
 import { ContentTypeDetailPanel } from "./ContentTypeDetailPanel";
+import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+
+/** Coerce catalog cell / sort keys so object JAXB wraps cannot throw. */
+function asCatalogText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/**
+ * Catalog rows must always be a real array. listContentTypes already unwraps;
+ * re-apply here so a missed envelope cannot {@code [...obj].sort} into
+ * DeveloperSectionErrorBoundary (#3706).
+ */
+function asContentTypeCatalog(raw: unknown): ContentTypeSummary[] {
+  return unwrapContentTypeList(raw);
+}
 
 function displayId(ct: ContentTypeSummary): string {
   return resolveContentTypeObjectGuid(ct) || "—";
 }
 
 function selectionKey(ct: ContentTypeSummary): string {
-  return ct.name || resolveContentTypeObjectGuid(ct) || displayId(ct);
+  return asCatalogText(ct.name) || resolveContentTypeObjectGuid(ct) || displayId(ct);
+}
+
+function catalogSortKey(ct: ContentTypeSummary): string {
+  return asCatalogText(ct.label) || asCatalogText(ct.name);
 }
 
 type SelectedContentType = {
@@ -53,7 +81,7 @@ export function ContentTypesPanel(): React.ReactElement {
     listContentTypes()
       .then((list) => {
         if (!cancelled) {
-          setItems(list);
+          setItems(asContentTypeCatalog(list));
         }
       })
       .catch((err: unknown) => {
@@ -79,11 +107,16 @@ export function ContentTypesPanel(): React.ReactElement {
 
   if (selected) {
     return (
-      <ContentTypeDetailPanel
-        idOrName={selected.idOrName}
-        catalogGuid={selected.catalogGuid}
-        onBack={() => setSelected(null)}
-      />
+      <DeveloperSectionErrorBoundary
+        label={DEV_MSG.TAB_CONTENT_TYPES}
+        testId="developer-ct-detail-error"
+      >
+        <ContentTypeDetailPanel
+          idOrName={selected.idOrName}
+          catalogGuid={selected.catalogGuid}
+          onBack={() => setSelected(null)}
+        />
+      </DeveloperSectionErrorBoundary>
     );
   }
 
@@ -104,7 +137,7 @@ export function ContentTypesPanel(): React.ReactElement {
   }
 
   const sorted = [...items].sort((a, b) =>
-    (a.label || a.name || "").localeCompare(b.label || b.name || "", undefined, {
+    catalogSortKey(a).localeCompare(catalogSortKey(b), undefined, {
       sensitivity: "base",
     }),
   );
@@ -123,10 +156,12 @@ export function ContentTypesPanel(): React.ReactElement {
         ]}
         rows={sorted.map((ct) => {
           const resolved = resolveContentTypeObjectGuid(ct);
+          const label = asCatalogText(ct.label);
+          const name = asCatalogText(ct.name);
           const key =
             resolved ||
-            ct.name ||
-            `${ct.label ?? "ct"}-${displayId(ct)}`;
+            name ||
+            `${label || "ct"}-${displayId(ct)}`;
           const openKey = selectionKey(ct);
           const interactive = openKey !== "—";
           return {
@@ -138,27 +173,27 @@ export function ContentTypesPanel(): React.ReactElement {
                   key="open"
                   type="button"
                   style={openButtonStyle}
-                  aria-label={`Open ${ct.label || ct.name || openKey}`}
+                  aria-label={`Open ${label || name || openKey}`}
                   onClick={(e) => {
                     e.stopPropagation();
                     openContentType(ct);
                   }}
                 >
-                  {ct.label || "—"}
+                  {label || "—"}
                 </button>
               ) : (
                 <span key="lbl" style={mutedCell}>
-                  {ct.label || "—"}
+                  {label || "—"}
                 </span>
               ),
               <span key="n" style={monoCell}>
-                {ct.name || "—"}
+                {name || "—"}
               </span>,
               <span key="i" style={monoCell}>
                 {displayId(ct)}
               </span>,
               <span key="d" style={mutedCell}>
-                {ct.description || ""}
+                {asCatalogText(ct.description)}
               </span>,
             ],
           };

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -21,6 +21,54 @@ describe("unwrapContentTypeList", () => {
     ).toEqual([{ name: "page", label: "Page" }]);
   });
 
+  it("unwraps Jackson ContentTypeList root array (#3706)", () => {
+    expect(
+      unwrapContentTypeList({
+        ContentTypeList: [{ name: "percPage", label: "Page" }],
+      }),
+    ).toEqual([{ name: "percPage", label: "Page" }]);
+  });
+
+  it("unwraps nested ContentTypeList.ContentType (#3706)", () => {
+    expect(
+      unwrapContentTypeList({
+        ContentTypeList: {
+          ContentType: [
+            { name: "percPage", label: "Page" },
+            { name: "percFileAsset", label: "File" },
+          ],
+        },
+      }),
+    ).toEqual([
+      { name: "percPage", label: "Page" },
+      { name: "percFileAsset", label: "File" },
+    ]);
+  });
+
+  it("unwraps ArrayList envelope and empty-collection beans (#3706)", () => {
+    expect(
+      unwrapContentTypeList({
+        ArrayList: [{ name: "percPage", label: "Page" }],
+      }),
+    ).toEqual([{ name: "percPage", label: "Page" }]);
+    expect(unwrapContentTypeList({ empty: true })).toEqual([]);
+    expect(unwrapContentTypeList({ empty: false })).toEqual([]);
+  });
+
+  it("unwraps per-item ContentType wraps inside an array (#3706)", () => {
+    expect(
+      unwrapContentTypeList({
+        ContentTypeList: [
+          { ContentType: { name: "percPage", label: "Page" } },
+          { ContentType: { name: "percFileAsset", label: "File" } },
+        ],
+      }),
+    ).toEqual([
+      { name: "percPage", label: "Page" },
+      { name: "percFileAsset", label: "File" },
+    ]);
+  });
+
   it("unwraps single ContentType object", () => {
     expect(unwrapContentTypeList({ ContentType: { name: "only" } })).toEqual([
       { name: "only" },
@@ -30,6 +78,13 @@ describe("unwrapContentTypeList", () => {
   it("handles null and empty", () => {
     expect(unwrapContentTypeList(null)).toEqual([]);
     expect(unwrapContentTypeList({})).toEqual([]);
+  });
+
+  it("never returns a non-array (catalog .map safety)", () => {
+    expect(Array.isArray(unwrapContentTypeList({ ContentTypeList: { empty: true } }))).toBe(
+      true,
+    );
+    expect(unwrapContentTypeList("nope")).toEqual([]);
   });
 
   it("fills guid.stringValue from host/type/uuid on list rows (#3319)", () => {

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -77,14 +77,19 @@ vi.mock("../../../main/ts/api/widgetbuilder/widgetBuilderApi", () => ({
   validateDefinition: vi.fn(),
 }));
 
-vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
-  listContentTypes: vi.fn().mockResolvedValue([]),
-  getContentTypeDetail: vi.fn().mockResolvedValue({
-    name: "x",
-    fields: [],
-    designGaps: [],
-  }),
-}));
+vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypesApi")>();
+  return {
+    ...actual,
+    listContentTypes: vi.fn().mockResolvedValue([]),
+    getContentTypeDetail: vi.fn().mockResolvedValue({
+      name: "x",
+      fields: [],
+      designGaps: [],
+    }),
+  };
+});
 
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   listTemplates: vi.fn().mockResolvedValue([]),

--- a/WebUI/src/test/ts/developer/ContentTypesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypesPanel.test.tsx
@@ -10,9 +10,14 @@ import * as contentTypesApi from "../../../main/ts/api/developer/contentTypesApi
 import { ContentTypesPanel } from "../../../main/ts/developer/ContentTypesPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
-  listContentTypes: vi.fn(),
-}));
+vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypesApi")>();
+  return {
+    ...actual,
+    listContentTypes: vi.fn(),
+  };
+});
 
 const listContentTypes = contentTypesApi.listContentTypes as ReturnType<typeof vi.fn>;
 
@@ -95,5 +100,53 @@ describe("ContentTypesPanel", () => {
       expect(screen.getByTestId("developer-ct-error")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-error").textContent).toBe(DEV_MSG.CT_ERROR);
+  });
+
+  it("unwraps ContentTypeList envelope instead of throwing into the section boundary (#3706)", async () => {
+    listContentTypes.mockResolvedValue({
+      ContentTypeList: {
+        ContentType: [
+          {
+            name: "percPage",
+            label: "Page",
+            description: "Page type",
+            guid: { stringValue: "0-2-301", type: 2, uuid: 301 },
+          },
+        ],
+      },
+    });
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-table").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-table").textContent).toContain("percPage");
+    expect(screen.queryByTestId("developer-section-error")).toBeNull();
+    expect(screen.queryByText(/Unable to load/i)).toBeNull();
+  });
+
+  it("does not crash when a row label is a non-string object (#3706)", async () => {
+    listContentTypes.mockResolvedValue([
+      {
+        name: "percPage",
+        label: { value: "Page" },
+        description: { $: "nested" },
+      },
+    ]);
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-table").textContent).toContain("percPage");
+    expect(screen.queryByTestId("developer-section-error")).toBeNull();
+  });
+
+  it("shows empty state for empty-collection beans instead of throwing (#3706)", async () => {
+    listContentTypes.mockResolvedValue({ empty: true });
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-section-error")).toBeNull();
   });
 });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -7,8 +7,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DeveloperShell } from "../../../main/ts/developer/DeveloperShell";
 
-vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
-  listContentTypes: vi.fn().mockResolvedValue([
+vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypesApi")>();
+  return {
+    ...actual,
+    listContentTypes: vi.fn().mockResolvedValue([
     {
       name: "percPage",
       label: "Page",
@@ -92,7 +96,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
     allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
-}));
+  };
+});
 
 const { defaultAclPayload } = vi.hoisted(() => ({
   defaultAclPayload: {

--- a/docs/ai-generated/code-reviews/3706-content-types-catalog-unwrap-erlang.md
+++ b/docs/ai-generated/code-reviews/3706-content-types-catalog-unwrap-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review — #3706 Content Types catalog Jackson list unwrap
+
+**Branch:** `fix/issue-3706-content-types-catalog`  
+**Date:** 2026-08-23  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Developer → Content Types catalog threw into `DeveloperSectionErrorBoundary`
+(`Unable to load Content Types…`) because `GET /services/contenttypes` is
+serialized with Jackson `WRAP_ROOT_VALUE` as `{"ContentTypeList":[…]}` (class
+name). SPA `unwrapContentTypeList` only read top-level `ContentType` /
+`contentType`, so a truthy non-array could reach `[...items].sort` / `.map`.
+
+This change recursively unwraps `ContentTypeList` / nested `ContentType` /
+`ArrayList` / empty-collection beans, re-applies unwrap in the panel, stringifies
+catalog cells so object JAXB wraps cannot throw as React children, and isolates
+detail with a nested error boundary (Templates peer). Rest unit test documents
+the live JSON root. Playwright covers catalog load + first-row Object ACL.
+
+Memory patterns hit: Jackson non-array `.map` (Slot #3554 / searches #3576);
+Playwright companion for WebUI screen; product-docs for REST wire.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path/file I/O in the diff (JSON unwrap + React
+catalog + Playwright selectors + REST JSON assertion).
+
+## Issues
+
+None blocking.
+
+### nit
+
+- `asContentTypeCatalog` is a one-line alias of `unwrapContentTypeList`; fine
+  as a named panel contract.
+
+## Tests
+
+- Vitest: `unwrapContentTypeList` envelopes (root array, nested list, ArrayList,
+  empty bean, per-item wrap); `ContentTypesPanel` does not throw on envelope /
+  object label / empty bean.
+- Rest: `JacksonContextResolverOptionalTest.contentTypeList_serializesNamesNotHideFromMenuOnly`
+  asserts `ContentTypeList` root array (plain JsonMapper, not UNWRAP_ROOT_VALUE).
+- Playwright: `bug-3706-developer-content-types-catalog.spec.js`.
+- Module clean install: `rest` BUILD SUCCESS (Tests run: 544, Failures: 0);
+  `WebUI` BUILD SUCCESS (Tests 3014 passed).
+- C5 H2 QA: `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:9993
+  HEALTH:healthy; hot-copied `cm/modern/assets`; Playwright
+  `tests/bugs/bug-3706-developer-content-types-catalog.spec.js` 1 passed;
+  console-clean=yes; server.log ERROR/FATAL for test window=none.
+
+## Change-class closure
+
+WebUI catalog + API unwrap + Vitest + Playwright + product-docs `rest.md` list
+envelope note + rest Jackson shape test. No sitemanage adaptor change (list
+already returns `List<ContentType>`).

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3706-developer-content-types-catalog.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3706-developer-content-types-catalog.spec.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer → Content Types catalog must load so Object ACL can be opened (#3706).
+ *
+ * Jackson WRAP_ROOT_VALUE on GET /services/contenttypes must not throw into
+ * DeveloperSectionErrorBoundary ("Unable to load Content Types…").
+ *
+ * Surface-filtered QA mode:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/bugs/bug-3706-developer-content-types-catalog.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const {
+  catalogRowSelector,
+} = require("../helpers/developer-catalog-selectors");
+
+function developerSectionUrl(section) {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section,
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Developer Content Types catalog (#3706)", () => {
+  test("catalog table loads and first row can open Object ACL", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto(developerSectionUrl("content-types"), {
+      waitUntil: "networkidle",
+    });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-content-types"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const sectionCrash = page.locator('[data-testid="developer-section-error"]');
+    await expect(sectionCrash).toHaveCount(0);
+
+    const error = page.locator('[data-testid="developer-ct-error"]');
+    const panel = page.locator('[data-testid="developer-ct-panel"]');
+    const empty = page.locator('[data-testid="developer-ct-empty"]');
+
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    expect(
+      await sectionCrash.count(),
+      "Content Types catalog must not hit DeveloperSectionErrorBoundary",
+    ).toBe(0);
+    expect(pageErrors, `uncaught pageerror: ${pageErrors.join(" | ")}`).toEqual(
+      [],
+    );
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Content types catalog error: ${msg}`);
+    }
+
+    if (await empty.isVisible()) {
+      test.skip(true, "No content types in CMS — cannot open Object ACL");
+      return;
+    }
+
+    const table = page.locator('[data-testid="developer-ct-table"]');
+    await expect(table).toBeVisible({ timeout: 15_000 });
+
+    const firstRow = page.locator(catalogRowSelector("developer-ct-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    const openBtn = firstRow.locator("button");
+    await expect(
+      openBtn,
+      "first content-type row should expose Open when selectionKey is set",
+    ).toBeVisible({ timeout: 5_000 });
+    await openBtn.click();
+
+    await expect(page.locator('[data-testid="developer-ct-detail"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-section"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const relatedConsole = consoleErrors.filter(
+      (t) =>
+        /content type|contenttypes|Unable to load Content Types/i.test(t) &&
+        !/favicon|Download the React DevTools/i.test(t),
+    );
+    expect(
+      relatedConsole,
+      `console errors on Content Types path: ${relatedConsole.join(" | ")}`,
+    ).toEqual([]);
+    expect(pageErrors, `uncaught pageerror after open: ${pageErrors.join(" | ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -198,6 +198,12 @@ SPA unwrap that envelope and read `guid.stringValue` (or synthesize
 `GET /services/acls/object/{guid}` for **Object ACL**. The list `guid` is a
 fallback when detail omits Guid parts.
 
+`GET /services/contenttypes` (the catalog list) may be a JSON array or a Jackson
+root envelope (`ContentTypeList` and/or `ContentType`). The Developer **Content
+Types** catalog unwraps those shapes so the table loads (and the first row can
+open Object ACL). Clients must not assume a bare array or call `.map` on the
+raw object.
+
 ### Field rule expressions (read-only)
 
 Content type **detail** field rows include boolean rule **flags** and, when rules exist,

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -89,6 +89,7 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
@@ -142,8 +143,15 @@ class JacksonContextResolverOptionalTest {
     assertTrue(json.contains("percPage"), json);
     assertTrue(json.contains("\"name\""), json);
     assertTrue(json.contains("\"label\""), json);
-    // List root wrap uses ContentType (XmlRootElement on ContentTypeList) or plain array
-    assertTrue(json.contains("ContentType") || json.startsWith("["), json);
+    // Production mapper WRAP_ROOT_VALUE uses class name ContentTypeList
+    // (@XmlRootElement is ignored without a JAXB introspector). Parse with a
+    // plain mapper — the production mapper also has UNWRAP_ROOT_VALUE.
+    // SPA unwrapContentTypeList must handle this envelope (#3706).
+    var tree = JsonMapper.builder().build().readTree(json);
+    assertTrue(tree.has("ContentTypeList") || tree.has("ContentType") || tree.isArray(), json);
+    if (tree.has("ContentTypeList")) {
+      assertTrue(tree.get("ContentTypeList").isArray(), json);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Developer → Content Types catalog failed to load (`Unable to load Content Types. Other Developer tabs remain available.`) because `GET /services/contenttypes` is Jackson `WRAP_ROOT_VALUE` as `{"ContentTypeList":[…]}`. The SPA only unwrapped top-level `ContentType` / `contentType`, so a truthy non-array could throw in `[...items].sort` / `.map` and hit `DeveloperSectionErrorBoundary`, blocking Object ACL on the first row.

This PR recursively unwraps `ContentTypeList` / nested `ContentType` / `ArrayList` / empty-collection beans, re-applies unwrap in the panel, stringifies catalog cells, and isolates detail with a nested error boundary (Templates peer). Rest unit test documents the live JSON root.

Fixes #3706

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. QA H2 Docker (`perc-devctl qa-up`). Log in as Admin.
2. Open **Developer → Content Types**. Catalog table must load (not section error boundary).
3. Open the first content type row. **Object ACL** section is visible (Design access / Runtime visibility).
4. Other Developer tabs remain usable.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (catalog list Jackson envelope)
- [x] **Unit / module tests** — Vitest unwrap + panel; rest Jackson root test; standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-3706-developer-content-types-catalog.spec.js`
- [x] **Build gates** — `cd rest && ../mvnw.cmd clean install`; `cd WebUI && ../mvnw.cmd clean install`
- [x] **Cross-platform** — N/A (JSON unwrap / React catalog; no filesystem path I/O)

## C3 evidence

- **modules_built:** `rest`, `WebUI`
- **build_evidence:** `cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 544, Failures: 0. `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS, Tests 3014 passed.
- **downstream_checked:** none (no production public API signature/`final` change; rest change is a unit test asserting existing JSON root)

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2` `RESULT:OK`
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/rest/mimetypes` → `RESULT:OK HTTP:200 HEALTH:healthy`
- Hot-copied `WebUI/target/generated-webui/cm/modern/assets/` into `perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/` (no docker restart)
- `qa-health` again → `RESULT:OK HTTP:200 HEALTH:healthy`
- Playwright: `npm run test:surface -- --path tests/bugs/bug-3706-developer-content-types-catalog.spec.js` → **1 passed** (catalog table + first row Object ACL)
- console-clean=yes (spec `pageerror` / related console errors empty)
- server.log-clean=yes (no ERROR/FATAL in CMS `server.log` for the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
