### PR TITLE
fix(virtualsite): sql-database rebuild reads current SQL (#3780)

### DIFF
--- a/docs/ai-generated/code-reviews/3780-sql-database-rebuild-current-sql-erlang.md
+++ b/docs/ai-generated/code-reviews/3780-sql-database-rebuild-current-sql-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review — #3780 sql-database rebuild reads current SQL
+
+**Branch:** `fix/issue-3780-sql-database-rebuild-current`  
+**Date:** 2026-08-23  
+**Reviewer:** Erlang (pre-commit, independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for changed logic; portable `Path`/`Files` (no Unix-only roots); product-docs companion for operator-facing rebuild note; no incomplete rest/sitemanage adaptor cache (none present)
+
+## Summary
+
+`PSSqlDatabaseVirtualSiteSource` already `Files.readString`s `sql.queryFile` (or uses the current inline `sql.query`) and re-runs the SELECT on every discover/load (no path/mtime or row cache). `VirtualSiteConfigLoader` always opens `_config.yaml` from disk. `PSVirtualSiteBuildService.build` reloads config then re-discovers. This change locks that no-stale-parse-cache contract (Javadoc), proves same-JVM `_config.yaml` + `queryFile` Path/Files edit→rebuild emits new HTML, and documents the operator rebuild path (no JVM restart; no file watchers).
+
+Peer: csv-filesystem rebuild #3708 / cluster absorb #3777. Parent epic: #2678. Slice of #3780.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Test I/O uses `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`
+- [x] No Unix-only `/tmp` or Windows-only `C:\` hardcodes
+- [x] No raw OS `toString()` path equality assertions
+- [x] Line-ending sensitive checks use `contains` tokens, not whole-file `\n` equality
+- [x] H2 is in-memory (`jdbc:h2:mem:` + `DB_CLOSE_DELAY=-1`); no file-H2 URLs
+
+## Issues
+
+None (hard-gate).
+
+## Nits
+
+- Two nearly parallel `secondBuildAfterSqlConfigAndQueryFileEditEmitsUpdatedHtmlWithoutRestart` tests (`PSVirtualSiteBuildServiceTest` factory wiring vs `PSSqlDatabaseVirtualSiteSourceTest` same-instance source). Acceptable as the SPI + assemble proofs for peer #3708 / #3367.
+
+## C2 API shape
+
+Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change. Reverse-deps (`rest` / `sitemanage`) not required.
+
+## Build
+
+Focused: `PSSqlDatabaseVirtualSiteSourceTest` Tests run: 25, Failures: 0, Skipped: 1 (Unix-only absolute queryFile). `PSVirtualSiteBuildServiceTest` Tests run: 12, Failures: 0. `VirtualSiteConfigLoaderTest` Tests run: 13, Failures: 0.  
+Product-docs: `scripts\ci-smoke-product-docs.bat` → **OK** (23 pages).  
+Standalone `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-23). Surefire: Tests run: 2370, Failures: 0, Errors: 0, Skipped: 243.

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -37,8 +37,9 @@ For Git/filesystem, CSV/filesystem, or SQL/database Virtual Sites such as produc
 - **Build** (`POST /sites/{nameOrId}/virtual/build`) writes a staging tree under
   `{install}/tmp/virtual-sites/{siteKey}` (or an optional `outputRoot`). Each build re-reads the
   current Git/filesystem, CSV tree (`csv-filesystem`), or H2 `SELECT` (`sql-database`). After
-  `git pull`, a local Markdown edit, a CSV change, a `_config.yaml` change, or a SQL row
-  change, run Build (or Publish) again — no CMS restart. `sql-database` requires
+  `git pull`, a local Markdown edit, a CSV change, a `_config.yaml` change, a SQL
+  `queryFile` / `sql.query` change, or an H2 row change, run Build (or Publish) again — no
+  CMS restart. `sql-database` requires
   `_config.yaml` with a `sql:` mapping (`jdbc:h2:mem:`; Oracle / MySQL / SQL Server URLs
   return **400**).
 - **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -216,10 +216,10 @@ virtual-publish chrome). After you save **SQL database**, **Build Virtual Site**
 4. Choose **Build Virtual Site**.
 5. After a `git pull` or a local Markdown/frontmatter edit on the host — or after the remote
    branch moves — or after a CSV file or `_config.yaml` change — or after the SQL
-   `SELECT` / H2 rows change — choose **Build Virtual Site** again. The build re-reads
-   the current tree (and re-fetches when a Git remote is configured) — **do not restart
-   the CMS** just to pick up those edits. There is no file watcher; the next explicit
-   build is the refresh.
+   `_config.yaml`, `sql.queryFile`, `SELECT`, or H2 rows change — choose **Build Virtual
+   Site** again. The build re-reads the current tree (and re-fetches when a Git remote is
+   configured) — **do not restart the CMS** just to pick up those edits. There is no file
+   watcher; the next explicit build is the refresh.
 6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -94,7 +94,7 @@ HTML path in the **virtual participant registry** (`IPSVirtualParticipantService
 | **Process-scoped (default)** | Registrations live in memory until the process exits, or until `clear(siteKey)` / `clearAll()` is called (SPI reset API). Unit tests and one-shot builds use this mode when no store directory is supplied. |
 | **Path-backed (optional)** | Construct the registry with a portable `java.nio.file.Path` base (CLI uses `outputRoot/_meta`). Existing `participants-<siteKey>.jsonl` files are loaded on construct; `flush(siteKey)` rewrites that site’s file. Survives JVM restart when the same Path base is reused. |
 | **Full rebuild** | A complete site build **clears** that site key, then upserts every discovered page, then flushes. A second build therefore does not keep pages removed from the source tree, and does not lose current ids. |
-| **Current filesystem** | Each build reloads `_config.yaml` and re-reads every Markdown/frontmatter file **and CSV row** from disk. The CMS process does **not** keep a parsed-page cache across builds. After `git pull`, a CSV/`_config.yaml` edit, or a local Markdown edit under `virtual.rootPath`, run **Build Virtual Site** (or the offline docs script) again — **no JVM / CMS restart** is required. File watchers are not used; the next explicit build is the refresh. |
+| **Current filesystem** | Each build reloads `_config.yaml` and re-reads every Markdown/frontmatter file, CSV row, and sql-database `SELECT` (`sql.query` or current `sql.queryFile` bytes plus H2 rows). The CMS process does **not** keep a parsed-page cache across builds. After `git pull`, a CSV/`_config.yaml` edit, a SQL `_config.yaml`/`queryFile` or H2 row edit, or a local Markdown edit under `virtual.rootPath`, run **Build Virtual Site** (or the offline docs script) again — **no JVM / CMS restart** is required. File watchers are not used; the next explicit build is the refresh. |
 
 Operators can treat the JSONL under the build meta directory as a diagnostic dump of stable ids after
 an offline docs build. The registry is **not** a substitute for Git as the system of record.
@@ -212,8 +212,11 @@ root) is required — not both. `queryFile` must be relative (no remaining `..`,
 Windows/Unix absolute roots). The query must be a single `SELECT` (no extra statements,
 no `INIT`/`RUNSCRIPT` in the JDBC URL). Missing required columns, blank `id`/`title`,
 duplicate ids, or an unsafe `path` fail closed (`VirtualSiteException`). Each
-discover/load re-runs the current SELECT (no process-lifetime row cache). Credentials
-are not written to logs; put the H2 user in `sql.user` (not in the JDBC URL).
+discover/load re-reads the current `_config.yaml` query (or `sql.queryFile` bytes) and
+re-runs the SELECT (no process-lifetime row cache). After you edit `_config.yaml`,
+`sql.queryFile`, or H2 rows on the CMS host, run **Build Virtual Site** again — **no JVM
+restart**. File watchers are not used. Credentials are not written to logs; put the H2
+user in `sql.user` (not in the JDBC URL).
 
 Example `_config.yaml` fragment:
 
@@ -341,19 +344,21 @@ local root from the panel until the remote is cleared.
 The CMS host must have `git` on `PATH`. Checkouts are server-managed; do not point `remoteUrl` at
 untrusted remotes.
 
-### Rebuild after git pull, a CSV edit, or a local edit (no CMS restart)
+### Rebuild after git pull, a CSV/SQL edit, or a local edit (no CMS restart)
 
-The Git/filesystem and CSV/filesystem adapters always see the **current** tree on the CMS host:
+The Git/filesystem, CSV/filesystem, and SQL/database adapters always see the **current**
+source on the CMS host:
 
-1. Update Markdown or frontmatter, a CSV file, or `_config.yaml` under `virtual.rootPath`
-   (`git pull`, copy, or an editor), **or** change the remote branch and Build again so the
-   server fetches (Git only).
+1. Update Markdown or frontmatter, a CSV file, `_config.yaml`, a SQL `queryFile` / inline
+   `sql.query`, or in-memory H2 rows under `virtual.rootPath` (`git pull`, copy, or an
+   editor), **or** change the remote branch and Build again so the server fetches (Git only).
 2. Run **Build Virtual Site** again (UI, `POST …/virtual/build`, `scripts/build-cms-docs.*`,
-   or `PSVirtualSiteBuildMain … csv-filesystem`).
+   `PSVirtualSiteBuildMain … csv-filesystem`, or `PSVirtualSiteBuildMain … sql-database`).
 3. Preview or publish the new output.
 
-You do **not** restart the CMS JVM for those file changes to appear. A restart is only needed
-when you change server code, Site properties that were never saved, or the process itself.
+You do **not** restart the CMS JVM for those file or H2 row changes to appear. A restart is
+only needed when you change server code, Site properties that were never saved, or the
+process itself.
 
 After a successful build, **Preview assembled site** opens the last output home in a new tab
 (`GET /sites/{nameOrId}/virtual/preview` for status; `GET …/virtual/preview/{relPath}` for the

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -206,10 +206,12 @@ Optional body field `outputRoot` overrides the default output directory
 unavailable). Link problems are reported in the JSON result (and in `link-report.txt` under
 the output root) without failing the HTTP status when the build itself succeeds.
 
-Each build re-reads current Markdown/frontmatter, CSV rows, and `_config.yaml` from
-`virtual.rootPath` (no CMS restart after `git pull`, a CSV/`_config.yaml` edit, or a local
-Markdown edit). The Developer Sites UI exposes this operation as **Build Virtual
-Site** when source kind is Virtual (never for traditional repository Sites). When
+Each build re-reads current Markdown/frontmatter, CSV rows, `_config.yaml`, and the
+sql-database `SELECT` (`sql.query` or current `sql.queryFile` plus H2 rows) from
+`virtual.rootPath` (no CMS restart after `git pull`, a CSV/`_config.yaml` edit, a SQL
+query-file/`_config.yaml` or H2 row edit, or a local Markdown edit). The Developer Sites
+UI exposes this operation as **Build Virtual Site** when source kind is Virtual (never
+for traditional repository Sites). When
 `hasLinkProblems` is true, the result panel shows the problem **count** and an expandable list
 of `linkProblems` (same text as `link-report.txt`). A clean build does not show that banner.
 See [Sites & content structure](id:admin-sites).

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -25,10 +25,11 @@ import java.util.List;
  * SQL / H2 adapter: {@link PSSqlDatabaseVirtualSiteSource} ({@code sql-database}). Future adapters
  * (API, object storage, …) implement this interface.
  *
- * <p>Filesystem implementations must read <em>current</em> file contents on every {@link
- * #discover} and {@link #load}. Process-lifetime parse caches that skip a file because its path
- * or mtime looks unchanged are not allowed — a second build in the same JVM (after {@code git
- * pull}, a CSV row edit, or a local Markdown/frontmatter edit) must see the new bytes. File
+ * <p>Filesystem and SQL implementations must read <em>current</em> source contents on every
+ * {@link #discover} and {@link #load}. Process-lifetime parse caches that skip a file because
+ * its path or mtime looks unchanged are not allowed — a second build in the same JVM (after
+ * {@code git pull}, a CSV row edit, a local Markdown/frontmatter edit, a {@code _config.yaml}
+ * or {@code sql.queryFile} edit, or an in-memory H2 row change) must see the new bytes. File
  * watchers are not required; the next explicit build is the refresh.
  */
 public interface IPSVirtualSiteSource {

--- a/system/services/src/com/percussion/services/virtualsite/PSSqlDatabaseVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSSqlDatabaseVirtualSiteSource.java
@@ -48,8 +48,12 @@ import java.util.regex.Pattern;
  * <p>This slice does not open Oracle, MySQL, SQL Server, or remote H2 ({@code tcp}/{@code ssl}/file)
  * URLs. {@code INIT=}/{@code RUNSCRIPT} in the JDBC URL are rejected.
  *
- * <p>Stateless: {@link #discover} and {@link #load} always re-run the current SELECT. No row cache
- * is kept on the instance or in statics.
+ * <p>Stateless: {@link #discover} and {@link #load} always re-read {@code sql.queryFile} via
+ * {@link Files#readString} (or the current inline {@code sql.query} from config) and re-run
+ * the SELECT. No path/mtime parse cache or row cache is kept on the instance or in statics — a
+ * second build in the same JVM after a {@code _config.yaml} or query-file edit, or after H2
+ * row changes, must see the new bytes. {@code _config.yaml} is reloaded by {@link
+ * PSVirtualSiteBuildService}, not this source.
  *
  * <p>Optional {@code sql.queryFile} is resolved with portable NIO {@link Path} under the site root.
  */

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -94,10 +94,12 @@ public class PSVirtualSiteBuildService {
    * Build a Virtual Site from a filesystem root into {@code outputRoot}.
    *
    * <p>Every invocation reloads {@code _config.yaml}, optional {@code _redirects.yaml}, and
-   * re-discovers and re-loads Markdown or CSV rows from the current tree, then overwrites emitted
-   * HTML. Missing {@code _redirects.yaml} is a no-op. The same service instance does not reuse
-   * parsed pages from a previous build — operators do not need a JVM restart after {@code git
-   * pull}, a CSV/{@code _config.yaml} edit, or a local Markdown edit.
+   * re-discovers and re-loads Markdown, CSV rows, or the current sql-database SELECT (inline
+   * {@code sql.query} or {@code sql.queryFile} bytes plus H2 rows) from the current tree, then
+   * overwrites emitted HTML. Missing {@code _redirects.yaml} is a no-op. The same service
+   * instance does not reuse parsed pages from a previous build — operators do not need a JVM
+   * restart after {@code git pull}, a CSV/{@code _config.yaml} edit, a local Markdown edit, a
+   * SQL query-file/{@code _config.yaml} edit, or an H2 row change.
    *
    * @param siteRoot source tree ({@code _config.yaml} required for git-filesystem and
    *     sql-database; optional for csv-filesystem)

--- a/system/src/test/java/com/percussion/services/virtualsite/PSSqlDatabaseVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSSqlDatabaseVirtualSiteSourceTest.java
@@ -19,6 +19,7 @@ package com.percussion.services.virtualsite;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -243,6 +244,66 @@ class PSSqlDatabaseVirtualSiteSourceTest {
     assertEquals("Second", second.frontmatter().title());
     assertTrue(second.markdownBody().contains("token-BBB"));
     assertFalse(second.markdownBody().contains("token-AAA"));
+  }
+
+  @Test
+  void secondBuildAfterSqlConfigAndQueryFileEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    String jdbc = newMemUrl();
+    seedPages(
+        jdbc,
+        "INSERT INTO pages (id, title, body, path, sort_order) VALUES"
+            + " ('live-home', 'First Title', 'First body unique-token-AAA', 'index.md', 1)");
+    Path root = writeSite(tempDir.resolve("sql-rebuild"), jdbc, null, "pages.sql");
+    Path queryFile = root.resolve("pages.sql");
+    Files.writeString(
+        queryFile,
+        "SELECT id, title, body, path, sort_order AS \"order\" FROM pages\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    writeSqlYaml(root, jdbc, "First Site Title", "pages.sql");
+
+    Path out = tempDir.resolve("sql-rebuild-out");
+    PSSqlDatabaseVirtualSiteSource source = new PSSqlDatabaseVirtualSiteSource();
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(source, new PSInMemoryVirtualParticipantService());
+
+    PSVirtualSiteBuildResult first = service.build(root, out, "sql-docs");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        queryFile,
+        "SELECT id, 'Second Title' AS title, 'Second body unique-token-BBB' AS body, path,"
+            + " sort_order AS \"order\" FROM pages\n",
+        StandardCharsets.UTF_8);
+    writeSqlYaml(root, jdbc, "Second Site Title", "pages.sql");
+
+    VirtualSiteConfig reloaded =
+        VirtualSiteConfigLoader.load(root, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, "sql-docs");
+    assertEquals("Second Site Title", reloaded.siteTitle());
+    VirtualItem loaded = source.load(reloaded, source.discover(reloaded).get(0));
+    assertEquals("Second Title", loaded.frontmatter().title());
+    assertTrue(loaded.markdownBody().contains("unique-token-BBB"), loaded.markdownBody());
+    assertFalse(loaded.markdownBody().contains("unique-token-AAA"), loaded.markdownBody());
+
+    PSVirtualSiteBuildResult second = service.build(root, out, "sql-docs");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
   }
 
   @Test
@@ -524,6 +585,30 @@ class PSSqlDatabaseVirtualSiteSourceTest {
               + " sort_order INT)");
       st.execute(insertSql);
     }
+  }
+
+  private static void writeSqlYaml(Path root, String jdbc, String siteTitle, String queryFile)
+      throws Exception {
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: %s
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        sql:
+          jdbcUrl: "%s"
+          user: sa
+          password: ""
+          queryFile: %s
+        """
+            .formatted(siteTitle, jdbc, queryFile),
+        StandardCharsets.UTF_8);
   }
 
   private static Path writeSite(Path root, String jdbc, String query, String queryFile)

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -26,6 +26,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -258,6 +261,106 @@ class PSVirtualSiteBuildServiceTest {
         StandardCharsets.UTF_8);
 
     PSVirtualSiteBuildResult second = service.build(siteRoot, out, "csv-live");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
+  }
+
+  @Test
+  void secondBuildAfterSqlConfigAndQueryFileEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    String jdbc = "jdbc:h2:mem:vsql_rebuild_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+    Class.forName("org.h2.Driver");
+    try (Connection c = DriverManager.getConnection(jdbc, "sa", "");
+        Statement st = c.createStatement()) {
+      st.execute(
+          "CREATE TABLE pages ("
+              + "id VARCHAR(128), title VARCHAR(256), body CLOB, path VARCHAR(512),"
+              + " sort_order INT)");
+      st.execute(
+          "INSERT INTO pages (id, title, body, path, sort_order) VALUES"
+              + " ('live-home', 'First Title', 'First body unique-token-AAA', 'index.md', 1)");
+    }
+
+    Path siteRoot = tempDir.resolve("sql-live-site");
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Path configYaml = siteRoot.resolve("_config.yaml");
+    Path queryFile = siteRoot.resolve("pages.sql");
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: First Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        sql:
+          jdbcUrl: "%s"
+          user: sa
+          password: ""
+          queryFile: pages.sql
+        """
+            .formatted(jdbc),
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        queryFile,
+        "SELECT id, title, body, path, sort_order AS \"order\" FROM pages\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("sql-live-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.SQL_DATABASE);
+
+    PSVirtualSiteBuildResult first = service.build(siteRoot, out, "sql-live");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        queryFile,
+        "SELECT id, 'Second Title' AS title, 'Second body unique-token-BBB' AS body, path,"
+            + " sort_order AS \"order\" FROM pages\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: Second Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        sql:
+          jdbcUrl: "%s"
+          user: sa
+          password: ""
+          queryFile: pages.sql
+        """
+            .formatted(jdbc),
+        StandardCharsets.UTF_8);
+
+    PSVirtualSiteBuildResult second = service.build(siteRoot, out, "sql-live");
     assertEquals(1, second.pageCount());
     String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
     assertTrue(secondHtml.contains("Second Site Title"), secondHtml);

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -161,6 +161,56 @@ class VirtualSiteConfigLoaderTest {
   }
 
   @Test
+  void secondLoadAfterSqlQueryAndQueryFileEditSeesCurrentSqlWithoutCache() throws Exception {
+    Path root = tempDir.resolve("live-sql-config");
+    Files.createDirectories(root);
+    Path yaml = root.resolve("_config.yaml");
+    Path queryFile = root.resolve("pages.sql");
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: SQL First
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        sql:
+          jdbcUrl: "jdbc:h2:mem:vsql_cfg_first;DB_CLOSE_DELAY=-1"
+          query: SELECT id, title, body FROM pages
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig first = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("SQL First", first.siteTitle());
+    assertEquals("jdbc:h2:mem:vsql_cfg_first;DB_CLOSE_DELAY=-1", first.sql().jdbcUrl());
+    assertTrue(first.sql().query().toLowerCase().contains("from pages"), first.sql().query());
+    assertTrue(first.sql().queryFile() == null || first.sql().queryFile().isBlank());
+
+    Files.writeString(queryFile, "SELECT id, title, body FROM catalog\n", StandardCharsets.UTF_8);
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: SQL Second
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        sql:
+          jdbcUrl: "jdbc:h2:mem:vsql_cfg_second;DB_CLOSE_DELAY=-1"
+          queryFile: pages.sql
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig second = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("SQL Second", second.siteTitle());
+    assertEquals("jdbc:h2:mem:vsql_cfg_second;DB_CLOSE_DELAY=-1", second.sql().jdbcUrl());
+    assertTrue(second.sql().query() == null || second.sql().query().isBlank());
+    assertEquals("pages.sql", second.sql().queryFile());
+  }
+
+  @Test
   void nullRootFails() {
     assertThrows(
         VirtualSiteException.class,


### PR DESCRIPTION
## Summary

sql-database Virtual Site **Build** always reads the **current** SQL source (`_config.yaml` plus inline `sql.query` or `sql.queryFile` bytes) and re-runs the in-memory H2 `SELECT`. Operators editing those files (or H2 rows) on the CMS host do not need a CMS process restart for title/body/config changes to appear in assembled HTML.

Discover/load already `Files.readString`s `sql.queryFile` and re-runs the SELECT (`PSSqlDatabaseVirtualSiteSource`); `VirtualSiteConfigLoader` always opens the current YAML; `PSVirtualSiteBuildService.build` reloads config then re-discovers. This PR locks that no-stale-parse-cache contract (Javadoc), proves same-JVM Path/Files edit→rebuild emits new HTML, and documents the operator rebuild path. No file watchers.

Peer: csv-filesystem rebuild #3708 / cluster absorb #3777; git-filesystem rebuild #3367 / PR #3373. Parent epic: #2678. Slice of #3780.

Stacked on cluster [#3777](https://github.com/intersoftdatalabs-in/percussioncms/pull/3777) (`cluster/night-issue-20260823-sql-virtual-site`) because `sql-database` SPI is not on `main` yet.

Fixes #3780

## Test plan

1. Review `PSVirtualSiteBuildServiceTest.secondBuildAfterSqlConfigAndQueryFileEditEmitsUpdatedHtmlWithoutRestart` and `PSSqlDatabaseVirtualSiteSourceTest.secondBuildAfterSqlConfigAndQueryFileEditEmitsUpdatedHtmlWithoutRestart`: two builds against the same `@TempDir` root after `_config.yaml` + `pages.sql` Path/Files edits change assembled HTML (portable `Path` / `Files`, in-memory H2).
2. Review `VirtualSiteConfigLoaderTest.secondLoadAfterSqlQueryAndQueryFileEditSeesCurrentSqlWithoutCache`.
3. Standalone: `cd system && ../mvnw.cmd clean install` (already green in this session).
4. Operator docs: product-docs 8.2 developer Virtual Sites, admin Sites/Publishing, reference site-config — rebuild after SQL `_config.yaml` / `queryFile` / H2 row edit, no JVM restart.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/virtual-sites.md`, `admin/sites.md`, `admin/publishing.md`, `reference/site-config.md`)
- [x] **Unit / module tests** — behavioral two-build HTML tests; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` **BUILD SUCCESS**
- [x] **Cross-platform** — tests use `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`; in-memory H2; no Unix-only roots

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (2026-08-23). Surefire: Tests run: 2370, Failures: 0, Errors: 0, Skipped: 243. Focused: `PSSqlDatabaseVirtualSiteSourceTest` 25/0/1 (Unix-only absolute queryFile skipped on Windows), `PSVirtualSiteBuildServiceTest` 12/0/0, `VirtualSiteConfigLoaderTest` 13/0/0. Product-docs: `scripts\ci-smoke-product-docs.bat` → **OK** (23 pages).
- **downstream_checked:** none (Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change). `rest` / `sitemanage` not touched.

## C5 UI proof

N/A — backend sql-database rebuild contract + operator docs. No WebUI/Playwright.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
