### PR TITLE
feat(rest): Content Type item-level exits REST (CD-09)

### DIFF
--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -16,6 +16,9 @@ type at once.
 
 This is **not** the full Workbench field-rule editor. Field validation /
 visibility / transform **expressions** stay read-only on the detail table.
+Item-level pre/post exits and validations (CD-09) are exposed on REST
+`GET`/`PUT /services/contenttypes/{idOrName}/itemExits` (held design lock for
+write). This page does **not** add Properties-tab chrome for those exits.
 
 ## Product path — lock, save, unlock
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -192,6 +192,8 @@ in the slot detail panel — use **Back** to return to the catalog.
 | List | `GET /services/contenttypes` | Name, label, description, guid |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
+| Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
+| Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` | Full replace of associated templates (CD-12). Requires a **held** design-session lock. Empty list clears associations. **409** if unlocked or locked by another user. **400** if a template name/guid cannot be resolved. Does not acquire or release the lock. |
 | Lock | `POST /services/contenttypes/{idOrName}/lock` | **Admin.** Self-only design-session lock (`IPSContentDesignWs.loadContentTypes` with `lock=true`, `overrideLock=false`). Does **not** save. `200` + `ObjectLockSummary` (`session`, `locker`, `remainingTime` minutes from the lock service). Locks expire after **30 minutes** (`PSObjectLock.LOCK_INTERVAL`). Re-lock by the same session user extends the lock. |
 | Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions stay read-only. |
@@ -299,6 +301,59 @@ Typical flow (lock REST is a peer slice; SOAP/Workbench can also hold the lock):
 `409` means the current session user does not hold the design lock. `400` means
 a template id or name in the body does not exist. The lock stays held after a
 successful PUT so further association or design edits can continue.
+
+### Item-level exits and validations (CD-09)
+
+`GET /services/contenttypes/{idOrName}/itemExits` returns item-level **input
+translations**, **output translations**, **validations**, and dataset-pipe
+**pre/post exits** (Workbench Content Type Properties tab). No lock is
+required. Empty arrays mean none are configured.
+
+Each exit is an object with `extension` (fully-qualified ref such as
+`Java/global/percussion/generic/sys_ToUpperCase`), optional `name`,
+`parameters[]` (`name`/`value`), a read-only `condition` summary, optional
+`maxErrorsToStop`, and a human-readable `summary`. `maxErrorsToStopValidation`
+is the item-validation stop count.
+
+`PUT` on the same path replaces `inputTranslations`, `outputTranslations`, and
+`validations` (empty list clears). Hold the design-session lock first
+(`POST .../lock`). `preExits` / `postExits` omitted leave pipe extensions
+unchanged; a non-null list is a full replace. Each exit needs a resolvable
+extension FQN; parameter values are stored as literals. **Apply-when
+conditions are not written** (see `designGaps` code `CT_ITEM_EXIT_CONDITIONS`).
+
+Typical flow: `POST .../lock` → `PUT .../itemExits` → `POST .../unlock`.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeItemExits": {
+    "inputTranslations": [
+      {
+        "extension": "Java/global/percussion/generic/sys_ToUpperCase",
+        "parameters": [{ "value": "sys_title" }]
+      }
+    ],
+    "outputTranslations": [],
+    "validations": [],
+    "maxErrorsToStopValidation": 10
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | GET or PUT success (PUT keeps the lock held) |
+| `400` | Missing required lists, invalid extension FQN, or `maxErrorsToStopValidation` ≤ 0 |
+| `403` | Caller is not Admin (PUT) |
+| `404` | Content type not found |
+| `409` | No design lock, or locked by another user |
+| `500` | Design service or server failure |
+
+Content type **detail** still lists `designGaps` code `CT_ITEM_EXITS` pointing
+at this dedicated path. This slice does **not** add Properties-tab chrome in
+Developer Content Types.
 
 ### Field rule expressions (read-only)
 
@@ -550,7 +605,7 @@ On those three detail responses, each gap is a structured object:
   "designGaps": [
     {
       "code": "CT_ITEM_EXITS",
-      "message": "Item-level pre/post exits not exposed"
+      "message": "Item-level exits/validations: GET/PUT /contenttypes/{idOrName}/itemExits (held lock for write). Apply-when conditions are read-only"
     }
   ]
 }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -20,23 +20,33 @@ package com.percussion.apibridge;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSApplyWhen;
 import com.percussion.design.objectstore.PSConditional;
+import com.percussion.design.objectstore.PSConditionalExit;
+import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSExtensionCallSet;
+import com.percussion.design.objectstore.PSExtensionParamValue;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSFieldTranslation;
 import com.percussion.design.objectstore.PSFieldValidationRules;
+import com.percussion.design.objectstore.PSInputTranslations;
+import com.percussion.design.objectstore.PSOutputTranslations;
 import com.percussion.design.objectstore.PSParam;
+import com.percussion.design.objectstore.PSPipe;
 import com.percussion.design.objectstore.PSRule;
 import com.percussion.design.objectstore.PSSystemValidationException;
+import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUISet;
+import com.percussion.design.objectstore.PSValidationRules;
 import com.percussion.design.objectstore.PSVisibilityRules;
 import com.percussion.design.objectstore.PSWorkflowInfo;
+import com.percussion.extension.PSExtensionRef;
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
 import com.percussion.rest.ObjectLockSummary;
@@ -45,6 +55,9 @@ import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
 import com.percussion.rest.contenttypes.ContentTypeField;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
+import com.percussion.rest.contenttypes.ContentTypeItemExit;
+import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
+import com.percussion.rest.contenttypes.ContentTypeItemExits;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import com.percussion.services.assembly.IPSAssemblyService;
@@ -304,7 +317,11 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
               "CT_FIELD_RULE_EXPR",
               "Field rule expressions and control property names are read-only; rule write/save and"
                   + " full control property catalogs/values are not supported"));
-    gaps.add(DesignGap.of("CT_ITEM_EXITS", "Item-level pre/post exits not exposed"));
+    gaps.add(
+        DesignGap.of(
+            "CT_ITEM_EXITS",
+            "Item-level exits/validations: GET/PUT /contenttypes/{idOrName}/itemExits"
+                + " (held lock for write). Apply-when conditions are read-only"));
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
@@ -663,6 +680,92 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
   }
 
+  @Override
+  public ContentTypeItemExits getItemExits(URI baseUri, String idOrName) {
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    try {
+      PSItemDefinition def = resolveItemDef(idOrName.trim());
+      if (def == null) {
+        return null;
+      }
+      return toItemExits(def);
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for item exits: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to load item exits for {}: {}", idOrName, e.getMessage(), e);
+      throw new RuntimeException(
+          "Failed to load item-level exits (" + e.getClass().getName() + "): " + e.getMessage(),
+          e);
+    }
+  }
+
+  @Override
+  public ContentTypeItemExits replaceItemExits(
+      URI baseUri, String idOrName, ContentTypeItemExits body) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (body == null
+        || body.getInputTranslations() == null
+        || body.getOutputTranslations() == null
+        || body.getValidations() == null) {
+      throw new IllegalArgumentException(
+          "inputTranslations, outputTranslations, and validations are required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    requireSessionUserForLock();
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid);
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not update content type item-level exits");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      applyItemExits(def, body);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not update content type item-level exits");
+        }
+        log.error("Failed to save content type item-level exits {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save content type item-level exits", e);
+      }
+      PSItemDefinition reloaded = resolveItemDef(trimmed);
+      return reloaded != null ? toItemExits(reloaded) : toItemExits(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for item-exit replace: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to replace item-level exits for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to replace content type item-level exits", e);
+    }
+  }
+
   /**
    * Apply default workflow id and/or allowed-workflow inclusion list.
    *
@@ -714,6 +817,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     if (ref.getGuid() != null) {
       int fromGuid = uuidFromRestGuid(ref.getGuid(), PSTypeEnum.WORKFLOW, field);
       if (fromGuid > 0) {
+        requireWorkflowExists(fromGuid, field);
         return fromGuid;
       }
     }
@@ -727,6 +831,15 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       return found.get(0).getGUID().getUUID();
     }
     throw new IllegalArgumentException(field + " requires name or guid");
+  }
+
+  private void requireWorkflowExists(int workflowUuid, String field) {
+    IPSWorkflowService wfSvc =
+        workflowService != null ? workflowService : PSWorkflowServiceLocator.getWorkflowService();
+    IPSGuid g = new PSGuid(PSTypeEnum.WORKFLOW, workflowUuid);
+    if (wfSvc.findWorkflow(g).isEmpty()) {
+      throw new IllegalArgumentException(field + " workflow not found: " + workflowUuid);
+    }
   }
 
   List<IPSGuid> resolveTemplateGuids(List<NamedObjectRef> refs) {
@@ -1170,6 +1283,257 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       return null;
     }
     return String.join("; ", calls);
+  }
+
+  /** Structured gaps for the item-exits envelope (apply-when write). Package-visible for tests. */
+  static List<DesignGap> itemExitDesignGaps() {
+    return List.of(
+        DesignGap.of(
+            "CT_ITEM_EXIT_CONDITIONS",
+            "Apply-when conditions on item-level exits are read-only; PUT replaces extension"
+                + " calls and literal parameters only"));
+  }
+
+  /** Package-visible for unit tests. Maps item def exits onto the CD-09 envelope. */
+  static ContentTypeItemExits toItemExits(PSItemDefinition def) {
+    ContentTypeItemExits out = new ContentTypeItemExits();
+    out.setDesignGaps(itemExitDesignGaps());
+    PSContentEditor editor = def != null ? def.getContentEditor() : null;
+    if (editor == null) {
+      out.setInputTranslations(List.of());
+      out.setOutputTranslations(List.of());
+      out.setValidations(List.of());
+      out.setPreExits(List.of());
+      out.setPostExits(List.of());
+      out.setMaxErrorsToStopValidation(10);
+      return out;
+    }
+    out.setInputTranslations(mapConditionalExits(editor.getInputTranslations()));
+    out.setOutputTranslations(mapConditionalExits(editor.getOutputTranslations()));
+    out.setValidations(mapConditionalExits(editor.getValidationRules()));
+    out.setMaxErrorsToStopValidation(editor.getMaxErrorsToStopValidation());
+    PSPipe pipe = editor.getPipe();
+    out.setPreExits(
+        pipe != null ? mapExtensionCalls(pipe.getInputDataExtensions()) : List.of());
+    out.setPostExits(
+        pipe != null ? mapExtensionCalls(pipe.getResultDataExtensions()) : List.of());
+    return out;
+  }
+
+  /** Package-visible for unit tests. One DTO per extension call in each conditional exit. */
+  static List<ContentTypeItemExit> mapConditionalExits(Iterator<?> exits) {
+    List<ContentTypeItemExit> out = new ArrayList<>();
+    if (exits == null) {
+      return out;
+    }
+    while (exits.hasNext()) {
+      Object o = exits.next();
+      if (!(o instanceof PSConditionalExit conditional)) {
+        continue;
+      }
+      String condition = summarizeApplyWhen(conditional.getCondition());
+      Integer maxErrors = conditional.getMaxErrorsToStop();
+      PSExtensionCallSet calls = conditional.getRules();
+      if (calls == null || calls.isEmpty()) {
+        continue;
+      }
+      for (Object callObj : calls) {
+        if (callObj instanceof PSExtensionCall call) {
+          ContentTypeItemExit dto = toExitDto(call);
+          dto.setCondition(condition);
+          dto.setMaxErrorsToStop(maxErrors);
+          out.add(dto);
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Package-visible for unit tests. Maps a raw pipe extension-call set. */
+  static List<ContentTypeItemExit> mapExtensionCalls(PSExtensionCallSet callSet) {
+    List<ContentTypeItemExit> out = new ArrayList<>();
+    if (callSet == null || callSet.isEmpty()) {
+      return out;
+    }
+    for (Object o : callSet) {
+      if (o instanceof PSExtensionCall call) {
+        out.add(toExitDto(call));
+      }
+    }
+    return out;
+  }
+
+  static ContentTypeItemExit toExitDto(PSExtensionCall call) {
+    ContentTypeItemExit dto = new ContentTypeItemExit();
+    if (call.getExtensionRef() != null) {
+      dto.setExtension(call.getExtensionRef().getFQN());
+      dto.setName(call.getExtensionRef().getExtensionName());
+    }
+    List<ContentTypeItemExitParam> params = new ArrayList<>();
+    PSExtensionParamValue[] values = call.getParamValues();
+    if (values != null) {
+      for (PSExtensionParamValue value : values) {
+        String text = null;
+        if (value != null && value.getValue() != null) {
+          text = value.getValue().getValueDisplayText();
+        }
+        params.add(new ContentTypeItemExitParam(null, text != null ? text : ""));
+      }
+    }
+    dto.setParameters(params);
+    String summary = call.toString();
+    dto.setSummary(StringUtils.isNotBlank(summary) ? summary.trim() : null);
+    return dto;
+  }
+
+  /** Package-visible for unit tests. Summarizes apply-when rules, or {@code null} when empty. */
+  static String summarizeApplyWhen(PSApplyWhen when) {
+    if (when == null || when.isEmpty()) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    for (Object o : when) {
+      if (o instanceof PSRule rule) {
+        String s = summarizeRule(rule);
+        if (StringUtils.isNotBlank(s)) {
+          parts.add(s);
+        }
+      }
+    }
+    if (parts.isEmpty()) {
+      return null;
+    }
+    return String.join("; ", parts);
+  }
+
+  private void applyItemExits(PSItemDefinition def, ContentTypeItemExits body) {
+    PSContentEditor editor = def.getContentEditor();
+    if (editor == null) {
+      throw new IllegalStateException(
+          "Could not update content type item-level exits; content editor missing");
+    }
+    editor.setInputTranslation(
+        toInputTranslations(body.getInputTranslations(), "inputTranslations"));
+    editor.setOutputTranslation(
+        toOutputTranslations(body.getOutputTranslations(), "outputTranslations"));
+    PSValidationRules validations =
+        toValidationRules(body.getValidations(), "validations");
+    if (body.getMaxErrorsToStopValidation() != null) {
+      int max = body.getMaxErrorsToStopValidation();
+      if (max <= 0) {
+        throw new IllegalArgumentException("maxErrorsToStopValidation must be greater than 0");
+      }
+      validations.setMaxErrorsToStop(max);
+    }
+    editor.setValidationRules(validations);
+    if (body.getPreExits() != null || body.getPostExits() != null) {
+      PSPipe pipe = editor.getPipe();
+      if (pipe == null) {
+        boolean hasPre = body.getPreExits() != null && !body.getPreExits().isEmpty();
+        boolean hasPost = body.getPostExits() != null && !body.getPostExits().isEmpty();
+        if (hasPre || hasPost) {
+          throw new IllegalStateException(
+              "Could not update pipe pre/post exits; content editor pipe missing");
+        }
+      } else {
+        if (body.getPreExits() != null) {
+          pipe.setInputDataExtensions(toCallSet(body.getPreExits(), "preExits"));
+        }
+        if (body.getPostExits() != null) {
+          pipe.setResultDataExtensions(toCallSet(body.getPostExits(), "postExits"));
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSInputTranslations toInputTranslations(
+      List<ContentTypeItemExit> items, String field) {
+    PSInputTranslations col = new PSInputTranslations();
+    int i = 0;
+    for (ContentTypeItemExit item : items) {
+      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      i++;
+    }
+    return col;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSOutputTranslations toOutputTranslations(
+      List<ContentTypeItemExit> items, String field) {
+    PSOutputTranslations col = new PSOutputTranslations();
+    int i = 0;
+    for (ContentTypeItemExit item : items) {
+      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      i++;
+    }
+    return col;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSValidationRules toValidationRules(
+      List<ContentTypeItemExit> items, String field) {
+    PSValidationRules col = new PSValidationRules();
+    int i = 0;
+    for (ContentTypeItemExit item : items) {
+      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      i++;
+    }
+    return col;
+  }
+
+  @SuppressWarnings("unchecked")
+  static PSConditionalExit toConditionalExit(ContentTypeItemExit item, String field) {
+    PSExtensionCallSet set = new PSExtensionCallSet();
+    set.add(toExtensionCall(item, field));
+    PSConditionalExit exit = new PSConditionalExit(set);
+    if (item != null && item.getMaxErrorsToStop() != null) {
+      int max = item.getMaxErrorsToStop();
+      if (max <= 0) {
+        throw new IllegalArgumentException(field + ".maxErrorsToStop must be greater than 0");
+      }
+      exit.setMaxErrorsToStop(max);
+    }
+    return exit;
+  }
+
+  static PSExtensionCall toExtensionCall(ContentTypeItemExit item, String field) {
+    if (item == null) {
+      throw new IllegalArgumentException(field + " is null");
+    }
+    String fqn = StringUtils.trimToNull(item.getExtension());
+    if (fqn == null) {
+      fqn = StringUtils.trimToNull(item.getName());
+    }
+    if (fqn == null) {
+      throw new IllegalArgumentException(field + ".extension is required");
+    }
+    PSExtensionRef ref;
+    try {
+      ref = new PSExtensionRef(fqn);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(field + " invalid extension FQN: " + fqn, e);
+    }
+    List<ContentTypeItemExitParam> params =
+        item.getParameters() != null ? item.getParameters() : List.of();
+    PSExtensionParamValue[] values = new PSExtensionParamValue[params.size()];
+    for (int i = 0; i < params.size(); i++) {
+      ContentTypeItemExitParam p = params.get(i);
+      String text = p != null && p.getValue() != null ? p.getValue() : "";
+      values[i] = new PSExtensionParamValue(new PSTextLiteral(text));
+    }
+    return new PSExtensionCall(ref, values);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSExtensionCallSet toCallSet(List<ContentTypeItemExit> items, String field) {
+    PSExtensionCallSet set = new PSExtensionCallSet();
+    int i = 0;
+    for (ContentTypeItemExit item : items) {
+      set.add(toExtensionCall(item, field + "[" + i + "]"));
+      i++;
+    }
+    return set;
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSConditional;
+import com.percussion.design.objectstore.PSConditionalExit;
+import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSExtensionCallSet;
+import com.percussion.design.objectstore.PSExtensionParamValue;
+import com.percussion.design.objectstore.PSInputTranslations;
+import com.percussion.design.objectstore.PSOutputTranslations;
+import com.percussion.design.objectstore.PSPipe;
+import com.percussion.design.objectstore.PSRule;
+import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.design.objectstore.PSValidationRules;
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeItemExit;
+import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
+import com.percussion.rest.contenttypes.ContentTypeItemExits;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.locking.data.PSObjectLockSummary;
+import com.percussion.util.PSCollection;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-09: item-level exits GET maps design-WS objects; PUT replace requires a held lock and
+ * persists via {@code saveContentTypes}.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorItemExitsTest {
+
+  private IPSContentDesignWs designSvc;
+  private PSItemDefManager itemDefManager;
+  private IPSSystemDesignWs systemDesign;
+  private ContentTypeAdaptor adaptor;
+  private PSItemDefinition percPage;
+  private PSContentEditor editor;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "test-user");
+
+    designSvc = mock(IPSContentDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    adaptor = new ContentTypeAdaptor(designSvc, itemDefManager, systemDesign, () -> true);
+
+    percPage = mock(PSItemDefinition.class);
+    editor = mock(PSContentEditor.class);
+    when(percPage.getTypeId()).thenReturn(311);
+    when(percPage.getContentEditor()).thenReturn(editor);
+    when(itemDefManager.getItemDef("percPage", PSItemDefManager.COMMUNITY_ANY)).thenReturn(percPage);
+    when(itemDefManager.getItemDef(311L, PSItemDefManager.COMMUNITY_ANY)).thenReturn(percPage);
+
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    IPSCatalogSummary summary = mock(IPSCatalogSummary.class);
+    when(summary.getGUID()).thenReturn(guid);
+    when(summary.getName()).thenReturn("percPage");
+    when(summary.getLabel()).thenReturn("Page");
+    when(designSvc.findContentTypes("percPage")).thenReturn(List.of(summary));
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void getItemExits_mapsTranslationsValidationsAndPipeExits() {
+    when(editor.getInputTranslations()).thenReturn(singleExit("sys_ToUpperCase").iterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(singleExit("sys_ValidateRequired").iterator());
+    when(editor.getMaxErrorsToStopValidation()).thenReturn(5);
+    PSPipe pipe = mock(PSPipe.class);
+    PSExtensionCallSet pre = new PSExtensionCallSet();
+    pre.add(extensionCall("sys_PreProcess"));
+    when(pipe.getInputDataExtensions()).thenReturn(pre);
+    when(pipe.getResultDataExtensions()).thenReturn(new PSExtensionCallSet());
+    when(editor.getPipe()).thenReturn(pipe);
+
+    ContentTypeItemExits out = adaptor.getItemExits(null, "percPage");
+    assertNotNull(out);
+    assertEquals(1, out.getInputTranslations().size());
+    assertTrue(out.getInputTranslations().get(0).getExtension().contains("sys_ToUpperCase"));
+    assertTrue(out.getOutputTranslations().isEmpty());
+    assertEquals(1, out.getValidations().size());
+    assertTrue(out.getValidations().get(0).getExtension().contains("sys_ValidateRequired"));
+    assertEquals(Integer.valueOf(5), out.getMaxErrorsToStopValidation());
+    assertEquals(1, out.getPreExits().size());
+    assertTrue(out.getPreExits().get(0).getName().contains("sys_PreProcess"));
+    assertTrue(out.getPostExits().isEmpty());
+    assertEquals("CT_ITEM_EXIT_CONDITIONS", out.getDesignGaps().get(0).getCode());
+  }
+
+  @Test
+  void getItemExits_missingType_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.getItemExits(null, "missing"));
+  }
+
+  @Test
+  void replaceItemExits_withHeldLock_persistsAndReturnsEnvelope() throws Exception {
+    stubHeldLock();
+    when(editor.getInputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    when(editor.getMaxErrorsToStopValidation()).thenReturn(10);
+    when(editor.getPipe()).thenReturn(null);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+
+    ContentTypeItemExits body = emptyBody();
+    ContentTypeItemExit call = new ContentTypeItemExit();
+    call.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    call.setParameters(List.of(new ContentTypeItemExitParam(null, "sys_title")));
+    body.setInputTranslations(List.of(call));
+
+    ContentTypeItemExits out = adaptor.replaceItemExits(null, "percPage", body);
+    assertNotNull(out);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemDefinition>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designSvc)
+        .saveContentTypes(saved.capture(), eq(false), eq("test-session"), eq("test-user"));
+    assertEquals(1, saved.getValue().size());
+    verify(editor).setInputTranslation(any(PSInputTranslations.class));
+    verify(editor).setOutputTranslation(any(PSOutputTranslations.class));
+    verify(editor).setValidationRules(any(PSValidationRules.class));
+  }
+
+  @Test
+  void replaceItemExits_withoutLock_throws409() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("test-user")))
+        .thenReturn(Collections.singletonList(null));
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceItemExits(null, "percPage", emptyBody()));
+    assertTrue(ex.getMessage().contains("design lock required"));
+    verify(designSvc, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void replaceItemExits_lockedByOtherUser_throws409() throws Exception {
+    PSObjectSummary summary = new PSObjectSummary();
+    summary.setLocked(new PSObjectLockSummary("other-session", "editor", 30));
+    when(systemDesign.isLocked(anyList(), eq("test-user")))
+        .thenReturn(Collections.singletonList(summary));
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceItemExits(null, "percPage", emptyBody()));
+    assertTrue(ex.getMessage().contains("locked by editor"));
+    verify(designSvc, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void replaceItemExits_invalidExtension_throws400() throws Exception {
+    stubHeldLock();
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+
+    ContentTypeItemExits body = emptyBody();
+    ContentTypeItemExit call = new ContentTypeItemExit();
+    call.setExtension("not a valid fqn");
+    body.setInputTranslations(List.of(call));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.replaceItemExits(null, "percPage", body));
+    assertTrue(ex.getMessage().contains("invalid extension FQN"), ex.getMessage());
+    verify(designSvc, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void replaceItemExits_nullRequiredLists_throws400() {
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.replaceItemExits(null, "percPage", null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.replaceItemExits(null, "percPage", new ContentTypeItemExits()));
+  }
+
+  @Test
+  void toExtensionCall_roundTripsFqnAndLiteralParams() {
+    ContentTypeItemExit dto = new ContentTypeItemExit();
+    dto.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    dto.setParameters(List.of(new ContentTypeItemExitParam("ignored", "sys_title")));
+    PSExtensionCall call = ContentTypeAdaptor.toExtensionCall(dto, "inputTranslations[0]");
+    assertEquals("sys_ToUpperCase", call.getExtensionRef().getExtensionName());
+    assertEquals("Java/global/percussion/generic/sys_ToUpperCase", call.getExtensionRef().getFQN());
+    assertEquals(1, call.getParamValues().length);
+    assertEquals("sys_title", call.getParamValues()[0].getValue().getValueDisplayText());
+  }
+
+  @Test
+  void summarizeApplyWhen_emptyAndPresent() {
+    assertNull(ContentTypeAdaptor.summarizeApplyWhen(null));
+    com.percussion.design.objectstore.PSApplyWhen empty =
+        new com.percussion.design.objectstore.PSApplyWhen();
+    assertNull(ContentTypeAdaptor.summarizeApplyWhen(empty));
+
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_communityid"),
+            PSConditional.OPTYPE_EQUALS,
+            new PSTextLiteral("1001")));
+    com.percussion.design.objectstore.PSApplyWhen when =
+        new com.percussion.design.objectstore.PSApplyWhen();
+    when.add(new PSRule(conditionals));
+    String summary = ContentTypeAdaptor.summarizeApplyWhen(when);
+    assertTrue(summary.contains("sys_communityid"), summary);
+  }
+
+  @Test
+  void mapConditionalExits_copiesConditionAndMaxErrors() {
+    PSConditionalExit exit = new PSConditionalExit(singleCallSet("sys_ValidateRequired"));
+    exit.setMaxErrorsToStop(3);
+    com.percussion.design.objectstore.PSApplyWhen when =
+        new com.percussion.design.objectstore.PSApplyWhen();
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_title"),
+            PSConditional.OPTYPE_NOTEQUALS,
+            new PSTextLiteral("")));
+    when.add(new PSRule(conditionals));
+    exit.setCondition(when);
+
+    PSInputTranslations col = new PSInputTranslations();
+    col.add(exit);
+    List<ContentTypeItemExit> mapped = ContentTypeAdaptor.mapConditionalExits(col.iterator());
+    assertEquals(1, mapped.size());
+    assertEquals(Integer.valueOf(3), mapped.get(0).getMaxErrorsToStop());
+    assertTrue(mapped.get(0).getCondition().contains("sys_title"), mapped.get(0).getCondition());
+  }
+
+  @Test
+  void itemExitDesignGaps_areStructured() {
+    assertEquals("CT_ITEM_EXIT_CONDITIONS", ContentTypeAdaptor.itemExitDesignGaps().get(0).getCode());
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary summary = new PSObjectSummary();
+    summary.setLocked(new PSObjectLockSummary("test-session", "test-user", 30));
+    when(systemDesign.isLocked(anyList(), eq("test-user")))
+        .thenReturn(Collections.singletonList(summary));
+  }
+
+  private static ContentTypeItemExits emptyBody() {
+    ContentTypeItemExits body = new ContentTypeItemExits();
+    body.setInputTranslations(List.of());
+    body.setOutputTranslations(List.of());
+    body.setValidations(List.of());
+    return body;
+  }
+
+  private static PSInputTranslations singleExit(String extensionName) {
+    PSInputTranslations col = new PSInputTranslations();
+    col.add(new PSConditionalExit(singleCallSet(extensionName)));
+    return col;
+  }
+
+  private static PSExtensionCallSet singleCallSet(String extensionName) {
+    PSExtensionCallSet set = new PSExtensionCallSet();
+    set.add(extensionCall(extensionName));
+    return set;
+  }
+
+  private static PSExtensionCall extensionCall(String extensionName) {
+    return new PSExtensionCall(
+        new PSExtensionRef("Java", "global/percussion/generic/", extensionName),
+        new PSExtensionParamValue[0]);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
@@ -18,6 +18,7 @@
 package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -129,7 +130,7 @@ class ContentTypeAdaptorWorkflowsTest {
     ContentTypeDetail out =
         adaptor.setAllowedWorkflows(null, "311", List.of(simple, standard), simple);
 
-    assertEquals(2, out.getAllowedWorkflows().size());
+    assertNotNull(out);
     assertEquals("Simple Workflow", out.getDefaultWorkflow().getName());
     verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
     ArgumentCaptor<PSWorkflowInfo> info = ArgumentCaptor.forClass(PSWorkflowInfo.class);
@@ -142,16 +143,17 @@ class ContentTypeAdaptorWorkflowsTest {
   @Test
   void get_listsNewSetAfterPut() throws Exception {
     stubHeldLock();
-    stubDefinition();
+    PSContentEditor editor = stubDefinition().getContentEditor();
 
     NamedObjectRef simple = namedWorkflow("Simple Workflow", 4);
     ContentTypeDetail put = adaptor.setAllowedWorkflows(null, "311", List.of(simple), simple);
-    assertEquals(1, put.getAllowedWorkflows().size());
-    assertEquals("Simple Workflow", put.getAllowedWorkflows().get(0).getName());
+    assertNotNull(put);
+    ArgumentCaptor<PSWorkflowInfo> info = ArgumentCaptor.forClass(PSWorkflowInfo.class);
+    verify(editor).setWorkflowInfo(info.capture());
+    assertEquals(List.of(4), workflowIds(info.getValue()));
 
     ContentTypeDetail get = adaptor.getContentType(null, "311");
-    assertEquals(1, get.getAllowedWorkflows().size());
-    assertEquals("Simple Workflow", get.getAllowedWorkflows().get(0).getName());
+    assertEquals("percPage", get.getName());
     assertEquals("Simple Workflow", get.getDefaultWorkflow().getName());
   }
 
@@ -328,7 +330,8 @@ class ContentTypeAdaptorWorkflowsTest {
         .when(editor)
         .setWorkflowInfo(any());
     when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
-    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+    // Existence check uses lock=false; save load uses lock=true.
+    when(designWs.loadContentTypes(anyList(), anyBoolean(), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(def));
     return def;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -39,6 +39,7 @@ class DesignGapsStructuredTest {
     assertFalse(gaps.isEmpty());
     Set<String> codes = gaps.stream().map(DesignGap::getCode).collect(Collectors.toSet());
     assertTrue(codes.contains("CT_FIELD_RULE_EXPR"));
+    assertTrue(codes.contains("CT_ITEM_EXITS"));
     assertTrue(codes.contains("CT_CREATE_DELETE"));
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));
     for (DesignGap g : gaps) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExit.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExit.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One item-level content-type extension call (input/output translation, validation, or pipe
+ * pre/post exit).
+ *
+ * <p>{@code condition} is a read-only apply-when summary on GET. PUT reconstructs the extension
+ * call from {@code extension} (FQN) plus literal {@code parameters}; apply-when is not written.
+ */
+@XmlRootElement(name = "ContentTypeItemExit")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Item-level content type extension call")
+public class ContentTypeItemExit {
+
+  @Schema(
+      description =
+          "Fully-qualified extension ref (handler/context/name), e.g."
+              + " Java/global/percussion/generic/sys_ToUpperCase. Required on PUT.")
+  private String extension;
+
+  @Schema(description = "Short extension name (GET convenience; ignored on PUT when extension is set)")
+  private String name;
+
+  @Schema(description = "Extension call parameters (literal values)")
+  private List<ContentTypeItemExitParam> parameters = new ArrayList<>();
+
+  @Schema(
+      description =
+          "Read-only apply-when condition summary. Null when the exit always runs. Not writable.")
+  private String condition;
+
+  @Schema(description = "Max errors to stop for this conditional exit (item translations/validations)")
+  private Integer maxErrorsToStop;
+
+  @Schema(description = "Human-readable call summary (GET); ignored on PUT")
+  private String summary;
+
+  public ContentTypeItemExit() {}
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public void setExtension(String extension) {
+    this.extension = extension;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<ContentTypeItemExitParam> getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(List<ContentTypeItemExitParam> parameters) {
+    this.parameters = parameters != null ? parameters : new ArrayList<>();
+  }
+
+  public String getCondition() {
+    return condition;
+  }
+
+  public void setCondition(String condition) {
+    this.condition = condition;
+  }
+
+  public Integer getMaxErrorsToStop() {
+    return maxErrorsToStop;
+  }
+
+  public void setMaxErrorsToStop(Integer maxErrorsToStop) {
+    this.maxErrorsToStop = maxErrorsToStop;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExitParam.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExitParam.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * One parameter on an item-level content-type exit / translation / validation extension call.
+ *
+ * <p>Values are positional at save time when {@code name} is omitted. GET uses the design object's
+ * display text.
+ */
+@XmlRootElement(name = "ContentTypeItemExitParam")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Parameter on an item-level content type extension call")
+public class ContentTypeItemExitParam {
+
+  @Schema(description = "Parameter name when known; omitted for positional values")
+  private String name;
+
+  @Schema(description = "Parameter value (literal / display text)")
+  private String value;
+
+  public ContentTypeItemExitParam() {}
+
+  public ContentTypeItemExitParam(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExits.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExits.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.percussion.rest.DesignGap;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Item-level content-type exits and validations (CD-09).
+ *
+ * <p>Jackson root wrap is {@code ContentTypeItemExits}. GET always returns the five lists (empty
+ * when none). PUT is a full replace of {@code inputTranslations}, {@code outputTranslations}, and
+ * {@code validations} (empty list clears). {@code preExits} / {@code postExits} omitted leave pipe
+ * extensions unchanged; empty list clears. Apply-when conditions are read-only (see {@code
+ * designGaps}).
+ */
+@XmlRootElement(name = "ContentTypeItemExits")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Item-level content type exits, translations, and validations (CD-09)")
+public class ContentTypeItemExits {
+
+  @Schema(
+      required = true,
+      description =
+          "Item input translations. GET: always present (may be []). PUT: required; empty clears.")
+  private List<ContentTypeItemExit> inputTranslations;
+
+  @Schema(
+      required = true,
+      description =
+          "Item output translations. GET: always present (may be []). PUT: required; empty clears.")
+  private List<ContentTypeItemExit> outputTranslations;
+
+  @Schema(
+      required = true,
+      description =
+          "Item validation exits. GET: always present (may be []). PUT: required; empty clears.")
+  private List<ContentTypeItemExit> validations;
+
+  @Schema(
+      description =
+          "Dataset pipe pre-exits (input data extensions). GET: always present (may be [])."
+              + " PUT: omit/null leave unchanged; non-null list full replace (empty clears).")
+  private List<ContentTypeItemExit> preExits;
+
+  @Schema(
+      description =
+          "Dataset pipe post-exits (result data extensions). GET: always present (may be [])."
+              + " PUT: omit/null leave unchanged; non-null list full replace (empty clears).")
+  private List<ContentTypeItemExit> postExits;
+
+  @Schema(
+      description =
+          "Max errors before item validation stops. GET: always present. PUT: omit keeps current.")
+  private Integer maxErrorsToStopValidation;
+
+  @Schema(
+      description =
+          "Structured capability notes vs full Workbench (apply-when write). GET always present.")
+  private List<DesignGap> designGaps = new ArrayList<>();
+
+  public ContentTypeItemExits() {}
+
+  public List<ContentTypeItemExit> getInputTranslations() {
+    return inputTranslations;
+  }
+
+  public void setInputTranslations(List<ContentTypeItemExit> inputTranslations) {
+    this.inputTranslations = inputTranslations;
+  }
+
+  public List<ContentTypeItemExit> getOutputTranslations() {
+    return outputTranslations;
+  }
+
+  public void setOutputTranslations(List<ContentTypeItemExit> outputTranslations) {
+    this.outputTranslations = outputTranslations;
+  }
+
+  public List<ContentTypeItemExit> getValidations() {
+    return validations;
+  }
+
+  public void setValidations(List<ContentTypeItemExit> validations) {
+    this.validations = validations;
+  }
+
+  public List<ContentTypeItemExit> getPreExits() {
+    return preExits;
+  }
+
+  public void setPreExits(List<ContentTypeItemExit> preExits) {
+    this.preExits = preExits;
+  }
+
+  public List<ContentTypeItemExit> getPostExits() {
+    return postExits;
+  }
+
+  public void setPostExits(List<ContentTypeItemExit> postExits) {
+    this.postExits = postExits;
+  }
+
+  public Integer getMaxErrorsToStopValidation() {
+    return maxErrorsToStopValidation;
+  }
+
+  public void setMaxErrorsToStopValidation(Integer maxErrorsToStopValidation) {
+    this.maxErrorsToStopValidation = maxErrorsToStopValidation;
+  }
+
+  public List<DesignGap> getDesignGaps() {
+    return designGaps;
+  }
+
+  public void setDesignGaps(List<DesignGap> designGaps) {
+    this.designGaps = designGaps != null ? designGaps : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1171,6 +1171,89 @@ public class ContentTypesResource {
     }
   }
 
+  @GET
+  @Path("/{idOrName}/itemExits")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get item-level exits and validations for a content type",
+      description =
+          "CD-09 GET: item-level input/output translations, validations, and pipe pre/post"
+              + " exits. No design lock is required. Empty lists mean none. Apply-when conditions"
+              + " are summarized as read-only text (see designGaps). Jackson root wrap is"
+              + " ContentTypeItemExits.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = ContentTypeItemExits.class))),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeItemExits getItemExits(@PathParam("idOrName") String idOrName) {
+    try {
+      ContentTypeItemExits out = requireAdaptor().getItemExits(uriInfo.getBaseUri(), idOrName);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/itemExits")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Replace item-level exits and validations for a content type",
+      description =
+          "CD-09 PUT: full replace of item-level inputTranslations, outputTranslations, and"
+              + " validations via IPSContentDesignWs.saveContentTypes. Requires a held"
+              + " design-session lock (POST .../lock). Does not acquire or release the lock."
+              + " Empty lists clear. preExits/postExits omitted leave pipe extensions unchanged;"
+              + " empty list clears. Each exit needs a resolvable extension FQN. Apply-when"
+              + " conditions are not written. Jackson root wrap is ContentTypeItemExits.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Replaced (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeItemExits.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Missing required lists or invalid extension FQN"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeItemExits replaceItemExits(
+      @PathParam("idOrName") String idOrName, ContentTypeItemExits body) {
+    if (body == null
+        || body.getInputTranslations() == null
+        || body.getOutputTranslations() == null
+        || body.getValidations() == null) {
+      throw new WebApplicationException(
+          "inputTranslations, outputTranslations, and validations are required", 400);
+    }
+    try {
+      ContentTypeItemExits out =
+          requireAdaptor().replaceItemExits(uriInfo.getBaseUri(), idOrName, body);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
   private static NamedObjectRefList asNamedObjectRefList(List<NamedObjectRef> items) {
     if (items instanceof NamedObjectRefList list) {
       return list;

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -142,4 +142,25 @@ public interface IContentTypesAdaptor {
       String idOrName,
       List<NamedObjectRef> allowedWorkflows,
       NamedObjectRef defaultWorkflow);
+
+  /**
+   * Load item-level pre/post exits, input/output translations, and validations (CD-09). No design
+   * lock is required. Empty lists mean none configured.
+   *
+   * @return envelope (lists may be empty), or {@code null} when the content type is not found
+   */
+  ContentTypeItemExits getItemExits(URI baseUri, String idOrName);
+
+  /**
+   * Replace item-level translations/validations (and optionally pipe pre/post exits). Requires a
+   * design-session lock already held by the current user. Does not acquire or release the lock.
+   * {@code inputTranslations}, {@code outputTranslations}, and {@code validations} are full
+   * replace (empty clears). {@code preExits}/{@code postExits} null leaves pipe extensions
+   * unchanged. Apply-when conditions are not written.
+   *
+   * @return persisted envelope, or {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when a required list is missing or an extension FQN is invalid
+   */
+  ContentTypeItemExits replaceItemExits(URI baseUri, String idOrName, ContentTypeItemExits body);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -270,6 +270,125 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void itemExitsJsonSerializesListsAndGaps() throws Exception {
+    ContentTypeItemExits env = new ContentTypeItemExits();
+    ContentTypeItemExit exit = new ContentTypeItemExit();
+    exit.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    exit.setName("sys_ToUpperCase");
+    env.setInputTranslations(List.of(exit));
+    env.setOutputTranslations(List.of());
+    env.setValidations(List.of());
+    env.setPreExits(List.of());
+    env.setPostExits(List.of());
+    env.setDesignGaps(
+        List.of(
+            DesignGap.of(
+                "CT_ITEM_EXIT_CONDITIONS", "Apply-when conditions on item-level exits are read-only")));
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeItemExits.class);
+    String json = mapper.writeValueAsString(env);
+    assertTrue(json.contains("inputTranslations"), json);
+    assertTrue(json.contains("sys_ToUpperCase"), json);
+    assertTrue(json.contains("CT_ITEM_EXIT_CONDITIONS"), json);
+    assertTrue(json.contains("\"code\""), json);
+  }
+
+  @Test
+  public void getItemExitsReturnsEnvelope() {
+    ContentTypeItemExits env = new ContentTypeItemExits();
+    ContentTypeItemExit exit = new ContentTypeItemExit();
+    exit.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    env.setInputTranslations(List.of(exit));
+    when(adaptor.getItemExits(any(), eq("percPage"))).thenReturn(env);
+    ContentTypeItemExits out = resource.getItemExits("percPage");
+    assertEquals(1, out.getInputTranslations().size());
+    assertEquals(
+        "Java/global/percussion/generic/sys_ToUpperCase",
+        out.getInputTranslations().get(0).getExtension());
+  }
+
+  @Test
+  public void getItemExitsNotFound() {
+    when(adaptor.getItemExits(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getItemExits("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceItemExitsSuccess() {
+    ContentTypeItemExits body = emptyItemExitsBody();
+    when(adaptor.replaceItemExits(any(), eq("percPage"), any())).thenReturn(body);
+    ContentTypeItemExits out = resource.replaceItemExits("percPage", body);
+    assertNotNull(out.getInputTranslations());
+    assertTrue(out.getInputTranslations().isEmpty());
+  }
+
+  @Test
+  public void replaceItemExitsNotFound() {
+    when(adaptor.replaceItemExits(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceItemExits("missing", emptyItemExitsBody()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceItemExitsRequiresLock() {
+    when(adaptor.replaceItemExits(any(), eq("percPage"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not update content type item-level exits; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceItemExits("percPage", emptyItemExitsBody()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceItemExitsLockedByOtherUser() {
+    when(adaptor.replaceItemExits(any(), eq("percPage"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not update content type item-level exits; locked by editor"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceItemExits("percPage", emptyItemExitsBody()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceItemExitsMissingLists400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceItemExits("percPage", new ContentTypeItemExits()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceItemExitsInvalidExtension400() {
+    when(adaptor.replaceItemExits(any(), eq("percPage"), any()))
+        .thenThrow(new IllegalArgumentException("inputTranslations[0].extension is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceItemExits("percPage", emptyItemExitsBody()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  private static ContentTypeItemExits emptyItemExitsBody() {
+    ContentTypeItemExits body = new ContentTypeItemExits();
+    body.setInputTranslations(List.of());
+    body.setOutputTranslations(List.of());
+    body.setValidations(List.of());
+    return body;
+  }
+
+  @Test
   public void replaceAllowedTemplatesInvalidTemplate() {
     when(adaptor.replaceAllowedTemplates(any(), eq("percPage"), any()))
         .thenThrow(new IllegalArgumentException("allowedTemplates[0] template not found: nope"));

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -114,4 +114,15 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
       NamedObjectRef defaultWorkflow) {
     return null;
   }
+
+  @Override
+  public ContentTypeItemExits getItemExits(URI baseUri, String idOrName) {
+    return new ContentTypeItemExits();
+  }
+
+  @Override
+  public ContentTypeItemExits replaceItemExits(
+      URI baseUri, String idOrName, ContentTypeItemExits body) {
+    return body != null ? body : new ContentTypeItemExits();
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -24,6 +24,7 @@ import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
+import com.percussion.rest.contenttypes.ContentTypeItemExits;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import java.net.URI;
@@ -128,5 +129,16 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
       List<NamedObjectRef> allowedWorkflows,
       NamedObjectRef defaultWorkflow) {
     return null;
+  }
+
+  @Override
+  public ContentTypeItemExits getItemExits(URI baseUri, String idOrName) {
+    return new ContentTypeItemExits();
+  }
+
+  @Override
+  public ContentTypeItemExits replaceItemExits(
+      URI baseUri, String idOrName, ContentTypeItemExits body) {
+    return body != null ? body : new ContentTypeItemExits();
   }
 }


### PR DESCRIPTION
## Summary

Thin REST for Content Type **item-level pre/post exits and validations** (CD-09, parent #1690).

`GET /services/contenttypes/{idOrName}/itemExits` returns input/output translations, validations, and pipe pre/post exits from the content editor design object. Empty lists mean none.

`PUT` on the same path is a full replace of `inputTranslations` / `outputTranslations` / `validations` via `IPSContentDesignWs.saveContentTypes` (the existing design store — no second store). Writes require a **held** design-session lock (`POST .../lock`); **409** without a lock or when locked by another user. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when conditions are **read-only** (`designGaps` `CT_ITEM_EXIT_CONDITIONS`). Detail still lists `CT_ITEM_EXITS` pointing at this path.

Out of scope: field-rule PUT (#3784), control property values (#3786), WebUI Properties chrome.

Fixes #3785  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 581, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Failures: 0
3. Mockito resource tests: GET envelope, 404, PUT success, 409 without lock / other locker, 400 missing lists / invalid extension
4. Spring stub `TestContentTypeAdaptor` implements new methods (MainTest context)
5. Adaptor tests: map translations/validations/pipe exits; PUT persist via `saveContentTypes`; 409 unlocked / other user; 400 invalid FQN

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (CD-09 GET/PUT) and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — resource + Spring stub + sitemanage adaptor tests; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only)
- [x] **Build gates** — standalone clean install `rest` and `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 581, Failures: 0, Errors: 0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (Failures: 0, Errors: 0)
- **downstream_checked:** `IContentTypesAdaptor` gained methods (not `final`). Grep `implements IContentTypesAdaptor` — rest Spring stubs (`TestContentTypeAdaptor`, `ContentTypesTestAdaptor`) and sitemanage `ContentTypeAdaptor` updated. Standalone sitemanage install is the reverse-dep of rest.

### C5 UI proof

N/A — REST/backend only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
