### PR TITLE
feat(rest): Content Type control property values REST (CD-07)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3786-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3786-erlang.md
@@ -1,0 +1,24 @@
+# Erlang review — issue #3786 Content Type control property values REST (CD-07)
+
+**Branch:** `fix/issue-3786-content-type-control-property-values`  
+**Date:** 2026-08-25  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor interface + wire DTOs + Spring stub + Mockito resource tests + sitemanage apibridge + adaptor tests + product-docs); no path I/O.
+
+## Summary
+
+Thin REST GET/PUT for Content Type field control property **values** and choice catalogs. PUT requires a held design-session lock (409 without). Companions match rest/sitemanage AGENTS.md. Standalone `clean install` green on `rest` and `projects/sitemanage`.
+
+## Issues
+
+None blocking.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction.
+
+## Tests
+
+- rest: Mockito GET/PUT/404/409/400; Spring stubs implement new methods; JSON includes `controlProperties` values
+- sitemanage: mapping helpers, GET values/choices, PUT persist, 409 lock, 400 invalid catalog, 404 field

--- a/docs/ai-generated/code-reviews/issue-3786-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3786-erlang.md
@@ -2,23 +2,81 @@
 
 **Branch:** `fix/issue-3786-content-type-control-property-values`  
 **Date:** 2026-08-25  
+**Latest pass:** Re-review (rebase onto main + Kilo cache-miss fix)  
 **Recommendation:** approve  
 **Gate:** May commit/push: yes  
-**Memory patterns hit:** change-class closure (rest resource + adaptor interface + wire DTOs + Spring stub + Mockito resource tests + sitemanage apibridge + adaptor tests + product-docs); no path I/O.
+**Memory patterns hit:** change-class closure (rest resource + adaptor interface + wire DTOs + Spring stub + Mockito resource tests + sitemanage apibridge + adaptor tests + product-docs); tests.structural-only (avoided — cache-miss test is behavioral); no path I/O.
 
-## Summary
+## Summary (original)
 
 Thin REST GET/PUT for Content Type field control property **values** and choice catalogs. PUT requires a held design-session lock (409 without). Companions match rest/sitemanage AGENTS.md. Standalone `clean install` green on `rest` and `projects/sitemanage`.
 
-## Issues
+## Issues (original)
 
 None blocking.
 
-## Cross-platform path checklist
+## Cross-platform path checklist (original)
 
 N/A — no filesystem path construction.
 
-## Tests
+## Tests (original)
 
 - rest: Mockito GET/PUT/404/409/400; Spring stubs implement new methods; JSON includes `controlProperties` values
 - sitemanage: mapping helpers, GET values/choices, PUT persist, 409 lock, 400 invalid catalog, 404 field
+
+---
+
+## Re-review (2026-08-25) — rebase onto main + Kilo `reloadItemDef` fix
+
+### Summary
+
+Follow-up after Kilo WARNING on PR #3804: `replaceFieldControlProperties` now reloads via `reloadItemDef` (not `resolveItemDef`) after a successful `saveContentTypes`, so a post-save item-def cache miss cannot 404 a write that already persisted. Rebase onto `origin/main` keeps CD-09 `itemExits` GET/PUT plus CD-07 `controlProperties`. `put_cacheMissAfterSave_fallsBackToLockedDef` exercises the fallback against `PSInvalidContentTypeException` on `getItemDef(311L)` after save. No blocking issues.
+
+### Scope
+
+- Base: `origin/main` (`458f521a6b501f0e2f52ea0e5858db163c460f4c`)
+- Head: `fix/issue-3786-content-type-control-property-values` worktree `C:/Users/Nate/.grok/worktrees/intersoft-workspace-percussioncms/pr-3804` (`a39ad4ba8226fde127412d6d13951ecfb727ac3b`)
+- PR: #3804 (GitHub files snapshot still showed pre-fix `363a179`; this pass reviewed the worktree tree, including the unpushed/local follow-up)
+- Files: rest + sitemanage CD-07 surface (adaptor, resource, `IContentTypesAdaptor`, two Spring stubs, resource tests, adaptor tests, product-docs); union verified against CD-09 `itemExits` already on main
+- Prior report: `docs/ai-generated/code-reviews/issue-3786-erlang.md` (this file)
+- Memory patterns hit: change-class closure (rest↔sitemanage companions); behavioral test for post-save cache miss (not structural-only); cross-platform I/O N/A
+
+### Recommendation
+
+approve
+
+### Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+### Issues
+
+None blocking.
+
+Kilo WARNING (`resolveItemDef` after PUT save → 404 on cache miss) is **fixed**. `replaceFieldControlProperties` at `ContentTypeAdaptor.java:846` uses `reloadItemDef`, which catches `PSInvalidContentTypeException` and returns null (`2047–2056`); caller falls back to the locked in-memory `def` (`847`). The dedicated catch that previously mapped that miss to “not found” was removed, so a successful save is no longer swallowed as 404. Test `put_cacheMissAfterSave_fallsBackToLockedDef` (`ContentTypeAdaptorControlPropertiesTest.java:251`) stubs `getItemDef(311L)` to throw after `stubDefinition()`; pre-save resolution uses numeric GUID + `loadContentTypes`, so the throw only hits the post-save reload. Asserts save was invoked and returned/in-memory values are `640`.
+
+CD-09 + CD-07 union: `IContentTypesAdaptor` has both `get/replaceItemExits` and `get/replaceFieldControlProperties`; `ContentTypesResource` exposes both path pairs; Spring stubs `TestContentTypeAdaptor` and `ContentTypesTestAdaptor` implement both. `contentTypeDesignGaps` `CT_ITEM_EXITS` message points at GET/PUT `itemExits` (main CD-09), not the old “not exposed” text.
+
+### Cross-platform path checklist
+
+Applied. No filesystem path construction. Choice `lookupHref` (`../sys_lookup/foo.xml`) is a design URL, not an OS path join. REST path strings in docs/OpenAPI use `/` (URI form).
+
+### Tests (this pass)
+
+- `put_cacheMissAfterSave_fallsBackToLockedDef` — behavioral coverage of the Kilo fix
+- Existing PUT persist / 409 / 400 / GET 404 field still present
+- rest resource Mockito GET/PUT/409/400; GET field-not-found 404; Spring stubs keep **both** itemExits and controlProperties
+- No new path/file I/O assertions
+
+### Non-blocking notes (not issues)
+
+- Kilo suggestions remain optional: PUT unknown-field 404 (GET already covers `requireFieldMapping`) and asserting `designGaps` on the control-properties envelope.
+- Pre-existing on this class (not introduced by CD-07): `setContentTypeEnabled` (`545`) and `setAllowedWorkflows` (`679`) still call `resolveItemDef` after save; those paths can still 404 on cache miss. Out of scope for this follow-up; do not treat as a CD-07 gate.
+
+### Handoff
+
+- Reviewed: PR #3804 follow-up (rebase onto main + Kilo `reloadItemDef` fix) in worktree `pr-3804`.
+- Top finding: none blocking; cache-miss 404 after successful PUT is fixed and tested.
+- Recommendation: **approve**. May commit/push: **yes**.
+- Artifact: `docs/ai-generated/code-reviews/issue-3786-erlang.md`

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -21,7 +21,7 @@
 - name, label, description, enabled, hideFromMenu, appName, editorUrl, guid
 - fields: name, label (display), origin (local/system/shared), dataType, control, searchable, fieldSet, required
 - fields **P0.2c rule flags**: readOnly, occurrence, hasValidation, hasVisibilityRules, hasInputTranslation, hasOutputTranslation
-- fields **CD-05–07 read-only expressions** (issue #2920): `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, `controlPropertyNames[]` (names only; no values)
+- fields **CD-05–07 read-only expressions** (issue #2920): `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, `controlPropertyNames[]` plus `controlProperties[]` name/value (CD-07 GET/PUT #3786)
 - child field set names
 - **allowedWorkflows[]** + **defaultWorkflow** (P0.2b)
 - **allowedTemplates[]** (P0.2b)
@@ -46,8 +46,8 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 
 |                         Gap                          |    FR IDs    |                       Notes                       |
 |------------------------------------------------------|--------------|---------------------------------------------------|
-| Full field rule **expressions** / control properties | CD-05–CD-07  | **Read-only expressions + control property names** shipped (#2920); write/save + full catalogs still open |
-| Control property + choice configuration              | CD-07        | Control **name** + **property names** (read-only); values/choices not exposed |
+| Full field rule **expressions** / control properties | CD-05–CD-07  | **Read-only expressions** shipped (#2920); **control property values + choice catalogs** GET/PUT (#3786). Rule write/save still open |
+| Control property + choice configuration              | CD-07        | **REST GET/PUT** `.../fields/{fieldName}/controlProperties` (#3786, held design lock for PUT). Choice filter / null-entry / default-selected not written |
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
@@ -64,7 +64,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 2. ~~Read-only field rule expressions + control property names~~ **Done CD-05-07 read path (#2920)**
 3. ~~Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`~~ **Lock** (#3742) + **PUT save requires held lock** (#3743)
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
-5. Control property value/choice catalogs + rule write/save
+5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
 6. Templates/slots design editors
 
 ## Client behavior

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -54,3 +54,7 @@ The chrome calls:
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on
 the same detail panel: [Object ACL & default template](id:admin-object-acl).
+
+Field **control property values** and **choice catalogs** are not edited in this chrome.
+Integrators use `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties`
+(hold the design-session lock before PUT). See [REST API — Content types](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -199,6 +199,8 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions stay read-only. |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
+| Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
+| Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
 Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types).
@@ -367,11 +369,60 @@ human-readable **expression summaries**:
 | `hasInputTranslation` / `inputTranslationExpression` | Input transform present / extension call summary |
 | `hasOutputTranslation` / `outputTranslationExpression` | Output transform present / extension call summary |
 | `control` | Display control name |
-| `controlPropertyNames` | Control parameter **names** only (values and full choice catalogs not exposed) |
+| `controlPropertyNames` | Control parameter names (compat; prefer `controlProperties`) |
+| `controlProperties` | Control parameter **name and value** pairs |
 
-These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They are **not**
-writable via `PUT` — rule write/save and full control property editors remain Workbench /
-future design APIs. `designGaps` on detail still calls out write and catalog gaps.
+These expression fields are **null/omitted when empty** (`NON_NULL` JSON). Field rule
+expressions are **not** writable via `PUT` detail. Control property **values** and choice
+catalogs use the dedicated CD-07 path below.
+
+### Control property values (CD-07)
+
+`GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` returns the
+display-control parameter **values** (not names only) and the field's choice catalog.
+No design lock is required. `404` means the content type or field mapping was not found.
+
+`PUT` on the same path replaces property values. Hold the design-session lock first; save
+keeps the lock so you can continue editing, then unlock.
+
+Typical flow: `POST .../lock` → `PUT .../fields/{fieldName}/controlProperties` → (optional
+further design writes) → `POST .../unlock`.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeFieldControlProperties": {
+    "fieldName": "sys_title",
+    "control": "sys_DropDownSingle",
+    "properties": [
+      { "name": "height", "value": "200" }
+    ],
+    "choices": {
+      "type": "local",
+      "sortOrder": "ascending",
+      "entries": [
+        { "value": "open", "label": "Open" }
+      ]
+    }
+  }
+}
+```
+
+`properties` is required on PUT (empty list clears parameters). `choices` omitted leaves
+the catalog unchanged. Choice `type` is `global` (keyword table id in `globalId`),
+`local` (inline `entries`), `lookup` / `internalLookup` (`lookupHref`), or `tableinfo`
+(`table` with `tableName` / `labelColumn` / `valueColumn`). `type: none` clears the
+catalog. Choice filters, null-entry, and default-selected are not written.
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | GET envelope, or PUT replaced (lock still held) |
+| `400` | Missing `properties`, invalid choice catalog, or field has no display control |
+| `403` | Caller is not Admin (PUT) |
+| `404` | Content type or field not found |
+| `409` | No design lock, or locked by another user |
+| `500` | Unexpected error |
 
 ## Templates (assembly catalog)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -21,6 +21,8 @@ import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSApplyWhen;
+import com.percussion.design.objectstore.PSChoiceTableInfo;
+import com.percussion.design.objectstore.PSChoices;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
@@ -28,6 +30,8 @@ import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSDisplayText;
+import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSExtensionCallSet;
 import com.percussion.design.objectstore.PSExtensionParamValue;
@@ -43,6 +47,7 @@ import com.percussion.design.objectstore.PSRule;
 import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUISet;
+import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.PSValidationRules;
 import com.percussion.design.objectstore.PSVisibilityRules;
 import com.percussion.design.objectstore.PSWorkflowInfo;
@@ -51,9 +56,14 @@ import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
 import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.contenttypes.ContentTypeChoiceCatalog;
+import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
+import com.percussion.rest.contenttypes.ContentTypeChoiceTable;
+import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
 import com.percussion.rest.contenttypes.ContentTypeField;
+import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExit;
 import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
@@ -80,6 +90,7 @@ import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.user.data.PSCurrentUser;
 import com.percussion.user.service.IPSUserService;
+import com.percussion.util.PSCollection;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
@@ -276,7 +287,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     detail.setGuid(ApiUtils.convertGuid(new PSGuid(PSTypeEnum.NODEDEF, def.getTypeId())));
 
     Map<String, String> controlByField = new HashMap<>();
-    Map<String, List<String>> controlPropsByField = new HashMap<>();
+    Map<String, List<ContentTypeControlProperty>> controlPropsByField = new HashMap<>();
     boolean controlsResolved = mapControls(def, controlByField, controlPropsByField);
     List<ContentTypeField> fields = new ArrayList<>();
     List<String> childSets = new ArrayList<>();
@@ -297,7 +308,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, def.getTypeId());
     int defaultWfId = def.getContentEditor() != null ? def.getContentEditor().getWorkflowId() : -1;
     // Always set non-null lists on GET so wire shape stays [] not omitted (NON_NULL include).
-    detail.setAllowedWorkflows(loadWorkflows(ctGuid, defaultWfId));
+    detail.setAllowedWorkflows(loadWorkflows(ctGuid, defaultWfId, def.getContentEditor()));
     if (defaultWfId > 0) {
       detail.setDefaultWorkflow(toWorkflowRef(defaultWfId, true));
     }
@@ -315,8 +326,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
               "CT_FIELD_RULE_EXPR",
-              "Field rule expressions and control property names are read-only; rule write/save and"
-                  + " full control property catalogs/values are not supported"));
+              "Field rule expressions are read-only; rule write/save is not supported. Control"
+                  + " property values and choice catalogs: GET/PUT"
+                  + " .../fields/{fieldName}/controlProperties"));
     gaps.add(
         DesignGap.of(
             "CT_ITEM_EXITS",
@@ -344,7 +356,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_FIELD_LABELS_WRITE",
-            "Field display labels and control properties are not writable via this API"));
+            "Field display labels are not writable via PUT content type detail"));
     if (!controlsResolved) {
       gaps.add(
           DesignGap.of(
@@ -751,18 +763,95 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         log.error("Failed to save content type item-level exits {}: {}", idOrName, e.getMessage(), e);
         throw new IllegalStateException("Failed to save content type item-level exits", e);
       }
-      PSItemDefinition reloaded = resolveItemDef(trimmed);
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
       return reloaded != null ? toItemExits(reloaded) : toItemExits(def);
     } catch (ContentTypeDesignLockException
         | IllegalArgumentException
         | WebApplicationException e) {
       throw e;
-    } catch (PSInvalidContentTypeException e) {
-      log.debug("Content type not found for item-exit replace: {}", idOrName);
-      return null;
     } catch (Exception e) {
       log.error("Failed to replace item-level exits for {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to replace content type item-level exits", e);
+    }
+  }
+
+  @Override
+  public ContentTypeFieldControlProperties getFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName) {
+    if (StringUtils.isBlank(idOrName) || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    try {
+      PSItemDefinition def = resolveItemDef(idOrName.trim());
+      if (def == null) {
+        return null;
+      }
+      return loadFieldControlProperties(def, fieldName.trim());
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for control properties: {}", idOrName);
+      return null;
+    }
+  }
+
+  @Override
+  public ContentTypeFieldControlProperties replaceFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (StringUtils.isBlank(fieldName)) {
+      throw new IllegalArgumentException("fieldName is required");
+    }
+    if (body == null || body.getProperties() == null) {
+      throw new IllegalArgumentException("properties is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String field = fieldName.trim();
+    String session = currentSession();
+    String user = currentUser();
+    requireSessionUserForLock();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid);
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not save control properties");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      PSDisplayMapping mapping = requireFieldMapping(def, field);
+      applyControlPropertyUpdates(mapping, body);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not save control properties");
+        }
+        log.error("Failed to save control properties for {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save control properties", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      return loadFieldControlProperties(reloaded != null ? reloaded : def, field);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to replace control properties for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to replace control properties", e);
     }
   }
 
@@ -1017,7 +1106,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     };
   }
 
-  private List<NamedObjectRef> loadWorkflows(IPSGuid ctGuid, int defaultWfId) {
+  private List<NamedObjectRef> loadWorkflows(
+      IPSGuid ctGuid, int defaultWfId, PSContentEditor editor) {
     List<NamedObjectRef> out = new ArrayList<>();
     try {
       IPSContentMgr mgr = PSContentMgrLocator.getContentMgr();
@@ -1032,6 +1122,17 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
     } catch (Exception e) {
       log.debug("Could not load workflows for content type {}: {}", ctGuid, e.getMessage());
+    }
+    if (out.isEmpty() && editor != null && editor.getWorkflowInfo() != null) {
+      Iterator<Integer> values = editor.getWorkflowInfo().getValues();
+      if (values != null) {
+        while (values.hasNext()) {
+          Integer id = values.next();
+          if (id != null && id > 0) {
+            out.add(toWorkflowRef(id, id == defaultWfId));
+          }
+        }
+      }
     }
     out.sort(
         Comparator.comparing(
@@ -1099,7 +1200,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       PSFieldSet fieldSet,
       String fieldSetName,
       Map<String, String> controlByField,
-      Map<String, List<String>> controlPropsByField,
+      Map<String, List<ContentTypeControlProperty>> controlPropsByField,
       List<ContentTypeField> out) {
     if (fieldSet == null) {
       return;
@@ -1139,9 +1240,16 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       f.setVisibilityExpression(summarizeVisibilityRules(field.getVisibilityRules()));
       f.setInputTranslationExpression(summarizeTranslation(field.getInputTranslation()));
       f.setOutputTranslationExpression(summarizeTranslation(field.getOutputTranslation()));
-      List<String> propNames = controlPropsByField.get(field.getSubmitName());
-      if (propNames != null && !propNames.isEmpty()) {
-        f.setControlPropertyNames(List.copyOf(propNames));
+      List<ContentTypeControlProperty> props = controlPropsByField.get(field.getSubmitName());
+      if (props != null && !props.isEmpty()) {
+        f.setControlProperties(List.copyOf(props));
+        List<String> names = new ArrayList<>(props.size());
+        for (ContentTypeControlProperty p : props) {
+          if (p != null && StringUtils.isNotBlank(p.getName())) {
+            names.add(p.getName());
+          }
+        }
+        f.setControlPropertyNames(names);
       }
       out.add(f);
     }
@@ -1541,17 +1649,289 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    * ref.
    */
   static List<String> controlPropertyNames(PSControlRef control) {
+    List<String> names = new ArrayList<>();
+    for (ContentTypeControlProperty p : controlProperties(control)) {
+      names.add(p.getName());
+    }
+    return names;
+  }
+
+  /** Package-visible for unit tests. Collects control parameter name/value pairs. */
+  static List<ContentTypeControlProperty> controlProperties(PSControlRef control) {
     if (control == null) {
       return List.of();
     }
-    List<String> names = new ArrayList<>();
+    List<ContentTypeControlProperty> out = new ArrayList<>();
     for (Iterator<?> it = control.getParameters(); it.hasNext(); ) {
       Object o = it.next();
       if (o instanceof PSParam param && StringUtils.isNotBlank(param.getName())) {
-        names.add(param.getName());
+        String value = param.getValue() != null ? param.getValue().getValueText() : null;
+        out.add(new ContentTypeControlProperty(param.getName(), value));
       }
     }
-    return names;
+    return out;
+  }
+
+  static List<DesignGap> controlPropertyDesignGaps() {
+    return List.of(
+        DesignGap.of(
+            "CT_CHOICE_FILTER",
+            "Choice filters, null-entry, and default-selected are not writable"));
+  }
+
+  static String choiceTypeName(int type) {
+    return switch (type) {
+      case PSChoices.TYPE_GLOBAL -> "global";
+      case PSChoices.TYPE_LOCAL -> "local";
+      case PSChoices.TYPE_LOOKUP -> "lookup";
+      case PSChoices.TYPE_INTERNAL_LOOKUP -> "internalLookup";
+      case PSChoices.TYPE_TABLE_INFO -> "tableinfo";
+      default -> "unknown";
+    };
+  }
+
+  static String sortOrderName(int sortOrder) {
+    return switch (sortOrder) {
+      case PSChoices.SORT_ORDER_ASCENDING -> "ascending";
+      case PSChoices.SORT_ORDER_DESCENDING -> "descending";
+      case PSChoices.SORT_ORDER_USER -> "user";
+      default -> "ascending";
+    };
+  }
+
+  static int parseSortOrder(String sortOrder) {
+    if (StringUtils.isBlank(sortOrder) || "ascending".equalsIgnoreCase(sortOrder)) {
+      return PSChoices.SORT_ORDER_ASCENDING;
+    }
+    if ("descending".equalsIgnoreCase(sortOrder)) {
+      return PSChoices.SORT_ORDER_DESCENDING;
+    }
+    if ("user".equalsIgnoreCase(sortOrder)) {
+      return PSChoices.SORT_ORDER_USER;
+    }
+    throw new IllegalArgumentException("choices.sortOrder must be ascending, descending, or user");
+  }
+
+  static ContentTypeChoiceCatalog toChoiceCatalog(PSChoices choices) {
+    if (choices == null) {
+      return null;
+    }
+    ContentTypeChoiceCatalog cat = new ContentTypeChoiceCatalog();
+    cat.setType(choiceTypeName(choices.getType()));
+    cat.setSortOrder(sortOrderName(choices.getSortOrder()));
+    if (choices.getType() == PSChoices.TYPE_GLOBAL) {
+      if (choices.getGlobal() >= 0) {
+        cat.setGlobalId(choices.getGlobal());
+      }
+    } else if (choices.getType() == PSChoices.TYPE_LOCAL) {
+      List<ContentTypeChoiceEntry> entries = new ArrayList<>();
+      for (Iterator<?> it = choices.getLocal(); it.hasNext(); ) {
+        Object o = it.next();
+        if (o instanceof PSEntry e) {
+          String label = e.getLabel() != null ? e.getLabel().getText() : null;
+          entries.add(new ContentTypeChoiceEntry(e.getValue(), label));
+        }
+      }
+      cat.setEntries(entries);
+    } else if (choices.getType() == PSChoices.TYPE_LOOKUP
+        || choices.getType() == PSChoices.TYPE_INTERNAL_LOOKUP) {
+      if (choices.getLookup() != null) {
+        cat.setLookupHref(choices.getLookup().getHref());
+        cat.setLookupName(choices.getLookup().getName());
+      }
+    } else if (choices.getType() == PSChoices.TYPE_TABLE_INFO) {
+      PSChoiceTableInfo ti = choices.getTableInfo();
+      if (ti != null) {
+        ContentTypeChoiceTable table = new ContentTypeChoiceTable();
+        table.setDataSource(ti.getDataSource());
+        table.setTableName(ti.getTableName());
+        table.setLabelColumn(ti.getLableColumn());
+        table.setValueColumn(ti.getValueColumn());
+        cat.setTable(table);
+      }
+    }
+    return cat;
+  }
+
+  static PSChoices fromChoiceCatalog(ContentTypeChoiceCatalog catalog) {
+    if (catalog == null) {
+      return null;
+    }
+    String type = catalog.getType() == null ? "" : catalog.getType().trim();
+    if (type.isEmpty() || "none".equalsIgnoreCase(type)) {
+      return null;
+    }
+    PSChoices choices;
+    if ("global".equalsIgnoreCase(type)) {
+      if (catalog.getGlobalId() == null || catalog.getGlobalId() < 0) {
+        throw new IllegalArgumentException("choices.globalId is required for type global");
+      }
+      choices = new PSChoices(catalog.getGlobalId());
+    } else if ("local".equalsIgnoreCase(type)) {
+      List<ContentTypeChoiceEntry> entries = catalog.getEntries();
+      if (entries == null || entries.isEmpty()) {
+        throw new IllegalArgumentException("choices.entries is required for type local");
+      }
+      PSCollection<PSEntry> local = new PSCollection<>(PSEntry.class);
+      for (int i = 0; i < entries.size(); i++) {
+        ContentTypeChoiceEntry e = entries.get(i);
+        if (e == null || e.getValue() == null) {
+          throw new IllegalArgumentException("choices.entries[" + i + "] value is required");
+        }
+        String label = e.getLabel() != null ? e.getLabel() : e.getValue();
+        local.add(new PSEntry(e.getValue(), new PSDisplayText(label)));
+      }
+      choices = new PSChoices(local);
+    } else if ("lookup".equalsIgnoreCase(type) || "internalLookup".equalsIgnoreCase(type)) {
+      if (StringUtils.isBlank(catalog.getLookupHref())) {
+        throw new IllegalArgumentException("choices.lookupHref is required for type " + type);
+      }
+      int lookupType =
+          "internalLookup".equalsIgnoreCase(type)
+              ? PSChoices.TYPE_INTERNAL_LOOKUP
+              : PSChoices.TYPE_LOOKUP;
+      String lookupName =
+          StringUtils.isBlank(catalog.getLookupName()) ? null : catalog.getLookupName().trim();
+      choices =
+          new PSChoices(
+              new PSUrlRequest(
+                  lookupName, catalog.getLookupHref(), new PSCollection<>(PSParam.class)),
+              lookupType);
+    } else if ("tableinfo".equalsIgnoreCase(type)) {
+      ContentTypeChoiceTable table = catalog.getTable();
+      if (table == null
+          || StringUtils.isBlank(table.getTableName())
+          || StringUtils.isBlank(table.getLabelColumn())
+          || StringUtils.isBlank(table.getValueColumn())) {
+        throw new IllegalArgumentException(
+            "choices.table tableName, labelColumn, and valueColumn are required for type tableinfo");
+      }
+      String ds = table.getDataSource() != null ? table.getDataSource() : "";
+      choices =
+          new PSChoices(
+              new PSChoiceTableInfo(
+                  ds, table.getTableName(), table.getLabelColumn(), table.getValueColumn()));
+    } else {
+      throw new IllegalArgumentException(
+          "choices.type must be global, local, lookup, internalLookup, tableinfo, or none");
+    }
+    if (StringUtils.isNotBlank(catalog.getSortOrder())) {
+      choices.setSortOrder(parseSortOrder(catalog.getSortOrder()));
+    }
+    return choices;
+  }
+
+  static PSCollection<PSParam> toParamCollection(List<ContentTypeControlProperty> properties) {
+    PSCollection<PSParam> params = new PSCollection<>(PSParam.class);
+    if (properties == null) {
+      return params;
+    }
+    for (int i = 0; i < properties.size(); i++) {
+      ContentTypeControlProperty p = properties.get(i);
+      if (p == null || StringUtils.isBlank(p.getName())) {
+        throw new IllegalArgumentException("properties[" + i + "] name is required");
+      }
+      String value = p.getValue() != null ? p.getValue() : "";
+      params.add(new PSParam(p.getName().trim(), new PSTextLiteral(value)));
+    }
+    return params;
+  }
+
+  static PSDisplayMapping findDisplayMapping(PSDisplayMapper dmapper, String fieldName) {
+    if (dmapper == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    for (Iterator<?> it = dmapper.iterator(); it.hasNext(); ) {
+      Object o = it.next();
+      if (!(o instanceof PSDisplayMapping entry)) {
+        continue;
+      }
+      if (fieldName.equals(entry.getFieldRef())) {
+        return entry;
+      }
+      if (entry.getDisplayMapper() != null) {
+        PSDisplayMapping nested = findDisplayMapping(entry.getDisplayMapper(), fieldName);
+        if (nested != null) {
+          return nested;
+        }
+      }
+    }
+    return null;
+  }
+
+  private PSDisplayMapper displayMapperOf(PSItemDefinition def) {
+    try {
+      if (def == null || def.getContentEditor() == null) {
+        return null;
+      }
+      Object pipeObj = def.getContentEditor().getPipe();
+      if (!(pipeObj instanceof PSContentEditorPipe pipe)) {
+        return null;
+      }
+      if (pipe.getMapper() == null || pipe.getMapper().getUIDefinition() == null) {
+        return null;
+      }
+      return pipe.getMapper().getUIDefinition().getDisplayMapper();
+    } catch (Exception e) {
+      log.warn(
+          "Could not resolve display mapper for {}: {}",
+          def != null ? def.getName() : "?",
+          e.getMessage(),
+          e);
+      return null;
+    }
+  }
+
+  private ContentTypeFieldControlProperties loadFieldControlProperties(
+      PSItemDefinition def, String fieldName) {
+    PSDisplayMapping mapping = requireFieldMapping(def, fieldName);
+    return toFieldControlProperties(fieldName, mapping);
+  }
+
+  private PSDisplayMapping requireFieldMapping(PSItemDefinition def, String fieldName) {
+    PSDisplayMapping mapping = findDisplayMapping(displayMapperOf(def), fieldName);
+    if (mapping == null) {
+      throw new WebApplicationException("Field not found: " + fieldName, 404);
+    }
+    return mapping;
+  }
+
+  private static ContentTypeFieldControlProperties toFieldControlProperties(
+      String fieldName, PSDisplayMapping mapping) {
+    ContentTypeFieldControlProperties out = new ContentTypeFieldControlProperties();
+    out.setFieldName(fieldName);
+    PSUISet ui = mapping != null ? mapping.getUISet() : null;
+    PSControlRef control = ui != null ? ui.getControl() : null;
+    if (control != null && StringUtils.isNotBlank(control.getName())) {
+      out.setControl(control.getName());
+    }
+    out.setProperties(new ArrayList<>(controlProperties(control)));
+    if (ui != null) {
+      out.setChoices(toChoiceCatalog(ui.getChoices()));
+    }
+    out.setDesignGaps(new ArrayList<>(controlPropertyDesignGaps()));
+    return out;
+  }
+
+  private static void applyControlPropertyUpdates(
+      PSDisplayMapping mapping, ContentTypeFieldControlProperties body) {
+    PSUISet ui = mapping.getUISet();
+    if (ui == null) {
+      ui = new PSUISet();
+      mapping.setUISet(ui);
+    }
+    List<ContentTypeControlProperty> properties = body.getProperties();
+    PSControlRef control = ui.getControl();
+    if (control == null) {
+      if (!properties.isEmpty()) {
+        throw new IllegalArgumentException("field has no display control");
+      }
+    } else {
+      control.setParameters(toParamCollection(properties));
+    }
+    if (body.getChoices() != null) {
+      ui.setChoices(fromChoiceCatalog(body.getChoices()));
+    }
   }
 
   /**
@@ -1563,7 +1943,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   private boolean mapControls(
       PSItemDefinition def,
       Map<String, String> map,
-      Map<String, List<String>> controlPropsByField) {
+      Map<String, List<ContentTypeControlProperty>> controlPropsByField) {
     try {
       if (def == null || def.getContentEditor() == null) {
         return false;
@@ -1584,7 +1964,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   private void walkDisplayMapper(
       PSDisplayMapper dmapper,
       Map<String, String> map,
-      Map<String, List<String>> controlPropsByField) {
+      Map<String, List<ContentTypeControlProperty>> controlPropsByField) {
     if (dmapper == null) {
       return;
     }
@@ -1603,9 +1983,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
           PSControlRef control = ui.getControl();
           if (control != null && StringUtils.isNotBlank(control.getName())) {
             map.put(fieldRef, control.getName());
-            List<String> propNames = controlPropertyNames(control);
-            if (!propNames.isEmpty()) {
-              controlPropsByField.put(fieldRef, propNames);
+            List<ContentTypeControlProperty> props = controlProperties(control);
+            if (!props.isEmpty()) {
+              controlPropsByField.put(fieldRef, props);
             }
           }
         }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSChoiceTableInfo;
+import com.percussion.design.objectstore.PSChoices;
+import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.design.objectstore.PSContentEditorMapper;
+import com.percussion.design.objectstore.PSContentEditorPipe;
+import com.percussion.design.objectstore.PSControlRef;
+import com.percussion.design.objectstore.PSDisplayMapper;
+import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSDisplayText;
+import com.percussion.design.objectstore.PSEntry;
+import com.percussion.design.objectstore.PSParam;
+import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.design.objectstore.PSUIDefinition;
+import com.percussion.design.objectstore.PSUISet;
+import com.percussion.rest.contenttypes.ContentTypeChoiceCatalog;
+import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
+import com.percussion.rest.contenttypes.ContentTypeChoiceTable;
+import com.percussion.rest.contenttypes.ContentTypeControlProperty;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.util.PSCollection;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-07 control property values and choice catalogs: GET returns name+value; PUT requires a held
+ * design-session lock and persists via {@code saveContentTypes}.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorControlPropertiesTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+  private PSUISet uiSet;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void controlProperties_emptyAndPresent() {
+    assertTrue(ContentTypeAdaptor.controlProperties(null).isEmpty());
+
+    PSControlRef bare = new PSControlRef("sys_EditBox");
+    assertTrue(ContentTypeAdaptor.controlProperties(bare).isEmpty());
+
+    PSCollection params = new PSCollection(PSParam.class);
+    params.add(new PSParam("height", new PSTextLiteral("200")));
+    params.add(new PSParam("width", new PSTextLiteral("400")));
+    PSControlRef withParams = new PSControlRef("sys_TextArea");
+    withParams.setParameters(params);
+    List<ContentTypeControlProperty> props = ContentTypeAdaptor.controlProperties(withParams);
+    assertEquals(2, props.size());
+    assertEquals("height", props.get(0).getName());
+    assertEquals("200", props.get(0).getValue());
+    assertEquals("width", props.get(1).getName());
+    assertEquals("400", props.get(1).getValue());
+    assertEquals(List.of("height", "width"), ContentTypeAdaptor.controlPropertyNames(withParams));
+  }
+
+  @Test
+  void toChoiceCatalog_localAndGlobal() {
+    PSCollection local = new PSCollection(PSEntry.class);
+    local.add(new PSEntry("open", new PSDisplayText("Open")));
+    ContentTypeChoiceCatalog localCat = ContentTypeAdaptor.toChoiceCatalog(new PSChoices(local));
+    assertEquals("local", localCat.getType());
+    assertEquals(1, localCat.getEntries().size());
+    assertEquals("open", localCat.getEntries().get(0).getValue());
+    assertEquals("Open", localCat.getEntries().get(0).getLabel());
+
+    ContentTypeChoiceCatalog globalCat = ContentTypeAdaptor.toChoiceCatalog(new PSChoices(42));
+    assertEquals("global", globalCat.getType());
+    assertEquals(42, globalCat.getGlobalId());
+  }
+
+  @Test
+  void fromChoiceCatalog_roundTripLocalAndNone() {
+    ContentTypeChoiceCatalog body = new ContentTypeChoiceCatalog();
+    body.setType("local");
+    body.setEntries(List.of(new ContentTypeChoiceEntry("closed", "Closed")));
+    PSChoices choices = ContentTypeAdaptor.fromChoiceCatalog(body);
+    assertEquals(PSChoices.TYPE_LOCAL, choices.getType());
+    Iterator<?> it = choices.getLocal();
+    PSEntry first = (PSEntry) it.next();
+    assertEquals("closed", first.getValue());
+
+    ContentTypeChoiceCatalog none = new ContentTypeChoiceCatalog();
+    none.setType("none");
+    assertNull(ContentTypeAdaptor.fromChoiceCatalog(none));
+  }
+
+  @Test
+  void fromChoiceCatalog_tableAndLookup() {
+    ContentTypeChoiceCatalog table = new ContentTypeChoiceCatalog();
+    table.setType("tableinfo");
+    ContentTypeChoiceTable t = new ContentTypeChoiceTable();
+    t.setDataSource("rxdefault");
+    t.setTableName("RXLOOKUP");
+    t.setLabelColumn("LABEL");
+    t.setValueColumn("VALUE");
+    table.setTable(t);
+    PSChoices tableChoices = ContentTypeAdaptor.fromChoiceCatalog(table);
+    assertEquals(PSChoices.TYPE_TABLE_INFO, tableChoices.getType());
+    PSChoiceTableInfo info = tableChoices.getTableInfo();
+    assertEquals("RXLOOKUP", info.getTableName());
+    assertEquals("LABEL", info.getLableColumn());
+
+    ContentTypeChoiceCatalog lookup = new ContentTypeChoiceCatalog();
+    lookup.setType("lookup");
+    lookup.setLookupHref("../sys_lookup/foo.xml");
+    PSChoices lookupChoices = ContentTypeAdaptor.fromChoiceCatalog(lookup);
+    assertEquals(PSChoices.TYPE_LOOKUP, lookupChoices.getType());
+    assertEquals("../sys_lookup/foo.xml", lookupChoices.getLookup().getHref());
+  }
+
+  @Test
+  void fromChoiceCatalog_rejectsInvalid() {
+    ContentTypeChoiceCatalog global = new ContentTypeChoiceCatalog();
+    global.setType("global");
+    IllegalArgumentException missingId =
+        assertThrows(
+            IllegalArgumentException.class, () -> ContentTypeAdaptor.fromChoiceCatalog(global));
+    assertTrue(missingId.getMessage().contains("globalId"), missingId.getMessage());
+
+    ContentTypeChoiceCatalog bogus = new ContentTypeChoiceCatalog();
+    bogus.setType("keyword");
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.fromChoiceCatalog(bogus));
+  }
+
+  @Test
+  void get_returnsPropertyValuesAndChoices() throws Exception {
+    stubDefinition();
+    ContentTypeFieldControlProperties out =
+        adaptor.getFieldControlProperties(null, "311", "sys_title");
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals("sys_TextArea", out.getControl());
+    assertEquals(1, out.getProperties().size());
+    assertEquals("height", out.getProperties().get(0).getName());
+    assertEquals("200", out.getProperties().get(0).getValue());
+    assertEquals("local", out.getChoices().getType());
+    assertEquals("open", out.getChoices().getEntries().get(0).getValue());
+  }
+
+  @Test
+  void get_unknownField_is404() throws Exception {
+    stubDefinition();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.getFieldControlProperties(null, "311", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void get_unknownType_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.getFieldControlProperties(null, "missing", "sys_title"));
+  }
+
+  @Test
+  void put_persistsValuesWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of(new ContentTypeControlProperty("width", "640")));
+    ContentTypeChoiceCatalog choices = new ContentTypeChoiceCatalog();
+    choices.setType("local");
+    choices.setEntries(List.of(new ContentTypeChoiceEntry("closed", "Closed")));
+    body.setChoices(choices);
+
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals("640", out.getProperties().get(0).getValue());
+    assertEquals("closed", out.getChoices().getEntries().get(0).getValue());
+    PSControlRef control = uiSet.getControl();
+    PSParam first = (PSParam) control.getParameters().next();
+    assertEquals("width", first.getName());
+    assertEquals("640", first.getValue().getValueText());
+  }
+
+  @Test
+  void put_cacheMissAfterSave_fallsBackToLockedDef() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("not cached"));
+
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of(new ContentTypeControlProperty("width", "640")));
+
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals("640", out.getProperties().get(0).getValue());
+    PSControlRef control = uiSet.getControl();
+    PSParam first = (PSParam) control.getParameters().next();
+    assertEquals("width", first.getName());
+    assertEquals("640", first.getValue().getValueText());
+  }
+
+  @Test
+  void put_emptyPropertiesClears() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+    assertTrue(out.getProperties().isEmpty());
+    assertTrue(!uiSet.getControl().getParameters().hasNext(), "expected empty control parameters");
+  }
+
+  @Test
+  void put_omittedChoicesLeaveCatalog() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of(new ContentTypeControlProperty("height", "12")));
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+    assertEquals("local", out.getChoices().getType());
+    assertEquals("open", out.getChoices().getEntries().get(0).getValue());
+  }
+
+  @Test
+  void put_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of());
+    stubDefinition();
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceFieldControlProperties(null, "311", "sys_title", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition();
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceFieldControlProperties(null, "311", "sys_title", body));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_missingProperties_isBadRequest() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.replaceFieldControlProperties(null, "311", "sys_title", body));
+    assertTrue(ex.getMessage().contains("properties"), ex.getMessage());
+  }
+
+  @Test
+  void put_unknownType_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    assertNull(adaptor.replaceFieldControlProperties(null, "missing", "sys_title", body));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.replaceFieldControlProperties(null, "311", "sys_title", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private PSItemDefinition stubDefinition() throws Exception {
+    uiSet = new PSUISet();
+    PSControlRef control = new PSControlRef("sys_TextArea");
+    PSCollection params = new PSCollection(PSParam.class);
+    params.add(new PSParam("height", new PSTextLiteral("200")));
+    control.setParameters(params);
+    uiSet.setControl(control);
+    PSCollection local = new PSCollection(PSEntry.class);
+    local.add(new PSEntry("open", new PSDisplayText("Open")));
+    uiSet.setChoices(new PSChoices(local));
+
+    PSDisplayMapper dmapper = new PSDisplayMapper("fs");
+    dmapper.add(new PSDisplayMapping("sys_title", uiSet));
+    PSUIDefinition uiDef = new PSUIDefinition(dmapper);
+    PSContentEditorMapper ceMapper = mock(PSContentEditorMapper.class);
+    when(ceMapper.getUIDefinition()).thenReturn(uiDef);
+    PSContentEditorPipe pipe = mock(PSContentEditorPipe.class);
+    when(pipe.getMapper()).thenReturn(ceMapper);
+    PSContentEditor editor = mock(PSContentEditor.class);
+    when(editor.getPipe()).thenReturn(pipe);
+
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getContentEditor()).thenReturn(editor);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
@@ -333,6 +333,10 @@ class ContentTypeAdaptorWorkflowsTest {
     // Existence check uses lock=false; save load uses lock=true.
     when(designWs.loadContentTypes(anyList(), anyBoolean(), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
     return def;
   }
 

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceCatalog.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceCatalog.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+/**
+ * Choice catalog for a field control (CD-07).
+ *
+ * <p>{@code type} is {@code global}, {@code local}, {@code lookup}, {@code internalLookup}, or
+ * {@code tableinfo}. PUT {@code type=none} (or empty) clears the catalog. Choice filters, null
+ * entry, and default-selected are not written.
+ */
+@XmlRootElement(name = "ContentTypeChoiceCatalog")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Choice catalog for a content type field control")
+public class ContentTypeChoiceCatalog {
+
+  @Schema(
+      description =
+          "global | local | lookup | internalLookup | tableinfo. PUT none/empty clears choices.")
+  private String type;
+
+  @Schema(description = "ascending | descending | user")
+  private String sortOrder;
+
+  @Schema(description = "Keyword / global lookup table id when type is global")
+  private Integer globalId;
+
+  @Schema(description = "Local entries when type is local")
+  private List<ContentTypeChoiceEntry> entries;
+
+  @Schema(description = "Lookup href when type is lookup or internalLookup")
+  private String lookupHref;
+
+  @Schema(description = "Optional lookup request name")
+  private String lookupName;
+
+  @Schema(description = "Table info when type is tableinfo")
+  private ContentTypeChoiceTable table;
+
+  public ContentTypeChoiceCatalog() {}
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public void setSortOrder(String sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  public Integer getGlobalId() {
+    return globalId;
+  }
+
+  public void setGlobalId(Integer globalId) {
+    this.globalId = globalId;
+  }
+
+  public List<ContentTypeChoiceEntry> getEntries() {
+    return entries;
+  }
+
+  public void setEntries(List<ContentTypeChoiceEntry> entries) {
+    this.entries = entries;
+  }
+
+  public String getLookupHref() {
+    return lookupHref;
+  }
+
+  public void setLookupHref(String lookupHref) {
+    this.lookupHref = lookupHref;
+  }
+
+  public String getLookupName() {
+    return lookupName;
+  }
+
+  public void setLookupName(String lookupName) {
+    this.lookupName = lookupName;
+  }
+
+  public ContentTypeChoiceTable getTable() {
+    return table;
+  }
+
+  public void setTable(ContentTypeChoiceTable table) {
+    this.table = table;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceEntry.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceEntry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Local choice catalog entry (label/value) for a field control (CD-07). */
+@XmlRootElement(name = "ContentTypeChoiceEntry")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Local choice entry for a content type field control")
+public class ContentTypeChoiceEntry {
+
+  @Schema(required = true, description = "Stored value")
+  private String value;
+
+  @Schema(description = "Display label; defaults to value when omitted on PUT")
+  private String label;
+
+  public ContentTypeChoiceEntry() {}
+
+  public ContentTypeChoiceEntry(String value, String label) {
+    this.value = value;
+    this.label = label;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceTable.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceTable.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Table-backed choice source for a field control (CD-07 {@code tableinfo}). */
+@XmlRootElement(name = "ContentTypeChoiceTable")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "SQL table choice source (datasource, table, label/value columns)")
+public class ContentTypeChoiceTable {
+
+  @Schema(description = "Datasource name; empty uses the default CMS datasource")
+  private String dataSource;
+
+  @Schema(required = true, description = "Table name")
+  private String tableName;
+
+  @Schema(required = true, description = "Label column")
+  private String labelColumn;
+
+  @Schema(required = true, description = "Value column")
+  private String valueColumn;
+
+  public ContentTypeChoiceTable() {}
+
+  public String getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(String dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
+  }
+
+  public String getLabelColumn() {
+    return labelColumn;
+  }
+
+  public void setLabelColumn(String labelColumn) {
+    this.labelColumn = labelColumn;
+  }
+
+  public String getValueColumn() {
+    return valueColumn;
+  }
+
+  public void setValueColumn(String valueColumn) {
+    this.valueColumn = valueColumn;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeControlProperty.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeControlProperty.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** One control parameter name/value on a content type field display mapping (CD-07). */
+@XmlRootElement(name = "ContentTypeControlProperty")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content type field control property (name and value)")
+public class ContentTypeControlProperty {
+
+  @Schema(required = true, description = "Control parameter name")
+  private String name;
+
+  @Schema(description = "Control parameter value as text (empty string when unset)")
+  private String value;
+
+  public ContentTypeControlProperty() {}
+
+  public ContentTypeControlProperty(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
@@ -92,9 +92,15 @@ public class ContentTypeField {
 
   @Schema(
       description =
-          "Control property / parameter names from the display mapping (cheap names only;"
-              + " values and full catalogs not exposed). Null or omitted when none. Not writable.")
+          "Control property / parameter names from the display mapping. Null or omitted when none."
+              + " Prefer controlProperties for name+value. Not writable via PUT detail.")
   private List<String> controlPropertyNames;
+
+  @Schema(
+      description =
+          "Control property name/value pairs from the display mapping. Null or omitted when none."
+              + " Writable via PUT .../fields/{fieldName}/controlProperties (held design lock).")
+  private List<ContentTypeControlProperty> controlProperties;
 
   @Schema(description = "Child field-set name when this field is nested; null for parent fields")
   private String fieldSet;
@@ -243,6 +249,14 @@ public class ContentTypeField {
 
   public void setControlPropertyNames(List<String> controlPropertyNames) {
     this.controlPropertyNames = controlPropertyNames;
+  }
+
+  public List<ContentTypeControlProperty> getControlProperties() {
+    return controlProperties;
+  }
+
+  public void setControlProperties(List<ContentTypeControlProperty> controlProperties) {
+    this.controlProperties = controlProperties;
   }
 
   public String getFieldSet() {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldControlProperties.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldControlProperties.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.percussion.rest.DesignGap;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Control property values and choice catalog for one content type field (CD-07).
+ *
+ * <p>Jackson root wrap is {@code ContentTypeFieldControlProperties}. GET always returns {@code
+ * properties} (may be empty). PUT is a full replace of {@code properties} (empty clears). {@code
+ * choices} omitted on PUT leaves the catalog unchanged; present replaces (type {@code none}
+ * clears).
+ */
+@XmlRootElement(name = "ContentTypeFieldControlProperties")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Field control property values and choice catalog (CD-07)")
+public class ContentTypeFieldControlProperties {
+
+  @Schema(description = "Field submit name (path {fieldName})")
+  private String fieldName;
+
+  @Schema(description = "Display control name; not changed by PUT")
+  private String control;
+
+  @Schema(
+      required = true,
+      description =
+          "Control parameter name/value pairs. GET: always present (may be []). PUT: required;"
+              + " empty clears.")
+  private List<ContentTypeControlProperty> properties;
+
+  @Schema(
+      description =
+          "Choice catalog. GET: omitted when none. PUT: omit/null leave unchanged; present"
+              + " replaces; type none/empty clears.")
+  private ContentTypeChoiceCatalog choices;
+
+  @Schema(description = "Structured capability notes vs full Workbench. GET always present.")
+  private List<DesignGap> designGaps = new ArrayList<>();
+
+  public ContentTypeFieldControlProperties() {}
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public void setFieldName(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  public String getControl() {
+    return control;
+  }
+
+  public void setControl(String control) {
+    this.control = control;
+  }
+
+  public List<ContentTypeControlProperty> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(List<ContentTypeControlProperty> properties) {
+    this.properties = properties;
+  }
+
+  public ContentTypeChoiceCatalog getChoices() {
+    return choices;
+  }
+
+  public void setChoices(ContentTypeChoiceCatalog choices) {
+    this.choices = choices;
+  }
+
+  public List<DesignGap> getDesignGaps() {
+    return designGaps;
+  }
+
+  public void setDesignGaps(List<DesignGap> designGaps) {
+    this.designGaps = designGaps != null ? designGaps : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -842,8 +842,10 @@ public class ContentTypesResource {
   @Operation(
       summary = "Get content type design summary",
       description =
-          "Content type detail including field catalog. Full rule expressions and control"
-              + " properties are not exposed (see designGaps).",
+          "Content type detail including field catalog. Field rows include control property"
+              + " names and values. Choice catalogs and property write use"
+              + " GET/PUT .../fields/{fieldName}/controlProperties. Field rule expressions remain"
+              + " read-only (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -885,7 +887,8 @@ public class ContentTypesResource {
               + " empty). Template associations are written after content-type save in a separate"
               + " design call — if that fails, meta/field/workflow changes may already be"
               + " committed (error message indicates partial success). Name/id and system field"
-              + " structure are not changed. Field rule expressions remain read-only; create/delete"
+              + " structure are not changed. Field rule expressions remain read-only. Control"
+              + " property values use PUT .../fields/{fieldName}/controlProperties. Create/delete"
               + " remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
@@ -1243,6 +1246,94 @@ public class ContentTypesResource {
     try {
       ContentTypeItemExits out =
           requireAdaptor().replaceItemExits(uriInfo.getBaseUri(), idOrName, body);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
+  @GET
+  @Path("/{idOrName}/fields/{fieldName}/controlProperties")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get field control property values and choice catalog",
+      description =
+          "CD-07 GET: control parameter name/value pairs and the choice catalog for one field."
+              + " No design lock is required. Empty properties means none. choices is omitted when"
+              + " none. Jackson root wrap is ContentTypeFieldControlProperties.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(
+                    schema = @Schema(implementation = ContentTypeFieldControlProperties.class))),
+        @ApiResponse(responseCode = "404", description = "Content type or field not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeFieldControlProperties getFieldControlProperties(
+      @PathParam("idOrName") String idOrName, @PathParam("fieldName") String fieldName) {
+    try {
+      ContentTypeFieldControlProperties out =
+          requireAdaptor()
+              .getFieldControlProperties(uriInfo.getBaseUri(), idOrName, fieldName);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/fields/{fieldName}/controlProperties")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Replace field control property values and optional choice catalog",
+      description =
+          "CD-07 PUT: full replace of control parameter values via IPSContentDesignWs"
+              + " .saveContentTypes. Requires a held design-session lock (POST .../lock). Does not"
+              + " acquire or release the lock. Empty properties clears parameters. choices omitted"
+              + " leaves the catalog unchanged; type none clears. Jackson root wrap is"
+              + " ContentTypeFieldControlProperties.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Replaced (lock is still held)",
+            content =
+                @Content(
+                    schema = @Schema(implementation = ContentTypeFieldControlProperties.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Missing properties or invalid choice catalog"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type or field not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeFieldControlProperties replaceFieldControlProperties(
+      @PathParam("idOrName") String idOrName,
+      @PathParam("fieldName") String fieldName,
+      ContentTypeFieldControlProperties body) {
+    if (body == null || body.getProperties() == null) {
+      throw new WebApplicationException("properties is required", 400);
+    }
+    try {
+      ContentTypeFieldControlProperties out =
+          requireAdaptor()
+              .replaceFieldControlProperties(
+                  uriInfo.getBaseUri(), idOrName, fieldName, body);
       if (out == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -66,7 +66,8 @@ public interface IContentTypesAdaptor {
    * <p>Supports label, description, enabled, per-field {@code searchable} (and optional
    * occurrence), allowed workflows (+ default workflow id), and allowed templates. Association
    * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
-   * Field rule expressions and control property values are read-only.
+   * Field rule expressions remain read-only. Control property values use {@link
+   * #replaceFieldControlProperties}.
    *
    * @return updated detail, or {@code null} when not found
    * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
@@ -163,4 +164,26 @@ public interface IContentTypesAdaptor {
    * @throws IllegalArgumentException when a required list is missing or an extension FQN is invalid
    */
   ContentTypeItemExits replaceItemExits(URI baseUri, String idOrName, ContentTypeItemExits body);
+
+  /**
+   * Load control property values and the choice catalog for one field (CD-07). No design lock is
+   * required. Empty {@code properties} means none configured. {@code choices} is null when none.
+   *
+   * @return envelope, or {@code null} when the content type is not found
+   */
+  ContentTypeFieldControlProperties getFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName);
+
+  /**
+   * Replace control property values (and optionally the choice catalog) for one field. Requires a
+   * design-session lock already held by the current user. Does not acquire or release the lock.
+   * {@code properties} is a full replace (empty clears). {@code choices} null leaves the catalog
+   * unchanged.
+   *
+   * @return persisted envelope, or {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when properties is missing or a choice catalog is invalid
+   */
+  ContentTypeFieldControlProperties replaceFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -138,6 +138,10 @@ public class ContentTypesResourceDetailTest {
     assertTrue(json.contains("sys_title <>"), json);
     assertTrue(json.contains("\"controlPropertyNames\""), json);
     assertTrue(json.contains("height"), json);
+    withRules.setControlProperties(List.of(new ContentTypeControlProperty("height", "200")));
+    json = mapper.writeValueAsString(d);
+    assertTrue(json.contains("\"controlProperties\""), json);
+    assertTrue(json.contains("200"), json);
     // empty expression fields must not force empty-string noise for the second field
     assertTrue(json.contains("page_title"), json);
   }
@@ -497,6 +501,109 @@ public class ContentTypesResourceDetailTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.unlockContentType("missing"));
     assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getFieldControlPropertiesReturnsValues() {
+    ContentTypeFieldControlProperties envelope = new ContentTypeFieldControlProperties();
+    envelope.setFieldName("sys_title");
+    envelope.setControl("sys_EditBox");
+    envelope.setProperties(List.of(new ContentTypeControlProperty("height", "200")));
+    when(adaptor.getFieldControlProperties(any(), eq("percPage"), eq("sys_title")))
+        .thenReturn(envelope);
+    ContentTypeFieldControlProperties out =
+        resource.getFieldControlProperties("percPage", "sys_title");
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals("200", out.getProperties().get(0).getValue());
+  }
+
+  @Test
+  public void getFieldControlPropertiesContentTypeNotFound() {
+    when(adaptor.getFieldControlProperties(any(), eq("missing"), eq("sys_title"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.getFieldControlProperties("missing", "sys_title"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getFieldControlPropertiesFieldNotFound() {
+    when(adaptor.getFieldControlProperties(any(), eq("percPage"), eq("nope")))
+        .thenThrow(new WebApplicationException("Field not found: nope", 404));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.getFieldControlProperties("percPage", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesSuccess() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of(new ContentTypeControlProperty("width", "400")));
+    ContentTypeFieldControlProperties updated = new ContentTypeFieldControlProperties();
+    updated.setFieldName("sys_title");
+    updated.setProperties(body.getProperties());
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenReturn(updated);
+    ContentTypeFieldControlProperties out =
+        resource.replaceFieldControlProperties("percPage", "sys_title", body);
+    assertEquals("400", out.getProperties().get(0).getValue());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesRequiresProperties() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.replaceFieldControlProperties(
+                    "percPage", "sys_title", new ContentTypeFieldControlProperties()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesRequiresLock() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save control properties; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldControlProperties("percPage", "sys_title", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesLockedByOtherUser() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save control properties; locked by editor"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldControlProperties("percPage", "sys_title", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesInvalidChoice() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(new IllegalArgumentException("choices.globalId is required for type global"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldControlProperties("percPage", "sys_title", body));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -125,4 +125,20 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
       URI baseUri, String idOrName, ContentTypeItemExits body) {
     return body != null ? body : new ContentTypeItemExits();
   }
+
+  @Override
+  public ContentTypeFieldControlProperties getFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName) {
+    ContentTypeFieldControlProperties out = new ContentTypeFieldControlProperties();
+    out.setFieldName(fieldName);
+    out.setControl("sys_EditBox");
+    out.setProperties(List.of());
+    return out;
+  }
+
+  @Override
+  public ContentTypeFieldControlProperties replaceFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body) {
+    return body;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -22,7 +22,9 @@ package com.percussion.rest.test.apibridge;
 import com.percussion.rest.Guid;
 import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
+import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
@@ -140,5 +142,21 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   public ContentTypeItemExits replaceItemExits(
       URI baseUri, String idOrName, ContentTypeItemExits body) {
     return body != null ? body : new ContentTypeItemExits();
+  }
+
+  @Override
+  public ContentTypeFieldControlProperties getFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName) {
+    ContentTypeFieldControlProperties out = new ContentTypeFieldControlProperties();
+    out.setFieldName(fieldName);
+    out.setControl("sys_EditBox");
+    out.setProperties(List.of(new ContentTypeControlProperty("height", "200")));
+    return out;
+  }
+
+  @Override
+  public ContentTypeFieldControlProperties replaceFieldControlProperties(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body) {
+    return body;
   }
 }


### PR DESCRIPTION
## Summary

Thin REST for Content Type field **control property values** and **choice catalogs** (CD-07, parent #1690). Today GET detail had **names only**.

`GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` returns control parameter name/value pairs and the field's choice catalog. Empty `properties` means none. `choices` omitted when none.

`PUT` on the same path is a full replace of `properties` via `IPSContentDesignWs.saveContentTypes`. Writes require a **held** design-session lock (`POST .../lock`); **409** without a lock or when locked by another user. `choices` omitted leave the catalog unchanged; `type: none` clears. Choice filters / null-entry / default-selected are not written (`designGaps` `CT_CHOICE_FILTER`). Detail GET field rows also include `controlProperties` name/value (compat: `controlPropertyNames` kept).

Out of scope: field-rule expression write (#3784), item-level exits (#3785), Workbench control-property UI chrome.

Fixes #3786  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 580, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1519, Failures: 0, Errors: 0, Skipped: 125
3. Mockito resource tests: GET values, 404 CT/field, PUT success, 409 without lock / other locker, 400 missing properties / invalid catalog
4. Spring stub `TestContentTypeAdaptor` implements new methods (MainTest context)
5. Adaptor tests: map name+value and local/global/lookup/tableinfo catalogs; PUT persist via `saveContentTypes`; 409 unlocked / other user; 400 invalid catalog; 404 missing field

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (CD-07 GET/PUT) and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — resource + Spring stub + sitemanage adaptor tests; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only)
- [x] **Build gates** — standalone clean install `rest` and `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 580, Failures: 0, Errors: 0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1519, Failures: 0, Errors: 0, Skipped: 125)
- **downstream_checked:** `IContentTypesAdaptor` gained methods (not `final`). Grep `implements IContentTypesAdaptor` — rest Spring stubs (`TestContentTypeAdaptor`, `ContentTypesTestAdaptor`) and sitemanage `ContentTypeAdaptor` updated. Standalone sitemanage install is the reverse-dep of rest.

### C5 UI proof

N/A — REST/backend only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
