### PR TITLE
fix(sitemanage): CD-08 workflow PUT lock persist and cache-miss 404

### DIFF
--- a/docs/ai-generated/code-reviews/3805-content-type-adaptor-workflows-erlang.md
+++ b/docs/ai-generated/code-reviews/3805-content-type-adaptor-workflows-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — issue #3805 ContentTypeAdaptor CD-08 workflows
+
+**Branch:** `fix/issue-3805-content-type-adaptor-workflows`  
+**Date:** 2026-08-25  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (bugfix of existing CD-08 adaptor; rest companions already on main); behavioral test for post-save cache miss (not structural-only); no path I/O; `resolveItemDef` after PUT save must not 404 a committed persist (CD-07 peer).
+
+## Summary
+
+`ContentTypeAdaptor.setAllowedWorkflows` (CD-08) now matches `setContentTypeEnabled` for existence (item-def lookup so unknown ids 404 before lock) and matches CD-07 `replaceFieldControlProperties` for post-save reload (`reloadItemDef` + fall back to the locked definition). A post-save `PSInvalidContentTypeException` is no longer swallowed as HTTP 404 after a successful `saveContentTypes`.
+
+Cycle Verify (#3805) reported 6 failures + 2 errors in `ContentTypeAdaptorWorkflowsTest` on the full sitemanage suite: lock 409 not thrown, unknown workflow 400 not thrown, empty-list `setWorkflowInfo` never invoked, PUT returning null. Those symptoms match an early null return (existence via `loadContentTypes(lock=false)`) and/or `resolveItemDef` throwing after save.
+
+## Issues
+
+None blocking.
+
+Existence via `resolveItemDef` is the same pattern as `setContentTypeEnabled` (suite-green peer). Post-save `reloadItemDef` is the CD-07 fix already approved on this class. `put_cacheMissAfterSave_fallsBackToLockedDef` stubs `getItemDef(311L)` as first-return / second-throw so existence succeeds and reload misses.
+
+Lock / unknown-workflow / empty-list / persist tests remain and now also assert allowed-workflow list size on GET after PUT.
+
+No public/protected signature change. No rest module change. Product-docs already describe `200` + `allowedWorkflows` (CD-08); this restores that contract.
+
+## Cross-platform path checklist
+
+Applied. No filesystem path construction. REST path strings in existing product-docs use URI `/`.
+
+## Tests
+
+- `put_cacheMissAfterSave_fallsBackToLockedDef` — behavioral coverage of cache-miss fallback
+- Persist / GET round-trip list size restored
+- Existing 409 lock / 400 unknown id and name / empty-list clear / 404 unknown type / 403 / session still present
+- Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install`: **BUILD SUCCESS**, Tests run: 1535, Failures: 0, Errors: 0, Skipped: 125; `ContentTypeAdaptorWorkflowsTest` 13/0/0
+
+## Non-blocking notes (not issues)
+
+- `setContentTypeEnabled` still calls `resolveItemDef` after save (same pre-existing cache-miss 404). Out of scope for #3805.
+- Empty `loadContentTypes(lock=true)` after a held lock still returns null (404). Same as enable/disable; do not treat as a CD-08 gate.
+
+## Handoff
+
+- Reviewed: uncommitted issue #3805 work in worktree `night-issue-prs`
+- Top finding: none blocking
+- Recommendation: **approve**. May commit/push: **yes**.
+- Artifact: `docs/ai-generated/code-reviews/3805-content-type-adaptor-workflows-erlang.md`

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -637,14 +637,16 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     if (trimmed.contains("*")) {
       throw new IllegalArgumentException("idOrName must not contain wildcards");
     }
+    requireSessionUserForLock();
     String session = currentSession();
     String user = currentUser();
-    requireSessionUserForLock();
     try {
-      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
-      if (ctGuid == null) {
+      // Peer setContentTypeEnabled: item-def existence so unknown ids 404 before lock.
+      PSItemDefinition current = resolveItemDef(trimmed);
+      if (current == null) {
         return null;
       }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
       requireHeldLock(ctGuid);
       List<PSItemDefinition> locked;
       try {
@@ -676,7 +678,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
             "Failed to save content type workflow associations {}: {}", idOrName, e.getMessage(), e);
         throw new IllegalStateException("Failed to save content type workflow associations", e);
       }
-      PSItemDefinition reloaded = resolveItemDef(trimmed);
+      // Cache miss after save must not 404 a successful persist (CD-07 peer).
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
       return reloaded != null ? toDetail(reloaded) : toDetail(def);
     } catch (ContentTypeDesignLockException
         | IllegalArgumentException

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorWorkflowsTest.java
@@ -131,6 +131,7 @@ class ContentTypeAdaptorWorkflowsTest {
         adaptor.setAllowedWorkflows(null, "311", List.of(simple, standard), simple);
 
     assertNotNull(out);
+    assertEquals(2, out.getAllowedWorkflows().size());
     assertEquals("Simple Workflow", out.getDefaultWorkflow().getName());
     verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
     ArgumentCaptor<PSWorkflowInfo> info = ArgumentCaptor.forClass(PSWorkflowInfo.class);
@@ -148,12 +149,16 @@ class ContentTypeAdaptorWorkflowsTest {
     NamedObjectRef simple = namedWorkflow("Simple Workflow", 4);
     ContentTypeDetail put = adaptor.setAllowedWorkflows(null, "311", List.of(simple), simple);
     assertNotNull(put);
+    assertEquals(1, put.getAllowedWorkflows().size());
+    assertEquals("Simple Workflow", put.getAllowedWorkflows().get(0).getName());
     ArgumentCaptor<PSWorkflowInfo> info = ArgumentCaptor.forClass(PSWorkflowInfo.class);
     verify(editor).setWorkflowInfo(info.capture());
     assertEquals(List.of(4), workflowIds(info.getValue()));
 
     ContentTypeDetail get = adaptor.getContentType(null, "311");
     assertEquals("percPage", get.getName());
+    assertEquals(1, get.getAllowedWorkflows().size());
+    assertEquals("Simple Workflow", get.getAllowedWorkflows().get(0).getName());
     assertEquals("Simple Workflow", get.getDefaultWorkflow().getName());
   }
 
@@ -164,10 +169,29 @@ class ContentTypeAdaptorWorkflowsTest {
 
     ContentTypeDetail out = adaptor.setAllowedWorkflows(null, "311", List.of(), null);
 
+    assertNotNull(out);
     ArgumentCaptor<PSWorkflowInfo> info = ArgumentCaptor.forClass(PSWorkflowInfo.class);
     verify(editor).setWorkflowInfo(info.capture());
     assertTrue(workflowIds(info.getValue()).isEmpty());
     assertTrue(out.getAllowedWorkflows().isEmpty());
+  }
+
+  @Test
+  void put_cacheMissAfterSave_fallsBackToLockedDef() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    // Existence uses item-def; post-save reload may miss the cache (CD-07 peer).
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenReturn(def)
+        .thenThrow(new PSInvalidContentTypeException("not cached"));
+
+    NamedObjectRef simple = namedWorkflow("Simple Workflow", 4);
+    ContentTypeDetail out = adaptor.setAllowedWorkflows(null, "311", List.of(simple), simple);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertNotNull(out);
+    assertEquals("Simple Workflow", out.getDefaultWorkflow().getName());
+    verify(def.getContentEditor()).setWorkflowId(4);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes Cycle Verify residual **#3805**: sitemanage `ContentTypeAdaptorWorkflowsTest` (CD-08 allowed-workflow PUT) was returning null instead of persisting, validating workflow ids, or throwing `ContentTypeDesignLockException`. REST mapped that to 404 / silent success.

`ContentTypeAdaptor.setAllowedWorkflows` now:

1. Resolves the content type via **item-def** (peer `setContentTypeEnabled`) so unknown ids 404 **before** lock checks, instead of a `loadContentTypes(lock=false)` existence probe.
2. Reloads after save via **`reloadItemDef`** (peer CD-07 control properties). A post-save item-def cache miss falls back to the locked in-memory definition instead of 404ing a persist that already committed.

Lock / unknown-workflow / empty-list / GET-after-PUT assertions are restored. Added `put_cacheMissAfterSave_fallsBackToLockedDef`.

Fixes #3805

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install` (Unix: `../../mvnw clean install`) — expect **BUILD SUCCESS**, Failures: 0, Errors: 0.
2. Confirm `ContentTypeAdaptorWorkflowsTest` is green (13 tests), including persist, GET after PUT, empty-list clear, unknown id/name 400, lock 409, and cache-miss fallback.
3. No WebUI / Playwright: Java adaptor-only.

## Checklist

- [x] **Product documentation** — **N/A**: not a new operator surface. CD-08 is already documented in `product-docs/8.2/developer/rest.md` (`200` + `allowedWorkflows` / `defaultWorkflow`; `409` lock; `400` unknown workflow). This restores that contract after a cache-miss 404 bug.
- [x] **Unit / module tests** — `put_cacheMissAfterSave_fallsBackToLockedDef` plus restored list-size assertions; standalone sitemanage `clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — standalone sitemanage `clean install` (no skipTests); no public/protected signature change
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: **1535**, Failures: **0**, Errors: **0**, Skipped: **125**. `ContentTypeAdaptorWorkflowsTest`: Tests run: 13, Failures: 0, Errors: 0.
- **downstream_checked:** none (C2 not applicable — no `final`/`sealed` or public/protected signature change; rest already depends on `IContentTypesAdaptor`, not this impl)

### C5 UI proof

N/A — Java sitemanage adaptor only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
