### PR TITLE
fix(architecture): enable Delete after Create for non-root sections (#3821)

### DIFF
--- a/WebUI/src/main/ts/api/architecture/index.ts
+++ b/WebUI/src/main/ts/api/architecture/index.ts
@@ -86,6 +86,7 @@ export {
   canConvertSectionToFolder,
   canCreateChildUnder,
   canDeleteNavNode,
+  resolveCreatedNavNodeId,
   canEditLinkNode,
   canMoveNavNode,
   canMoveNavNodeDown,

--- a/WebUI/src/main/ts/api/architecture/sectionApi.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionApi.ts
@@ -221,10 +221,12 @@ export async function loadSectionProperties(
 
 /**
  * Create a regular (or blog) site section under {@code fields.folderPath}.
+ * Returns the parsed {@code SiteSection} when the POST body includes an id
+ * (used to auto-select the new navon after Create).
  */
 export async function createSiteSection(
   fields: CreateSiteSectionFields,
-): Promise<unknown> {
+): Promise<SiteSectionWire | null> {
   if (!fields.templateId?.trim()) {
     throw new Error("Template is required to create a section");
   }
@@ -232,7 +234,8 @@ export async function createSiteSection(
     throw new Error("Parent folder path is required to create a section");
   }
   const body = buildCreateSiteSectionBody(fields);
-  return post<unknown>(PATHS.SECTION_CREATE_SECTION, body);
+  const payload = await post<unknown>(PATHS.SECTION_CREATE_SECTION, body);
+  return parseSiteSectionPayload(payload);
 }
 
 /**

--- a/WebUI/src/main/ts/api/architecture/sectionMutations.ts
+++ b/WebUI/src/main/ts/api/architecture/sectionMutations.ts
@@ -171,6 +171,67 @@ export function canDeleteNavNode(
 }
 
 /**
+ * Resolve the nav node created under {@code parentId} after a tree reload.
+ *
+ * Prefers a POST-returned id when it exists in {@code nextRoot} and is not
+ * the site root. Otherwise diffs the parent's children (optional title hint)
+ * so Create can auto-select when the create payload omits an id (#3821).
+ */
+export function resolveCreatedNavNodeId(
+  previousRoot: NavTreeNode | null | undefined,
+  nextRoot: NavTreeNode | null | undefined,
+  parentId: string,
+  hint?: { id?: string | null; title?: string | null },
+): string | null {
+  if (!nextRoot) {
+    return null;
+  }
+  const hintId = hint?.id != null ? String(hint.id).trim() : "";
+  if (
+    hintId &&
+    findNavNodeById(nextRoot, hintId) &&
+    !isRootNavNode(nextRoot, hintId)
+  ) {
+    return hintId;
+  }
+  const parentKey = parentId.trim();
+  if (!parentKey) {
+    return null;
+  }
+  const nextParent = findNavNodeById(nextRoot, parentKey);
+  if (!nextParent) {
+    return null;
+  }
+  const prevParent = previousRoot
+    ? findNavNodeById(previousRoot, parentKey)
+    : null;
+  const prevIds = new Set((prevParent?.children ?? []).map((c) => c.id));
+  const added = nextParent.children.filter((c) => !prevIds.has(c.id));
+  const hintTitle =
+    hint?.title != null ? String(hint.title).trim().toLowerCase() : "";
+  const pickNonRoot = (id: string): string | null =>
+    isRootNavNode(nextRoot, id) ? null : id;
+  if (hintTitle) {
+    const byTitle = added.find(
+      (c) => c.title.trim().toLowerCase() === hintTitle,
+    );
+    if (byTitle) {
+      return pickNonRoot(byTitle.id);
+    }
+    const amongChildren = nextParent.children.find(
+      (c) => c.title.trim().toLowerCase() === hintTitle,
+    );
+    if (amongChildren) {
+      return pickNonRoot(amongChildren.id);
+    }
+  }
+  if (added.length === 1) {
+    return pickNonRoot(added[0].id);
+  }
+  return null;
+}
+
+/**
  * Whether the node can move up among siblings (same parent).
  */
 export function canMoveNavNodeUp(

--- a/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
+++ b/WebUI/src/main/ts/architecture/ArchitectureShell.tsx
@@ -58,10 +58,12 @@ import {
   findNavNodeById,
   findSiblingPlacement,
   isExternalLinkType,
+  isRootNavNode,
   isSectionLinkType,
   mapCreateSectionDialogToFields,
   resolveCreateFolderPath,
   resolveCreateParentFolderPath,
+  resolveCreatedNavNodeId,
 } from "../api/architecture/sectionMutations";
 import type {
   CreateSectionDialogFields,
@@ -217,6 +219,12 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const selectedNodeIdRef = useRef<string | null>(null);
   selectedNodeIdRef.current = selectedNodeId;
+  const previousTreeRootRef = useRef<NavTreeNode | null>(null);
+  const pendingCreateSelectRef = useRef<{
+    parentId: string;
+    title: string;
+    id?: string | null;
+  } | null>(null);
   const [landingStatus, setLandingStatus] = useState<{
     sectionId: string;
     pageId: string;
@@ -411,6 +419,8 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
   useEffect(() => {
     setSelectedNodeId(null);
     setLandingStatus(null);
+    pendingCreateSelectRef.current = null;
+    previousTreeRootRef.current = null;
   }, [selectedSite]);
 
   // Load tree when site or refresh changes
@@ -426,7 +436,23 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
       try {
         const root = await loadSectionTree(selectedSite);
         if (cancelled) return;
+        const previous = previousTreeRootRef.current;
         setTreeState({ status: "ready", root });
+        previousTreeRootRef.current = root;
+        const pending = pendingCreateSelectRef.current;
+        if (pending) {
+          pendingCreateSelectRef.current = null;
+          const resolved = resolveCreatedNavNodeId(
+            previous,
+            root,
+            pending.parentId,
+            { id: pending.id, title: pending.title },
+          );
+          if (resolved && !isRootNavNode(root, resolved)) {
+            setSelectedNodeId(resolved);
+            return;
+          }
+        }
         const keep = selectedNodeIdRef.current;
         if (keep && root && !findNavNodeById(root, keep)) {
           setSelectedNodeId(null);
@@ -592,10 +618,20 @@ export const ArchitectureShell: React.FC<ArchitectureShellProps> = ({
           loadedFolderPath,
           selectedSite,
         );
-        await createSiteSection(
+        const created = await createSiteSection(
           mapCreateSectionDialogToFields(input, folderPath),
         );
         setCreateOpen(false);
+        const createdId =
+          created?.id != null ? String(created.id).trim() : "";
+        pendingCreateSelectRef.current = {
+          parentId: createParent.id,
+          title: input.title.trim(),
+          id: createdId || null,
+        };
+        if (createdId) {
+          setSelectedNodeId(createdId);
+        }
       });
     },
     [selectedSite, createParent, runMutation],

--- a/WebUI/src/test/ts/api/architecture/sectionApi.mutations.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionApi.mutations.test.ts
@@ -78,6 +78,22 @@ describe("sectionApi mutations (#3096)", () => {
     );
   });
 
+  it("createSiteSection parses SiteSection id from POST payload (#3821)", async () => {
+    vi.spyOn(client, "post").mockResolvedValue({
+      SiteSection: { id: "guid-new", title: "News" },
+    });
+    const created = await createSiteSection({
+      pageTitle: "News",
+      pageLinkTitle: "News",
+      pageName: "news",
+      pageUrlIdentifier: "news",
+      templateId: "tpl-1",
+      folderPath: "//Sites/Demo",
+    });
+    expect(created?.id).toBe("guid-new");
+    expect(created?.title).toBe("News");
+  });
+
   it("loadSectionProperties unwraps SiteSectionProperties", async () => {
     vi.spyOn(client, "get").mockResolvedValue({
       SiteSectionProperties: {

--- a/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
+++ b/WebUI/src/test/ts/api/architecture/sectionMutations.test.ts
@@ -30,6 +30,7 @@ import {
   canConvertSectionToFolder,
   canCreateChildUnder,
   canDeleteNavNode,
+  resolveCreatedNavNodeId,
   canMoveNavNode,
   canMoveNavNodeDown,
   canMoveNavNodeUp,
@@ -111,6 +112,34 @@ describe("sectionMutations (#3096)", () => {
     expect(canMoveNavNodeUp(sampleTree, "b")).toBe(true);
     expect(canMoveNavNodeDown(sampleTree, "c")).toBe(false);
     expect(canMoveNavNodeDown(sampleTree, "a")).toBe(true);
+  });
+
+  it("resolves created child id after tree reload (#3821)", () => {
+    const after = node("root", "Home", [
+      node("a", "About"),
+      node("b", "News", [node("b1", "Press")]),
+      node("c", "Link", [], { sectionType: "sectionlink" }),
+      node("n1", "Products"),
+    ]);
+    expect(
+      resolveCreatedNavNodeId(sampleTree, after, "root", { id: "n1" }),
+    ).toBe("n1");
+    expect(
+      resolveCreatedNavNodeId(sampleTree, after, "root", {
+        title: "Products",
+      }),
+    ).toBe("n1");
+    expect(
+      resolveCreatedNavNodeId(sampleTree, after, "root", {}),
+    ).toBe("n1");
+    expect(
+      canDeleteNavNode(after, findNavNodeById(after, "n1")),
+    ).toBe(true);
+    expect(canDeleteNavNode(after, after)).toBe(false);
+    expect(
+      resolveCreatedNavNodeId(sampleTree, after, "root", { id: "root" }),
+    ).toBe("n1");
+    expect(resolveCreatedNavNodeId(sampleTree, after, "missing")).toBeNull();
   });
 
   it("gates convert-to-folder to regular non-root navons (#3302)", () => {

--- a/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
+++ b/WebUI/src/test/ts/architecture/ArchitectureShell.test.tsx
@@ -674,6 +674,135 @@ describe("ArchitectureShell (#3095/#3096)", () => {
     });
   });
 
+  it("enables Delete after Create by selecting the new non-root section (#3821)", async () => {
+    const createdNode = {
+      id: "c-new",
+      title: "Products",
+      folderPath: "//Sites/Demo/Products",
+      sectionType: "section" as const,
+      requiresLogin: false,
+      children: [] as typeof treeFixture.children,
+    };
+    let currentTree: typeof treeFixture = treeFixture;
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockImplementation(async () => {
+      return currentTree;
+    });
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
+      { id: "tpl-1", name: "Base" },
+    ]);
+    vi.spyOn(sectionApi, "createSiteSection").mockImplementation(async () => {
+      currentTree = {
+        ...treeFixture,
+        children: [...treeFixture.children, createdNode],
+      };
+      return { id: "c-new", title: "Products" };
+    });
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-root")).toBeTruthy();
+    });
+    expect(
+      (screen.getByTestId("architecture-action-delete") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByTestId("architecture-action-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-create-dialog")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Products" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
+      target: { value: "products" },
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "products.html" } },
+    );
+    const tpl = screen.queryByTestId("architecture-create-template-select");
+    if (tpl) {
+      fireEvent.change(tpl, { target: { value: "tpl-1" } });
+    }
+    fireEvent.click(screen.getByTestId("architecture-create-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-c-new")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("architecture-action-delete") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+
+    fireEvent.click(screen.getByTestId("nav-tree-item-root"));
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("architecture-action-delete") as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    });
+  });
+
+  it("selects created section by title when POST omits id (#3821)", async () => {
+    const createdNode = {
+      id: "c-untitled-id",
+      title: "Widget Hub",
+      folderPath: "//Sites/Demo/widget-hub",
+      sectionType: "section" as const,
+      requiresLogin: false,
+      children: [] as typeof treeFixture.children,
+    };
+    let currentTree: typeof treeFixture = treeFixture;
+    vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
+    vi.spyOn(sectionApi, "loadSectionTree").mockImplementation(async () => {
+      return currentTree;
+    });
+    vi.spyOn(homeApi, "fetchTemplatesForSectionCreate").mockResolvedValue([
+      { id: "tpl-1", name: "Base" },
+    ]);
+    vi.spyOn(sectionApi, "createSiteSection").mockImplementation(async () => {
+      currentTree = {
+        ...treeFixture,
+        children: [...treeFixture.children, createdNode],
+      };
+      return null;
+    });
+
+    render(<ArchitectureShell embedded initialSite="Demo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("nav-tree-item-root")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("architecture-action-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("architecture-create-dialog")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-title-input"), {
+      target: { value: "Widget Hub" },
+    });
+    fireEvent.change(screen.getByTestId("architecture-create-url-input"), {
+      target: { value: "widget-hub" },
+    });
+    fireEvent.change(
+      screen.getByTestId("architecture-create-page-name-input"),
+      { target: { value: "widget-hub.html" } },
+    );
+    const tpl = screen.queryByTestId("architecture-create-template-select");
+    if (tpl) {
+      fireEvent.change(tpl, { target: { value: "tpl-1" } });
+    }
+    fireEvent.click(screen.getByTestId("architecture-create-submit"));
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("architecture-action-delete") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+    expect(screen.getByTestId("nav-tree-item-c-untitled-id")).toBeTruthy();
+  });
+
   it("create under a selected non-root section posts that parent folderPath", async () => {
     vi.spyOn(homeApi, "fetchSites").mockResolvedValue([{ name: "Demo" }]);
     vi.spyOn(sectionApi, "loadSectionTree").mockResolvedValue(treeFixture);

--- a/docs/ai-generated/code-reviews/3821-architecture-delete-nonroot-erlang.md
+++ b/docs/ai-generated/code-reviews/3821-architecture-delete-nonroot-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review — #3821 Architecture Delete enabled for non-root section
+
+**Branch:** `fix/issue-3821-architecture-delete-nonroot`  
+**Base:** `origin/main`  
+**Date:** 2026-08-25  
+**Reviewer:** Erlang (independent pre-commit)  
+**Memory patterns hit:** missing behavioral tests; change-class completeness (Vitest + Playwright + product-docs for WebUI screens); URL `/` vs filesystem paths
+
+## Summary
+
+After Architecture **Create section**, the new non-root navon was not selected (selection stayed on the parent/root or empty). `canDeleteNavNode` is already true for any non-root selected node, so `architecture-action-delete` stayed disabled. This slice auto-selects the created child (POST `SiteSection` id, else parent-child diff / title hint after tree reload). Root remains not deletable. Confirm-cancel does not delete; confirm DELETEs and the tree reload drops the node.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral tests: `resolveCreatedNavNodeId` + `canDeleteNavNode`; `createSiteSection` parse; ArchitectureShell enablement after Create (id and title-fallback) and root still disabled; Playwright H2 surface create → Delete enabled → cancel keeps → confirm removes. Product-docs Create/Delete procedures updated.
+
+Cross-platform path checklist: **clean** — no filesystem path joins; REST/Playwright matchers use URL `/`; helper unit tests use `http://127.0.0.1` URLs.
+
+## Issues
+
+None (blocking).
+
+### Suggestions (non-blocking)
+
+1. DELETE success is HTTP 204 (client already treats 204 as success). Playwright asserts 2xx rather than 200 only.
+2. Sibling spec `#3797` rename POST 500 on a 4-day-old `--skip-image-build` matrix image is backend stale vs merged PR #3816, not this selection fix.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Auto-select after Create (`ArchitectureShell` + `resolveCreatedNavNodeId`) | Present |
+| Vitest helper + shell enablement after create; root still blocked | Present |
+| Playwright `architecture-nav-mutations-smoke.spec.js` (#3821) | Present |
+| Helper `isSectionDeleteRequest` + unit tests | Present |
+| `product-docs/8.2/admin/architecture-navigation.md` | Present |
+| rest/sitemanage | N/A (delete REST already works) |
+
+## Tests / builds observed
+
+- `WebUI`: standalone `mvnw.cmd clean install` BUILD SUCCESS; Vitest 392 files / 3079 passed
+- `modules/perc-qa-automation`: standalone `mvnw.cmd clean install` BUILD SUCCESS; helper unit tests 452 passed
+- Playwright H2: `qa-up --skip-image-build` `TEST_CMS_URL=http://127.0.0.1:9993`; hot-copy `WebUI/target/generated-webui/cm/modern/assets/` into cell WAR; `qa-health` RESULT:OK HTTP:200 HEALTH:healthy; `npm run test:surface -- --path tests/architecture-nav-mutations-smoke.spec.js --grep "#3821"` 1 passed
+- console-clean=yes (spec filters known noise); 3821 path did not add feature-related server.log ERROR/FATAL

--- a/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js
@@ -40,6 +40,7 @@ const {
   isCreateSiteSectionRequest,
   isSectionUpdateRequest,
   isSectionMoveRequest,
+  isSectionDeleteRequest,
   sectionChildTitles,
   isKnownArchitectureConsoleNoise,
   missingNavTreeFailMessage,
@@ -437,6 +438,173 @@ test.describe("Architecture nav structure mutations (#3096)", () => {
     expect(uiIdxB, "B visible after reload").toBeGreaterThanOrEqual(0);
     expect(uiIdxA, "renamed A visible after reload").toBeGreaterThanOrEqual(0);
     expect(uiIdxB, "Move up must survive reload").toBeLessThan(uiIdxA);
+
+    expect(
+      consoleErrors.filter((e) => !isKnownArchitectureConsoleNoise(e)),
+    ).toEqual([]);
+  });
+
+  test("create non-root section enables Delete; cancel keeps; confirm removes (#3821) @smoke @ui @architecture-nav-mutations", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    expect(
+      shouldRequireNavTree(),
+      "this surface is the H2 no-skip gate; set TEST_DB_TYPE=h2",
+    ).toBe(true);
+
+    const sitesResp = await page.request.get(siteListUrl(BASE_URL));
+    expect(sitesResp.status(), "site list must be HTTP 200").toBe(200);
+    const names = siteNamesFromPayload(await sitesResp.json());
+    const demoSite = firstSampleDemoSite(names);
+    expect(
+      demoSite,
+      `QA cell must list a #3352 sample site; got ${JSON.stringify(names)}`,
+    ).toBeTruthy();
+
+    const treeResp = await page.request.get(sectionTreeUrl(BASE_URL, demoSite));
+    expect(treeResp.status(), `tree GET for ${demoSite}`).toBe(200);
+    expect(
+      isEmptyTreePayload(await treeResp.text()),
+      missingNavTreeFailMessage(),
+    ).toBe(false);
+
+    await page.goto(architectureSpaUrl(BASE_URL, { site: demoSite }), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByTestId(TEST_IDS.navTree)).toBeVisible({
+      timeout: 20_000,
+    });
+    const treeItems = page.locator(
+      `[data-testid="${TEST_IDS.navTree}"] [role="treeitem"]`,
+    );
+    await expect(treeItems.first()).toBeVisible({ timeout: 20_000 });
+    await treeItems.first().click();
+
+    const deleteBtn = page.getByTestId(TEST_IDS.actionDelete);
+    await expect(deleteBtn).toBeDisabled();
+
+    const title = uniqueSectionTitle(Date.now(), "QA3821");
+    const createBtn = page.getByTestId(TEST_IDS.actionCreate);
+    await expect(createBtn).toBeEnabled();
+    await createBtn.click();
+    const createDialog = page.getByTestId(TEST_IDS.createDialog);
+    await expect(createDialog).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId(TEST_IDS.createTitle).fill(title);
+    await page.getByTestId(TEST_IDS.createUrl).fill(uniqueSectionUrlName(title));
+    await page
+      .getByTestId(TEST_IDS.createPageName)
+      .fill(uniqueLandingPageName(title));
+    await expect
+      .poll(
+        async () =>
+          (await page
+            .getByTestId(TEST_IDS.createTemplatesLoading)
+            .isVisible()
+            .catch(() => false))
+            ? "loading"
+            : "ready",
+        { timeout: 20_000 },
+      )
+      .toBe("ready");
+    const templateSelect = page.getByTestId(TEST_IDS.createTemplate);
+    await expect(templateSelect).toBeEnabled({ timeout: 20_000 });
+    await templateSelect.selectOption({ index: 0 });
+    const postPromise = page.waitForRequest(
+      (req) => isCreateSiteSectionRequest(req.url(), req.method()),
+      { timeout: 30_000 },
+    );
+    await page.getByTestId(TEST_IDS.createSubmit).click();
+    const postReq = await postPromise;
+    const postResp = await postReq.response();
+    expect(
+      postResp && postResp.status(),
+      "POST /section/create must be HTTP 200",
+    ).toBe(200);
+    await expect(createDialog).toHaveCount(0, { timeout: 30_000 });
+    const createdItem = page.getByRole("treeitem", {
+      name: new RegExp(title, "i"),
+    });
+    await expect(createdItem).toBeVisible({ timeout: 20_000 });
+
+    // Auto-select after Create — do not click the new node first (#3821).
+    await expect(deleteBtn).toBeEnabled({ timeout: 20_000 });
+
+    await treeItems.first().click();
+    await expect(deleteBtn).toBeDisabled();
+    await createdItem.click();
+    await expect(deleteBtn).toBeEnabled();
+
+    page.once("dialog", (dialog) => {
+      void dialog.dismiss();
+    });
+    await deleteBtn.click();
+    await expect(createdItem).toBeVisible();
+    const treeAfterCancel = await page.request.get(
+      sectionTreeUrl(BASE_URL, demoSite),
+    );
+    expect(treeAfterCancel.status()).toBe(200);
+    expect(
+      sectionChildTitles(await treeAfterCancel.json()).some((t) =>
+        t.includes(title),
+      ),
+      `cancel must keep ${title}`,
+    ).toBe(true);
+
+    const deletePromise = page.waitForRequest(
+      (req) => isSectionDeleteRequest(req.url(), req.method()),
+      { timeout: 30_000 },
+    );
+    page.once("dialog", (dialog) => {
+      void dialog.accept();
+    });
+    await deleteBtn.click();
+    const deleteReq = await deletePromise;
+    const deleteResp = await deleteReq.response();
+    const deleteStatus = deleteResp && deleteResp.status();
+    expect(
+      deleteStatus,
+      "DELETE /section/{id} must be HTTP 2xx (200 or 204)",
+    ).toBeGreaterThanOrEqual(200);
+    expect(deleteStatus).toBeLessThan(300);
+    await expect(createdItem).toHaveCount(0, { timeout: 20_000 });
+    await expect(page.getByTestId("architecture-mutation-error")).toHaveCount(0);
+
+    await expect
+      .poll(
+        async () => {
+          const resp = await page.request.get(
+            sectionTreeUrl(BASE_URL, demoSite),
+          );
+          if (!resp.ok()) {
+            return "http-error";
+          }
+          const titles = sectionChildTitles(await resp.json());
+          return titles.some((t) => t.includes(title)) ? "present" : "gone";
+        },
+        { timeout: 25_000 },
+      )
+      .toBe("gone");
+
+    await page.goto(architectureSpaUrl(BASE_URL, { site: demoSite }), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByTestId(TEST_IDS.navTree)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.getByRole("treeitem", { name: new RegExp(title, "i") }),
+    ).toHaveCount(0);
 
     expect(
       consoleErrors.filter((e) => !isKnownArchitectureConsoleNoise(e)),

--- a/modules/perc-qa-automation/frontend/tests/helpers/architecture-create-section.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/architecture-create-section.js
@@ -50,6 +50,7 @@ const TEST_IDS = Object.freeze({
   actionRename: "architecture-action-rename",
   actionMoveUp: "architecture-action-move-up",
   actionMoveDown: "architecture-action-move-down",
+  actionDelete: "architecture-action-delete",
   renameDialog: "architecture-rename-dialog",
   renameTitle: "architecture-rename-title-input",
   renameSubmit: "architecture-rename-submit",
@@ -136,6 +137,24 @@ function isSectionMoveRequest(url, method) {
     String(method || "").toUpperCase() === "POST" &&
     /\/section\/move(\/|\?|$)/i.test(String(url || ""))
   );
+}
+
+/**
+ * True for {@code DELETE …/section/{id}} (not deleteSectionLink).
+ *
+ * @param {unknown} url
+ * @param {unknown} method
+ * @returns {boolean}
+ */
+function isSectionDeleteRequest(url, method) {
+  if (String(method || "").toUpperCase() !== "DELETE") {
+    return false;
+  }
+  const path = String(url || "");
+  if (/deleteSectionLink/i.test(path)) {
+    return false;
+  }
+  return /\/section\/[^/?]+(\?|$)/i.test(path);
 }
 
 /**
@@ -284,6 +303,7 @@ module.exports = {
   isCreateSiteSectionRequest,
   isSectionUpdateRequest,
   isSectionMoveRequest,
+  isSectionDeleteRequest,
   sectionChildTitles,
   shouldRequireNavTree,
   firstSampleDemoSite,

--- a/modules/perc-qa-automation/frontend/tests/unit/architecture-create-section.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/architecture-create-section.test.js
@@ -32,6 +32,7 @@ const {
   isCreateSiteSectionRequest,
   isSectionUpdateRequest,
   isSectionMoveRequest,
+  isSectionDeleteRequest,
   sectionChildTitles,
   shouldRequireNavTree,
   firstSampleDemoSite,
@@ -46,6 +47,7 @@ const {
 describe("architecture-create-section helpers (#3589)", () => {
   it("exports stable product test ids", () => {
     assert.equal(TEST_IDS.actionCreate, "architecture-action-create");
+    assert.equal(TEST_IDS.actionDelete, "architecture-action-delete");
     assert.equal(TEST_IDS.createDialog, "architecture-create-dialog");
     assert.equal(TEST_IDS.createPageName, "architecture-create-page-name-input");
     assert.equal(TEST_IDS.createCancel, "architecture-create-cancel");
@@ -226,6 +228,37 @@ describe("architecture-create-section helpers (#3589)", () => {
     assert.equal(
       isSectionMoveRequest(
         "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/move",
+        "GET",
+      ),
+      false,
+    );
+  });
+
+  it("matches DELETE /section/{id} and not deleteSectionLink (#3821)", () => {
+    assert.equal(
+      isSectionDeleteRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/guid-1",
+        "DELETE",
+      ),
+      true,
+    );
+    assert.equal(
+      isSectionDeleteRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/guid-1?x=1",
+        "delete",
+      ),
+      true,
+    );
+    assert.equal(
+      isSectionDeleteRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/deleteSectionLink/s1/p1",
+        "DELETE",
+      ),
+      false,
+    );
+    assert.equal(
+      isSectionDeleteRequest(
+        "http://127.0.0.1:9992/Rhythmyx/services/sitemanage/section/guid-1",
         "GET",
       ),
       false,

--- a/product-docs/8.2/admin/architecture-navigation.md
+++ b/product-docs/8.2/admin/architecture-navigation.md
@@ -156,7 +156,7 @@ With a site selected, use the structure action bar above the tree:
 
 | Action | Behavior |
 |--------|----------|
-| **Create section** | Opens a dialog to add a regular section with a landing page under the selected section, or under the site root when nothing is selected. Enter **title**, **URL name** (folder segment), **landing page name** (file name, for example `products.html`), and a **template** from the site catalog. **Create** posts `POST /section/create` (`CreateSiteSection`) and returns **HTTP 200** on sample FastForward sites (`rffNavTree` type 315) — the dialog closes and the child appears in the tree. Empty required fields stay in the dialog (no HTTP 500). **Cancel** or **Escape** does not post. |
+| **Create section** | Opens a dialog to add a regular section with a landing page under the selected section, or under the site root when nothing is selected. Enter **title**, **URL name** (folder segment), **landing page name** (file name, for example `products.html`), and a **template** from the site catalog. **Create** posts `POST /section/create` (`CreateSiteSection`) and returns **HTTP 200** on sample FastForward sites (`rffNavTree` type 315) — the dialog closes, the child appears in the tree, and the **new section is selected** so **Delete** (and other non-root actions) are enabled. Empty required fields stay in the dialog (no HTTP 500). **Cancel** or **Escape** does not post. |
 | **Create section from folder** | Promotes an existing site folder to a section under the selected parent (or site root). Choose the folder and a landing page that already exists in that folder. The server creates a navon and attaches the folder. |
 | **Create section link** | Creates a link under the selected parent that points at another section in the same site tree (browse target in the section picker). |
 | **Create external link** | Creates a nav entry that points at an external or relative URL (link text, URL, target window). |
@@ -168,11 +168,13 @@ With a site selected, use the structure action bar above the tree:
 | **Move section** | Opens a target-parent picker for the selected **non-root** section. Choose a regular section (not the section you are moving or one of its children) as the new parent, optionally a position among that parent's children, then **Move**. The shell posts `POST /sitemanage/section/move` and **refreshes the tree**. **Cancel** (or Escape) does not post. An invalid parent shows a clear message in the dialog — it does not produce an error 500. |
 | **Move up / Move down** | Reorders the selected section among its siblings under the same parent (`POST /sitemanage/section/move`, one step). The tree order changes immediately after a successful POST and **survives Refresh / reload** (`GET /section/tree/{site}`). Same-parent reorder does not check out the parent navon. |
 | **Convert to folder** | After confirmation, removes the selected regular (non-root) section and its sub-sections from Navigation. The folder and its pages stay in the site. |
-| **Delete** | Deletes the selected non-root section after confirmation. Section links use the section-link delete path. |
+| **Delete** | Deletes the selected **non-root** section after confirmation. The site root cannot be deleted from Navigation. Section links use the section-link delete path. After **Create section**, the new child is selected automatically so **Delete** is enabled without clicking the tree again. **Cancel** on the confirm prompt leaves the section in the tree. |
 
 Server errors from create, convert, create-from-folder, rename, properties, move, delete, landing-page, or link mutations are
 shown in the panel (no silent failure). The tree reloads after a successful mutation
-and keeps the previously selected section when it still exists.
+and keeps the previously selected section when it still exists. After **Create section**,
+the new child is selected instead of the parent (so **Delete** is enabled for that
+non-root section). The site root stays not deletable.
 
 ### Create a section with a landing page
 
@@ -190,11 +192,23 @@ and keeps the previously selected section when it still exists.
 5. Choose **Create**. The shell posts `POST /sitemanage/section/create` with
    `CreateSiteSection` (`pageTitle`, `pageName`, `pageUrlIdentifier`,
    `templateId`) and **refreshes the tree**. The new section appears under the
-   parent.
+   parent and is **selected** so **Delete** is enabled (the site root stays not
+   deletable).
 6. **Cancel** or **Escape** closes without posting.
 7. If a required field is empty or invalid (title, URL name, landing page
    name, or template), the error stays in the dialog — the server is not
    called and this does not produce an HTTP 500.
+
+### Delete a section
+
+1. Select a **non-root** section in the Navigation tree (or create one — the
+   new child is selected automatically). **Delete** stays disabled on the site
+   root.
+2. Choose **Delete**. Confirm the prompt to remove the section from Navigation.
+3. **Cancel** on the confirm prompt leaves the section in the tree.
+4. Confirming posts `DELETE /sitemanage/section/{id}` (section links use the
+   section-link delete path) and **refreshes the tree**. The section is gone
+   after reload.
 
 ### Edit section properties
 


### PR DESCRIPTION
## Summary

After Architecture **Create section**, the new non-root navon was not selected (selection stayed on the parent, site root, or empty). `canDeleteNavNode` already returns true for any non-root selected node, so **Delete** stayed disabled. This slice auto-selects the created child from the create POST `SiteSection` id, or by parent-child diff / title after tree reload.

Root remains not deletable. Confirm-cancel leaves the section; confirm DELETEs and the tree reload drops it.

Fixes #3821
Parent QA: #3151 (do not steal/close)
Prior residual: #3797 / PR #3816 (rename + move — already merged)

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Sign in as Admin; open **Navigation** (`spa.jsp?entry=architecture`) on a sample site with a NavTree.
2. Select the site root (Delete is disabled). **Create section** with a unique title/URL/landing/template.
3. After the dialog closes, **do not click the new node** — **Delete** must be enabled.
4. Click the site root — **Delete** disabled. Click the new section — **Delete** enabled.
5. Delete → cancel confirm: section remains (GET tree still lists it).
6. Delete → confirm: section gone after reload (GET tree + UI).
7. Confirm no JS console errors on the path.

Env: H2 QA Docker (`perc-devctl qa-up`).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/architecture-navigation.md` (Create auto-selects the new section; Delete procedure)
- [x] **Unit / module tests** — Vitest (`resolveCreatedNavNodeId`, shell enablement after Create, `createSiteSection` parse); perc-qa-automation helper unit for DELETE matcher
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/architecture-nav-mutations-smoke.spec.js` (#3821)
- [x] **Build gates** — standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path I/O; REST/Playwright URLs use `/`)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest Tests 3079 passed (392 files); Total time 01:55
  - `cd modules/perc-qa-automation && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; helper unit 452 passed
- **downstream_checked:** none (no Java `final`/public API shape change; TS `createSiteSection` return parse is WebUI-internal)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Hot-copy: `docker cp WebUI/target/generated-webui/cm/modern/assets/. perc-matrix-cms-h2:/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/`
- `python docker/scripts/perc-devctl.py qa-health` → `RESULT:OK HTTP:200 HEALTH:healthy URL:http://127.0.0.1:9993/Rhythmyx/rest/mimetypes`
- Playwright: `npm run test:surface -- --path tests/architecture-nav-mutations-smoke.spec.js --grep "#3821"` → **1 passed** (create → Delete enabled without extra click → cancel keeps → confirm removes, DELETE 2xx)
- Structure-action-bar smoke in the same spec also passed
- **console-clean=yes** (spec filters known architecture noise)
- **server.log-clean=yes** for the #3821 path (no feature-related ERROR/FATAL). Sibling `#3797` rename POST 500 on this 4-day-old skip-image-build cell is stale backend vs merged PR #3816, not this selection fix.

Erlang review: `docs/ai-generated/code-reviews/3821-architecture-delete-nonroot-erlang.md` — approve.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
