### PR TITLE
feat(rest): PUT Content Type field rule expressions (CD-05-07) (#3784)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3784-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3784-erlang.md
@@ -1,0 +1,58 @@
+# Erlang review — issue #3784 Content Type field rule expressions PUT REST (CD-05-07)
+
+**Branch:** `fix/issue-3784-field-rule-expressions-put`  
+**Date:** 2026-08-25  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor interface + wire DTOs + two Spring stubs + Mockito resource tests + sitemanage apibridge + adaptor tests + product-docs); behavioral tests for lock 409, unknown field, persist, post-save cache miss; no path I/O.
+
+## Summary
+
+Thin REST GET/PUT for Content Type **field-level** validation, visibility, and input/output translation expressions. PUT requires a held design-session lock (`409` without). Unknown field names are rejected (`404` GET, `400` PUT). Companions match rest/sitemanage AGENTS.md. Standalone `clean install` green on `rest` and `projects/sitemanage`.
+
+## Scope
+
+- Base: `origin/main`
+- Head: `fix/issue-3784-field-rule-expressions-put`
+- Files: rest content-type resource/adaptor/DTOs/stubs/tests; sitemanage `ContentTypeAdaptor` + `ContentTypeAdaptorFieldRuleExpressionsTest`; `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
+- Peer: CD-07 `controlProperties` (#3786) and CD-09 `itemExits`
+- Prior report: none for this ticket
+- Memory patterns hit: rest↔sitemanage companions; Spring `TestContentTypeAdaptor` + `ContentTypesTestAdaptor`; post-save `reloadItemDef` fallback (CD-07 pattern)
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- Missing behavioral tests: no
+- Non-portable path/file I/O: no
+- May commit/push: yes
+
+## Issues
+
+None blocking.
+
+PUT persist uses `IPSContentDesignWs.saveContentTypes` with `lock=true` load and does not release the lock. `requireHeldLock` maps unlocked / other-user to `ContentTypeDesignLockException` (HTTP 409). Unknown field on PUT is `IllegalArgumentException` ("Unknown field") → 400; GET is 404. Post-save item-def cache miss falls back to the locked in-memory `PSField` (`reloadItemDef` + `findField` null → `target`), matching the CD-07 Kilo cache-miss fix.
+
+Change-class closure: `IContentTypesAdaptor` `get/replaceFieldRuleExpressions`; `ContentTypesResource` GET/PUT `.../fields/{fieldName}/ruleExpressions`; Spring stubs implement both new methods; sitemanage apibridge + 18 adaptor tests; product-docs REST + Developer Content Types notes. Detail PUT still ignores expression strings (`update_ignoresReadOnlyFieldExpressions`).
+
+`contentTypeDesignGaps` `CT_FIELD_RULE_EXPR` now points at the dedicated write path. Envelope `designGaps` code `CT_FIELD_RULE_APPLY_WHEN` documents apply-when / literal limits.
+
+## Cross-platform path checklist
+
+Applied. No filesystem path construction. REST `/services/contenttypes/...` strings are URI paths (correct `/`).
+
+## Tests
+
+- rest: Mockito GET/PUT success, 404 missing type/field, 400 missing lists and unknown field, 409 lock not held / other user, JSON envelope
+- rest Spring stubs: `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`
+- sitemanage: mapping round-trip (`!=` → `<>`), extension FQN, empty clears, visibility rejects `reference`, GET maps conditionals + summary, PUT persist + cache-miss fallback, 409 lock, 400 unknown field, 403 not admin
+- Module suites: `rest` Tests run: 605, Failures: 0; `sitemanage` Tests run: 1568, Failures: 0, Skipped: 125
+
+## Non-blocking notes
+
+- WebUI expression editor remains out of scope (issue #3784).
+- Conditional variable/value are text literals (documented gap); not a bug for this slice.
+- C5 Playwright N/A (no WebUI chrome).

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -15,10 +15,12 @@ use an explicit **design-session lock** so two Admins cannot overwrite the same
 type at once.
 
 This is **not** the full Workbench field-rule editor. Field validation /
-visibility / transform **expressions** stay read-only on the detail table.
-Item-level pre/post exits and validations (CD-09) are exposed on REST
-`GET`/`PUT /services/contenttypes/{idOrName}/itemExits` (held design lock for
-write). This page does **not** add Properties-tab chrome for those exits.
+visibility / transform **expressions** stay summary-only on the detail table.
+Integrators write them with REST
+`GET`/`PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`
+(held design lock for PUT). Item-level pre/post exits and validations (CD-09)
+use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
+**not** add Properties-tab or expression-editor chrome.
 
 ## Product path — lock, save, unlock
 
@@ -55,6 +57,10 @@ The chrome calls:
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on
 the same detail panel: [Object ACL & default template](id:admin-object-acl).
 
-Field **control property values** and **choice catalogs** are not edited in this chrome.
-Integrators use `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties`
-(hold the design-session lock before PUT). See [REST API — Content types](id:developer-rest).
+Field **control property values**, **choice catalogs**, and **rule expressions** are not
+edited in this chrome. Integrators use:
+
+* `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties`
+* `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`
+
+Hold the design-session lock before either PUT. See [REST API — Content types](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -196,11 +196,13 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` | Full replace of associated templates (CD-12). Requires a **held** design-session lock. Empty list clears associations. **409** if unlocked or locked by another user. **400** if a template name/guid cannot be resolved. Does not acquire or release the lock. |
 | Lock | `POST /services/contenttypes/{idOrName}/lock` | **Admin.** Self-only design-session lock (`IPSContentDesignWs.loadContentTypes` with `lock=true`, `overrideLock=false`). Does **not** save. `200` + `ObjectLockSummary` (`session`, `locker`, `remainingTime` minutes from the lock service). Locks expire after **30 minutes** (`PSObjectLock.LOCK_INTERVAL`). Re-lock by the same session user extends the lock. |
-| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions stay read-only. |
+| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
 | Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
 | Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
+| Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
+| Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
 Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types).
@@ -357,10 +359,11 @@ Content type **detail** still lists `designGaps` code `CT_ITEM_EXITS` pointing
 at this dedicated path. This slice does **not** add Properties-tab chrome in
 Developer Content Types.
 
-### Field rule expressions (read-only)
+### Field rule expressions (CD-05–07)
 
 Content type **detail** field rows include boolean rule **flags** and, when rules exist,
-human-readable **expression summaries**:
+human-readable **expression summaries**. Those summary strings are **not** written by
+`PUT /contenttypes/{idOrName}`. Use the dedicated field path to persist rules.
 
 | Field | Meaning |
 |-------|---------|
@@ -372,9 +375,62 @@ human-readable **expression summaries**:
 | `controlPropertyNames` | Control parameter names (compat; prefer `controlProperties`) |
 | `controlProperties` | Control parameter **name and value** pairs |
 
-These expression fields are **null/omitted when empty** (`NON_NULL` JSON). Field rule
-expressions are **not** writable via `PUT` detail. Control property **values** and choice
-catalogs use the dedicated CD-07 path below.
+`GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` returns the
+structured rules for one field. No design lock is required. Empty arrays mean none.
+`404` means the content type or field was not found. GET also repeats the same summary
+strings as the detail field row.
+
+`PUT` on the same path replaces validation, visibility, and input/output translation
+expressions. Hold the design-session lock first; save keeps the lock so you can continue
+editing, then unlock.
+
+Typical flow: `POST .../lock` → `PUT .../fields/{fieldName}/ruleExpressions` → (optional
+further design writes) → `POST .../unlock`.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeFieldRuleExpressions": {
+    "fieldName": "sys_title",
+    "validation": [
+      {
+        "type": "conditional",
+        "conditionals": [
+          { "variable": "sys_title", "operator": "<>", "value": "" }
+        ]
+      }
+    ],
+    "visibility": [],
+    "inputTranslation": [
+      {
+        "extension": "Java/global/percussion/generic/sys_ToUpperCase",
+        "parameters": [{ "value": "sys_title" }]
+      }
+    ],
+    "outputTranslation": []
+  }
+}
+```
+
+`validation`, `visibility`, `inputTranslation`, and `outputTranslation` are required on
+PUT (empty list clears). Rule `type` is `conditional`, `extension`, or `reference`
+(validation only; visibility rejects `reference`). Conditional `variable` / `value` are
+stored as text literals. Operator `!=` is accepted as `<>`. Apply-when on field
+validation is not written (see `designGaps` code `CT_FIELD_RULE_APPLY_WHEN`).
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | GET envelope, or PUT replaced (lock still held) |
+| `400` | Missing required lists, invalid rule, or unknown field name |
+| `403` | Caller is not Admin (PUT) |
+| `404` | Content type not found (PUT), or content type / field not found (GET) |
+| `409` | No design lock, or locked by another user |
+| `500` | Unexpected error |
+
+This slice does **not** add a field-rule expression editor in Developer Content Types
+chrome. Control property **values** and choice catalogs use the dedicated CD-07 path
+below.
 
 ### Control property values (CD-07)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -39,6 +39,7 @@ import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSFieldTranslation;
 import com.percussion.design.objectstore.PSFieldValidationRules;
+import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSInputTranslations;
 import com.percussion.design.objectstore.PSOutputTranslations;
 import com.percussion.design.objectstore.PSParam;
@@ -63,7 +64,10 @@ import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
 import com.percussion.rest.contenttypes.ContentTypeField;
+import com.percussion.rest.contenttypes.ContentTypeFieldConditional;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
+import com.percussion.rest.contenttypes.ContentTypeFieldRule;
+import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExit;
 import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
@@ -326,9 +330,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
               "CT_FIELD_RULE_EXPR",
-              "Field rule expressions are read-only; rule write/save is not supported. Control"
-                  + " property values and choice catalogs: GET/PUT"
-                  + " .../fields/{fieldName}/controlProperties"));
+              "Field rule expressions: GET/PUT .../fields/{fieldName}/ruleExpressions"
+                  + " (held lock for write). Detail field rows remain summary strings."
+                  + " Apply-when on field validation is read-only. Control property values:"
+                  + " GET/PUT .../fields/{fieldName}/controlProperties"));
     gaps.add(
         DesignGap.of(
             "CT_ITEM_EXITS",
@@ -858,6 +863,95 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
   }
 
+  @Override
+  public ContentTypeFieldRuleExpressions getFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName) {
+    if (StringUtils.isBlank(idOrName) || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    try {
+      PSItemDefinition def = resolveItemDef(idOrName.trim());
+      if (def == null) {
+        return null;
+      }
+      return loadFieldRuleExpressions(def, fieldName.trim(), true);
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for field rule expressions: {}", idOrName);
+      return null;
+    }
+  }
+
+  @Override
+  public ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (StringUtils.isBlank(fieldName)) {
+      throw new IllegalArgumentException("fieldName is required");
+    }
+    if (body == null
+        || body.getValidation() == null
+        || body.getVisibility() == null
+        || body.getInputTranslation() == null
+        || body.getOutputTranslation() == null) {
+      throw new IllegalArgumentException(
+          "validation, visibility, inputTranslation, and outputTranslation are required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String field = fieldName.trim();
+    String session = currentSession();
+    String user = currentUser();
+    requireSessionUserForLock();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid);
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not save field rule expressions");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      PSField target = requireField(def, field, true);
+      applyFieldRuleExpressions(target, body);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not save field rule expressions");
+        }
+        log.error("Failed to save field rule expressions for {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save field rule expressions", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      PSField after = reloaded != null ? findField(reloaded, field) : null;
+      if (after == null) {
+        after = target;
+      }
+      return toFieldRuleExpressions(field, after);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to replace field rule expressions for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to replace field rule expressions", e);
+    }
+  }
+
   /**
    * Apply default workflow id and/or allowed-workflow inclusion list.
    *
@@ -1039,7 +1133,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
   /**
    * Apply writable field patches only ({@code searchable}, occurrence / required). Rule
-   * expressions, control property names/values, and field labels on the wire DTO are ignored.
+   * expressions use {@link #replaceFieldRuleExpressions}; control property names/values use
+   * {@link #replaceFieldControlProperties}. Field labels on the wire DTO are ignored.
    */
   private void applyFieldUpdates(PSItemDefinition def, List<ContentTypeField> fields) {
     if (fields == null || fields.isEmpty()) {
@@ -1637,7 +1732,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   @SuppressWarnings("unchecked")
-  private static PSExtensionCallSet toCallSet(List<ContentTypeItemExit> items, String field) {
+  static PSExtensionCallSet toCallSet(List<ContentTypeItemExit> items, String field) {
     PSExtensionCallSet set = new PSExtensionCallSet();
     int i = 0;
     for (ContentTypeItemExit item : items) {
@@ -1897,6 +1992,358 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       throw new WebApplicationException("Field not found: " + fieldName, 404);
     }
     return mapping;
+  }
+
+  /**
+   * Locate a field by submit name on the parent field set and complex children.
+   *
+   * @param notFoundIsBadRequest {@code true} throws {@link IllegalArgumentException} (PUT);
+   *     {@code false} throws HTTP 404 (GET)
+   */
+  private PSField requireField(
+      PSItemDefinition def, String fieldName, boolean notFoundIsBadRequest) {
+    PSField field = findField(def, fieldName);
+    if (field == null) {
+      String msg = "Unknown field: " + fieldName;
+      if (notFoundIsBadRequest) {
+        throw new IllegalArgumentException(msg);
+      }
+      throw new WebApplicationException(msg, 404);
+    }
+    return field;
+  }
+
+  static PSField findField(PSItemDefinition def, String fieldName) {
+    if (def == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    PSFieldSet parentFs = def.getFieldSet();
+    if (parentFs != null) {
+      PSField field = parentFs.findFieldByName(fieldName, false);
+      if (field != null) {
+        return field;
+      }
+    }
+    List<PSFieldSet> children = def.getComplexChildren();
+    if (children != null) {
+      for (PSFieldSet child : children) {
+        if (child == null) {
+          continue;
+        }
+        PSField field = child.findFieldByName(fieldName, false);
+        if (field != null) {
+          return field;
+        }
+      }
+    }
+    return null;
+  }
+
+  private ContentTypeFieldRuleExpressions loadFieldRuleExpressions(
+      PSItemDefinition def, String fieldName, boolean missingFieldIs404) {
+    PSField field = requireField(def, fieldName, !missingFieldIs404);
+    return toFieldRuleExpressions(fieldName, field);
+  }
+
+  static ContentTypeFieldRuleExpressions toFieldRuleExpressions(String fieldName, PSField field) {
+    ContentTypeFieldRuleExpressions out = new ContentTypeFieldRuleExpressions();
+    out.setFieldName(fieldName);
+    out.setDesignGaps(new ArrayList<>(fieldRuleDesignGaps()));
+    if (field == null) {
+      out.setValidation(List.of());
+      out.setVisibility(List.of());
+      out.setInputTranslation(List.of());
+      out.setOutputTranslation(List.of());
+      return out;
+    }
+    PSFieldValidationRules validation = field.getValidationRules();
+    out.setValidation(toValidationFieldRules(validation));
+    out.setVisibility(toVisibilityFieldRules(field.getVisibilityRules()));
+    out.setInputTranslation(mapExtensionCalls(translationCalls(field.getInputTranslation())));
+    out.setOutputTranslation(mapExtensionCalls(translationCalls(field.getOutputTranslation())));
+    out.setValidationExpression(summarizeValidationRules(validation));
+    out.setVisibilityExpression(summarizeVisibilityRules(field.getVisibilityRules()));
+    out.setInputTranslationExpression(summarizeTranslation(field.getInputTranslation()));
+    out.setOutputTranslationExpression(summarizeTranslation(field.getOutputTranslation()));
+    if (validation != null) {
+      out.setMaxErrorsToStop(validation.getMaxErrorsToStop());
+      if (validation.getErrorMessage() != null
+          && StringUtils.isNotBlank(validation.getErrorMessage().getText())) {
+        out.setErrorMessage(validation.getErrorMessage().getText());
+      }
+    }
+    return out;
+  }
+
+  static List<DesignGap> fieldRuleDesignGaps() {
+    return List.of(
+        DesignGap.of(
+            "CT_FIELD_RULE_APPLY_WHEN",
+            "Apply-when on field validation is not written; conditional variable/value are"
+                + " stored as text literals"));
+  }
+
+  static List<ContentTypeFieldRule> toValidationFieldRules(PSFieldValidationRules rules) {
+    List<ContentTypeFieldRule> out = new ArrayList<>();
+    if (rules == null) {
+      return out;
+    }
+    for (Iterator<?> it = rules.getRules(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSRule rule) {
+        out.addAll(toFieldRules(rule));
+      }
+    }
+    for (Iterator<?> it = rules.getRuleReferences(); it.hasNext(); ) {
+      Object ref = it.next();
+      if (ref != null && StringUtils.isNotBlank(ref.toString())) {
+        ContentTypeFieldRule dto = new ContentTypeFieldRule();
+        dto.setType(ContentTypeFieldRule.TYPE_REFERENCE);
+        dto.setReference(ref.toString().trim());
+        dto.setSummary("ref:" + ref.toString().trim());
+        out.add(dto);
+      }
+    }
+    return out;
+  }
+
+  static List<ContentTypeFieldRule> toVisibilityFieldRules(PSVisibilityRules rules) {
+    List<ContentTypeFieldRule> out = new ArrayList<>();
+    if (rules == null || rules.isEmpty()) {
+      return out;
+    }
+    for (Object o : rules) {
+      if (o instanceof PSRule rule) {
+        out.addAll(toFieldRules(rule));
+      }
+    }
+    return out;
+  }
+
+  static List<ContentTypeFieldRule> toFieldRules(PSRule rule) {
+    if (rule == null) {
+      return List.of();
+    }
+    if (rule.isExtensionSetRule()) {
+      List<ContentTypeFieldRule> out = new ArrayList<>();
+      PSExtensionCallSet set = rule.getExtensionRules();
+      if (set == null || set.isEmpty()) {
+        return out;
+      }
+      for (Object o : set) {
+        if (o instanceof PSExtensionCall call) {
+          ContentTypeItemExit exit = toExitDto(call);
+          ContentTypeFieldRule dto = new ContentTypeFieldRule();
+          dto.setType(ContentTypeFieldRule.TYPE_EXTENSION);
+          dto.setExtension(exit.getExtension());
+          dto.setName(exit.getName());
+          dto.setParameters(exit.getParameters());
+          dto.setSummary(exit.getSummary());
+          out.add(dto);
+        }
+      }
+      return out;
+    }
+    ContentTypeFieldRule dto = new ContentTypeFieldRule();
+    dto.setType(ContentTypeFieldRule.TYPE_CONDITIONAL);
+    List<ContentTypeFieldConditional> conds = new ArrayList<>();
+    for (Iterator<?> it = rule.getConditionalRules(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSConditional conditional) {
+        ContentTypeFieldConditional cond = new ContentTypeFieldConditional();
+        cond.setVariable(replacementText(conditional.getVariable()));
+        cond.setOperator(conditional.getOperator());
+        cond.setValue(replacementText(conditional.getValue()));
+        cond.setBooleanOperator(conditional.getBoolean());
+        conds.add(cond);
+      }
+    }
+    dto.setConditionals(conds);
+    dto.setSummary(summarizeRule(rule));
+    return List.of(dto);
+  }
+
+  static String replacementText(IPSReplacementValue value) {
+    if (value == null) {
+      return null;
+    }
+    String text = value.getValueText();
+    if (StringUtils.isNotBlank(text)) {
+      return text;
+    }
+    String display = value.getValueDisplayText();
+    return StringUtils.isNotBlank(display) ? display : null;
+  }
+
+  private static PSExtensionCallSet translationCalls(PSFieldTranslation translation) {
+    return translation != null ? translation.getTranslations() : null;
+  }
+
+  static void applyFieldRuleExpressions(PSField field, ContentTypeFieldRuleExpressions body) {
+    field.setValidationRules(toFieldValidationRules(body));
+    field.setVisibilityRules(toVisibilityRules(body.getVisibility(), "visibility"));
+    field.setInputTranslation(
+        toFieldTranslation(body.getInputTranslation(), "inputTranslation"));
+    field.setOutputTranslation(
+        toFieldTranslation(body.getOutputTranslation(), "outputTranslation"));
+  }
+
+  @SuppressWarnings("unchecked")
+  static PSFieldValidationRules toFieldValidationRules(ContentTypeFieldRuleExpressions body) {
+    List<ContentTypeFieldRule> items = body.getValidation();
+    if (items.isEmpty()
+        && body.getMaxErrorsToStop() == null
+        && body.getErrorMessage() == null) {
+      return null;
+    }
+    PSCollection<PSRule> rules = new PSCollection<>(PSRule.class);
+    PSCollection<String> refs = new PSCollection<>(String.class);
+    int i = 0;
+    for (ContentTypeFieldRule item : items) {
+      String field = "validation[" + i + "]";
+      String type = ruleType(item, field);
+      if (ContentTypeFieldRule.TYPE_REFERENCE.equals(type)) {
+        if (item == null || StringUtils.isBlank(item.getReference())) {
+          throw new IllegalArgumentException(field + ".reference is required");
+        }
+        refs.add(item.getReference().trim());
+      } else {
+        rules.add(toPsRule(item, field));
+      }
+      i++;
+    }
+    if (rules.isEmpty() && refs.isEmpty()) {
+      return null;
+    }
+    PSFieldValidationRules out = new PSFieldValidationRules();
+    out.setRules(rules);
+    out.setRuleReferences(refs);
+    if (body.getMaxErrorsToStop() != null) {
+      int max = body.getMaxErrorsToStop();
+      if (max <= 0) {
+        throw new IllegalArgumentException("maxErrorsToStop must be greater than 0");
+      }
+      out.setMaxErrorsToStop(max);
+    }
+    if (body.getErrorMessage() != null) {
+      if (StringUtils.isBlank(body.getErrorMessage())) {
+        out.setErrorMessage(null);
+      } else {
+        out.setErrorMessage(new PSDisplayText(body.getErrorMessage().trim()));
+      }
+    }
+    return out;
+  }
+
+  @SuppressWarnings("unchecked")
+  static PSVisibilityRules toVisibilityRules(List<ContentTypeFieldRule> items, String field) {
+    if (items.isEmpty()) {
+      return null;
+    }
+    PSVisibilityRules out = new PSVisibilityRules();
+    int i = 0;
+    for (ContentTypeFieldRule item : items) {
+      String path = field + "[" + i + "]";
+      String type = ruleType(item, path);
+      if (ContentTypeFieldRule.TYPE_REFERENCE.equals(type)) {
+        throw new IllegalArgumentException(path + " type=reference is not allowed on visibility");
+      }
+      out.add(toPsRule(item, path));
+      i++;
+    }
+    return out;
+  }
+
+  static PSFieldTranslation toFieldTranslation(List<ContentTypeItemExit> items, String field) {
+    if (items.isEmpty()) {
+      return null;
+    }
+    return new PSFieldTranslation(toCallSet(items, field));
+  }
+
+  static String ruleType(ContentTypeFieldRule item, String field) {
+    if (item == null) {
+      throw new IllegalArgumentException(field + " is null");
+    }
+    String type = StringUtils.trimToNull(item.getType());
+    if (type == null) {
+      throw new IllegalArgumentException(field + ".type is required");
+    }
+    String lower = type.toLowerCase();
+    if (ContentTypeFieldRule.TYPE_CONDITIONAL.equals(lower)
+        || ContentTypeFieldRule.TYPE_EXTENSION.equals(lower)
+        || ContentTypeFieldRule.TYPE_REFERENCE.equals(lower)) {
+      return lower;
+    }
+    throw new IllegalArgumentException(
+        field + ".type must be conditional, extension, or reference");
+  }
+
+  @SuppressWarnings("unchecked")
+  static PSRule toPsRule(ContentTypeFieldRule item, String field) {
+    String type = ruleType(item, field);
+    if (ContentTypeFieldRule.TYPE_EXTENSION.equals(type)) {
+      ContentTypeItemExit exit = new ContentTypeItemExit();
+      exit.setExtension(item.getExtension());
+      exit.setName(item.getName());
+      exit.setParameters(item.getParameters());
+      PSExtensionCallSet set = new PSExtensionCallSet();
+      set.add(toExtensionCall(exit, field));
+      return new PSRule(set);
+    }
+    if (!ContentTypeFieldRule.TYPE_CONDITIONAL.equals(type)) {
+      throw new IllegalArgumentException(field + ".type must be conditional or extension");
+    }
+    if (item.getConditionals() == null || item.getConditionals().isEmpty()) {
+      throw new IllegalArgumentException(field + ".conditionals is required");
+    }
+    PSCollection<PSConditional> conds = new PSCollection<>(PSConditional.class);
+    int i = 0;
+    for (ContentTypeFieldConditional conditional : item.getConditionals()) {
+      conds.add(toPsConditional(conditional, field + ".conditionals[" + i + "]"));
+      i++;
+    }
+    return new PSRule(conds);
+  }
+
+  static PSConditional toPsConditional(ContentTypeFieldConditional item, String field) {
+    if (item == null) {
+      throw new IllegalArgumentException(field + " is null");
+    }
+    if (StringUtils.isBlank(item.getVariable())) {
+      throw new IllegalArgumentException(field + ".variable is required");
+    }
+    if (StringUtils.isBlank(item.getOperator())) {
+      throw new IllegalArgumentException(field + ".operator is required");
+    }
+    String op = normalizeOperator(item.getOperator());
+    boolean nullOp =
+        PSConditional.OPTYPE_ISNULL.equalsIgnoreCase(op)
+            || PSConditional.OPTYPE_ISNOTNULL.equalsIgnoreCase(op);
+    IPSReplacementValue value =
+        item.getValue() != null
+            ? new PSTextLiteral(item.getValue())
+            : (nullOp ? null : new PSTextLiteral(""));
+    try {
+      return new PSConditional(
+          new PSTextLiteral(item.getVariable().trim()),
+          op,
+          value,
+          StringUtils.trimToNull(item.getBooleanOperator()));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(field + " invalid conditional: " + e.getMessage(), e);
+    }
+  }
+
+  static String normalizeOperator(String operator) {
+    String op = operator.trim();
+    if ("!=".equals(op)) {
+      return PSConditional.OPTYPE_NOTEQUALS;
+    }
+    if ("==".equals(op)) {
+      return PSConditional.OPTYPE_EQUALS;
+    }
+    return op;
   }
 
   private static ContentTypeFieldControlProperties toFieldControlProperties(

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorFieldRuleExpressionsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorFieldRuleExpressionsTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSConditional;
+import com.percussion.design.objectstore.PSField;
+import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSFieldTranslation;
+import com.percussion.design.objectstore.PSFieldValidationRules;
+import com.percussion.design.objectstore.PSRule;
+import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.design.objectstore.PSVisibilityRules;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeFieldConditional;
+import com.percussion.rest.contenttypes.ContentTypeFieldRule;
+import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
+import com.percussion.rest.contenttypes.ContentTypeItemExit;
+import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.util.PSCollection;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-05–07 field rule expressions: GET maps design objects; PUT requires a held lock and persists
+ * via {@code saveContentTypes}.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorFieldRuleExpressionsTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+  private PSField field;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void toPsConditional_mapsAliasAndRoundTrips() {
+    ContentTypeFieldConditional body = new ContentTypeFieldConditional("sys_title", "!=", "");
+    PSConditional cond = ContentTypeAdaptor.toPsConditional(body, "validation[0].conditionals[0]");
+    assertEquals(PSConditional.OPTYPE_NOTEQUALS, cond.getOperator());
+    assertEquals("sys_title", cond.getVariable().getValueText());
+
+    List<ContentTypeFieldRule> mapped =
+        ContentTypeAdaptor.toFieldRules(new PSRule(singleConditional(cond)));
+    assertEquals(1, mapped.size());
+    assertEquals(ContentTypeFieldRule.TYPE_CONDITIONAL, mapped.get(0).getType());
+    assertEquals("sys_title", mapped.get(0).getConditionals().get(0).getVariable());
+    assertEquals("<>", mapped.get(0).getConditionals().get(0).getOperator());
+  }
+
+  @Test
+  void toPsRule_extensionRoundTrip() {
+    ContentTypeFieldRule dto = new ContentTypeFieldRule();
+    dto.setType(ContentTypeFieldRule.TYPE_EXTENSION);
+    dto.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    dto.setParameters(List.of(new ContentTypeItemExitParam(null, "sys_title")));
+    PSRule rule = ContentTypeAdaptor.toPsRule(dto, "input[0]");
+    assertTrue(rule.isExtensionSetRule());
+    List<ContentTypeFieldRule> mapped = ContentTypeAdaptor.toFieldRules(rule);
+    assertEquals(1, mapped.size());
+    assertEquals(ContentTypeFieldRule.TYPE_EXTENSION, mapped.get(0).getType());
+    assertTrue(mapped.get(0).getExtension().contains("sys_ToUpperCase"));
+  }
+
+  @Test
+  void toFieldValidationRules_emptyClears() {
+    ContentTypeFieldRuleExpressions body = emptyBody();
+    assertNull(ContentTypeAdaptor.toFieldValidationRules(body));
+    assertNull(ContentTypeAdaptor.toVisibilityRules(body.getVisibility(), "visibility"));
+    assertNull(ContentTypeAdaptor.toFieldTranslation(body.getInputTranslation(), "inputTranslation"));
+  }
+
+  @Test
+  void toVisibilityRules_rejectsReference() {
+    ContentTypeFieldRule ref = new ContentTypeFieldRule();
+    ref.setType(ContentTypeFieldRule.TYPE_REFERENCE);
+    ref.setReference("sharedRequired");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.toVisibilityRules(List.of(ref), "visibility"));
+    assertTrue(ex.getMessage().contains("reference"), ex.getMessage());
+  }
+
+  @Test
+  void toPsConditional_requiresVariableAndOperator() {
+    ContentTypeFieldConditional missingVar = new ContentTypeFieldConditional();
+    missingVar.setOperator("=");
+    IllegalArgumentException varEx =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.toPsConditional(missingVar, "c"));
+    assertTrue(varEx.getMessage().contains("variable"), varEx.getMessage());
+
+    ContentTypeFieldConditional missingOp = new ContentTypeFieldConditional();
+    missingOp.setVariable("sys_title");
+    IllegalArgumentException opEx =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.toPsConditional(missingOp, "c"));
+    assertTrue(opEx.getMessage().contains("operator"), opEx.getMessage());
+  }
+
+  @Test
+  void get_returnsMappedRulesAndSummary() throws Exception {
+    stubDefinition();
+    stubExistingValidation();
+
+    ContentTypeFieldRuleExpressions out =
+        adaptor.getFieldRuleExpressions(null, "311", "sys_title");
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals(1, out.getValidation().size());
+    assertEquals("sys_title", out.getValidation().get(0).getConditionals().get(0).getVariable());
+    assertTrue(out.getValidationExpression().contains("sys_title"), out.getValidationExpression());
+    assertTrue(out.getVisibility().isEmpty());
+    assertTrue(out.getInputTranslation().isEmpty());
+    assertEquals("CT_FIELD_RULE_APPLY_WHEN", out.getDesignGaps().get(0).getCode());
+  }
+
+  @Test
+  void get_unknownField_is404() throws Exception {
+    stubDefinition();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.getFieldRuleExpressions(null, "311", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Unknown field"), ex.getMessage());
+  }
+
+  @Test
+  void get_unknownType_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.getFieldRuleExpressions(null, "missing", "sys_title"));
+  }
+
+  @Test
+  void put_persistsWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+
+    ContentTypeFieldRuleExpressions body = emptyBody();
+    ContentTypeFieldRule rule = new ContentTypeFieldRule();
+    rule.setType(ContentTypeFieldRule.TYPE_CONDITIONAL);
+    rule.setConditionals(List.of(new ContentTypeFieldConditional("sys_title", "<>", "")));
+    body.setValidation(List.of(rule));
+    ContentTypeItemExit call = new ContentTypeItemExit();
+    call.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    call.setParameters(List.of(new ContentTypeItemExitParam(null, "sys_title")));
+    body.setInputTranslation(List.of(call));
+
+    ContentTypeFieldRuleExpressions out =
+        adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", body);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    ArgumentCaptor<PSFieldValidationRules> rules =
+        ArgumentCaptor.forClass(PSFieldValidationRules.class);
+    verify(field).setValidationRules(rules.capture());
+    assertTrue(rules.getValue().getRules().hasNext());
+    ArgumentCaptor<PSFieldTranslation> in = ArgumentCaptor.forClass(PSFieldTranslation.class);
+    verify(field).setInputTranslation(in.capture());
+    assertTrue(in.getValue().getTranslations().size() > 0);
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals(1, out.getValidation().size());
+    assertEquals(1, out.getInputTranslation().size());
+  }
+
+  @Test
+  void put_emptyListsClear() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    ContentTypeFieldRuleExpressions out =
+        adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", emptyBody());
+    verify(field).setValidationRules(null);
+    verify(field).setVisibilityRules(null);
+    verify(field).setInputTranslation(null);
+    verify(field).setOutputTranslation(null);
+    assertTrue(out.getValidation().isEmpty());
+  }
+
+  @Test
+  void put_cacheMissAfterSave_fallsBackToLockedField() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("not cached"));
+
+    ContentTypeFieldRuleExpressions body = emptyBody();
+    ContentTypeFieldRule rule = new ContentTypeFieldRule();
+    rule.setType(ContentTypeFieldRule.TYPE_CONDITIONAL);
+    rule.setConditionals(List.of(new ContentTypeFieldConditional("sys_title", "=", "x")));
+    body.setValidation(List.of(rule));
+
+    ContentTypeFieldRuleExpressions out =
+        adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", body);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals(1, out.getValidation().size());
+  }
+
+  @Test
+  void put_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of());
+    stubDefinition();
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", emptyBody()));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition();
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", emptyBody()));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_unknownField_isBadRequest() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.replaceFieldRuleExpressions(null, "311", "nope", emptyBody()));
+    assertTrue(ex.getMessage().contains("Unknown field"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_unknownType_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.replaceFieldRuleExpressions(null, "missing", "sys_title", emptyBody()));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_missingLists_isBadRequest() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.replaceFieldRuleExpressions(null, "311", "sys_title", null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            adaptor.replaceFieldRuleExpressions(
+                null, "311", "sys_title", new ContentTypeFieldRuleExpressions()));
+  }
+
+  @Test
+  void put_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.replaceFieldRuleExpressions(null, "311", "sys_title", emptyBody()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void fieldRuleDesignGaps_areStructured() {
+    assertEquals(
+        "CT_FIELD_RULE_APPLY_WHEN", ContentTypeAdaptor.fieldRuleDesignGaps().get(0).getCode());
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private PSItemDefinition stubDefinition() throws Exception {
+    field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_title");
+    final PSFieldValidationRules[] storedVal = new PSFieldValidationRules[1];
+    final PSVisibilityRules[] storedVis = new PSVisibilityRules[1];
+    final PSFieldTranslation[] storedIn = new PSFieldTranslation[1];
+    final PSFieldTranslation[] storedOut = new PSFieldTranslation[1];
+    when(field.getValidationRules()).thenAnswer(inv -> storedVal[0]);
+    when(field.getVisibilityRules()).thenAnswer(inv -> storedVis[0]);
+    when(field.getInputTranslation()).thenAnswer(inv -> storedIn[0]);
+    when(field.getOutputTranslation()).thenAnswer(inv -> storedOut[0]);
+    doAnswer(
+            inv -> {
+              storedVal[0] = inv.getArgument(0);
+              return null;
+            })
+        .when(field)
+        .setValidationRules(any());
+    doAnswer(
+            inv -> {
+              storedVis[0] = inv.getArgument(0);
+              return null;
+            })
+        .when(field)
+        .setVisibilityRules(any());
+    doAnswer(
+            inv -> {
+              storedIn[0] = inv.getArgument(0);
+              return null;
+            })
+        .when(field)
+        .setInputTranslation(any());
+    doAnswer(
+            inv -> {
+              storedOut[0] = inv.getArgument(0);
+              return null;
+            })
+        .when(field)
+        .setOutputTranslation(any());
+
+    PSFieldSet fieldSet = mock(PSFieldSet.class);
+    when(fieldSet.findFieldByName("sys_title", false)).thenReturn(field);
+    when(fieldSet.findFieldByName("nope", false)).thenReturn(null);
+
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(fieldSet);
+    when(def.getComplexChildren()).thenReturn(List.of());
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+
+  private void stubExistingValidation() {
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_title"),
+            PSConditional.OPTYPE_NOTEQUALS,
+            new PSTextLiteral("")));
+    PSFieldValidationRules rules = new PSFieldValidationRules();
+    PSCollection ruleCol = new PSCollection(PSRule.class);
+    ruleCol.add(new PSRule(conditionals));
+    rules.setRules(ruleCol);
+    when(field.getValidationRules()).thenReturn(rules);
+  }
+
+  private static ContentTypeFieldRuleExpressions emptyBody() {
+    ContentTypeFieldRuleExpressions body = new ContentTypeFieldRuleExpressions();
+    body.setValidation(List.of());
+    body.setVisibility(List.of());
+    body.setInputTranslation(List.of());
+    body.setOutputTranslation(List.of());
+    return body;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSCollection singleConditional(PSConditional cond) {
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(cond);
+    return conditionals;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -28,11 +28,13 @@ import java.util.List;
 /**
  * Content type design summary for the Developer module (read + partial write).
  *
- * <p>Full field rule expressions and control properties remain Workbench / SOAP parity work.
- * Partial update supports label, description, enabled, field searchable / occurrence, allowed
- * workflows (+ default), and allowed templates. PUT requires a design-session lock already held
- * by the current user ({@code POST /services/contenttypes/{idOrName}/lock}) and does not release
- * it. Field rule expressions are read-only.
+ * <p>Field rule expressions use {@code GET/PUT .../fields/{fieldName}/ruleExpressions} (held
+ * design lock for write). Control properties use {@code GET/PUT
+ * .../fields/{fieldName}/controlProperties}. Partial update supports label, description, enabled,
+ * field searchable / occurrence, allowed workflows (+ default), and allowed templates. PUT
+ * requires a design-session lock already held by the current user ({@code POST
+ * /services/contenttypes/{idOrName}/lock}) and does not release it. Field rule expressions on this
+ * detail payload remain summary strings (not written by PUT detail).
  *
  * <p><strong>GET:</strong> adaptors always populate {@code allowedWorkflows} and {@code
  * allowedTemplates} (empty arrays when none) so clients see stable wire shape.

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
@@ -71,23 +71,27 @@ public class ContentTypeField {
 
   @Schema(
       description =
-          "Read-only summary of field validation rule expressions (conditionals / extensions)."
-              + " Null when no validation rules are defined. Not writable via PUT.")
+          "Summary of field validation rule expressions (conditionals / extensions)."
+              + " Null when no validation rules are defined. Writable via PUT"
+              + " .../fields/{fieldName}/ruleExpressions (held design lock), not PUT detail.")
   private String validationExpression;
 
   @Schema(
       description =
-          "Read-only summary of visibility rule expressions. Null when none defined. Not writable.")
+          "Summary of visibility rule expressions. Null when none defined. Writable via PUT"
+              + " .../fields/{fieldName}/ruleExpressions, not PUT detail.")
   private String visibilityExpression;
 
   @Schema(
       description =
-          "Read-only summary of input translation extension calls. Null when none. Not writable.")
+          "Summary of input translation extension calls. Null when none. Writable via PUT"
+              + " .../fields/{fieldName}/ruleExpressions, not PUT detail.")
   private String inputTranslationExpression;
 
   @Schema(
       description =
-          "Read-only summary of output translation extension calls. Null when none. Not writable.")
+          "Summary of output translation extension calls. Null when none. Writable via PUT"
+              + " .../fields/{fieldName}/ruleExpressions, not PUT detail.")
   private String outputTranslationExpression;
 
   @Schema(

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldConditional.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldConditional.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * One field-rule conditional ({@code variable operator value}). Variable and value are stored as
+ * text literals on PUT.
+ */
+@XmlRootElement(name = "ContentTypeFieldConditional")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "One field validation/visibility conditional")
+public class ContentTypeFieldConditional {
+
+  @Schema(description = "Left-hand variable (field name or literal). Required on PUT.")
+  private String variable;
+
+  @Schema(
+      description =
+          "Relational operator: =, <>, <, <=, >, >=, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN,"
+              + " IN, NOT IN, LIKE, NOT LIKE. Alias != is accepted as <>.")
+  private String operator;
+
+  @Schema(description = "Right-hand value. Optional for IS NULL / IS NOT NULL.")
+  private String value;
+
+  @Schema(description = "Boolean join to the next conditional in the same rule: AND (default) or OR")
+  private String booleanOperator;
+
+  public ContentTypeFieldConditional() {}
+
+  public ContentTypeFieldConditional(String variable, String operator, String value) {
+    this.variable = variable;
+    this.operator = operator;
+    this.value = value;
+  }
+
+  public String getVariable() {
+    return variable;
+  }
+
+  public void setVariable(String variable) {
+    this.variable = variable;
+  }
+
+  public String getOperator() {
+    return operator;
+  }
+
+  public void setOperator(String operator) {
+    this.operator = operator;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getBooleanOperator() {
+    return booleanOperator;
+  }
+
+  public void setBooleanOperator(String booleanOperator) {
+    this.booleanOperator = booleanOperator;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRule.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRule.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One field validation or visibility rule (conditional set, extension call, or named rule
+ * reference).
+ *
+ * <p>{@code type} is {@code conditional}, {@code extension}, or {@code reference}. GET {@code
+ * summary} is a human-readable dump and is ignored on PUT.
+ */
+@XmlRootElement(name = "ContentTypeFieldRule")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "One field validation or visibility rule")
+public class ContentTypeFieldRule {
+
+  public static final String TYPE_CONDITIONAL = "conditional";
+  public static final String TYPE_EXTENSION = "extension";
+  public static final String TYPE_REFERENCE = "reference";
+
+  @Schema(
+      required = true,
+      description = "Rule kind: conditional | extension | reference. Required on PUT.")
+  private String type;
+
+  @Schema(description = "Conditionals when type is conditional. Required and non-empty on PUT.")
+  private List<ContentTypeFieldConditional> conditionals;
+
+  @Schema(
+      description =
+          "Fully-qualified extension ref when type is extension, e.g."
+              + " Java/global/percussion/generic/sys_ToUpperCase")
+  private String extension;
+
+  @Schema(description = "Short extension name (GET convenience; ignored on PUT when extension is set)")
+  private String name;
+
+  @Schema(description = "Extension call parameters (literal values) when type is extension")
+  private List<ContentTypeItemExitParam> parameters = new ArrayList<>();
+
+  @Schema(description = "Named validation rule reference when type is reference")
+  private String reference;
+
+  @Schema(description = "Human-readable summary (GET); ignored on PUT")
+  private String summary;
+
+  public ContentTypeFieldRule() {}
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public List<ContentTypeFieldConditional> getConditionals() {
+    return conditionals;
+  }
+
+  public void setConditionals(List<ContentTypeFieldConditional> conditionals) {
+    this.conditionals = conditionals;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public void setExtension(String extension) {
+    this.extension = extension;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<ContentTypeItemExitParam> getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(List<ContentTypeItemExitParam> parameters) {
+    this.parameters = parameters != null ? parameters : new ArrayList<>();
+  }
+
+  public String getReference() {
+    return reference;
+  }
+
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressions.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressions.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.percussion.rest.DesignGap;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Field-level validation, visibility, and input/output translation expressions (CD-05–CD-07).
+ *
+ * <p>Jackson root wrap is {@code ContentTypeFieldRuleExpressions}. GET always returns the four
+ * lists (may be empty) plus summary strings when rules exist. PUT is a full replace of {@code
+ * validation}, {@code visibility}, {@code inputTranslation}, and {@code outputTranslation} (empty
+ * list clears). Requires a held design-session lock.
+ */
+@XmlRootElement(name = "ContentTypeFieldRuleExpressions")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Field validation, visibility, and translation expressions (CD-05–07)")
+public class ContentTypeFieldRuleExpressions {
+
+  @Schema(description = "Field submit name (path {fieldName})")
+  private String fieldName;
+
+  @Schema(
+      required = true,
+      description =
+          "Validation rules. GET: always present (may be []). PUT: required; empty clears.")
+  private List<ContentTypeFieldRule> validation;
+
+  @Schema(
+      required = true,
+      description =
+          "Visibility rules. GET: always present (may be []). PUT: required; empty clears."
+              + " type=reference is not allowed.")
+  private List<ContentTypeFieldRule> visibility;
+
+  @Schema(
+      required = true,
+      description =
+          "Input translation extension calls. GET: always present (may be []). PUT: required;"
+              + " empty clears.")
+  private List<ContentTypeItemExit> inputTranslation;
+
+  @Schema(
+      required = true,
+      description =
+          "Output translation extension calls. GET: always present (may be []). PUT: required;"
+              + " empty clears.")
+  private List<ContentTypeItemExit> outputTranslation;
+
+  @Schema(
+      description =
+          "Max errors before field validation stops. GET: present when validation rules exist."
+              + " PUT: omit keeps current (or default 10 when creating rules).")
+  private Integer maxErrorsToStop;
+
+  @Schema(description = "Validation error message text. PUT: omit leaves unchanged; empty clears.")
+  private String errorMessage;
+
+  @Schema(description = "GET convenience: summary of validation rules (same as detail field row)")
+  private String validationExpression;
+
+  @Schema(description = "GET convenience: summary of visibility rules")
+  private String visibilityExpression;
+
+  @Schema(description = "GET convenience: summary of input translation calls")
+  private String inputTranslationExpression;
+
+  @Schema(description = "GET convenience: summary of output translation calls")
+  private String outputTranslationExpression;
+
+  @Schema(description = "Structured capability notes vs full Workbench. GET always present.")
+  private List<DesignGap> designGaps = new ArrayList<>();
+
+  public ContentTypeFieldRuleExpressions() {}
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public void setFieldName(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  public List<ContentTypeFieldRule> getValidation() {
+    return validation;
+  }
+
+  public void setValidation(List<ContentTypeFieldRule> validation) {
+    this.validation = validation;
+  }
+
+  public List<ContentTypeFieldRule> getVisibility() {
+    return visibility;
+  }
+
+  public void setVisibility(List<ContentTypeFieldRule> visibility) {
+    this.visibility = visibility;
+  }
+
+  public List<ContentTypeItemExit> getInputTranslation() {
+    return inputTranslation;
+  }
+
+  public void setInputTranslation(List<ContentTypeItemExit> inputTranslation) {
+    this.inputTranslation = inputTranslation;
+  }
+
+  public List<ContentTypeItemExit> getOutputTranslation() {
+    return outputTranslation;
+  }
+
+  public void setOutputTranslation(List<ContentTypeItemExit> outputTranslation) {
+    this.outputTranslation = outputTranslation;
+  }
+
+  public Integer getMaxErrorsToStop() {
+    return maxErrorsToStop;
+  }
+
+  public void setMaxErrorsToStop(Integer maxErrorsToStop) {
+    this.maxErrorsToStop = maxErrorsToStop;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public String getValidationExpression() {
+    return validationExpression;
+  }
+
+  public void setValidationExpression(String validationExpression) {
+    this.validationExpression = validationExpression;
+  }
+
+  public String getVisibilityExpression() {
+    return visibilityExpression;
+  }
+
+  public void setVisibilityExpression(String visibilityExpression) {
+    this.visibilityExpression = visibilityExpression;
+  }
+
+  public String getInputTranslationExpression() {
+    return inputTranslationExpression;
+  }
+
+  public void setInputTranslationExpression(String inputTranslationExpression) {
+    this.inputTranslationExpression = inputTranslationExpression;
+  }
+
+  public String getOutputTranslationExpression() {
+    return outputTranslationExpression;
+  }
+
+  public void setOutputTranslationExpression(String outputTranslationExpression) {
+    this.outputTranslationExpression = outputTranslationExpression;
+  }
+
+  public List<DesignGap> getDesignGaps() {
+    return designGaps;
+  }
+
+  public void setDesignGaps(List<DesignGap> designGaps) {
+    this.designGaps = designGaps != null ? designGaps : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -844,8 +844,8 @@ public class ContentTypesResource {
       description =
           "Content type detail including field catalog. Field rows include control property"
               + " names and values. Choice catalogs and property write use"
-              + " GET/PUT .../fields/{fieldName}/controlProperties. Field rule expressions remain"
-              + " read-only (see designGaps).",
+              + " GET/PUT .../fields/{fieldName}/controlProperties. Field rule expressions use"
+              + " GET/PUT .../fields/{fieldName}/ruleExpressions (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -887,9 +887,10 @@ public class ContentTypesResource {
               + " empty). Template associations are written after content-type save in a separate"
               + " design call — if that fails, meta/field/workflow changes may already be"
               + " committed (error message indicates partial success). Name/id and system field"
-              + " structure are not changed. Field rule expressions remain read-only. Control"
-              + " property values use PUT .../fields/{fieldName}/controlProperties. Create/delete"
-              + " remain unsupported (see designGaps).",
+              + " structure are not changed. Field rule expressions use PUT"
+              + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
+              + " .../fields/{fieldName}/controlProperties. Create/delete remain unsupported (see"
+              + " designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1334,6 +1335,97 @@ public class ContentTypesResource {
           requireAdaptor()
               .replaceFieldControlProperties(
                   uriInfo.getBaseUri(), idOrName, fieldName, body);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
+  @GET
+  @Path("/{idOrName}/fields/{fieldName}/ruleExpressions")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get field rule expressions",
+      description =
+          "CD-05–07 GET: field-level validation, visibility, and input/output translation"
+              + " expressions for one field. No design lock is required. Empty lists mean none."
+              + " Summary strings match ContentTypeDetail field rows. Jackson root wrap is"
+              + " ContentTypeFieldRuleExpressions.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(schema = @Schema(implementation = ContentTypeFieldRuleExpressions.class))),
+        @ApiResponse(responseCode = "404", description = "Content type or field not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeFieldRuleExpressions getFieldRuleExpressions(
+      @PathParam("idOrName") String idOrName, @PathParam("fieldName") String fieldName) {
+    try {
+      ContentTypeFieldRuleExpressions out =
+          requireAdaptor().getFieldRuleExpressions(uriInfo.getBaseUri(), idOrName, fieldName);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/fields/{fieldName}/ruleExpressions")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Replace field rule expressions",
+      description =
+          "CD-05–07 PUT: full replace of field validation, visibility, and input/output"
+              + " translation expressions via IPSContentDesignWs.saveContentTypes. Requires a held"
+              + " design-session lock (POST .../lock). Does not acquire or release the lock. Empty"
+              + " lists clear. Unknown field names are rejected. Conditional variable/value are"
+              + " stored as text literals. Apply-when on field validation is not written. Jackson"
+              + " root wrap is ContentTypeFieldRuleExpressions.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Replaced (lock is still held)",
+            content =
+                @Content(schema = @Schema(implementation = ContentTypeFieldRuleExpressions.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Missing required lists, invalid rule, or unknown field name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
+      @PathParam("idOrName") String idOrName,
+      @PathParam("fieldName") String fieldName,
+      ContentTypeFieldRuleExpressions body) {
+    if (body == null
+        || body.getValidation() == null
+        || body.getVisibility() == null
+        || body.getInputTranslation() == null
+        || body.getOutputTranslation() == null) {
+      throw new WebApplicationException(
+          "validation, visibility, inputTranslation, and outputTranslation are required", 400);
+    }
+    try {
+      ContentTypeFieldRuleExpressions out =
+          requireAdaptor()
+              .replaceFieldRuleExpressions(uriInfo.getBaseUri(), idOrName, fieldName, body);
       if (out == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -66,8 +66,8 @@ public interface IContentTypesAdaptor {
    * <p>Supports label, description, enabled, per-field {@code searchable} (and optional
    * occurrence), allowed workflows (+ default workflow id), and allowed templates. Association
    * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
-   * Field rule expressions remain read-only. Control property values use {@link
-   * #replaceFieldControlProperties}.
+   * Field rule expressions use {@link #replaceFieldRuleExpressions}. Control property values use
+   * {@link #replaceFieldControlProperties}.
    *
    * @return updated detail, or {@code null} when not found
    * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
@@ -186,4 +186,28 @@ public interface IContentTypesAdaptor {
    */
   ContentTypeFieldControlProperties replaceFieldControlProperties(
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body);
+
+  /**
+   * Load field-level validation, visibility, and input/output translation expressions (CD-05–07).
+   * No design lock is required. Empty lists mean none configured.
+   *
+   * @return envelope, or {@code null} when the content type is not found
+   * @throws jakarta.ws.rs.WebApplicationException {@code 404} when the field name is unknown
+   */
+  ContentTypeFieldRuleExpressions getFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName);
+
+  /**
+   * Replace field-level validation, visibility, and translation expressions. Requires a
+   * design-session lock already held by the current user. Does not acquire or release the lock.
+   * {@code validation}, {@code visibility}, {@code inputTranslation}, and {@code outputTranslation}
+   * are full replace (empty clears).
+   *
+   * @return persisted envelope, or {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when required lists are missing, a rule is invalid, or the
+   *     field name is unknown
+   */
+  ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -607,6 +607,143 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void getFieldRuleExpressionsReturnsEnvelope() {
+    ContentTypeFieldRuleExpressions envelope = new ContentTypeFieldRuleExpressions();
+    envelope.setFieldName("sys_title");
+    ContentTypeFieldRule rule = new ContentTypeFieldRule();
+    rule.setType(ContentTypeFieldRule.TYPE_CONDITIONAL);
+    rule.setConditionals(List.of(new ContentTypeFieldConditional("sys_title", "<>", "")));
+    envelope.setValidation(List.of(rule));
+    envelope.setVisibility(List.of());
+    envelope.setInputTranslation(List.of());
+    envelope.setOutputTranslation(List.of());
+    envelope.setValidationExpression("sys_title <> ");
+    when(adaptor.getFieldRuleExpressions(any(), eq("percPage"), eq("sys_title")))
+        .thenReturn(envelope);
+    ContentTypeFieldRuleExpressions out = resource.getFieldRuleExpressions("percPage", "sys_title");
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals(1, out.getValidation().size());
+    assertEquals("<>", out.getValidation().get(0).getConditionals().get(0).getOperator());
+  }
+
+  @Test
+  public void getFieldRuleExpressionsContentTypeNotFound() {
+    when(adaptor.getFieldRuleExpressions(any(), eq("missing"), eq("sys_title"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.getFieldRuleExpressions("missing", "sys_title"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getFieldRuleExpressionsFieldNotFound() {
+    when(adaptor.getFieldRuleExpressions(any(), eq("percPage"), eq("nope")))
+        .thenThrow(new WebApplicationException("Unknown field: nope", 404));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.getFieldRuleExpressions("percPage", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldRuleExpressionsSuccess() {
+    ContentTypeFieldRuleExpressions body = emptyRuleExpressionsBody();
+    ContentTypeFieldRuleExpressions updated = emptyRuleExpressionsBody();
+    updated.setFieldName("sys_title");
+    when(adaptor.replaceFieldRuleExpressions(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenReturn(updated);
+    ContentTypeFieldRuleExpressions out =
+        resource.replaceFieldRuleExpressions("percPage", "sys_title", body);
+    assertEquals("sys_title", out.getFieldName());
+  }
+
+  @Test
+  public void replaceFieldRuleExpressionsRequiresLists() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.replaceFieldRuleExpressions(
+                    "percPage", "sys_title", new ContentTypeFieldRuleExpressions()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldRuleExpressionsRequiresLock() {
+    ContentTypeFieldRuleExpressions body = emptyRuleExpressionsBody();
+    when(adaptor.replaceFieldRuleExpressions(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save field rule expressions; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldRuleExpressions("percPage", "sys_title", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldRuleExpressionsLockedByOtherUser() {
+    ContentTypeFieldRuleExpressions body = emptyRuleExpressionsBody();
+    when(adaptor.replaceFieldRuleExpressions(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save field rule expressions; locked by editor"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldRuleExpressions("percPage", "sys_title", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceFieldRuleExpressionsUnknownField400() {
+    ContentTypeFieldRuleExpressions body = emptyRuleExpressionsBody();
+    when(adaptor.replaceFieldRuleExpressions(any(), eq("percPage"), eq("nope"), any()))
+        .thenThrow(new IllegalArgumentException("Unknown field: nope"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldRuleExpressions("percPage", "nope", body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void fieldRuleExpressionsJsonSerializesRulesAndSummaries() throws Exception {
+    ContentTypeFieldRuleExpressions env = emptyRuleExpressionsBody();
+    env.setFieldName("sys_title");
+    ContentTypeFieldRule rule = new ContentTypeFieldRule();
+    rule.setType(ContentTypeFieldRule.TYPE_CONDITIONAL);
+    rule.setConditionals(List.of(new ContentTypeFieldConditional("sys_title", "<>", "")));
+    env.setValidation(List.of(rule));
+    env.setValidationExpression("sys_title <> ");
+    env.setDesignGaps(
+        List.of(
+            DesignGap.of(
+                "CT_FIELD_RULE_APPLY_WHEN",
+                "Apply-when on field validation is read-only")));
+
+    ObjectMapper mapper =
+        new JacksonContextResolver().getContext(ContentTypeFieldRuleExpressions.class);
+    String json = mapper.writeValueAsString(env);
+    assertTrue(json.contains("validation"), json);
+    assertTrue(json.contains("sys_title"), json);
+    assertTrue(json.contains("validationExpression"), json);
+    assertTrue(json.contains("CT_FIELD_RULE_APPLY_WHEN"), json);
+  }
+
+  private static ContentTypeFieldRuleExpressions emptyRuleExpressionsBody() {
+    ContentTypeFieldRuleExpressions body = new ContentTypeFieldRuleExpressions();
+    body.setValidation(List.of());
+    body.setVisibility(List.of());
+    body.setInputTranslation(List.of());
+    body.setOutputTranslation(List.of());
+    return body;
+  }
+
+  @Test
   public void unlockContentTypeConflictWhenLockedByOtherUser() {
     when(adaptor.unlockContentType(any(), eq("percPage")))
         .thenThrow(

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -141,4 +141,22 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body) {
     return body;
   }
+
+  @Override
+  public ContentTypeFieldRuleExpressions getFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName) {
+    ContentTypeFieldRuleExpressions out = new ContentTypeFieldRuleExpressions();
+    out.setFieldName(fieldName);
+    out.setValidation(List.of());
+    out.setVisibility(List.of());
+    out.setInputTranslation(List.of());
+    out.setOutputTranslation(List.of());
+    return out;
+  }
+
+  @Override
+  public ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body) {
+    return body;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -25,6 +25,7 @@ import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
+import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
@@ -157,6 +158,24 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeFieldControlProperties replaceFieldControlProperties(
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldControlProperties body) {
+    return body;
+  }
+
+  @Override
+  public ContentTypeFieldRuleExpressions getFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName) {
+    ContentTypeFieldRuleExpressions out = new ContentTypeFieldRuleExpressions();
+    out.setFieldName(fieldName);
+    out.setValidation(List.of());
+    out.setVisibility(List.of());
+    out.setInputTranslation(List.of());
+    out.setOutputTranslation(List.of());
+    return out;
+  }
+
+  @Override
+  public ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
+      URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body) {
     return body;
   }
 }


### PR DESCRIPTION
## Summary

Parent: #1690. Slice: Content Type field rule expressions PUT REST (CD-05–07).

Adds **GET/PUT** `/services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` for field-level **validation**, **visibility**, and **input/output translation** expressions. GET already existed as read-only summaries on content type detail (#2920). PUT requires a **held** design-session lock (`POST .../lock`); **409** without lock or when locked by another user. Unknown field names are rejected (**404** GET, **400** PUT). Empty lists clear. Conditional variable/value are stored as text literals; apply-when on field validation is not written.

Peer of CD-07 `controlProperties` (#3786) and CD-09 `itemExits`. WebUI expression editor, catalog crash #3706, and chrome slices are out of scope.

Fixes #3784

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 605, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1568, Failures: 0, Skipped: 125
3. Mockito resource tests: GET/PUT success, 409 lock, 400 unknown field / missing lists
4. Sitemanage adaptor tests: persist with held lock, cache-miss fallback, 409, unknown field, mapping round-trip (`!=` → `<>`)
5. Integrator (optional live): `POST .../lock` → `PUT .../fields/{field}/ruleExpressions` → `GET` same path → `POST .../unlock`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — behavioral tests; standalone `mvnw clean install` green on `rest` and `projects/sitemanage`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on each changed Maven module; reverse-dep `projects/sitemanage` built after rest (new `IContentTypesAdaptor` methods)
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 605, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1568, Failures: 0, Errors: 0, Skipped: 125
  - No new compiler warnings on changed `ContentTypeAdaptor` helpers (raw `PSCollection` suppressed/typed)
- **downstream_checked:** `projects/sitemanage` standalone clean install (implements `IContentTypesAdaptor`). Grep `implements IContentTypesAdaptor` — rest Spring stubs `TestContentTypeAdaptor` + `ContentTypesTestAdaptor` and sitemanage `ContentTypeAdaptor` all implement `get/replaceFieldRuleExpressions`. No other implementations.

## C5 UI proof

N/A — REST adaptor/resource only; no WebUI chrome.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
