### PR TITLE
feat(webui): Developer Content Type enable/disable chrome (CD-13) (#3781)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -291,25 +291,54 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code enabled} here — use {@link setContentTypeEnabled} (CD-13).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
-  }
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeEnabled}. */
+export const CONTENT_TYPE_ENABLED_ROOT = "ContentTypeEnabled";
+
+/**
+ * Build the wire JSON body for {@code PUT .../enabled} under
+ * {@link CONTENT_TYPE_ENABLED_ROOT}. A flat {@code { enabled }} body fails
+ * server UNWRAP_ROOT_VALUE.
+ */
+export function wrapContentTypeEnabledForWire(
+  enabled: boolean,
+): Record<string, { enabled: boolean }> {
+  return { [CONTENT_TYPE_ENABLED_ROOT]: { enabled } };
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/enabled — CD-13 dedicated enable/disable.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. Response is {@code ContentTypeDetail}
+ * with the new {@code enabled} value (lock still held).
+ */
+export async function setContentTypeEnabled(
+  idOrName: string,
+  enabled: boolean,
+): Promise<ContentTypeDetail> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/enabled`,
+    wrapContentTypeEnabledForWire(enabled),
+  );
+  return unwrapContentTypeDetail(payload);
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -427,6 +427,11 @@ export function ContentTypeDetailPanel({
         }));
 
       let saved: ContentTypeDetail | null = null;
+      // Enabled PUT first so a failed enable/disable cannot leave bulk fields persisted
+      // (CD-13 two-call save; no shared rollback).
+      if (enabledDirty) {
+        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
+      }
       if (otherDirty) {
         const body: ContentTypeUpdateBody = {
           label,
@@ -443,10 +448,15 @@ export function ContentTypeDetailPanel({
         if (templatesDirty) {
           body.allowedTemplates = toRefPayload(templates);
         }
-        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
-      }
-      if (enabledDirty) {
-        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
+        try {
+          saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
+        } catch (bulkErr) {
+          if (saved != null) {
+            setDetail(saved);
+            setEnabled(saved.enabled !== false);
+          }
+          throw bulkErr;
+        }
       }
       if (saved == null) {
         return;

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -20,6 +20,7 @@ import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   getContentTypeDetail,
   lockContentType,
+  setContentTypeEnabled,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -393,6 +394,19 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (detail == null) {
+      return;
+    }
+    const enabledDirty = enabled !== (detail.enabled !== false);
+    const otherDirty =
+      label !== (detail.label || "") ||
+      description !== (detail.description || "") ||
+      fieldsDirty ||
+      workflowsDirty ||
+      templatesDirty;
+    if (!enabledDirty && !otherDirty) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,24 +426,31 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
-      if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+      let saved: ContentTypeDetail | null = null;
+      if (otherDirty) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          fields: fieldPatches,
+        };
+        if (workflowsDirty) {
+          body.allowedWorkflows = toRefPayload(workflows);
+          const def = workflows.find((w) => w.isDefault) || workflows[0];
+          if (def) {
+            body.defaultWorkflow = toRefPayload([def])[0];
+          }
         }
+        if (templatesDirty) {
+          body.allowedTemplates = toRefPayload(templates);
+        }
+        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       }
-      if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+      if (enabledDirty) {
+        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
       }
-
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
+      if (saved == null) {
+        return;
+      }
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
@@ -490,7 +511,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>
@@ -525,6 +546,7 @@ export function ContentTypeDetailPanel({
                 <input
                   type="checkbox"
                   data-testid="developer-ct-enabled"
+                  aria-label={DEV_MSG.CT_FORM_ENABLED}
                   checked={enabled}
                   onChange={() => setEnabled((v) => !v)}
                   disabled={!canEdit}

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  setContentTypeEnabled,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapContentTypeEnabledForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -270,7 +270,7 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("updateContentTypeDetail PUT without lock wrap", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +289,81 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("PUTs save only — lock chrome owns lock/unlock (#3781)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toMatch(/\/enabled$/);
+    expect(JSON.parse(String(init.body))).toEqual(
+      wrapContentTypeDetailForWire({ description: "updated" }),
+    );
+  });
+});
+
+describe("setContentTypeEnabled CD-13 dedicated PUT (#3781)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("wraps enabled under ContentTypeEnabled", () => {
+    expect(wrapContentTypeEnabledForWire(false)).toEqual({
+      ContentTypeEnabled: { enabled: false },
+    });
+    expect(wrapContentTypeEnabledForWire(true)).toEqual({
+      ContentTypeEnabled: { enabled: true },
+    });
+  });
+
+  it("PUTs /contenttypes/{id}/enabled without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", enabled: false },
+      }),
+    );
+
+    const saved = await setContentTypeEnabled("percPage", false);
+    expect(saved.enabled).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/enabled`,
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeEnabled: { enabled: false },
+    });
+  });
+
+  it("encodes idOrName on the enabled path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ ContentTypeDetail: { name: "perc Page", enabled: true } }),
+    );
+    await setContentTypeEnabled("perc Page", true);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/${encodeURIComponent("perc Page")}/enabled`,
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -13,6 +13,7 @@ import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDe
 vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   getContentTypeDetail: vi.fn(),
   updateContentTypeDetail: vi.fn(),
+  setContentTypeEnabled: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
 }));
@@ -36,6 +37,7 @@ const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<
 const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as ReturnType<
   typeof vi.fn
 >;
+const setContentTypeEnabled = contentTypesApi.setContentTypeEnabled as ReturnType<typeof vi.fn>;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
 const unlockContentType = contentTypesApi.unlockContentType as ReturnType<typeof vi.fn>;
 
@@ -60,6 +62,7 @@ describe("ContentTypeDetailPanel", () => {
     };
     getContentTypeDetail.mockReset();
     updateContentTypeDetail.mockReset();
+    setContentTypeEnabled.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
@@ -67,6 +70,10 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
+    }));
+    setContentTypeEnabled.mockImplementation(async (_id, enabled: boolean) => ({
+      ...sampleDetail,
+      enabled,
     }));
   });
 
@@ -78,6 +85,7 @@ describe("ContentTypeDetailPanel", () => {
       expect(screen.getByTestId("developer-ct-detail-title")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-detail-title").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
     expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
@@ -347,6 +355,11 @@ describe("ContentTypeDetailPanel", () => {
       "percPage",
       expect.objectContaining({ description: "Updated description" }),
     );
+    const saveBody = updateContentTypeDetail.mock.calls.at(-1)?.[1] as {
+      enabled?: boolean;
+    };
+    expect(saveBody.enabled).toBeUndefined();
+    expect(setContentTypeEnabled).not.toHaveBeenCalled();
     expect(unlockContentType).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
@@ -428,5 +441,107 @@ describe("ContentTypeDetailPanel", () => {
       expect(unlockContentType).toHaveBeenCalledWith("percPage");
     });
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("keeps the enabled toggle disabled until lock (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-enabled")).toBeTruthy();
+    });
+    const box = screen.getByTestId("developer-ct-enabled") as HTMLInputElement;
+    expect(box.disabled).toBe(true);
+    expect(box.checked).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(setContentTypeEnabled).not.toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+  });
+
+  it("saves enabled via dedicated PUT after lock (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    });
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(unlockContentType).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("saves description with bulk PUT then enabled with dedicated PUT (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    });
+    expect(updateContentTypeDetail).toHaveBeenCalledWith(
+      "percPage",
+      expect.objectContaining({ description: "Updated description" }),
+    );
+    const saveBody = updateContentTypeDetail.mock.calls.at(-1)?.[1] as {
+      enabled?: boolean;
+    };
+    expect(saveBody.enabled).toBeUndefined();
+    expect(updateContentTypeDetail.mock.invocationCallOrder[0]).toBeLessThan(
+      setContentTypeEnabled.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("clears the held lock when enabled PUT returns 409 (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    setContentTypeEnabled.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -484,7 +484,7 @@ describe("ContentTypeDetailPanel", () => {
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
   });
 
-  it("saves description with bulk PUT then enabled with dedicated PUT (#3781)", async () => {
+  it("saves enabled with dedicated PUT first then description with bulk PUT (#3781)", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
@@ -512,8 +512,74 @@ describe("ContentTypeDetailPanel", () => {
       enabled?: boolean;
     };
     expect(saveBody.enabled).toBeUndefined();
-    expect(updateContentTypeDetail.mock.invocationCallOrder[0]).toBeLessThan(
-      setContentTypeEnabled.mock.invocationCallOrder[0],
+    expect(setContentTypeEnabled.mock.invocationCallOrder[0]).toBeLessThan(
+      updateContentTypeDetail.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not bulk PUT when enabled PUT fails (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    setContentTypeEnabled.mockRejectedValueOnce({
+      status: 500,
+      statusText: "Error",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(setContentTypeEnabled).toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+  });
+
+  it("keeps enabled from dedicated PUT when bulk PUT fails (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    updateContentTypeDetail.mockRejectedValueOnce({
+      status: 500,
+      statusText: "Error",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    expect(updateContentTypeDetail).toHaveBeenCalled();
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).value).toBe(
+      "Updated description",
     );
   });
 

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -96,6 +96,18 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
     allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
+    setContentTypeEnabled: vi.fn().mockImplementation(async (_id, enabled: boolean) => ({
+      name: "percPage",
+      label: "Page",
+      description: "A page",
+      enabled,
+      guid: { stringValue: "0-2-301", uuid: 301 },
+      fields: [],
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", label: "Simple Workflow", isDefault: true },
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+      designGaps: [],
+    })),
     lockContentType: vi.fn().mockResolvedValue({ locker: "Admin", remainingTime: 30 }),
     unlockContentType: vi.fn().mockResolvedValue(undefined),
   };
@@ -781,9 +793,10 @@ it("loads views catalog section", async () => {
         expect.objectContaining({ name: "page_title", searchable: true }),
       ]),
     );
-    // Field-only save must not wipe associations
+    // Field-only save must not wipe associations or bulk-PUT enabled (CD-13)
     expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toBeUndefined();
+    expect(body.enabled).toBeUndefined();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });

--- a/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review — issue #3781 Developer Content Type enable/disable chrome (CD-13)
+
+**Scope:** uncommitted work on `feat/issue-3781-ct-enable-disable-chrome-2` vs `origin/main`.
+**Change class:** WebUI product screen (Developer Content Type detail) consuming existing REST CD-13 `PUT /services/contenttypes/{idOrName}/enabled`.
+**Memory patterns hit:** incomplete change-class closure (Playwright + product-docs); behavioral tests for new helpers; URL `/` paths are URI not filesystem (false-positive guard).
+
+## Summary
+
+The SPA already showed an Enabled checkbox on Content Type detail but saved it on the bulk `PUT /contenttypes/{id}` and `updateContentTypeDetail` still wrapped lock → PUT → unlock (leftover from before lock chrome). Live H2 QA showed dedicated PUT `ContentTypeEnabled.enabled=false` returning `enabled:true` because design save always passed `enable=true` and item-def load never copied the application flag. This change:
+
+1. Adds `setContentTypeEnabled` + `wrapContentTypeEnabledForWire` (`ContentTypeEnabled` Jackson root).
+2. Saves enabled only via dedicated PUT after a held lock; bulk PUT omits `enabled`.
+3. Stops wrapping lock/unlock on bulk PUT so save keeps the design lock.
+4. Design save passes `PSItemDefinition.isEnabled()` into `saveContentType` (CD-13 persist).
+5. `loadItemDef` copies `ceApp.isEnabled()`; adaptor GET falls back to object-store after cache miss.
+6. Extends Vitest, Playwright lock-save spec (fail closed, GET persist), and product-docs.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Combined save (bulk then enabled PUT) can leave a partial write if the dedicated PUT fails after a successful bulk save. Chrome already surfaces the error; lock is cleared on 409. Acceptable for this slice.
+- Playwright enable test restores the flag in `finally` so a failed assert does not leave `percPage` disabled on a shared H2 QA cell.
+
+## Cross-platform path checklist
+
+- No new filesystem path joins (`/` or `\\`).
+- New URLs use `/` for REST paths (correct).
+- Tests use `encodeURIComponent` for idOrName; Playwright GET uses `BASE_URL` + `/Rhythmyx/services/...` (URI).
+- No temp-dir or line-ending assertions.
+
+## Companions
+
+| Companion | Status |
+|-----------|--------|
+| Vitest API helper (`setContentTypeEnabled`, wrap, no lock wrap on bulk PUT) | yes |
+| Vitest panel: disabled until lock, dedicated PUT, combined save order, 409 | yes |
+| Playwright surface spec extended; empty catalog fails closed | yes |
+| `product-docs/8.2/admin/developer-content-types.md` + rest note | yes |
+| REST / sitemanage re-implement | out of scope (CD-13 already shipped) |
+
+## Tests
+
+- `WebUI/src/test/ts/api/developer/contentTypesApi.test.ts`
+- `WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx`
+- `WebUI/src/test/ts/developer/DeveloperShell.test.tsx` (bulk body omits enabled)
+- `modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js`

--- a/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
@@ -29,8 +29,38 @@ None (hard-gate).
 
 ### Notes (non-blocking)
 
-- Combined save (bulk then enabled PUT) can leave a partial write if the dedicated PUT fails after a successful bulk save. Chrome already surfaces the error; lock is cleared on 409. Acceptable for this slice.
+- Combined save (enabled PUT first, then bulk) can still leave enabled persisted if bulk then fails. Chrome surfaces the error, keeps the description draft, and syncs the Enabled checkbox from the dedicated PUT. No shared rollback.
 - Playwright enable test restores the flag in `finally` so a failed assert does not leave `percPage` disabled on a shared H2 QA cell.
+
+## Re-review (PR #3828 Kilo threads)
+
+**Scope:** uncommitted review-response vs `HEAD` on `feat/issue-3781-ct-enable-disable-chrome-2`.
+**Change class:** same CD-13 chrome; review-thread mitigations only.
+**Memory patterns hit:** behavioral tests for new/changed non-trivial logic; swallowed exceptions must log.
+
+### Summary
+
+Kilo threads on PR #3828:
+1. Object-store fallback on `resolveItemDef` is now opt-in (`includeDisabledFromStore`). Only GET detail and `setContentTypeEnabled` pass `true`. Templates / item exits / control properties keep cache-only 404.
+2. Combined save runs enabled PUT first so a failed enable cannot leave bulk fields persisted. Bulk failure after enabled success syncs the checkbox from the dedicated PUT and keeps local drafts.
+3. `loadItemDefFromObjectStore` debug log includes exception class, message, and throwable stack.
+
+### Recommendation
+
+approve
+
+### Gate
+
+May commit/push: yes
+
+### Issues
+
+None (hard-gate).
+
+### Cross-platform path checklist
+
+- No new filesystem path joins.
+- No temp-dir or line-ending assertions.
 
 ## Cross-platform path checklist
 

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
@@ -15,9 +15,11 @@
  */
 
 /**
- * Developer Content Type detail lock / save / unlock chrome (#3744 / #3772 / parent #1690).
+ * Developer Content Type detail lock / save / unlock / enable chrome
+ * (#3744 / #3772 / #3781 CD-13 / parent #1690).
  *
- * Admin locks a type, saves a description, then unlocks. Surface-filtered QA:
+ * Admin locks a type, saves a description, toggles enabled via dedicated PUT,
+ * then unlocks. Surface-filtered QA:
  * <pre>
  *   perc-devctl qa-up
  *   cd modules/perc-qa-automation/frontend
@@ -42,7 +44,81 @@ function developerContentTypesUrl() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
 }
 
-test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
+function unwrapEnabled(payload) {
+  if (payload == null || typeof payload !== "object") {
+    return undefined;
+  }
+  const nested =
+    payload.ContentTypeDetail && typeof payload.ContentTypeDetail === "object"
+      ? payload.ContentTypeDetail
+      : payload.contentTypeDetail && typeof payload.contentTypeDetail === "object"
+        ? payload.contentTypeDetail
+        : payload;
+  return nested.enabled;
+}
+
+async function openContentTypeDetail(page, namePattern) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    throw new Error(
+      "No content types in catalog — fail closed (H2 QA must include sample types)",
+    );
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
+    hasText: namePattern || /percPage/,
+  });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(
+      `Content type detail error: ${(await detailError.innerText()).trim()}`,
+    );
+  }
+  return detail;
+}
+
+async function getContentTypeEnabled(page, idOrName) {
+  const res = await page.request.get(
+    `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(idOrName)}`,
+  );
+  expect(res.ok(), `GET content type HTTP ${res.status()}`).toBe(true);
+  return unwrapEnabled(await res.json());
+}
+
+test.describe("Developer content type lock/save chrome (#3744 / #3772 / #3781)", () => {
   test("Admin can lock, save a description, and unlock", async ({ page }) => {
     test.setTimeout(120_000);
     const pageErrors = [];
@@ -57,55 +133,10 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     });
 
     await loginAsAdmin(page);
-    await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
-
-    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
-      timeout: 20_000,
-    });
-
-    const panel = page.locator('[data-testid="developer-ct-panel"]');
-    const empty = page.locator('[data-testid="developer-ct-empty"]');
-    const listError = page.locator('[data-testid="developer-ct-error"]');
-    await expect(panel.or(empty).or(listError).first()).toBeVisible({
-      timeout: 30_000,
-    });
-
-    if (await listError.isVisible()) {
-      throw new Error(
-        `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
-      );
-    }
-    if (await empty.isVisible()) {
-      test.skip(true, "No content types in catalog — cannot exercise lock/save");
-    }
-
-    const table = page.locator('[data-testid="developer-ct-table"]');
-    await expect(table).toBeVisible({ timeout: 15_000 });
-    const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
-      hasText: /percPage/,
-    });
-    const targetRow =
-      (await named.count()) > 0
-        ? named.first()
-        : page.locator(catalogRowSelector("developer-ct-row", 0));
-    await expect(targetRow).toBeVisible();
-    const openBtn = targetRow.locator('button[aria-label^="Open "]');
-    if (await openBtn.count()) {
-      await openBtn.click();
-    } else {
-      await targetRow.click();
-    }
-
-    const detail = page.locator('[data-testid="developer-ct-detail"]');
-    const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
-    await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
-    if (await detailError.isVisible()) {
-      throw new Error(
-        `Content type detail error: ${(await detailError.innerText()).trim()}`,
-      );
-    }
+    await openContentTypeDetail(page);
 
     const desc = page.locator('[data-testid="developer-ct-description"]');
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
     const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
     const saveBtn = page.locator('[data-testid="developer-ct-save"]');
     const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
@@ -116,11 +147,13 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     await expect(saveBtn).toBeDisabled();
     await expect(unlockBtn).toBeDisabled();
     await expect(desc).toBeDisabled();
+    await expect(enabledBox).toBeDisabled();
     await expect(status).toHaveText(/Not locked/i);
 
     await lockBtn.click();
     await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
     await expect(desc).toBeEnabled();
+    await expect(enabledBox).toBeEnabled();
     await expect(unlockBtn).toBeEnabled();
 
     const original = (await desc.inputValue()).replace(MARKER, "");
@@ -146,6 +179,7 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     await unlockBtn.click();
     await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
     await expect(desc).toBeDisabled();
+    await expect(enabledBox).toBeDisabled();
     await expect(saveBtn).toBeDisabled();
     await expect(lockBtn).toBeEnabled();
 
@@ -157,5 +191,156 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
       unexpectedConsole,
       `console error: ${unexpectedConsole.join(" | ")}`,
     ).toEqual([]);
+  });
+
+  test("Admin lock then toggle enabled persists on GET (#3781 CD-13)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(
+      page,
+      /percFileAsset|percSimpleTextAsset|percRawHtmlAsset/,
+    );
+
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    await expect(enabledBox).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+
+    await lockBtn.click();
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(enabledBox).toBeEnabled();
+
+    const originalEnabled = await enabledBox.isChecked();
+    const typeName = (
+      await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
+    ).trim();
+    expect(typeName.length, "detail name for GET").toBeGreaterThan(0);
+
+    const saveEnabled = async (label) => {
+      const enabledResp = page.waitForResponse(
+        (res) =>
+          res.request().method() === "PUT" &&
+          /\/contenttypes\/[^/?]+\/enabled(?:\?|$)/.test(res.url()),
+        { timeout: 20_000 },
+      );
+      await expect(saveBtn).toBeEnabled();
+      await saveBtn.click();
+      const resp = await enabledResp;
+      const reqBody = resp.request().postData() || "";
+      let putEnabled;
+      let putBody = "";
+      try {
+        const putJson = await resp.json();
+        putEnabled = unwrapEnabled(putJson);
+        putBody = `req=${reqBody} respEnabled=${putEnabled}`;
+      } catch (e) {
+        putBody = `non-json ${resp.status()} req=${reqBody} ${(e && e.message) || e}`;
+      }
+      await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+      if (await saveError.isVisible()) {
+        throw new Error(
+          `${label}: ${(await saveError.innerText()).trim()} PUT ${resp.status()} ${putBody}`,
+        );
+      }
+      await expect(notice).toContainText(/saved/i);
+      return { status: resp.status(), putBody };
+    };
+
+    try {
+      await enabledBox.click();
+      expect(await enabledBox.isChecked()).toBe(!originalEnabled);
+      const putResult = await saveEnabled("Enable save failed");
+      const getRes = await page.request.get(
+        `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}`,
+      );
+      const getJson = await getRes.json();
+      const afterToggle = unwrapEnabled(getJson);
+      expect(putResult.status, putResult.putBody).toBe(200);
+      expect(putResult.putBody).toContain("ContentTypeEnabled");
+      expect(
+        afterToggle,
+        `GET enabled after toggle ${putResult.putBody} getEnabled=${afterToggle}`,
+      ).toBe(!originalEnabled);
+
+      await enabledBox.click();
+      await saveEnabled("Enable restore failed");
+      const restored = await getContentTypeEnabled(page, typeName);
+      expect(restored, "GET enabled after restore").toBe(originalEnabled);
+    } finally {
+      if (await enabledBox.isEnabled()) {
+        if ((await enabledBox.isChecked()) !== originalEnabled) {
+          await enabledBox.click();
+          try {
+            await saveEnabled("Enable finally restore failed");
+          } catch {
+            // Best-effort restore so a failed assert does not leave the type disabled.
+          }
+        }
+        if (await unlockBtn.isEnabled()) {
+          await unlockBtn.click();
+          await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+        }
+      }
+    }
+
+    await expect(enabledBox).toBeDisabled();
+
+    expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+    const unexpectedConsole = consoleErrors.filter(
+      (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+    );
+    expect(
+      unexpectedConsole,
+      `console error: ${unexpectedConsole.join(" | ")}`,
+    ).toEqual([]);
+  });
+
+  test("other-user lock is 409; enabled toggle stays disabled (#3781)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page);
+
+    await page.route("**/services/contenttypes/**/lock", async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Locked by another user" }),
+      });
+    });
+
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+
+    await expect(enabledBox).toBeDisabled();
+    await lockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-detail-error"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(status).toHaveText(/Not locked/i);
+    await expect(enabledBox).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
   });
 });

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, save, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, save, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -35,14 +35,32 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).
-6. Change the **Description** (and any other unlocked fields), then click
-   **Save content type**. Save writes while the lock is still held. It does
-   **not** unlock.
+6. Change the **Description**, **Enabled** checkbox, and any other unlocked
+   fields, then click **Save content type**. Save writes while the lock is still
+   held. It does **not** unlock. **Enabled** is written with a dedicated
+   `PUT /services/contenttypes/{idOrName}/enabled` (CD-13), not the bulk
+   content-type save. Without a lock the checkbox stays disabled and a toggle
+   cannot persist.
 7. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.
+
+## Enable or disable a content type
+
+The **Enabled** checkbox on Developer Content Type detail controls whether the
+type is available for runtime use.
+
+1. Hold the design-session **Lock**. The checkbox is read-only until you do.
+2. Toggle **Enabled**, then **Save content type**. The SPA calls
+   `PUT /services/contenttypes/{idOrName}/enabled` (Jackson root
+   `ContentTypeEnabled`) while the lock is still held.
+3. A following `GET /services/contenttypes/{idOrName}` reflects the new
+   `enabled` value.
+4. If another user already holds the lock, **Lock** returns **409**. The
+   product does **not** steal the lock, Save stays disabled, and **Enabled**
+   remains read-only.
 
 ## REST
 
@@ -51,7 +69,8 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, associations) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`) |
+| Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -205,7 +205,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types).
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT).
 
 Lock / save / unlock status codes:
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -27,6 +27,7 @@ import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorPipe;
+import com.percussion.design.objectstore.PSContentTypeHelper;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
@@ -259,24 +260,52 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private PSItemDefinition resolveItemDef(String idOrName) throws PSInvalidContentTypeException {
-    // Prefer numeric uuid
-    if (StringUtils.isNumeric(idOrName)) {
-      long uuid = Long.parseLong(idOrName);
-      return itemDefManager.getItemDef(uuid, PSItemDefManager.COMMUNITY_ANY);
-    }
-    // Guid string forms: 0-2-301 or 0-301
-    if (idOrName.contains("-")) {
-      try {
-        PSGuid g = new PSGuid(idOrName);
-        if (g.getType() == 0) {
-          g = new PSGuid(PSTypeEnum.NODEDEF, g.getUUID());
-        }
-        return itemDefManager.getItemDef(g.getUUID(), PSItemDefManager.COMMUNITY_ANY);
-      } catch (Exception ignore) {
-        // fall through to name
+    try {
+      // Prefer numeric uuid
+      if (StringUtils.isNumeric(idOrName)) {
+        long uuid = Long.parseLong(idOrName);
+        return itemDefManager.getItemDef(uuid, PSItemDefManager.COMMUNITY_ANY);
       }
+      // Guid string forms: 0-2-301 or 0-301
+      if (idOrName.contains("-")) {
+        try {
+          PSGuid g = new PSGuid(idOrName);
+          if (g.getType() == 0) {
+            g = new PSGuid(PSTypeEnum.NODEDEF, g.getUUID());
+          }
+          return itemDefManager.getItemDef(g.getUUID(), PSItemDefManager.COMMUNITY_ANY);
+        } catch (PSInvalidContentTypeException e) {
+          throw e;
+        } catch (Exception ignore) {
+          // fall through to name
+        }
+      }
+      return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
+    } catch (PSInvalidContentTypeException e) {
+      PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
+      if (fromStore != null) {
+        return fromStore;
+      }
+      throw e;
     }
-    return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
+  }
+
+  /**
+   * Object-store load when the item-def cache no longer has a running editor
+   * (disabled content types unregister). Used so GET {@code enabled} still
+   * reflects the saved application flag (CD-13).
+   */
+  private PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
+    try {
+      IPSGuid guid = resolveExistingContentTypeGuid(idOrName);
+      if (guid == null) {
+        return null;
+      }
+      return PSContentTypeHelper.loadItemDef(guid);
+    } catch (Exception e) {
+      log.debug("Object-store content type load after cache miss {}: {}", idOrName, e.getMessage());
+      return null;
+    }
   }
 
   private ContentTypeDetail toDetail(PSItemDefinition def) {
@@ -547,8 +576,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         log.error("Failed to save content type enabled flag {}: {}", idOrName, e.getMessage(), e);
         throw new IllegalStateException("Failed to save content type enabled flag", e);
       }
-      PSItemDefinition reloaded = resolveItemDef(trimmed);
-      return reloaded != null ? toDetail(reloaded) : toDetail(def);
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      if (reloaded != null && reloaded != def) {
+        reloaded.setEnabled(enabled);
+        return toDetail(reloaded);
+      }
+      return toDetail(def);
     } catch (ContentTypeDesignLockException
         | IllegalArgumentException
         | WebApplicationException e) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -244,7 +244,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       return null;
     }
     try {
-      PSItemDefinition def = resolveItemDef(idOrName.trim());
+      PSItemDefinition def = resolveItemDef(idOrName.trim(), true);
       if (def == null) {
         return null;
       }
@@ -260,6 +260,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private PSItemDefinition resolveItemDef(String idOrName) throws PSInvalidContentTypeException {
+    return resolveItemDef(idOrName, false);
+  }
+
+  /**
+   * Resolve a content type from the running item-def cache.
+   *
+   * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
+   *     object store so disabled types (unregistered from the editor cache) still load.
+   *     Only GET detail and enable/disable (CD-13) pass {@code true}; other callers keep
+   *     the pre-CD-13 cache-only 404 for disabled types.
+   */
+  private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
+      throws PSInvalidContentTypeException {
     try {
       // Prefer numeric uuid
       if (StringUtils.isNumeric(idOrName)) {
@@ -282,9 +295,11 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
       return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
     } catch (PSInvalidContentTypeException e) {
-      PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
-      if (fromStore != null) {
-        return fromStore;
+      if (includeDisabledFromStore) {
+        PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
+        if (fromStore != null) {
+          return fromStore;
+        }
       }
       throw e;
     }
@@ -293,9 +308,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   /**
    * Object-store load when the item-def cache no longer has a running editor
    * (disabled content types unregister). Used so GET {@code enabled} still
-   * reflects the saved application flag (CD-13).
+   * reflects the saved application flag (CD-13). Package-visible for tests.
    */
-  private PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
+  PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
     try {
       IPSGuid guid = resolveExistingContentTypeGuid(idOrName);
       if (guid == null) {
@@ -303,7 +318,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
       return PSContentTypeHelper.loadItemDef(guid);
     } catch (Exception e) {
-      log.debug("Object-store content type load after cache miss {}: {}", idOrName, e.getMessage());
+      log.debug(
+          "Object-store content type load after cache miss {}: {}: {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
       return null;
     }
   }
@@ -548,7 +568,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     String session = currentSession();
     String user = currentUser();
     try {
-      PSItemDefinition current = resolveItemDef(trimmed);
+      PSItemDefinition current = resolveItemDef(trimmed, true);
       if (current == null) {
         return null;
       }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
@@ -27,9 +27,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -112,6 +114,28 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getAllowedTemplates(null, "missing"));
+  }
+
+  @Test
+  void getAllowedTemplates_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getAllowedTemplates(null, "311"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
+  }
+
+  @Test
+  void replaceAllowedTemplates_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    NamedObjectRef ref = new NamedObjectRef();
+    ref.setName("perc.page");
+    assertNull(spy.replaceAllowedTemplates(null, "311", List.of(ref)));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
@@ -25,8 +25,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -221,6 +223,16 @@ class ContentTypeAdaptorControlPropertiesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getFieldControlProperties(null, "missing", "sys_title"));
+  }
+
+  @Test
+  void get_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(mock(PSItemDefinition.class)).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getFieldControlProperties(null, "311", "sys_title"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorEnabledTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorEnabledTest.java
@@ -26,8 +26,10 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -198,6 +200,38 @@ class ContentTypeAdaptorEnabledTest {
     verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
   }
 
+  @Test
+  void get_cacheMiss_usesObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeDetail get = spy.getContentType(null, "311");
+
+    assertEquals(Boolean.FALSE, get.getEnabled());
+    verify(spy).loadItemDefFromObjectStore("311");
+  }
+
+  @Test
+  void enable_cacheMiss_usesObjectStoreFallback() throws Exception {
+    stubHeldLock();
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(storeDef));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeDetail out = spy.setContentTypeEnabled(null, "311", true);
+
+    assertEquals(Boolean.TRUE, out.getEnabled());
+    verify(spy).loadItemDefFromObjectStore("311");
+    verify(storeDef).setEnabled(true);
+  }
+
   private void stubHeldLock() throws Exception {
     PSObjectSummary held = new PSObjectSummary(guid, "percPage");
     held.setLockedInfo("test-session", "Admin", 30);
@@ -205,6 +239,14 @@ class ContentTypeAdaptorEnabledTest {
   }
 
   private PSItemDefinition stubDefinition(boolean initiallyEnabled) throws Exception {
+    PSItemDefinition def = stubStoreDefinition(initiallyEnabled);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+
+  private PSItemDefinition stubStoreDefinition(boolean initiallyEnabled) {
     PSItemDefinition def = mock(PSItemDefinition.class);
     when(def.getName()).thenReturn("percPage");
     when(def.getLabel()).thenReturn("Page");
@@ -223,9 +265,6 @@ class ContentTypeAdaptorEnabledTest {
             })
         .when(def)
         .setEnabled(anyBoolean());
-    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
-    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
-        .thenReturn(List.of(def));
     return def;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
@@ -26,8 +26,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -147,6 +149,16 @@ class ContentTypeAdaptorItemExitsTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getItemExits(null, "missing"));
+  }
+
+  @Test
+  void getItemExits_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getItemExits(null, "311"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
@@ -749,6 +749,7 @@ public class PSContentTypeHelper {
             nodeDef.getHideFromMenu(),
             nodeDef.getObjectType());
     PSItemDefinition itemDef = new PSItemDefinition(appName, contentType, ce);
+    itemDef.setEnabled(ceApp.isEnabled());
 
     return itemDef;
   }

--- a/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsSaveEnabledTest.java
+++ b/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsSaveEnabledTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webservices.content.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-13: design save must pass {@link PSItemDefinition#isEnabled()} into the application save, not
+ * a hardcoded {@code true}.
+ */
+class PSContentDesignWsSaveEnabledTest {
+
+  @Test
+  void contentTypeSaveAppEnabledFollowsItemDef() {
+    PSItemDefinition enabled = mock(PSItemDefinition.class);
+    when(enabled.isEnabled()).thenReturn(true);
+    assertTrue(PSContentDesignWs.contentTypeSaveAppEnabled(enabled));
+
+    PSItemDefinition disabled = mock(PSItemDefinition.class);
+    when(disabled.isEnabled()).thenReturn(false);
+    assertFalse(PSContentDesignWs.contentTypeSaveAppEnabled(disabled));
+  }
+
+  @Test
+  void contentTypeSaveAppEnabledNullIsFalse() {
+    assertFalse(PSContentDesignWs.contentTypeSaveAppEnabled(null));
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
@@ -1653,8 +1653,8 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                         lockService);
                   }
 
-                  PSContentTypeHelper.saveContentType(def, null, version,
-                     listener, true);
+                  PSContentTypeHelper.saveContentType(
+                      def, null, version, listener, contentTypeSaveAppEnabled(def));
 
                   if (listener != null)
                   {
@@ -1739,6 +1739,18 @@ public class PSContentDesignWs extends PSContentBaseWs implements
     */
    static IPSGuid contentTypeLockObjectId(long typeId) {
       return new PSDesignGuid(PSTypeEnum.NODEDEF, typeId);
+   }
+
+   /**
+    * Application {@code enabled} flag written by content-type design save (CD-13).
+    *
+    * <p>{@link PSContentTypeHelper#saveContentType} starts or stops the editor
+    * application from this boolean. A hardcoded {@code true} ignored
+    * {@link PSItemDefinition#isEnabled()} so {@code PUT .../enabled} never
+    * persisted.
+    */
+   static boolean contentTypeSaveAppEnabled(PSItemDefinition def) {
+      return def != null && def.isEnabled();
    }
 
    // @see IPSContentDesignWs#saveKeywords(List, boolean, String, String)


### PR DESCRIPTION
## Summary

Developer Content Type enable/disable chrome (CD-13) for parent **#1690**. The SPA now calls dedicated `PUT /services/contenttypes/{idOrName}/enabled` after a held design-session lock (Jackson root `ContentTypeEnabled`). Bulk `PUT /contenttypes/{id}` no longer sends `enabled` and no longer wraps lock→save→unlock.

Live H2 QA showed the dedicated PUT was already correct (`{"ContentTypeEnabled":{"enabled":false}}`) but GET stayed `true` because design save always passed `enable=true` and item-def load never copied the application flag. This PR also persists `PSItemDefinition.isEnabled()` on save and loads it on GET (object-store fallback after cache miss).

Fixes #3781
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `perc-devctl qa-up` (H2 Docker) → `qa-health`.
2. Sign in as Admin → Developer → Content types → open a type (Playwright uses percFileAsset when present).
3. Enabled checkbox is disabled until Lock.
4. Lock → toggle Enabled → Save content type. Network shows `PUT .../enabled`. GET `/services/contenttypes/{name}` matches. Unlock. Other-user lock is 409; no steal.
5. Vitest: `contentTypesApi.test.ts`, `ContentTypeDetailPanel.test.tsx`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-content-types.md` (enable/disable after lock; dedicated PUT) and `product-docs/8.2/developer/rest.md` (SPA consumes dedicated PUT)
- [x] **Unit / module tests** — Vitest API + panel; `PSContentDesignWsSaveEnabledTest`; sitemanage `ContentTypeAdaptorEnabledTest`
- [x] **WebUI + Playwright** — `developer-content-type-lock-save.spec.js` (3 passed, fail closed, GET persist)
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — REST URL `/` only; no filesystem path joins

### C3 evidence

- **modules_built:** WebUI, system, projects/sitemanage, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3082 passed
  - `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1550, Failures: 0
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; no Java tests)
- **downstream_checked:** sitemanage standalone clean install against the new perc-system SNAPSHOT. No public type made final/sealed; no public method signature change. C2 grep not required beyond the reverse-dep install.

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → TEST_CMS_URL=http://127.0.0.1:9993 CONTAINER=perc-matrix-cms-h2
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/login` RESULT:OK HTTP:200 HEALTH:healthy
- Hot-copy: WebUI `cm/modern/assets`; `rest-8.2.0-SNAPSHOT.jar` (m2, CD-13); then after persist fix `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; StopJetty/StartJetty inside cell; `qa-health` again RESULT:OK
- Playwright: `npm run test:surface -- --path tests/developer-content-type-lock-save.spec.js` — **3 passed** (lock/save, enable GET persist, 409 no steal)
- console-clean=yes (pageerror/console error assertions empty)
- server.log-clean=yes (no content-type enable ERROR/FATAL in test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
