### PR TITLE
feat(WebUI): Developer Content Type allowed-workflow chrome (CD-08) (#3782)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -216,11 +216,17 @@ export type ContentTypeUpdateBody = {
   description?: string;
   enabled?: boolean;
   fields?: Pick<ContentTypeFieldSummary, "name" | "searchable" | "required" | "occurrence">[];
-  /** Omit to leave unchanged; non-null list is a full replace. */
+  /** Omit to leave unchanged; non-null list is a full replace. Prefer CD-08 PUT. */
   allowedWorkflows?: NamedObjectRef[];
   defaultWorkflow?: NamedObjectRef | null;
   /** Omit to leave unchanged; non-null list is a full replace. */
   allowedTemplates?: NamedObjectRef[];
+};
+
+/** Wire body for {@code PUT .../allowedWorkflows} (Jackson root {@code ContentTypeWorkflows}). */
+export type ContentTypeWorkflowsBody = {
+  allowedWorkflows: NamedObjectRef[];
+  defaultWorkflow?: NamedObjectRef | null;
 };
 
 /** Wire shape for {@code POST .../lock} ({@code ObjectLockSummary}). */
@@ -291,25 +297,55 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code allowedWorkflows} here — use
+ * {@link setContentTypeAllowedWorkflows} (CD-08).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
-  }
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeWorkflows}. */
+export const CONTENT_TYPE_WORKFLOWS_ROOT = "ContentTypeWorkflows";
+
+/**
+ * Build the wire JSON body for {@code PUT .../allowedWorkflows} under
+ * {@link CONTENT_TYPE_WORKFLOWS_ROOT}. A flat body fails server UNWRAP_ROOT_VALUE.
+ */
+export function wrapContentTypeWorkflowsForWire(
+  body: ContentTypeWorkflowsBody,
+): Record<string, ContentTypeWorkflowsBody> {
+  return { [CONTENT_TYPE_WORKFLOWS_ROOT]: body };
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/allowedWorkflows — CD-08 dedicated replace.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. Empty {@code allowedWorkflows}
+ * clears associations. Response is {@code ContentTypeDetail} with the new set
+ * (lock still held).
+ */
+export async function setContentTypeAllowedWorkflows(
+  idOrName: string,
+  body: ContentTypeWorkflowsBody,
+): Promise<ContentTypeDetail> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/allowedWorkflows`,
+    wrapContentTypeWorkflowsForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -20,6 +20,7 @@ import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   getContentTypeDetail,
   lockContentType,
+  setContentTypeAllowedWorkflows,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -35,6 +36,13 @@ import type {
   ContentTypeFieldSummary,
   NamedObjectRef,
 } from "../api/developer/types";
+import {
+  buildAllowedWorkflowsReplaceBody,
+  cloneNamedObjectRefs,
+  namedObjectRefsEqual,
+  toNamedObjectRefPayload,
+  withDefaultWorkflowFlags,
+} from "./contentTypeWorkflows";
 import {
   designGapCode,
   designGapKey,
@@ -88,15 +96,6 @@ function toDrafts(fields: unknown): Record<string, FieldDraft> {
   return out;
 }
 
-function cloneRefs(list: unknown): NamedObjectRef[] {
-  return normalizeNamedObjectRefs(list).map((r) => ({
-    name: r.name,
-    label: r.label,
-    isDefault: r.isDefault,
-    guid: r.guid ? { ...r.guid } : undefined,
-  }));
-}
-
 function contentTypeFields(detail: ContentTypeDetail | null | undefined): ContentTypeFieldSummary[] {
   return normalizeContentTypeFields(detail?.fields);
 }
@@ -129,49 +128,6 @@ function refKey(r: NamedObjectRef, index: number): string {
 
 /** Canonical Percussion GUID shape: type-host-uuid (three numeric groups). */
 const PERC_GUID_RE = /^\d+-\d+-\d+$/;
-
-function refsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (refKey(a[i], i) !== refKey(b[i], i)) return false;
-    if (!!a[i].isDefault !== !!b[i].isDefault) return false;
-  }
-  return true;
-}
-
-/**
- * Align isDefault flags with server defaultWorkflow (or first row when missing).
- */
-function withDefaultFlags(
-  list: unknown,
-  defaultWorkflow?: NamedObjectRef | null,
-): NamedObjectRef[] {
-  const wfs = cloneRefs(list);
-  if (defaultWorkflow) {
-    const defKey = refKey(defaultWorkflow, -1);
-    for (const w of wfs) {
-      w.isDefault = refKey(w, -1) === defKey || w.name === defaultWorkflow.name;
-    }
-  }
-  if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
-    wfs[0] = { ...wfs[0], isDefault: true };
-  }
-  return wfs;
-}
-
-function toRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
-  return list.map((r) => {
-    const out: NamedObjectRef = {};
-    if (r.name) out.name = r.name;
-    if (r.guid?.stringValue || r.guid?.uuid != null) {
-      out.guid = {};
-      if (r.guid.stringValue) out.guid.stringValue = r.guid.stringValue;
-      if (r.guid.uuid != null) out.guid.uuid = r.guid.uuid;
-    }
-    if (r.isDefault) out.isDefault = true;
-    return out;
-  });
-}
 
 export function ContentTypeDetailPanel({
   idOrName,
@@ -228,8 +184,10 @@ export function ContentTypeDetailPanel({
         setDescription(normalized.description || "");
         setEnabled(normalized.enabled !== false);
         setFieldDrafts(toDrafts(normalized.fields));
-        setWorkflows(withDefaultFlags(normalized.allowedWorkflows, normalized.defaultWorkflow));
-        setTemplates(cloneRefs(normalized.allowedTemplates));
+        setWorkflows(
+          withDefaultWorkflowFlags(normalized.allowedWorkflows, normalized.defaultWorkflow),
+        );
+        setTemplates(cloneNamedObjectRefs(normalized.allowedTemplates));
         setNewWfName("");
         setNewTplName("");
       })
@@ -254,10 +212,13 @@ export function ContentTypeDetailPanel({
       return d.searchable !== i.searchable || d.required !== i.required;
     });
 
-  const initialWorkflows = withDefaultFlags(detail?.allowedWorkflows, detail?.defaultWorkflow);
-  const initialTemplates = cloneRefs(detail?.allowedTemplates);
-  const workflowsDirty = detail != null && !refsEqual(workflows, initialWorkflows);
-  const templatesDirty = detail != null && !refsEqual(templates, initialTemplates);
+  const initialWorkflows = withDefaultWorkflowFlags(
+    detail?.allowedWorkflows,
+    detail?.defaultWorkflow,
+  );
+  const initialTemplates = cloneNamedObjectRefs(detail?.allowedTemplates);
+  const workflowsDirty = detail != null && !namedObjectRefsEqual(workflows, initialWorkflows);
+  const templatesDirty = detail != null && !namedObjectRefsEqual(templates, initialTemplates);
 
   const dirty =
     detail != null &&
@@ -393,6 +354,9 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (!detail) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,31 +376,53 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
+      let saved: ContentTypeDetail | undefined;
+      let workflowSaved: ContentTypeDetail | undefined;
       if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+        workflowSaved = await setContentTypeAllowedWorkflows(
+          idOrName,
+          buildAllowedWorkflowsReplaceBody(workflows),
+        );
+        saved = workflowSaved;
+      }
+      const bulkNeeded =
+        label !== (detail.label || "") ||
+        description !== (detail.description || "") ||
+        enabled !== (detail.enabled !== false) ||
+        fieldsDirty ||
+        templatesDirty;
+      if (bulkNeeded) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          enabled,
+          fields: fieldPatches,
+        };
+        if (templatesDirty) {
+          body.allowedTemplates = toNamedObjectRefPayload(templates);
         }
+        const bulkSaved = await updateContentTypeDetail(idOrName, body);
+        saved = workflowSaved
+          ? {
+              ...bulkSaved,
+              allowedWorkflows: workflowSaved.allowedWorkflows,
+              defaultWorkflow: workflowSaved.defaultWorkflow,
+            }
+          : bulkSaved;
       }
-      if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+      if (!saved) {
+        saved = await getContentTypeDetail(idOrName);
       }
-
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
-      setDetail(saved);
-      setLabel(saved.label || "");
-      setDescription(saved.description || "");
-      setEnabled(saved.enabled !== false);
-      setFieldDrafts(toDrafts(saved.fields));
-      setWorkflows(withDefaultFlags(saved.allowedWorkflows, saved.defaultWorkflow));
-      setTemplates(cloneRefs(saved.allowedTemplates));
+      const normalized = normalizeDetailLists(saved);
+      setDetail(normalized);
+      setLabel(normalized.label || "");
+      setDescription(normalized.description || "");
+      setEnabled(normalized.enabled !== false);
+      setFieldDrafts(toDrafts(normalized.fields));
+      setWorkflows(
+        withDefaultWorkflowFlags(normalized.allowedWorkflows, normalized.defaultWorkflow),
+      );
+      setTemplates(cloneNamedObjectRefs(normalized.allowedTemplates));
       setNotice(DEV_MSG.CT_SAVED);
     } catch (err: unknown) {
       if (isApiError(err) && err.status === 409) {
@@ -490,7 +476,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>

--- a/WebUI/src/main/ts/developer/contentTypeWorkflows.ts
+++ b/WebUI/src/main/ts/developer/contentTypeWorkflows.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { normalizeNamedObjectRefs } from "../api/developer/contentTypeLists";
+import type { ContentTypeWorkflowsBody } from "../api/developer/contentTypesApi";
+import type { NamedObjectRef } from "../api/developer/types";
+
+function refKey(r: NamedObjectRef, index: number): string {
+  if (r.name) return `name:${r.name}`;
+  if (r.guid?.stringValue) return `guid:${r.guid.stringValue}`;
+  if (r.guid?.uuid != null) return `uuid:${r.guid.uuid}`;
+  return `idx:${index}`;
+}
+
+export function cloneNamedObjectRefs(list: unknown): NamedObjectRef[] {
+  return normalizeNamedObjectRefs(list).map((r) => ({
+    name: r.name,
+    label: r.label,
+    isDefault: r.isDefault,
+    guid: r.guid ? { ...r.guid } : undefined,
+  }));
+}
+
+export function namedObjectRefsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (refKey(a[i], i) !== refKey(b[i], i)) return false;
+    if (!!a[i].isDefault !== !!b[i].isDefault) return false;
+  }
+  return true;
+}
+
+/**
+ * Align isDefault flags with server defaultWorkflow (or first row when missing).
+ */
+export function withDefaultWorkflowFlags(
+  list: unknown,
+  defaultWorkflow?: NamedObjectRef | null,
+): NamedObjectRef[] {
+  const wfs = cloneNamedObjectRefs(list);
+  if (defaultWorkflow) {
+    const defKey = refKey(defaultWorkflow, -1);
+    for (const w of wfs) {
+      w.isDefault = refKey(w, -1) === defKey || w.name === defaultWorkflow.name;
+    }
+  }
+  if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+    wfs[0] = { ...wfs[0], isDefault: true };
+  }
+  return wfs;
+}
+
+/** Strip UI-only fields for CD-08 PUT .../allowedWorkflows. */
+export function toNamedObjectRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
+  return list.map((r) => {
+    const out: NamedObjectRef = {};
+    if (r.name) out.name = r.name;
+    if (r.guid?.stringValue || r.guid?.uuid != null) {
+      out.guid = {};
+      if (r.guid.stringValue) out.guid.stringValue = r.guid.stringValue;
+      if (r.guid.uuid != null) out.guid.uuid = r.guid.uuid;
+    }
+    if (r.isDefault) out.isDefault = true;
+    return out;
+  });
+}
+
+/**
+ * Full-replace body for {@code PUT .../allowedWorkflows}. Empty list clears.
+ * Omits {@code defaultWorkflow} when the set is empty.
+ */
+export function buildAllowedWorkflowsReplaceBody(
+  workflows: NamedObjectRef[],
+): ContentTypeWorkflowsBody {
+  const allowedWorkflows = toNamedObjectRefPayload(workflows);
+  const def = workflows.find((w) => w.isDefault) || workflows[0];
+  if (!def) {
+    return { allowedWorkflows };
+  }
+  return {
+    allowedWorkflows,
+    defaultWorkflow: toNamedObjectRefPayload([def])[0],
+  };
+}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -181,7 +181,8 @@ export const DEV_MSG_KEYS = {
   CT_RULE_IN_XFORM: "perc.ui.developer@in-xform",
   CT_RULE_OUT_XFORM: "perc.ui.developer@out-xform",
   CT_WORKFLOWS: "perc.ui.developer@Allowed workflows",
-  CT_WORKFLOWS_HINT: "perc.ui.developer@Full replace on save when changed. Add by workflow name; set default with the radio.",
+  CT_WORKFLOWS_HINT:
+    "perc.ui.developer@Lock to edit. Add or remove workflows by name, set the default, then save. Save replaces the allowed-workflow set and does not unlock.",
   CT_DEFAULT_WF: "perc.ui.developer@Default workflow",
   CT_TEMPLATES: "perc.ui.developer@Allowed templates",
   CT_TEMPLATES_HINT: "perc.ui.developer@Full replace on save when changed. Add by template name or GUID (type-host-uuid, e.g. 0-10-347).",

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  setContentTypeAllowedWorkflows,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapContentTypeWorkflowsForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -250,6 +250,22 @@ describe("wrapContentTypeDetailForWire", () => {
   });
 });
 
+describe("wrapContentTypeWorkflowsForWire", () => {
+  it("wraps allowedWorkflows under ContentTypeWorkflows", () => {
+    expect(
+      wrapContentTypeWorkflowsForWire({
+        allowedWorkflows: [{ name: "Simple Workflow" }],
+        defaultWorkflow: { name: "Simple Workflow" },
+      }),
+    ).toEqual({
+      ContentTypeWorkflows: {
+        allowedWorkflows: [{ name: "Simple Workflow" }],
+        defaultWorkflow: { name: "Simple Workflow" },
+      },
+    });
+  });
+});
+
 describe("unwrapObjectLockSummary", () => {
   it("unwraps Jackson ObjectLockSummary root", () => {
     expect(
@@ -270,7 +286,7 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("content type design PUTs (held lock, no wrap)", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +305,52 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("updateContentTypeDetail PUTs only and does not lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("allowedWorkflows");
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeDetail: { description: "updated" },
+    });
+  });
+
+  it("setContentTypeAllowedWorkflows PUTs CD-08 wrap without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: {
+          name: "percPage",
+          allowedWorkflows: [{ name: "Standard Workflow" }],
+          defaultWorkflow: { name: "Standard Workflow" },
+        },
+      }),
+    );
+
+    const saved = await setContentTypeAllowedWorkflows("percPage", {
+      allowedWorkflows: [{ name: "Standard Workflow" }],
+      defaultWorkflow: { name: "Standard Workflow" },
+    });
+    expect(saved.allowedWorkflows).toEqual([{ name: "Standard Workflow" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/allowedWorkflows`,
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeWorkflows: {
+        allowedWorkflows: [{ name: "Standard Workflow" }],
+        defaultWorkflow: { name: "Standard Workflow" },
+      },
+    });
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -13,6 +13,7 @@ import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDe
 vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   getContentTypeDetail: vi.fn(),
   updateContentTypeDetail: vi.fn(),
+  setContentTypeAllowedWorkflows: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
 }));
@@ -34,6 +35,9 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<typeof vi.fn>;
 const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as ReturnType<
+  typeof vi.fn
+>;
+const setContentTypeAllowedWorkflows = contentTypesApi.setContentTypeAllowedWorkflows as ReturnType<
   typeof vi.fn
 >;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
@@ -60,6 +64,7 @@ describe("ContentTypeDetailPanel", () => {
     };
     getContentTypeDetail.mockReset();
     updateContentTypeDetail.mockReset();
+    setContentTypeAllowedWorkflows.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
@@ -67,6 +72,11 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
+    }));
+    setContentTypeAllowedWorkflows.mockImplementation(async (_id, body) => ({
+      ...sampleDetail,
+      allowedWorkflows: body.allowedWorkflows,
+      defaultWorkflow: body.defaultWorkflow ?? null,
     }));
   });
 
@@ -410,6 +420,117 @@ describe("ContentTypeDetailPanel", () => {
     expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
       true,
     );
+  });
+
+  it("keeps workflow editors disabled until lock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-wf-add") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-wf-remove-0") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("saves allowed workflows via CD-08 PUT without bulk PUT or unlock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeAllowedWorkflows).toHaveBeenCalled();
+    });
+    expect(setContentTypeAllowedWorkflows).toHaveBeenCalledWith(
+      "percPage",
+      expect.objectContaining({
+        allowedWorkflows: expect.arrayContaining([
+          expect.objectContaining({ name: "Simple Workflow" }),
+          expect.objectContaining({ name: "Standard Workflow" }),
+        ]),
+        defaultWorkflow: expect.objectContaining({ name: "Simple Workflow" }),
+      }),
+    );
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(unlockContentType).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("blocks save without a held lock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-save")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    expect(setContentTypeAllowedWorkflows).not.toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(lockContentType).not.toHaveBeenCalled();
+  });
+
+  it("clears the held lock when allowedWorkflows PUT returns 409 (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", isDefault: true }],
+    });
+    setContentTypeAllowedWorkflows.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect(lockContentType).toHaveBeenCalledTimes(1);
   });
 
   it("unlocks on back when the session holds the lock (#3744)", async () => {

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -96,6 +96,35 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
     allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
+    setContentTypeAllowedWorkflows: vi.fn().mockImplementation(async (_id, body) => ({
+      name: "percPage",
+      label: "Page",
+      description: "A page",
+      enabled: true,
+      guid: { stringValue: "0-2-301", uuid: 301 },
+      fields: [
+        {
+          name: "sys_title",
+          label: "Title",
+          fieldType: "system",
+          searchable: true,
+          required: true,
+          occurrence: "required",
+        },
+        {
+          name: "page_title",
+          label: "Page title",
+          fieldType: "local",
+          searchable: false,
+          required: false,
+          occurrence: "optional",
+        },
+      ],
+      allowedWorkflows: body.allowedWorkflows,
+      defaultWorkflow: body.defaultWorkflow ?? null,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+      designGaps: [],
+    })),
     lockContentType: vi.fn().mockResolvedValue({ locker: "Admin", remainingTime: 30 }),
     unlockContentType: vi.fn().mockResolvedValue(undefined),
   };
@@ -874,10 +903,11 @@ it("loads views catalog section", async () => {
   });
 
   it("edits content type workflow and template associations on save", async () => {
-    const { updateContentTypeDetail } = await import(
+    const { updateContentTypeDetail, setContentTypeAllowedWorkflows } = await import(
       "../../../main/ts/api/developer/contentTypesApi"
     );
     (updateContentTypeDetail as ReturnType<typeof vi.fn>).mockClear();
+    (setContentTypeAllowedWorkflows as ReturnType<typeof vi.fn>).mockClear();
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -908,18 +938,25 @@ it("loads views catalog section", async () => {
     });
     fireEvent.click(screen.getByTestId("developer-ct-save"));
     await waitFor(() => {
-      expect(updateContentTypeDetail).toHaveBeenCalled();
+      expect(setContentTypeAllowedWorkflows).toHaveBeenCalled();
     });
-    const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
-    expect(body.allowedWorkflows).toEqual(
+    const wfBody = (setContentTypeAllowedWorkflows as ReturnType<typeof vi.fn>).mock.calls.at(
+      -1,
+    )?.[1];
+    expect(wfBody.allowedWorkflows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "Simple Workflow" }),
         expect.objectContaining({ name: "Standard Workflow" }),
       ]),
     );
-    expect(body.defaultWorkflow).toEqual(
+    expect(wfBody.defaultWorkflow).toEqual(
       expect.objectContaining({ name: "Simple Workflow" }),
     );
+    await waitFor(() => {
+      expect(updateContentTypeDetail).toHaveBeenCalled();
+    });
+    const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+    expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "perc.page" }),

--- a/WebUI/src/test/ts/developer/contentTypeWorkflows.test.ts
+++ b/WebUI/src/test/ts/developer/contentTypeWorkflows.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildAllowedWorkflowsReplaceBody,
+  cloneNamedObjectRefs,
+  namedObjectRefsEqual,
+  toNamedObjectRefPayload,
+  withDefaultWorkflowFlags,
+} from "../../../main/ts/developer/contentTypeWorkflows";
+
+describe("contentTypeWorkflows helpers (CD-08)", () => {
+  it("clones refs without sharing guid objects", () => {
+    const guid = { stringValue: "0-23-4", uuid: 4 };
+    const src = [{ name: "Simple Workflow", label: "Simple", guid, isDefault: true }];
+    const cloned = cloneNamedObjectRefs(src);
+    expect(cloned).toEqual(src);
+    expect(cloned[0].guid).not.toBe(guid);
+    cloned[0].guid!.uuid = 99;
+    expect(guid.uuid).toBe(4);
+  });
+
+  it("treats default-flag mismatch as dirty", () => {
+    const a = [{ name: "Simple Workflow", isDefault: true }];
+    const b = [{ name: "Simple Workflow", isDefault: false }];
+    expect(namedObjectRefsEqual(a, b)).toBe(false);
+    expect(namedObjectRefsEqual(a, [{ name: "Simple Workflow", isDefault: true }])).toBe(true);
+  });
+
+  it("marks the matching defaultWorkflow row and falls back to first", () => {
+    const list = [{ name: "Simple Workflow" }, { name: "Standard Workflow" }];
+    expect(
+      withDefaultWorkflowFlags(list, { name: "Standard Workflow" }).map((w) => ({
+        name: w.name,
+        isDefault: w.isDefault,
+      })),
+    ).toEqual([
+      { name: "Simple Workflow", isDefault: false },
+      { name: "Standard Workflow", isDefault: true },
+    ]);
+    expect(withDefaultWorkflowFlags([{ name: "Simple Workflow" }])[0].isDefault).toBe(true);
+  });
+
+  it("builds a full-replace body with payload refs and defaultWorkflow", () => {
+    const body = buildAllowedWorkflowsReplaceBody([
+      {
+        name: "Simple Workflow",
+        label: "Simple Workflow",
+        isDefault: true,
+        guid: { stringValue: "0-23-4", uuid: 4 },
+      },
+      { name: "Standard Workflow", label: "Standard Workflow" },
+    ]);
+    expect(body.allowedWorkflows).toEqual([
+      {
+        name: "Simple Workflow",
+        isDefault: true,
+        guid: { stringValue: "0-23-4", uuid: 4 },
+      },
+      { name: "Standard Workflow" },
+    ]);
+    expect(body.defaultWorkflow).toEqual({
+      name: "Simple Workflow",
+      isDefault: true,
+      guid: { stringValue: "0-23-4", uuid: 4 },
+    });
+    expect(toNamedObjectRefPayload(body.allowedWorkflows)[1]).toEqual({
+      name: "Standard Workflow",
+    });
+  });
+
+  it("omits defaultWorkflow when the allowed set is empty", () => {
+    expect(buildAllowedWorkflowsReplaceBody([])).toEqual({ allowedWorkflows: [] });
+  });
+});

--- a/docs/ai-generated/code-reviews/issue-3782-ct-workflow-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3782-ct-workflow-assoc-chrome-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review: issue #3782 Developer Content Type workflow associations chrome (CD-08)
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-26 |
+| **Branch** | `feat/issue-3782-ct-workflow-assoc-chrome` |
+| **Base** | `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: yes |
+| **Memory patterns hit** | Change-class closure (WebUI API + panel + Vitest + Playwright + product-docs); behavioral tests for dedicated PUT / 409 / unlocked save; REST URL `/` not filesystem paths |
+
+## Summary
+
+Developer Content Type detail consumes held-lock `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (Jackson `ContentTypeWorkflows`) instead of stuffing `allowedWorkflows` onto the generic content-type PUT. Save does not acquire or release the lock. Unlocked editors and Save stay disabled. Template association chrome is unchanged (still bulk PUT when templates are dirty). REST internals are not reimplemented.
+
+## Gate
+
+- No bugs found in the diff after standalone `WebUI` and `modules/perc-qa-automation` `mvnw clean install`.
+- Behavioral tests: wrap helper, dedicated PUT (no lock/unlock), panel lock → CD-08 save, 409 clears lock, unlocked save blocked, helper empty-list / default flags.
+- Companions: Playwright `developer-content-type-workflows.spec.js`; product-docs Developer Content Types + REST CD-08 SPA note.
+- Cross-platform path checklist: N/A for filesystem joins (REST/URL `/` only; Playwright `encodeURIComponent` on type name).
+- C2 reverse-deps: none (no Java public type/signature change).
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Generic `updateContentTypeDetail` no longer wraps lock→PUT→unlock; lock chrome (#3744) is the session owner. Mixed saves call CD-08 first, then bulk PUT without `allowedWorkflows`.
+- Playwright fails closed if the catalog is empty or both stock workflow names are already associated.

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type allowed-workflow associations chrome (CD-08 / #3782).
+ *
+ * Admin locks a type, replaces the allowed-workflow set, saves via
+ * PUT .../allowedWorkflows, then GET lists the new set. Unlocked save is
+ * disabled (no lock steal). Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-workflows.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const { catalogRowSelector } = require("./helpers/developer-catalog-selectors");
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function asWorkflowList(raw) {
+  if (raw == null) {
+    return [];
+  }
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw.NamedObjectRef != null) {
+    return [].concat(raw.NamedObjectRef);
+  }
+  if (typeof raw.empty === "boolean") {
+    return [];
+  }
+  if (raw.name || raw.label) {
+    return [raw];
+  }
+  return [];
+}
+
+function unwrapContentTypeDetail(body) {
+  if (body == null || typeof body !== "object") {
+    return {};
+  }
+  return body.ContentTypeDetail || body.contentTypeDetail || body;
+}
+
+async function getAllowedWorkflowState(request, typeName) {
+  const headers = {
+    ...adminBasicAuthHeaders(),
+    Accept: "application/json",
+  };
+  const url = `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}`;
+  const res = await request.get(url, { headers });
+  expect(res.status(), `GET ${url}`).toBe(200);
+  const detail = unwrapContentTypeDetail(await res.json());
+  const names = asWorkflowList(detail.allowedWorkflows)
+    .map((w) => w && w.name)
+    .filter(Boolean);
+  const defaultName =
+    (detail.defaultWorkflow && detail.defaultWorkflow.name) || names[0] || "";
+  return { names, defaultName };
+}
+
+async function openPercPageDetail(page) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    throw new Error("No content types in catalog — cannot exercise workflow associations");
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
+    hasText: /percPage/,
+  });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(
+      `Content type detail error: ${(await detailError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible();
+  const nameEl = page.locator('[data-testid="developer-ct-detail-name"]');
+  const typeName = ((await nameEl.count()) ? await nameEl.innerText() : "percPage").trim();
+  return typeName || "percPage";
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return {
+    assertClean() {
+      expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      const unexpectedConsole = consoleErrors.filter(
+        (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+      );
+      expect(
+        unexpectedConsole,
+        `console error: ${unexpectedConsole.join(" | ")}`,
+      ).toEqual([]);
+    },
+  };
+}
+
+test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => {
+  test("without lock, workflow editors and save stay disabled", async ({ page }) => {
+    test.setTimeout(120_000);
+    const guards = attachConsoleGuards(page);
+    await loginAsAdmin(page);
+    await openPercPageDetail(page);
+
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const addName = page.locator('[data-testid="developer-ct-wf-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-wf-add"]');
+    await expect(saveBtn).toBeDisabled();
+    await expect(addName).toBeDisabled();
+    await expect(addBtn).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-lock-status"]')).toHaveText(
+      /Not locked/i,
+    );
+    const remove0 = page.locator('[data-testid="developer-ct-wf-remove-0"]');
+    if ((await remove0.count()) > 0) {
+      await expect(remove0).toBeDisabled();
+    }
+    guards.assertClean();
+  });
+
+  test("Admin lock, PUT allowedWorkflows, GET lists the new set", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const guards = attachConsoleGuards(page);
+    const putUrls = [];
+    page.on("request", (req) => {
+      if (req.method() === "PUT") {
+        putUrls.push(req.url());
+      }
+    });
+
+    await loginAsAdmin(page);
+    const typeName = await openPercPageDetail(page);
+    const original = await getAllowedWorkflowState(request, typeName);
+    const originalNames = original.names;
+    if (originalNames.length < 2) {
+      throw new Error(
+        `${typeName} needs at least two allowed workflows to replace (have: ${originalNames.join(", ") || "none"})`,
+      );
+    }
+    const toRemove =
+      originalNames.find((n) => n && n !== original.defaultName) ||
+      originalNames[originalNames.length - 1];
+
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    await expect(lockBtn).toBeEnabled();
+    const lockResponsePromise = page.waitForResponse(
+      (r) => r.request().method() === "POST" && /\/contenttypes\/[^/]+\/lock(?:\?|$)/.test(r.url()),
+      { timeout: 20_000 },
+    );
+    await lockBtn.click();
+    const lockRes = await lockResponsePromise;
+    if (!lockRes.ok()) {
+      const body = await lockRes.text();
+      throw new Error(`Lock HTTP ${lockRes.status()} ${body}`);
+    }
+    if (await saveError.isVisible()) {
+      throw new Error(`Lock failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeEnabled();
+
+    const removeRow = page
+      .locator('[data-testid^="developer-ct-wf-row-"]')
+      .filter({ hasText: toRemove });
+    await expect(removeRow).toHaveCount(1);
+    await removeRow.locator('[data-testid^="developer-ct-wf-remove-"]').click();
+    await expect(saveBtn).toBeEnabled();
+
+    putUrls.length = 0;
+    await saveBtn.click();
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Workflow save failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(notice).toContainText(/saved/i);
+    await expect(status).toHaveText(/Locked by you/i);
+
+    const workflowPuts = putUrls.filter((u) => /\/allowedWorkflows(?:\?|$)/.test(u));
+    expect(
+      workflowPuts.length,
+      `expected PUT .../allowedWorkflows, got: ${putUrls.join(" | ") || "(none)"}`,
+    ).toBeGreaterThan(0);
+
+    const afterNames = (await getAllowedWorkflowState(request, typeName)).names;
+    expect(afterNames, "GET after save should omit the removed workflow").not.toContain(toRemove);
+
+    await page.locator('[data-testid="developer-ct-wf-add-name"]').fill(toRemove);
+    await page.locator('[data-testid="developer-ct-wf-add"]').click();
+    await expect(page.locator('[data-testid="developer-ct-workflows"]')).toContainText(toRemove);
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Restore save failed: ${(await saveError.innerText()).trim()}`);
+    }
+    const restored = (await getAllowedWorkflowState(request, typeName)).names;
+    expect(restored.sort()).toEqual([...originalNames].sort());
+
+    await unlockBtn.click();
+    await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+    await expect(saveBtn).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeDisabled();
+
+    guards.assertClean();
+  });
+});

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, save, and unlock a content type from Developer detail chrome
+description: Lock, save, and unlock a content type from Developer detail chrome, including allowed workflows
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -39,6 +39,23 @@ write). This page does **not** add Properties-tab chrome for those exits.
 7. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
+### Allowed workflows (after lock)
+
+The **Allowed workflows** list is read-only until you hold the lock. After
+**Lock**:
+
+1. Add a workflow by its existing name (for example **Standard Workflow**) and
+   click **Add**, or **Remove** a row. Use **Default** to choose the default
+   workflow.
+2. Click **Save content type**. The product replaces the allowed-workflow set
+   (`PUT /services/contenttypes/{idOrName}/allowedWorkflows`). Save does **not**
+   unlock. Reloading the type (or GET detail) lists the new set.
+3. Without a lock, Add / Remove / Save stay **disabled**. The product does
+   **not** steal another user's lock (lock failure is **409**).
+
+This is not a full Workbench workflow picker. The name you add must already
+exist on the server. Template association chrome is a separate surface.
+
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.
 
@@ -49,7 +66,8 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, templates) | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -258,8 +258,9 @@ Capability gaps still render as the human-readable **message** (fallback **code*
 `PUT /services/contenttypes/{idOrName}/allowedWorkflows` replaces the content
 type's allowed-workflow associations. Hold the design-session lock first; save
 keeps the lock so you can continue editing, then unlock. This dedicated action
-does **not** auto lock-save-unlock (the generic `PUT /contenttypes/{idOrName}`
-still does that for mixed meta/field updates).
+does **not** acquire or release the lock. The Developer SPA **Content types**
+detail chrome uses this PUT after **Lock** (not the generic content-type PUT)
+when the allowed-workflow set changes.
 
 Typical flow: `POST .../lock` → `PUT .../allowedWorkflows` → (optional further
 design writes) → `POST .../unlock`.


### PR DESCRIPTION
## Summary

Developer Content Type **allowed-workflow associations** chrome (CD-08) for parent **#1690**. After **Lock**, save replaces the allowed-workflow set via dedicated `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (Jackson root `ContentTypeWorkflows`). The client does **not** acquire or release the lock. Unlocked add/remove/save stay disabled (no lock steal). Template association chrome is unchanged (still bulk PUT when templates are dirty — slice #3783). REST internals are not reimplemented.

Partial #3782
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `perc-devctl qa-up` (H2 Docker) → `qa-health`.
2. Sign in as Admin → Developer → Content types → open a type (Playwright prefers percPage).
3. Allowed-workflow add/remove and Save are disabled until Lock.
4. Lock → remove a non-default workflow → Save. Network shows `PUT .../allowedWorkflows`. GET `/services/contenttypes/{name}` omits the removed name. Add it back → Save → GET matches the original set. Unlock.
5. Vitest: `contentTypeWorkflows.test.ts`, `contentTypesApi.test.ts`, `ContentTypeDetailPanel.test.tsx`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-content-types.md` (allowed workflows after lock; dedicated PUT) and `product-docs/8.2/developer/rest.md` (SPA consumes dedicated PUT)
- [x] **Unit / module tests** — Vitest helpers + API PUT (no lock wrap) + panel lock/save/409
- [x] **WebUI + Playwright** — `developer-content-type-workflows.spec.js` (unlocked-disabled **passed**; lock/save **failed** on this skip-image-build cell — lock POST 500 NPE after hot-copying rest/sitemanage/system). Do not treat C5 lock/save as green.
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — REST URL `/` only; no filesystem path joins

### C3 evidence

- **modules_built:** WebUI, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3086 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; no Java tests)
- **downstream_checked:** none (no Java public type made final/sealed; no public method/ctor signature change). C2 reverse-dep install not required.

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → TEST_CMS_URL=http://127.0.0.1:9993 CONTAINER=perc-matrix-cms-h2
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/login` RESULT:OK HTTP:200 HEALTH:healthy
- Hot-copy: WebUI `cm/modern/assets`; then `rest-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` + `perc-system-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib` (skip-image-build cell lacked lock REST — POST lock was 404 until copy); StopJetty/StartJetty inside cell; `qa-health` again RESULT:OK
- Playwright: `npm run test:surface -- --path tests/developer-content-type-workflows.spec.js` — **1 passed** (unlocked editors/save disabled), **1 failed** (Lock HTTP 500 `NullPointerException` on POST `.../contenttypes/percPage/lock` after jar copy)
- console-clean=yes on the passing test (pageerror/console error assertions empty)
- server.log-clean=yes (no ERROR/FATAL for the feature in `jetty/base/logs/server.log`; REST 500 is returned on the wire without a matching server.log ERROR)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
