### PR TITLE
feat(webui): Developer Content Type template associations chrome (CD-12) (#3783)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -219,7 +219,10 @@ export type ContentTypeUpdateBody = {
   /** Omit to leave unchanged; non-null list is a full replace. */
   allowedWorkflows?: NamedObjectRef[];
   defaultWorkflow?: NamedObjectRef | null;
-  /** Omit to leave unchanged; non-null list is a full replace. */
+  /**
+   * Omit to leave unchanged. Prefer {@link replaceContentTypeAllowedTemplates}
+   * (CD-12 dedicated PUT) instead of sending this on the bulk detail PUT.
+   */
   allowedTemplates?: NamedObjectRef[];
 };
 
@@ -291,25 +294,92 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code allowedTemplates} here — use
+ * {@link replaceContentTypeAllowedTemplates} (CD-12).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code NamedObjectRefList}. */
+export const NAMED_OBJECT_REF_LIST_ROOT = "NamedObjectRefList";
+
+/**
+ * Build the wire JSON body for {@code PUT .../allowedTemplates} under
+ * {@link NAMED_OBJECT_REF_LIST_ROOT}. A bare array fails server UNWRAP_ROOT_VALUE.
+ */
+export function wrapNamedObjectRefListForWire(
+  items: NamedObjectRef[],
+): Record<string, NamedObjectRef[]> {
+  return { [NAMED_OBJECT_REF_LIST_ROOT]: items };
+}
+
+/**
+ * Flatten GET/PUT {@code .../allowedTemplates} JSON to {@link NamedObjectRef}[].
+ *
+ * <p>Handles WRAP_ROOT {@code NamedObjectRefList}, JAXB {@code NamedObjectRef}
+ * envelope, bare array, singleton object, and empty-collection beans.
+ */
+export function unwrapNamedObjectRefList(payload: unknown): NamedObjectRef[] {
+  if (payload == null) {
+    return [];
   }
+  if (Array.isArray(payload)) {
+    return normalizeNamedObjectRefs(payload);
+  }
+  const root = asRecord(payload);
+  if (!root) {
+    return [];
+  }
+  if (root[NAMED_OBJECT_REF_LIST_ROOT] != null) {
+    return normalizeNamedObjectRefs(root[NAMED_OBJECT_REF_LIST_ROOT]);
+  }
+  if (root.namedObjectRefList != null) {
+    return normalizeNamedObjectRefs(root.namedObjectRefList);
+  }
+  return normalizeNamedObjectRefs(payload);
+}
+
+/**
+ * GET /services/contenttypes/{idOrName}/allowedTemplates — CD-12 read.
+ * No design lock required. Empty list means none.
+ */
+export async function getContentTypeAllowedTemplates(
+  idOrName: string,
+): Promise<NamedObjectRef[]> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await get<unknown>(`${PATHS.CONTENT_TYPES}/${key}/allowedTemplates`);
+  return unwrapNamedObjectRefList(payload);
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/allowedTemplates — CD-12 full replace.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. HTTP 400 when a template name/guid
+ * cannot be resolved. Empty list clears associations.
+ */
+export async function replaceContentTypeAllowedTemplates(
+  idOrName: string,
+  templates: NamedObjectRef[],
+): Promise<NamedObjectRef[]> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/allowedTemplates`,
+    wrapNamedObjectRefListForWire(templates),
+  );
+  return unwrapNamedObjectRefList(payload);
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -18,8 +18,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
+  getContentTypeAllowedTemplates,
   getContentTypeDetail,
   lockContentType,
+  replaceContentTypeAllowedTemplates,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -393,6 +395,18 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (detail == null) {
+      return;
+    }
+    const otherDirty =
+      label !== (detail.label || "") ||
+      description !== (detail.description || "") ||
+      enabled !== (detail.enabled !== false) ||
+      fieldsDirty ||
+      workflowsDirty;
+    if (!otherDirty && !templatesDirty) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,24 +426,29 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
-      if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+      let saved: ContentTypeDetail = normalizeDetailLists(detail);
+      if (otherDirty) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          enabled,
+          fields: fieldPatches,
+        };
+        if (workflowsDirty) {
+          body.allowedWorkflows = toRefPayload(workflows);
+          const def = workflows.find((w) => w.isDefault) || workflows[0];
+          if (def) {
+            body.defaultWorkflow = toRefPayload([def])[0];
+          }
         }
+        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       }
       if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+        await replaceContentTypeAllowedTemplates(idOrName, toRefPayload(templates));
+        const listed = await getContentTypeAllowedTemplates(idOrName);
+        saved = { ...saved, allowedTemplates: listed };
       }
 
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
@@ -490,7 +509,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
+  getContentTypeAllowedTemplates,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  replaceContentTypeAllowedTemplates,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
+  unwrapNamedObjectRefList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapNamedObjectRefListForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -270,7 +272,39 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("wrapNamedObjectRefListForWire / unwrapNamedObjectRefList (CD-12)", () => {
+  it("wraps a list under NamedObjectRefList", () => {
+    expect(wrapNamedObjectRefListForWire([{ name: "perc.page" }])).toEqual({
+      NamedObjectRefList: [{ name: "perc.page" }],
+    });
+  });
+
+  it("wraps an empty list (clears associations)", () => {
+    expect(wrapNamedObjectRefListForWire([])).toEqual({ NamedObjectRefList: [] });
+  });
+
+  it("unwraps WRAP_ROOT NamedObjectRefList", () => {
+    expect(
+      unwrapNamedObjectRefList({
+        NamedObjectRefList: [{ name: "perc.page", label: "Page" }],
+      }),
+    ).toEqual([{ name: "perc.page", label: "Page" }]);
+  });
+
+  it("unwraps a bare array", () => {
+    expect(unwrapNamedObjectRefList([{ name: "perc.page" }])).toEqual([{ name: "perc.page" }]);
+  });
+
+  it("unwraps JAXB NamedObjectRef singleton and empty beans", () => {
+    expect(
+      unwrapNamedObjectRefList({ NamedObjectRef: { name: "perc.page" } }),
+    ).toEqual([{ name: "perc.page" }]);
+    expect(unwrapNamedObjectRefList({ empty: true })).toEqual([]);
+    expect(unwrapNamedObjectRefList(null)).toEqual([]);
+  });
+});
+
+describe("updateContentTypeDetail held-lock PUT", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +323,77 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("PUTs save without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("allowedTemplates");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("/lock");
+  });
+});
+
+describe("allowedTemplates GET/PUT (CD-12)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("GETs allowedTemplates and unwraps the list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ NamedObjectRefList: [{ name: "perc.page", label: "Page" }] }),
+    );
+    const listed = await getContentTypeAllowedTemplates("percPage");
+    expect(listed).toEqual([{ name: "perc.page", label: "Page" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("GET");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/allowedTemplates`,
+    );
+  });
+
+  it("PUTs allowedTemplates wrapped under NamedObjectRefList and returns the set", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ NamedObjectRefList: [{ name: "perc.page.summary" }] }),
+    );
+    const listed = await replaceContentTypeAllowedTemplates("percPage", [
+      { name: "perc.page.summary" },
+    ]);
+    expect(listed).toEqual([{ name: "perc.page.summary" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("PUT");
+    expect(String(url)).toContain(`${PATHS.CONTENT_TYPES}/percPage/allowedTemplates`);
+    expect(JSON.parse(String(init.body))).toEqual({
+      NamedObjectRefList: [{ name: "perc.page.summary" }],
+    });
+  });
+
+  it("PUTs an empty list to clear associations", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ NamedObjectRefList: [] }));
+    const listed = await replaceContentTypeAllowedTemplates("percPage", []);
+    expect(listed).toEqual([]);
+    const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(body).toEqual({ NamedObjectRefList: [] });
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -15,6 +15,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   updateContentTypeDetail: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
+  getContentTypeAllowedTemplates: vi.fn(),
+  replaceContentTypeAllowedTemplates: vi.fn(),
 }));
 
 // ObjectAclSection loads ACL via separate API; stub so detail success path stays isolated.
@@ -38,6 +40,10 @@ const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as Retur
 >;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
 const unlockContentType = contentTypesApi.unlockContentType as ReturnType<typeof vi.fn>;
+const getContentTypeAllowedTemplates =
+  contentTypesApi.getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
+const replaceContentTypeAllowedTemplates =
+  contentTypesApi.replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
   name: "percPage",
@@ -62,12 +68,16 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
+    getContentTypeAllowedTemplates.mockReset();
+    replaceContentTypeAllowedTemplates.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
     unlockContentType.mockResolvedValue(undefined);
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
     }));
+    replaceContentTypeAllowedTemplates.mockImplementation(async (_id, templates) => templates);
+    getContentTypeAllowedTemplates.mockImplementation(async () => []);
   });
 
   it("loads detail on success and supports back", async () => {
@@ -78,6 +88,7 @@ describe("ContentTypeDetailPanel", () => {
       expect(screen.getByTestId("developer-ct-detail-title")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-detail-title").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
     expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
@@ -347,6 +358,8 @@ describe("ContentTypeDetailPanel", () => {
       "percPage",
       expect.objectContaining({ description: "Updated description" }),
     );
+    expect(updateContentTypeDetail.mock.calls.at(-1)?.[1].allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).not.toHaveBeenCalled();
     expect(unlockContentType).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
@@ -408,6 +421,125 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("locks, replaces allowed templates via dedicated PUT then GET (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    replaceContentTypeAllowedTemplates.mockResolvedValueOnce([]);
+    getContentTypeAllowedTemplates.mockResolvedValueOnce([]);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage", []);
+    });
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("adds an existing template id after lock and PUTs the new set (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    const next = [
+      { name: "perc.page" },
+      { name: "perc.page.summary", label: "perc.page.summary" },
+    ];
+    replaceContentTypeAllowedTemplates.mockResolvedValueOnce(next);
+    getContentTypeAllowedTemplates.mockResolvedValueOnce(next);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-tpl-add-name"), {
+      target: { value: "perc.page.summary" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalled();
+    });
+    expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith(
+      "percPage",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "perc.page" }),
+        expect.objectContaining({ name: "perc.page.summary" }),
+      ]),
+    );
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-1").textContent).toContain(
+        "perc.page.summary",
+      );
+    });
+  });
+
+  it("clears the held lock when allowedTemplates PUT returns 409 (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    replaceContentTypeAllowedTemplates.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-remove-0") as HTMLButtonElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
       true,
     );
   });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -61,6 +61,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
       "Field rule flags are exposed (validation/visibility/transforms present); full rule expressions and control properties are not",
     ],
   }),
+  replaceContentTypeAllowedTemplates: vi.fn().mockImplementation(async (_id, templates) => templates),
+  getContentTypeAllowedTemplates: vi.fn().mockResolvedValue([{ name: "perc.page", label: "Page" }]),
   updateContentTypeDetail: vi.fn().mockImplementation(async (_id, body) => ({
     name: "percPage",
     label: body.label ?? "Page",
@@ -750,9 +752,10 @@ it("loads views catalog section", async () => {
 
 
   it("edits content type field searchable and saves with design lock path", async () => {
-    const { updateContentTypeDetail } = await import(
+    const { updateContentTypeDetail, replaceContentTypeAllowedTemplates } = await import(
       "../../../main/ts/api/developer/contentTypesApi"
     );
+    (replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -784,6 +787,7 @@ it("loads views catalog section", async () => {
     // Field-only save must not wipe associations
     expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });
@@ -873,11 +877,19 @@ it("loads views catalog section", async () => {
     expect(screen.getByTestId("developer-site-table").textContent).toContain("Corporate");
   });
 
-  it("edits content type workflow and template associations on save", async () => {
-    const { updateContentTypeDetail } = await import(
-      "../../../main/ts/api/developer/contentTypesApi"
-    );
+  it("edits content type workflow associations on bulk save and templates via CD-12 PUT", async () => {
+    const {
+      updateContentTypeDetail,
+      replaceContentTypeAllowedTemplates,
+      getContentTypeAllowedTemplates,
+    } = await import("../../../main/ts/api/developer/contentTypesApi");
     (updateContentTypeDetail as ReturnType<typeof vi.fn>).mockClear();
+    (replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
+    (getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
+    (getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { name: "perc.page" },
+      { name: "perc.page.summary", label: "perc.page.summary" },
+    ]);
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -910,6 +922,9 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(updateContentTypeDetail).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalled();
+    });
     const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
     expect(body.allowedWorkflows).toEqual(
       expect.arrayContaining([
@@ -920,12 +935,15 @@ it("loads views catalog section", async () => {
     expect(body.defaultWorkflow).toEqual(
       expect.objectContaining({ name: "Simple Workflow" }),
     );
-    expect(body.allowedTemplates).toEqual(
+    expect(body.allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith(
+      "percPage",
       expect.arrayContaining([
         expect.objectContaining({ name: "perc.page" }),
         expect.objectContaining({ name: "perc.page.summary" }),
       ]),
     );
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });

--- a/docs/ai-generated/code-reviews/issue-3783-ct-template-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3783-ct-template-assoc-chrome-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — #3783 Developer Content Type template associations chrome (CD-12)
+
+**Date:** 2026-08-26  
+**Branch:** `feat/issue-3783-ct-template-assoc-chrome`  
+**Scope:** uncommitted vs `HEAD` (WebUI SPA, rest DTO/resource, sitemanage adaptor, Vitest, Playwright, product-docs)  
+**Memory patterns hit:** change-class closure (Vitest + Playwright for WebUI screen; rest DTO XmlSeeAlso peer SiteList #3090); dedicated REST consumed with live-wire fixes; no path I/O.
+
+## Summary
+
+Developer Content Type detail replaces allowed templates via dedicated
+`PUT /services/contenttypes/{idOrName}/allowedTemplates` after a held design
+lock, then `GET` lists the new set. Bulk `PUT /contenttypes/{id}` no longer
+sends `allowedTemplates` and no longer wraps lock→save→unlock (held lock is
+required; save must not steal/release). Unlocked editors stay disabled; 409
+clears the UI lock without steal.
+
+Live H2 required two wire/lock companions so the chrome could consume REST:
+`NamedObjectRefList` JAXB `@XmlSeeAlso` + distinct root name (peer SiteList #3090);
+PUT body typed as `List<NamedObjectRef>` so CXF does not cast `ArrayList`;
+`replaceAllowedTemplates` uses `resolveExistingContentTypeGuid` so lock and PUT
+share the packed NODEDEF id.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+None blocking.
+
+### Companions (checked)
+
+| Artifact | Present |
+|----------|---------|
+| WebUI API wrap/unwrap for `NamedObjectRefList` | yes |
+| ContentTypeDetailPanel lock → PUT → GET | yes |
+| Vitest API + panel + DeveloperShell | yes |
+| rest `NamedObjectRefList` XmlSeeAlso + List PUT param + serial test | yes |
+| sitemanage lock GUID alignment + adaptor tests | yes |
+| Playwright surface spec | `developer-content-type-template-associations.spec.js` |
+| product-docs `8.2/admin/developer-content-types.md` + REST CD-12 | yes |
+| Out of scope: workflow chrome (#3782), enable/disable (#3781) | not shipped |
+
+### Notes (non-blocking)
+
+- Whole-object PUT still exists for label/description/fields/workflows; templates use the CD-12 sub-resource only.
+- Jackson WRAP_ROOT uses class name `NamedObjectRefList` (XmlRootElement ignored without JAXB introspector) — client wrap matches.
+- Cross-platform path checklist: N/A (REST URL `/` only; no filesystem joins).

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type allowed-template associations chrome (CD-12 / #3783).
+ *
+ * Admin locks a type, replaces the allowed-template set (add/remove existing
+ * ids), saves via PUT .../allowedTemplates, then GET lists the new set.
+ * Unlocked save is blocked; lock is not stolen.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-template-associations.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { catalogRowSelector } = require("./helpers/developer-catalog-selectors");
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function unwrapNamedObjectRefs(payload) {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (typeof payload !== "object") {
+    return [];
+  }
+  if (Array.isArray(payload.NamedObjectRefList)) {
+    return payload.NamedObjectRefList;
+  }
+  if (payload.NamedObjectRefList && typeof payload.NamedObjectRefList === "object") {
+    return unwrapNamedObjectRefs(payload.NamedObjectRefList);
+  }
+  if (payload.NamedObjectRef) {
+    return unwrapNamedObjectRefs(payload.NamedObjectRef);
+  }
+  if (typeof payload.empty === "boolean" && Object.keys(payload).every((k) => k === "empty")) {
+    return [];
+  }
+  if (payload.name || payload.label || payload.guid) {
+    return [payload];
+  }
+  return [];
+}
+
+function refName(item) {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+  return String(item.name || item.label || "").trim();
+}
+
+async function openContentTypeDetail(page, namePattern) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    test.skip(true, "No content types in catalog — cannot exercise template associations");
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = namePattern
+    ? table.locator('[data-testid^="developer-ct-row-"]').filter({ hasText: namePattern })
+    : table.locator('[data-testid^="developer-ct-row-"]').filter({ hasText: /percPage/ });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
+  }
+}
+
+async function getAllowedTemplatesViaRest(page, typeName) {
+  const result = await page.evaluate(async (name) => {
+    const res = await fetch(
+      `/Rhythmyx/services/contenttypes/${encodeURIComponent(name)}/allowedTemplates`,
+      { credentials: "same-origin", headers: { Accept: "application/json" } },
+    );
+    const text = await res.text();
+    return { status: res.status, text };
+  }, typeName);
+  expect(
+    result.status,
+    `GET allowedTemplates ${result.status} ${String(result.text).slice(0, 400)}`,
+  ).toBe(200);
+  let json = {};
+  try {
+    json = JSON.parse(result.text);
+  } catch {
+    throw new Error(`GET allowedTemplates non-JSON: ${String(result.text).slice(0, 400)}`);
+  }
+  return unwrapNamedObjectRefs(json).map(refName).filter(Boolean);
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(unexpectedConsole, `console error: ${unexpectedConsole.join(" | ")}`).toEqual([]);
+}
+
+test.describe("Developer content type template associations (CD-12 / #3783)", () => {
+  test("unlocked template editors and save stay blocked; 409 lock is not stolen", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page);
+
+    const addName = page.locator('[data-testid="developer-ct-tpl-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-tpl-add"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+
+    await expect(page.locator('[data-testid="developer-ct-templates"]')).toBeVisible();
+    await expect(addName).toBeDisabled();
+    await expect(addBtn).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+    await expect(status).toHaveText(/Not locked/i);
+
+    await page.route("**/services/contenttypes/**/lock", async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Locked by another user" }),
+      });
+    });
+
+    await lockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-detail-error"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(status).toHaveText(/Not locked/i);
+    await expect(addName).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Admin lock, replace allowed templates, GET lists the new set", async ({ page }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page, /percPage/);
+
+    const addName = page.locator('[data-testid="developer-ct-tpl-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-tpl-add"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    const typeName = (
+      await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
+    ).trim();
+    expect(typeName.length, "detail name for GET").toBeGreaterThan(0);
+
+    const original = await getAllowedTemplatesViaRest(page, typeName);
+
+    await expect(addName).toBeDisabled();
+    await lockBtn.click();
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(addName).toBeEnabled();
+    await expect(unlockBtn).toBeEnabled();
+
+    const rows = page.locator('[data-testid^="developer-ct-tpl-row-"]');
+    const originalRowCount = await rows.count();
+    expect(originalRowCount, "UI rows vs GET allowedTemplates").toBe(original.length);
+
+    const saveTemplates = async (label) => {
+      const putWait = page.waitForResponse(
+        (res) =>
+          res.request().method() === "PUT" &&
+          /\/contenttypes\/[^/?]+\/allowedTemplates(?:\?|$)/.test(res.url()),
+        { timeout: 20_000 },
+      );
+      await expect(saveBtn).toBeEnabled();
+      await saveBtn.click();
+      const putRes = await putWait;
+      const putBody = putRes.request().postData() || "";
+      await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+      if (await saveError.isVisible()) {
+        throw new Error(
+          `${label}: ${(await saveError.innerText()).trim()} PUT ${putRes.status()} ${putBody}`,
+        );
+      }
+      expect(putRes.status(), `${label} PUT allowedTemplates ${putBody}`).toBe(200);
+      expect(putBody, `${label} PUT wrap`).toContain("NamedObjectRefList");
+      await expect(notice).toContainText(/saved/i);
+      return getAllowedTemplatesViaRest(page, typeName);
+    };
+
+    try {
+      if (original.length > 0) {
+        const removedName = original[original.length - 1];
+        await page.locator(`[data-testid="developer-ct-tpl-remove-${original.length - 1}"]`).click();
+        const afterRemove = await saveTemplates("Remove template save failed");
+        const restGet = await getAllowedTemplatesViaRest(page, typeName);
+        expect(restGet).toEqual(afterRemove);
+        if (removedName) {
+          expect(restGet).not.toContain(removedName);
+        }
+        expect(restGet.length).toBe(original.length - 1);
+
+        if (removedName) {
+          await addName.fill(removedName);
+          await addBtn.click();
+        }
+      } else {
+        await addName.fill("perc.page");
+        await addBtn.click();
+        const afterAdd = await saveTemplates("Add perc.page save failed");
+        const restGet = await getAllowedTemplatesViaRest(page, typeName);
+        expect(restGet).toEqual(afterAdd);
+        expect(restGet).toContain("perc.page");
+        await page.locator('[data-testid="developer-ct-tpl-remove-0"]').click();
+      }
+
+      const restoredUi = await saveTemplates("Restore template save failed");
+      const restored = await getAllowedTemplatesViaRest(page, typeName);
+      expect(restored).toEqual(restoredUi);
+      expect(restored.sort()).toEqual([...original].sort());
+    } finally {
+      if (await unlockBtn.isEnabled()) {
+        await unlockBtn.click();
+        await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+      }
+    }
+
+    await expect(addName).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -38,7 +38,12 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 6. Change the **Description** (and any other unlocked fields), then click
    **Save content type**. Save writes while the lock is still held. It does
    **not** unlock.
-7. Click **Unlock** when you are done. Status returns to **Not locked** and the
+7. To change **Allowed templates**, lock the type, add or remove existing
+   template names or GUIDs (`type-host-uuid`, for example `0-10-347`), then
+   **Save content type**. Save replaces the whole allowed-template set. An empty
+   list clears associations. Unknown names return an error; the lock is not
+   stolen. This is not the full Workbench template picker.
+8. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
 Locks expire after **30 minutes**. If Save fails because the lock expired,
@@ -51,7 +56,9 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, workflows) | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |
+| Confirm allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -295,12 +295,17 @@ allowed template associations. Body is a JSON array of named refs (`name` and/or
 `guid`). Full-replace semantics: the supplied list becomes the new set; an empty
 array clears associations.
 
-Typical flow (lock REST is a peer slice; SOAP/Workbench can also hold the lock):
+Typical flow:
 
-1. Hold a design lock on the content type.
+1. Hold a design lock on the content type (`POST .../lock` from Developer, or SOAP/Workbench).
 2. `PUT /services/contenttypes/{idOrName}/allowedTemplates` with the new set.
 3. `GET` the same path (or `GET /services/contenttypes/{idOrName}`) to confirm.
 4. Release the design lock when editing is finished.
+
+**Developer → Content types** detail chrome follows that flow after **Lock**: add or
+remove existing template names/GUIDs, **Save content type** (dedicated PUT, then GET
+lists the new set), then **Unlock**. Save is disabled until the lock is held; the
+product does not steal another user's lock. See [Developer Content Types](id:admin-developer-content-types).
 
 `409` means the current session user does not hold the design lock. `400` means
 a template id or name in the body does not exist. The lock stays held after a

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -593,11 +593,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     String session = currentSession();
     String user = currentUser();
     try {
-      PSItemDefinition current = resolveItemDef(idOrName.trim());
-      if (current == null) {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(idOrName.trim());
+      if (ctGuid == null) {
         return null;
       }
-      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
       requireHeldLock(ctGuid);
       List<IPSGuid> templateGuids = resolveTemplateGuids(templates);
       try {
@@ -615,9 +614,6 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         | IllegalArgumentException
         | WebApplicationException e) {
       throw e;
-    } catch (PSInvalidContentTypeException e) {
-      log.debug("Content type not found for template association replace: {}", idOrName);
-      return null;
     } catch (Exception e) {
       log.error(
           "Failed to replace template associations for {}: {}", idOrName, e.getMessage(), e);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
@@ -39,6 +39,7 @@ import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.catalog.data.PSObjectSummary;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -87,6 +88,12 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     percPage = mock(PSItemDefinition.class);
     when(percPage.getTypeId()).thenReturn(311);
     when(itemDefManager.getItemDef("percPage", PSItemDefManager.COMMUNITY_ANY)).thenReturn(percPage);
+    IPSCatalogSummary percPageSum = mock(IPSCatalogSummary.class);
+    IPSGuid percPageGuid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    when(percPageSum.getGUID()).thenReturn(percPageGuid);
+    when(percPageSum.getName()).thenReturn("percPage");
+    when(percPageSum.getLabel()).thenReturn("Page");
+    when(designSvc.findContentTypes("percPage")).thenReturn(List.of(percPageSum));
   }
 
   @AfterEach
@@ -112,6 +119,12 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getAllowedTemplates(null, "missing"));
+  }
+
+  @Test
+  void replaceAllowedTemplates_missingType_returnsNull() {
+    when(designSvc.findContentTypes("missing")).thenReturn(List.of());
+    assertNull(adaptor.replaceAllowedTemplates(null, "missing", List.of()));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1160,7 +1160,7 @@ public class ContentTypesResource {
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public NamedObjectRefList replaceAllowedTemplates(
-      @PathParam("idOrName") String idOrName, NamedObjectRefList body) {
+      @PathParam("idOrName") String idOrName, List<NamedObjectRef> body) {
     try {
       List<NamedObjectRef> items =
           requireAdaptor().replaceAllowedTemplates(uriInfo.getBaseUri(), idOrName, body);

--- a/rest/src/main/java/com/percussion/rest/contenttypes/NamedObjectRefList.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/NamedObjectRefList.java
@@ -17,16 +17,32 @@
 
 package com.percussion.rest.contenttypes;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
-/** Wire list of {@link NamedObjectRef} (content-type allowed templates/workflows). */
-@XmlRootElement(name = "NamedObjectRef")
+/**
+ * Wire list of {@link NamedObjectRef} (content-type allowed templates/workflows).
+ *
+ * <p>{@link XmlSeeAlso} registers {@link NamedObjectRef} in the JAXB context so GET/PUT {@code
+ * .../allowedTemplates} can marshal list elements. Without it, live H2 returns {@code
+ * JAXBException}: {@code NamedObjectRef nor any of its super class is known to this context}. Peer:
+ * {@code SiteList} (#3090), {@code TemplateSummaryList}.
+ *
+ * <p>{@link JsonFormat.Shape#ARRAY} keeps Jackson from treating this {@code ArrayList} subclass as
+ * a bean ({@code {"empty":false}}) under WRAP_ROOT_VALUE.
+ */
+@XmlRootElement(name = "NamedObjectRefList")
+@JsonRootName("NamedObjectRefList")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @ArraySchema(schema = @Schema(implementation = NamedObjectRef.class))
+@XmlSeeAlso(NamedObjectRef.class)
 public class NamedObjectRefList extends ArrayList<NamedObjectRef> {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/test/java/com/percussion/rest/contenttypes/NamedObjectRefListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/NamedObjectRefListSerialDeserialTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@code GET}/{@code PUT .../allowedTemplates} {@link NamedObjectRefList}.
+ *
+ * <p>Live H2 returned JAXBException {@code NamedObjectRef nor any of its super class is known to
+ * this context} when the list wrapper omitted {@code @XmlSeeAlso} and reused the item root name.
+ * Peer: {@code SiteListSerialDeserialTest} (#3090).
+ */
+@Tag("UnitTest")
+public class NamedObjectRefListSerialDeserialTest {
+
+  private static NamedObjectRef sampleRef() {
+    NamedObjectRef ref = new NamedObjectRef();
+    ref.setName("perc.page");
+    ref.setLabel("Page");
+    return ref;
+  }
+
+  @Test
+  public void productionMapperSerializesNamedObjectRefListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(NamedObjectRefList.class);
+    NamedObjectRefList list = new NamedObjectRefList();
+    list.add(sampleRef());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"NamedObjectRefList\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("["), "list must be a JSON array, not a bean: " + json);
+    assertTrue(json.contains("perc.page"), json);
+    assertFalse(
+        json.contains("\"empty\""),
+        "ArrayList subclass must not serialize as {empty:false} bean: " + json);
+
+    NamedObjectRefList roundTrip = mapper.readValue(json, NamedObjectRefList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("perc.page", roundTrip.get(0).getName());
+    assertEquals("Page", roundTrip.get(0).getLabel());
+  }
+
+  @Test
+  public void productionMapperSerializesEmptyListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(NamedObjectRefList.class);
+    String json = mapper.writeValueAsString(new NamedObjectRefList());
+    assertTrue(json.contains("NamedObjectRefList") || json.contains("["), json);
+  }
+
+  @Test
+  public void jaxbContextKnowsNamedObjectRefFromList() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(NamedObjectRefList.class);
+    Marshaller marshaller = ctx.createMarshaller();
+    NamedObjectRefList list = new NamedObjectRefList();
+    list.add(sampleRef());
+    StringWriter writer = new StringWriter();
+    marshaller.marshal(list, writer);
+    String xml = writer.toString();
+    assertFalse(xml.isBlank(), "marshalled XML must not be empty");
+    assertTrue(
+        xml.contains("NamedObjectRefList") || xml.contains("namedObjectRefList"),
+        "expected NamedObjectRefList root in XML, got: " + xml);
+    assertFalse(
+        xml.toLowerCase().contains("known to this context"),
+        "JAXB context must include NamedObjectRef: " + xml);
+  }
+}


### PR DESCRIPTION
## Summary

Developer Content Type **allowed-template associations** chrome (CD-12) for parent **#1690**. After a held design-session lock, Admin can add/remove existing template names or GUIDs and **Save content type**. The SPA calls dedicated `PUT /services/contenttypes/{idOrName}/allowedTemplates` (Jackson root `NamedObjectRefList`) then `GET` lists the new set. Bulk `PUT /contenttypes/{id}` no longer sends `allowedTemplates` and no longer wraps lock→save→unlock.

Live H2 also required REST/adaptor wire companions so the chrome can consume CD-12: `NamedObjectRefList` JAXB `@XmlSeeAlso` + distinct root name (peer SiteList #3090); PUT body typed as `List<NamedObjectRef>` so CXF does not cast `ArrayList`; `replaceAllowedTemplates` uses the packed NODEDEF lock GUID so lock and PUT agree.

Fixes #3783
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `perc-devctl qa-up` (H2 Docker) → `qa-health`.
2. Sign in as Admin → Developer → Content types → open percPage.
3. Allowed-template add/remove and Save stay disabled until Lock. Foreign lock is 409; no steal.
4. Lock → remove (or add) an existing template id → Save. Network shows `PUT .../allowedTemplates` then GET lists the new set. Restore original set. Unlock.
5. Vitest: `contentTypesApi.test.ts`, `ContentTypeDetailPanel.test.tsx`, `DeveloperShell.test.tsx`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-content-types.md` (lock then edit allowed templates) and `product-docs/8.2/developer/rest.md` (SPA consumes dedicated GET/PUT)
- [x] **Unit / module tests** — Vitest API + panel + shell; rest `NamedObjectRefListSerialDeserialTest`; sitemanage `ContentTypeAdaptorAllowedTemplatesTest`
- [x] **WebUI + Playwright** — `developer-content-type-template-associations.spec.js` (2 passed, fail closed)
- [x] **Build gates** — standalone clean install on changed modules
- [x] **Cross-platform** — REST URL `/` only; no filesystem path joins

### C3 evidence

- **modules_built:** WebUI, rest, projects/sitemanage, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3093 passed; Java Tests run: 63, Failures: 0
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 609, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1573, Failures: 0, Skipped: 125
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; no Java tests)
- **downstream_checked:** rest + sitemanage standalone clean install. `ContentTypesResource.replaceAllowedTemplates` param widened from `NamedObjectRefList` to `List<NamedObjectRef>` (still a List; resource tests compile). Grep: no `extends ContentTypesResource` / anonymous subclass. No type made final/sealed.

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → TEST_CMS_URL=http://127.0.0.1:9993 CONTAINER=perc-matrix-cms-h2
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/login` RESULT:OK HTTP:200 HEALTH:healthy
- Hot-copy: WebUI `cm/modern/assets`; `rest-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` + `perc-system-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; StopJetty/StartJetty inside cell; `qa-health` again RESULT:OK
- Playwright: `npm run test:surface -- --path tests/developer-content-type-template-associations.spec.js` — **2 passed** (unlocked/409 no steal; lock/replace/GET persist)
- console-clean=yes (pageerror/console error assertions empty)
- server.log-clean=yes (no content-type template ERROR/FATAL in test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
