### PR TITLE
feat(errorcodes): retype nav/sfp/workflow IPS*Errors (#3770)

### DIFF
--- a/docs/ai-generated/code-reviews/3770-nav-sfp-workflow-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3770-nav-sfp-workflow-errorcodes-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review: #3770 nav/sfp/workflow IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted work on `fix/issue-3770-nav-sfp-workflow-errorcodes` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Date:** 2026-08-26
+
+## Summary
+
+Leftover `modules/extensions-nav`, `modules/extensions-sfp`, and `modules/extensions-workflow` production `IPS*Errors` sites now construct typed `ExtensionErrorCodes` / `CmsErrorCodes` / `ServerErrorCodes` / `PathItemErrorCodes`. Additive `IPSErrorCode` constructors on workflow/system/utils exception types. Allow-list `scripts/ipserrors-residual-allowlist.txt` shrunk by those exact paths only. Dual-write skip tests cover leftover non-auditable catalog codes. Language+typed constructors live on subclasses (not `PSException(String, IPSErrorCode)`) to avoid `(String, Throwable)` null-arg ambiguity. No product UI/config surface.
+
+Memory patterns hit: change-class closure (typed ctors + production retype + allow-list + dual-write skip + producer module install); additive constructors (not `final` / signature-breaking); behavioral production throws for sfp calendar + workflow mail.
+
+## Gate
+
+No bugs. Behavioral tests cover typed construction, production throws (`PSExpandRecurringEvents`, `PSMakeCalendar`, `PSJavaxMailProgram`, `PSSecureMailProgram`), and dual-write skip. Cross-platform path checklist: new tests use mocks / typed constructors; no hardcoded separators. Did not add `PSException(String, IPSErrorCode)` on the base class after it made `new PSException("msg", null)` ambiguous with `(String, Throwable)`.
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New tests do not assert Unix-only absolute path shapes
+- [x] N/A for product scripts / installers

--- a/modules/extensions-nav/pom.xml
+++ b/modules/extensions-nav/pom.xml
@@ -16,6 +16,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
@@ -16,7 +16,8 @@
  */
 package com.percussion.fastforward.managednav;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.server.PSAuthTypes;
 import com.percussion.data.PSInternalRequestCallException;
@@ -28,7 +29,6 @@ import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -236,7 +236,7 @@ public class PSNavTreeSlotMarker extends PSDefaultExtension implements IPSResult
     String resource = PSAuthTypes.getInstance().getResourceForAuthtype("" + authType);
     if (resource == null || resource.length() == 0) {
       String[] args = {"" + authType, PSAuthTypes.getInstance().getConfigFile().getAbsolutePath()};
-      throw new PSNavException(new PSCmsException(IPSCmsErrors.INVALID_AUTHTYPE, args));
+      throw new PSNavException(new PSCmsException(CmsErrorCodes.INVALID_AUTHTYPE, args));
     }
     Set<String> resultSet = new HashSet<>();
     Map<String, Object> params = new HashMap<>();
@@ -246,7 +246,7 @@ public class PSNavTreeSlotMarker extends PSDefaultExtension implements IPSResult
     if (ir == null) {
       Object[] args = {resource, "No request handler found."};
       throw new PSNavException(
-          new PSNotFoundException(IPSServerErrors.MISSING_INTERNAL_REQUEST_RESOURCE, args));
+          new PSNotFoundException(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE, args));
     }
     try {
       Document doc = ir.getResultDoc();

--- a/modules/extensions-nav/src/test/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarkerTypedErrorCodeSliceTest.java
+++ b/modules/extensions-nav/src/test/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarkerTypedErrorCodeSliceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.fastforward.managednav;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.cms.PSCmsException;
+import com.percussion.error.PSNotFoundException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Leftover nav production throw sites now construct typed {@code *ErrorCodes} (issue #3770).
+ * Authtype / internal-request paths require live server config; the typed exceptions they wrap
+ * are asserted here.
+ */
+@Tag("UnitTest")
+class PSNavTreeSlotMarkerTypedErrorCodeSliceTest {
+
+  @Test
+  void invalidAuthtypeCmsExceptionIsTypedAndNonAuditable() {
+    Object[] args = {"3", "authtypes.xml"};
+    PSCmsException ex = new PSCmsException(CmsErrorCodes.INVALID_AUTHTYPE, args);
+    assertSame(CmsErrorCodes.INVALID_AUTHTYPE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void missingInternalRequestNotFoundExceptionIsTypedAndNonAuditable() {
+    Object[] args = {"sys_casSupport/casSupport_0", "No request handler found."};
+    PSNotFoundException ex =
+        new PSNotFoundException(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE, args);
+    assertSame(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/extensions-sfp/pom.xml
+++ b/modules/extensions-sfp/pom.xml
@@ -16,6 +16,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.fastforward.calendar;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -87,11 +87,11 @@ public class PSExpandRecurringEvents extends PSDefaultExtension
     // it is an error if either parameter is missing
     if (calendarStartString == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"calendarStart", "is a required parameter"});
     if (calendarEndString == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"calendarEnd", "is a required parameter"});
 
     // try to parse the parameters into Dates
@@ -99,16 +99,16 @@ public class PSExpandRecurringEvents extends PSDefaultExtension
     Date calendarEnd = PSDataTypeConverter.parseStringToDate(calendarEndString);
     if (calendarStart == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"calendarStart", "could not be parsed as a Date"});
     if (calendarEnd == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"calendarEnd", "could not be parsed as a Date"});
 
     if (calendarEnd.before(calendarStart))
       throw new PSExtensionProcessingException(
-          IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+          ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
           new Object[] {
             "ExpandRecurringEvents", "Calendar end must be greater than than calendar start"
           });

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.fastforward.calendar;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -80,7 +80,7 @@ public class PSMakeCalendar implements IPSResultDocumentProcessor {
     // get the calendar start date
     if (params[0] == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"date", "is a required parameter"});
     Date date = PSDataTypeConverter.parseStringToDate(params[0].toString());
     if (date == null)

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSBuildRelationshipsFromIdsExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSBuildRelationshipsFromIdsExit.java
@@ -16,12 +16,12 @@
  */
 package com.percussion.fastforward.relationship;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.handlers.PSContentEditorHandler;
 import com.percussion.cms.handlers.PSModifyCommandHandler;
 import com.percussion.cms.handlers.PSQueryCommandHandler;
 import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -103,21 +103,21 @@ public class PSBuildRelationshipsFromIdsExit extends PSDefaultExtension
         String fieldName = paramMap.get("fieldname");
         if (StringUtils.isBlank(fieldName)) {
           throw new PSParameterMismatchException(
-              IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+              ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
               new Object[] {"fieldname", "is a required parameter"});
         }
 
         String slotName = paramMap.get("slotname");
         if (StringUtils.isBlank(slotName)) {
           throw new PSParameterMismatchException(
-              IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+              ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
               new Object[] {"slotname", "is a required parameter"});
         }
 
         String templateName = paramMap.get("templatename");
         if (StringUtils.isBlank(templateName)) {
           throw new PSParameterMismatchException(
-              IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+              ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
               new Object[] {"templatename", "is a required parameter"});
         }
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.fastforward.sfp;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSFolder;
 import com.percussion.cms.objectstore.PSRelationshipProcessorProxy;
@@ -339,7 +339,7 @@ public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     if (irq == null) {
       // Fatal error
       String[] args = {resource, ""};
-      throw new PSExtensionProcessingException(IPSCmsErrors.CMS_INTERNAL_REQUEST_ERROR, args);
+      throw new PSExtensionProcessingException(CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR, args);
     }
     Document doc = null;
     try {
@@ -347,7 +347,7 @@ public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     } catch (PSInternalRequestCallException e) {
       // Fatal error
       String[] args = {resource, e.getLocalizedMessage()};
-      throw new PSExtensionProcessingException(IPSCmsErrors.CMS_INTERNAL_REQUEST_ERROR, args);
+      throw new PSExtensionProcessingException(CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR, args);
     }
     return doc;
   }
@@ -372,7 +372,7 @@ public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     if (irq == null) {
       // Fatal error
       String[] args = {resource, ""};
-      throw new PSExtensionProcessingException(IPSCmsErrors.CMS_INTERNAL_REQUEST_ERROR, args);
+      throw new PSExtensionProcessingException(CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR, args);
     }
     ResultSet rs = null;
     List<PageData> items = new ArrayList<>();
@@ -389,7 +389,7 @@ public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     } catch (PSInternalRequestCallException e) {
       // Fatal error
       String[] args = {resource, e.getLocalizedMessage()};
-      throw new PSExtensionProcessingException(IPSCmsErrors.CMS_INTERNAL_REQUEST_ERROR, args);
+      throw new PSExtensionProcessingException(CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR, args);
     } catch (SQLException e) {
       // Should be very rare
       throw new PSExtensionProcessingException(m_def.getRef().getExtensionName(), e);

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
@@ -16,7 +16,8 @@
  */
 package com.percussion.fastforward.sfp;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.data.macro.PSMacroUtils;
@@ -30,7 +31,6 @@ import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.extension.services.PSDatabasePool;
 import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.util.PSSqlHelper;
 import java.sql.Date;
@@ -346,7 +346,7 @@ public class PSSiteFolderCListBulk extends PSSiteFolderCListBase {
     try {
       fixupItems = PSMacroUtils.getLastPublicRevisions(idList);
     } catch (PSException e) {
-      throw new PSCmsException(IPSServerErrors.EXCEPTION_NOT_CAUGHT, e.toString());
+      throw new PSCmsException(ServerErrorCodes.EXCEPTION_NOT_CAUGHT, e.toString());
     }
     for (Map.Entry<Integer, Integer> entry : fixupItems.entrySet()) {
       Integer contentid = entry.getKey();
@@ -401,7 +401,7 @@ public class PSSiteFolderCListBulk extends PSSiteFolderCListBase {
 
     if (ir == null)
       throw new PSExtensionProcessingException(
-          IPSCmsErrors.REQUIRED_RESOURCE_MISSING, m_contentResourceName);
+          CmsErrorCodes.REQUIRED_RESOURCE_MISSING, m_contentResourceName);
     try {
       ResultSet rs = ir.getResultSet();
 
@@ -473,7 +473,7 @@ public class PSSiteFolderCListBulk extends PSSiteFolderCListBase {
         }
       }
     } catch (Exception e) {
-      throw new PSCmsException(IPSServerErrors.EXCEPTION_NOT_CAUGHT, e.toString());
+      throw new PSCmsException(ServerErrorCodes.EXCEPTION_NOT_CAUGHT, e.toString());
     } finally {
       ir.cleanUp();
     }

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
@@ -16,9 +16,9 @@
  */
 package com.percussion.fastforward.sfp;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.design.objectstore.PSServerConfiguration;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -99,14 +99,14 @@ public abstract class PSSiteFolderContentListBaseExit implements IPSResultDocume
     String siteid = request.getParameter(IPSHtmlParameters.SYS_SITEID);
     if (siteid == null)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"PSXParam/sys_siteid", "null"});
 
     String folderPath = PSSite.lookupFolderRootForSite(siteid, request);
 
     if (folderPath == null || folderPath.trim().length() == 0)
       throw new PSParameterMismatchException(
-          IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+          ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
           new Object[] {"folderPath", "null"});
 
     String filenameContext =

--- a/modules/extensions-sfp/src/test/java/com/percussion/fastforward/calendar/PSExpandRecurringEventsTypedErrorCodeSliceTest.java
+++ b/modules/extensions-sfp/src/test/java/com/percussion/fastforward/calendar/PSExpandRecurringEventsTypedErrorCodeSliceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.fastforward.calendar;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.percussion.extension.PSParameterMismatchException;
+import com.percussion.server.IPSRequestContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Leftover sfp calendar production throw sites now construct typed {@link ExtensionErrorCodes}
+ * (issue #3770).
+ */
+@Tag("UnitTest")
+class PSExpandRecurringEventsTypedErrorCodeSliceTest {
+
+  @Test
+  void missingCalendarStartThrowsTypedMismatch() throws Exception {
+    PSExpandRecurringEvents exit = new PSExpandRecurringEvents();
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    Document doc = mock(Document.class);
+
+    PSParameterMismatchException ex =
+        assertThrows(
+            PSParameterMismatchException.class,
+            () -> exit.processResultDocument(new Object[] {null, "2026-01-31"}, request, doc));
+    assertSame(ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void makeCalendarNullDateThrowsTypedMismatch() throws Exception {
+    PSMakeCalendar calendar = new PSMakeCalendar();
+    IPSRequestContext request = mock(IPSRequestContext.class);
+    Document doc = mock(Document.class);
+
+    PSParameterMismatchException ex =
+        assertThrows(
+            PSParameterMismatchException.class,
+            () -> calendar.processResultDocument(new Object[] {null}, request, doc));
+    assertSame(ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/modules/extensions-workflow/pom.xml
+++ b/modules/extensions-workflow/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
+            <artifactId>audit-log</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.percussion</groupId>
             <artifactId>utils</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/modules/extensions-workflow/src/main/java/com/percussion/relationship/effect/PSNotifyEffect.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/relationship/effect/PSNotifyEffect.java
@@ -17,8 +17,8 @@
 
 package com.percussion.relationship.effect;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSWorkFlowContext;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.extension.PSParameterMismatchException;
@@ -91,14 +91,14 @@ public class PSNotifyEffect extends PSEffect {
       if (params.length < i + 1) {
         Object[] args = {REQUIRED_PARAMS[i], "missing"};
         throw new PSExtensionProcessingException(
-            IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
       }
 
       String parameter = params[i].toString().trim();
       if (parameter.length() == 0) {
         Object[] args = {REQUIRED_PARAMS[i], "empty"};
         throw new PSExtensionProcessingException(
-            IPSExtensionErrors.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
       }
 
       parameters.put(REQUIRED_PARAMS[i], parameter);
@@ -110,7 +110,7 @@ public class PSNotifyEffect extends PSEffect {
       if (parameter == null || parameter.length() == 0) {
         Object[] args = {REQUIRED_HTML_PARAMS[i], "null or empty"};
         throw new PSExtensionProcessingException(
-            IPSExtensionErrors.EXT_MISSING_HTML_PARAMETER_ERROR, args);
+            ExtensionErrorCodes.EXT_MISSING_HTML_PARAMETER_ERROR, args);
       }
 
       parameters.put(REQUIRED_HTML_PARAMS[i], parameter);
@@ -178,7 +178,7 @@ public class PSNotifyEffect extends PSEffect {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {
       Object[] args = {name, e.getLocalizedMessage()};
-      throw new PSExtensionProcessingException(IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, args);
+      throw new PSExtensionProcessingException(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, args);
     }
   }
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCheckInCheckOutException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCheckInCheckOutException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -37,6 +38,17 @@ public class PSCheckInCheckOutException extends PSException {
   }
 
   /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSCheckInCheckOutException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception for messages taking locale and message code arguments and and a single
    * argument.
    *
@@ -48,6 +60,18 @@ public class PSCheckInCheckOutException extends PSException {
    */
   public PSCheckInCheckOutException(String language, int msgCode, Object singleArg) {
     super(language, msgCode, singleArg);
+  }
+
+  /**
+   * Typed construction with locale and a single message argument.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSCheckInCheckOutException(String language, IPSErrorCode code, Object singleArg) {
+    super(language, requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
   }
 
   /**
@@ -63,5 +87,17 @@ public class PSCheckInCheckOutException extends PSException {
    */
   public PSCheckInCheckOutException(String language, int msgCode, Object[] arrayArgs) {
     super(language, msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with locale and message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSCheckInCheckOutException(String language, IPSErrorCode code, Object[] arrayArgs) {
+    super(language, requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
   }
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.workflow;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.services.system.PSSystemServiceLocator;
 import com.percussion.services.workflow.data.PSContentAdhocUser;
@@ -175,7 +175,7 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
       m_nCount = 0;
       while (moveNext()) {
         if (m_sUserName.length() == 0) {
-          throw new PSRoleException(IPSExtensionErrors.USERNAME_NULL_EMPTY_TRIM);
+          throw new PSRoleException(ExtensionErrorCodes.USERNAME_NULL_EMPTY_TRIM);
         }
         m_nCount++;
 
@@ -205,7 +205,7 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
             m_adhocAnonymousRoleIDs.add(roleID);
           }
         } else {
-          throw new PSRoleException(IPSExtensionErrors.INVALID_ADHOC);
+          throw new PSRoleException(ExtensionErrorCodes.INVALID_ADHOC);
         }
       }
     } finally {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.workflow;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.system.IPSSystemService;
@@ -66,7 +66,7 @@ public final class PSContentStatusHistoryContext implements IPSContentStatusHist
     m_rows = svc.findContentStatusHistory(id);
     if (m_rows == null || m_rows.isEmpty()) {
       m_nCount = 0;
-      throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+      throw new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
     }
     m_nCount = m_rows.size();
     m_rowIndex = 0;

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.workflow;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.contentmgr.IPSNodeDefinition;
 import com.percussion.services.contentmgr.PSContentMgrLocator;
@@ -122,7 +122,7 @@ public final class PSContentTypesContext implements IPSContentTypesContext {
 
       if (false == rs.next()) {
         close();
-        throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+        throw new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
       }
 
       m_sContentTypeName = rs.getString("CONTENTTYPENAME");

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.handlers.PSConditionalCloneHandler;
 import com.percussion.cms.handlers.PSRelationshipCommandHandler;
@@ -29,7 +30,6 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.*;
 import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.services.legacy.IPSCmsObjectMgr;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
@@ -216,7 +216,7 @@ public class PSCreateTranslations implements IPSWorkflowAction {
         ir = request.getInternalRequest(ceurl);
         if (ir == null) {
           Object[] args = {ceurl, "No request handler found."};
-          throw new PSNotFoundException(IPSServerErrors.MISSING_INTERNAL_REQUEST_RESOURCE, args);
+          throw new PSNotFoundException(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE, args);
         }
         ir.makeRequest();
       }
@@ -247,7 +247,7 @@ public class PSCreateTranslations implements IPSWorkflowAction {
       ir = request.getInternalRequest(resource);
       if (ir == null) {
         Object[] args = {resource, "No request handler found."};
-        throw new PSNotFoundException(IPSServerErrors.MISSING_INTERNAL_REQUEST_RESOURCE, args);
+        throw new PSNotFoundException(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE, args);
       }
       doc = ir.getResultDoc();
     } catch (PSException e) {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSDuplicateApprovalException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSDuplicateApprovalException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -48,6 +49,18 @@ public class PSDuplicateApprovalException extends PSException {
    */
   public PSDuplicateApprovalException(String language, int msgCode, Object singleArg) {
     super(language, msgCode, singleArg);
+  }
+
+  /**
+   * Typed construction with locale and a single message argument.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSDuplicateApprovalException(String language, IPSErrorCode code, Object singleArg) {
+    super(language, requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
   }
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSExtensionManager;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.IPSWorkFlowContext;
@@ -144,7 +144,7 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
 
     // If the workflow action list is empty, it is an error
     if (workflowActions.isEmpty()) {
-      String key = Integer.toString(IPSExtensionErrors.WKFLOW_ACTIONLIST_EMPTY);
+      String key = Integer.toString(ExtensionErrorCodes.WKFLOW_ACTIONLIST_EMPTY.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       throw new PSExtensionProcessingException(lang, m_fullExtensionName, new Exception(msg));
     }
@@ -155,7 +155,7 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
 
     // If there is no workflow context it is an error
     if (null == wfContext) {
-      String key = Integer.toString(IPSExtensionErrors.WKFLOW_CONTEXT_NULL);
+      String key = Integer.toString(ExtensionErrorCodes.WKFLOW_CONTEXT_NULL.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       throw new PSExtensionProcessingException(m_fullExtensionName, new Exception(msg));
     }
@@ -177,7 +177,7 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
           IPSExtension ext = ms_extensionMgr.prepareExtension(ref, null);
           if (!(ext instanceof IPSWorkflowAction)) {
             // fix except type
-            String key = Integer.toString(IPSExtensionErrors.INVALID_WKFLOW_EXT);
+            String key = Integer.toString(ExtensionErrorCodes.INVALID_WKFLOW_EXT.numericCode());
             String msg = PSI18nUtils.getString(key, lang);
             throw new PSExtensionProcessingException(lang, m_fullExtensionName, new Exception(msg));
           }
@@ -211,7 +211,7 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
        * in the previous while loop.
        */
       if (null == wfActionExtension) {
-        String key = Integer.toString(IPSExtensionErrors.EXEC_EXT_NOTFOUND);
+        String key = Integer.toString(ExtensionErrorCodes.EXEC_EXT_NOTFOUND.numericCode());
         String msg = PSI18nUtils.getString(key, lang);
 
         throw new PSExtensionProcessingException(m_fullExtensionName, new Exception(msg));

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddEditAuthFlag.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddEditAuthFlag.java
@@ -17,9 +17,9 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -106,18 +106,18 @@ public class PSExitAddEditAuthFlag implements IPSResultDocumentProcessor {
 
       // Set username
       if (null == params[0] || params[0].toString().trim().length() == 0) {
-        throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME1);
+        throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME1);
       }
       localParams.m_userName = params[0].toString();
       localParams.m_userName = PSWorkFlowUtils.filterUserName(localParams.m_userName);
       if (0 == localParams.m_userName.length()) {
-        throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME2);
+        throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME2);
       }
 
       // Set RoleNameList
       if (null == params[1] || params[1].toString().trim().length() == 0) {
         throw new PSInvalidParameterTypeException(
-            lang, IPSExtensionErrors.EMPTY_ROLE_LIST, localParams.m_userName);
+            lang, ExtensionErrorCodes.EMPTY_ROLE_LIST, localParams.m_userName);
       }
       localParams.m_roleNameList = params[1].toString();
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
@@ -17,9 +17,9 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -97,7 +97,7 @@ public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor 
         if (ms_correctParamCount != nParamCount) {
           String[] exParams = {Integer.toString(ms_correctParamCount), String.valueOf(nParamCount)};
           throw new PSInvalidNumberOfParametersException(
-              lang, IPSExtensionErrors.INVALID_PARAM_NUM, exParams);
+              lang, ExtensionErrorCodes.INVALID_PARAM_NUM, exParams);
         }
 
         if (null == params[0] || 0 == params[0].toString().trim().length()) {
@@ -115,13 +115,13 @@ public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor 
         localParams.m_userName = PSWorkFlowUtils.filterUserName(localParams.m_userName);
 
         if (null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.STATUS_DOC_EMPTY);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.STATUS_DOC_EMPTY);
         }
         localParams.m_statusDocElementName = params[1].toString();
 
         if (null == params[2] || 0 == params[2].toString().trim().length()) {
           throw new PSInvalidParameterTypeException(
-              lang, IPSExtensionErrors.CONTENTID_NODENAME_EMPTY);
+              lang, ExtensionErrorCodes.CONTENTID_NODENAME_EMPTY);
         }
         localParams.m_contentIDNodeName = params[2].toString();
       } catch (PSInvalidNumberOfParametersException | PSInvalidParameterTypeException ne) {
@@ -175,24 +175,24 @@ public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor 
       sContentID = elemParent.getAttribute(localParams.m_contentIDName);
       if (null != sContentID) sContentID = sContentID.trim();
       if (null == sContentID || sContentID.length() < 1)
-        throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING_EMPTY);
+        throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY);
       contentID = Integer.parseInt(sContentID);
     } else {
       NodeList nodes = elemParent.getElementsByTagName(localParams.m_contentIDNodeName);
 
       if (null == nodes || nodes.getLength() < 1)
-        throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING_EMPTY);
+        throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY);
       Element elem = (Element) nodes.item(0);
       localParams.m_contentIDName = elem.getNodeName();
       sContentID = ((Text) (elem.getFirstChild())).getData();
       if (null != sContentID) sContentID = sContentID.trim();
       if (null == sContentID || sContentID.length() < 1)
-        throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING_EMPTY);
+        throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY);
       contentID = Integer.parseInt(sContentID);
     }
 
     if (contentID < 1)
-      throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING);
+      throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING);
 
     sContentID = Integer.toString(contentID);
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
@@ -17,11 +17,11 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -230,13 +230,13 @@ public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcesso
         localParams.m_userName = params[0].toString();
 
         if (nParamCount < 2 || null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.STATUS_DOC_EMPTY);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.STATUS_DOC_EMPTY);
         }
         localParams.m_statusDocElementName = params[1].toString();
 
         if (nParamCount < 3 || null == params[2] || 0 == params[2].toString().trim().length()) {
           throw new PSInvalidParameterTypeException(
-              lang, IPSExtensionErrors.CONTENTID_NODENAME_EMPTY);
+              lang, ExtensionErrorCodes.CONTENTID_NODENAME_EMPTY);
         }
         localParams.m_contentIDNodeName = params[2].toString();
 
@@ -386,20 +386,20 @@ public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcesso
     } else {
       NodeList nodes = elemParent.getElementsByTagName(localParams.m_contentIDNodeName);
       if (null == nodes || nodes.getLength() < 1) {
-        throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING_EMPTY);
+        throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY);
       }
       Element elem = (Element) nodes.item(0);
       localParams.m_contentIDName = elem.getNodeName();
       sContentID = ((Text) (elem.getFirstChild())).getData();
       if (null != sContentID) sContentID = sContentID.trim();
       if (null == sContentID || sContentID.length() < 1) {
-        throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING_EMPTY);
+        throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY);
       }
       contentID = Integer.parseInt(sContentID);
     }
 
     if (contentID < 1)
-      throw new PSXMLNodeMissingException(lang, IPSExtensionErrors.CONTENTID_NODE_MISSING);
+      throw new PSXMLNodeMissingException(lang, ExtensionErrorCodes.CONTENTID_NODE_MISSING);
 
     // Phase 4d-1a: CONTENTSTATUS read via Hibernate (Phase 4b loadComponentSummary).
     com.percussion.cms.objectstore.PSComponentSummary summary =

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
@@ -17,7 +17,8 @@
 
 package com.percussion.workflow;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSCmsObject;
@@ -130,7 +131,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
           String[] exParams = {String.valueOf(ms_correctParamCount), String.valueOf(nParamCount)};
 
           throw new PSInvalidNumberOfParametersException(
-              lang, IPSExtensionErrors.INVALID_PARAM_NUM, exParams);
+              lang, ExtensionErrorCodes.INVALID_PARAM_NUM, exParams);
         }
 
         // Get contentid
@@ -142,18 +143,18 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
 
         // Get username
         if (null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME1);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME1);
         }
 
         localParams.m_userName = params[1].toString();
 
         if (0 == localParams.m_userName.length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME2);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME2);
         }
         // Get role list
         if (null == params[2] || 0 == params[2].toString().trim().length()) {
           throw new PSInvalidParameterTypeException(
-              lang, IPSExtensionErrors.EMPTY_ROLE_LIST, localParams.m_userName);
+              lang, ExtensionErrorCodes.EMPTY_ROLE_LIST, localParams.m_userName);
         }
         localParams.m_roleNameList = params[2].toString();
 
@@ -210,7 +211,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
             String language = PSI18nUtils.DEFAULT_LANG;
             log.error(PSExceptionUtils.getMessageForLog(e));
             throw new PSInvalidParameterTypeException(
-                language, IPSExtensionErrors.INVALID_WORKFLOWID, params[5].toString());
+                language, ExtensionErrorCodes.INVALID_WORKFLOWID, params[5].toString());
           }
         }
       } catch (PSInvalidNumberOfParametersException | PSInvalidParameterTypeException ne) {
@@ -312,7 +313,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
     if (localParams.m_isNewItem) {
       // validate user is able to create doc in initial state
       if (!canUserCreate(localParams)) {
-        throw new PSAuthorizationException(lang, IPSExtensionErrors.ILLEGAL_CONTENTTYPE, null);
+        throw new PSAuthorizationException(lang, ExtensionErrorCodes.ILLEGAL_CONTENTTYPE, null);
       }
 
       // if a new item, we're all done
@@ -349,7 +350,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
     if (csc.getObjectType() == PSCmsObject.TYPE_FOLDER) {
       if (!PSFolderSecurityManager.verifyFolderPermissions(
           contentID, PSObjectPermissions.ACCESS_READ)) {
-        throw new PSAuthorizationException(IPSExtensionErrors.AUTHENTICATION_FAILED2, null);
+        throw new PSAuthorizationException(ExtensionErrorCodes.AUTHENTICATION_FAILED2, null);
       }
       return;
     }
@@ -382,7 +383,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
 
     // first check folder security
     if (!PSCms.canReadInFolders(contentID)) {
-      throw new PSAuthorizationException(lang, IPSExtensionErrors.AUTHENTICATION_FAILED2, null);
+      throw new PSAuthorizationException(lang, ExtensionErrorCodes.AUTHENTICATION_FAILED2, null);
     }
 
     // Check whether the user is Workflow admin
@@ -435,7 +436,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       // Someone else has it checked out
       if (checkInOutCondition.equalsIgnoreCase(PSWorkFlowUtils.CHECKINOUT_CONDITION_CHECKIN)
           && null != checkedOutUser) {
-        throw new PSAuthorizationException(lang, IPSExtensionErrors.ILLEGAL_IF_CHECKEDOUT, null);
+        throw new PSAuthorizationException(lang, ExtensionErrorCodes.ILLEGAL_IF_CHECKEDOUT, null);
       } else if (checkInOutCondition.equalsIgnoreCase(PSWorkFlowUtils.CHECKINOUT_CONDITION_CHECKOUT)
           && (!userName.equalsIgnoreCase(checkedOutUser))) {
         // Checkout overridden by administrator
@@ -443,11 +444,11 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
             && localParams.m_actionTrigger.equalsIgnoreCase(
                 PSWorkFlowUtils.properties.getProperty(PSWorkFlowUtils.TRIGGER_CHECK_IN))) {
           throw new PSAuthorizationException(
-              lang, IPSExtensionErrors.ILLEGAL_IF_CHECKEDOUT_OVERRIDE, null);
+              lang, ExtensionErrorCodes.ILLEGAL_IF_CHECKEDOUT_OVERRIDE, null);
         } else {
           // Not checked out, may have been overridden by administrator
           throw new PSAuthorizationException(
-              lang, IPSExtensionErrors.ILLEGAL_IFNOT_CHECKEDOUT, null);
+              lang, ExtensionErrorCodes.ILLEGAL_IFNOT_CHECKEDOUT, null);
         }
       }
     }
@@ -464,7 +465,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       if (language == null) language = PSI18nUtils.DEFAULT_LANG;
       throw new PSAuthorizationException(
           language,
-          IPSExtensionErrors.ROLE_ERROR_STATEID_WORKFLOWID,
+          ExtensionErrorCodes.ROLE_ERROR_STATEID_WORKFLOWID,
           new Object[] {
             Integer.toString(csc.getContentStateId()),
             Integer.toString(nWorkFlowAppID),
@@ -475,7 +476,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       if (language == null) language = PSI18nUtils.DEFAULT_LANG;
       throw new PSAuthorizationException(
           lang,
-          IPSExtensionErrors.ROLES_NOT_ASSIGNED,
+          ExtensionErrorCodes.ROLES_NOT_ASSIGNED,
           new Object[] {
             Integer.toString(requiredAccessLevel),
             Integer.toString(csc.getContentStateId()),
@@ -485,7 +486,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       log.error(PSExceptionUtils.getMessageForLog(e));
       throw new PSAuthorizationException(
           lang,
-          IPSExtensionErrors.ROLES_NOT_ASSIGNED,
+          ExtensionErrorCodes.ROLES_NOT_ASSIGNED,
           new Object[] {
             Integer.toString(requiredAccessLevel),
             Integer.toString(csc.getContentStateId()),
@@ -498,7 +499,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
     actorRoles = PSWorkflowRoleInfoStatic.getActorRoles(userName, roleNameList, src, cauc, true);
 
     if (null == actorRoles || actorRoles.isEmpty()) {
-      throw new PSAuthorizationException(lang, IPSExtensionErrors.AUTHENTICATION_FAILED1, null);
+      throw new PSAuthorizationException(lang, ExtensionErrorCodes.AUTHENTICATION_FAILED1, null);
     }
     assignmentType = PSWorkflowRoleInfoStatic.getAssignmentType(src, actorRoles);
 
@@ -509,7 +510,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
         PSWorkflowRoleInfo.WORKFLOW_ROLE_INFO_PRIVATE_OBJECT, wfRoleInfo);
 
     if (PSWorkFlowUtils.ASSIGNMENT_TYPE_NONE == assignmentType) {
-      throw new PSAuthorizationException(lang, IPSExtensionErrors.AUTHENTICATION_FAILED2, null);
+      throw new PSAuthorizationException(lang, ExtensionErrorCodes.AUTHENTICATION_FAILED2, null);
     }
     localParams.m_assignmentType = assignmentType;
     PSWorkFlowUtils.printWorkflowMessage(localParams.m_request, "  Exiting authenticateUser");
@@ -546,7 +547,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       log.debug("Checking if user {} can write to Folders...", localParams.m_userName);
       if (!PSCms.canWriteToFolders(localParams.m_request)) {
         // User must have write access
-        throw new PSAuthorizationException(IPSCmsErrors.FOLDER_PERMISSION_DENIED, new String[] {});
+        throw new PSAuthorizationException(PathItemErrorCodes.FOLDER_PERMISSION_DENIED, new String[] {});
       }
     }
 
@@ -583,7 +584,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       log.error(PSExceptionUtils.getMessageForLog(e));
       throw new PSAuthorizationException(
           lang,
-          IPSExtensionErrors.ROLE_ERROR_STATEID_WORKFLOWID,
+          ExtensionErrorCodes.ROLE_ERROR_STATEID_WORKFLOWID,
           new Object[] {
             Integer.toString(wcxt.getWorkFlowInitialStateID()),
             Integer.toString(localParams.m_workflowAppID),
@@ -593,7 +594,7 @@ public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
       log.error(PSExceptionUtils.getMessageForLog(e));
       throw new PSAuthorizationException(
           lang,
-          IPSExtensionErrors.ROLE_ERROR_STATEID_WORKFLOWID,
+          ExtensionErrorCodes.ROLE_ERROR_STATEID_WORKFLOWID,
           new Object[] {
             Integer.toString(wcxt.getWorkFlowInitialStateID()),
             Integer.toString(localParams.m_workflowAppID),

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
@@ -17,10 +17,10 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -86,7 +86,7 @@ public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
     if (lang == null) lang = PSI18nUtils.DEFAULT_LANG;
 
     if (null == params) {
-      String key = Integer.toString(IPSExtensionErrors.EXIT_PARAM_NULL);
+      String key = Integer.toString(ExtensionErrorCodes.EXIT_PARAM_NULL.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       Object[] args = {ms_exitName, msg};
 
@@ -97,7 +97,7 @@ public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
       throw new PSParameterMismatchException(lang, ms_correctParamCount, params.length);
 
     if (null == params[0] || 0 == params[0].toString().trim().length()) {
-      String key = Integer.toString(IPSExtensionErrors.CONTENTID_NULL);
+      String key = Integer.toString(ExtensionErrorCodes.CONTENTID_NULL.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       Object[] args = {ms_exitName, msg};
       throw new PSExtensionProcessingException(lang, IPSExtension.ERROR_INVALID_PARAMETER, args);
@@ -140,7 +140,7 @@ public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
     } else {
       IPSStatesContext sc = scOpt.get();
       if (sc.getIsValid()) {
-        String key = Integer.toString(IPSExtensionErrors.PUBDOC_UPDATE_ERROR);
+        String key = Integer.toString(ExtensionErrorCodes.PUBDOC_UPDATE_ERROR.numericCode());
         String msg = PSI18nUtils.getString(key, lang);
         throw new PSExtensionProcessingException(lang, ms_exitName, new Exception(msg));
       }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
@@ -17,11 +17,11 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.data.PSIdGenerator;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
@@ -85,7 +85,7 @@ public class PSExitNextNumber implements IPSRequestPreProcessor {
       throw new PSParameterMismatchException(lang, ms_correctParamCount, nParamCount);
 
     if (null == params[0] || 0 == params[0].toString().trim().length()) {
-      String key = Integer.toString(IPSExtensionErrors.HTML_PARAM_NULL1);
+      String key = Integer.toString(ExtensionErrorCodes.HTML_PARAM_NULL1.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       Object args[] = {ms_exitName, msg};
       throw new PSExtensionProcessingException(lang, IPSExtension.ERROR_INVALID_PARAMETER, args);

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.data.PSConversionException;
@@ -27,7 +28,6 @@ import com.percussion.design.objectstore.PSSubject;
 import com.percussion.error.PSException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.IPSWorkFlowContext;
 import com.percussion.extension.PSExtensionException;
@@ -194,7 +194,7 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
         if (ms_correctParamCount != nParamCount) {
           String[] exParams = {Integer.toString(ms_correctParamCount), String.valueOf(nParamCount)};
           throw new PSInvalidNumberOfParametersException(
-              lang, IPSExtensionErrors.INVALID_PARAM_NUM, exParams);
+              lang, ExtensionErrorCodes.INVALID_PARAM_NUM, exParams);
         }
 
         // Note: we could get content id from workflow context
@@ -222,7 +222,7 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
         }
 
         if (null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME1);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME1);
         }
 
         userName = params[1].toString();
@@ -281,7 +281,7 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
 
       if (null == wfRoleInfo) {
         throw new PSExtensionProcessingException(
-            m_fullExtensionName, new PSRoleException(lang, IPSExtensionErrors.ROLEINFO_OBJ_NULL));
+            m_fullExtensionName, new PSRoleException(lang, ExtensionErrorCodes.ROLEINFO_OBJ_NULL));
       }
 
       try {
@@ -1186,21 +1186,21 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
 
         mailDomain = PSWorkFlowUtils.properties.getProperty("MAIL_DOMAIN", "");
         if (null == mailDomain) {
-          throw new PSMailException(IPSExtensionErrors.MAIL_DOMAIN_NULL);
+          throw new PSMailException(ExtensionErrorCodes.MAIL_DOMAIN_NULL);
         }
         mailDomain = mailDomain.trim();
         if (0 == mailDomain.length()) {
-          throw new PSMailException(IPSExtensionErrors.MAIL_DOMAIN_EMPTY);
+          throw new PSMailException(ExtensionErrorCodes.MAIL_DOMAIN_EMPTY);
         }
 
         smtpHost = PSWorkFlowUtils.properties.getProperty("SMTP_HOST", "");
         if (null == smtpHost) {
-          throw new PSMailException(IPSExtensionErrors.SMTP_HOST_NULL);
+          throw new PSMailException(ExtensionErrorCodes.SMTP_HOST_NULL);
         }
 
         smtpHost = smtpHost.trim();
         if (0 == smtpHost.length()) {
-          throw new PSMailException(IPSExtensionErrors.SMTP_HOST_EMPTY);
+          throw new PSMailException(ExtensionErrorCodes.SMTP_HOST_EMPTY);
         }
 
         smtpUsername = PSWorkFlowUtils.properties.getProperty("SMTP_USERNAME", "");

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -17,11 +17,11 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.error.PSException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSRequestPreProcessor;
 import com.percussion.extension.IPSWorkFlowContext;
 import com.percussion.extension.IPSWorkflowAction;
@@ -312,7 +312,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
           String[] exParams = {String.valueOf(ms_correctParamCount), String.valueOf(nParamCount)};
 
           throw new PSInvalidNumberOfParametersException(
-              lang, IPSExtensionErrors.INVALID_PARAM_NUM, exParams);
+              lang, ExtensionErrorCodes.INVALID_PARAM_NUM, exParams);
         }
 
         if (null == params[0] || 0 == params[0].toString().trim().length()) {
@@ -322,13 +322,13 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         }
         localParams.m_contentID = Integer.parseInt(params[0].toString());
         if (null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME1);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME1);
         }
 
         localParams.m_userName = params[1].toString();
 
         if (0 == localParams.m_userName.length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME2);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME2);
         }
 
         if (null == params[2] || 0 == params[2].toString().trim().length()) {
@@ -364,7 +364,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
           && localParams.m_transitionComment.length() > 255) {
 
         throw new PSExtensionProcessingException(
-            lang, IPSExtensionErrors.WF_COMMENT_CANNOT_EXCEED_255);
+            lang, ExtensionErrorCodes.WF_COMMENT_CANNOT_EXCEED_255);
       }
 
       adhocUserList = (String) htmlParams.get(IPSHtmlParameters.SYS_WF_ADHOC_USERLIST);
@@ -379,7 +379,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         throw new PSExtensionProcessingException(
             lang,
             m_fullExtensionName,
-            new PSRoleException(lang, IPSExtensionErrors.ROLEINFO_OBJ_NULL));
+            new PSRoleException(lang, ExtensionErrorCodes.ROLEINFO_OBJ_NULL));
       }
       localParams.m_wfRoleInfo = wfRoleInfo;
 
@@ -512,7 +512,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
          * tried to checkin a doc what wasn't checked out, really
          * just a warning condition.
          */
-        if (IPSExtensionErrors.DOC_NOT_CHECKEDOUT != e.getErrorCode()) {
+        if (ExtensionErrorCodes.DOC_NOT_CHECKEDOUT.numericCode() != e.getErrorCode()) {
           except = e;
         }
       } catch (PSTransitionException e) {
@@ -699,7 +699,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
           // Factory returns an empty context (matching the legacy constructor's
           // PSEntryNotFoundException
           // path) — surface it so the existing MISSING_TRANSITION handler runs.
-          throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+          throw new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
         }
       }
       // No JDBC resources to release — Hibernate-backed factory manages its own session.
@@ -710,7 +710,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         localParams.m_transitionFromStateID,
         localParams.m_actionTrigger
       };
-      throw new PSTransitionException(lang, IPSExtensionErrors.MISSING_TRANSITION, args);
+      throw new PSTransitionException(lang, ExtensionErrorCodes.MISSING_TRANSITION, args);
     }
 
     // The current stateid must match with from state id of the transition
@@ -722,12 +722,12 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         tc.getTransitionFromStateID(),
         localParams.m_actionTrigger
       };
-      throw new PSTransitionException(lang, IPSExtensionErrors.INVALID_TRANSITION, args);
+      throw new PSTransitionException(lang, ExtensionErrorCodes.INVALID_TRANSITION, args);
     }
 
     /* Only an admin can transition an item that is checked out */
     if (localParams.m_checkedOut && !localParams.m_isAdministrator) {
-      throw new PSTransitionException(lang, IPSExtensionErrors.ADMIN_CHECKOUT_ONLY);
+      throw new PSTransitionException(lang, ExtensionErrorCodes.ADMIN_CHECKOUT_ONLY);
     }
 
     localParams.m_transitionToStateID = tc.getTransitionToStateID();
@@ -755,7 +755,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       transitionRequiredRoles = tc.getTransitionRoles();
       if (null != transitionRequiredRoles && !transitionRequiredRoles.isEmpty()) {
         if (!PSWorkFlowUtils.compareRoleList(transitionRequiredRoles, userRoleList)) {
-          throw new PSTransitionException(lang, IPSExtensionErrors.INVALID_TRANSITION_ROLE);
+          throw new PSTransitionException(lang, ExtensionErrorCodes.INVALID_TRANSITION_ROLE);
         }
       }
     }
@@ -766,7 +766,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
      */
 
     if (tc.isTransitionCommentRequired() && null == localParams.m_transitionComment) {
-      throw new PSTransitionException(lang, IPSExtensionErrors.TRANSITION_COMMENT_NOT_SPECIFIED);
+      throw new PSTransitionException(lang, ExtensionErrorCodes.TRANSITION_COMMENT_NOT_SPECIFIED);
     }
 
     // Phase 4d-1c: Hibernate-backed read of STATEROLES for the to-state.
@@ -921,12 +921,12 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       // Make sure the user is eligible to check in the document
       if (!localParams.m_checkedOut) // It must be checked out
       {
-        throw new PSCheckInCheckOutException(lang, IPSExtensionErrors.DOC_NOT_CHECKEDOUT);
+        throw new PSCheckInCheckOutException(lang, ExtensionErrorCodes.DOC_NOT_CHECKEDOUT);
       }
 
       // It must have an edit revision
       else if (IPSConstants.NO_CORRESPONDING_REVISION_VALUE == editRevision) {
-        throw new PSCheckInCheckOutException(lang, IPSExtensionErrors.EDIT_REVISION_MISSING);
+        throw new PSCheckInCheckOutException(lang, ExtensionErrorCodes.EDIT_REVISION_MISSING);
       }
 
       /*
@@ -935,7 +935,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
        */
       else if (!localParams.m_isAdministrator
           && (PSWorkFlowUtils.CHECKOUT_STATUS_CURRENT_USER != localParams.m_checkoutStatus)) {
-        throw new PSCheckInCheckOutException(lang, IPSExtensionErrors.CHECKIN_NOT_ALLOWED);
+        throw new PSCheckInCheckOutException(lang, ExtensionErrorCodes.CHECKIN_NOT_ALLOWED);
       }
 
       /*
@@ -978,7 +978,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
               .map(IPSStatesContext::getIsValid)
               .orElse(false);
       if (isValidState)
-        throw new PSCheckInCheckOutException(lang, IPSExtensionErrors.CHECKOUT_FROM_PUBLIC_STATE);
+        throw new PSCheckInCheckOutException(lang, ExtensionErrorCodes.CHECKOUT_FROM_PUBLIC_STATE);
 
       // The default checkout revision is the tip revision
       int checkoutRequestRevision =
@@ -989,14 +989,14 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       if (localParams.m_checkedOut) {
         // It's an error if document is checked out by somebody else
         if (localParams.m_checkoutStatus != PSWorkFlowUtils.CHECKOUT_STATUS_CURRENT_USER) {
-          throw new PSCheckInCheckOutException(lang, IPSExtensionErrors.CHECKOUT_NOT_ALLOWED);
+          throw new PSCheckInCheckOutException(lang, ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED);
         }
 
         // You have checked it out, but it must be the edit revision
         else if (checkoutRequestRevision != editRevision) {
           throw new PSCheckInCheckOutException(
               lang,
-              IPSExtensionErrors.CHECKOUT_REVISION_MISMATCH,
+              ExtensionErrorCodes.CHECKOUT_REVISION_MISMATCH,
               new Object[] {
                 Integer.toString(checkoutRequestRevision), Integer.toString(editRevision)
               });
@@ -1021,7 +1021,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       else if (checkoutRequestRevision > tipRevision) {
         throw new PSCheckInCheckOutException(
             lang,
-            IPSExtensionErrors.CHECKOUT_REVISION_LIMIT,
+            ExtensionErrorCodes.CHECKOUT_REVISION_LIMIT,
             new Object[] {
               Integer.toString(checkoutRequestRevision), Integer.toString(tipRevision)
             });
@@ -1195,7 +1195,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       bHasActed = hasUserActed(stateApprovals, userName);
       if (bHasActed) {
         throw new PSDuplicateApprovalException(
-            lang, IPSExtensionErrors.TRANSITION_ATTEMPT, userName);
+            lang, ExtensionErrorCodes.TRANSITION_ATTEMPT, userName);
       }
 
       HashSet userRoles = new HashSet(workflowInfo.getUserActingRoleNames());
@@ -1207,7 +1207,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         // if the user contains no roles in specified role list toss them
         userRoles.retainAll(tc.getTransitionRoles());
         if (userRoles.isEmpty()) {
-          throw new PSEntryNotFoundException(lang, IPSExtensionErrors.INVALID_TRANSITION_ROLE);
+          throw new PSEntryNotFoundException(lang, ExtensionErrorCodes.INVALID_TRANSITION_ROLE);
         }
       }
 
@@ -1228,7 +1228,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       }
       if (keepRoles.isEmpty()) {
         throw new PSDuplicateApprovalException(
-            lang, IPSExtensionErrors.TRANSITION_ATTEMPT, userRoles + " Role(s)");
+            lang, ExtensionErrorCodes.TRANSITION_ATTEMPT, userRoles + " Role(s)");
       }
       // be sure to reset the userRoles set with only the ones that have
       // not been acted upon

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPrepareQueryFilters.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPrepareQueryFilters.java
@@ -17,6 +17,7 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.extension.*;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.server.IPSRequestContext;
@@ -87,14 +88,14 @@ public class PSExitPrepareQueryFilters implements IPSRequestPreProcessor {
     }
 
     if (null == params[0] || 0 == params[0].toString().trim().length()) {
-      String key = Integer.toString(IPSExtensionErrors.EMPTY_USRNAME1);
+      String key = Integer.toString(ExtensionErrorCodes.EMPTY_USRNAME1.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       Object args[] = {ms_exitName, msg};
       throw new PSExtensionProcessingException(lang, IPSExtension.ERROR_INVALID_PARAMETER, args);
     }
 
     if (null == params[1] || 0 == params[1].toString().trim().length()) {
-      String key = Integer.toString(IPSExtensionErrors.ROLELIST_EMPTY);
+      String key = Integer.toString(ExtensionErrorCodes.ROLELIST_EMPTY.numericCode());
       String msg = PSI18nUtils.getString(key, lang);
       Object args[] = {ms_exitName, msg};
       throw new PSExtensionProcessingException(lang, IPSExtension.ERROR_INVALID_PARAMETER, args);

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitUpdateHistory.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitUpdateHistory.java
@@ -17,7 +17,9 @@
 
 package com.percussion.workflow;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSCmsException;
@@ -25,7 +27,6 @@ import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.error.PSException;
 import com.percussion.extension.IPSExtension;
 import com.percussion.extension.IPSExtensionDef;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.IPSWorkFlowContext;
 import com.percussion.extension.PSExtensionException;
@@ -33,7 +34,6 @@ import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSInternalRequest;
 import com.percussion.server.PSServer;
 import com.percussion.services.legacy.IPSCmsObjectMgr;
@@ -196,7 +196,7 @@ public class PSExitUpdateHistory implements IPSResultDocumentProcessor {
         }
 
         if (null == params[1] || 0 == params[1].toString().trim().length()) {
-          throw new PSInvalidParameterTypeException(lang, IPSExtensionErrors.EMPTY_USRNAME1);
+          throw new PSInvalidParameterTypeException(lang, ExtensionErrorCodes.EMPTY_USRNAME1);
         }
         userName = params[1].toString();
         userName = PSWorkFlowUtils.filterUserName(userName);
@@ -282,7 +282,7 @@ public class PSExitUpdateHistory implements IPSResultDocumentProcessor {
           // by PSActionSet
           if (except instanceof SQLException) {
             Object args[] = new Object[] {"CONTENTSTATUSHISTORY"};
-            e.setArgs(IPSServerErrors.SQL_PROBLEM, args);
+            e.setArgs(ServerErrorCodes.SQL_PROBLEM, args);
           }
           throw e;
         }
@@ -465,7 +465,7 @@ public class PSExitUpdateHistory implements IPSResultDocumentProcessor {
 
     /** If the internal request is <code>null</code> now, we did not find the resource. */
     if (ir == null)
-      throw new PSCmsException(IPSCmsErrors.REQUIRED_RESOURCE_MISSING, PUT_LASTPUBREV_RSC);
+      throw new PSCmsException(CmsErrorCodes.REQUIRED_RESOURCE_MISSING, PUT_LASTPUBREV_RSC);
 
     ir.performUpdate();
   }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckoutStatus.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckoutStatus.java
@@ -17,6 +17,7 @@
 
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.data.PSConversionException;
@@ -25,7 +26,6 @@ import com.percussion.extension.IPSUdfProcessor;
 import com.percussion.extension.PSSimpleJavaUdfExtension;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.services.legacy.IPSCmsObjectMgr;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
 import org.apache.commons.lang3.StringUtils;
@@ -95,7 +95,7 @@ public class PSGetCheckoutStatus extends PSSimpleJavaUdfExtension implements IPS
     } catch (RuntimeException | com.percussion.data.PSDataExtractionException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       throw new PSConversionException(
-          IPSServerErrors.SQL_PROBLEM, PSExceptionUtils.getMessageForLog(e));
+          ServerErrorCodes.SQL_PROBLEM, PSExceptionUtils.getMessageForLog(e));
     }
 
     return result;

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -65,6 +66,19 @@ public class PSInvalidNumberOfParametersException extends PSException {
    */
   public PSInvalidNumberOfParametersException(String language, int msgCode, Object[] arrayArgs) {
     super(language, msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with locale and message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSInvalidNumberOfParametersException(
+      String language, IPSErrorCode code, Object[] arrayArgs) {
+    super(language, requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
   }
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidParameterTypeException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidParameterTypeException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /** This exception is throws when an invalid parameter is detected. */
@@ -36,6 +37,17 @@ public class PSInvalidParameterTypeException extends PSException {
   }
 
   /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSInvalidParameterTypeException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception for messages taking locale and message code arguments and and a single
    * argument.
    *
@@ -47,6 +59,18 @@ public class PSInvalidParameterTypeException extends PSException {
    */
   public PSInvalidParameterTypeException(String language, int msgCode, Object singleArg) {
     super(language, msgCode, singleArg);
+  }
+
+  /**
+   * Typed construction with locale and a single message argument.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSInvalidParameterTypeException(String language, IPSErrorCode code, Object singleArg) {
+    super(language, requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
   }
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSRoleException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSRoleException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -44,6 +45,15 @@ public class PSRoleException extends PSException {
   }
 
   /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSRoleException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
    * Construct an exception for messages taking locale and msgCode arguments.
    *
    * @param language language string to use while lookingup for the message text in the resource
@@ -52,6 +62,29 @@ public class PSRoleException extends PSException {
    */
   public PSRoleException(String language, int msgCode) {
     super(language, msgCode);
+  }
+
+  /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSRoleException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with locale and a single message argument.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSRoleException(String language, IPSErrorCode code, Object singleArg) {
+    super(language, requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
   }
 
   /**
@@ -94,5 +127,15 @@ public class PSRoleException extends PSException {
    */
   public PSRoleException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSRoleException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSStateRolesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSStateRolesContext.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.workflow;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.services.workflow.IPSWorkflowService;
 import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.services.workflow.data.PSAssignedRole;
@@ -70,7 +70,7 @@ public class PSStateRolesContext implements IPSStateRolesContext {
     IPSWorkflowService wfSvc = PSWorkflowServiceLocator.getWorkflowService();
     List<PSAssignedRole> rows = wfSvc.findStateRoles(workflowId, stateId, assignmentType);
     if (rows.isEmpty()) {
-      throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+      throw new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
     }
 
     Set<Long> roleIds = new HashSet<>();
@@ -115,7 +115,7 @@ public class PSStateRolesContext implements IPSStateRolesContext {
       int assignmentType = row.getAssignmentType().getValue();
       String roleName = roleNameById.get(roleIdLong);
       if (roleName == null || roleName.isEmpty()) {
-        throw new PSRoleException(IPSExtensionErrors.STATEROLE_NULL_EMPTY_TRIM);
+        throw new PSRoleException(ExtensionErrorCodes.STATEROLE_NULL_EMPTY_TRIM);
       }
 
       m_nCount++;
@@ -136,7 +136,7 @@ public class PSStateRolesContext implements IPSStateRolesContext {
       } else if (adhocType == PSWorkFlowUtils.ADHOC_ANONYMOUS) {
         m_adhocAnonymousStateRoleIDs.add(roleID);
       } else {
-        throw new PSRoleException(IPSExtensionErrors.INVALID_ADHOC);
+        throw new PSRoleException(ExtensionErrorCodes.INVALID_ADHOC);
       }
     }
   }
@@ -168,7 +168,7 @@ public class PSStateRolesContext implements IPSStateRolesContext {
       rs = statement.executeQuery();
       while (moveNext()) {
         if (m_sStateRoleName.length() == 0) {
-          throw new PSRoleException(IPSExtensionErrors.STATEROLE_NULL_EMPTY_TRIM);
+          throw new PSRoleException(ExtensionErrorCodes.STATEROLE_NULL_EMPTY_TRIM);
         }
         m_nCount++;
         roleID = m_nStateRoleID;
@@ -190,11 +190,11 @@ public class PSStateRolesContext implements IPSStateRolesContext {
         } else if (m_nAdhocType == PSWorkFlowUtils.ADHOC_ANONYMOUS) {
           m_adhocAnonymousStateRoleIDs.add(roleID);
         } else {
-          throw new PSRoleException(IPSExtensionErrors.INVALID_ADHOC);
+          throw new PSRoleException(ExtensionErrorCodes.INVALID_ADHOC);
         }
       }
       if (0 == m_nCount) {
-        throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+        throw new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
       }
     } finally {
       close();

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /** Exception thrown when an error occurs while performing a workflow transition. */
@@ -36,6 +37,17 @@ public class PSTransitionException extends PSException {
   }
 
   /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSTransitionException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception for messages taking locale and message code arguments and and a single
    * argument.
    *
@@ -47,6 +59,18 @@ public class PSTransitionException extends PSException {
    */
   public PSTransitionException(String language, int msgCode, Object singleArg) {
     super(language, msgCode, singleArg);
+  }
+
+  /**
+   * Typed construction with locale and a single message argument.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSTransitionException(String language, IPSErrorCode code, Object singleArg) {
+    super(language, requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
   }
 
   /**
@@ -62,5 +86,17 @@ public class PSTransitionException extends PSException {
    */
   public PSTransitionException(String language, int msgCode, Object[] arrayArgs) {
     super(language, msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with locale and message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSTransitionException(String language, IPSErrorCode code, Object[] arrayArgs) {
+    super(language, requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
   }
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import static com.percussion.server.PSServer.getProperty;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.Validate.notNull;
@@ -24,7 +25,6 @@ import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSSubject;
-import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.IPSTypedPrincipal;
 import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
@@ -495,7 +495,7 @@ public class PSWorkflowRoleInfoStatic {
         // Throw exception: the unassigned users have no home
         throw new PSRoleException(
             lang,
-            IPSExtensionErrors.ADHOC_ASSIGNMENT_NOT_FOUND,
+            ExtensionErrorCodes.ADHOC_ASSIGNMENT_NOT_FOUND,
             PSWorkFlowUtils.listToDelimitedString(unassignedUserList, ", "));
       }
     }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSXMLNodeMissingException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSXMLNodeMissingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /** Exception thrown when a required XML node is missing while processing workflow data. */
@@ -31,6 +32,17 @@ public class PSXMLNodeMissingException extends PSException {
    */
   public PSXMLNodeMissingException(String language, int msgCode) {
     super(language, msgCode);
+  }
+
+  /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSXMLNodeMissingException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
   }
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSJavaxMailProgram.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSJavaxMailProgram.java
@@ -16,7 +16,7 @@
 
 package com.percussion.workflow.mail;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -56,7 +56,7 @@ public class PSJavaxMailProgram implements IPSMailProgram {
       Message msg = new MimeMessage(session);
       String mailDomain = messageContext.getMailDomain();
       if ((null == mailDomain) || mailDomain.length() == 0) {
-        throw new PSMailException(IPSExtensionErrors.MAIL_DOMAIN_EMPTY);
+        throw new PSMailException(ExtensionErrorCodes.MAIL_DOMAIN_EMPTY);
       }
       String mailCc = messageContext.getCc();
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSSecureMailProgram.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSSecureMailProgram.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.workflow.mail;
 
-import com.percussion.extension.IPSExtensionErrors;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
 import com.percussion.security.PSEncryptProperties;
 import com.percussion.security.PSEncryptor;
@@ -94,7 +94,7 @@ public class PSSecureMailProgram implements IPSMailProgram {
     String smtpHost = messageContext.getSmtpHost();
 
     if (StringUtils.isEmpty(smtpHost)) {
-      throw new PSMailException(IPSExtensionErrors.SMTP_HOST_EMPTY);
+      throw new PSMailException(ExtensionErrorCodes.SMTP_HOST_EMPTY);
     }
   }
 

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExtensionsWorkflowTypedErrorCodeSliceTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExtensionsWorkflowTypedErrorCodeSliceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.percussion.workflow.mail.IPSMailMessageContext;
+import com.percussion.workflow.mail.PSJavaxMailProgram;
+import com.percussion.workflow.mail.PSMailException;
+import com.percussion.workflow.mail.PSSecureMailProgram;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Leftover workflow production throw sites now construct typed {@link ExtensionErrorCodes} (issue
+ * #3770).
+ */
+@Tag("UnitTest")
+class PSExtensionsWorkflowTypedErrorCodeSliceTest {
+
+  @Test
+  void javaxMailEmptyDomainThrowsTypedMailException() throws Exception {
+    IPSMailMessageContext ctx = mock(IPSMailMessageContext.class);
+    when(ctx.getSmtpHost()).thenReturn("localhost");
+    when(ctx.getMailDomain()).thenReturn("");
+
+    PSMailException ex =
+        assertThrows(PSMailException.class, () -> new PSJavaxMailProgram().sendMessage(ctx));
+    assertSame(ExtensionErrorCodes.MAIL_DOMAIN_EMPTY, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void secureMailEmptySmtpHostThrowsTypedMailException() {
+    IPSMailMessageContext ctx = mock(IPSMailMessageContext.class);
+    when(ctx.getSmtpHost()).thenReturn("");
+
+    PSMailException ex =
+        assertThrows(PSMailException.class, () -> new PSSecureMailProgram().sendMessage(ctx));
+    assertSame(ExtensionErrorCodes.SMTP_HOST_EMPTY, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void roleExceptionLanguageTypedCtorIsNonAuditable() {
+    PSRoleException ex = new PSRoleException("en-us", ExtensionErrorCodes.ROLEINFO_OBJ_NULL);
+    assertSame(ExtensionErrorCodes.ROLEINFO_OBJ_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void invalidParameterLanguageTypedCtorIsNonAuditable() {
+    PSInvalidParameterTypeException ex =
+        new PSInvalidParameterTypeException("en-us", ExtensionErrorCodes.EMPTY_USRNAME1);
+    assertSame(ExtensionErrorCodes.EMPTY_USRNAME1, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void checkInExceptionLanguageTypedCtorIsAuditableWhenCatalogSaysSo() {
+    PSCheckInCheckOutException ex =
+        new PSCheckInCheckOutException("en-us", ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED);
+    assertSame(ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/NavSfpWorkflowResidualErrorCodesDualWriteTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/NavSfpWorkflowResidualErrorCodesDualWriteTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Dual-write skip coverage for leftover nav/sfp/workflow catalog codes (#3770). Leftovers listed
+ * here are non-auditable operational / validation noise. Auditable authz leftovers (e.g. {@link
+ * ExtensionErrorCodes#AUTHENTICATION_FAILED2}) keep dual-write and are not skipped.
+ */
+class NavSfpWorkflowResidualErrorCodesDualWriteTest {
+
+  @BeforeEach
+  void rebootstrap() {
+    LegacyErrorCodeRegistry.clearForTests();
+    LegacyErrorCodeRegistry.bootstrap();
+  }
+
+  @Test
+  void leftoverExtensionCodesSkipDualWrite() {
+    List<ExtensionErrorCodes> leftovers =
+        List.of(
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR,
+            ExtensionErrorCodes.EXT_MISSING_HTML_PARAMETER_ERROR,
+            ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID,
+            ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
+            ExtensionErrorCodes.EMPTY_USRNAME1,
+            ExtensionErrorCodes.EMPTY_USRNAME2,
+            ExtensionErrorCodes.INVALID_WORKFLOWID,
+            ExtensionErrorCodes.ROLE_ERROR_STATEID_WORKFLOWID,
+            ExtensionErrorCodes.WKFLOW_ACTIONLIST_EMPTY,
+            ExtensionErrorCodes.WKFLOW_CONTEXT_NULL,
+            ExtensionErrorCodes.INVALID_WKFLOW_EXT,
+            ExtensionErrorCodes.EXEC_EXT_NOTFOUND,
+            ExtensionErrorCodes.STATUS_DOC_EMPTY,
+            ExtensionErrorCodes.CONTENTID_NODENAME_EMPTY,
+            ExtensionErrorCodes.CONTENTID_NODE_MISSING_EMPTY,
+            ExtensionErrorCodes.CONTENTID_NODE_MISSING,
+            ExtensionErrorCodes.EXIT_PARAM_NULL,
+            ExtensionErrorCodes.CONTENTID_NULL,
+            ExtensionErrorCodes.PUBDOC_UPDATE_ERROR,
+            ExtensionErrorCodes.HTML_PARAM_NULL1,
+            ExtensionErrorCodes.ROLEINFO_OBJ_NULL,
+            ExtensionErrorCodes.ROLELIST_EMPTY,
+            ExtensionErrorCodes.INVALID_PARAM_NUM,
+            ExtensionErrorCodes.TRANSITION_COMMENT_NOT_SPECIFIED,
+            ExtensionErrorCodes.DOC_NOT_CHECKEDOUT,
+            ExtensionErrorCodes.EDIT_REVISION_MISSING,
+            ExtensionErrorCodes.CHECKOUT_REVISION_MISMATCH,
+            ExtensionErrorCodes.CHECKOUT_REVISION_LIMIT,
+            ExtensionErrorCodes.TRANSITION_ATTEMPT,
+            ExtensionErrorCodes.MAIL_DOMAIN_NULL,
+            ExtensionErrorCodes.MAIL_DOMAIN_EMPTY,
+            ExtensionErrorCodes.SMTP_HOST_NULL,
+            ExtensionErrorCodes.SMTP_HOST_EMPTY,
+            ExtensionErrorCodes.USERNAME_NULL_EMPTY_TRIM,
+            ExtensionErrorCodes.INVALID_ADHOC,
+            ExtensionErrorCodes.STATEROLE_NULL_EMPTY_TRIM,
+            ExtensionErrorCodes.NO_RECORDS,
+            ExtensionErrorCodes.ADHOC_ASSIGNMENT_NOT_FOUND,
+            ExtensionErrorCodes.INVALID_TRANSITION,
+            ExtensionErrorCodes.MISSING_TRANSITION,
+            ExtensionErrorCodes.WF_COMMENT_CANNOT_EXCEED_255);
+
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    for (ExtensionErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      assertSame(code, LegacyErrorCodeRegistry.find(code.numericCode()).orElseThrow());
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void leftoverCmsAndServerCodesSkipDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    assertFalse(CmsErrorCodes.INVALID_AUTHTYPE.isAuditable());
+    assertFalse(CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR.isAuditable());
+    assertFalse(CmsErrorCodes.REQUIRED_RESOURCE_MISSING.isAuditable());
+    assertFalse(ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE.isAuditable());
+    assertFalse(ServerErrorCodes.EXCEPTION_NOT_CAUGHT.isAuditable());
+    assertFalse(ServerErrorCodes.SQL_PROBLEM.isAuditable());
+
+    for (int numeric :
+        new int[] {
+          CmsErrorCodes.INVALID_AUTHTYPE.numericCode(),
+          CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR.numericCode(),
+          CmsErrorCodes.REQUIRED_RESOURCE_MISSING.numericCode(),
+          ServerErrorCodes.MISSING_INTERNAL_REQUEST_RESOURCE.numericCode(),
+          ServerErrorCodes.EXCEPTION_NOT_CAUGHT.numericCode(),
+          ServerErrorCodes.SQL_PROBLEM.numericCode()
+        }) {
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, numeric, AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/error/PSException.java
+++ b/modules/utils/src/main/java/com/percussion/error/PSException.java
@@ -407,7 +407,7 @@ public class PSException extends java.lang.Exception implements IPSException {
     return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
   }
 
-  private static IPSErrorCode requireCode(IPSErrorCode code) {
+  protected static IPSErrorCode requireCode(IPSErrorCode code) {
     if (code == null) {
       throw new IllegalArgumentException("code may not be null");
     }

--- a/modules/utils/src/main/java/com/percussion/error/PSNotFoundException.java
+++ b/modules/utils/src/main/java/com/percussion/error/PSNotFoundException.java
@@ -50,6 +50,35 @@ public class PSNotFoundException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSNotFoundException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSNotFoundException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSNotFoundException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
    * Construct an exception for messages taking no arguments.
    *
    * @param msgCode the error string to load

--- a/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
@@ -85,6 +85,15 @@ class PSExceptionTypedErrorCodeTest {
   }
 
   @Test
+  void notFoundTypedCtorRetainsCode() {
+    Object[] args = {"sys_casSupport/casSupport_0", "No request handler found."};
+    PSNotFoundException ex = new PSNotFoundException(SAMPLE, args);
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    assertEquals(2011, ex.getErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
   void typedCtorRejectsNullCode() {
     assertThrows(IllegalArgumentException.class, () -> new PSException((IPSErrorCode) null));
   }

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -9,6 +9,7 @@
 #   #3739 deployer catalog/client/objectstore/PSDeployService
 #   #3740 deployer server/handlers + server/dependencies
 #   #3741 DCE/ContentUI/TableFactory leftover call sites
+#   #3770 leftover nav/sfp/workflow extension modules
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -38,34 +39,6 @@ modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationC
 modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
 modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
 modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
-modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSBuildRelationshipsFromIdsExit.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
-modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
-modules/extensions-workflow/src/main/java/com/percussion/relationship/effect/PSNotifyEffect.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddEditAuthFlag.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPrepareQueryFilters.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitUpdateHistory.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckoutStatus.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSStateRolesContext.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSJavaxMailProgram.java
-modules/extensions-workflow/src/main/java/com/percussion/workflow/mail/PSSecureMailProgram.java
 modules/perc-i18n/src/main/java/com/percussion/i18n/ui/PSI18NTranslationKeyValues.java
 modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
 modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSAbstractBuildRelationshipsExtension.java

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -112,6 +112,17 @@ public class PSExtensionProcessingException extends PSException {
   }
 
   /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSExtensionProcessingException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Construct an exception when an unknown exception occurs during processing.
    *
    * @param extName the name of the extension being processed

--- a/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
+++ b/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -87,5 +88,25 @@ public class PSParameterMismatchException extends PSException {
   /** See {@link com.percussion.error.PSException#PSException(int, Object)} for documentation. */
   public PSParameterMismatchException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSParameterMismatchException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSParameterMismatchException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 }

--- a/system/src/main/java/com/percussion/security/PSAuthorizationException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthorizationException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -102,5 +103,27 @@ public class PSAuthorizationException extends PSException {
    */
   public PSAuthorizationException(String language, int msgCode, Object[] arrayArgs) {
     super(language, msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSAuthorizationException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with locale and message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSAuthorizationException(String language, IPSErrorCode code, Object[] arrayArgs) {
+    super(language, requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
   }
 }

--- a/system/src/main/java/com/percussion/workflow/PSEntryNotFoundException.java
+++ b/system/src/main/java/com/percussion/workflow/PSEntryNotFoundException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 public class PSEntryNotFoundException extends PSException {
@@ -38,6 +39,15 @@ public class PSEntryNotFoundException extends PSException {
   }
 
   /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSEntryNotFoundException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
    * Construct an exception for messages taking locale and msgCode arguments.
    *
    * @param language language string to use while lookingup for the message text in the resource
@@ -46,6 +56,17 @@ public class PSEntryNotFoundException extends PSException {
    */
   public PSEntryNotFoundException(String language, int msgCode) {
     super(language, msgCode);
+  }
+
+  /**
+   * Typed construction with locale and no message arguments.
+   *
+   * @param language language string to use while looking up the message text
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSEntryNotFoundException(String language, IPSErrorCode code) {
+    super(language, requireCode(code).numericCode());
+    m_typedErrorCode = code;
   }
 
   /**

--- a/system/src/main/java/com/percussion/workflow/mail/PSMailException.java
+++ b/system/src/main/java/com/percussion/workflow/mail/PSMailException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.workflow.mail;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import java.util.Locale;
 
@@ -74,6 +75,15 @@ public class PSMailException extends PSException {
    */
   public PSMailException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSMailException(IPSErrorCode code) {
+    super(code);
   }
 
   /**

--- a/system/src/test/java/com/percussion/extension/PSExtensionTypedErrorCodeCtorTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionTypedErrorCodeCtorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -27,7 +28,10 @@ import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.error.IPSErrorCode;
+import com.percussion.security.PSAuthorizationException;
 import com.percussion.server.PSRequestValidationException;
+import com.percussion.workflow.PSEntryNotFoundException;
+import com.percussion.workflow.mail.PSMailException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -121,5 +125,44 @@ class PSExtensionTypedErrorCodeCtorTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> new PSRequestValidationException((IPSErrorCode) null));
+  }
+
+  @Test
+  void processingExceptionLanguageTypedCtor() {
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException("en-us", ExtensionErrorCodes.WF_COMMENT_CANNOT_EXCEED_255);
+    assertSame(ExtensionErrorCodes.WF_COMMENT_CANNOT_EXCEED_255, ex.getTypedErrorCode());
+    assertEquals("en-us", ex.getLanguageString());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void parameterMismatchTypedCtor() {
+    Object[] args = {"calendarStart", "is a required parameter"};
+    PSParameterMismatchException ex =
+        new PSParameterMismatchException(
+            ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, args);
+    assertSame(ExtensionErrorCodes.EXT_MISSING_REQUIRED_PARAMETER_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void authorizationLanguageTypedCtor() {
+    PSAuthorizationException ex =
+        new PSAuthorizationException(
+            "en-us", ExtensionErrorCodes.AUTHENTICATION_FAILED2, null);
+    assertSame(ExtensionErrorCodes.AUTHENTICATION_FAILED2, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+  }
+
+  @Test
+  void mailAndEntryNotFoundTypedCtors() {
+    PSMailException mail = new PSMailException(ExtensionErrorCodes.MAIL_DOMAIN_EMPTY);
+    assertSame(ExtensionErrorCodes.MAIL_DOMAIN_EMPTY, mail.getTypedErrorCode());
+    assertFalse(mail.isAuditable());
+
+    PSEntryNotFoundException missing = new PSEntryNotFoundException(ExtensionErrorCodes.NO_RECORDS);
+    assertSame(ExtensionErrorCodes.NO_RECORDS, missing.getTypedErrorCode());
+    assertFalse(missing.isAuditable());
   }
 }


### PR DESCRIPTION
## Summary

Parent **#2616** leftover slice after **#3756** / PR #3769. Leftover **nav / sfp / workflow extension modules** production `IPS*Errors` int sites now throw typed `ExtensionErrorCodes` / `CmsErrorCodes` / `ServerErrorCodes` / `PathItemErrorCodes`.

- Additive typed constructors on workflow/system/utils exception types (`getTypedErrorCode()` / `isAuditable()`). Language+typed constructors live on subclasses (not `PSException(String, IPSErrorCode)`) to avoid `(String, Throwable)` null-arg ambiguity.
- Allow-list `scripts/ipserrors-residual-allowlist.txt` shrunk by the exact nav/sfp/workflow paths only.
- Dual-write: leftover catalog codes remain non-auditable (`isAuditable()==false`); skip tests added in perc-auditlog. Auditable authz leftovers keep dual-write.
- Out of scope: extensions-main (#3756 / PR #3769), deployer / DCE / ContentUI / TableFactory (cluster #3757), remaining `system/` residuals.

Fixes #3770  
Partial #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/utils && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 393, Failures: 0, Skipped: 9
2. `cd modules/perc-auditlog && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 304, Failures: 0 (`NavSfpWorkflowResidualErrorCodesDualWriteTest` 2)
3. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2423, Failures: 0, Skipped: 244 (`PSExtensionTypedErrorCodeCtorTest` 11)
4. `cd modules/extensions-nav && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 14, Failures: 0 (`PSNavTreeSlotMarkerTypedErrorCodeSliceTest` 2)
5. `cd modules/extensions-sfp && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 24, Failures: 0, Skipped: 4 (`PSExpandRecurringEventsTypedErrorCodeSliceTest` 2)
6. `cd modules/extensions-workflow && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 72, Failures: 0, Skipped: 41 (`PSExtensionsWorkflowTypedErrorCodeSliceTest` 5)
7. `python scripts/verify-no-bare-ipserrors.py` — PASS; `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 17 passed

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — typed construction, production throws, dual-write skip; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when constructors added (utils + system producers + extension consumers)
- [x] **Cross-platform** — new tests use mocks / typed constructors; no hardcoded separators

### C3 evidence

- **modules_built:** `modules/utils`, `modules/perc-auditlog`, `system`, `modules/extensions-nav`, `modules/extensions-sfp`, `modules/extensions-workflow`
- **build_evidence:**
  - `cd modules/utils && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 393, Failures: 0, Skipped: 9
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 304, Failures: 0
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2423, Failures: 0, Skipped: 244
  - `cd modules/extensions-nav && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 14, Failures: 0
  - `cd modules/extensions-sfp && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 24, Failures: 0, Skipped: 4
  - `cd modules/extensions-workflow && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 72, Failures: 0, Skipped: 41
  - `python scripts/verify-no-bare-ipserrors.py` → PASS; pytest 17 passed
- **downstream_checked:** C2 constructors are additive (not `final` / signature-breaking). Did **not** add `PSException(String, IPSErrorCode)` (ambiguous with `(String, Throwable)` for `null`). Grepped `extends PSAuthorizationException` (`PSAuthenticationRequiredException` only); no anonymous `new <Type>() {` for changed exception types. Standalone utils + system + three extension modules install green.

### C5 UI proof

N/A — no WebUI / Playwright surface.

Erlang: approve (`docs/ai-generated/code-reviews/3770-nav-sfp-workflow-errorcodes-erlang.md`).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
