### PR TITLE
cluster: Developer Content Type chrome (CD-13/CD-08/CD-12) (#3828 #3829 #3830)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -291,25 +291,54 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code enabled} here — use {@link setContentTypeEnabled} (CD-13).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
-  }
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeEnabled}. */
+export const CONTENT_TYPE_ENABLED_ROOT = "ContentTypeEnabled";
+
+/**
+ * Build the wire JSON body for {@code PUT .../enabled} under
+ * {@link CONTENT_TYPE_ENABLED_ROOT}. A flat {@code { enabled }} body fails
+ * server UNWRAP_ROOT_VALUE.
+ */
+export function wrapContentTypeEnabledForWire(
+  enabled: boolean,
+): Record<string, { enabled: boolean }> {
+  return { [CONTENT_TYPE_ENABLED_ROOT]: { enabled } };
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/enabled — CD-13 dedicated enable/disable.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. Response is {@code ContentTypeDetail}
+ * with the new {@code enabled} value (lock still held).
+ */
+export async function setContentTypeEnabled(
+  idOrName: string,
+  enabled: boolean,
+): Promise<ContentTypeDetail> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/enabled`,
+    wrapContentTypeEnabledForWire(enabled),
+  );
+  return unwrapContentTypeDetail(payload);
 }

--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -219,7 +219,10 @@ export type ContentTypeUpdateBody = {
   /** Omit to leave unchanged; non-null list is a full replace. */
   allowedWorkflows?: NamedObjectRef[];
   defaultWorkflow?: NamedObjectRef | null;
-  /** Omit to leave unchanged; non-null list is a full replace. */
+  /**
+   * Omit to leave unchanged. Prefer {@link replaceContentTypeAllowedTemplates}
+   * (CD-12 dedicated PUT) instead of sending this on the bulk detail PUT.
+   */
   allowedTemplates?: NamedObjectRef[];
 };
 
@@ -291,25 +294,92 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code allowedTemplates} here — use
+ * {@link replaceContentTypeAllowedTemplates} (CD-12).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code NamedObjectRefList}. */
+export const NAMED_OBJECT_REF_LIST_ROOT = "NamedObjectRefList";
+
+/**
+ * Build the wire JSON body for {@code PUT .../allowedTemplates} under
+ * {@link NAMED_OBJECT_REF_LIST_ROOT}. A bare array fails server UNWRAP_ROOT_VALUE.
+ */
+export function wrapNamedObjectRefListForWire(
+  items: NamedObjectRef[],
+): Record<string, NamedObjectRef[]> {
+  return { [NAMED_OBJECT_REF_LIST_ROOT]: items };
+}
+
+/**
+ * Flatten GET/PUT {@code .../allowedTemplates} JSON to {@link NamedObjectRef}[].
+ *
+ * <p>Handles WRAP_ROOT {@code NamedObjectRefList}, JAXB {@code NamedObjectRef}
+ * envelope, bare array, singleton object, and empty-collection beans.
+ */
+export function unwrapNamedObjectRefList(payload: unknown): NamedObjectRef[] {
+  if (payload == null) {
+    return [];
   }
+  if (Array.isArray(payload)) {
+    return normalizeNamedObjectRefs(payload);
+  }
+  const root = asRecord(payload);
+  if (!root) {
+    return [];
+  }
+  if (root[NAMED_OBJECT_REF_LIST_ROOT] != null) {
+    return normalizeNamedObjectRefs(root[NAMED_OBJECT_REF_LIST_ROOT]);
+  }
+  if (root.namedObjectRefList != null) {
+    return normalizeNamedObjectRefs(root.namedObjectRefList);
+  }
+  return normalizeNamedObjectRefs(payload);
+}
+
+/**
+ * GET /services/contenttypes/{idOrName}/allowedTemplates — CD-12 read.
+ * No design lock required. Empty list means none.
+ */
+export async function getContentTypeAllowedTemplates(
+  idOrName: string,
+): Promise<NamedObjectRef[]> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await get<unknown>(`${PATHS.CONTENT_TYPES}/${key}/allowedTemplates`);
+  return unwrapNamedObjectRefList(payload);
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/allowedTemplates — CD-12 full replace.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. HTTP 400 when a template name/guid
+ * cannot be resolved. Empty list clears associations.
+ */
+export async function replaceContentTypeAllowedTemplates(
+  idOrName: string,
+  templates: NamedObjectRef[],
+): Promise<NamedObjectRef[]> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/allowedTemplates`,
+    wrapNamedObjectRefListForWire(templates),
+  );
+  return unwrapNamedObjectRefList(payload);
 }

--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -216,11 +216,17 @@ export type ContentTypeUpdateBody = {
   description?: string;
   enabled?: boolean;
   fields?: Pick<ContentTypeFieldSummary, "name" | "searchable" | "required" | "occurrence">[];
-  /** Omit to leave unchanged; non-null list is a full replace. */
+  /** Omit to leave unchanged; non-null list is a full replace. Prefer CD-08 PUT. */
   allowedWorkflows?: NamedObjectRef[];
   defaultWorkflow?: NamedObjectRef | null;
   /** Omit to leave unchanged; non-null list is a full replace. */
   allowedTemplates?: NamedObjectRef[];
+};
+
+/** Wire body for {@code PUT .../allowedWorkflows} (Jackson root {@code ContentTypeWorkflows}). */
+export type ContentTypeWorkflowsBody = {
+  allowedWorkflows: NamedObjectRef[];
+  defaultWorkflow?: NamedObjectRef | null;
 };
 
 /** Wire shape for {@code POST .../lock} ({@code ObjectLockSummary}). */
@@ -291,25 +297,55 @@ export function wrapContentTypeDetailForWire(
 }
 
 /**
- * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not release it.
+ * PUT /services/contenttypes/{idOrName} — requires a held design lock; does not
+ * acquire or release it. Call {@link lockContentType} first. HTTP 409 when
+ * unlocked or locked by another user.
  *
- * <p>This client wraps lock → PUT → unlock so the Developer SPA save path keeps working until
- * lock-button chrome (#3744) lands. The server PUT is 409 unless the current user already holds
- * the lock.
+ * <p>Do not send {@code allowedWorkflows} here — use
+ * {@link setContentTypeAllowedWorkflows} (CD-08).
  */
 export async function updateContentTypeDetail(
   idOrName: string,
   body: ContentTypeUpdateBody,
 ): Promise<ContentTypeDetail> {
-  await lockContentType(idOrName);
-  try {
-    const key = encodeURIComponent(idOrName);
-    const payload = await put<unknown>(
-      `${PATHS.CONTENT_TYPES}/${key}`,
-      wrapContentTypeDetailForWire(body),
-    );
-    return unwrapContentTypeDetail(payload);
-  } finally {
-    await unlockContentType(idOrName).catch(() => undefined);
-  }
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}`,
+    wrapContentTypeDetailForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
+}
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeWorkflows}. */
+export const CONTENT_TYPE_WORKFLOWS_ROOT = "ContentTypeWorkflows";
+
+/**
+ * Build the wire JSON body for {@code PUT .../allowedWorkflows} under
+ * {@link CONTENT_TYPE_WORKFLOWS_ROOT}. A flat body fails server UNWRAP_ROOT_VALUE.
+ */
+export function wrapContentTypeWorkflowsForWire(
+  body: ContentTypeWorkflowsBody,
+): Record<string, ContentTypeWorkflowsBody> {
+  return { [CONTENT_TYPE_WORKFLOWS_ROOT]: body };
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/allowedWorkflows — CD-08 dedicated replace.
+ *
+ * <p>Requires a design-session lock already held by the current user
+ * ({@link lockContentType}). Does not acquire or release the lock. HTTP 409
+ * when unlocked or locked by another user. Empty {@code allowedWorkflows}
+ * clears associations. Response is {@code ContentTypeDetail} with the new set
+ * (lock still held).
+ */
+export async function setContentTypeAllowedWorkflows(
+  idOrName: string,
+  body: ContentTypeWorkflowsBody,
+): Promise<ContentTypeDetail> {
+  const key = encodeURIComponent(idOrName);
+  const payload = await put<unknown>(
+    `${PATHS.CONTENT_TYPES}/${key}/allowedWorkflows`,
+    wrapContentTypeWorkflowsForWire(body),
+  );
+  return unwrapContentTypeDetail(payload);
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -427,6 +427,11 @@ export function ContentTypeDetailPanel({
         }));
 
       let saved: ContentTypeDetail | null = null;
+      // Enabled PUT first so a failed enable/disable cannot leave bulk fields persisted
+      // (CD-13 two-call save; no shared rollback).
+      if (enabledDirty) {
+        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
+      }
       if (otherDirty) {
         const body: ContentTypeUpdateBody = {
           label,
@@ -443,10 +448,15 @@ export function ContentTypeDetailPanel({
         if (templatesDirty) {
           body.allowedTemplates = toRefPayload(templates);
         }
-        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
-      }
-      if (enabledDirty) {
-        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
+        try {
+          saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
+        } catch (bulkErr) {
+          if (saved != null) {
+            setDetail(saved);
+            setEnabled(saved.enabled !== false);
+          }
+          throw bulkErr;
+        }
       }
       if (saved == null) {
         return;

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -18,8 +18,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
+  getContentTypeAllowedTemplates,
   getContentTypeDetail,
   lockContentType,
+  replaceContentTypeAllowedTemplates,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -393,6 +395,18 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (detail == null) {
+      return;
+    }
+    const otherDirty =
+      label !== (detail.label || "") ||
+      description !== (detail.description || "") ||
+      enabled !== (detail.enabled !== false) ||
+      fieldsDirty ||
+      workflowsDirty;
+    if (!otherDirty && !templatesDirty) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,24 +426,29 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
-      if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+      let saved: ContentTypeDetail = normalizeDetailLists(detail);
+      if (otherDirty) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          enabled,
+          fields: fieldPatches,
+        };
+        if (workflowsDirty) {
+          body.allowedWorkflows = toRefPayload(workflows);
+          const def = workflows.find((w) => w.isDefault) || workflows[0];
+          if (def) {
+            body.defaultWorkflow = toRefPayload([def])[0];
+          }
         }
+        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       }
       if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+        await replaceContentTypeAllowedTemplates(idOrName, toRefPayload(templates));
+        const listed = await getContentTypeAllowedTemplates(idOrName);
+        saved = { ...saved, allowedTemplates: listed };
       }
 
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
@@ -490,7 +509,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -20,6 +20,7 @@ import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   getContentTypeDetail,
   lockContentType,
+  setContentTypeAllowedWorkflows,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -35,6 +36,13 @@ import type {
   ContentTypeFieldSummary,
   NamedObjectRef,
 } from "../api/developer/types";
+import {
+  buildAllowedWorkflowsReplaceBody,
+  cloneNamedObjectRefs,
+  namedObjectRefsEqual,
+  toNamedObjectRefPayload,
+  withDefaultWorkflowFlags,
+} from "./contentTypeWorkflows";
 import {
   designGapCode,
   designGapKey,
@@ -88,15 +96,6 @@ function toDrafts(fields: unknown): Record<string, FieldDraft> {
   return out;
 }
 
-function cloneRefs(list: unknown): NamedObjectRef[] {
-  return normalizeNamedObjectRefs(list).map((r) => ({
-    name: r.name,
-    label: r.label,
-    isDefault: r.isDefault,
-    guid: r.guid ? { ...r.guid } : undefined,
-  }));
-}
-
 function contentTypeFields(detail: ContentTypeDetail | null | undefined): ContentTypeFieldSummary[] {
   return normalizeContentTypeFields(detail?.fields);
 }
@@ -129,49 +128,6 @@ function refKey(r: NamedObjectRef, index: number): string {
 
 /** Canonical Percussion GUID shape: type-host-uuid (three numeric groups). */
 const PERC_GUID_RE = /^\d+-\d+-\d+$/;
-
-function refsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (refKey(a[i], i) !== refKey(b[i], i)) return false;
-    if (!!a[i].isDefault !== !!b[i].isDefault) return false;
-  }
-  return true;
-}
-
-/**
- * Align isDefault flags with server defaultWorkflow (or first row when missing).
- */
-function withDefaultFlags(
-  list: unknown,
-  defaultWorkflow?: NamedObjectRef | null,
-): NamedObjectRef[] {
-  const wfs = cloneRefs(list);
-  if (defaultWorkflow) {
-    const defKey = refKey(defaultWorkflow, -1);
-    for (const w of wfs) {
-      w.isDefault = refKey(w, -1) === defKey || w.name === defaultWorkflow.name;
-    }
-  }
-  if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
-    wfs[0] = { ...wfs[0], isDefault: true };
-  }
-  return wfs;
-}
-
-function toRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
-  return list.map((r) => {
-    const out: NamedObjectRef = {};
-    if (r.name) out.name = r.name;
-    if (r.guid?.stringValue || r.guid?.uuid != null) {
-      out.guid = {};
-      if (r.guid.stringValue) out.guid.stringValue = r.guid.stringValue;
-      if (r.guid.uuid != null) out.guid.uuid = r.guid.uuid;
-    }
-    if (r.isDefault) out.isDefault = true;
-    return out;
-  });
-}
 
 export function ContentTypeDetailPanel({
   idOrName,
@@ -228,8 +184,10 @@ export function ContentTypeDetailPanel({
         setDescription(normalized.description || "");
         setEnabled(normalized.enabled !== false);
         setFieldDrafts(toDrafts(normalized.fields));
-        setWorkflows(withDefaultFlags(normalized.allowedWorkflows, normalized.defaultWorkflow));
-        setTemplates(cloneRefs(normalized.allowedTemplates));
+        setWorkflows(
+          withDefaultWorkflowFlags(normalized.allowedWorkflows, normalized.defaultWorkflow),
+        );
+        setTemplates(cloneNamedObjectRefs(normalized.allowedTemplates));
         setNewWfName("");
         setNewTplName("");
       })
@@ -254,10 +212,13 @@ export function ContentTypeDetailPanel({
       return d.searchable !== i.searchable || d.required !== i.required;
     });
 
-  const initialWorkflows = withDefaultFlags(detail?.allowedWorkflows, detail?.defaultWorkflow);
-  const initialTemplates = cloneRefs(detail?.allowedTemplates);
-  const workflowsDirty = detail != null && !refsEqual(workflows, initialWorkflows);
-  const templatesDirty = detail != null && !refsEqual(templates, initialTemplates);
+  const initialWorkflows = withDefaultWorkflowFlags(
+    detail?.allowedWorkflows,
+    detail?.defaultWorkflow,
+  );
+  const initialTemplates = cloneNamedObjectRefs(detail?.allowedTemplates);
+  const workflowsDirty = detail != null && !namedObjectRefsEqual(workflows, initialWorkflows);
+  const templatesDirty = detail != null && !namedObjectRefsEqual(templates, initialTemplates);
 
   const dirty =
     detail != null &&
@@ -393,6 +354,9 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (!detail) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,31 +376,53 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
+      let saved: ContentTypeDetail | undefined;
+      let workflowSaved: ContentTypeDetail | undefined;
       if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+        workflowSaved = await setContentTypeAllowedWorkflows(
+          idOrName,
+          buildAllowedWorkflowsReplaceBody(workflows),
+        );
+        saved = workflowSaved;
+      }
+      const bulkNeeded =
+        label !== (detail.label || "") ||
+        description !== (detail.description || "") ||
+        enabled !== (detail.enabled !== false) ||
+        fieldsDirty ||
+        templatesDirty;
+      if (bulkNeeded) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          enabled,
+          fields: fieldPatches,
+        };
+        if (templatesDirty) {
+          body.allowedTemplates = toNamedObjectRefPayload(templates);
         }
+        const bulkSaved = await updateContentTypeDetail(idOrName, body);
+        saved = workflowSaved
+          ? {
+              ...bulkSaved,
+              allowedWorkflows: workflowSaved.allowedWorkflows,
+              defaultWorkflow: workflowSaved.defaultWorkflow,
+            }
+          : bulkSaved;
       }
-      if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+      if (!saved) {
+        saved = await getContentTypeDetail(idOrName);
       }
-
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
-      setDetail(saved);
-      setLabel(saved.label || "");
-      setDescription(saved.description || "");
-      setEnabled(saved.enabled !== false);
-      setFieldDrafts(toDrafts(saved.fields));
-      setWorkflows(withDefaultFlags(saved.allowedWorkflows, saved.defaultWorkflow));
-      setTemplates(cloneRefs(saved.allowedTemplates));
+      const normalized = normalizeDetailLists(saved);
+      setDetail(normalized);
+      setLabel(normalized.label || "");
+      setDescription(normalized.description || "");
+      setEnabled(normalized.enabled !== false);
+      setFieldDrafts(toDrafts(normalized.fields));
+      setWorkflows(
+        withDefaultWorkflowFlags(normalized.allowedWorkflows, normalized.defaultWorkflow),
+      );
+      setTemplates(cloneNamedObjectRefs(normalized.allowedTemplates));
       setNotice(DEV_MSG.CT_SAVED);
     } catch (err: unknown) {
       if (isApiError(err) && err.status === 409) {
@@ -490,7 +476,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -20,6 +20,7 @@ import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   getContentTypeDetail,
   lockContentType,
+  setContentTypeEnabled,
   unlockContentType,
   updateContentTypeDetail,
   type ContentTypeUpdateBody,
@@ -393,6 +394,19 @@ export function ContentTypeDetailPanel({
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
     }
+    if (detail == null) {
+      return;
+    }
+    const enabledDirty = enabled !== (detail.enabled !== false);
+    const otherDirty =
+      label !== (detail.label || "") ||
+      description !== (detail.description || "") ||
+      fieldsDirty ||
+      workflowsDirty ||
+      templatesDirty;
+    if (!enabledDirty && !otherDirty) {
+      return;
+    }
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -412,24 +426,31 @@ export function ContentTypeDetailPanel({
           required: d.required,
         }));
 
-      const body: ContentTypeUpdateBody = {
-        label,
-        description,
-        enabled,
-        fields: fieldPatches,
-      };
-      if (workflowsDirty) {
-        body.allowedWorkflows = toRefPayload(workflows);
-        const def = workflows.find((w) => w.isDefault) || workflows[0];
-        if (def) {
-          body.defaultWorkflow = toRefPayload([def])[0];
+      let saved: ContentTypeDetail | null = null;
+      if (otherDirty) {
+        const body: ContentTypeUpdateBody = {
+          label,
+          description,
+          fields: fieldPatches,
+        };
+        if (workflowsDirty) {
+          body.allowedWorkflows = toRefPayload(workflows);
+          const def = workflows.find((w) => w.isDefault) || workflows[0];
+          if (def) {
+            body.defaultWorkflow = toRefPayload([def])[0];
+          }
         }
+        if (templatesDirty) {
+          body.allowedTemplates = toRefPayload(templates);
+        }
+        saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
       }
-      if (templatesDirty) {
-        body.allowedTemplates = toRefPayload(templates);
+      if (enabledDirty) {
+        saved = normalizeDetailLists(await setContentTypeEnabled(idOrName, enabled));
       }
-
-      const saved = normalizeDetailLists(await updateContentTypeDetail(idOrName, body));
+      if (saved == null) {
+        return;
+      }
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
@@ -490,7 +511,7 @@ export function ContentTypeDetailPanel({
               {label || detail.name || idOrName}
             </h2>
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              {detail.name}
+              <span data-testid="developer-ct-detail-name">{detail.name}</span>
               {" · "}
               <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
             </div>
@@ -525,6 +546,7 @@ export function ContentTypeDetailPanel({
                 <input
                   type="checkbox"
                   data-testid="developer-ct-enabled"
+                  aria-label={DEV_MSG.CT_FORM_ENABLED}
                   checked={enabled}
                   onChange={() => setEnabled((v) => !v)}
                   disabled={!canEdit}

--- a/WebUI/src/main/ts/developer/contentTypeWorkflows.ts
+++ b/WebUI/src/main/ts/developer/contentTypeWorkflows.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { normalizeNamedObjectRefs } from "../api/developer/contentTypeLists";
+import type { ContentTypeWorkflowsBody } from "../api/developer/contentTypesApi";
+import type { NamedObjectRef } from "../api/developer/types";
+
+function refKey(r: NamedObjectRef, index: number): string {
+  if (r.name) return `name:${r.name}`;
+  if (r.guid?.stringValue) return `guid:${r.guid.stringValue}`;
+  if (r.guid?.uuid != null) return `uuid:${r.guid.uuid}`;
+  return `idx:${index}`;
+}
+
+export function cloneNamedObjectRefs(list: unknown): NamedObjectRef[] {
+  return normalizeNamedObjectRefs(list).map((r) => ({
+    name: r.name,
+    label: r.label,
+    isDefault: r.isDefault,
+    guid: r.guid ? { ...r.guid } : undefined,
+  }));
+}
+
+export function namedObjectRefsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (refKey(a[i], i) !== refKey(b[i], i)) return false;
+    if (!!a[i].isDefault !== !!b[i].isDefault) return false;
+  }
+  return true;
+}
+
+/**
+ * Align isDefault flags with server defaultWorkflow (or first row when missing).
+ */
+export function withDefaultWorkflowFlags(
+  list: unknown,
+  defaultWorkflow?: NamedObjectRef | null,
+): NamedObjectRef[] {
+  const wfs = cloneNamedObjectRefs(list);
+  if (defaultWorkflow) {
+    const defKey = refKey(defaultWorkflow, -1);
+    for (const w of wfs) {
+      w.isDefault = refKey(w, -1) === defKey || w.name === defaultWorkflow.name;
+    }
+  }
+  if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+    wfs[0] = { ...wfs[0], isDefault: true };
+  }
+  return wfs;
+}
+
+/** Strip UI-only fields for CD-08 PUT .../allowedWorkflows. */
+export function toNamedObjectRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
+  return list.map((r) => {
+    const out: NamedObjectRef = {};
+    if (r.name) out.name = r.name;
+    if (r.guid?.stringValue || r.guid?.uuid != null) {
+      out.guid = {};
+      if (r.guid.stringValue) out.guid.stringValue = r.guid.stringValue;
+      if (r.guid.uuid != null) out.guid.uuid = r.guid.uuid;
+    }
+    if (r.isDefault) out.isDefault = true;
+    return out;
+  });
+}
+
+/**
+ * Full-replace body for {@code PUT .../allowedWorkflows}. Empty list clears.
+ * Omits {@code defaultWorkflow} when the set is empty.
+ */
+export function buildAllowedWorkflowsReplaceBody(
+  workflows: NamedObjectRef[],
+): ContentTypeWorkflowsBody {
+  const allowedWorkflows = toNamedObjectRefPayload(workflows);
+  const def = workflows.find((w) => w.isDefault) || workflows[0];
+  if (!def) {
+    return { allowedWorkflows };
+  }
+  return {
+    allowedWorkflows,
+    defaultWorkflow: toNamedObjectRefPayload([def])[0],
+  };
+}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -181,7 +181,8 @@ export const DEV_MSG_KEYS = {
   CT_RULE_IN_XFORM: "perc.ui.developer@in-xform",
   CT_RULE_OUT_XFORM: "perc.ui.developer@out-xform",
   CT_WORKFLOWS: "perc.ui.developer@Allowed workflows",
-  CT_WORKFLOWS_HINT: "perc.ui.developer@Full replace on save when changed. Add by workflow name; set default with the radio.",
+  CT_WORKFLOWS_HINT:
+    "perc.ui.developer@Lock to edit. Add or remove workflows by name, set the default, then save. Save replaces the allowed-workflow set and does not unlock.",
   CT_DEFAULT_WF: "perc.ui.developer@Default workflow",
   CT_TEMPLATES: "perc.ui.developer@Allowed templates",
   CT_TEMPLATES_HINT: "perc.ui.developer@Full replace on save when changed. Add by template name or GUID (type-host-uuid, e.g. 0-10-347).",

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
+  getContentTypeAllowedTemplates,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  replaceContentTypeAllowedTemplates,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
+  unwrapNamedObjectRefList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapNamedObjectRefListForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -270,7 +272,39 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("wrapNamedObjectRefListForWire / unwrapNamedObjectRefList (CD-12)", () => {
+  it("wraps a list under NamedObjectRefList", () => {
+    expect(wrapNamedObjectRefListForWire([{ name: "perc.page" }])).toEqual({
+      NamedObjectRefList: [{ name: "perc.page" }],
+    });
+  });
+
+  it("wraps an empty list (clears associations)", () => {
+    expect(wrapNamedObjectRefListForWire([])).toEqual({ NamedObjectRefList: [] });
+  });
+
+  it("unwraps WRAP_ROOT NamedObjectRefList", () => {
+    expect(
+      unwrapNamedObjectRefList({
+        NamedObjectRefList: [{ name: "perc.page", label: "Page" }],
+      }),
+    ).toEqual([{ name: "perc.page", label: "Page" }]);
+  });
+
+  it("unwraps a bare array", () => {
+    expect(unwrapNamedObjectRefList([{ name: "perc.page" }])).toEqual([{ name: "perc.page" }]);
+  });
+
+  it("unwraps JAXB NamedObjectRef singleton and empty beans", () => {
+    expect(
+      unwrapNamedObjectRefList({ NamedObjectRef: { name: "perc.page" } }),
+    ).toEqual([{ name: "perc.page" }]);
+    expect(unwrapNamedObjectRefList({ empty: true })).toEqual([]);
+    expect(unwrapNamedObjectRefList(null)).toEqual([]);
+  });
+});
+
+describe("updateContentTypeDetail held-lock PUT", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +323,77 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("PUTs save without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("allowedTemplates");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("/lock");
+  });
+});
+
+describe("allowedTemplates GET/PUT (CD-12)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("GETs allowedTemplates and unwraps the list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ NamedObjectRefList: [{ name: "perc.page", label: "Page" }] }),
+    );
+    const listed = await getContentTypeAllowedTemplates("percPage");
+    expect(listed).toEqual([{ name: "perc.page", label: "Page" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("GET");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/allowedTemplates`,
+    );
+  });
+
+  it("PUTs allowedTemplates wrapped under NamedObjectRefList and returns the set", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ NamedObjectRefList: [{ name: "perc.page.summary" }] }),
+    );
+    const listed = await replaceContentTypeAllowedTemplates("percPage", [
+      { name: "perc.page.summary" },
+    ]);
+    expect(listed).toEqual([{ name: "perc.page.summary" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("PUT");
+    expect(String(url)).toContain(`${PATHS.CONTENT_TYPES}/percPage/allowedTemplates`);
+    expect(JSON.parse(String(init.body))).toEqual({
+      NamedObjectRefList: [{ name: "perc.page.summary" }],
+    });
+  });
+
+  it("PUTs an empty list to clear associations", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ NamedObjectRefList: [] }));
+    const listed = await replaceContentTypeAllowedTemplates("percPage", []);
+    expect(listed).toEqual([]);
+    const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(body).toEqual({ NamedObjectRefList: [] });
   });
 });

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  setContentTypeEnabled,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapContentTypeEnabledForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -270,7 +270,7 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("updateContentTypeDetail PUT without lock wrap", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +289,81 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("PUTs save only — lock chrome owns lock/unlock (#3781)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toMatch(/\/enabled$/);
+    expect(JSON.parse(String(init.body))).toEqual(
+      wrapContentTypeDetailForWire({ description: "updated" }),
+    );
+  });
+});
+
+describe("setContentTypeEnabled CD-13 dedicated PUT (#3781)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("wraps enabled under ContentTypeEnabled", () => {
+    expect(wrapContentTypeEnabledForWire(false)).toEqual({
+      ContentTypeEnabled: { enabled: false },
+    });
+    expect(wrapContentTypeEnabledForWire(true)).toEqual({
+      ContentTypeEnabled: { enabled: true },
+    });
+  });
+
+  it("PUTs /contenttypes/{id}/enabled without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", enabled: false },
+      }),
+    );
+
+    const saved = await setContentTypeEnabled("percPage", false);
+    expect(saved.enabled).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/enabled`,
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeEnabled: { enabled: false },
+    });
+  });
+
+  it("encodes idOrName on the enabled path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ ContentTypeDetail: { name: "perc Page", enabled: true } }),
+    );
+    await setContentTypeEnabled("perc Page", true);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/${encodeURIComponent("perc Page")}/enabled`,
+    );
   });
 });

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,17 +4,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  lockContentType,
   normalizeContentTypeDesignGaps,
   normalizeContentTypeFields,
   normalizeContentTypeStringList,
   normalizeNamedObjectRefs,
-  unlockContentType,
+  setContentTypeAllowedWorkflows,
   unwrapContentTypeDetail,
   unwrapContentTypeList,
   unwrapObjectLockSummary,
   updateContentTypeDetail,
   wrapContentTypeDetailForWire,
+  wrapContentTypeWorkflowsForWire,
 } from "../../../../main/ts/api/developer/contentTypesApi";
 import { PATHS } from "../../../../main/ts/api/paths";
 
@@ -250,6 +250,22 @@ describe("wrapContentTypeDetailForWire", () => {
   });
 });
 
+describe("wrapContentTypeWorkflowsForWire", () => {
+  it("wraps allowedWorkflows under ContentTypeWorkflows", () => {
+    expect(
+      wrapContentTypeWorkflowsForWire({
+        allowedWorkflows: [{ name: "Simple Workflow" }],
+        defaultWorkflow: { name: "Simple Workflow" },
+      }),
+    ).toEqual({
+      ContentTypeWorkflows: {
+        allowedWorkflows: [{ name: "Simple Workflow" }],
+        defaultWorkflow: { name: "Simple Workflow" },
+      },
+    });
+  });
+});
+
 describe("unwrapObjectLockSummary", () => {
   it("unwraps Jackson ObjectLockSummary root", () => {
     expect(
@@ -270,7 +286,7 @@ describe("unwrapObjectLockSummary", () => {
   });
 });
 
-describe("updateContentTypeDetail lock-save-unlock wrap", () => {
+describe("content type design PUTs (held lock, no wrap)", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -289,24 +305,52 @@ describe("updateContentTypeDetail lock-save-unlock wrap", () => {
     });
   }
 
-  it("POSTs lock, PUTs save, then POSTs unlock", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ session: "s", locker: "Admin", remainingTime: 30 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+  it("updateContentTypeDetail PUTs only and does not lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: { name: "percPage", label: "Page", description: "updated" },
+      }),
+    );
 
     const saved = await updateContentTypeDetail("percPage", { description: "updated" });
     expect(saved.description).toBe("updated");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method);
-    expect(methods).toEqual(["POST", "PUT", "POST"]);
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(urls[0]).toContain(`${PATHS.CONTENT_TYPES}/percPage/lock`);
-    expect(urls[1]).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
-    expect(urls[2]).toContain(`${PATHS.CONTENT_TYPES}/percPage/unlock`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${PATHS.CONTENT_TYPES}/percPage`);
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("allowedWorkflows");
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeDetail: { description: "updated" },
+    });
+  });
+
+  it("setContentTypeAllowedWorkflows PUTs CD-08 wrap without lock or unlock", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ContentTypeDetail: {
+          name: "percPage",
+          allowedWorkflows: [{ name: "Standard Workflow" }],
+          defaultWorkflow: { name: "Standard Workflow" },
+        },
+      }),
+    );
+
+    const saved = await setContentTypeAllowedWorkflows("percPage", {
+      allowedWorkflows: [{ name: "Standard Workflow" }],
+      defaultWorkflow: { name: "Standard Workflow" },
+    });
+    expect(saved.allowedWorkflows).toEqual([{ name: "Standard Workflow" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      `${PATHS.CONTENT_TYPES}/percPage/allowedWorkflows`,
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      ContentTypeWorkflows: {
+        allowedWorkflows: [{ name: "Standard Workflow" }],
+        defaultWorkflow: { name: "Standard Workflow" },
+      },
+    });
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -13,6 +13,7 @@ import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDe
 vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   getContentTypeDetail: vi.fn(),
   updateContentTypeDetail: vi.fn(),
+  setContentTypeEnabled: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
 }));
@@ -36,6 +37,7 @@ const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<
 const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as ReturnType<
   typeof vi.fn
 >;
+const setContentTypeEnabled = contentTypesApi.setContentTypeEnabled as ReturnType<typeof vi.fn>;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
 const unlockContentType = contentTypesApi.unlockContentType as ReturnType<typeof vi.fn>;
 
@@ -60,6 +62,7 @@ describe("ContentTypeDetailPanel", () => {
     };
     getContentTypeDetail.mockReset();
     updateContentTypeDetail.mockReset();
+    setContentTypeEnabled.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
@@ -67,6 +70,10 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
+    }));
+    setContentTypeEnabled.mockImplementation(async (_id, enabled: boolean) => ({
+      ...sampleDetail,
+      enabled,
     }));
   });
 
@@ -78,6 +85,7 @@ describe("ContentTypeDetailPanel", () => {
       expect(screen.getByTestId("developer-ct-detail-title")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-detail-title").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
     expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
@@ -347,6 +355,11 @@ describe("ContentTypeDetailPanel", () => {
       "percPage",
       expect.objectContaining({ description: "Updated description" }),
     );
+    const saveBody = updateContentTypeDetail.mock.calls.at(-1)?.[1] as {
+      enabled?: boolean;
+    };
+    expect(saveBody.enabled).toBeUndefined();
+    expect(setContentTypeEnabled).not.toHaveBeenCalled();
     expect(unlockContentType).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
@@ -428,5 +441,107 @@ describe("ContentTypeDetailPanel", () => {
       expect(unlockContentType).toHaveBeenCalledWith("percPage");
     });
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("keeps the enabled toggle disabled until lock (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-enabled")).toBeTruthy();
+    });
+    const box = screen.getByTestId("developer-ct-enabled") as HTMLInputElement;
+    expect(box.disabled).toBe(true);
+    expect(box.checked).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(setContentTypeEnabled).not.toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+  });
+
+  it("saves enabled via dedicated PUT after lock (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    });
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(unlockContentType).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("saves description with bulk PUT then enabled with dedicated PUT (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    });
+    expect(updateContentTypeDetail).toHaveBeenCalledWith(
+      "percPage",
+      expect.objectContaining({ description: "Updated description" }),
+    );
+    const saveBody = updateContentTypeDetail.mock.calls.at(-1)?.[1] as {
+      enabled?: boolean;
+    };
+    expect(saveBody.enabled).toBeUndefined();
+    expect(updateContentTypeDetail.mock.invocationCallOrder[0]).toBeLessThan(
+      setContentTypeEnabled.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("clears the held lock when enabled PUT returns 409 (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    setContentTypeEnabled.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -13,6 +13,7 @@ import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDe
 vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   getContentTypeDetail: vi.fn(),
   updateContentTypeDetail: vi.fn(),
+  setContentTypeAllowedWorkflows: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
 }));
@@ -34,6 +35,9 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<typeof vi.fn>;
 const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as ReturnType<
+  typeof vi.fn
+>;
+const setContentTypeAllowedWorkflows = contentTypesApi.setContentTypeAllowedWorkflows as ReturnType<
   typeof vi.fn
 >;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
@@ -60,6 +64,7 @@ describe("ContentTypeDetailPanel", () => {
     };
     getContentTypeDetail.mockReset();
     updateContentTypeDetail.mockReset();
+    setContentTypeAllowedWorkflows.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
@@ -67,6 +72,11 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
+    }));
+    setContentTypeAllowedWorkflows.mockImplementation(async (_id, body) => ({
+      ...sampleDetail,
+      allowedWorkflows: body.allowedWorkflows,
+      defaultWorkflow: body.defaultWorkflow ?? null,
     }));
   });
 
@@ -410,6 +420,117 @@ describe("ContentTypeDetailPanel", () => {
     expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
       true,
     );
+  });
+
+  it("keeps workflow editors disabled until lock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-wf-add") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-wf-remove-0") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("saves allowed workflows via CD-08 PUT without bulk PUT or unlock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(setContentTypeAllowedWorkflows).toHaveBeenCalled();
+    });
+    expect(setContentTypeAllowedWorkflows).toHaveBeenCalledWith(
+      "percPage",
+      expect.objectContaining({
+        allowedWorkflows: expect.arrayContaining([
+          expect.objectContaining({ name: "Simple Workflow" }),
+          expect.objectContaining({ name: "Standard Workflow" }),
+        ]),
+        defaultWorkflow: expect.objectContaining({ name: "Simple Workflow" }),
+      }),
+    );
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(unlockContentType).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("blocks save without a held lock (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-save")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    expect(setContentTypeAllowedWorkflows).not.toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(lockContentType).not.toHaveBeenCalled();
+  });
+
+  it("clears the held lock when allowedWorkflows PUT returns 409 (#3782)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", isDefault: true }],
+    });
+    setContentTypeAllowedWorkflows.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect(lockContentType).toHaveBeenCalledTimes(1);
   });
 
   it("unlocks on back when the session holds the lock (#3744)", async () => {

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -15,6 +15,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   updateContentTypeDetail: vi.fn(),
   lockContentType: vi.fn(),
   unlockContentType: vi.fn(),
+  getContentTypeAllowedTemplates: vi.fn(),
+  replaceContentTypeAllowedTemplates: vi.fn(),
 }));
 
 // ObjectAclSection loads ACL via separate API; stub so detail success path stays isolated.
@@ -38,6 +40,10 @@ const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as Retur
 >;
 const lockContentType = contentTypesApi.lockContentType as ReturnType<typeof vi.fn>;
 const unlockContentType = contentTypesApi.unlockContentType as ReturnType<typeof vi.fn>;
+const getContentTypeAllowedTemplates =
+  contentTypesApi.getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
+const replaceContentTypeAllowedTemplates =
+  contentTypesApi.replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
   name: "percPage",
@@ -62,12 +68,16 @@ describe("ContentTypeDetailPanel", () => {
     updateContentTypeDetail.mockReset();
     lockContentType.mockReset();
     unlockContentType.mockReset();
+    getContentTypeAllowedTemplates.mockReset();
+    replaceContentTypeAllowedTemplates.mockReset();
     lockContentType.mockResolvedValue({ locker: "Admin", remainingTime: 30 });
     unlockContentType.mockResolvedValue(undefined);
     updateContentTypeDetail.mockImplementation(async (_id, body) => ({
       ...sampleDetail,
       ...body,
     }));
+    replaceContentTypeAllowedTemplates.mockImplementation(async (_id, templates) => templates);
+    getContentTypeAllowedTemplates.mockImplementation(async () => []);
   });
 
   it("loads detail on success and supports back", async () => {
@@ -78,6 +88,7 @@ describe("ContentTypeDetailPanel", () => {
       expect(screen.getByTestId("developer-ct-detail-title")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-detail-title").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
     expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
@@ -347,6 +358,8 @@ describe("ContentTypeDetailPanel", () => {
       "percPage",
       expect.objectContaining({ description: "Updated description" }),
     );
+    expect(updateContentTypeDetail.mock.calls.at(-1)?.[1].allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).not.toHaveBeenCalled();
     expect(unlockContentType).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
@@ -408,6 +421,125 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("locks, replaces allowed templates via dedicated PUT then GET (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    replaceContentTypeAllowedTemplates.mockResolvedValueOnce([]);
+    getContentTypeAllowedTemplates.mockResolvedValueOnce([]);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage", []);
+    });
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("adds an existing template id after lock and PUTs the new set (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    const next = [
+      { name: "perc.page" },
+      { name: "perc.page.summary", label: "perc.page.summary" },
+    ];
+    replaceContentTypeAllowedTemplates.mockResolvedValueOnce(next);
+    getContentTypeAllowedTemplates.mockResolvedValueOnce(next);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-tpl-add-name"), {
+      target: { value: "perc.page.summary" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalled();
+    });
+    expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith(
+      "percPage",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "perc.page" }),
+        expect.objectContaining({ name: "perc.page.summary" }),
+      ]),
+    );
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-1").textContent).toContain(
+        "perc.page.summary",
+      );
+    });
+  });
+
+  it("clears the held lock when allowedTemplates PUT returns 409 (#3783)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    replaceContentTypeAllowedTemplates.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-tpl-remove-0") as HTMLButtonElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
       true,
     );
   });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -484,7 +484,7 @@ describe("ContentTypeDetailPanel", () => {
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
   });
 
-  it("saves description with bulk PUT then enabled with dedicated PUT (#3781)", async () => {
+  it("saves enabled with dedicated PUT first then description with bulk PUT (#3781)", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
@@ -512,8 +512,74 @@ describe("ContentTypeDetailPanel", () => {
       enabled?: boolean;
     };
     expect(saveBody.enabled).toBeUndefined();
-    expect(updateContentTypeDetail.mock.invocationCallOrder[0]).toBeLessThan(
-      setContentTypeEnabled.mock.invocationCallOrder[0],
+    expect(setContentTypeEnabled.mock.invocationCallOrder[0]).toBeLessThan(
+      updateContentTypeDetail.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not bulk PUT when enabled PUT fails (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    setContentTypeEnabled.mockRejectedValueOnce({
+      status: 500,
+      statusText: "Error",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(setContentTypeEnabled).toHaveBeenCalled();
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+  });
+
+  it("keeps enabled from dedicated PUT when bulk PUT fails (#3781)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    updateContentTypeDetail.mockRejectedValueOnce({
+      status: 500,
+      statusText: "Error",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not save content type.",
+      );
+    });
+    expect(setContentTypeEnabled).toHaveBeenCalledWith("percPage", false);
+    expect(updateContentTypeDetail).toHaveBeenCalled();
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId("developer-ct-description") as HTMLInputElement).value).toBe(
+      "Updated description",
     );
   });
 

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -96,6 +96,18 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
     allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
+    setContentTypeEnabled: vi.fn().mockImplementation(async (_id, enabled: boolean) => ({
+      name: "percPage",
+      label: "Page",
+      description: "A page",
+      enabled,
+      guid: { stringValue: "0-2-301", uuid: 301 },
+      fields: [],
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", label: "Simple Workflow", isDefault: true },
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+      designGaps: [],
+    })),
     lockContentType: vi.fn().mockResolvedValue({ locker: "Admin", remainingTime: 30 }),
     unlockContentType: vi.fn().mockResolvedValue(undefined),
   };
@@ -781,9 +793,10 @@ it("loads views catalog section", async () => {
         expect.objectContaining({ name: "page_title", searchable: true }),
       ]),
     );
-    // Field-only save must not wipe associations
+    // Field-only save must not wipe associations or bulk-PUT enabled (CD-13)
     expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toBeUndefined();
+    expect(body.enabled).toBeUndefined();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -61,6 +61,8 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
       "Field rule flags are exposed (validation/visibility/transforms present); full rule expressions and control properties are not",
     ],
   }),
+  replaceContentTypeAllowedTemplates: vi.fn().mockImplementation(async (_id, templates) => templates),
+  getContentTypeAllowedTemplates: vi.fn().mockResolvedValue([{ name: "perc.page", label: "Page" }]),
   updateContentTypeDetail: vi.fn().mockImplementation(async (_id, body) => ({
     name: "percPage",
     label: body.label ?? "Page",
@@ -750,9 +752,10 @@ it("loads views catalog section", async () => {
 
 
   it("edits content type field searchable and saves with design lock path", async () => {
-    const { updateContentTypeDetail } = await import(
+    const { updateContentTypeDetail, replaceContentTypeAllowedTemplates } = await import(
       "../../../main/ts/api/developer/contentTypesApi"
     );
+    (replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -784,6 +787,7 @@ it("loads views catalog section", async () => {
     // Field-only save must not wipe associations
     expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });
@@ -873,11 +877,19 @@ it("loads views catalog section", async () => {
     expect(screen.getByTestId("developer-site-table").textContent).toContain("Corporate");
   });
 
-  it("edits content type workflow and template associations on save", async () => {
-    const { updateContentTypeDetail } = await import(
-      "../../../main/ts/api/developer/contentTypesApi"
-    );
+  it("edits content type workflow associations on bulk save and templates via CD-12 PUT", async () => {
+    const {
+      updateContentTypeDetail,
+      replaceContentTypeAllowedTemplates,
+      getContentTypeAllowedTemplates,
+    } = await import("../../../main/ts/api/developer/contentTypesApi");
     (updateContentTypeDetail as ReturnType<typeof vi.fn>).mockClear();
+    (replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
+    (getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockClear();
+    (getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { name: "perc.page" },
+      { name: "perc.page.summary", label: "perc.page.summary" },
+    ]);
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -910,6 +922,9 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(updateContentTypeDetail).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalled();
+    });
     const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
     expect(body.allowedWorkflows).toEqual(
       expect.arrayContaining([
@@ -920,12 +935,15 @@ it("loads views catalog section", async () => {
     expect(body.defaultWorkflow).toEqual(
       expect.objectContaining({ name: "Simple Workflow" }),
     );
-    expect(body.allowedTemplates).toEqual(
+    expect(body.allowedTemplates).toBeUndefined();
+    expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith(
+      "percPage",
       expect.arrayContaining([
         expect.objectContaining({ name: "perc.page" }),
         expect.objectContaining({ name: "perc.page.summary" }),
       ]),
     );
+    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
     });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -96,6 +96,35 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
     allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
+    setContentTypeAllowedWorkflows: vi.fn().mockImplementation(async (_id, body) => ({
+      name: "percPage",
+      label: "Page",
+      description: "A page",
+      enabled: true,
+      guid: { stringValue: "0-2-301", uuid: 301 },
+      fields: [
+        {
+          name: "sys_title",
+          label: "Title",
+          fieldType: "system",
+          searchable: true,
+          required: true,
+          occurrence: "required",
+        },
+        {
+          name: "page_title",
+          label: "Page title",
+          fieldType: "local",
+          searchable: false,
+          required: false,
+          occurrence: "optional",
+        },
+      ],
+      allowedWorkflows: body.allowedWorkflows,
+      defaultWorkflow: body.defaultWorkflow ?? null,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+      designGaps: [],
+    })),
     lockContentType: vi.fn().mockResolvedValue({ locker: "Admin", remainingTime: 30 }),
     unlockContentType: vi.fn().mockResolvedValue(undefined),
   };
@@ -874,10 +903,11 @@ it("loads views catalog section", async () => {
   });
 
   it("edits content type workflow and template associations on save", async () => {
-    const { updateContentTypeDetail } = await import(
+    const { updateContentTypeDetail, setContentTypeAllowedWorkflows } = await import(
       "../../../main/ts/api/developer/contentTypesApi"
     );
     (updateContentTypeDetail as ReturnType<typeof vi.fn>).mockClear();
+    (setContentTypeAllowedWorkflows as ReturnType<typeof vi.fn>).mockClear();
     render(<DeveloperShell embedded />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
@@ -908,18 +938,25 @@ it("loads views catalog section", async () => {
     });
     fireEvent.click(screen.getByTestId("developer-ct-save"));
     await waitFor(() => {
-      expect(updateContentTypeDetail).toHaveBeenCalled();
+      expect(setContentTypeAllowedWorkflows).toHaveBeenCalled();
     });
-    const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
-    expect(body.allowedWorkflows).toEqual(
+    const wfBody = (setContentTypeAllowedWorkflows as ReturnType<typeof vi.fn>).mock.calls.at(
+      -1,
+    )?.[1];
+    expect(wfBody.allowedWorkflows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "Simple Workflow" }),
         expect.objectContaining({ name: "Standard Workflow" }),
       ]),
     );
-    expect(body.defaultWorkflow).toEqual(
+    expect(wfBody.defaultWorkflow).toEqual(
       expect.objectContaining({ name: "Simple Workflow" }),
     );
+    await waitFor(() => {
+      expect(updateContentTypeDetail).toHaveBeenCalled();
+    });
+    const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+    expect(body.allowedWorkflows).toBeUndefined();
     expect(body.allowedTemplates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "perc.page" }),

--- a/WebUI/src/test/ts/developer/contentTypeWorkflows.test.ts
+++ b/WebUI/src/test/ts/developer/contentTypeWorkflows.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildAllowedWorkflowsReplaceBody,
+  cloneNamedObjectRefs,
+  namedObjectRefsEqual,
+  toNamedObjectRefPayload,
+  withDefaultWorkflowFlags,
+} from "../../../main/ts/developer/contentTypeWorkflows";
+
+describe("contentTypeWorkflows helpers (CD-08)", () => {
+  it("clones refs without sharing guid objects", () => {
+    const guid = { stringValue: "0-23-4", uuid: 4 };
+    const src = [{ name: "Simple Workflow", label: "Simple", guid, isDefault: true }];
+    const cloned = cloneNamedObjectRefs(src);
+    expect(cloned).toEqual(src);
+    expect(cloned[0].guid).not.toBe(guid);
+    cloned[0].guid!.uuid = 99;
+    expect(guid.uuid).toBe(4);
+  });
+
+  it("treats default-flag mismatch as dirty", () => {
+    const a = [{ name: "Simple Workflow", isDefault: true }];
+    const b = [{ name: "Simple Workflow", isDefault: false }];
+    expect(namedObjectRefsEqual(a, b)).toBe(false);
+    expect(namedObjectRefsEqual(a, [{ name: "Simple Workflow", isDefault: true }])).toBe(true);
+  });
+
+  it("marks the matching defaultWorkflow row and falls back to first", () => {
+    const list = [{ name: "Simple Workflow" }, { name: "Standard Workflow" }];
+    expect(
+      withDefaultWorkflowFlags(list, { name: "Standard Workflow" }).map((w) => ({
+        name: w.name,
+        isDefault: w.isDefault,
+      })),
+    ).toEqual([
+      { name: "Simple Workflow", isDefault: false },
+      { name: "Standard Workflow", isDefault: true },
+    ]);
+    expect(withDefaultWorkflowFlags([{ name: "Simple Workflow" }])[0].isDefault).toBe(true);
+  });
+
+  it("builds a full-replace body with payload refs and defaultWorkflow", () => {
+    const body = buildAllowedWorkflowsReplaceBody([
+      {
+        name: "Simple Workflow",
+        label: "Simple Workflow",
+        isDefault: true,
+        guid: { stringValue: "0-23-4", uuid: 4 },
+      },
+      { name: "Standard Workflow", label: "Standard Workflow" },
+    ]);
+    expect(body.allowedWorkflows).toEqual([
+      {
+        name: "Simple Workflow",
+        isDefault: true,
+        guid: { stringValue: "0-23-4", uuid: 4 },
+      },
+      { name: "Standard Workflow" },
+    ]);
+    expect(body.defaultWorkflow).toEqual({
+      name: "Simple Workflow",
+      isDefault: true,
+      guid: { stringValue: "0-23-4", uuid: 4 },
+    });
+    expect(toNamedObjectRefPayload(body.allowedWorkflows)[1]).toEqual({
+      name: "Standard Workflow",
+    });
+  });
+
+  it("omits defaultWorkflow when the allowed set is empty", () => {
+    expect(buildAllowedWorkflowsReplaceBody([])).toEqual({ allowedWorkflows: [] });
+  });
+});

--- a/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review — issue #3781 Developer Content Type enable/disable chrome (CD-13)
+
+**Scope:** uncommitted work on `feat/issue-3781-ct-enable-disable-chrome-2` vs `origin/main`.
+**Change class:** WebUI product screen (Developer Content Type detail) consuming existing REST CD-13 `PUT /services/contenttypes/{idOrName}/enabled`.
+**Memory patterns hit:** incomplete change-class closure (Playwright + product-docs); behavioral tests for new helpers; URL `/` paths are URI not filesystem (false-positive guard).
+
+## Summary
+
+The SPA already showed an Enabled checkbox on Content Type detail but saved it on the bulk `PUT /contenttypes/{id}` and `updateContentTypeDetail` still wrapped lock → PUT → unlock (leftover from before lock chrome). Live H2 QA showed dedicated PUT `ContentTypeEnabled.enabled=false` returning `enabled:true` because design save always passed `enable=true` and item-def load never copied the application flag. This change:
+
+1. Adds `setContentTypeEnabled` + `wrapContentTypeEnabledForWire` (`ContentTypeEnabled` Jackson root).
+2. Saves enabled only via dedicated PUT after a held lock; bulk PUT omits `enabled`.
+3. Stops wrapping lock/unlock on bulk PUT so save keeps the design lock.
+4. Design save passes `PSItemDefinition.isEnabled()` into `saveContentType` (CD-13 persist).
+5. `loadItemDef` copies `ceApp.isEnabled()`; adaptor GET falls back to object-store after cache miss.
+6. Extends Vitest, Playwright lock-save spec (fail closed, GET persist), and product-docs.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Combined save (bulk then enabled PUT) can leave a partial write if the dedicated PUT fails after a successful bulk save. Chrome already surfaces the error; lock is cleared on 409. Acceptable for this slice.
+- Playwright enable test restores the flag in `finally` so a failed assert does not leave `percPage` disabled on a shared H2 QA cell.
+
+## Cross-platform path checklist
+
+- No new filesystem path joins (`/` or `\\`).
+- New URLs use `/` for REST paths (correct).
+- Tests use `encodeURIComponent` for idOrName; Playwright GET uses `BASE_URL` + `/Rhythmyx/services/...` (URI).
+- No temp-dir or line-ending assertions.
+
+## Companions
+
+| Companion | Status |
+|-----------|--------|
+| Vitest API helper (`setContentTypeEnabled`, wrap, no lock wrap on bulk PUT) | yes |
+| Vitest panel: disabled until lock, dedicated PUT, combined save order, 409 | yes |
+| Playwright surface spec extended; empty catalog fails closed | yes |
+| `product-docs/8.2/admin/developer-content-types.md` + rest note | yes |
+| REST / sitemanage re-implement | out of scope (CD-13 already shipped) |
+
+## Tests
+
+- `WebUI/src/test/ts/api/developer/contentTypesApi.test.ts`
+- `WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx`
+- `WebUI/src/test/ts/developer/DeveloperShell.test.tsx` (bulk body omits enabled)
+- `modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js`

--- a/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3781-ct-enable-disable-chrome-erlang.md
@@ -29,8 +29,38 @@ None (hard-gate).
 
 ### Notes (non-blocking)
 
-- Combined save (bulk then enabled PUT) can leave a partial write if the dedicated PUT fails after a successful bulk save. Chrome already surfaces the error; lock is cleared on 409. Acceptable for this slice.
+- Combined save (enabled PUT first, then bulk) can still leave enabled persisted if bulk then fails. Chrome surfaces the error, keeps the description draft, and syncs the Enabled checkbox from the dedicated PUT. No shared rollback.
 - Playwright enable test restores the flag in `finally` so a failed assert does not leave `percPage` disabled on a shared H2 QA cell.
+
+## Re-review (PR #3828 Kilo threads)
+
+**Scope:** uncommitted review-response vs `HEAD` on `feat/issue-3781-ct-enable-disable-chrome-2`.
+**Change class:** same CD-13 chrome; review-thread mitigations only.
+**Memory patterns hit:** behavioral tests for new/changed non-trivial logic; swallowed exceptions must log.
+
+### Summary
+
+Kilo threads on PR #3828:
+1. Object-store fallback on `resolveItemDef` is now opt-in (`includeDisabledFromStore`). Only GET detail and `setContentTypeEnabled` pass `true`. Templates / item exits / control properties keep cache-only 404.
+2. Combined save runs enabled PUT first so a failed enable cannot leave bulk fields persisted. Bulk failure after enabled success syncs the checkbox from the dedicated PUT and keeps local drafts.
+3. `loadItemDefFromObjectStore` debug log includes exception class, message, and throwable stack.
+
+### Recommendation
+
+approve
+
+### Gate
+
+May commit/push: yes
+
+### Issues
+
+None (hard-gate).
+
+### Cross-platform path checklist
+
+- No new filesystem path joins.
+- No temp-dir or line-ending assertions.
 
 ## Cross-platform path checklist
 

--- a/docs/ai-generated/code-reviews/issue-3782-ct-workflow-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3782-ct-workflow-assoc-chrome-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review: issue #3782 Developer Content Type workflow associations chrome (CD-08)
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-26 |
+| **Branch** | `feat/issue-3782-ct-workflow-assoc-chrome` |
+| **Base** | `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: yes |
+| **Memory patterns hit** | Change-class closure (WebUI API + panel + Vitest + Playwright + product-docs); behavioral tests for dedicated PUT / 409 / unlocked save; REST URL `/` not filesystem paths |
+
+## Summary
+
+Developer Content Type detail consumes held-lock `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (Jackson `ContentTypeWorkflows`) instead of stuffing `allowedWorkflows` onto the generic content-type PUT. Save does not acquire or release the lock. Unlocked editors and Save stay disabled. Template association chrome is unchanged (still bulk PUT when templates are dirty). REST internals are not reimplemented.
+
+## Gate
+
+- No bugs found in the diff after standalone `WebUI` and `modules/perc-qa-automation` `mvnw clean install`.
+- Behavioral tests: wrap helper, dedicated PUT (no lock/unlock), panel lock → CD-08 save, 409 clears lock, unlocked save blocked, helper empty-list / default flags.
+- Companions: Playwright `developer-content-type-workflows.spec.js`; product-docs Developer Content Types + REST CD-08 SPA note.
+- Cross-platform path checklist: N/A for filesystem joins (REST/URL `/` only; Playwright `encodeURIComponent` on type name).
+- C2 reverse-deps: none (no Java public type/signature change).
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Generic `updateContentTypeDetail` no longer wraps lock→PUT→unlock; lock chrome (#3744) is the session owner. Mixed saves call CD-08 first, then bulk PUT without `allowedWorkflows`.
+- Playwright fails closed if the catalog is empty or both stock workflow names are already associated.

--- a/docs/ai-generated/code-reviews/issue-3783-ct-template-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3783-ct-template-assoc-chrome-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — #3783 Developer Content Type template associations chrome (CD-12)
+
+**Date:** 2026-08-26  
+**Branch:** `feat/issue-3783-ct-template-assoc-chrome`  
+**Scope:** uncommitted vs `HEAD` (WebUI SPA, rest DTO/resource, sitemanage adaptor, Vitest, Playwright, product-docs)  
+**Memory patterns hit:** change-class closure (Vitest + Playwright for WebUI screen; rest DTO XmlSeeAlso peer SiteList #3090); dedicated REST consumed with live-wire fixes; no path I/O.
+
+## Summary
+
+Developer Content Type detail replaces allowed templates via dedicated
+`PUT /services/contenttypes/{idOrName}/allowedTemplates` after a held design
+lock, then `GET` lists the new set. Bulk `PUT /contenttypes/{id}` no longer
+sends `allowedTemplates` and no longer wraps lock→save→unlock (held lock is
+required; save must not steal/release). Unlocked editors stay disabled; 409
+clears the UI lock without steal.
+
+Live H2 required two wire/lock companions so the chrome could consume REST:
+`NamedObjectRefList` JAXB `@XmlSeeAlso` + distinct root name (peer SiteList #3090);
+PUT body typed as `List<NamedObjectRef>` so CXF does not cast `ArrayList`;
+`replaceAllowedTemplates` uses `resolveExistingContentTypeGuid` so lock and PUT
+share the packed NODEDEF id.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+None blocking.
+
+### Companions (checked)
+
+| Artifact | Present |
+|----------|---------|
+| WebUI API wrap/unwrap for `NamedObjectRefList` | yes |
+| ContentTypeDetailPanel lock → PUT → GET | yes |
+| Vitest API + panel + DeveloperShell | yes |
+| rest `NamedObjectRefList` XmlSeeAlso + List PUT param + serial test | yes |
+| sitemanage lock GUID alignment + adaptor tests | yes |
+| Playwright surface spec | `developer-content-type-template-associations.spec.js` |
+| product-docs `8.2/admin/developer-content-types.md` + REST CD-12 | yes |
+| Out of scope: workflow chrome (#3782), enable/disable (#3781) | not shipped |
+
+### Notes (non-blocking)
+
+- Whole-object PUT still exists for label/description/fields/workflows; templates use the CD-12 sub-resource only.
+- Jackson WRAP_ROOT uses class name `NamedObjectRefList` (XmlRootElement ignored without JAXB introspector) — client wrap matches.
+- Cross-platform path checklist: N/A (REST URL `/` only; no filesystem joins).

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
@@ -15,9 +15,11 @@
  */
 
 /**
- * Developer Content Type detail lock / save / unlock chrome (#3744 / #3772 / parent #1690).
+ * Developer Content Type detail lock / save / unlock / enable chrome
+ * (#3744 / #3772 / #3781 CD-13 / parent #1690).
  *
- * Admin locks a type, saves a description, then unlocks. Surface-filtered QA:
+ * Admin locks a type, saves a description, toggles enabled via dedicated PUT,
+ * then unlocks. Surface-filtered QA:
  * <pre>
  *   perc-devctl qa-up
  *   cd modules/perc-qa-automation/frontend
@@ -42,7 +44,81 @@ function developerContentTypesUrl() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
 }
 
-test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
+function unwrapEnabled(payload) {
+  if (payload == null || typeof payload !== "object") {
+    return undefined;
+  }
+  const nested =
+    payload.ContentTypeDetail && typeof payload.ContentTypeDetail === "object"
+      ? payload.ContentTypeDetail
+      : payload.contentTypeDetail && typeof payload.contentTypeDetail === "object"
+        ? payload.contentTypeDetail
+        : payload;
+  return nested.enabled;
+}
+
+async function openContentTypeDetail(page, namePattern) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    throw new Error(
+      "No content types in catalog — fail closed (H2 QA must include sample types)",
+    );
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
+    hasText: namePattern || /percPage/,
+  });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(
+      `Content type detail error: ${(await detailError.innerText()).trim()}`,
+    );
+  }
+  return detail;
+}
+
+async function getContentTypeEnabled(page, idOrName) {
+  const res = await page.request.get(
+    `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(idOrName)}`,
+  );
+  expect(res.ok(), `GET content type HTTP ${res.status()}`).toBe(true);
+  return unwrapEnabled(await res.json());
+}
+
+test.describe("Developer content type lock/save chrome (#3744 / #3772 / #3781)", () => {
   test("Admin can lock, save a description, and unlock", async ({ page }) => {
     test.setTimeout(120_000);
     const pageErrors = [];
@@ -57,55 +133,10 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     });
 
     await loginAsAdmin(page);
-    await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
-
-    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
-      timeout: 20_000,
-    });
-
-    const panel = page.locator('[data-testid="developer-ct-panel"]');
-    const empty = page.locator('[data-testid="developer-ct-empty"]');
-    const listError = page.locator('[data-testid="developer-ct-error"]');
-    await expect(panel.or(empty).or(listError).first()).toBeVisible({
-      timeout: 30_000,
-    });
-
-    if (await listError.isVisible()) {
-      throw new Error(
-        `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
-      );
-    }
-    if (await empty.isVisible()) {
-      test.skip(true, "No content types in catalog — cannot exercise lock/save");
-    }
-
-    const table = page.locator('[data-testid="developer-ct-table"]');
-    await expect(table).toBeVisible({ timeout: 15_000 });
-    const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
-      hasText: /percPage/,
-    });
-    const targetRow =
-      (await named.count()) > 0
-        ? named.first()
-        : page.locator(catalogRowSelector("developer-ct-row", 0));
-    await expect(targetRow).toBeVisible();
-    const openBtn = targetRow.locator('button[aria-label^="Open "]');
-    if (await openBtn.count()) {
-      await openBtn.click();
-    } else {
-      await targetRow.click();
-    }
-
-    const detail = page.locator('[data-testid="developer-ct-detail"]');
-    const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
-    await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
-    if (await detailError.isVisible()) {
-      throw new Error(
-        `Content type detail error: ${(await detailError.innerText()).trim()}`,
-      );
-    }
+    await openContentTypeDetail(page);
 
     const desc = page.locator('[data-testid="developer-ct-description"]');
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
     const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
     const saveBtn = page.locator('[data-testid="developer-ct-save"]');
     const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
@@ -116,11 +147,13 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     await expect(saveBtn).toBeDisabled();
     await expect(unlockBtn).toBeDisabled();
     await expect(desc).toBeDisabled();
+    await expect(enabledBox).toBeDisabled();
     await expect(status).toHaveText(/Not locked/i);
 
     await lockBtn.click();
     await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
     await expect(desc).toBeEnabled();
+    await expect(enabledBox).toBeEnabled();
     await expect(unlockBtn).toBeEnabled();
 
     const original = (await desc.inputValue()).replace(MARKER, "");
@@ -146,6 +179,7 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
     await unlockBtn.click();
     await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
     await expect(desc).toBeDisabled();
+    await expect(enabledBox).toBeDisabled();
     await expect(saveBtn).toBeDisabled();
     await expect(lockBtn).toBeEnabled();
 
@@ -157,5 +191,156 @@ test.describe("Developer content type lock/save chrome (#3744 / #3772)", () => {
       unexpectedConsole,
       `console error: ${unexpectedConsole.join(" | ")}`,
     ).toEqual([]);
+  });
+
+  test("Admin lock then toggle enabled persists on GET (#3781 CD-13)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(String(err && err.message ? err.message : err));
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(
+      page,
+      /percFileAsset|percSimpleTextAsset|percRawHtmlAsset/,
+    );
+
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    await expect(enabledBox).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+
+    await lockBtn.click();
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(enabledBox).toBeEnabled();
+
+    const originalEnabled = await enabledBox.isChecked();
+    const typeName = (
+      await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
+    ).trim();
+    expect(typeName.length, "detail name for GET").toBeGreaterThan(0);
+
+    const saveEnabled = async (label) => {
+      const enabledResp = page.waitForResponse(
+        (res) =>
+          res.request().method() === "PUT" &&
+          /\/contenttypes\/[^/?]+\/enabled(?:\?|$)/.test(res.url()),
+        { timeout: 20_000 },
+      );
+      await expect(saveBtn).toBeEnabled();
+      await saveBtn.click();
+      const resp = await enabledResp;
+      const reqBody = resp.request().postData() || "";
+      let putEnabled;
+      let putBody = "";
+      try {
+        const putJson = await resp.json();
+        putEnabled = unwrapEnabled(putJson);
+        putBody = `req=${reqBody} respEnabled=${putEnabled}`;
+      } catch (e) {
+        putBody = `non-json ${resp.status()} req=${reqBody} ${(e && e.message) || e}`;
+      }
+      await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+      if (await saveError.isVisible()) {
+        throw new Error(
+          `${label}: ${(await saveError.innerText()).trim()} PUT ${resp.status()} ${putBody}`,
+        );
+      }
+      await expect(notice).toContainText(/saved/i);
+      return { status: resp.status(), putBody };
+    };
+
+    try {
+      await enabledBox.click();
+      expect(await enabledBox.isChecked()).toBe(!originalEnabled);
+      const putResult = await saveEnabled("Enable save failed");
+      const getRes = await page.request.get(
+        `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}`,
+      );
+      const getJson = await getRes.json();
+      const afterToggle = unwrapEnabled(getJson);
+      expect(putResult.status, putResult.putBody).toBe(200);
+      expect(putResult.putBody).toContain("ContentTypeEnabled");
+      expect(
+        afterToggle,
+        `GET enabled after toggle ${putResult.putBody} getEnabled=${afterToggle}`,
+      ).toBe(!originalEnabled);
+
+      await enabledBox.click();
+      await saveEnabled("Enable restore failed");
+      const restored = await getContentTypeEnabled(page, typeName);
+      expect(restored, "GET enabled after restore").toBe(originalEnabled);
+    } finally {
+      if (await enabledBox.isEnabled()) {
+        if ((await enabledBox.isChecked()) !== originalEnabled) {
+          await enabledBox.click();
+          try {
+            await saveEnabled("Enable finally restore failed");
+          } catch {
+            // Best-effort restore so a failed assert does not leave the type disabled.
+          }
+        }
+        if (await unlockBtn.isEnabled()) {
+          await unlockBtn.click();
+          await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+        }
+      }
+    }
+
+    await expect(enabledBox).toBeDisabled();
+
+    expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+    const unexpectedConsole = consoleErrors.filter(
+      (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+    );
+    expect(
+      unexpectedConsole,
+      `console error: ${unexpectedConsole.join(" | ")}`,
+    ).toEqual([]);
+  });
+
+  test("other-user lock is 409; enabled toggle stays disabled (#3781)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page);
+
+    await page.route("**/services/contenttypes/**/lock", async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Locked by another user" }),
+      });
+    });
+
+    const enabledBox = page.locator('[data-testid="developer-ct-enabled"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+
+    await expect(enabledBox).toBeDisabled();
+    await lockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-detail-error"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(status).toHaveText(/Not locked/i);
+    await expect(enabledBox).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type allowed-template associations chrome (CD-12 / #3783).
+ *
+ * Admin locks a type, replaces the allowed-template set (add/remove existing
+ * ids), saves via PUT .../allowedTemplates, then GET lists the new set.
+ * Unlocked save is blocked; lock is not stolen.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-template-associations.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { catalogRowSelector } = require("./helpers/developer-catalog-selectors");
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function unwrapNamedObjectRefs(payload) {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (typeof payload !== "object") {
+    return [];
+  }
+  if (Array.isArray(payload.NamedObjectRefList)) {
+    return payload.NamedObjectRefList;
+  }
+  if (payload.NamedObjectRefList && typeof payload.NamedObjectRefList === "object") {
+    return unwrapNamedObjectRefs(payload.NamedObjectRefList);
+  }
+  if (payload.NamedObjectRef) {
+    return unwrapNamedObjectRefs(payload.NamedObjectRef);
+  }
+  if (typeof payload.empty === "boolean" && Object.keys(payload).every((k) => k === "empty")) {
+    return [];
+  }
+  if (payload.name || payload.label || payload.guid) {
+    return [payload];
+  }
+  return [];
+}
+
+function refName(item) {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+  return String(item.name || item.label || "").trim();
+}
+
+async function openContentTypeDetail(page, namePattern) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    test.skip(true, "No content types in catalog — cannot exercise template associations");
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = namePattern
+    ? table.locator('[data-testid^="developer-ct-row-"]').filter({ hasText: namePattern })
+    : table.locator('[data-testid^="developer-ct-row-"]').filter({ hasText: /percPage/ });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
+  }
+}
+
+async function getAllowedTemplatesViaRest(page, typeName) {
+  const result = await page.evaluate(async (name) => {
+    const res = await fetch(
+      `/Rhythmyx/services/contenttypes/${encodeURIComponent(name)}/allowedTemplates`,
+      { credentials: "same-origin", headers: { Accept: "application/json" } },
+    );
+    const text = await res.text();
+    return { status: res.status, text };
+  }, typeName);
+  expect(
+    result.status,
+    `GET allowedTemplates ${result.status} ${String(result.text).slice(0, 400)}`,
+  ).toBe(200);
+  let json = {};
+  try {
+    json = JSON.parse(result.text);
+  } catch {
+    throw new Error(`GET allowedTemplates non-JSON: ${String(result.text).slice(0, 400)}`);
+  }
+  return unwrapNamedObjectRefs(json).map(refName).filter(Boolean);
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(unexpectedConsole, `console error: ${unexpectedConsole.join(" | ")}`).toEqual([]);
+}
+
+test.describe("Developer content type template associations (CD-12 / #3783)", () => {
+  test("unlocked template editors and save stay blocked; 409 lock is not stolen", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page);
+
+    const addName = page.locator('[data-testid="developer-ct-tpl-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-tpl-add"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+
+    await expect(page.locator('[data-testid="developer-ct-templates"]')).toBeVisible();
+    await expect(addName).toBeDisabled();
+    await expect(addBtn).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+    await expect(status).toHaveText(/Not locked/i);
+
+    await page.route("**/services/contenttypes/**/lock", async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Locked by another user" }),
+      });
+    });
+
+    await lockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-detail-error"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(status).toHaveText(/Not locked/i);
+    await expect(addName).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Admin lock, replace allowed templates, GET lists the new set", async ({ page }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page, /percPage/);
+
+    const addName = page.locator('[data-testid="developer-ct-tpl-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-tpl-add"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    const typeName = (
+      await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
+    ).trim();
+    expect(typeName.length, "detail name for GET").toBeGreaterThan(0);
+
+    const original = await getAllowedTemplatesViaRest(page, typeName);
+
+    await expect(addName).toBeDisabled();
+    await lockBtn.click();
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(addName).toBeEnabled();
+    await expect(unlockBtn).toBeEnabled();
+
+    const rows = page.locator('[data-testid^="developer-ct-tpl-row-"]');
+    const originalRowCount = await rows.count();
+    expect(originalRowCount, "UI rows vs GET allowedTemplates").toBe(original.length);
+
+    const saveTemplates = async (label) => {
+      const putWait = page.waitForResponse(
+        (res) =>
+          res.request().method() === "PUT" &&
+          /\/contenttypes\/[^/?]+\/allowedTemplates(?:\?|$)/.test(res.url()),
+        { timeout: 20_000 },
+      );
+      await expect(saveBtn).toBeEnabled();
+      await saveBtn.click();
+      const putRes = await putWait;
+      const putBody = putRes.request().postData() || "";
+      await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+      if (await saveError.isVisible()) {
+        throw new Error(
+          `${label}: ${(await saveError.innerText()).trim()} PUT ${putRes.status()} ${putBody}`,
+        );
+      }
+      expect(putRes.status(), `${label} PUT allowedTemplates ${putBody}`).toBe(200);
+      expect(putBody, `${label} PUT wrap`).toContain("NamedObjectRefList");
+      await expect(notice).toContainText(/saved/i);
+      return getAllowedTemplatesViaRest(page, typeName);
+    };
+
+    try {
+      if (original.length > 0) {
+        const removedName = original[original.length - 1];
+        await page.locator(`[data-testid="developer-ct-tpl-remove-${original.length - 1}"]`).click();
+        const afterRemove = await saveTemplates("Remove template save failed");
+        const restGet = await getAllowedTemplatesViaRest(page, typeName);
+        expect(restGet).toEqual(afterRemove);
+        if (removedName) {
+          expect(restGet).not.toContain(removedName);
+        }
+        expect(restGet.length).toBe(original.length - 1);
+
+        if (removedName) {
+          await addName.fill(removedName);
+          await addBtn.click();
+        }
+      } else {
+        await addName.fill("perc.page");
+        await addBtn.click();
+        const afterAdd = await saveTemplates("Add perc.page save failed");
+        const restGet = await getAllowedTemplatesViaRest(page, typeName);
+        expect(restGet).toEqual(afterAdd);
+        expect(restGet).toContain("perc.page");
+        await page.locator('[data-testid="developer-ct-tpl-remove-0"]').click();
+      }
+
+      const restoredUi = await saveTemplates("Restore template save failed");
+      const restored = await getAllowedTemplatesViaRest(page, typeName);
+      expect(restored).toEqual(restoredUi);
+      expect(restored.sort()).toEqual([...original].sort());
+    } finally {
+      if (await unlockBtn.isEnabled()) {
+        await unlockBtn.click();
+        await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+      }
+    }
+
+    await expect(addName).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type allowed-workflow associations chrome (CD-08 / #3782).
+ *
+ * Admin locks a type, replaces the allowed-workflow set, saves via
+ * PUT .../allowedWorkflows, then GET lists the new set. Unlocked save is
+ * disabled (no lock steal). Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-workflows.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const { catalogRowSelector } = require("./helpers/developer-catalog-selectors");
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function asWorkflowList(raw) {
+  if (raw == null) {
+    return [];
+  }
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw.NamedObjectRef != null) {
+    return [].concat(raw.NamedObjectRef);
+  }
+  if (typeof raw.empty === "boolean") {
+    return [];
+  }
+  if (raw.name || raw.label) {
+    return [raw];
+  }
+  return [];
+}
+
+function unwrapContentTypeDetail(body) {
+  if (body == null || typeof body !== "object") {
+    return {};
+  }
+  return body.ContentTypeDetail || body.contentTypeDetail || body;
+}
+
+async function getAllowedWorkflowState(request, typeName) {
+  const headers = {
+    ...adminBasicAuthHeaders(),
+    Accept: "application/json",
+  };
+  const url = `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}`;
+  const res = await request.get(url, { headers });
+  expect(res.status(), `GET ${url}`).toBe(200);
+  const detail = unwrapContentTypeDetail(await res.json());
+  const names = asWorkflowList(detail.allowedWorkflows)
+    .map((w) => w && w.name)
+    .filter(Boolean);
+  const defaultName =
+    (detail.defaultWorkflow && detail.defaultWorkflow.name) || names[0] || "";
+  return { names, defaultName };
+}
+
+async function openPercPageDetail(page) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    throw new Error("No content types in catalog — cannot exercise workflow associations");
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
+    hasText: /percPage/,
+  });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(
+      `Content type detail error: ${(await detailError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible();
+  const nameEl = page.locator('[data-testid="developer-ct-detail-name"]');
+  const typeName = ((await nameEl.count()) ? await nameEl.innerText() : "percPage").trim();
+  return typeName || "percPage";
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return {
+    assertClean() {
+      expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+      const unexpectedConsole = consoleErrors.filter(
+        (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+      );
+      expect(
+        unexpectedConsole,
+        `console error: ${unexpectedConsole.join(" | ")}`,
+      ).toEqual([]);
+    },
+  };
+}
+
+test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => {
+  test("without lock, workflow editors and save stay disabled", async ({ page }) => {
+    test.setTimeout(120_000);
+    const guards = attachConsoleGuards(page);
+    await loginAsAdmin(page);
+    await openPercPageDetail(page);
+
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const addName = page.locator('[data-testid="developer-ct-wf-add-name"]');
+    const addBtn = page.locator('[data-testid="developer-ct-wf-add"]');
+    await expect(saveBtn).toBeDisabled();
+    await expect(addName).toBeDisabled();
+    await expect(addBtn).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-lock-status"]')).toHaveText(
+      /Not locked/i,
+    );
+    const remove0 = page.locator('[data-testid="developer-ct-wf-remove-0"]');
+    if ((await remove0.count()) > 0) {
+      await expect(remove0).toBeDisabled();
+    }
+    guards.assertClean();
+  });
+
+  test("Admin lock, PUT allowedWorkflows, GET lists the new set", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const guards = attachConsoleGuards(page);
+    const putUrls = [];
+    page.on("request", (req) => {
+      if (req.method() === "PUT") {
+        putUrls.push(req.url());
+      }
+    });
+
+    await loginAsAdmin(page);
+    const typeName = await openPercPageDetail(page);
+    const original = await getAllowedWorkflowState(request, typeName);
+    const originalNames = original.names;
+    if (originalNames.length < 2) {
+      throw new Error(
+        `${typeName} needs at least two allowed workflows to replace (have: ${originalNames.join(", ") || "none"})`,
+      );
+    }
+    const toRemove =
+      originalNames.find((n) => n && n !== original.defaultName) ||
+      originalNames[originalNames.length - 1];
+
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+
+    await expect(lockBtn).toBeEnabled();
+    const lockResponsePromise = page.waitForResponse(
+      (r) => r.request().method() === "POST" && /\/contenttypes\/[^/]+\/lock(?:\?|$)/.test(r.url()),
+      { timeout: 20_000 },
+    );
+    await lockBtn.click();
+    const lockRes = await lockResponsePromise;
+    if (!lockRes.ok()) {
+      const body = await lockRes.text();
+      throw new Error(`Lock HTTP ${lockRes.status()} ${body}`);
+    }
+    if (await saveError.isVisible()) {
+      throw new Error(`Lock failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeEnabled();
+
+    const removeRow = page
+      .locator('[data-testid^="developer-ct-wf-row-"]')
+      .filter({ hasText: toRemove });
+    await expect(removeRow).toHaveCount(1);
+    await removeRow.locator('[data-testid^="developer-ct-wf-remove-"]').click();
+    await expect(saveBtn).toBeEnabled();
+
+    putUrls.length = 0;
+    await saveBtn.click();
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Workflow save failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(notice).toContainText(/saved/i);
+    await expect(status).toHaveText(/Locked by you/i);
+
+    const workflowPuts = putUrls.filter((u) => /\/allowedWorkflows(?:\?|$)/.test(u));
+    expect(
+      workflowPuts.length,
+      `expected PUT .../allowedWorkflows, got: ${putUrls.join(" | ") || "(none)"}`,
+    ).toBeGreaterThan(0);
+
+    const afterNames = (await getAllowedWorkflowState(request, typeName)).names;
+    expect(afterNames, "GET after save should omit the removed workflow").not.toContain(toRemove);
+
+    await page.locator('[data-testid="developer-ct-wf-add-name"]').fill(toRemove);
+    await page.locator('[data-testid="developer-ct-wf-add"]').click();
+    await expect(page.locator('[data-testid="developer-ct-workflows"]')).toContainText(toRemove);
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Restore save failed: ${(await saveError.innerText()).trim()}`);
+    }
+    const restored = (await getAllowedWorkflowState(request, typeName)).names;
+    expect(restored.sort()).toEqual([...originalNames].sort());
+
+    await unlockBtn.click();
+    await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+    await expect(saveBtn).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeDisabled();
+
+    guards.assertClean();
+  });
+});

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -38,7 +38,12 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 6. Change the **Description** (and any other unlocked fields), then click
    **Save content type**. Save writes while the lock is still held. It does
    **not** unlock.
-7. Click **Unlock** when you are done. Status returns to **Not locked** and the
+7. To change **Allowed templates**, lock the type, add or remove existing
+   template names or GUIDs (`type-host-uuid`, for example `0-10-347`), then
+   **Save content type**. Save replaces the whole allowed-template set. An empty
+   list clears associations. Unknown names return an error; the lock is not
+   stolen. This is not the full Workbench template picker.
+8. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
 Locks expire after **30 minutes**. If Save fails because the lock expired,
@@ -51,7 +56,9 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, workflows) | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |
+| Confirm allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, save, and unlock a content type from Developer detail chrome
+description: Lock, save, and unlock a content type from Developer detail chrome, including allowed workflows
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -39,6 +39,23 @@ write). This page does **not** add Properties-tab chrome for those exits.
 7. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
+### Allowed workflows (after lock)
+
+The **Allowed workflows** list is read-only until you hold the lock. After
+**Lock**:
+
+1. Add a workflow by its existing name (for example **Standard Workflow**) and
+   click **Add**, or **Remove** a row. Use **Default** to choose the default
+   workflow.
+2. Click **Save content type**. The product replaces the allowed-workflow set
+   (`PUT /services/contenttypes/{idOrName}/allowedWorkflows`). Save does **not**
+   unlock. Reloading the type (or GET detail) lists the new set.
+3. Without a lock, Add / Remove / Save stay **disabled**. The product does
+   **not** steal another user's lock (lock failure is **409**).
+
+This is not a full Workbench workflow picker. The name you add must already
+exist on the server. Template association chrome is a separate surface.
+
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.
 
@@ -49,7 +66,8 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, templates) | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, save, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, save, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -35,14 +35,32 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).
-6. Change the **Description** (and any other unlocked fields), then click
-   **Save content type**. Save writes while the lock is still held. It does
-   **not** unlock.
+6. Change the **Description**, **Enabled** checkbox, and any other unlocked
+   fields, then click **Save content type**. Save writes while the lock is still
+   held. It does **not** unlock. **Enabled** is written with a dedicated
+   `PUT /services/contenttypes/{idOrName}/enabled` (CD-13), not the bulk
+   content-type save. Without a lock the checkbox stays disabled and a toggle
+   cannot persist.
 7. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.
+
+## Enable or disable a content type
+
+The **Enabled** checkbox on Developer Content Type detail controls whether the
+type is available for runtime use.
+
+1. Hold the design-session **Lock**. The checkbox is read-only until you do.
+2. Toggle **Enabled**, then **Save content type**. The SPA calls
+   `PUT /services/contenttypes/{idOrName}/enabled` (Jackson root
+   `ContentTypeEnabled`) while the lock is still held.
+3. A following `GET /services/contenttypes/{idOrName}` reflects the new
+   `enabled` value.
+4. If another user already holds the lock, **Lock** returns **409**. The
+   product does **not** steal the lock, Save stays disabled, and **Enabled**
+   remains read-only.
 
 ## REST
 
@@ -51,7 +69,8 @@ The chrome calls:
 | Action | Request |
 |--------|---------|
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
-| Save | `PUT /services/contenttypes/{idOrName}` (requires a held lock) |
+| Save (label, description, fields, associations) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`) |
+| Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -205,7 +205,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types).
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT).
 
 Lock / save / unlock status codes:
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -295,12 +295,17 @@ allowed template associations. Body is a JSON array of named refs (`name` and/or
 `guid`). Full-replace semantics: the supplied list becomes the new set; an empty
 array clears associations.
 
-Typical flow (lock REST is a peer slice; SOAP/Workbench can also hold the lock):
+Typical flow:
 
-1. Hold a design lock on the content type.
+1. Hold a design lock on the content type (`POST .../lock` from Developer, or SOAP/Workbench).
 2. `PUT /services/contenttypes/{idOrName}/allowedTemplates` with the new set.
 3. `GET` the same path (or `GET /services/contenttypes/{idOrName}`) to confirm.
 4. Release the design lock when editing is finished.
+
+**Developer → Content types** detail chrome follows that flow after **Lock**: add or
+remove existing template names/GUIDs, **Save content type** (dedicated PUT, then GET
+lists the new set), then **Unlock**. Save is disabled until the lock is held; the
+product does not steal another user's lock. See [Developer Content Types](id:admin-developer-content-types).
 
 `409` means the current session user does not hold the design lock. `400` means
 a template id or name in the body does not exist. The lock stays held after a

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -258,8 +258,9 @@ Capability gaps still render as the human-readable **message** (fallback **code*
 `PUT /services/contenttypes/{idOrName}/allowedWorkflows` replaces the content
 type's allowed-workflow associations. Hold the design-session lock first; save
 keeps the lock so you can continue editing, then unlock. This dedicated action
-does **not** auto lock-save-unlock (the generic `PUT /contenttypes/{idOrName}`
-still does that for mixed meta/field updates).
+does **not** acquire or release the lock. The Developer SPA **Content types**
+detail chrome uses this PUT after **Lock** (not the generic content-type PUT)
+when the allowed-workflow set changes.
 
 Typical flow: `POST .../lock` → `PUT .../allowedWorkflows` → (optional further
 design writes) → `POST .../unlock`.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -27,6 +27,7 @@ import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorPipe;
+import com.percussion.design.objectstore.PSContentTypeHelper;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
@@ -259,24 +260,52 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private PSItemDefinition resolveItemDef(String idOrName) throws PSInvalidContentTypeException {
-    // Prefer numeric uuid
-    if (StringUtils.isNumeric(idOrName)) {
-      long uuid = Long.parseLong(idOrName);
-      return itemDefManager.getItemDef(uuid, PSItemDefManager.COMMUNITY_ANY);
-    }
-    // Guid string forms: 0-2-301 or 0-301
-    if (idOrName.contains("-")) {
-      try {
-        PSGuid g = new PSGuid(idOrName);
-        if (g.getType() == 0) {
-          g = new PSGuid(PSTypeEnum.NODEDEF, g.getUUID());
-        }
-        return itemDefManager.getItemDef(g.getUUID(), PSItemDefManager.COMMUNITY_ANY);
-      } catch (Exception ignore) {
-        // fall through to name
+    try {
+      // Prefer numeric uuid
+      if (StringUtils.isNumeric(idOrName)) {
+        long uuid = Long.parseLong(idOrName);
+        return itemDefManager.getItemDef(uuid, PSItemDefManager.COMMUNITY_ANY);
       }
+      // Guid string forms: 0-2-301 or 0-301
+      if (idOrName.contains("-")) {
+        try {
+          PSGuid g = new PSGuid(idOrName);
+          if (g.getType() == 0) {
+            g = new PSGuid(PSTypeEnum.NODEDEF, g.getUUID());
+          }
+          return itemDefManager.getItemDef(g.getUUID(), PSItemDefManager.COMMUNITY_ANY);
+        } catch (PSInvalidContentTypeException e) {
+          throw e;
+        } catch (Exception ignore) {
+          // fall through to name
+        }
+      }
+      return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
+    } catch (PSInvalidContentTypeException e) {
+      PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
+      if (fromStore != null) {
+        return fromStore;
+      }
+      throw e;
     }
-    return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
+  }
+
+  /**
+   * Object-store load when the item-def cache no longer has a running editor
+   * (disabled content types unregister). Used so GET {@code enabled} still
+   * reflects the saved application flag (CD-13).
+   */
+  private PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
+    try {
+      IPSGuid guid = resolveExistingContentTypeGuid(idOrName);
+      if (guid == null) {
+        return null;
+      }
+      return PSContentTypeHelper.loadItemDef(guid);
+    } catch (Exception e) {
+      log.debug("Object-store content type load after cache miss {}: {}", idOrName, e.getMessage());
+      return null;
+    }
   }
 
   private ContentTypeDetail toDetail(PSItemDefinition def) {
@@ -547,8 +576,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         log.error("Failed to save content type enabled flag {}: {}", idOrName, e.getMessage(), e);
         throw new IllegalStateException("Failed to save content type enabled flag", e);
       }
-      PSItemDefinition reloaded = resolveItemDef(trimmed);
-      return reloaded != null ? toDetail(reloaded) : toDetail(def);
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      if (reloaded != null && reloaded != def) {
+        reloaded.setEnabled(enabled);
+        return toDetail(reloaded);
+      }
+      return toDetail(def);
     } catch (ContentTypeDesignLockException
         | IllegalArgumentException
         | WebApplicationException e) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -593,11 +593,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     String session = currentSession();
     String user = currentUser();
     try {
-      PSItemDefinition current = resolveItemDef(idOrName.trim());
-      if (current == null) {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(idOrName.trim());
+      if (ctGuid == null) {
         return null;
       }
-      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
       requireHeldLock(ctGuid);
       List<IPSGuid> templateGuids = resolveTemplateGuids(templates);
       try {
@@ -615,9 +614,6 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         | IllegalArgumentException
         | WebApplicationException e) {
       throw e;
-    } catch (PSInvalidContentTypeException e) {
-      log.debug("Content type not found for template association replace: {}", idOrName);
-      return null;
     } catch (Exception e) {
       log.error(
           "Failed to replace template associations for {}: {}", idOrName, e.getMessage(), e);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -244,7 +244,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       return null;
     }
     try {
-      PSItemDefinition def = resolveItemDef(idOrName.trim());
+      PSItemDefinition def = resolveItemDef(idOrName.trim(), true);
       if (def == null) {
         return null;
       }
@@ -260,6 +260,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private PSItemDefinition resolveItemDef(String idOrName) throws PSInvalidContentTypeException {
+    return resolveItemDef(idOrName, false);
+  }
+
+  /**
+   * Resolve a content type from the running item-def cache.
+   *
+   * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
+   *     object store so disabled types (unregistered from the editor cache) still load.
+   *     Only GET detail and enable/disable (CD-13) pass {@code true}; other callers keep
+   *     the pre-CD-13 cache-only 404 for disabled types.
+   */
+  private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
+      throws PSInvalidContentTypeException {
     try {
       // Prefer numeric uuid
       if (StringUtils.isNumeric(idOrName)) {
@@ -282,9 +295,11 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
       return itemDefManager.getItemDef(idOrName, PSItemDefManager.COMMUNITY_ANY);
     } catch (PSInvalidContentTypeException e) {
-      PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
-      if (fromStore != null) {
-        return fromStore;
+      if (includeDisabledFromStore) {
+        PSItemDefinition fromStore = loadItemDefFromObjectStore(idOrName);
+        if (fromStore != null) {
+          return fromStore;
+        }
       }
       throw e;
     }
@@ -293,9 +308,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   /**
    * Object-store load when the item-def cache no longer has a running editor
    * (disabled content types unregister). Used so GET {@code enabled} still
-   * reflects the saved application flag (CD-13).
+   * reflects the saved application flag (CD-13). Package-visible for tests.
    */
-  private PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
+  PSItemDefinition loadItemDefFromObjectStore(String idOrName) {
     try {
       IPSGuid guid = resolveExistingContentTypeGuid(idOrName);
       if (guid == null) {
@@ -303,7 +318,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
       return PSContentTypeHelper.loadItemDef(guid);
     } catch (Exception e) {
-      log.debug("Object-store content type load after cache miss {}: {}", idOrName, e.getMessage());
+      log.debug(
+          "Object-store content type load after cache miss {}: {}: {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
       return null;
     }
   }
@@ -548,7 +568,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     String session = currentSession();
     String user = currentUser();
     try {
-      PSItemDefinition current = resolveItemDef(trimmed);
+      PSItemDefinition current = resolveItemDef(trimmed, true);
       if (current == null) {
         return null;
       }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
@@ -39,6 +39,7 @@ import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.catalog.data.PSObjectSummary;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -87,6 +88,12 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     percPage = mock(PSItemDefinition.class);
     when(percPage.getTypeId()).thenReturn(311);
     when(itemDefManager.getItemDef("percPage", PSItemDefManager.COMMUNITY_ANY)).thenReturn(percPage);
+    IPSCatalogSummary percPageSum = mock(IPSCatalogSummary.class);
+    IPSGuid percPageGuid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    when(percPageSum.getGUID()).thenReturn(percPageGuid);
+    when(percPageSum.getName()).thenReturn("percPage");
+    when(percPageSum.getLabel()).thenReturn("Page");
+    when(designSvc.findContentTypes("percPage")).thenReturn(List.of(percPageSum));
   }
 
   @AfterEach
@@ -112,6 +119,12 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getAllowedTemplates(null, "missing"));
+  }
+
+  @Test
+  void replaceAllowedTemplates_missingType_returnsNull() {
+    when(designSvc.findContentTypes("missing")).thenReturn(List.of());
+    assertNull(adaptor.replaceAllowedTemplates(null, "missing", List.of()));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java
@@ -27,9 +27,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -112,6 +114,28 @@ class ContentTypeAdaptorAllowedTemplatesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getAllowedTemplates(null, "missing"));
+  }
+
+  @Test
+  void getAllowedTemplates_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getAllowedTemplates(null, "311"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
+  }
+
+  @Test
+  void replaceAllowedTemplates_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new com.percussion.cms.objectstore.PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    NamedObjectRef ref = new NamedObjectRef();
+    ref.setName("perc.page");
+    assertNull(spy.replaceAllowedTemplates(null, "311", List.of(ref)));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
@@ -25,8 +25,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -221,6 +223,16 @@ class ContentTypeAdaptorControlPropertiesTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getFieldControlProperties(null, "missing", "sys_title"));
+  }
+
+  @Test
+  void get_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(mock(PSItemDefinition.class)).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getFieldControlProperties(null, "311", "sys_title"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorEnabledTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorEnabledTest.java
@@ -26,8 +26,10 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -198,6 +200,38 @@ class ContentTypeAdaptorEnabledTest {
     verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
   }
 
+  @Test
+  void get_cacheMiss_usesObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeDetail get = spy.getContentType(null, "311");
+
+    assertEquals(Boolean.FALSE, get.getEnabled());
+    verify(spy).loadItemDefFromObjectStore("311");
+  }
+
+  @Test
+  void enable_cacheMiss_usesObjectStoreFallback() throws Exception {
+    stubHeldLock();
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(storeDef));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeDetail out = spy.setContentTypeEnabled(null, "311", true);
+
+    assertEquals(Boolean.TRUE, out.getEnabled());
+    verify(spy).loadItemDefFromObjectStore("311");
+    verify(storeDef).setEnabled(true);
+  }
+
   private void stubHeldLock() throws Exception {
     PSObjectSummary held = new PSObjectSummary(guid, "percPage");
     held.setLockedInfo("test-session", "Admin", 30);
@@ -205,6 +239,14 @@ class ContentTypeAdaptorEnabledTest {
   }
 
   private PSItemDefinition stubDefinition(boolean initiallyEnabled) throws Exception {
+    PSItemDefinition def = stubStoreDefinition(initiallyEnabled);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+
+  private PSItemDefinition stubStoreDefinition(boolean initiallyEnabled) {
     PSItemDefinition def = mock(PSItemDefinition.class);
     when(def.getName()).thenReturn("percPage");
     when(def.getLabel()).thenReturn("Page");
@@ -223,9 +265,6 @@ class ContentTypeAdaptorEnabledTest {
             })
         .when(def)
         .setEnabled(anyBoolean());
-    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
-    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
-        .thenReturn(List.of(def));
     return def;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
@@ -26,8 +26,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -147,6 +149,16 @@ class ContentTypeAdaptorItemExitsTest {
     when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
         .thenThrow(new PSInvalidContentTypeException("missing"));
     assertNull(adaptor.getItemExits(null, "missing"));
+  }
+
+  @Test
+  void getItemExits_cacheMiss_doesNotUseObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(percPage).when(spy).loadItemDefFromObjectStore("311");
+    assertNull(spy.getItemExits(null, "311"));
+    verify(spy, never()).loadItemDefFromObjectStore("311");
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1160,7 +1160,7 @@ public class ContentTypesResource {
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public NamedObjectRefList replaceAllowedTemplates(
-      @PathParam("idOrName") String idOrName, NamedObjectRefList body) {
+      @PathParam("idOrName") String idOrName, List<NamedObjectRef> body) {
     try {
       List<NamedObjectRef> items =
           requireAdaptor().replaceAllowedTemplates(uriInfo.getBaseUri(), idOrName, body);

--- a/rest/src/main/java/com/percussion/rest/contenttypes/NamedObjectRefList.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/NamedObjectRefList.java
@@ -17,16 +17,32 @@
 
 package com.percussion.rest.contenttypes;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
-/** Wire list of {@link NamedObjectRef} (content-type allowed templates/workflows). */
-@XmlRootElement(name = "NamedObjectRef")
+/**
+ * Wire list of {@link NamedObjectRef} (content-type allowed templates/workflows).
+ *
+ * <p>{@link XmlSeeAlso} registers {@link NamedObjectRef} in the JAXB context so GET/PUT {@code
+ * .../allowedTemplates} can marshal list elements. Without it, live H2 returns {@code
+ * JAXBException}: {@code NamedObjectRef nor any of its super class is known to this context}. Peer:
+ * {@code SiteList} (#3090), {@code TemplateSummaryList}.
+ *
+ * <p>{@link JsonFormat.Shape#ARRAY} keeps Jackson from treating this {@code ArrayList} subclass as
+ * a bean ({@code {"empty":false}}) under WRAP_ROOT_VALUE.
+ */
+@XmlRootElement(name = "NamedObjectRefList")
+@JsonRootName("NamedObjectRefList")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @ArraySchema(schema = @Schema(implementation = NamedObjectRef.class))
+@XmlSeeAlso(NamedObjectRef.class)
 public class NamedObjectRefList extends ArrayList<NamedObjectRef> {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/test/java/com/percussion/rest/contenttypes/NamedObjectRefListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/NamedObjectRefListSerialDeserialTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@code GET}/{@code PUT .../allowedTemplates} {@link NamedObjectRefList}.
+ *
+ * <p>Live H2 returned JAXBException {@code NamedObjectRef nor any of its super class is known to
+ * this context} when the list wrapper omitted {@code @XmlSeeAlso} and reused the item root name.
+ * Peer: {@code SiteListSerialDeserialTest} (#3090).
+ */
+@Tag("UnitTest")
+public class NamedObjectRefListSerialDeserialTest {
+
+  private static NamedObjectRef sampleRef() {
+    NamedObjectRef ref = new NamedObjectRef();
+    ref.setName("perc.page");
+    ref.setLabel("Page");
+    return ref;
+  }
+
+  @Test
+  public void productionMapperSerializesNamedObjectRefListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(NamedObjectRefList.class);
+    NamedObjectRefList list = new NamedObjectRefList();
+    list.add(sampleRef());
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("\"NamedObjectRefList\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("["), "list must be a JSON array, not a bean: " + json);
+    assertTrue(json.contains("perc.page"), json);
+    assertFalse(
+        json.contains("\"empty\""),
+        "ArrayList subclass must not serialize as {empty:false} bean: " + json);
+
+    NamedObjectRefList roundTrip = mapper.readValue(json, NamedObjectRefList.class);
+    assertEquals(1, roundTrip.size());
+    assertEquals("perc.page", roundTrip.get(0).getName());
+    assertEquals("Page", roundTrip.get(0).getLabel());
+  }
+
+  @Test
+  public void productionMapperSerializesEmptyListEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(NamedObjectRefList.class);
+    String json = mapper.writeValueAsString(new NamedObjectRefList());
+    assertTrue(json.contains("NamedObjectRefList") || json.contains("["), json);
+  }
+
+  @Test
+  public void jaxbContextKnowsNamedObjectRefFromList() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(NamedObjectRefList.class);
+    Marshaller marshaller = ctx.createMarshaller();
+    NamedObjectRefList list = new NamedObjectRefList();
+    list.add(sampleRef());
+    StringWriter writer = new StringWriter();
+    marshaller.marshal(list, writer);
+    String xml = writer.toString();
+    assertFalse(xml.isBlank(), "marshalled XML must not be empty");
+    assertTrue(
+        xml.contains("NamedObjectRefList") || xml.contains("namedObjectRefList"),
+        "expected NamedObjectRefList root in XML, got: " + xml);
+    assertFalse(
+        xml.toLowerCase().contains("known to this context"),
+        "JAXB context must include NamedObjectRef: " + xml);
+  }
+}

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
@@ -749,6 +749,7 @@ public class PSContentTypeHelper {
             nodeDef.getHideFromMenu(),
             nodeDef.getObjectType());
     PSItemDefinition itemDef = new PSItemDefinition(appName, contentType, ce);
+    itemDef.setEnabled(ceApp.isEnabled());
 
     return itemDef;
   }

--- a/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsSaveEnabledTest.java
+++ b/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsSaveEnabledTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webservices.content.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-13: design save must pass {@link PSItemDefinition#isEnabled()} into the application save, not
+ * a hardcoded {@code true}.
+ */
+class PSContentDesignWsSaveEnabledTest {
+
+  @Test
+  void contentTypeSaveAppEnabledFollowsItemDef() {
+    PSItemDefinition enabled = mock(PSItemDefinition.class);
+    when(enabled.isEnabled()).thenReturn(true);
+    assertTrue(PSContentDesignWs.contentTypeSaveAppEnabled(enabled));
+
+    PSItemDefinition disabled = mock(PSItemDefinition.class);
+    when(disabled.isEnabled()).thenReturn(false);
+    assertFalse(PSContentDesignWs.contentTypeSaveAppEnabled(disabled));
+  }
+
+  @Test
+  void contentTypeSaveAppEnabledNullIsFalse() {
+    assertFalse(PSContentDesignWs.contentTypeSaveAppEnabled(null));
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
@@ -1653,8 +1653,8 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                         lockService);
                   }
 
-                  PSContentTypeHelper.saveContentType(def, null, version,
-                     listener, true);
+                  PSContentTypeHelper.saveContentType(
+                      def, null, version, listener, contentTypeSaveAppEnabled(def));
 
                   if (listener != null)
                   {
@@ -1739,6 +1739,18 @@ public class PSContentDesignWs extends PSContentBaseWs implements
     */
    static IPSGuid contentTypeLockObjectId(long typeId) {
       return new PSDesignGuid(PSTypeEnum.NODEDEF, typeId);
+   }
+
+   /**
+    * Application {@code enabled} flag written by content-type design save (CD-13).
+    *
+    * <p>{@link PSContentTypeHelper#saveContentType} starts or stops the editor
+    * application from this boolean. A hardcoded {@code true} ignored
+    * {@link PSItemDefinition#isEnabled()} so {@code PUT .../enabled} never
+    * persisted.
+    */
+   static boolean contentTypeSaveAppEnabled(PSItemDefinition def) {
+      return def != null && def.isEnabled();
    }
 
    // @see IPSContentDesignWs#saveKeywords(List, boolean, String, String)


### PR DESCRIPTION
## Summary

Overnight cluster of three Developer Content Type chrome PRs that all edit the same SPA/API/docs files. Absorbing them into one PR against `main` so they do not thrash `ContentTypeDetailPanel` / `contentTypesApi` / product-docs on merge.

**Thrash files**

- `WebUI/src/main/ts/api/developer/contentTypesApi.ts`
- `WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx`
- `WebUI/src/test/ts/api/developer/contentTypesApi.test.ts`
- `WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx`
- `WebUI/src/test/ts/developer/DeveloperShell.test.tsx`
- `product-docs/8.2/admin/developer-content-types.md`
- `product-docs/8.2/developer/rest.md`
- `projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java`
- `projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorAllowedTemplatesTest.java`

Union semantics: dedicated PUTs for enable/disable (CD-13), allowed workflows (CD-08), and allowed templates (CD-12). Bulk content-type PUT is label/description/fields only. Enabled PUT runs first. Save does not steal or release the lock.

Unrelated this-run PRs **not** absorbed: #3831 (nav/sfp/workflow error codes), #3832 (preview render HTML writer).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3828](https://github.com/intersoftdatalabs-in/percussioncms/pull/3828) | `feat/issue-3781-ct-enable-disable-chrome-2` | yes | CD-13 enable/disable chrome |
| yes | [#3829](https://github.com/intersoftdatalabs-in/percussioncms/pull/3829) | `feat/issue-3782-ct-workflow-assoc-chrome` | yes | CD-08 allowed-workflow chrome |
| yes | [#3830](https://github.com/intersoftdatalabs-in/percussioncms/pull/3830) | `feat/issue-3783-ct-template-assoc-chrome` | yes | CD-12 template associations chrome |

## modules_built

`WebUI, rest, system, projects/sitemanage, modules/perc-qa-automation`

## build_evidence

- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 609, Failures: 0
- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2421, Failures: 0, Skipped: 244
- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3116 passed; Java Tests run: 63, Failures: 0
- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1579, Failures: 0, Skipped: 125
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; Surefire no Java tests)

Reverse-dep: `ContentTypesResource.replaceAllowedTemplates` takes `List<NamedObjectRef>` (from #3830). Grep: no `extends ContentTypesResource`. No type made final/sealed. sitemanage standalone clean install against new rest + perc-system SNAPSHOTs.

## Product documentation

- [x] Product documentation (`product-docs/`) updated for the unioned Developer Content Type chrome

## Checklist

- [x] Standalone Maven clean install of every changed module
- [x] Union of dedicated enable / workflow / template save paths
- [x] Do not merge this PR without human review

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
