### PR TITLE
fix(WebUI): CT lock toolbar always present; Enabled disabled until lock (#3834)

### DIFF
--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -236,7 +236,7 @@ export function ContentTypeDetailPanel({
   const fieldRows = contentTypeFields(detail);
   const childSets = contentTypeChildSets(detail);
   const gapRows = contentTypeDesignGaps(detail);
-  const canEdit = heldLock && !busy;
+  const canEdit = heldLock && !busy && detail != null;
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -516,6 +516,105 @@ export function ContentTypeDetailPanel({
         </div>
       ) : null}
 
+      {/* Always mount lock/enabled chrome so Playwright and operators see it
+          before GET detail finishes and without scrolling past the fields table. */}
+      <div
+        role="toolbar"
+        aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
+        data-testid="developer-ct-lock-toolbar"
+        style={{
+          marginBottom: "16px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          alignItems: "center",
+          position: "sticky",
+          top: 0,
+          zIndex: 2,
+          background: "#fff",
+          padding: "8px 0",
+        }}
+      >
+        <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DEV_MSG.CT_LOCK_HINT}
+        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="developer-ct-lock-status"
+          style={{ marginRight: "8px", fontSize: "0.9rem" }}
+        >
+          {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
+        </div>
+        <button
+          type="button"
+          data-testid="developer-ct-lock"
+          aria-label={DEV_MSG.CT_LOCK}
+          disabled={busy || heldLock || detail == null}
+          onClick={() => void handleLock()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock ? catalogColors.disabled : catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || heldLock || detail == null ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_LOCK}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-save"
+          aria-label={DEV_MSG.CT_SAVE}
+          disabled={busy || !heldLock || !dirty}
+          onClick={() => void handleSave()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_SAVE}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-unlock"
+          aria-label={DEV_MSG.CT_UNLOCK}
+          disabled={busy || !heldLock}
+          onClick={() => void handleUnlock()}
+          style={{
+            padding: "8px 16px",
+            background: "transparent",
+            color: "inherit",
+            border: `1px solid ${catalogColors.softBorder}`,
+            borderRadius: "4px",
+            cursor: busy || !heldLock ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_UNLOCK}
+        </button>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "8px" }}>
+          <input
+            type="checkbox"
+            data-testid="developer-ct-enabled"
+            aria-label={DEV_MSG.CT_FORM_ENABLED}
+            checked={enabled}
+            onChange={() => {
+              if (!canEdit) {
+                return;
+              }
+              setEnabled((v) => !v);
+            }}
+            disabled={!canEdit}
+          />
+          {DEV_MSG.CT_FORM_ENABLED}
+        </label>
+      </div>
+
       {!error && detail == null ? (
         <div data-testid="developer-ct-detail-loading">{DEV_MSG.CT_DETAIL_LOADING}</div>
       ) : null}
@@ -556,19 +655,6 @@ export function ContentTypeDetailPanel({
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={!canEdit}
               />
-            </div>
-            <div style={{ marginTop: "12px" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="checkbox"
-                  data-testid="developer-ct-enabled"
-                  aria-label={DEV_MSG.CT_FORM_ENABLED}
-                  checked={enabled}
-                  onChange={() => setEnabled((v) => !v)}
-                  disabled={!canEdit}
-                />
-                {DEV_MSG.CT_FORM_ENABLED}
-              </label>
             </div>
             <dl
               style={{
@@ -927,82 +1013,6 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
-
-          <div
-            role="toolbar"
-            aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
-            data-testid="developer-ct-lock-toolbar"
-            style={{
-              marginBottom: "16px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "8px",
-              alignItems: "center",
-            }}
-          >
-            <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
-              {DEV_MSG.CT_LOCK_HINT}
-            </p>
-            <div
-              role="status"
-              aria-live="polite"
-              data-testid="developer-ct-lock-status"
-              style={{ marginRight: "8px", fontSize: "0.9rem" }}
-            >
-              {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
-            </div>
-            <button
-              type="button"
-              data-testid="developer-ct-lock"
-              aria-label={DEV_MSG.CT_LOCK}
-              disabled={busy || heldLock || detail == null}
-              onClick={() => void handleLock()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock ? catalogColors.disabled : catalogColors.accent,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_LOCK}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-save"
-              aria-label={DEV_MSG.CT_SAVE}
-              disabled={busy || !heldLock || !dirty}
-              onClick={() => void handleSave()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_SAVE}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-unlock"
-              aria-label={DEV_MSG.CT_UNLOCK}
-              disabled={busy || !heldLock}
-              onClick={() => void handleUnlock()}
-              style={{
-                padding: "8px 16px",
-                background: "transparent",
-                color: "inherit",
-                border: `1px solid ${catalogColors.softBorder}`,
-                borderRadius: "4px",
-                cursor: busy || !heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_UNLOCK}
-            </button>
-          </div>
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -413,7 +413,10 @@ describe("ContentTypeDetailPanel", () => {
       );
     });
     expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(true);
   });
 
   it("clears the held lock when save returns 409 (#3744)", async () => {
@@ -583,6 +586,26 @@ describe("ContentTypeDetailPanel", () => {
       expect(unlockContentType).toHaveBeenCalledWith("percPage");
     });
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("renders lock toolbar and disabled enabled chrome while detail is loading (#3834)", async () => {
+    let resolveDetail: (value: typeof sampleDetail) => void = () => undefined;
+    getContentTypeDetail.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
+    );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    resolveDetail(sampleDetail);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
   });
 
   it("keeps the enabled toggle disabled until lock (#3781)", async () => {

--- a/docs/ai-generated/code-reviews/issue-3834-ct-lock-save-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3834-ct-lock-save-chrome-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — issue 3834 CT lock/save chrome
+
+**Scope:** uncommitted + `fix/issue-3834-ct-lock-save-chrome` vs cluster tip
+`cluster/night-issue-20260826-ct-chrome` @ `8229288b11` (stacked; parent #3781 / epic #1690).
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** behavioral tests for changed chrome; Playwright companion for WebUI screens; product-docs for operator-facing toolbar placement.
+
+## Summary
+
+Cycle Verify residual: H2 Playwright `developer-content-type-lock-save.spec.js` failed because lock toolbar / Enabled chrome were not in the first paint (toolbar lived after the fields table, gated on GET `detail`). 409 other-user lock could appear to leave Enabled interactive if the checkbox was missing or not lock-gated on the loaded bundle.
+
+This change always mounts `developer-ct-lock-toolbar` (Lock / Save / Unlock / Enabled) at the top of Content Type detail, sticky, as soon as the panel shell mounts. Enabled stays `disabled` until `heldLock && !busy && detail != null`. 409 lock keeps `heldLock` false; onChange is no-op without `canEdit`. Playwright helper waits for toolbar + enabled-disabled + Lock enabled. Vitest covers loading-state chrome and 409 Enabled stays disabled. Product-docs note the top-of-panel toolbar.
+
+## Issues
+
+None (hard-gate).
+
+## Cross-platform path checklist
+
+Not applicable: no filesystem path construction, installers, or path assertions. Playwright URLs and REST paths correctly use `/`.
+
+## Companions
+
+- Vitest: loading toolbar/enabled; 409 lock does not enable Enabled
+- Playwright surface spec helper waits for lock chrome
+- product-docs/8.2/admin/developer-content-types.md (toolbar placement / 409 Enabled)
+- Maven: `WebUI` and `modules/perc-qa-automation` standalone clean install
+- C5: `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:60026; qa-health RESULT:OK HTTP:200 HEALTH:healthy; docker cp rest + perc-system + sitemanage + WebUI `cm/modern/assets`; in-cell StopJetty/StartJetty; qa-health again RESULT:OK HTTP:200 HEALTH:healthy; `npm run test:surface -- --path tests/developer-content-type-lock-save.spec.js` **3 passed**; console-clean=yes (spec pageerror/console); server.log-clean=yes (no ERROR/FATAL in test window)

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
@@ -107,6 +107,15 @@ async function openContentTypeDetail(page, namePattern) {
       `Content type detail error: ${(await detailError.innerText()).trim()}`,
     );
   }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-enabled"]')).toBeDisabled({
+    timeout: 15_000,
+  });
   return detail;
 }
 

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,9 +29,12 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
 3. Open a catalog row.
-4. The detail toolbar shows **Lock**, **Save content type**, and **Unlock**.
-   The status line starts as **Not locked**. Label, description, enabled, field
-   flags, and association editors stay **read-only** until you hold the lock.
+4. The **detail toolbar at the top of the panel** shows **Lock**, **Save content
+   type**, **Unlock**, and the **Enabled** checkbox. The status line starts as
+   **Not locked**. Label, description, enabled, field flags, and association
+   editors stay **read-only** until you hold the lock. Enabled stays disabled
+   until you hold the lock; a failed lock (**409**) does not steal another
+   user's lock or enable the checkbox.
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).


### PR DESCRIPTION
## Summary

Cycle Verify residual for Playwright `tests/developer-content-type-lock-save.spec.js` on cluster tip #3833 (`cluster/night-issue-20260826-ct-chrome` @ `8229288b11`). Cluster union left lock/Enabled chrome after the fields table and gated on GET `detail`, so H2 QA timed out looking for `developer-ct-lock-toolbar` / `developer-ct-enabled`, and a 409 other-user lock could leave Enabled interactive.

This PR **stacks on #3833** (do not treat #3833 as coverage). Developer Content Type detail now **always** mounts Lock / Save / Unlock / **Enabled** at the **top** of the panel (sticky). Enabled stays disabled until a held lock (`heldLock && !busy && detail != null`); 409 lock does not steal or enable the checkbox.

Fixes #3834
Parent: #3781 / epic #1690
Stacked on: #3833

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

## Test plan

1. `perc-devctl qa-up --skip-image-build`; capture `TEST_CMS_URL` (freeport) and Admin password.
2. `perc-devctl qa-health` — require `RESULT:OK HTTP:200 HEALTH:healthy`.
3. Hot-copy SNAPSHOT `rest`, `perc-system`, `sitemanage` into WAR `WEB-INF/lib` and WebUI `cm/modern/assets`; in-cell `StopJetty` / `StartJetty` (do **not** `docker restart` the cell).
4. `qa-health` again.
5. From `modules/perc-qa-automation/frontend`:
   `npm run test:surface -- --path tests/developer-content-type-lock-save.spec.js`
   Expect 3 passed: lock/save/unlock, enabled PUT persist, 409 Enabled stays disabled.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-content-types.md` (toolbar at top of panel; Enabled disabled until lock; 409 does not steal)
- [x] **Unit / module tests** — Vitest loading toolbar/enabled + 409 Enabled stays disabled; `WebUI` and `modules/perc-qa-automation` standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `developer-content-type-lock-save.spec.js` helper waits for lock toolbar / Enabled disabled / Lock enabled
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path/file I/O); URLs/REST use `/`

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **Test Files 393 passed, Tests 3117 passed**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (npm ci; No tests to run at Surefire)
- **downstream_checked:** none (no Java public API / `final` / signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:60026` `QA_CONTAINER:perc-matrix-cms-h2`
- `qa-health` → `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy`
- Deploy: `docker cp` `rest-8.2.0-SNAPSHOT.jar`, `perc-system-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar` → WAR `WEB-INF/lib`; `docker cp` `WebUI/target/generated-webui/cm/modern/assets` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`; in-cell `StopJetty.sh` then `StartJetty.sh`
- `qa-health` again → `RESULT:OK HTTP:200 HEALTH:healthy`
- `npm run test:surface -- --path tests/developer-content-type-lock-save.spec.js` → **3 passed (9.2s)**
- **console-clean=yes** (spec `pageerror` + console error listeners)
- **server.log-clean=yes** (no ERROR/FATAL in the test window)
