### PR TITLE
fix(WebUI): sticky CT lock toolbar; workflow editors disabled until lock (#3835)

### DIFF
--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -236,7 +236,7 @@ export function ContentTypeDetailPanel({
   const fieldRows = contentTypeFields(detail);
   const childSets = contentTypeChildSets(detail);
   const gapRows = contentTypeDesignGaps(detail);
-  const canEdit = heldLock && !busy;
+  const canEdit = heldLock && !busy && detail != null;
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -248,6 +248,9 @@ export function ContentTypeDetailPanel({
   }
 
   function removeWorkflow(index: number) {
+    if (!heldLock) {
+      return;
+    }
     setWorkflows((prev) => {
       const next = prev.filter((_, i) => i !== index);
       if (next.length > 0 && !next.some((w) => w.isDefault)) {
@@ -259,6 +262,9 @@ export function ContentTypeDetailPanel({
   }
 
   function addWorkflow() {
+    if (!heldLock) {
+      return;
+    }
     const name = newWfName.trim();
     if (!name) return;
     if (workflows.some((w) => (w.name || "").toLowerCase() === name.toLowerCase())) {
@@ -274,6 +280,9 @@ export function ContentTypeDetailPanel({
   }
 
   function setDefaultWorkflow(index: number) {
+    if (!heldLock) {
+      return;
+    }
     setWorkflows((prev) => prev.map((w, i) => ({ ...w, isDefault: i === index })));
     setNotice(null);
   }
@@ -516,6 +525,105 @@ export function ContentTypeDetailPanel({
         </div>
       ) : null}
 
+      {/* Always mount lock chrome so operators and Playwright see it before GET
+          detail finishes and without scrolling past the fields table (#3835). */}
+      <div
+        role="toolbar"
+        aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
+        data-testid="developer-ct-lock-toolbar"
+        style={{
+          marginBottom: "16px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          alignItems: "center",
+          position: "sticky",
+          top: 0,
+          zIndex: 2,
+          background: "#fff",
+          padding: "8px 0",
+        }}
+      >
+        <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DEV_MSG.CT_LOCK_HINT}
+        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="developer-ct-lock-status"
+          style={{ marginRight: "8px", fontSize: "0.9rem" }}
+        >
+          {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
+        </div>
+        <button
+          type="button"
+          data-testid="developer-ct-lock"
+          aria-label={DEV_MSG.CT_LOCK}
+          disabled={busy || heldLock || detail == null}
+          onClick={() => void handleLock()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock ? catalogColors.disabled : catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || heldLock || detail == null ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_LOCK}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-save"
+          aria-label={DEV_MSG.CT_SAVE}
+          disabled={busy || !heldLock || !dirty}
+          onClick={() => void handleSave()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_SAVE}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-unlock"
+          aria-label={DEV_MSG.CT_UNLOCK}
+          disabled={busy || !heldLock}
+          onClick={() => void handleUnlock()}
+          style={{
+            padding: "8px 16px",
+            background: "transparent",
+            color: "inherit",
+            border: `1px solid ${catalogColors.softBorder}`,
+            borderRadius: "4px",
+            cursor: busy || !heldLock ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_UNLOCK}
+        </button>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "8px" }}>
+          <input
+            type="checkbox"
+            data-testid="developer-ct-enabled"
+            aria-label={DEV_MSG.CT_FORM_ENABLED}
+            checked={enabled}
+            onChange={() => {
+              if (!canEdit) {
+                return;
+              }
+              setEnabled((v) => !v);
+            }}
+            disabled={!canEdit}
+          />
+          {DEV_MSG.CT_FORM_ENABLED}
+        </label>
+      </div>
+
       {!error && detail == null ? (
         <div data-testid="developer-ct-detail-loading">{DEV_MSG.CT_DETAIL_LOADING}</div>
       ) : null}
@@ -556,19 +664,6 @@ export function ContentTypeDetailPanel({
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={!canEdit}
               />
-            </div>
-            <div style={{ marginTop: "12px" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="checkbox"
-                  data-testid="developer-ct-enabled"
-                  aria-label={DEV_MSG.CT_FORM_ENABLED}
-                  checked={enabled}
-                  onChange={() => setEnabled((v) => !v)}
-                  disabled={!canEdit}
-                />
-                {DEV_MSG.CT_FORM_ENABLED}
-              </label>
             </div>
             <dl
               style={{
@@ -687,9 +782,18 @@ export function ContentTypeDetailPanel({
                   style={inputStyle}
                   placeholder={DEV_MSG.CT_WF_NAME_PLACEHOLDER}
                   value={newWfName}
-                  onChange={(e) => setNewWfName(e.target.value)}
+                  onChange={(e) => {
+                    if (!canEdit) {
+                      return;
+                    }
+                    setNewWfName(e.target.value);
+                  }}
                   disabled={!canEdit}
+                  aria-disabled={!canEdit}
                   onKeyDown={(e) => {
+                    if (!canEdit) {
+                      return;
+                    }
                     if (e.key === "Enter") {
                       e.preventDefault();
                       addWorkflow();
@@ -927,82 +1031,6 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
-
-          <div
-            role="toolbar"
-            aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
-            data-testid="developer-ct-lock-toolbar"
-            style={{
-              marginBottom: "16px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "8px",
-              alignItems: "center",
-            }}
-          >
-            <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
-              {DEV_MSG.CT_LOCK_HINT}
-            </p>
-            <div
-              role="status"
-              aria-live="polite"
-              data-testid="developer-ct-lock-status"
-              style={{ marginRight: "8px", fontSize: "0.9rem" }}
-            >
-              {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
-            </div>
-            <button
-              type="button"
-              data-testid="developer-ct-lock"
-              aria-label={DEV_MSG.CT_LOCK}
-              disabled={busy || heldLock || detail == null}
-              onClick={() => void handleLock()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock ? catalogColors.disabled : catalogColors.accent,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_LOCK}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-save"
-              aria-label={DEV_MSG.CT_SAVE}
-              disabled={busy || !heldLock || !dirty}
-              onClick={() => void handleSave()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_SAVE}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-unlock"
-              aria-label={DEV_MSG.CT_UNLOCK}
-              disabled={busy || !heldLock}
-              onClick={() => void handleUnlock()}
-              style={{
-                padding: "8px 16px",
-                background: "transparent",
-                color: "inherit",
-                border: `1px solid ${catalogColors.softBorder}`,
-                borderRadius: "4px",
-                cursor: busy || !heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_UNLOCK}
-            </button>
-          </div>
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -97,6 +97,34 @@ describe("ContentTypeDetailPanel", () => {
     getContentTypeAllowedTemplates.mockImplementation(async () => []);
   });
 
+  it("renders lock toolbar while detail is loading so workflow lock is findable (#3835)", async () => {
+    let resolveDetail: (value: typeof sampleDetail) => void = () => undefined;
+    getContentTypeDetail.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
+    );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
+    expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByTestId("developer-ct-wf-add-name")).toBeNull();
+    resolveDetail({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-wf-add") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+  });
+
   it("loads detail on success and supports back", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     const onBack = vi.fn();
@@ -751,6 +779,26 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("ignores workflow add/remove while unlocked (#3835)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    fireEvent.click(screen.getByTestId("developer-ct-wf-remove-0"));
+    expect(screen.queryByTestId("developer-ct-wf-row-1")).toBeNull();
+    expect(screen.getByTestId("developer-ct-wf-row-0").textContent).toContain("Simple Workflow");
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("keeps workflow editors disabled until lock (#3782)", async () => {

--- a/docs/ai-generated/code-reviews/issue-3835-ct-workflow-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3835-ct-workflow-assoc-chrome-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review: issue #3835 Developer Content Type workflow-assoc chrome (Cycle Verify)
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-26 |
+| **Branch** | `fix/issue-3835-ct-workflow-assoc-chrome` |
+| **Base** | `origin/main` (#3833 cluster already merged) |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: yes |
+| **Memory patterns hit** | Change-class closure (WebUI panel + Vitest + Playwright + product-docs); lock chrome must be findable without scrolling past fields table (peer #3834); unlocked association editors stay disabled |
+
+## Summary
+
+Cycle Verify residual for `tests/developer-content-type-workflows.spec.js` on the #3833 cluster tip. Cluster union left Lock / Save / Unlock after the fields table and gated on GET `detail`, so H2 Playwright timed out on `developer-ct-lock` and saw `developer-ct-wf-add-name` enabled while unlocked.
+
+This change always mounts a **sticky top** lock toolbar (Lock / Save / Unlock / Enabled) before GET detail finishes. Workflow add/remove/default no-op without a held lock. Playwright waits for the toolbar and asserts add-name disabled. Product-docs: toolbar at top; Add/Remove stay disabled until Lock.
+
+## Gate
+
+- No bugs found. Standalone `WebUI` and `modules/perc-qa-automation` `mvnw clean install` succeeded (Vitest 3118 passed).
+- Behavioral tests: toolbar present while detail is loading; workflow add-name disabled after load; unlocked add/remove ignored; existing CD-08 lock → PUT path unchanged.
+- Companions: Playwright workflows spec (toolbar + lock timeout); lock-save / template specs wait for the same toolbar; product-docs Developer Content Types.
+- Cross-platform path checklist: N/A (no filesystem path/file I/O; REST/URL `/` only).
+- C2 reverse-deps: none (no Java public type/signature change).
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Peer residual #3834 / PR #3840 moved the same toolbar for lock-save Playwright. This PR is stacked on merged #3833, not on #3840 (CONFLICTING vs current main). Landing both will need a small toolbar-union if #3840 is still open.
+- Unlocked workflow add still uses native `disabled` plus handler guards so a click on a disabled control cannot dirty the set.

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
@@ -107,6 +107,15 @@ async function openContentTypeDetail(page, namePattern) {
       `Content type detail error: ${(await detailError.innerText()).trim()}`,
     );
   }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-enabled"]')).toBeDisabled({
+    timeout: 15_000,
+  });
   return detail;
 }
 

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -124,6 +124,12 @@ async function openContentTypeDetail(page, namePattern) {
   if (await detailError.isVisible()) {
     throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
   }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
 }
 
 async function getAllowedTemplatesViaRest(page, typeName) {

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
@@ -136,7 +136,16 @@ async function openPercPageDetail(page) {
       `Content type detail error: ${(await detailError.innerText()).trim()}`,
     );
   }
-  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible();
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeDisabled();
   const nameEl = page.locator('[data-testid="developer-ct-detail-name"]');
   const typeName = ((await nameEl.count()) ? await nameEl.innerText() : "percPage").trim();
   return typeName || "percPage";
@@ -177,6 +186,9 @@ test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => 
     const saveBtn = page.locator('[data-testid="developer-ct-save"]');
     const addName = page.locator('[data-testid="developer-ct-wf-add-name"]');
     const addBtn = page.locator('[data-testid="developer-ct-wf-add"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible();
+    await expect(lockBtn).toBeEnabled();
     await expect(saveBtn).toBeDisabled();
     await expect(addName).toBeDisabled();
     await expect(addBtn).toBeDisabled();
@@ -223,7 +235,7 @@ test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => 
     const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
     const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
 
-    await expect(lockBtn).toBeEnabled();
+    await expect(lockBtn).toBeEnabled({ timeout: 30_000 });
     const lockResponsePromise = page.waitForResponse(
       (r) => r.request().method() === "POST" && /\/contenttypes\/[^/]+\/lock(?:\?|$)/.test(r.url()),
       { timeout: 20_000 },

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,9 +29,11 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
 3. Open a catalog row.
-4. The detail toolbar shows **Lock**, **Save content type**, and **Unlock**.
-   The status line starts as **Not locked**. Label, description, enabled, field
-   flags, and association editors stay **read-only** until you hold the lock.
+4. The **detail toolbar at the top of the panel** (sticky) shows **Lock**,
+   **Save content type**, **Unlock**, and the **Enabled** checkbox. The status
+   line starts as **Not locked**. Label, description, enabled, field flags, and
+   association editors stay **read-only** until you hold the lock. You do not
+   need to scroll past the fields table to lock or save.
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).
@@ -51,8 +53,9 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 
 ### Allowed workflows (after lock)
 
-The **Allowed workflows** list is read-only until you hold the lock. After
-**Lock**:
+The **Allowed workflows** list is read-only until you hold the lock. Add,
+Remove, and the workflow-name field stay **disabled** while status is **Not
+locked**. After **Lock**:
 
 1. Add a workflow by its existing name (for example **Standard Workflow**) and
    click **Add**, or **Remove** a row. Use **Default** to choose the default


### PR DESCRIPTION
## Summary

Cycle Verify residual for Playwright `tests/developer-content-type-workflows.spec.js` on cluster tip #3833 (`cluster/night-issue-20260826-ct-chrome`, now on `main`). Cluster union left lock chrome after the fields table and gated on GET `detail`, so H2 QA timed out looking for `developer-ct-lock` and saw `developer-ct-wf-add-name` enabled while unlocked.

This PR **stacks on #3833** (do not treat #3833 as coverage). Developer Content Type detail now **always** mounts Lock / Save / Unlock / **Enabled** at the **top** of the panel (sticky). Workflow add/remove/default no-op without a held lock; unlocked add-name stays disabled.

Fixes #3835
Parent: #3782 / epic #1690
Stacked on: #3833

Peer lock-save residual #3834 / PR #3840 made the same toolbar move against a pre-merge base (CONFLICTING). This PR applies that chrome on current `main` and greens the workflows surface.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

## Test plan

1. `perc-devctl qa-up --skip-image-build`; capture `TEST_CMS_URL` (freeport) and Admin password.
2. `perc-devctl qa-health` — require `RESULT:OK HTTP:200 HEALTH:healthy`.
3. Hot-copy SNAPSHOT `rest`, `perc-system`, `sitemanage` into WAR `WEB-INF/lib` and WebUI `cm/modern/assets`; in-cell `StopJetty` / `StartJetty` (do **not** `docker restart` the cell).
4. `qa-health` again.
5. From `modules/perc-qa-automation/frontend`:
   `npm run test:surface -- --path tests/developer-content-type-workflows.spec.js`
   Expect 2 passed: unlocked editors disabled; Admin lock → PUT allowedWorkflows → GET lists the new set; no lock steal.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-content-types.md` (sticky toolbar at top; workflow Add/Remove disabled until lock)
- [x] **Unit / module tests** — Vitest loading toolbar + unlocked add/remove ignored; `WebUI` and `modules/perc-qa-automation` standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `developer-content-type-workflows.spec.js` waits for lock toolbar / add-name disabled / Lock enabled
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path/file I/O); URLs/REST use `/`

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **Test Files 393 passed, Tests 3118 passed**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (npm ci; No tests to run at Surefire)
- **downstream_checked:** none (no Java public API / `final` / signature change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- `qa-health` → `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy`
- Deploy: `docker cp` `rest-8.2.0-SNAPSHOT.jar`, `perc-system-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar` → WAR `WEB-INF/lib`; `docker cp` `WebUI/target/generated-webui/cm/modern/assets` → `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets`; in-cell `StopJetty.sh` then `StartJetty.sh`
- `qa-health` again → `RESULT:OK HTTP:200 HEALTH:healthy`
- `npm run test:surface -- --path tests/developer-content-type-workflows.spec.js` → **2 passed (6.3s)**
- **console-clean=yes** (spec `pageerror` + console error listeners)
- **server.log-clean=yes** (no ERROR/FATAL in the test window)
